### PR TITLE
github-issue-238-fix-opencode

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -218,7 +218,7 @@ describe('OpenCodeClient stream cleanup', () => {
     );
   });
 
-  it('should fail fast when question.asked is received without handler', async () => {
+  it('should reject question.asked without handler and continue processing', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([
       {
@@ -234,6 +234,17 @@ describe('OpenCodeClient stream cleanup', () => {
             },
           ],
         },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: { id: 'p-q1', type: 'text', text: 'continued response' },
+          delta: 'continued response',
+        },
+      },
+      {
+        type: 'session.idle',
+        properties: { sessionID: 'session-4' },
       },
     ]);
 
@@ -260,8 +271,8 @@ describe('OpenCodeClient stream cleanup', () => {
       model: 'opencode/big-pickle',
     });
 
-    expect(result.status).toBe('error');
-    expect(result.content).toContain('no question handler');
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('continued response');
     expect(questionReject).toHaveBeenCalledWith(
       {
         requestID: 'q-1',

--- a/src/__tests__/opencode-stream-handler.test.ts
+++ b/src/__tests__/opencode-stream-handler.test.ts
@@ -12,6 +12,7 @@ import {
   emitToolResult,
   emitResult,
   handlePartUpdated,
+  type OpenCodeStreamEvent,
   type OpenCodeTextPart,
   type OpenCodeReasoningPart,
   type OpenCodeToolPart,
@@ -349,5 +350,37 @@ describe('handlePartUpdated', () => {
 
     const part: OpenCodeTextPart = { id: 'p1', type: 'text', text: 'Hello' };
     handlePartUpdated(part, 'Hello', undefined, state);
+  });
+});
+
+describe('OpenCodeStreamEvent typing', () => {
+  it('should accept message.completed event shape', () => {
+    const event: OpenCodeStreamEvent = {
+      type: 'message.completed',
+      properties: {
+        info: {
+          sessionID: 'session-1',
+          role: 'assistant',
+          error: undefined,
+        },
+      },
+    };
+
+    expect(event.type).toBe('message.completed');
+  });
+
+  it('should accept message.failed event shape', () => {
+    const event: OpenCodeStreamEvent = {
+      type: 'message.failed',
+      properties: {
+        info: {
+          sessionID: 'session-2',
+          role: 'assistant',
+          error: { message: 'failed' },
+        },
+      },
+    };
+
+    expect(event.type).toBe('message.failed');
   });
 });

--- a/src/infra/opencode/OpenCodeStreamHandler.ts
+++ b/src/infra/opencode/OpenCodeStreamHandler.ts
@@ -75,6 +75,28 @@ export interface OpenCodeMessageUpdatedEvent {
   };
 }
 
+export interface OpenCodeMessageCompletedEvent {
+  type: 'message.completed';
+  properties: {
+    info: {
+      sessionID: string;
+      role: 'assistant' | 'user';
+      error?: unknown;
+    };
+  };
+}
+
+export interface OpenCodeMessageFailedEvent {
+  type: 'message.failed';
+  properties: {
+    info: {
+      sessionID: string;
+      role: 'assistant' | 'user';
+      error?: unknown;
+    };
+  };
+}
+
 export interface OpenCodePermissionAskedEvent {
   type: 'permission.asked';
   properties: {
@@ -107,6 +129,8 @@ export interface OpenCodeQuestionAskedEvent {
 export type OpenCodeStreamEvent =
   | OpenCodeMessagePartUpdatedEvent
   | OpenCodeMessageUpdatedEvent
+  | OpenCodeMessageCompletedEvent
+  | OpenCodeMessageFailedEvent
   | OpenCodeSessionStatusEvent
   | OpenCodeSessionIdleEvent
   | OpenCodeSessionErrorEvent

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -411,9 +411,7 @@ export class OpenCodeClient {
                   OPENCODE_INTERACTION_TIMEOUT_MS,
                   'OpenCode question reject timed out',
                 );
-                success = false;
-                failureMessage = 'OpenCode asked a question, but no question handler is configured';
-                break;
+                continue;
               }
 
               try {


### PR DESCRIPTION
## Summary

## 概要

opencode プロバイダーのイベントハンドリングに不足・不整合がある。TAKT は非対話で動作するため、対話を要求するイベントで実行が中断されるべきではない。

## 関連 Issue

- #236 (プロバイダー共通のイベント可視化ログ導入)
  - 本 Issue の「`session.status` retry のログ出力」は #236 の共通 Provider Event Logger 経由で記録する。個別に `log.info` を足さず、#236 のロガーに乗せる。
  - 型定義の補完（本 Issue の 3.）は #236 の実装時にも有用（イベントの正規化が正確になる）。

## 問題点

### 1. `question.asked` のハンドラ無し時に実行が失敗する

`src/infra/opencode/client.ts:402-445`

ハンドラが未設定の場合、question を reject した上で `success = false` → `break` となり、実行全体が失敗扱いになる。TAKT は非対話実行が前提なので、reject して**続行**すべき。

```typescript
// 現状: reject → fail → break（実行中断）
success = false;
failureMessage = 'OpenCode asked a question, but no question handler is configured';
break;
```

### 2. `session.status` の `retry` 状態がサイレント

`session.status` イベントの `type: 'retry'` 時に `attempt` / `message` / `next` フィールドがあるにもかかわらず、何もログ出力せずスルーしている。opencode がリトライ中であることを把握できない。

**→ #236 の共通 Provider Event Logger で対応する。** 個別の `log.info` ではなくロガー経由で記録。

### 3. `message.completed` / `message.failed` が型定義に欠落

`src/infra/opencode/OpenCodeStreamHandler.ts` の `OpenCodeStreamEvent` union に `message.completed` と `message.failed` が定義されておらず、catch-all の `{ type: string; properties: Record<string, unknown> }` に落ちている。機能上は問題ないが型安全性が欠ける。

## 対応方針

| # | 内容 | 依存 |
|---|------|------|
| 1 | `question.asked`（ハンドラ無し）: reject して `continue`（break しない、success を false にしない） | 単独で対応可 |
| 2 | `session.status` の `retry`: #236 の共通ロガーで記録 | #236 の完了後 |
| 3 | `message.completed` / `message.failed` を `OpenCodeStreamEvent` union に追加 | 単独で対応可 |

## 実装順序

- 1 と 3 は #236 と無関係に先行実装できる
- 2 は #236 完了後に対応

## Execution Report

Piece `default` completed successfully.

Closes #238