### PR TITLE
github-issue-193-takt-add-issue

### DIFF
--- a/src/__tests__/createIssueFromTask.test.ts
+++ b/src/__tests__/createIssueFromTask.test.ts
@@ -114,6 +114,42 @@ describe('createIssueFromTask', () => {
     expect(mockSuccess).not.toHaveBeenCalled();
   });
 
+  describe('return value', () => {
+    it('should return issue number when creation succeeds', () => {
+      // Given
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/owner/repo/issues/42' });
+
+      // When
+      const result = createIssueFromTask('Test task');
+
+      // Then
+      expect(result).toBe(42);
+    });
+
+    it('should return undefined when creation fails', () => {
+      // Given
+      mockCreateIssue.mockReturnValue({ success: false, error: 'auth failed' });
+
+      // When
+      const result = createIssueFromTask('Test task');
+
+      // Then
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined and display error when URL has non-numeric suffix', () => {
+      // Given
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/owner/repo/issues/abc' });
+
+      // When
+      const result = createIssueFromTask('Test task');
+
+      // Then
+      expect(result).toBeUndefined();
+      expect(mockError).toHaveBeenCalledWith('Failed to extract issue number from URL');
+    });
+  });
+
   it('should use first line as title and full text as body for multi-line task', () => {
     // Given: multi-line task
     const task = 'First line title\nSecond line details\nThird line more info';

--- a/src/__tests__/saveTaskFile.test.ts
+++ b/src/__tests__/saveTaskFile.test.ts
@@ -122,4 +122,16 @@ describe('saveTaskFromInteractive', () => {
 
     expect(mockInfo).toHaveBeenCalledWith('  Piece: review');
   });
+
+  it('should record issue number in tasks.yaml when issue option is provided', async () => {
+    // Given: user declines worktree
+    mockConfirm.mockResolvedValueOnce(false);
+
+    // When
+    await saveTaskFromInteractive(testDir, 'Fix login bug', 'default', { issue: 42 });
+
+    // Then
+    const task = loadTasks(testDir).tasks[0]!;
+    expect(task.issue).toBe(42);
+  });
 });

--- a/src/app/cli/routing.ts
+++ b/src/app/cli/routing.ts
@@ -9,7 +9,7 @@ import { info, error } from '../../shared/ui/index.js';
 import { getErrorMessage } from '../../shared/utils/index.js';
 import { getLabel } from '../../shared/i18n/index.js';
 import { fetchIssue, formatIssueAsTask, checkGhCli, parseIssueNumbers, type GitHubIssue } from '../../infra/github/index.js';
-import { selectAndExecuteTask, determinePiece, saveTaskFromInteractive, createIssueFromTask, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
+import { selectAndExecuteTask, determinePiece, saveTaskFromInteractive, createIssueAndSaveTask, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
 import { executePipeline } from '../../features/pipeline/index.js';
 import {
   interactiveMode,
@@ -188,7 +188,7 @@ export async function executeDefaultAction(task?: string): Promise<void> {
       break;
 
     case 'create_issue':
-      createIssueFromTask(result.task);
+      await createIssueAndSaveTask(resolvedCwd, result.task, pieceId);
       break;
 
     case 'save_task':

--- a/src/features/tasks/index.ts
+++ b/src/features/tasks/index.ts
@@ -14,7 +14,7 @@ export {
   type SelectAndExecuteOptions,
   type WorktreeConfirmationResult,
 } from './execute/selectAndExecute.js';
-export { addTask, saveTaskFile, saveTaskFromInteractive, createIssueFromTask } from './add/index.js';
+export { addTask, saveTaskFile, saveTaskFromInteractive, createIssueFromTask, createIssueAndSaveTask } from './add/index.js';
 export { watchTasks } from './watch/index.js';
 export {
   listTasks,


### PR DESCRIPTION
## Summary

## 現状

`takt add` の対話モードで `/issue` を選択すると、GitHub Issue は作成されるがタスク（.takt/tasks.yaml）には追加されない。タスクとして実行するには `takt add #N` で改めて追加する必要がある。

## 期待動作

`/issue` 選択時に Issue 作成後、同じ内容を `.takt/tasks.yaml` にもタスクとして追加する。Issue 番号も `issue` フィールドに記録する。

## 変更箇所

`src/features/tasks/add/index.ts` line 163-166

```typescript
// Before
if (result.action === 'create_issue') {
  createIssueFromTask(result.task);
  return;
}

// After: Issue 作成後にタスクにも追加
if (result.action === 'create_issue') {
  const issueResult = createIssueFromTask(result.task);  // 戻り値で issue 番号を返す
  // ワークツリー設定 → saveTaskFile() でタスク追加（issue 番号付き）
}
```

`createIssueFromTask` の戻り値を変更して Issue 番号を返す必要がある。

## Execution Report

Piece `default` completed successfully.

Closes #193