### PR TITLE
fix: reportDirに.takt/reports/プレフィックスを含め、ルート直下へのレポート作成を修正 (#37)

### DIFF
--- a/src/__tests__/engine-report.test.ts
+++ b/src/__tests__/engine-report.test.ts
@@ -14,6 +14,8 @@ import type { WorkflowStep, ReportObjectConfig, ReportConfig } from '../models/t
 /**
  * Extracted emitStepReports logic for unit testing.
  * Mirrors engine.ts emitStepReports + emitIfReportExists.
+ *
+ * reportDir already includes the `.takt/reports/` prefix (set by engine constructor).
  */
 function emitStepReports(
   emitter: EventEmitter,
@@ -22,7 +24,7 @@ function emitStepReports(
   projectCwd: string,
 ): void {
   if (!step.report || !reportDir) return;
-  const baseDir = join(projectCwd, '.takt', 'reports', reportDir);
+  const baseDir = join(projectCwd, reportDir);
 
   if (typeof step.report === 'string') {
     emitIfReportExists(emitter, step, baseDir, step.report);
@@ -62,11 +64,12 @@ function createStep(overrides: Partial<WorkflowStep> = {}): WorkflowStep {
 describe('emitStepReports', () => {
   let tmpDir: string;
   let reportBaseDir: string;
-  const reportDirName = 'test-report-dir';
+  // reportDir now includes .takt/reports/ prefix (matches engine constructor behavior)
+  const reportDirName = '.takt/reports/test-report-dir';
 
   beforeEach(() => {
     tmpDir = join(tmpdir(), `takt-report-test-${Date.now()}`);
-    reportBaseDir = join(tmpDir, '.takt', 'reports', reportDirName);
+    reportBaseDir = join(tmpDir, reportDirName);
     mkdirSync(reportBaseDir, { recursive: true });
   });
 

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -64,7 +64,7 @@ export class WorkflowEngine extends EventEmitter {
     this.options = options;
     this.language = options.language;
     this.loopDetector = new LoopDetector(config.loopDetection);
-    this.reportDir = generateReportDir(task);
+    this.reportDir = `.takt/reports/${generateReportDir(task)}`;
     this.ensureReportDirExists();
     this.validateConfig();
     this.state = createInitialState(config, options);
@@ -78,7 +78,7 @@ export class WorkflowEngine extends EventEmitter {
 
   /** Ensure report directory exists (always in project root, not clone) */
   private ensureReportDirExists(): void {
-    const reportDirPath = join(this.projectCwd, '.takt', 'reports', this.reportDir);
+    const reportDirPath = join(this.projectCwd, this.reportDir);
     if (!existsSync(reportDirPath)) {
       mkdirSync(reportDirPath, { recursive: true });
     }
@@ -176,7 +176,7 @@ export class WorkflowEngine extends EventEmitter {
    */
   private emitStepReports(step: WorkflowStep): void {
     if (!step.report || !this.reportDir) return;
-    const baseDir = join(this.projectCwd, '.takt', 'reports', this.reportDir);
+    const baseDir = join(this.projectCwd, this.reportDir);
 
     if (typeof step.report === 'string') {
       this.emitIfReportExists(step, baseDir, step.report);


### PR DESCRIPTION
## Summary

- `this.reportDir` にコンストラクタで `.takt/reports/` プレフィックスを付与し、エージェントに渡されるパスが正しくなるよう修正
- `ensureReportDirExists()` と `emitStepReports()` から二重プレフィックスを除去
- テストも同様に修正

Closes #37