### PR TITLE
fix: eject.tsの未使用import削除

### DIFF
--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -6,7 +6,7 @@
  */
 
 import { existsSync, readdirSync, statSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join, basename, dirname } from 'node:path';
+import { join, dirname } from 'node:path';
 import { getGlobalWorkflowsDir, getGlobalAgentsDir, getBuiltinWorkflowsDir, getBuiltinAgentsDir } from '../config/paths.js';
 import { getLanguage } from '../config/globalConfig.js';
 import { header, success, info, warn, error } from '../utils/ui.js';


### PR DESCRIPTION
## Summary

- `eject.ts` の未使用import `basename` を削除し、lint errorを解消