### PR TITLE
improve-parallel-output-prefix

### DIFF
--- a/src/__tests__/parallel-logger.test.ts
+++ b/src/__tests__/parallel-logger.test.ts
@@ -67,6 +67,29 @@ describe('ParallelLogger', () => {
       // No padding needed (0 spaces)
       expect(prefix).toMatch(/\x1b\[0m $/);
     });
+
+    it('should build rich prefix with task and parent movement for parallel task mode', () => {
+      const logger = new ParallelLogger({
+        subMovementNames: ['arch-review'],
+        writeFn,
+        progressInfo: {
+          iteration: 4,
+          maxIterations: 30,
+        },
+        taskLabel: 'override-persona-provider',
+        taskColorIndex: 0,
+        parentMovementName: 'reviewers',
+        movementIteration: 1,
+      });
+
+      const prefix = logger.buildPrefix('arch-review', 0);
+      expect(prefix).toContain('\x1b[36m');
+      expect(prefix).toContain('[over]');
+      expect(prefix).toContain('[reviewers]');
+      expect(prefix).toContain('[arch-review]');
+      expect(prefix).toContain('(4/30)(1)');
+      expect(prefix).not.toContain('step 1/1');
+    });
   });
 
   describe('text event line buffering', () => {

--- a/src/__tests__/runAllTasks-concurrency.test.ts
+++ b/src/__tests__/runAllTasks-concurrency.test.ts
@@ -225,11 +225,11 @@ describe('runAllTasks concurrency', () => {
 
       // Then: Task names displayed with prefix in stdout
       const allOutput = stdoutChunks.join('');
-      expect(allOutput).toContain('[task-1]');
+      expect(allOutput).toContain('[task]');
       expect(allOutput).toContain('=== Task: task-1 ===');
-      expect(allOutput).toContain('[task-2]');
+      expect(allOutput).toContain('[task]');
       expect(allOutput).toContain('=== Task: task-2 ===');
-      expect(allOutput).toContain('[task-3]');
+      expect(allOutput).toContain('[task]');
       expect(allOutput).toContain('=== Task: task-3 ===');
       expect(mockStatus).toHaveBeenCalledWith('Total', '3');
     });

--- a/src/__tests__/task-prefix-writer.test.ts
+++ b/src/__tests__/task-prefix-writer.test.ts
@@ -42,13 +42,13 @@ describe('TaskPrefixWriter', () => {
   });
 
   describe('writeLine', () => {
-    it('should output single line with prefix', () => {
+    it('should output single line with truncated task prefix', () => {
       const writer = new TaskPrefixWriter({ taskName: 'my-task', colorIndex: 0, writeFn });
 
       writer.writeLine('Hello World');
 
       expect(output).toHaveLength(1);
-      expect(output[0]).toContain('[my-task]');
+      expect(output[0]).toContain('[my-t]');
       expect(output[0]).toContain('Hello World');
       expect(output[0]).toMatch(/\n$/);
     });
@@ -94,7 +94,7 @@ describe('TaskPrefixWriter', () => {
 
       writer.writeChunk(' World\n');
       expect(output).toHaveLength(1);
-      expect(output[0]).toContain('[task-a]');
+      expect(output[0]).toContain('[task]');
       expect(output[0]).toContain('Hello World');
     });
 
@@ -154,7 +154,7 @@ describe('TaskPrefixWriter', () => {
       writer.flush();
 
       expect(output).toHaveLength(1);
-      expect(output[0]).toContain('[task-a]');
+      expect(output[0]).toContain('[task]');
       expect(output[0]).toContain('partial content');
       expect(output[0]).toMatch(/\n$/);
     });
@@ -178,6 +178,25 @@ describe('TaskPrefixWriter', () => {
 
       writer.flush();
       expect(output).toHaveLength(0);
+    });
+  });
+
+  describe('setMovementContext', () => {
+    it('should include movement context in prefix after context update', () => {
+      const writer = new TaskPrefixWriter({ taskName: 'override-persona-provider', colorIndex: 0, writeFn });
+
+      writer.setMovementContext({
+        movementName: 'implement',
+        iteration: 4,
+        maxIterations: 30,
+        movementIteration: 2,
+      });
+      writer.writeLine('content');
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain('[over]');
+      expect(output[0]).toContain('[implement](4/30)(2)');
+      expect(output[0]).toContain('content');
     });
   });
 

--- a/src/__tests__/workerPool.test.ts
+++ b/src/__tests__/workerPool.test.ts
@@ -118,7 +118,7 @@ describe('runWithWorkerPool', () => {
     // Then: Task names appear in prefixed stdout output
     writeSpy.mockRestore();
     const allOutput = stdoutChunks.join('');
-    expect(allOutput).toContain('[alpha]');
+    expect(allOutput).toContain('[alph]');
     expect(allOutput).toContain('=== Task: alpha ===');
     expect(allOutput).toContain('[beta]');
     expect(allOutput).toContain('=== Task: beta ===');

--- a/src/core/piece/engine/PieceEngine.ts
+++ b/src/core/piece/engine/PieceEngine.ts
@@ -69,6 +69,7 @@ export class PieceEngine extends EventEmitter {
 
   constructor(config: PieceConfig, cwd: string, task: string, options: PieceEngineOptions) {
     super();
+    this.assertTaskPrefixPair(options.taskPrefix, options.taskColorIndex);
     this.config = config;
     this.projectCwd = options.projectCwd;
     this.cwd = cwd;
@@ -144,6 +145,14 @@ export class PieceEngine extends EventEmitter {
       initialMovement: config.initialMovement,
       maxIterations: config.maxIterations,
     });
+  }
+
+  private assertTaskPrefixPair(taskPrefix: string | undefined, taskColorIndex: number | undefined): void {
+    const hasTaskPrefix = taskPrefix != null;
+    const hasTaskColorIndex = taskColorIndex != null;
+    if (hasTaskPrefix !== hasTaskColorIndex) {
+      throw new Error('taskPrefix and taskColorIndex must be provided together');
+    }
   }
 
   /** Ensure report directory exists (in cwd, which is clone dir in worktree mode) */

--- a/src/core/piece/types.ts
+++ b/src/core/piece/types.ts
@@ -189,6 +189,10 @@ export interface PieceEngineOptions {
   startMovement?: string;
   /** Retry note explaining why task is being retried */
   retryNote?: string;
+  /** Task name prefix for parallel task execution output */
+  taskPrefix?: string;
+  /** Color index for task prefix (cycled across tasks) */
+  taskColorIndex?: number;
 }
 
 /** Loop detection result */


### PR DESCRIPTION
## Summary

## 現状

タスク並列実行時（`takt run` concurrency > 1）の出力プレフィックスに以下の問題がある。

1. **タスク名が長すぎる**: `[override-persona-provider]` のようにタスク名がそのまま表示され、行が埋まる
2. **ムーブメント名が表示されない**: 現在どのムーブメントを実行中か分からない
3. **並列サブムーブメントでペルソナ/親ムーブメントが不明**: `ParallelLogger` は sub-movement 名しか出さない
4. **ムーブメント実行回数が不明**: 同じムーブメントが何回目の実行か分からない

## 現状の出力例

```
[override-persona-provider] [arch-review](4/30) step 1/2 content...
```

## 期待する出力フォーマット

```
[over][implement](4/30)(2) content...
[over][reviewers][arch-review](4/30)(1) content...
```

- `[over]` — タスク名を4文字に切り詰め、色付きで表示（タスク並列時のみ）
- `[implement]` / `[reviewers]` — ムーブメント名
- `[arch-review]` — サブムーブメント名（並列ムーブメントの場合のみ）
- `(4/30)` — イテレーション数/最大イテレーション数
- `(2)` — そのムーブメントの実行回数

## 影響範囲

- `src/shared/ui/TaskPrefixWriter.ts` — タスク名切り詰め、動的ムーブメントコンテキスト
- `src/core/piece/engine/parallel-logger.ts` — タスクラベル＋親ムーブメント名の追加
- `src/features/tasks/execute/pieceExecution.ts` — movement:start でプレフィックス更新
- `src/core/piece/engine/ParallelRunner.ts` — タスク/ムーブメント情報を ParallelLogger に渡す

## Execution Report

Piece `default` completed successfully.

Closes #169