### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.0] - 2026-02-05
+
+RC1/RC2 の内容を正式リリース。機能変更なし。
+
 ## [0.6.0-rc1] - 2026-02-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.6.0-rc1",
+  "version": "0.6.0",
   "description": "TAKT: Task Agent Koordination Tool - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- RC1/RC2 で十分テスト済みの内容を v0.6.0 正式版としてリリース
- CHANGELOG の RC エントリを v0.6.0 に統合
- version bump: 0.6.0-rc1 → 0.6.0

## Changes from v0.5.1

### Added
- `coding` ビルトインピース
- `conductor` エージェント + Phase 3 判定フォールバック戦略
- セッション状態管理 (#89)
- TAKT メタ情報のエージェント引き渡し
- `/play` コマンド
- E2Eテスト基盤

### Fixed
- ai_review ↔ ai_fix 無限ループ修正

### Changed
- Phase 3 判定ロジック刷新
- CLI ルーティング改善 (#32)
- default ピースのレビュアー構成変更