### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.0] - 2026-02-08
+
+alpha.1 の内容を正式リリース。機能変更なし。
+
 ## [0.8.0-alpha.1] - 2026-02-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -456,10 +456,16 @@ Use `takt switch` to switch pieces.
 | **coder** | Feature implementation, bug fixing |
 | **ai-antipattern-reviewer** | AI-specific antipattern review (non-existent APIs, incorrect assumptions, scope creep) |
 | **architecture-reviewer** | Architecture and code quality review, spec compliance verification |
+| **frontend-reviewer** | Frontend (React/Next.js) code quality and best practices review |
+| **cqrs-es-reviewer** | CQRS+Event Sourcing architecture and implementation review |
 | **qa-reviewer** | Test coverage and quality assurance review |
 | **security-reviewer** | Security vulnerability assessment |
 | **conductor** | Phase 3 judgment specialist: reads reports/responses and outputs status tags |
 | **supervisor** | Final validation, approval |
+| **expert-supervisor** | Expert-level final validation with comprehensive review integration |
+| **research-planner** | Research task planning and scope definition |
+| **research-digger** | Deep investigation and information gathering |
+| **research-supervisor** | Research quality validation and completeness assessment |
 
 ## Custom Personas
 
@@ -523,11 +529,17 @@ default_piece: default
 log_level: info
 provider: claude         # Default provider: claude or codex
 model: sonnet            # Default model (optional)
+branch_name_strategy: romaji  # Branch name generation: 'romaji' (fast) or 'ai' (slow)
+prevent_sleep: false     # Prevent macOS idle sleep during execution (caffeinate)
 
 # API Key configuration (optional)
 # Can be overridden by environment variables TAKT_ANTHROPIC_API_KEY / TAKT_OPENAI_API_KEY
 anthropic_api_key: sk-ant-...  # For Claude (Anthropic)
 # openai_api_key: sk-...       # For Codex (OpenAI)
+
+# Builtin piece filtering (optional)
+# builtin_pieces_enabled: true           # Set false to disable all builtins
+# disabled_builtins: [magi, passthrough] # Disable specific builtin pieces
 
 # Pipeline execution configuration (optional)
 # Customize branch names, commit messages, and PR body.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -452,10 +452,16 @@ TAKTには複数のビルトインピースが同梱されています:
 | **coder** | 機能の実装、バグ修正 |
 | **ai-antipattern-reviewer** | AI特有のアンチパターンレビュー（存在しないAPI、誤った仮定、スコープクリープ） |
 | **architecture-reviewer** | アーキテクチャとコード品質のレビュー、仕様準拠の検証 |
+| **frontend-reviewer** | フロントエンド（React/Next.js）のコード品質とベストプラクティスのレビュー |
+| **cqrs-es-reviewer** | CQRS+Event Sourcingアーキテクチャと実装のレビュー |
 | **qa-reviewer** | テストカバレッジと品質保証のレビュー |
 | **security-reviewer** | セキュリティ脆弱性の評価 |
 | **conductor** | Phase 3 判定専用: レポートやレスポンスを読み取り、ステータスタグを出力 |
 | **supervisor** | 最終検証、バリデーション、承認 |
+| **expert-supervisor** | 包括的なレビュー統合による専門レベルの最終検証 |
+| **research-planner** | リサーチタスクの計画・スコープ定義 |
+| **research-digger** | 深掘り調査と情報収集 |
+| **research-supervisor** | リサーチ品質の検証と網羅性の評価 |
 
 ## カスタムペルソナ
 
@@ -519,11 +525,17 @@ default_piece: default
 log_level: info
 provider: claude         # デフォルトプロバイダー: claude または codex
 model: sonnet            # デフォルトモデル（オプション）
+branch_name_strategy: romaji  # ブランチ名生成: 'romaji'（高速）または 'ai'（低速）
+prevent_sleep: false     # macOS の実行中スリープ防止（caffeinate）
 
 # API Key 設定（オプション）
 # 環境変数 TAKT_ANTHROPIC_API_KEY / TAKT_OPENAI_API_KEY で上書き可能
 anthropic_api_key: sk-ant-...  # Claude (Anthropic) を使う場合
 # openai_api_key: sk-...       # Codex (OpenAI) を使う場合
+
+# ビルトインピースのフィルタリング（オプション）
+# builtin_pieces_enabled: true           # false でビルトイン全体を無効化
+# disabled_builtins: [magi, passthrough] # 特定のビルトインピースを無効化
 
 # パイプライン実行設定（オプション）
 # ブランチ名、コミットメッセージ、PRの本文をカスタマイズできます。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.8.0-alpha.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.8.0-alpha.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.8.0-alpha.1",
+  "version": "0.8.0",
   "description": "TAKT: Task Agent Koordination Tool - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

alpha.1 の内容を正式リリース。機能変更なし。

### 主要な変更点（v0.7.1 →  v0.8.0）

#### Added
- **Faceted Prompting アーキテクチャ**: プロンプト構成要素（personas, policies, knowledge, instructions, output-contracts）を独立ファイルとして管理し、ピース間で自由に組み合わせ可能に
- **Output Contracts と Quality Gates**: レポート出力の構造化定義と品質基準の AI ディレクティブ
- **Knowledge システム**: ドメイン知識をペルソナから分離し、ピースレベルで管理・注入
- Faceted Prompting ドキュメント、Hybrid Codex ピース生成ツール
- 失敗タスクの再投入機能 (#110)、auto-PR 機能 (#98)、Issue参照時のピース選択 (#97)

#### Changed (BREAKING)
- `resources/global/` → `builtins/` リネーム
- `agent` → `persona` リネーム（YAML・型・ディレクトリ全て）
- `report` → `output_contracts` に変更
- `stances` → `policies`、`report_formats` → `output_contracts` リネーム
- SDK 更新: claude-agent-sdk v0.2.34、codex-sdk v0.98.0

#### Fixed
- レポートディレクトリパスの解決バグ
- PR Issue番号リンクの修正
- stageAndCommit で gitignored ファイルがコミットされる問題

## Commits

- 1d3ba5d update e2e
- ad42c5b Release v0.8.0-alpha.1
- 2c5ae74 update sdk
- 99ab354 未使用import OutputContractEntry を削除（lint修正）
- 7ae4a78 Output Contracts と Quality Gates の実装 + 未使用コード検出ポリシー厳格化
- 487b8bf Merge branch 'takt/20260207T1212-tasuku-output-contracts-to-qua' into develop
- 1466a71 takt: Output Contracts と Quality Gates の実装
- 9e50e9d README刷新: agent→persona, セクションマップ導入, 制御・管理セクション追加
- e506c40 ドキュメント: Policy末尾配置の理由と合成例の順序を実装に合わせて修正
- d92f5aa Faceted Prompting テンプレート整備
- 5f1d852 update hybrid
- 2c7bd48 Faceted Prompting リネーム: stances→policies, report_formats→output_contracts
- 247b500 Faceted Prompting 導入: knowledge セクション追加、スキルドキュメント刷新
- ea7ce54 takt: resources/ → builtins/ リネーム + export-cc 修正
- 401b2ff wanakana制限
- b7c2a4d takt: 専門知識のknowledgeへの抽出と付与
- e7d5dbf knowledge システム追加
- b963261 avoid git add
- 3786644 対話モードもスタンス方式に
- 3b23493 update stances
- e23cfa9 agent 周りの抽象化
- 1df3531 旧仕様削除
- b5e9d1f 旧仕様を削除
- 6f94681 change agent to persona
- 6473f97 change pieces
- 191ca1f add stance & persona #127
- 00ffb84 Merge branch 'develop' into takt/#98
- 5fde582 Merge branch 'develop' into takt/#100
- b9c47d2 takt: github-issue-100-macosdesuriip
- d479707 takt: github-issue-106-suteppu-niite
- 24361b3 auto-PR 機能の追加とPR作成ロジックの共通化 #98
- 973c7df issue参照時にもピース選択を実施 #97
- 4c0b3c1 takt: github-issue-98-pr-no-wo-ni-sh
- 919215f 失敗タスクの再投入とムーブメント開始位置の選択機能 #110
- 163561a ブランチ名生成戦略を設定可能に
- 7c928e0 stageAndCommit の IT 追加
- 8c83cf6 stageAndCommit から git add -f .takt/reports/ を削除
- 00174ee Merge branch 'main' into develop
- af6f59c Merge branch 'takt/#113' into develop
- e3be883 Merge branch 'takt/#112' into develop
- c89ac4c takt: fix-report-dir-path
- 73db206 takt: fix-pr-issue-number