### PR TITLE
github-issue-204-takt-tasks

### DIFF
--- a/builtins/project/tasks/TASK-FORMAT
+++ b/builtins/project/tasks/TASK-FORMAT
@@ -1,37 +1,48 @@
-TAKT Task File Format
-=====================
+TAKT Task Directory Format
+==========================
 
-Tasks placed in this directory (.takt/tasks/) will be processed by TAKT.
+`.takt/tasks/` is the task input directory. Each task uses one subdirectory.
 
-## YAML Format (Recommended)
+## Directory Layout (Recommended)
 
-  # .takt/tasks/my-task.yaml
-  task: "Task description"
-  worktree: true                  # (optional) true | "/path/to/dir"
-  branch: "feat/my-feature"      # (optional) branch name
-  piece: "default"             # (optional) piece name
+  .takt/
+    tasks/
+      20260201-015714-foptng/
+        order.md
+        schema.sql
+        wireframe.png
+
+- Directory name should match the report directory slug.
+- `order.md` is required.
+- Other files are optional reference materials.
+
+## tasks.yaml Format
+
+Store task metadata in `.takt/tasks.yaml`, and point to the task directory with `task_dir`.
+
+  tasks:
+    - name: add-auth-feature
+      status: pending
+      task_dir: .takt/tasks/20260201-015714-foptng
+      piece: default
+      created_at: "2026-02-01T01:57:14.000Z"
+      started_at: null
+      completed_at: null
 
 Fields:
-  task      (required)  Task description (string)
-  worktree  (optional)  true: create shared clone, "/path": clone at path
-  branch    (optional)  Branch name (auto-generated if omitted: takt/{timestamp}-{slug})
-  piece  (optional)  Piece name (uses current piece if omitted)
+  task_dir   (recommended)  Path to task directory that contains `order.md`
+  content    (legacy)       Inline task text (kept for compatibility)
+  content_file (legacy)     Path to task text file (kept for compatibility)
 
-## Markdown Format (Simple)
+## Command Behavior
 
-  # .takt/tasks/my-task.md
-
-  Entire file content becomes the task description.
-  Supports multiline. No structured options available.
-
-## Supported Extensions
-
-  .yaml, .yml  ->  YAML format (parsed and validated)
-  .md          ->  Markdown format (plain text, backward compatible)
+- `takt add` creates `.takt/tasks/{slug}/order.md` automatically.
+- `takt run` and `takt watch` read `.takt/tasks.yaml` and resolve `task_dir`.
+- Report output is written to `.takt/reports/{slug}/`.
 
 ## Commands
 
-  takt /add-task     Add a task interactively
-  takt /run-tasks    Run all pending tasks
-  takt /watch        Watch and auto-run tasks
-  takt /list-tasks   List task branches (merge/delete)
+  takt add     Add a task and create task directory
+  takt run     Run all pending tasks in tasks.yaml
+  takt watch   Watch tasks.yaml and run pending tasks
+  takt list    List task branches (merge/delete)

--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -26,13 +26,13 @@ E2Eテストを追加・変更した場合は、このドキュメントも更�
 
 ## シナリオ一覧
 - Add task and run（`e2e/specs/add-and-run.e2e.ts`）
-  - 目的: `.takt/tasks/` にタスクYAMLを配置し、`takt run` が実行できることを確認。
+  - 目的: `.takt/tasks.yaml` に pending タスクを配置し、`takt run` が実行できることを確認。
   - LLM: 条件付き（`TAKT_E2E_PROVIDER` が `claude` / `codex` の場合に呼び出す）
   - 手順（ユーザー行動/コマンド）:
-    - `.takt/tasks/e2e-test-task.yaml` にタスクを作成（`piece` は `e2e/fixtures/pieces/simple.yaml` を指定）。
+    - `.takt/tasks.yaml` にタスクを作成（`piece` は `e2e/fixtures/pieces/simple.yaml` を指定）。
     - `takt run` を実行する。
     - `README.md` に行が追加されることを確認する。
-    - タスクファイルが `tasks/` から移動されることを確認する。
+    - 実行後にタスクが `tasks.yaml` から消えることを確認する。
 - Worktree/Clone isolation（`e2e/specs/worktree.e2e.ts`）
   - 目的: `--create-worktree yes` 指定で隔離環境に実行されることを確認。
   - LLM: 条件付き（`TAKT_E2E_PROVIDER` が `claude` / `codex` の場合に呼び出す）
@@ -83,13 +83,13 @@ E2Eテストを追加・変更した場合は、このドキュメントも更�
     - `gh issue create ...` でIssueを作成する。
     - `TAKT_MOCK_SCENARIO=e2e/fixtures/scenarios/add-task.json` を設定する。
     - `takt add '#<issue>'` を実行し、`Create worktree?` に `n` で回答する。
-    - `.takt/tasks/` にYAMLが生成されることを確認する。
+    - `.takt/tasks.yaml` に `task_dir` が保存され、`.takt/tasks/{slug}/order.md` が生成されることを確認する。
 - Watch tasks（`e2e/specs/watch.e2e.ts`）
   - 目的: `takt watch` が監視中に追加されたタスクを実行できることを確認。
   - LLM: 呼び出さない（`--provider mock` 固定）
   - 手順（ユーザー行動/コマンド）:
     - `takt watch --provider mock` を起動する。
-    - `.takt/tasks/` にタスクYAMLを追加する（`piece` に `e2e/fixtures/pieces/mock-single-step.yaml` を指定）。
+    - `.takt/tasks.yaml` に pending タスクを追加する（`piece` に `e2e/fixtures/pieces/mock-single-step.yaml` を指定）。
     - 出力に `Task "watch-task" completed` が含まれることを確認する。
     - `Ctrl+C` で終了する。
 - Run tasks graceful shutdown on SIGINT（`e2e/specs/run-sigint-graceful.e2e.ts`）

--- a/e2e/specs/add.e2e.ts
+++ b/e2e/specs/add.e2e.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
@@ -87,8 +87,12 @@ describe('E2E: Add task from GitHub issue (takt add)', () => {
 
     const tasksFile = join(testRepo.path, '.takt', 'tasks.yaml');
     const content = readFileSync(tasksFile, 'utf-8');
-    const parsed = parseYaml(content) as { tasks?: Array<{ issue?: number }> };
+    const parsed = parseYaml(content) as { tasks?: Array<{ issue?: number; task_dir?: string }> };
     expect(parsed.tasks?.length).toBe(1);
     expect(parsed.tasks?.[0]?.issue).toBe(Number(issueNumber));
+    expect(parsed.tasks?.[0]?.task_dir).toBeTypeOf('string');
+    const orderPath = join(testRepo.path, String(parsed.tasks?.[0]?.task_dir), 'order.md');
+    expect(existsSync(orderPath)).toBe(true);
+    expect(readFileSync(orderPath, 'utf-8')).toContain('E2E Add Issue');
   }, 240_000);
 });

--- a/src/__tests__/addTask.test.ts
+++ b/src/__tests__/addTask.test.ts
@@ -97,6 +97,10 @@ afterEach(() => {
 });
 
 describe('addTask', () => {
+  function readOrderContent(dir: string, taskDir: unknown): string {
+    return fs.readFileSync(path.join(dir, String(taskDir), 'order.md'), 'utf-8');
+  }
+
   it('should create task entry from interactive result', async () => {
     mockInteractiveMode.mockResolvedValue({ action: 'execute', task: '# 認証機能追加\nJWT認証を実装する' });
 
@@ -104,7 +108,9 @@ describe('addTask', () => {
 
     const tasks = loadTasks(testDir).tasks;
     expect(tasks).toHaveLength(1);
-    expect(tasks[0]?.content).toContain('JWT認証を実装する');
+    expect(tasks[0]?.content).toBeUndefined();
+    expect(tasks[0]?.task_dir).toBeTypeOf('string');
+    expect(readOrderContent(testDir, tasks[0]?.task_dir)).toContain('JWT認証を実装する');
     expect(tasks[0]?.piece).toBe('default');
   });
 
@@ -128,7 +134,8 @@ describe('addTask', () => {
 
     expect(mockInteractiveMode).not.toHaveBeenCalled();
     const task = loadTasks(testDir).tasks[0]!;
-    expect(task.content).toContain('Fix login timeout');
+    expect(task.content).toBeUndefined();
+    expect(readOrderContent(testDir, task.task_dir)).toContain('Fix login timeout');
     expect(task.issue).toBe(99);
   });
 
@@ -153,7 +160,8 @@ describe('addTask', () => {
     const tasks = loadTasks(testDir).tasks;
     expect(tasks).toHaveLength(1);
     expect(tasks[0]?.issue).toBe(55);
-    expect(tasks[0]?.content).toContain('New feature');
+    expect(tasks[0]?.content).toBeUndefined();
+    expect(readOrderContent(testDir, tasks[0]?.task_dir)).toContain('New feature');
   });
 
   it('should not save task when issue creation fails in create_issue action', async () => {

--- a/src/__tests__/saveTaskFile.test.ts
+++ b/src/__tests__/saveTaskFile.test.ts
@@ -42,10 +42,13 @@ function loadTasks(testDir: string): { tasks: Array<Record<string, unknown>> } {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-02-10T04:40:00.000Z'));
   testDir = fs.mkdtempSync(path.join(tmpdir(), 'takt-test-save-'));
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   if (testDir && fs.existsSync(testDir)) {
     fs.rmSync(testDir, { recursive: true });
   }
@@ -61,7 +64,11 @@ describe('saveTaskFile', () => {
 
     const tasks = loadTasks(testDir).tasks;
     expect(tasks).toHaveLength(1);
-    expect(tasks[0]?.content).toContain('Implement feature X');
+    expect(tasks[0]?.content).toBeUndefined();
+    expect(tasks[0]?.task_dir).toBeTypeOf('string');
+    const taskDir = path.join(testDir, String(tasks[0]?.task_dir));
+    expect(fs.existsSync(path.join(taskDir, 'order.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(taskDir, 'order.md'), 'utf-8')).toContain('Implement feature X');
   });
 
   it('should include optional fields', async () => {
@@ -79,6 +86,7 @@ describe('saveTaskFile', () => {
     expect(task.worktree).toBe(true);
     expect(task.branch).toBe('feat/my-branch');
     expect(task.auto_pr).toBe(false);
+    expect(task.task_dir).toBeTypeOf('string');
   });
 
   it('should generate unique names on duplicates', async () => {
@@ -86,6 +94,13 @@ describe('saveTaskFile', () => {
     const second = await saveTaskFile(testDir, 'Same title');
 
     expect(first.taskName).not.toBe(second.taskName);
+
+    const tasks = loadTasks(testDir).tasks;
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0]?.task_dir).toBe('.takt/tasks/20260210-044000-same-title');
+    expect(tasks[1]?.task_dir).toBe('.takt/tasks/20260210-044000-same-title-2');
+    expect(fs.readFileSync(path.join(testDir, String(tasks[0]?.task_dir), 'order.md'), 'utf-8')).toContain('Same title');
+    expect(fs.readFileSync(path.join(testDir, String(tasks[1]?.task_dir), 'order.md'), 'utf-8')).toContain('Same title');
   });
 });
 

--- a/src/__tests__/task-schema.test.ts
+++ b/src/__tests__/task-schema.test.ts
@@ -216,8 +216,38 @@ describe('TaskRecordSchema', () => {
       expect(() => TaskRecordSchema.parse(record)).not.toThrow();
     });
 
-    it('should reject record with neither content nor content_file', () => {
+    it('should accept record with task_dir', () => {
+      const record = { ...makePendingRecord(), content: undefined, task_dir: '.takt/tasks/20260201-000000-task' };
+      expect(() => TaskRecordSchema.parse(record)).not.toThrow();
+    });
+
+    it('should reject record with neither content, content_file, nor task_dir', () => {
       const record = { ...makePendingRecord(), content: undefined };
+      expect(() => TaskRecordSchema.parse(record)).toThrow();
+    });
+
+    it('should reject record with both content and task_dir', () => {
+      const record = { ...makePendingRecord(), task_dir: '.takt/tasks/20260201-000000-task' };
+      expect(() => TaskRecordSchema.parse(record)).toThrow();
+    });
+
+    it('should reject record with invalid task_dir format', () => {
+      const record = { ...makePendingRecord(), content: undefined, task_dir: '.takt/reports/invalid' };
+      expect(() => TaskRecordSchema.parse(record)).toThrow();
+    });
+
+    it('should reject record with parent-directory task_dir', () => {
+      const record = { ...makePendingRecord(), content: undefined, task_dir: '.takt/tasks/..' };
+      expect(() => TaskRecordSchema.parse(record)).toThrow();
+    });
+
+    it('should reject record with empty content', () => {
+      const record = { ...makePendingRecord(), content: '' };
+      expect(() => TaskRecordSchema.parse(record)).toThrow();
+    });
+
+    it('should reject record with empty content_file', () => {
+      const record = { ...makePendingRecord(), content: undefined, content_file: '' };
       expect(() => TaskRecordSchema.parse(record)).toThrow();
     });
   });

--- a/src/__tests__/taskExecution.test.ts
+++ b/src/__tests__/taskExecution.test.ts
@@ -511,4 +511,52 @@ describe('resolveTaskExecution', () => {
     expect(mockSummarizeTaskName).not.toHaveBeenCalled();
     expect(mockCreateSharedClone).not.toHaveBeenCalled();
   });
+
+  it('should return reportDirName from taskDir basename', async () => {
+    const task: TaskInfo = {
+      name: 'task-with-dir',
+      content: 'Task content',
+      taskDir: '.takt/tasks/20260201-015714-foptng',
+      filePath: '/tasks/task.yaml',
+      data: {
+        task: 'Task content',
+      },
+    };
+
+    const result = await resolveTaskExecution(task, '/project', 'default');
+
+    expect(result.reportDirName).toBe('20260201-015714-foptng');
+  });
+
+  it('should throw when taskDir format is invalid', async () => {
+    const task: TaskInfo = {
+      name: 'task-with-invalid-dir',
+      content: 'Task content',
+      taskDir: '.takt/reports/20260201-015714-foptng',
+      filePath: '/tasks/task.yaml',
+      data: {
+        task: 'Task content',
+      },
+    };
+
+    await expect(resolveTaskExecution(task, '/project', 'default')).rejects.toThrow(
+      'Invalid task_dir format: .takt/reports/20260201-015714-foptng',
+    );
+  });
+
+  it('should throw when taskDir contains parent directory segment', async () => {
+    const task: TaskInfo = {
+      name: 'task-with-parent-dir',
+      content: 'Task content',
+      taskDir: '.takt/tasks/..',
+      filePath: '/tasks/task.yaml',
+      data: {
+        task: 'Task content',
+      },
+    };
+
+    await expect(resolveTaskExecution(task, '/project', 'default')).rejects.toThrow(
+      'Invalid task_dir format: .takt/tasks/..',
+    );
+  });
 });

--- a/src/app/cli/commands.ts
+++ b/src/app/cli/commands.ts
@@ -15,7 +15,7 @@ import { resolveAgentOverrides } from './helpers.js';
 
 program
   .command('run')
-  .description('Run all pending tasks from .takt/tasks/')
+  .description('Run all pending tasks from .takt/tasks.yaml')
   .action(async () => {
     const piece = getCurrentPiece(resolvedCwd);
     await runAllTasks(resolvedCwd, piece, resolveAgentOverrides(program));

--- a/src/core/piece/engine/PieceEngine.ts
+++ b/src/core/piece/engine/PieceEngine.ts
@@ -27,7 +27,7 @@ import {
   addUserInput as addUserInputToState,
   incrementMovementIteration,
 } from './state-manager.js';
-import { generateReportDir, getErrorMessage, createLogger } from '../../../shared/utils/index.js';
+import { generateReportDir, getErrorMessage, createLogger, isValidReportDirName } from '../../../shared/utils/index.js';
 import { OptionsBuilder } from './OptionsBuilder.js';
 import { MovementExecutor } from './MovementExecutor.js';
 import { ParallelRunner } from './ParallelRunner.js';
@@ -79,7 +79,11 @@ export class PieceEngine extends EventEmitter {
     this.options = options;
     this.loopDetector = new LoopDetector(config.loopDetection);
     this.cycleDetector = new CycleDetector(config.loopMonitors ?? []);
-    this.reportDir = `.takt/reports/${generateReportDir(task)}`;
+    if (options.reportDirName !== undefined && !isValidReportDirName(options.reportDirName)) {
+      throw new Error(`Invalid reportDirName: ${options.reportDirName}`);
+    }
+    const reportDirName = options.reportDirName ?? generateReportDir(task);
+    this.reportDir = `.takt/reports/${reportDirName}`;
     this.ensureReportDirExists();
     this.validateConfig();
     this.state = createInitialState(config, options);

--- a/src/core/piece/types.ts
+++ b/src/core/piece/types.ts
@@ -190,6 +190,8 @@ export interface PieceEngineOptions {
   startMovement?: string;
   /** Retry note explaining why task is being retried */
   retryNote?: string;
+  /** Override report directory name (without parent path). */
+  reportDirName?: string;
   /** Task name prefix for parallel task execution output */
   taskPrefix?: string;
   /** Color index for task prefix (cycled across tasks) */

--- a/src/features/tasks/execute/parallelExecution.ts
+++ b/src/features/tasks/execute/parallelExecution.ts
@@ -7,7 +7,7 @@
  * (concurrency>1) execution through the same code path.
  *
  * Polls for newly added tasks at a configurable interval so that tasks
- * added to .takt/tasks/ during execution are picked up without waiting
+ * added to .takt/tasks.yaml during execution are picked up without waiting
  * for an active task to complete.
  */
 

--- a/src/features/tasks/execute/pieceExecution.ts
+++ b/src/features/tasks/execute/pieceExecution.ts
@@ -347,6 +347,7 @@ export async function executePiece(
     callAiJudge,
     startMovement: options.startMovement,
     retryNote: options.retryNote,
+    reportDirName: options.reportDirName,
     taskPrefix: options.taskPrefix,
     taskColorIndex: options.taskColorIndex,
   });

--- a/src/features/tasks/execute/taskExecution.ts
+++ b/src/features/tasks/execute/taskExecution.ts
@@ -49,7 +49,7 @@ function resolveTaskIssue(issueNumber: number | undefined): ReturnType<typeof fe
 }
 
 async function executeTaskWithResult(options: ExecuteTaskOptions): Promise<PieceExecutionResult> {
-  const { task, cwd, pieceIdentifier, projectCwd, agentOverrides, interactiveUserInput, interactiveMetadata, startMovement, retryNote, abortSignal, taskPrefix, taskColorIndex } = options;
+  const { task, cwd, pieceIdentifier, projectCwd, agentOverrides, interactiveUserInput, interactiveMetadata, startMovement, retryNote, reportDirName, abortSignal, taskPrefix, taskColorIndex } = options;
   const pieceConfig = loadPieceByIdentifier(pieceIdentifier, projectCwd);
 
   if (!pieceConfig) {
@@ -80,6 +80,7 @@ async function executeTaskWithResult(options: ExecuteTaskOptions): Promise<Piece
     interactiveMetadata,
     startMovement,
     retryNote,
+    reportDirName,
     abortSignal,
     taskPrefix,
     taskColorIndex,
@@ -128,7 +129,7 @@ export async function executeAndCompleteTask(
   }
 
   try {
-    const { execCwd, execPiece, isWorktree, branch, baseBranch, startMovement, retryNote, autoPr, issueNumber } = await resolveTaskExecution(task, cwd, pieceName, taskAbortSignal);
+    const { execCwd, execPiece, isWorktree, reportDirName, branch, baseBranch, startMovement, retryNote, autoPr, issueNumber } = await resolveTaskExecution(task, cwd, pieceName, taskAbortSignal);
 
     // cwd is always the project root; pass it as projectCwd so reports/sessions go there
     const taskRunResult = await executeTaskWithResult({
@@ -139,6 +140,7 @@ export async function executeAndCompleteTask(
       agentOverrides: options,
       startMovement,
       retryNote,
+      reportDirName,
       abortSignal: taskAbortSignal,
       taskPrefix: parallelOptions?.taskPrefix,
       taskColorIndex: parallelOptions?.taskColorIndex,
@@ -227,7 +229,7 @@ export async function executeAndCompleteTask(
 }
 
 /**
- * Run all pending tasks from .takt/tasks/
+ * Run all pending tasks from .takt/tasks.yaml
  *
  * Uses a worker pool for both sequential (concurrency=1) and parallel
  * (concurrency>1) execution through the same code path.

--- a/src/features/tasks/execute/types.ts
+++ b/src/features/tasks/execute/types.ts
@@ -42,6 +42,8 @@ export interface PieceExecutionOptions {
   startMovement?: string;
   /** Retry note explaining why task is being retried */
   retryNote?: string;
+  /** Override report directory name (e.g. "20260201-015714-foptng") */
+  reportDirName?: string;
   /** External abort signal for parallel execution — when provided, SIGINT handling is delegated to caller */
   abortSignal?: AbortSignal;
   /** Task name prefix for parallel execution output (e.g. "[task-name] output...") */
@@ -74,6 +76,8 @@ export interface ExecuteTaskOptions {
   startMovement?: string;
   /** Retry note explaining why task is being retried */
   retryNote?: string;
+  /** Override report directory name (e.g. "20260201-015714-foptng") */
+  reportDirName?: string;
   /** External abort signal for parallel execution — when provided, SIGINT handling is delegated to caller */
   abortSignal?: AbortSignal;
   /** Task name prefix for parallel execution output (e.g. "[task-name] output...") */

--- a/src/features/tasks/list/index.ts
+++ b/src/features/tasks/list/index.ts
@@ -2,7 +2,7 @@
  * List tasks command — main entry point.
  *
  * Interactive UI for reviewing branch-based task results,
- * pending tasks (.takt/tasks/), and failed tasks (.takt/failed/).
+ * pending tasks (.takt/tasks.yaml), and failed tasks.
  * Individual actions (merge, delete, instruct, diff) are in taskActions.ts.
  * Task delete actions are in taskDeleteActions.ts.
  * Non-interactive mode is in listNonInteractive.ts.

--- a/src/infra/task/runner.ts
+++ b/src/infra/task/runner.ts
@@ -29,13 +29,17 @@ export class TaskRunner {
     return this.tasksFile;
   }
 
-  addTask(content: string, options?: Omit<TaskFileData, 'task'>): TaskInfo {
+  addTask(
+    content: string,
+    options?: Omit<TaskFileData, 'task'> & { content_file?: string; task_dir?: string },
+  ): TaskInfo {
     const state = this.store.update((current) => {
       const name = this.generateTaskName(content, current.tasks.map((task) => task.name));
+      const contentValue = options?.task_dir ? undefined : content;
       const record: TaskRecord = TaskRecordSchema.parse({
         name,
         status: 'pending',
-        content,
+        content: contentValue,
         created_at: nowIso(),
         started_at: null,
         completed_at: null,

--- a/src/infra/task/types.ts
+++ b/src/infra/task/types.ts
@@ -10,6 +10,7 @@ export interface TaskInfo {
   filePath: string;
   name: string;
   content: string;
+  taskDir?: string;
   createdAt: string;
   status: TaskStatus;
   data: TaskFileData | null;

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -8,6 +8,7 @@ export * from './notification.js';
 export * from './reportDir.js';
 export * from './sleep.js';
 export * from './slug.js';
+export * from './taskPaths.js';
 export * from './text.js';
 export * from './types.js';
 export * from './updateNotifier.js';

--- a/src/shared/utils/taskPaths.ts
+++ b/src/shared/utils/taskPaths.ts
@@ -1,0 +1,20 @@
+const TASK_SLUG_PATTERN =
+  '[a-z0-9\\u3040-\\u309f\\u30a0-\\u30ff\\u4e00-\\u9faf](?:[a-z0-9\\u3040-\\u309f\\u30a0-\\u30ff\\u4e00-\\u9faf-]*[a-z0-9\\u3040-\\u309f\\u30a0-\\u30ff\\u4e00-\\u9faf])?';
+const TASK_DIR_PREFIX = '.takt/tasks/';
+const TASK_DIR_PATTERN = new RegExp(`^\\.takt/tasks/${TASK_SLUG_PATTERN}$`);
+const REPORT_DIR_NAME_PATTERN = new RegExp(`^${TASK_SLUG_PATTERN}$`);
+
+export function isValidTaskDir(taskDir: string): boolean {
+  return TASK_DIR_PATTERN.test(taskDir);
+}
+
+export function getTaskSlugFromTaskDir(taskDir: string): string | undefined {
+  if (!isValidTaskDir(taskDir)) {
+    return undefined;
+  }
+  return taskDir.slice(TASK_DIR_PREFIX.length);
+}
+
+export function isValidReportDirName(reportDirName: string): boolean {
+  return REPORT_DIR_NAME_PATTERN.test(reportDirName);
+}


### PR DESCRIPTION
## Summary

## 背景

- `.takt/tasks/` は旧タスクファイル方式の名残で、現在は `tasks.yaml` に統合済み。ディレクトリは空き地
- 長文タスクをそのままプロンプトに渡すと `Prompt is too long` で失敗する
- `expert` / `expert-cqrs` の coder movement に `pass_previous_response: false` を設定し、instruction も Report Directory 優先に更新済みだが、ユーザー入力自体が長文だと再び肥大化する

## 方針

### 1. タスクディレクトリ構造

タスク単位でディレクトリを作成し、仕様書・参考資料など複数ファイルを格納する。

```
.takt/
  tasks/
    20260201-015714-foptng/     # タスク単位のディレクトリ
      order.md                   # タスク仕様
      schema.sql                 # 参考資料
      wireframe.png              # 追加コンテキスト
  reports/
    20260201-015714-foptng/     # 同じスラッグで対応
      01-plan.md                 # 出力レポート
      02-review.md
```

- **入力（tasks/）と出力（reports/）がスラッグで対応する**
- `tasks.yaml` の `content` にタスク本文を丸ごと入れる代わりに、`task_dir` でディレクトリを参照
- 仕様書・スキーマ・画像など複数ファイルをタスクコンテキストとして渡せる

### 2. 推奨ファイル配置

- `order.md` — タスク仕様（必須）
- その他 — スキーマ、ワイヤーフレーム、既存コード抜粋など（任意）

### 3. 実行時プロンプトの原則

- プロンプトは短くする（参照先 + 制約のみ）
- 例:
  - 「仕様は `.takt/tasks/{slug}/` を唯一のソースとして実装」
  - 「Report Directory のレポートを一次情報として参照」
  - 「Previous Response と会話履歴要約に依存しない」

### 4. piece 側設定（対応済み）

- `expert` / `expert-cqrs` の coder movement（implement, ai_fix, fix, fix_supervisor）に `pass_previous_response: false` 設定済み
- instruction も Report Directory 優先に更新済み

### 5. 期待効果

- Prompt 長の削減
- 履歴肥大による失敗（`Prompt is too long`）の抑制
- 参照元の一貫性向上（Report Directory 中心）
- 仕様書以外の参考資料も構造的に渡せる

### 6. 注意点

- `pass_previous_response: false` だけでは不十分
- ユーザー入力自体が長文だと再び長くなるため、必ず `.takt/tasks/` 参照運用に寄せる

## やること

- [ ] `tasks.yaml` にタスクディレクトリ参照（`task_dir`）を追加
- [ ] タスク作成時に `.takt/tasks/{slug}/` ディレクトリを自動生成
- [ ] reports と同じスラッグ体系で tasks/reports を対応付ける
- [ ] `.takt/tasks/` の `TASK-FORMAT` を新方針に更新
- [ ] 運用ガイド（作成・実行・確認の手順書）を整備
- [ ] 必要に応じて piece の instruction_template にタスクディレクトリ参照パターンを組み込む

## Execution Report

Piece `default` completed successfully.

Closes #204