### PR TITLE
update-category-spec

### DIFF
--- a/src/__tests__/global-pieceCategories.test.ts
+++ b/src/__tests__/global-pieceCategories.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for global piece category path resolution.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadGlobalConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../infra/config/paths.js', () => ({
+  getGlobalConfigDir: () => '/tmp/.takt',
+}));
+
+vi.mock('../infra/config/global/globalConfig.js', () => ({
+  loadGlobalConfig: loadGlobalConfigMock,
+}));
+
+const { getPieceCategoriesPath, resetPieceCategories } = await import(
+  '../infra/config/global/pieceCategories.js'
+);
+
+function createTempCategoriesPath(): string {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'takt-piece-categories-'));
+  return join(tempRoot, 'preferences', 'piece-categories.yaml');
+}
+
+describe('getPieceCategoriesPath', () => {
+  beforeEach(() => {
+    loadGlobalConfigMock.mockReset();
+  });
+
+  it('should return configured path when pieceCategoriesFile is set', () => {
+    // Given
+    loadGlobalConfigMock.mockReturnValue({
+      pieceCategoriesFile: '/custom/piece-categories.yaml',
+    });
+
+    // When
+    const path = getPieceCategoriesPath();
+
+    // Then
+    expect(path).toBe('/custom/piece-categories.yaml');
+  });
+
+  it('should return default path when pieceCategoriesFile is not set', () => {
+    // Given
+    loadGlobalConfigMock.mockReturnValue({});
+
+    // When
+    const path = getPieceCategoriesPath();
+
+    // Then
+    expect(path).toBe('/tmp/.takt/preferences/piece-categories.yaml');
+  });
+
+  it('should rethrow when global config loading fails', () => {
+    // Given
+    loadGlobalConfigMock.mockImplementation(() => {
+      throw new Error('invalid global config');
+    });
+
+    // When / Then
+    expect(() => getPieceCategoriesPath()).toThrow('invalid global config');
+  });
+});
+
+describe('resetPieceCategories', () => {
+  const tempRoots: string[] = [];
+
+  beforeEach(() => {
+    loadGlobalConfigMock.mockReset();
+  });
+
+  afterEach(() => {
+    for (const tempRoot of tempRoots) {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+    tempRoots.length = 0;
+  });
+
+  it('should create parent directory and initialize with empty user categories', () => {
+    // Given
+    const categoriesPath = createTempCategoriesPath();
+    tempRoots.push(dirname(dirname(categoriesPath)));
+    loadGlobalConfigMock.mockReturnValue({
+      pieceCategoriesFile: categoriesPath,
+    });
+
+    // When
+    resetPieceCategories();
+
+    // Then
+    expect(existsSync(dirname(categoriesPath))).toBe(true);
+    expect(readFileSync(categoriesPath, 'utf-8')).toBe('piece_categories: {}\n');
+  });
+
+  it('should overwrite existing file with empty user categories', () => {
+    // Given
+    const categoriesPath = createTempCategoriesPath();
+    const categoriesDir = dirname(categoriesPath);
+    const tempRoot = dirname(categoriesDir);
+    tempRoots.push(tempRoot);
+    loadGlobalConfigMock.mockReturnValue({
+      pieceCategoriesFile: categoriesPath,
+    });
+    mkdirSync(categoriesDir, { recursive: true });
+    writeFileSync(categoriesPath, 'piece_categories:\n  old:\n    - stale-piece\n', 'utf-8');
+
+    // When
+    resetPieceCategories();
+
+    // Then
+    expect(readFileSync(categoriesPath, 'utf-8')).toBe('piece_categories: {}\n');
+  });
+});

--- a/src/__tests__/piece-category-config.test.ts
+++ b/src/__tests__/piece-category-config.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -19,6 +19,8 @@ vi.mock('../infra/config/global/globalConfig.js', async (importOriginal) => {
   return {
     ...original,
     getLanguage: () => 'en',
+    getBuiltinPiecesEnabled: () => true,
+    getDisabledBuiltins: () => [],
   };
 });
 
@@ -30,9 +32,11 @@ vi.mock('../infra/resources/index.js', async (importOriginal) => {
   };
 });
 
-vi.mock('../infra/config/global/pieceCategories.js', async () => {
+vi.mock('../infra/config/global/pieceCategories.js', async (importOriginal) => {
+  const original = await importOriginal() as Record<string, unknown>;
   return {
-    ensureUserCategoriesFile: () => pathsState.userCategoriesPath,
+    ...original,
+    getPieceCategoriesPath: () => pathsState.userCategoriesPath,
   };
 });
 
@@ -74,72 +78,15 @@ describe('piece category config loading', () => {
 
     mkdirSync(resourcesDir, { recursive: true });
     pathsState.resourcesDir = resourcesDir;
+    pathsState.userCategoriesPath = join(testDir, 'user-piece-categories.yaml');
   });
 
   afterEach(() => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it('should load categories from user file (auto-copied from default)', () => {
-    const userPath = join(testDir, 'piece-categories.yaml');
-    writeYaml(userPath, `
-piece_categories:
-  Default:
-    pieces:
-      - simple
-show_others_category: true
-others_category_name: "Others"
-`);
-    pathsState.userCategoriesPath = userPath;
-
+  it('should return null when builtin categories file is missing', () => {
     const config = getPieceCategories();
-    expect(config).not.toBeNull();
-    expect(config!.pieceCategories).toEqual([
-      { name: 'Default', pieces: ['simple'], children: [] },
-    ]);
-    expect(config!.showOthersCategory).toBe(true);
-    expect(config!.othersCategoryName).toBe('Others');
-  });
-
-  it('should return null when user file has no piece_categories', () => {
-    const userPath = join(testDir, 'piece-categories.yaml');
-    writeYaml(userPath, `
-show_others_category: true
-`);
-    pathsState.userCategoriesPath = userPath;
-
-    const config = getPieceCategories();
-    expect(config).toBeNull();
-  });
-
-  it('should parse nested categories from user file', () => {
-    const userPath = join(testDir, 'piece-categories.yaml');
-    writeYaml(userPath, `
-piece_categories:
-  Parent:
-    pieces:
-      - parent-piece
-    Child:
-      pieces:
-        - child-piece
-`);
-    pathsState.userCategoriesPath = userPath;
-
-    const config = getPieceCategories();
-    expect(config).not.toBeNull();
-    expect(config!.pieceCategories).toEqual([
-      {
-        name: 'Parent',
-        pieces: ['parent-piece'],
-        children: [
-          { name: 'Child', pieces: ['child-piece'], children: [] },
-        ],
-      },
-    ]);
-  });
-
-  it('should return null when default categories file is missing', () => {
-    const config = loadDefaultCategories();
     expect(config).toBeNull();
   });
 
@@ -156,19 +103,151 @@ piece_categories:
     expect(config!.pieceCategories).toEqual([
       { name: 'Quick Start', pieces: ['default'], children: [] },
     ]);
+    expect(config!.builtinPieceCategories).toEqual([
+      { name: 'Quick Start', pieces: ['default'], children: [] },
+    ]);
+    expect(config!.userPieceCategories).toEqual([]);
+  });
+
+  it('should use builtin categories when user overlay file is missing', () => {
+    writeYaml(join(resourcesDir, 'piece-categories.yaml'), `
+piece_categories:
+  Main:
+    pieces:
+      - default
+show_others_category: true
+others_category_name: Others
+`);
+
+    const config = getPieceCategories();
+    expect(config).not.toBeNull();
+    expect(config!.pieceCategories).toEqual([
+      { name: 'Main', pieces: ['default'], children: [] },
+    ]);
+    expect(config!.userPieceCategories).toEqual([]);
+    expect(config!.showOthersCategory).toBe(true);
+    expect(config!.othersCategoryName).toBe('Others');
+  });
+
+  it('should merge user overlay categories with builtin categories', () => {
+    writeYaml(join(resourcesDir, 'piece-categories.yaml'), `
+piece_categories:
+  Main:
+    pieces:
+      - default
+      - coding
+    Child:
+      pieces:
+        - nested
+  Review:
+    pieces:
+      - review-only
+show_others_category: true
+others_category_name: Others
+`);
+
+    writeYaml(pathsState.userCategoriesPath, `
+piece_categories:
+  Main:
+    pieces:
+      - custom
+  My Team:
+    pieces:
+      - team-flow
+show_others_category: false
+others_category_name: Unclassified
+`);
+
+    const config = getPieceCategories();
+    expect(config).not.toBeNull();
+    expect(config!.pieceCategories).toEqual([
+      {
+        name: 'Main',
+        pieces: ['custom'],
+        children: [
+          { name: 'Child', pieces: ['nested'], children: [] },
+        ],
+      },
+      { name: 'Review', pieces: ['review-only'], children: [] },
+      { name: 'My Team', pieces: ['team-flow'], children: [] },
+    ]);
+    expect(config!.builtinPieceCategories).toEqual([
+      {
+        name: 'Main',
+        pieces: ['default', 'coding'],
+        children: [
+          { name: 'Child', pieces: ['nested'], children: [] },
+        ],
+      },
+      { name: 'Review', pieces: ['review-only'], children: [] },
+    ]);
+    expect(config!.userPieceCategories).toEqual([
+      { name: 'Main', pieces: ['custom'], children: [] },
+      { name: 'My Team', pieces: ['team-flow'], children: [] },
+    ]);
+    expect(config!.showOthersCategory).toBe(false);
+    expect(config!.othersCategoryName).toBe('Unclassified');
+  });
+
+  it('should override others settings without replacing categories when user overlay has no piece_categories', () => {
+    writeYaml(join(resourcesDir, 'piece-categories.yaml'), `
+piece_categories:
+  Main:
+    pieces:
+      - default
+  Review:
+    pieces:
+      - review-only
+show_others_category: true
+others_category_name: Others
+`);
+
+    writeYaml(pathsState.userCategoriesPath, `
+show_others_category: false
+others_category_name: Unclassified
+`);
+
+    const config = getPieceCategories();
+    expect(config).not.toBeNull();
+    expect(config!.pieceCategories).toEqual([
+      { name: 'Main', pieces: ['default'], children: [] },
+      { name: 'Review', pieces: ['review-only'], children: [] },
+    ]);
+    expect(config!.builtinPieceCategories).toEqual([
+      { name: 'Main', pieces: ['default'], children: [] },
+      { name: 'Review', pieces: ['review-only'], children: [] },
+    ]);
+    expect(config!.userPieceCategories).toEqual([]);
+    expect(config!.showOthersCategory).toBe(false);
+    expect(config!.othersCategoryName).toBe('Unclassified');
   });
 });
 
 describe('buildCategorizedPieces', () => {
-  it('should place all pieces (user and builtin) into a unified category tree', () => {
+  it('should collect missing pieces with source information', () => {
     const allPieces = createPieceMap([
-      { name: 'a', source: 'user' },
-      { name: 'b', source: 'user' },
-      { name: 'c', source: 'builtin' },
+      { name: 'custom', source: 'user' },
+      { name: 'nested', source: 'builtin' },
+      { name: 'team-flow', source: 'user' },
     ]);
     const config = {
       pieceCategories: [
-        { name: 'Cat', pieces: ['a', 'missing', 'c'], children: [] },
+        {
+          name: 'Main',
+          pieces: ['custom'],
+          children: [{ name: 'Child', pieces: ['nested'], children: [] }],
+        },
+        { name: 'My Team', pieces: ['team-flow'], children: [] },
+      ],
+      builtinPieceCategories: [
+        {
+          name: 'Main',
+          pieces: ['default'],
+          children: [{ name: 'Child', pieces: ['nested'], children: [] }],
+        },
+      ],
+      userPieceCategories: [
+        { name: 'My Team', pieces: ['missing-user-piece'], children: [] },
       ],
       showOthersCategory: true,
       othersCategoryName: 'Others',
@@ -176,28 +255,17 @@ describe('buildCategorizedPieces', () => {
 
     const categorized = buildCategorizedPieces(allPieces, config);
     expect(categorized.categories).toEqual([
-      { name: 'Cat', pieces: ['a', 'c'], children: [] },
-      { name: 'Others', pieces: ['b'], children: [] },
+      {
+        name: 'Main',
+        pieces: ['custom'],
+        children: [{ name: 'Child', pieces: ['nested'], children: [] }],
+      },
+      { name: 'My Team', pieces: ['team-flow'], children: [] },
     ]);
     expect(categorized.missingPieces).toEqual([
-      { categoryPath: ['Cat'], pieceName: 'missing' },
+      { categoryPath: ['Main'], pieceName: 'default', source: 'builtin' },
+      { categoryPath: ['My Team'], pieceName: 'missing-user-piece', source: 'user' },
     ]);
-  });
-
-  it('should skip empty categories', () => {
-    const allPieces = createPieceMap([
-      { name: 'a', source: 'user' },
-    ]);
-    const config = {
-      pieceCategories: [
-        { name: 'Empty', pieces: [], children: [] },
-      ],
-      showOthersCategory: false,
-      othersCategoryName: 'Others',
-    };
-
-    const categorized = buildCategorizedPieces(allPieces, config);
-    expect(categorized.categories).toEqual([]);
   });
 
   it('should append Others category for uncategorized pieces', () => {
@@ -209,6 +277,10 @@ describe('buildCategorizedPieces', () => {
       pieceCategories: [
         { name: 'Main', pieces: ['default'], children: [] },
       ],
+      builtinPieceCategories: [
+        { name: 'Main', pieces: ['default'], children: [] },
+      ],
+      userPieceCategories: [],
       showOthersCategory: true,
       othersCategoryName: 'Others',
     };
@@ -217,28 +289,6 @@ describe('buildCategorizedPieces', () => {
     expect(categorized.categories).toEqual([
       { name: 'Main', pieces: ['default'], children: [] },
       { name: 'Others', pieces: ['extra'], children: [] },
-    ]);
-  });
-
-  it('should merge uncategorized pieces into existing Others category', () => {
-    const allPieces = createPieceMap([
-      { name: 'default', source: 'builtin' },
-      { name: 'extra', source: 'builtin' },
-      { name: 'user-piece', source: 'user' },
-    ]);
-    const config = {
-      pieceCategories: [
-        { name: 'Main', pieces: ['default'], children: [] },
-        { name: 'Others', pieces: ['extra'], children: [] },
-      ],
-      showOthersCategory: true,
-      othersCategoryName: 'Others',
-    };
-
-    const categorized = buildCategorizedPieces(allPieces, config);
-    expect(categorized.categories).toEqual([
-      { name: 'Main', pieces: ['default'], children: [] },
-      { name: 'Others', pieces: ['extra', 'user-piece'], children: [] },
     ]);
   });
 
@@ -251,6 +301,10 @@ describe('buildCategorizedPieces', () => {
       pieceCategories: [
         { name: 'Main', pieces: ['default'], children: [] },
       ],
+      builtinPieceCategories: [
+        { name: 'Main', pieces: ['default'], children: [] },
+      ],
+      userPieceCategories: [],
       showOthersCategory: false,
       othersCategoryName: 'Others',
     };
@@ -284,27 +338,5 @@ describe('buildCategorizedPieces', () => {
 
     const paths = findPieceCategories('nested', categories);
     expect(paths).toEqual(['Parent / Child']);
-  });
-});
-
-describe('ensureUserCategoriesFile (integration)', () => {
-  let testDir: string;
-
-  beforeEach(() => {
-    testDir = join(tmpdir(), `takt-cat-ensure-${randomUUID()}`);
-    mkdirSync(testDir, { recursive: true });
-  });
-
-  afterEach(() => {
-    rmSync(testDir, { recursive: true, force: true });
-  });
-
-  it('should copy default categories to user path when missing', async () => {
-    // Use real ensureUserCategoriesFile (not mocked)
-    const { ensureUserCategoriesFile } = await import('../infra/config/global/pieceCategories.js');
-
-    // This test depends on the mock still being active — just verify the mock returns our path
-    const result = ensureUserCategoriesFile('/tmp/default.yaml');
-    expect(typeof result).toBe('string');
   });
 });

--- a/src/__tests__/resetCategories.test.ts
+++ b/src/__tests__/resetCategories.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for reset categories command behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../infra/config/global/pieceCategories.js', () => ({
+  resetPieceCategories: vi.fn(),
+  getPieceCategoriesPath: vi.fn(() => '/tmp/user-piece-categories.yaml'),
+}));
+
+vi.mock('../shared/ui/index.js', () => ({
+  header: vi.fn(),
+  success: vi.fn(),
+  info: vi.fn(),
+}));
+
+import { resetPieceCategories } from '../infra/config/global/pieceCategories.js';
+import { header, success, info } from '../shared/ui/index.js';
+import { resetCategoriesToDefault } from '../features/config/resetCategories.js';
+
+const mockResetPieceCategories = vi.mocked(resetPieceCategories);
+const mockHeader = vi.mocked(header);
+const mockSuccess = vi.mocked(success);
+const mockInfo = vi.mocked(info);
+
+describe('resetCategoriesToDefault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should reset user category overlay and show updated message', async () => {
+    // Given
+
+    // When
+    await resetCategoriesToDefault();
+
+    // Then
+    expect(mockHeader).toHaveBeenCalledWith('Reset Categories');
+    expect(mockResetPieceCategories).toHaveBeenCalledTimes(1);
+    expect(mockSuccess).toHaveBeenCalledWith('User category overlay reset.');
+    expect(mockInfo).toHaveBeenCalledWith('  /tmp/user-piece-categories.yaml');
+  });
+});

--- a/src/__tests__/switchPiece.test.ts
+++ b/src/__tests__/switchPiece.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for switchPiece behavior.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../infra/config/index.js', () => ({
+  listPieceEntries: vi.fn(() => []),
+  loadAllPiecesWithSources: vi.fn(() => new Map()),
+  getPieceCategories: vi.fn(() => null),
+  buildCategorizedPieces: vi.fn(),
+  loadPiece: vi.fn(() => null),
+  getCurrentPiece: vi.fn(() => 'default'),
+  setCurrentPiece: vi.fn(),
+}));
+
+vi.mock('../features/pieceSelection/index.js', () => ({
+  warnMissingPieces: vi.fn(),
+  selectPieceFromCategorizedPieces: vi.fn(),
+  selectPieceFromEntries: vi.fn(),
+}));
+
+vi.mock('../shared/ui/index.js', () => ({
+  info: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+import {
+  loadAllPiecesWithSources,
+  getPieceCategories,
+  buildCategorizedPieces,
+} from '../infra/config/index.js';
+import {
+  warnMissingPieces,
+  selectPieceFromCategorizedPieces,
+} from '../features/pieceSelection/index.js';
+import { switchPiece } from '../features/config/switchPiece.js';
+
+const mockLoadAllPiecesWithSources = vi.mocked(loadAllPiecesWithSources);
+const mockGetPieceCategories = vi.mocked(getPieceCategories);
+const mockBuildCategorizedPieces = vi.mocked(buildCategorizedPieces);
+const mockWarnMissingPieces = vi.mocked(warnMissingPieces);
+const mockSelectPieceFromCategorizedPieces = vi.mocked(selectPieceFromCategorizedPieces);
+
+describe('switchPiece', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should warn only user-origin missing pieces during interactive switch', async () => {
+    // Given
+    mockLoadAllPiecesWithSources.mockReturnValue(new Map([
+      ['default', {
+        source: 'builtin',
+        config: {
+          name: 'default',
+          movements: [],
+          initialMovement: 'start',
+          maxIterations: 1,
+        },
+      }],
+    ]));
+    mockGetPieceCategories.mockReturnValue({
+      pieceCategories: [],
+      builtinPieceCategories: [],
+      userPieceCategories: [],
+      showOthersCategory: true,
+      othersCategoryName: 'Others',
+    });
+    mockBuildCategorizedPieces.mockReturnValue({
+      categories: [],
+      allPieces: new Map(),
+      missingPieces: [
+        { categoryPath: ['Quick Start'], pieceName: 'default', source: 'builtin' },
+        { categoryPath: ['Custom'], pieceName: 'my-missing', source: 'user' },
+      ],
+    });
+    mockSelectPieceFromCategorizedPieces.mockResolvedValue(null);
+
+    // When
+    const switched = await switchPiece('/project');
+
+    // Then
+    expect(switched).toBe(false);
+    expect(mockWarnMissingPieces).toHaveBeenCalledWith([
+      { categoryPath: ['Custom'], pieceName: 'my-missing', source: 'user' },
+    ]);
+  });
+});

--- a/src/features/config/resetCategories.ts
+++ b/src/features/config/resetCategories.ts
@@ -1,18 +1,16 @@
 /**
- * Reset piece categories to builtin defaults.
+ * Reset user piece categories overlay.
  */
 
-import { getDefaultCategoriesPath } from '../../infra/config/loaders/pieceCategories.js';
 import { resetPieceCategories, getPieceCategoriesPath } from '../../infra/config/global/pieceCategories.js';
 import { header, success, info } from '../../shared/ui/index.js';
 
 export async function resetCategoriesToDefault(): Promise<void> {
   header('Reset Categories');
 
-  const defaultPath = getDefaultCategoriesPath();
-  resetPieceCategories(defaultPath);
+  resetPieceCategories();
 
   const userPath = getPieceCategoriesPath();
-  success('Categories reset to builtin defaults.');
+  success('User category overlay reset.');
   info(`  ${userPath}`);
 }

--- a/src/features/config/switchPiece.ts
+++ b/src/features/config/switchPiece.ts
@@ -37,7 +37,7 @@ export async function switchPiece(cwd: string, pieceName?: string): Promise<bool
         selected = null;
       } else {
         const categorized = buildCategorizedPieces(allPieces, categoryConfig);
-        warnMissingPieces(categorized.missingPieces);
+        warnMissingPieces(categorized.missingPieces.filter((missing) => missing.source === 'user'));
         selected = await selectPieceFromCategorizedPieces(categorized, current);
       }
     } else {

--- a/src/features/tasks/execute/selectAndExecute.ts
+++ b/src/features/tasks/execute/selectAndExecute.ts
@@ -68,7 +68,7 @@ async function selectPiece(cwd: string): Promise<string | null> {
       return DEFAULT_PIECE_NAME;
     }
     const categorized = buildCategorizedPieces(allPieces, categoryConfig);
-    warnMissingPieces(categorized.missingPieces);
+    warnMissingPieces(categorized.missingPieces.filter((missing) => missing.source === 'user'));
     return selectPieceFromCategorizedPieces(categorized, current);
   }
   return selectPieceWithDirectoryCategories(cwd);

--- a/src/infra/config/global/index.ts
+++ b/src/infra/config/global/index.ts
@@ -27,7 +27,6 @@ export {
 
 export {
   getPieceCategoriesPath,
-  ensureUserCategoriesFile,
   resetPieceCategories,
 } from './pieceCategories.js';
 

--- a/src/infra/config/global/pieceCategories.ts
+++ b/src/infra/config/global/pieceCategories.ts
@@ -1,15 +1,15 @@
 /**
  * Piece categories file management.
  *
- * The categories file (~/.takt/preferences/piece-categories.yaml) uses the same
- * format as the builtin piece-categories.yaml (piece_categories key).
- * If the file doesn't exist, it's auto-copied from builtin defaults.
+ * User category file is treated as overlay on top of builtin categories.
  */
 
-import { existsSync, mkdirSync, copyFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { getGlobalConfigDir } from '../paths.js';
 import { loadGlobalConfig } from './globalConfig.js';
+
+const INITIAL_USER_CATEGORIES_CONTENT = 'piece_categories: {}\n';
 
 function getDefaultPieceCategoriesPath(): string {
   return join(getGlobalConfigDir(), 'preferences', 'piece-categories.yaml');
@@ -17,51 +17,22 @@ function getDefaultPieceCategoriesPath(): string {
 
 /** Get the path to the user's piece categories file. */
 export function getPieceCategoriesPath(): string {
-  try {
-    const config = loadGlobalConfig();
-    if (config.pieceCategoriesFile) {
-      return config.pieceCategoriesFile;
-    }
-  } catch {
-    // Ignore errors, use default
+  const config = loadGlobalConfig();
+  if (config.pieceCategoriesFile) {
+    return config.pieceCategoriesFile;
   }
   return getDefaultPieceCategoriesPath();
 }
 
 /**
- * Ensure user categories file exists by copying from builtin defaults.
- * Returns the path to the user categories file.
+ * Reset user categories overlay file to initial content.
  */
-export function ensureUserCategoriesFile(defaultCategoriesPath: string): string {
-  const userPath = getPieceCategoriesPath();
-  if (existsSync(userPath)) {
-    return userPath;
-  }
-
-  if (!existsSync(defaultCategoriesPath)) {
-    throw new Error(`Default categories file not found: ${defaultCategoriesPath}`);
-  }
-
-  const dir = dirname(userPath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-  copyFileSync(defaultCategoriesPath, userPath);
-  return userPath;
-}
-
-/**
- * Reset user categories file by overwriting with builtin defaults.
- */
-export function resetPieceCategories(defaultCategoriesPath: string): void {
-  if (!existsSync(defaultCategoriesPath)) {
-    throw new Error(`Default categories file not found: ${defaultCategoriesPath}`);
-  }
-
+export function resetPieceCategories(): void {
   const userPath = getPieceCategoriesPath();
   const dir = dirname(userPath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  copyFileSync(defaultCategoriesPath, userPath);
+
+  writeFileSync(userPath, INITIAL_USER_CATEGORIES_CONTENT, 'utf-8');
 }


### PR DESCRIPTION
## Summary

# タスク指示書

## 目的
ビルトインとユーザー定義のカテゴリ設定まわりの現行仕様をコードベースで再確認し、`not found` 警告が運用ノイズになる問題に対して、採用すべき仕様案を確定する。

## 前提（会話で確定している意図）
- ユーザーの関心は「現行仕様の調査」と「望ましい仕様の提案」。
- 問題意識: ビルトイン側のピース欠損で `not found` 警告が発生しやすい。

## 作業項目

### 1. 現行仕様の事実確認（優先度: 高）
- 対象モジュール:
  - `src/infra/config/loaders/pieceCategories.ts`
  - `src/infra/config/global/pieceCategories.ts`
  - `src/infra/config/loaders/pieceResolver.ts`
  - `src/features/pieceSelection/index.ts`
  - `src/features/config/switchPiece.ts`
  - `src/features/tasks/execute/selectAndExecute.ts`
  - `builtins/ja/piece-categories.yaml` / `builtins/en/piece-categories.yaml`
- 実施内容:
  - カテゴリ設定ファイルの読み込み元・初期化フローを確認
  - ピース解決順序（builtin/user/project）と上書き優先順位を確認
  - missing 判定条件、warning 出力条件、除外条件（無効化ビルトイン等）を確認
  - 警告がどの操作で表示されるか（switch / 実行時選択）を確認

### 2. 仕様案の具体化（優先度: 高）
- 対象モジュール/仕様論点:
  - カテゴリ構成モデル（builtin と user の責務分離）
  - missing ピース時の挙動ポリシー
  - `takt reset categories` の期待挙動
  - 設定項目追加要否（例: missing policy）
- 実施内容:
  - 以下の方向性をベースに、採用仕様を明文化する:
    - カテゴリ2層化（builtin read-only + user overlay）
    - 既定は欠損スキップ（ビルトイン由来欠損で警告しない）
    - ユーザー定義由来の欠損のみ通知対象
    - reset の意味を「ユーザー側カテゴリ初期化」に再定義
    - 必要なら missing 挙動を設定化（ignore/warn/error）
  - 仕様を「挙動定義」「互換影響」「移行方針」に分けて記述

### 3. 実装計画まで落とし込む（優先度: 中）
- 対象モジュール:
  - `src/infra/config/loaders/pieceCategories.ts`
  - `src/infra/config/global/pieceCategories.ts`
  - `src/features/pieceSelection/index.ts`
  - `src/features/config/resetCategories.ts`
  - 関連テスト群（`src/__tests__/piece-category-config.test.ts` など）
- 実施内容:
  - 採用仕様を実装する場合の最小変更範囲を提示
  - 追加/更新すべきテスト観点を列挙
  - リスク（既存ユーザー設定への影響）を明示

### 4. ドキュメント反映方針の提示（優先度: 低）
- 対象ドキュメント:
  - `README.md`
  - `docs/README.ja.md`
  - カテゴリ仕様に関するドキュメント（既存がなければ新設候補を提案）
- 実施内容:
  - 新仕様に合わせた説明差分を整理
  - 設定例（ユーザーオーバーレイ、missing policy）を提示

## 再現手順（現状問題）
1. カテゴリ設定に存在しないピース名を含める（またはビルトイン側で参照先が欠損する状態を作る）。
2. `takt switch` またはタスク実行時のピース選択フローを開始する。
3. `Piece "... " in category "... " not found` 警告が表示されることを確認する。

## 確認方法（成果物）
1. 現行仕様の根拠がコード参照付きで整理されていること。
2. 採用候補仕様が曖昧さなく定義されていること（missing 挙動、警告対象、reset の意味）。
3. 実装時の変更対象とテスト観点が具体化されていること。

## Execution Report

Piece `default` completed successfully.

Closes #183