### PR TITLE
feat: Builtin管理をバンドル埋め込み方式に移行し、/ejectコマンドを追加

### DIFF
--- a/resources/global/en/workflows/default.yaml
+++ b/resources/global/en/workflows/default.yaml
@@ -29,7 +29,7 @@ initial_step: plan
 steps:
   - name: plan
     edit: false
-    agent: ~/.takt/agents/default/planner.md
+    agent: ../agents/default/planner.md
     report:
       name: 00-plan.md
       format: |
@@ -89,7 +89,7 @@ steps:
 
   - name: implement
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     report:
       - Scope: 01-coder-scope.md
       - Decisions: 02-coder-decisions.md
@@ -144,7 +144,7 @@ steps:
 
   - name: ai_review
     edit: false
-    agent: ~/.takt/agents/default/ai-antipattern-reviewer.md
+    agent: ../agents/default/ai-antipattern-reviewer.md
     report:
       name: 03-ai-review.md
       format: |
@@ -194,7 +194,7 @@ steps:
 
   - name: ai_fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -224,7 +224,7 @@ steps:
 
   - name: review
     edit: false
-    agent: ~/.takt/agents/default/architecture-reviewer.md
+    agent: ../agents/default/architecture-reviewer.md
     report:
       name: 04-architect-review.md
       format: |
@@ -275,7 +275,7 @@ steps:
 
   - name: improve
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -307,7 +307,7 @@ steps:
 
   - name: fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -334,7 +334,7 @@ steps:
 
   - name: security_review
     edit: false
-    agent: ~/.takt/agents/default/security-reviewer.md
+    agent: ../agents/default/security-reviewer.md
     report:
       name: 05-security-review.md
       format: |
@@ -387,7 +387,7 @@ steps:
 
   - name: security_fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -413,7 +413,7 @@ steps:
 
   - name: supervise
     edit: false
-    agent: ~/.takt/agents/default/supervisor.md
+    agent: ../agents/default/supervisor.md
     report:
       - Validation: 06-supervisor-validation.md
       - Summary: summary.md

--- a/resources/global/en/workflows/expert-cqrs.yaml
+++ b/resources/global/en/workflows/expert-cqrs.yaml
@@ -32,7 +32,7 @@ steps:
   # ===========================================
   - name: plan
     edit: false
-    agent: ~/.takt/agents/default/planner.md
+    agent: ../agents/default/planner.md
     report:
       name: 00-plan.md
       format: |
@@ -89,7 +89,7 @@ steps:
   # ===========================================
   - name: implement
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     report:
       - Scope: 01-coder-scope.md
       - Decisions: 02-coder-decisions.md
@@ -146,7 +146,7 @@ steps:
   # ===========================================
   - name: ai_review
     edit: false
-    agent: ~/.takt/agents/default/ai-antipattern-reviewer.md
+    agent: ../agents/default/ai-antipattern-reviewer.md
     report:
       name: 03-ai-review.md
       format: |
@@ -196,7 +196,7 @@ steps:
 
   - name: ai_fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -228,7 +228,7 @@ steps:
   # ===========================================
   - name: cqrs_es_review
     edit: false
-    agent: ~/.takt/agents/expert-cqrs/cqrs-es-reviewer.md
+    agent: ../agents/expert-cqrs/cqrs-es-reviewer.md
     report:
       name: 04-cqrs-es-review.md
       format: |
@@ -282,7 +282,7 @@ steps:
 
   - name: fix_cqrs_es
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -316,7 +316,7 @@ steps:
   # ===========================================
   - name: frontend_review
     edit: false
-    agent: ~/.takt/agents/expert/frontend-reviewer.md
+    agent: ../agents/expert/frontend-reviewer.md
     report:
       name: 05-frontend-review.md
       format: |
@@ -370,7 +370,7 @@ steps:
 
   - name: fix_frontend
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -404,7 +404,7 @@ steps:
   # ===========================================
   - name: security_review
     edit: false
-    agent: ~/.takt/agents/expert/security-reviewer.md
+    agent: ../agents/expert/security-reviewer.md
     report:
       name: 06-security-review.md
       format: |
@@ -455,7 +455,7 @@ steps:
 
   - name: fix_security
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -499,7 +499,7 @@ steps:
   # ===========================================
   - name: qa_review
     edit: false
-    agent: ~/.takt/agents/expert/qa-reviewer.md
+    agent: ../agents/expert/qa-reviewer.md
     report:
       name: 07-qa-review.md
       format: |
@@ -550,7 +550,7 @@ steps:
 
   - name: fix_qa
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -598,7 +598,7 @@ steps:
   # ===========================================
   - name: supervise
     edit: false
-    agent: ~/.takt/agents/expert/supervisor.md
+    agent: ../agents/expert/supervisor.md
     report:
       - Validation: 08-supervisor-validation.md
       - Summary: summary.md
@@ -691,7 +691,7 @@ steps:
 
   - name: fix_supervisor
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob

--- a/resources/global/en/workflows/expert.yaml
+++ b/resources/global/en/workflows/expert.yaml
@@ -44,7 +44,7 @@ steps:
   # ===========================================
   - name: plan
     edit: false
-    agent: ~/.takt/agents/default/planner.md
+    agent: ../agents/default/planner.md
     report:
       name: 00-plan.md
       format: |
@@ -101,7 +101,7 @@ steps:
   # ===========================================
   - name: implement
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     report:
       - Scope: 01-coder-scope.md
       - Decisions: 02-coder-decisions.md
@@ -158,7 +158,7 @@ steps:
   # ===========================================
   - name: ai_review
     edit: false
-    agent: ~/.takt/agents/default/ai-antipattern-reviewer.md
+    agent: ../agents/default/ai-antipattern-reviewer.md
     report:
       name: 03-ai-review.md
       format: |
@@ -208,7 +208,7 @@ steps:
 
   - name: ai_fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -240,7 +240,7 @@ steps:
   # ===========================================
   - name: architect_review
     edit: false
-    agent: ~/.takt/agents/default/architecture-reviewer.md
+    agent: ../agents/default/architecture-reviewer.md
     report:
       name: 04-architect-review.md
       format: |
@@ -300,7 +300,7 @@ steps:
 
   - name: fix_architect
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -330,7 +330,7 @@ steps:
   # ===========================================
   - name: frontend_review
     edit: false
-    agent: ~/.takt/agents/expert/frontend-reviewer.md
+    agent: ../agents/expert/frontend-reviewer.md
     report:
       name: 05-frontend-review.md
       format: |
@@ -384,7 +384,7 @@ steps:
 
   - name: fix_frontend
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -418,7 +418,7 @@ steps:
   # ===========================================
   - name: security_review
     edit: false
-    agent: ~/.takt/agents/expert/security-reviewer.md
+    agent: ../agents/expert/security-reviewer.md
     report:
       name: 06-security-review.md
       format: |
@@ -469,7 +469,7 @@ steps:
 
   - name: fix_security
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -513,7 +513,7 @@ steps:
   # ===========================================
   - name: qa_review
     edit: false
-    agent: ~/.takt/agents/expert/qa-reviewer.md
+    agent: ../agents/expert/qa-reviewer.md
     report:
       name: 07-qa-review.md
       format: |
@@ -564,7 +564,7 @@ steps:
 
   - name: fix_qa
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -612,7 +612,7 @@ steps:
   # ===========================================
   - name: supervise
     edit: false
-    agent: ~/.takt/agents/expert/supervisor.md
+    agent: ../agents/expert/supervisor.md
     report:
       - Validation: 08-supervisor-validation.md
       - Summary: summary.md
@@ -705,7 +705,7 @@ steps:
 
   - name: fix_supervisor
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob

--- a/resources/global/en/workflows/magi.yaml
+++ b/resources/global/en/workflows/magi.yaml
@@ -18,7 +18,7 @@ max_iterations: 5
 
 steps:
   - name: melchior
-    agent: ~/.takt/agents/magi/melchior.md
+    agent: ../agents/magi/melchior.md
     allowed_tools:
       - Read
       - Glob
@@ -55,7 +55,7 @@ steps:
         next: balthasar
 
   - name: balthasar
-    agent: ~/.takt/agents/magi/balthasar.md
+    agent: ../agents/magi/balthasar.md
     allowed_tools:
       - Read
       - Glob
@@ -97,7 +97,7 @@ steps:
         next: casper
 
   - name: casper
-    agent: ~/.takt/agents/magi/casper.md
+    agent: ../agents/magi/casper.md
     allowed_tools:
       - Read
       - Glob

--- a/resources/global/en/workflows/research.yaml
+++ b/resources/global/en/workflows/research.yaml
@@ -22,7 +22,7 @@ max_iterations: 10
 
 steps:
   - name: plan
-    agent: ~/.takt/agents/research/planner.md
+    agent: ../agents/research/planner.md
     allowed_tools:
       - Read
       - Glob
@@ -59,7 +59,7 @@ steps:
         next: ABORT
 
   - name: dig
-    agent: ~/.takt/agents/research/digger.md
+    agent: ../agents/research/digger.md
     allowed_tools:
       - Read
       - Glob
@@ -101,7 +101,7 @@ steps:
         next: ABORT
 
   - name: supervise
-    agent: ~/.takt/agents/research/supervisor.md
+    agent: ../agents/research/supervisor.md
     allowed_tools:
       - Read
       - Glob

--- a/resources/global/en/workflows/simple.yaml
+++ b/resources/global/en/workflows/simple.yaml
@@ -26,7 +26,7 @@ initial_step: plan
 steps:
   - name: plan
     edit: false
-    agent: ~/.takt/agents/default/planner.md
+    agent: ../agents/default/planner.md
     report:
       name: 00-plan.md
       format: |
@@ -82,7 +82,7 @@ steps:
 
   - name: implement
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     report:
       - Scope: 01-coder-scope.md
       - Decisions: 02-coder-decisions.md
@@ -137,7 +137,7 @@ steps:
 
   - name: ai_review
     edit: false
-    agent: ~/.takt/agents/default/ai-antipattern-reviewer.md
+    agent: ../agents/default/ai-antipattern-reviewer.md
     report:
       name: 03-ai-review.md
       format: |
@@ -187,7 +187,7 @@ steps:
 
   - name: review
     edit: false
-    agent: ~/.takt/agents/default/architecture-reviewer.md
+    agent: ../agents/default/architecture-reviewer.md
     report:
       name: 04-architect-review.md
       format: |
@@ -239,7 +239,7 @@ steps:
 
   - name: supervise
     edit: false
-    agent: ~/.takt/agents/default/supervisor.md
+    agent: ../agents/default/supervisor.md
     report:
       - Validation: 05-supervisor-validation.md
       - Summary: summary.md

--- a/resources/global/ja/workflows/default.yaml
+++ b/resources/global/ja/workflows/default.yaml
@@ -20,7 +20,7 @@ initial_step: plan
 steps:
   - name: plan
     edit: false
-    agent: ~/.takt/agents/default/planner.md
+    agent: ../agents/default/planner.md
     report:
       name: 00-plan.md
       format: |
@@ -80,7 +80,7 @@ steps:
 
   - name: implement
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     report:
       - Scope: 01-coder-scope.md
       - Decisions: 02-coder-decisions.md
@@ -140,7 +140,7 @@ steps:
 
   - name: ai_review
     edit: false
-    agent: ~/.takt/agents/default/ai-antipattern-reviewer.md
+    agent: ../agents/default/ai-antipattern-reviewer.md
     report:
       name: 03-ai-review.md
       format: |
@@ -190,7 +190,7 @@ steps:
 
   - name: ai_fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -220,7 +220,7 @@ steps:
 
   - name: review
     edit: false
-    agent: ~/.takt/agents/default/architecture-reviewer.md
+    agent: ../agents/default/architecture-reviewer.md
     report:
       name: 04-architect-review.md
       format: |
@@ -282,7 +282,7 @@ steps:
 
   - name: improve
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -314,7 +314,7 @@ steps:
 
   - name: fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -340,7 +340,7 @@ steps:
 
   - name: security_review
     edit: false
-    agent: ~/.takt/agents/default/security-reviewer.md
+    agent: ../agents/default/security-reviewer.md
     report:
       name: 05-security-review.md
       format: |
@@ -393,7 +393,7 @@ steps:
 
   - name: security_fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -419,7 +419,7 @@ steps:
 
   - name: supervise
     edit: false
-    agent: ~/.takt/agents/default/supervisor.md
+    agent: ../agents/default/supervisor.md
     report:
       - Validation: 06-supervisor-validation.md
       - Summary: summary.md

--- a/resources/global/ja/workflows/expert-cqrs.yaml
+++ b/resources/global/ja/workflows/expert-cqrs.yaml
@@ -41,7 +41,7 @@ steps:
   # ===========================================
   - name: plan
     edit: false
-    agent: ~/.takt/agents/default/planner.md
+    agent: ../agents/default/planner.md
     report:
       name: 00-plan.md
       format: |
@@ -98,7 +98,7 @@ steps:
   # ===========================================
   - name: implement
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     report:
       - Scope: 01-coder-scope.md
       - Decisions: 02-coder-decisions.md
@@ -155,7 +155,7 @@ steps:
   # ===========================================
   - name: ai_review
     edit: false
-    agent: ~/.takt/agents/default/ai-antipattern-reviewer.md
+    agent: ../agents/default/ai-antipattern-reviewer.md
     report:
       name: 03-ai-review.md
       format: |
@@ -205,7 +205,7 @@ steps:
 
   - name: ai_fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -237,7 +237,7 @@ steps:
   # ===========================================
   - name: cqrs_es_review
     edit: false
-    agent: ~/.takt/agents/expert-cqrs/cqrs-es-reviewer.md
+    agent: ../agents/expert-cqrs/cqrs-es-reviewer.md
     report:
       name: 04-cqrs-es-review.md
       format: |
@@ -291,7 +291,7 @@ steps:
 
   - name: fix_cqrs_es
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -325,7 +325,7 @@ steps:
   # ===========================================
   - name: frontend_review
     edit: false
-    agent: ~/.takt/agents/expert/frontend-reviewer.md
+    agent: ../agents/expert/frontend-reviewer.md
     report:
       name: 05-frontend-review.md
       format: |
@@ -379,7 +379,7 @@ steps:
 
   - name: fix_frontend
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -413,7 +413,7 @@ steps:
   # ===========================================
   - name: security_review
     edit: false
-    agent: ~/.takt/agents/expert/security-reviewer.md
+    agent: ../agents/expert/security-reviewer.md
     report:
       name: 06-security-review.md
       format: |
@@ -464,7 +464,7 @@ steps:
 
   - name: fix_security
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -508,7 +508,7 @@ steps:
   # ===========================================
   - name: qa_review
     edit: false
-    agent: ~/.takt/agents/expert/qa-reviewer.md
+    agent: ../agents/expert/qa-reviewer.md
     report:
       name: 07-qa-review.md
       format: |
@@ -559,7 +559,7 @@ steps:
 
   - name: fix_qa
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -607,7 +607,7 @@ steps:
   # ===========================================
   - name: supervise
     edit: false
-    agent: ~/.takt/agents/expert/supervisor.md
+    agent: ../agents/expert/supervisor.md
     report:
       - Validation: 08-supervisor-validation.md
       - Summary: summary.md
@@ -700,7 +700,7 @@ steps:
 
   - name: fix_supervisor
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob

--- a/resources/global/ja/workflows/expert.yaml
+++ b/resources/global/ja/workflows/expert.yaml
@@ -32,7 +32,7 @@ steps:
   # ===========================================
   - name: plan
     edit: false
-    agent: ~/.takt/agents/default/planner.md
+    agent: ../agents/default/planner.md
     report:
       name: 00-plan.md
       format: |
@@ -89,7 +89,7 @@ steps:
   # ===========================================
   - name: implement
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     report:
       - Scope: 01-coder-scope.md
       - Decisions: 02-coder-decisions.md
@@ -146,7 +146,7 @@ steps:
   # ===========================================
   - name: ai_review
     edit: false
-    agent: ~/.takt/agents/default/ai-antipattern-reviewer.md
+    agent: ../agents/default/ai-antipattern-reviewer.md
     report:
       name: 03-ai-review.md
       format: |
@@ -196,7 +196,7 @@ steps:
 
   - name: ai_fix
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -228,7 +228,7 @@ steps:
   # ===========================================
   - name: architect_review
     edit: false
-    agent: ~/.takt/agents/default/architecture-reviewer.md
+    agent: ../agents/default/architecture-reviewer.md
     report:
       name: 04-architect-review.md
       format: |
@@ -288,7 +288,7 @@ steps:
 
   - name: fix_architect
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -318,7 +318,7 @@ steps:
   # ===========================================
   - name: frontend_review
     edit: false
-    agent: ~/.takt/agents/expert/frontend-reviewer.md
+    agent: ../agents/expert/frontend-reviewer.md
     report:
       name: 05-frontend-review.md
       format: |
@@ -372,7 +372,7 @@ steps:
 
   - name: fix_frontend
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -406,7 +406,7 @@ steps:
   # ===========================================
   - name: security_review
     edit: false
-    agent: ~/.takt/agents/expert/security-reviewer.md
+    agent: ../agents/expert/security-reviewer.md
     report:
       name: 06-security-review.md
       format: |
@@ -457,7 +457,7 @@ steps:
 
   - name: fix_security
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -501,7 +501,7 @@ steps:
   # ===========================================
   - name: qa_review
     edit: false
-    agent: ~/.takt/agents/expert/qa-reviewer.md
+    agent: ../agents/expert/qa-reviewer.md
     report:
       name: 07-qa-review.md
       format: |
@@ -552,7 +552,7 @@ steps:
 
   - name: fix_qa
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob
@@ -600,7 +600,7 @@ steps:
   # ===========================================
   - name: supervise
     edit: false
-    agent: ~/.takt/agents/expert/supervisor.md
+    agent: ../agents/expert/supervisor.md
     report:
       - Validation: 08-supervisor-validation.md
       - Summary: summary.md
@@ -693,7 +693,7 @@ steps:
 
   - name: fix_supervisor
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     allowed_tools:
       - Read
       - Glob

--- a/resources/global/ja/workflows/magi.yaml
+++ b/resources/global/ja/workflows/magi.yaml
@@ -18,7 +18,7 @@ max_iterations: 5
 
 steps:
   - name: melchior
-    agent: ~/.takt/agents/magi/melchior.md
+    agent: ../agents/magi/melchior.md
     allowed_tools:
       - Read
       - Glob
@@ -55,7 +55,7 @@ steps:
         next: balthasar
 
   - name: balthasar
-    agent: ~/.takt/agents/magi/balthasar.md
+    agent: ../agents/magi/balthasar.md
     allowed_tools:
       - Read
       - Glob
@@ -97,7 +97,7 @@ steps:
         next: casper
 
   - name: casper
-    agent: ~/.takt/agents/magi/casper.md
+    agent: ../agents/magi/casper.md
     allowed_tools:
       - Read
       - Glob

--- a/resources/global/ja/workflows/research.yaml
+++ b/resources/global/ja/workflows/research.yaml
@@ -22,7 +22,7 @@ max_iterations: 10
 
 steps:
   - name: plan
-    agent: ~/.takt/agents/research/planner.md
+    agent: ../agents/research/planner.md
     allowed_tools:
       - Read
       - Glob
@@ -59,7 +59,7 @@ steps:
         next: ABORT
 
   - name: dig
-    agent: ~/.takt/agents/research/digger.md
+    agent: ../agents/research/digger.md
     allowed_tools:
       - Read
       - Glob
@@ -101,7 +101,7 @@ steps:
         next: ABORT
 
   - name: supervise
-    agent: ~/.takt/agents/research/supervisor.md
+    agent: ../agents/research/supervisor.md
     allowed_tools:
       - Read
       - Glob

--- a/resources/global/ja/workflows/simple.yaml
+++ b/resources/global/ja/workflows/simple.yaml
@@ -21,7 +21,7 @@ initial_step: plan
 steps:
   - name: plan
     edit: false
-    agent: ~/.takt/agents/default/planner.md
+    agent: ../agents/default/planner.md
     report:
       name: 00-plan.md
       format: |
@@ -81,7 +81,7 @@ steps:
 
   - name: implement
     edit: true
-    agent: ~/.takt/agents/default/coder.md
+    agent: ../agents/default/coder.md
     report:
       - Scope: 01-coder-scope.md
       - Decisions: 02-coder-decisions.md
@@ -136,7 +136,7 @@ steps:
 
   - name: ai_review
     edit: false
-    agent: ~/.takt/agents/default/ai-antipattern-reviewer.md
+    agent: ../agents/default/ai-antipattern-reviewer.md
     report:
       name: 03-ai-review.md
       format: |
@@ -186,7 +186,7 @@ steps:
 
   - name: review
     edit: false
-    agent: ~/.takt/agents/default/architecture-reviewer.md
+    agent: ../agents/default/architecture-reviewer.md
     report:
       name: 04-architect-review.md
       format: |
@@ -238,7 +238,7 @@ steps:
 
   - name: supervise
     edit: false
-    agent: ~/.takt/agents/default/supervisor.md
+    agent: ../agents/default/supervisor.md
     report:
       - Validation: 05-supervisor-validation.md
       - Summary: summary.md

--- a/src/__tests__/initialization.test.ts
+++ b/src/__tests__/initialization.test.ts
@@ -26,8 +26,8 @@ vi.mock('../prompt/index.js', () => ({
 
 // Import after mocks are set up
 const { needsLanguageSetup } = await import('../config/initialization.js');
-const { getGlobalAgentsDir, getGlobalWorkflowsDir } = await import('../config/paths.js');
-const { copyLanguageResourcesToDir, copyProjectResourcesToDir, getLanguageResourcesDir, getProjectResourcesDir } = await import('../resources/index.js');
+const { getGlobalConfigPath } = await import('../config/paths.js');
+const { copyProjectResourcesToDir, getLanguageResourcesDir, getProjectResourcesDir } = await import('../resources/index.js');
 
 describe('initialization', () => {
   beforeEach(() => {
@@ -43,48 +43,17 @@ describe('initialization', () => {
   });
 
   describe('needsLanguageSetup', () => {
-    it('should return true when neither agents nor workflows exist', () => {
+    it('should return true when config.yaml does not exist', () => {
       expect(needsLanguageSetup()).toBe(true);
     });
 
-    it('should return true when only agents exists', () => {
-      mkdirSync(getGlobalAgentsDir(), { recursive: true });
-      expect(needsLanguageSetup()).toBe(true);
-    });
-
-    it('should return true when only workflows exists', () => {
-      mkdirSync(getGlobalWorkflowsDir(), { recursive: true });
-      expect(needsLanguageSetup()).toBe(true);
-    });
-
-    it('should return false when both agents and workflows exist', () => {
-      mkdirSync(getGlobalAgentsDir(), { recursive: true });
-      mkdirSync(getGlobalWorkflowsDir(), { recursive: true });
+    it('should return false when config.yaml exists', () => {
+      mkdirSync(testTaktDir, { recursive: true });
+      writeFileSync(getGlobalConfigPath(), 'language: en\n', 'utf-8');
       expect(needsLanguageSetup()).toBe(false);
     });
   });
 
-  describe('copyLanguageResourcesToDir', () => {
-    it('should throw error when language directory does not exist', () => {
-      const nonExistentLang = 'xx' as 'en' | 'ja';
-      expect(() => copyLanguageResourcesToDir(testTaktDir, nonExistentLang)).toThrow(
-        /Language resources not found/
-      );
-    });
-
-    it('should copy language resources to target directory', () => {
-      // This test requires actual language resources to exist
-      const langDir = getLanguageResourcesDir('ja');
-      if (existsSync(langDir)) {
-        mkdirSync(testTaktDir, { recursive: true });
-        copyLanguageResourcesToDir(testTaktDir, 'ja');
-
-        // Verify that agents and workflows directories were created
-        expect(existsSync(join(testTaktDir, 'agents'))).toBe(true);
-        expect(existsSync(join(testTaktDir, 'workflows'))).toBe(true);
-      }
-    });
-  });
 });
 
 describe('copyProjectResourcesToDir', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import {
   switchConfig,
   addTask,
   refreshBuiltin,
+  ejectBuiltin,
   watchTasks,
   listTasks,
 } from './commands/index.js';
@@ -171,6 +172,10 @@ program
           await refreshBuiltin();
           return;
 
+        case 'eject':
+          await ejectBuiltin(args[0]);
+          return;
+
         case 'watch':
           await watchTasks(cwd);
           return;
@@ -182,7 +187,7 @@ program
 
         default:
           error(`Unknown command: /${command}`);
-          info('Available: /run-tasks (/run), /watch, /add-task (/add), /list-tasks (/list), /switch (/sw), /clear, /refresh-builtin, /help, /config');
+          info('Available: /run-tasks (/run), /watch, /add-task (/add), /list-tasks (/list), /switch (/sw), /clear, /eject, /help, /config');
           process.exit(1);
       }
     }

--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -1,0 +1,124 @@
+/**
+ * /eject command implementation
+ *
+ * Copies a builtin workflow (and its agents) to ~/.takt/ for user customization.
+ * Once ejected, the user copy takes priority over the builtin version.
+ */
+
+import { existsSync, readdirSync, statSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, basename, dirname } from 'node:path';
+import { getGlobalWorkflowsDir, getGlobalAgentsDir, getBuiltinWorkflowsDir, getBuiltinAgentsDir } from '../config/paths.js';
+import { getLanguage } from '../config/globalConfig.js';
+import { header, success, info, warn, error } from '../utils/ui.js';
+
+/**
+ * Eject a builtin workflow to user space for customization.
+ * Copies the workflow YAML and related agent .md files to ~/.takt/.
+ * Agent paths in the ejected workflow are rewritten from ../agents/ to ~/.takt/agents/.
+ */
+export async function ejectBuiltin(name?: string): Promise<void> {
+  header('Eject Builtin');
+
+  const lang = getLanguage();
+  const builtinWorkflowsDir = getBuiltinWorkflowsDir(lang);
+
+  if (!name) {
+    // List available builtins
+    listAvailableBuiltins(builtinWorkflowsDir);
+    return;
+  }
+
+  const builtinPath = join(builtinWorkflowsDir, `${name}.yaml`);
+  if (!existsSync(builtinPath)) {
+    error(`Builtin workflow not found: ${name}`);
+    info('Run "takt /eject" to see available builtins.');
+    return;
+  }
+
+  const userWorkflowsDir = getGlobalWorkflowsDir();
+  const userAgentsDir = getGlobalAgentsDir();
+  const builtinAgentsDir = getBuiltinAgentsDir(lang);
+
+  // Copy workflow YAML (rewrite agent paths)
+  const workflowDest = join(userWorkflowsDir, `${name}.yaml`);
+  if (existsSync(workflowDest)) {
+    warn(`User workflow already exists: ${workflowDest}`);
+    warn('Skipping workflow copy (user version takes priority).');
+  } else {
+    mkdirSync(dirname(workflowDest), { recursive: true });
+    const content = readFileSync(builtinPath, 'utf-8');
+    // Rewrite relative agent paths to ~/.takt/agents/
+    const rewritten = content.replace(
+      /agent:\s*\.\.\/agents\//g,
+      'agent: ~/.takt/agents/',
+    );
+    writeFileSync(workflowDest, rewritten, 'utf-8');
+    success(`Ejected workflow: ${workflowDest}`);
+  }
+
+  // Copy related agent files
+  const agentPaths = extractAgentRelativePaths(builtinPath);
+  let copiedAgents = 0;
+
+  for (const relPath of agentPaths) {
+    const srcPath = join(builtinAgentsDir, relPath);
+    const destPath = join(userAgentsDir, relPath);
+
+    if (!existsSync(srcPath)) continue;
+
+    if (existsSync(destPath)) {
+      info(`  Agent already exists: ${destPath}`);
+      continue;
+    }
+
+    mkdirSync(dirname(destPath), { recursive: true });
+    writeFileSync(destPath, readFileSync(srcPath));
+    info(`  ✓ ${destPath}`);
+    copiedAgents++;
+  }
+
+  if (copiedAgents > 0) {
+    success(`${copiedAgents} agent file(s) ejected.`);
+  }
+}
+
+/** List available builtin workflows for ejection */
+function listAvailableBuiltins(builtinWorkflowsDir: string): void {
+  if (!existsSync(builtinWorkflowsDir)) {
+    warn('No builtin workflows found.');
+    return;
+  }
+
+  info('Available builtin workflows:');
+  console.log();
+
+  for (const entry of readdirSync(builtinWorkflowsDir).sort()) {
+    if (!entry.endsWith('.yaml') && !entry.endsWith('.yml')) continue;
+    if (!statSync(join(builtinWorkflowsDir, entry)).isFile()) continue;
+
+    const name = entry.replace(/\.ya?ml$/, '');
+    info(`  ${name}`);
+  }
+
+  console.log();
+  info('Usage: takt /eject {name}');
+}
+
+/**
+ * Extract agent relative paths from a builtin workflow YAML.
+ * Matches `agent: ../agents/{path}` and returns the {path} portions.
+ */
+function extractAgentRelativePaths(workflowPath: string): string[] {
+  const content = readFileSync(workflowPath, 'utf-8');
+  const paths = new Set<string>();
+  const regex = /agent:\s*\.\.\/agents\/(.+)/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content)) !== null) {
+    if (match[1]) {
+      paths.add(match[1].trim());
+    }
+  }
+
+  return Array.from(paths);
+}

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -21,7 +21,8 @@ Usage:
   takt /list-tasks (/list)         List task branches (merge/delete)
   takt /switch            Switch workflow interactively
   takt /clear             Clear agent conversation sessions (reset to initial state)
-  takt /refresh-builtin   Overwrite builtin agents/workflows with latest version
+  takt /eject             Copy builtin workflow/agents to ~/.takt/ for customization
+  takt /eject {name}      Eject a specific builtin workflow
   takt /help              Show this help
 
 Examples:
@@ -34,7 +35,8 @@ Examples:
   takt /add-task                        # Interactive task creation
   takt /clear                           # Clear sessions, start fresh
   takt /watch                            # Watch & auto-execute tasks
-  takt /refresh-builtin                 # Update builtin resources
+  takt /eject                            # List available builtins
+  takt /eject default                    # Eject default workflow for customization
   takt /list-tasks                       # List & merge task branches
   takt /switch
   takt /run-tasks

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,6 +6,7 @@ export { executeWorkflow, type WorkflowExecutionResult, type WorkflowExecutionOp
 export { executeTask, runAllTasks } from './taskExecution.js';
 export { addTask } from './addTask.js';
 export { refreshBuiltin } from './refreshBuiltin.js';
+export { ejectBuiltin } from './eject.js';
 export { watchTasks } from './watchTasks.js';
 export { showHelp } from './help.js';
 export { withAgentSession } from './session.js';

--- a/src/commands/refreshBuiltin.ts
+++ b/src/commands/refreshBuiltin.ts
@@ -1,43 +1,22 @@
 /**
- * /refresh-builtin command implementation
+ * /refresh-builtin command — DEPRECATED
  *
- * Overwrites builtin workflow and agent files in ~/.takt/ with the latest
- * embedded resources. Does NOT touch config.yaml or user-added files.
+ * Builtin resources are now loaded directly from the package bundle.
+ * Use /eject to copy individual builtins to ~/.takt/ for customization.
  */
 
-import { getGlobalConfigDir } from '../config/paths.js';
-import { getLanguage } from '../config/globalConfig.js';
-import { forceRefreshLanguageResources } from '../resources/index.js';
-import { header, success, info, error } from '../utils/ui.js';
-import { createLogger } from '../utils/debug.js';
-
-const log = createLogger('refresh-builtin');
+import { warn, info } from '../utils/ui.js';
 
 /**
- * Refresh builtin agents and workflows to latest version.
+ * Show deprecation notice and guide user to /eject.
  */
 export async function refreshBuiltin(): Promise<void> {
-  const globalDir = getGlobalConfigDir();
-  const lang = getLanguage();
-
-  header('Refresh Builtin Resources');
-  info(`Language: ${lang}`);
-  info(`Target: ${globalDir}`);
-
-  try {
-    const overwritten = forceRefreshLanguageResources(globalDir, lang);
-
-    log.info('Builtin resources refreshed', { count: overwritten.length, lang });
-
-    console.log();
-    success(`${overwritten.length} files refreshed.`);
-
-    for (const filePath of overwritten) {
-      info(`  ✓ ${filePath}`);
-    }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error('Failed to refresh builtin resources', { error: message });
-    error(`Failed to refresh: ${message}`);
-  }
+  warn('/refresh-builtin is deprecated.');
+  console.log();
+  info('Builtin workflows and agents are now loaded directly from the package.');
+  info('They no longer need to be copied to ~/.takt/.');
+  console.log();
+  info('To customize a builtin, use:');
+  info('  takt /eject           List available builtins');
+  info('  takt /eject {name}    Copy a builtin to ~/.takt/ for editing');
 }

--- a/src/config/globalConfig.ts
+++ b/src/config/globalConfig.ts
@@ -36,6 +36,7 @@ export function loadGlobalConfig(): GlobalConfig {
       logFile: parsed.debug.log_file,
     } : undefined,
     worktreeDir: parsed.worktree_dir,
+    disabledBuiltins: parsed.disabled_builtins,
   };
 }
 
@@ -61,7 +62,20 @@ export function saveGlobalConfig(config: GlobalConfig): void {
   if (config.worktreeDir) {
     raw.worktree_dir = config.worktreeDir;
   }
+  if (config.disabledBuiltins && config.disabledBuiltins.length > 0) {
+    raw.disabled_builtins = config.disabledBuiltins;
+  }
   writeFileSync(configPath, stringifyYaml(raw), 'utf-8');
+}
+
+/** Get list of disabled builtin names */
+export function getDisabledBuiltins(): string[] {
+  try {
+    const config = loadGlobalConfig();
+    return config.disabledBuiltins ?? [];
+  } catch {
+    return [];
+  }
 }
 
 /** Get current language setting */

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -8,6 +8,8 @@
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { existsSync, mkdirSync } from 'node:fs';
+import type { Language } from '../models/types.js';
+import { getLanguageResourcesDir } from '../resources/index.js';
 
 /** Get takt global config directory (~/.takt) */
 export function getGlobalConfigDir(): string {
@@ -32,6 +34,16 @@ export function getGlobalLogsDir(): string {
 /** Get takt global config file path */
 export function getGlobalConfigPath(): string {
   return join(getGlobalConfigDir(), 'config.yaml');
+}
+
+/** Get builtin workflows directory (resources/global/{lang}/workflows) */
+export function getBuiltinWorkflowsDir(lang: Language): string {
+  return join(getLanguageResourcesDir(lang), 'workflows');
+}
+
+/** Get builtin agents directory (resources/global/{lang}/agents) */
+export function getBuiltinAgentsDir(lang: Language): string {
+  return join(getLanguageResourcesDir(lang), 'agents');
 }
 
 /** Get project takt config directory (.takt in project) */

--- a/src/models/schemas.ts
+++ b/src/models/schemas.ts
@@ -170,6 +170,8 @@ export const GlobalConfigSchema = z.object({
   debug: DebugConfigSchema.optional(),
   /** Directory for shared clones (worktree_dir in config). If empty, uses ../{clone-name} relative to project */
   worktree_dir: z.string().optional(),
+  /** List of builtin workflow/agent names to exclude from fallback loading */
+  disabled_builtins: z.array(z.string()).optional().default([]),
 });
 
 /** Project config schema */

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -189,6 +189,8 @@ export interface GlobalConfig {
   debug?: DebugConfig;
   /** Directory for shared clones (worktree_dir in config). If empty, uses ../{clone-name} relative to project */
   worktreeDir?: string;
+  /** List of builtin workflow/agent names to exclude from fallback loading */
+  disabledBuiltins?: string[];
 }
 
 /** Project-level configuration */


### PR DESCRIPTION
## Summary

- ローダーの読み込み優先順位を変更: ユーザーファイル → dist/resources/のbuiltin
- `/eject` コマンド追加（builtinを `~/.takt/` にコピーしてカスタマイズ可能に）
- `/refresh-builtin` を簡素化（ejectへの移行案内）
- `config.yaml` に `disabled_builtins` フィールドを追加（特定builtinの無効化）
- ワークフローYAMLを `rules` 形式に統一

## Test plan

- [x] 全474テストパス
- [x] ビルドクリーン
- [x] `config.test.ts` — builtin読み込み・disabled_builtinsの検証
- [x] `initialization.test.ts` — 初期化フローの検証

Closes #4