### PR TITLE
github-issue-236-feat-claude-codex-opencode

### DIFF
--- a/src/__tests__/globalConfig-defaults.test.ts
+++ b/src/__tests__/globalConfig-defaults.test.ts
@@ -314,6 +314,43 @@ describe('loadGlobalConfig', () => {
     });
   });
 
+  it('should load observability.provider_events config from config.yaml', () => {
+    const taktDir = join(testHomeDir, '.takt');
+    mkdirSync(taktDir, { recursive: true });
+    writeFileSync(
+      getGlobalConfigPath(),
+      [
+        'language: en',
+        'observability:',
+        '  provider_events: false',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const config = loadGlobalConfig();
+    expect(config.observability).toEqual({
+      providerEvents: false,
+    });
+  });
+
+  it('should save and reload observability.provider_events config', () => {
+    const taktDir = join(testHomeDir, '.takt');
+    mkdirSync(taktDir, { recursive: true });
+    writeFileSync(getGlobalConfigPath(), 'language: en\n', 'utf-8');
+
+    const config = loadGlobalConfig();
+    config.observability = {
+      providerEvents: false,
+    };
+    saveGlobalConfig(config);
+    invalidateGlobalConfigCache();
+
+    const reloaded = loadGlobalConfig();
+    expect(reloaded.observability).toEqual({
+      providerEvents: false,
+    });
+  });
+
   it('should save and reload notification_sound_events config', () => {
     const taktDir = join(testHomeDir, '.takt');
     mkdirSync(taktDir, { recursive: true });

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -410,15 +410,20 @@ describe('GlobalConfigSchema', () => {
     expect(result.default_piece).toBe('default');
     expect(result.log_level).toBe('info');
     expect(result.provider).toBe('claude');
+    expect(result.observability).toBeUndefined();
   });
 
   it('should accept valid config', () => {
     const config = {
       default_piece: 'custom',
       log_level: 'debug' as const,
+      observability: {
+        provider_events: false,
+      },
     };
 
     const result = GlobalConfigSchema.parse(config);
     expect(result.log_level).toBe('debug');
+    expect(result.observability?.provider_events).toBe(false);
   });
 });

--- a/src/__tests__/providerEventLogger.test.ts
+++ b/src/__tests__/providerEventLogger.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  createProviderEventLogger,
+  isProviderEventsEnabled,
+} from '../shared/utils/providerEventLogger.js';
+import type { ProviderType } from '../core/piece/index.js';
+
+describe('providerEventLogger', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `takt-provider-events-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should enable provider events by default', () => {
+    expect(isProviderEventsEnabled()).toBe(true);
+    expect(isProviderEventsEnabled({})).toBe(true);
+    expect(isProviderEventsEnabled({ observability: {} })).toBe(true);
+    expect(isProviderEventsEnabled({ observability: { providerEvents: true } })).toBe(true);
+  });
+
+  it('should disable provider events only when explicitly false', () => {
+    expect(isProviderEventsEnabled({ observability: { providerEvents: false } })).toBe(false);
+  });
+
+  it('should write normalized JSONL records when enabled', () => {
+    const logger = createProviderEventLogger({
+      logsDir: tempDir,
+      sessionId: 'session-1',
+      runId: 'run-1',
+      provider: 'opencode',
+      movement: 'implement',
+      enabled: true,
+    });
+
+    const original = vi.fn();
+    const wrapped = logger.wrapCallback(original);
+
+    wrapped({
+      type: 'tool_use',
+      data: {
+        tool: 'Read',
+        id: 'call-123',
+        messageId: 'msg-123',
+        requestId: 'req-123',
+        sessionID: 'session-abc',
+      },
+    });
+
+    expect(original).toHaveBeenCalledTimes(1);
+    expect(existsSync(logger.filepath)).toBe(true);
+
+    const lines = readFileSync(logger.filepath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+
+    const parsed = JSON.parse(lines[0]!) as {
+      provider: ProviderType;
+      event_type: string;
+      run_id: string;
+      movement: string;
+      session_id?: string;
+      call_id?: string;
+      message_id?: string;
+      request_id?: string;
+      data: Record<string, unknown>;
+    };
+
+    expect(parsed.provider).toBe('opencode');
+    expect(parsed.event_type).toBe('tool_use');
+    expect(parsed.run_id).toBe('run-1');
+    expect(parsed.movement).toBe('implement');
+    expect(parsed.session_id).toBe('session-abc');
+    expect(parsed.call_id).toBe('call-123');
+    expect(parsed.message_id).toBe('msg-123');
+    expect(parsed.request_id).toBe('req-123');
+    expect(parsed.data['tool']).toBe('Read');
+  });
+
+  it('should update movement and provider for subsequent events', () => {
+    const logger = createProviderEventLogger({
+      logsDir: tempDir,
+      sessionId: 'session-2',
+      runId: 'run-2',
+      provider: 'claude',
+      movement: 'plan',
+      enabled: true,
+    });
+
+    const wrapped = logger.wrapCallback();
+
+    wrapped({ type: 'init', data: { model: 'sonnet', sessionId: 's-1' } });
+    logger.setMovement('implement');
+    logger.setProvider('codex');
+    wrapped({ type: 'result', data: { result: 'ok', sessionId: 's-1', success: true } });
+
+    const lines = readFileSync(logger.filepath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+
+    const first = JSON.parse(lines[0]!) as { provider: ProviderType; movement: string };
+    const second = JSON.parse(lines[1]!) as { provider: ProviderType; movement: string };
+
+    expect(first.provider).toBe('claude');
+    expect(first.movement).toBe('plan');
+    expect(second.provider).toBe('codex');
+    expect(second.movement).toBe('implement');
+  });
+
+  it('should not write records when disabled', () => {
+    const logger = createProviderEventLogger({
+      logsDir: tempDir,
+      sessionId: 'session-3',
+      runId: 'run-3',
+      provider: 'claude',
+      movement: 'plan',
+      enabled: false,
+    });
+
+    const original = vi.fn();
+    const wrapped = logger.wrapCallback(original);
+    wrapped({ type: 'text', data: { text: 'hello' } });
+
+    expect(original).toHaveBeenCalledTimes(1);
+    expect(existsSync(logger.filepath)).toBe(false);
+  });
+
+  it('should truncate long text fields', () => {
+    const logger = createProviderEventLogger({
+      logsDir: tempDir,
+      sessionId: 'session-4',
+      runId: 'run-4',
+      provider: 'claude',
+      movement: 'plan',
+      enabled: true,
+    });
+
+    const wrapped = logger.wrapCallback();
+    const longText = 'a'.repeat(11_000);
+    wrapped({ type: 'text', data: { text: longText } });
+
+    const line = readFileSync(logger.filepath, 'utf-8').trim();
+    const parsed = JSON.parse(line) as { data: { text: string } };
+
+    expect(parsed.data.text.length).toBeLessThan(longText.length);
+    expect(parsed.data.text).toContain('...[truncated]');
+  });
+
+  it('should write init event records with typed data objects', () => {
+    const logger = createProviderEventLogger({
+      logsDir: tempDir,
+      sessionId: 'session-5',
+      runId: 'run-5',
+      provider: 'codex',
+      movement: 'implement',
+      enabled: true,
+    });
+
+    const wrapped = logger.wrapCallback();
+    wrapped({
+      type: 'init',
+      data: {
+        model: 'gpt-5-codex',
+        sessionId: 'thread-1',
+      },
+    });
+
+    const line = readFileSync(logger.filepath, 'utf-8').trim();
+    const parsed = JSON.parse(line) as {
+      provider: ProviderType;
+      event_type: string;
+      session_id?: string;
+      data: { model: string; sessionId: string };
+    };
+
+    expect(parsed.provider).toBe('codex');
+    expect(parsed.event_type).toBe('init');
+    expect(parsed.session_id).toBe('thread-1');
+    expect(parsed.data.model).toBe('gpt-5-codex');
+    expect(parsed.data.sessionId).toBe('thread-1');
+  });
+});

--- a/src/core/models/global-config.ts
+++ b/src/core/models/global-config.ts
@@ -20,6 +20,12 @@ export interface DebugConfig {
   logFile?: string;
 }
 
+/** Observability configuration for runtime event logs */
+export interface ObservabilityConfig {
+  /** Enable provider stream event logging (default: true when undefined) */
+  providerEvents?: boolean;
+}
+
 /** Language setting for takt */
 export type Language = 'en' | 'ja';
 
@@ -55,6 +61,7 @@ export interface GlobalConfig {
   provider?: 'claude' | 'codex' | 'opencode' | 'mock';
   model?: string;
   debug?: DebugConfig;
+  observability?: ObservabilityConfig;
   /** Directory for shared clones (worktree_dir in config). If empty, uses ../{clone-name} relative to project */
   worktreeDir?: string;
   /** Auto-create PR after worktree execution (default: prompt in interactive mode) */

--- a/src/core/models/index.ts
+++ b/src/core/models/index.ts
@@ -22,6 +22,7 @@ export type {
   PieceState,
   CustomAgentConfig,
   DebugConfig,
+  ObservabilityConfig,
   Language,
   PipelineConfig,
   GlobalConfig,

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -309,6 +309,10 @@ export const DebugConfigSchema = z.object({
   log_file: z.string().optional(),
 });
 
+export const ObservabilityConfigSchema = z.object({
+  provider_events: z.boolean().optional(),
+});
+
 /** Language setting schema */
 export const LanguageSchema = z.enum(['en', 'ja']);
 
@@ -341,6 +345,7 @@ export const GlobalConfigSchema = z.object({
   provider: z.enum(['claude', 'codex', 'opencode', 'mock']).optional().default('claude'),
   model: z.string().optional(),
   debug: DebugConfigSchema.optional(),
+  observability: ObservabilityConfigSchema.optional(),
   /** Directory for shared clones (worktree_dir in config). If empty, uses ../{clone-name} relative to project */
   worktree_dir: z.string().optional(),
   /** Auto-create PR after worktree execution (default: prompt in interactive mode) */

--- a/src/core/models/types.ts
+++ b/src/core/models/types.ts
@@ -45,6 +45,7 @@ export type {
 export type {
   CustomAgentConfig,
   DebugConfig,
+  ObservabilityConfig,
   Language,
   PipelineConfig,
   GlobalConfig,

--- a/src/infra/config/global/globalConfig.ts
+++ b/src/infra/config/global/globalConfig.ts
@@ -105,6 +105,9 @@ export class GlobalConfigManager {
         enabled: parsed.debug.enabled,
         logFile: parsed.debug.log_file,
       } : undefined,
+      observability: parsed.observability ? {
+        providerEvents: parsed.observability.provider_events,
+      } : undefined,
       worktreeDir: parsed.worktree_dir,
       autoPr: parsed.auto_pr,
       disabledBuiltins: parsed.disabled_builtins,
@@ -156,6 +159,11 @@ export class GlobalConfigManager {
       raw.debug = {
         enabled: config.debug.enabled,
         log_file: config.debug.logFile,
+      };
+    }
+    if (config.observability && config.observability.providerEvents !== undefined) {
+      raw.observability = {
+        provider_events: config.observability.providerEvents,
       };
     }
     if (config.worktreeDir) {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -5,6 +5,7 @@
 export * from './debug.js';
 export * from './error.js';
 export * from './notification.js';
+export * from './providerEventLogger.js';
 export * from './reportDir.js';
 export * from './sleep.js';
 export * from './slug.js';

--- a/src/shared/utils/providerEventLogger.ts
+++ b/src/shared/utils/providerEventLogger.ts
@@ -1,0 +1,137 @@
+import { appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ProviderType, StreamCallback, StreamEvent } from '../../core/piece/index.js';
+
+export interface ProviderEventLoggerConfig {
+  logsDir: string;
+  sessionId: string;
+  runId: string;
+  provider: ProviderType;
+  movement: string;
+  enabled: boolean;
+}
+
+export interface ProviderEventLogger {
+  readonly filepath: string;
+  setMovement(movement: string): void;
+  setProvider(provider: ProviderType): void;
+  wrapCallback(original?: StreamCallback): StreamCallback;
+}
+
+interface ProviderEventLogRecord {
+  timestamp: string;
+  provider: ProviderType;
+  event_type: string;
+  run_id: string;
+  movement: string;
+  session_id?: string;
+  message_id?: string;
+  call_id?: string;
+  request_id?: string;
+  data: Record<string, unknown>;
+}
+
+const MAX_TEXT_LENGTH = 10_000;
+const HEAD_LENGTH = 5_000;
+const TAIL_LENGTH = 2_000;
+const TRUNCATED_MARKER = '...[truncated]';
+
+function truncateString(value: string): string {
+  if (value.length <= MAX_TEXT_LENGTH) {
+    return value;
+  }
+  return value.slice(0, HEAD_LENGTH) + TRUNCATED_MARKER + value.slice(-TAIL_LENGTH);
+}
+
+function sanitizeData(data: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(data).map(([key, value]) => {
+      if (typeof value === 'string') {
+        return [key, truncateString(value)];
+      }
+      return [key, value];
+    })
+  );
+}
+
+function pickString(source: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function buildLogRecord(
+  event: StreamEvent,
+  provider: ProviderType,
+  movement: string,
+  runId: string,
+): ProviderEventLogRecord {
+  const data = sanitizeData(event.data as unknown as Record<string, unknown>);
+  const sessionId = pickString(data, ['session_id', 'sessionId', 'sessionID', 'thread_id', 'threadId']);
+  const messageId = pickString(data, ['message_id', 'messageId', 'item_id', 'itemId']);
+  const callId = pickString(data, ['call_id', 'callId', 'id']);
+  const requestId = pickString(data, ['request_id', 'requestId']);
+
+  return {
+    timestamp: new Date().toISOString(),
+    provider,
+    event_type: event.type,
+    run_id: runId,
+    movement,
+    ...(sessionId ? { session_id: sessionId } : {}),
+    ...(messageId ? { message_id: messageId } : {}),
+    ...(callId ? { call_id: callId } : {}),
+    ...(requestId ? { request_id: requestId } : {}),
+    data,
+  };
+}
+
+export function createProviderEventLogger(config: ProviderEventLoggerConfig): ProviderEventLogger {
+  const filepath = join(config.logsDir, `${config.sessionId}-provider-events.jsonl`);
+  let movement = config.movement;
+  let provider = config.provider;
+
+  const write = (event: StreamEvent): void => {
+    try {
+      const record = buildLogRecord(event, provider, movement, config.runId);
+      appendFileSync(filepath, JSON.stringify(record) + '\n', 'utf-8');
+    } catch {
+      // Silently fail - observability logging should not interrupt main flow.
+    }
+  };
+
+  return {
+    filepath,
+    setMovement(nextMovement: string): void {
+      movement = nextMovement;
+    },
+    setProvider(nextProvider: ProviderType): void {
+      provider = nextProvider;
+    },
+    wrapCallback(original?: StreamCallback): StreamCallback {
+      if (!config.enabled && original) {
+        return original;
+      }
+      if (!config.enabled) {
+        return () => {};
+      }
+
+      return (event: StreamEvent): void => {
+        write(event);
+        original?.(event);
+      };
+    },
+  };
+}
+
+export function isProviderEventsEnabled(config?: {
+  observability?: {
+    providerEvents?: boolean;
+  };
+}): boolean {
+  return config?.observability?.providerEvents !== false;
+}


### PR DESCRIPTION
## Summary

## 背景
OpenCode 実行時のハング調査で、ストリームイベントの観測性不足がボトルネックになっている。
同種の問題は Codex/Claude 側でも再現し得るため、provider 依存の個別対応ではなく共通仕様として定義・実装したい。

## 目的
Claude / Codex / OpenCode の各プロバイダーで、実行中に受信したイベントを**専用ログファイル**へ一貫フォーマットで記録し、停止箇所の特定を容易にする。

## 要件
- デフォルトは `ON`（イベントログを常時記録）
- 設定で明示的に `OFF` 可能
- 既存 `debug.enabled` とは独立したトグルにする
- 3プロバイダー（claude/codex/opencode）を対象に同一方針で適用
- **標準出力には出さない**（運用ログ汚染を防ぐ）

## 設定仕様
`~/.takt/config.yaml`
```yaml
observability:
  provider_events: true  # default: true
```

## 出力仕様
- 出力先: **専用ファイル（JSONL）**
- 既存 run ディレクトリ配下に配置（例: `.takt/runs/<run-id>/logs/<session-id>-provider-events.jsonl`）
- 1イベント1行、共通フォーマット
- 最低限含める項目:
  - timestamp
  - provider
  - event_type
  - session_id（あれば）
  - message_id / call_id / request_id（あれば）
  - run_id / movement（突合用）

例:
```json
{"timestamp":"2026-02-11T13:00:00.000Z","provider":"opencode","event_type":"session.status","session_id":"...","status":"busy","run_id":"...","movement":"plan"}
{"timestamp":"2026-02-11T13:00:01.000Z","provider":"codex","event_type":"item.completed","thread_id":"...","item_id":"...","run_id":"...","movement":"implement"}
```

## 突合要件
- 既存の prompt/response jsonl（`*-prompts.jsonl`）と時刻・session_id 等で突合可能であること
- 同一 run 内で「イベント専用 jsonl」と「既存 jsonl」の相互参照ができること

## 実装方針
- provider ごとに個別ログ実装を増やさない
- `src/shared` 配下に共通 Provider Event Logger を追加し、各 provider adapter から呼ぶ
- フィールド名正規化（`sessionID` / `thread_id` など差異を吸収）
- DRY を維持し、ロガーのI/Oと正規化を集約する

## 受け入れ条件
- `provider_events: true` で 3 provider すべてイベントが専用 jsonl に記録される
- `provider_events: false` で 3 provider とも記録されない
- 既存の `debug.enabled` の ON/OFF に影響されない
- 標準出力にイベント行が出ない
- 単体テストで ON/OFF と出力フォーマットを検証

## 非目標
- フォールバック追加
- 後方互換のための複雑な分岐追加
- provider ごとの独自ログ仕様の増殖


## Execution Report

Piece `default` completed successfully.

Closes #236