### PR TITLE
fix: pin @opencode-ai/sdk to <1.2.7 to fix broken v2 exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.47",
     "@openai/codex-sdk": "^0.103.0",
-    "@opencode-ai/sdk": "^1.1.53",
+    "@opencode-ai/sdk": ">=1.1.53 <1.2.7",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "update-notifier": "^7.3.1",


### PR DESCRIPTION
## Problem

`npm install -g takt` followed by `takt --version` fails with:

```
Failed to load TAKT CLI. Have you run "npm run build"?
Cannot find module '.../node_modules/@opencode-ai/sdk/dist/v2/index.js'
imported from .../dist/infra/opencode/client.js
```

## Root Cause

`@opencode-ai/sdk` versions **1.2.7, 1.2.8, 1.2.9** have a broken build artifact. The package's `exports` field maps `./v2` to `./dist/v2/index.js`, but the actual files are placed under `./dist/src/v2/` instead of `./dist/v2/`.

| SDK Version | `dist/v2/index.js` exists? |
|---|---|
| 1.1.53 | Yes |
| 1.2.0 – 1.2.6 | Yes |
| **1.2.7 – 1.2.9** | **No (broken)** |

Since takt's `package.json` specifies `"@opencode-ai/sdk": "^1.1.53"`, npm resolves to the latest 1.2.9 which is broken.

## Fix

Pin the depe
`npm install -g takt` followed by `takt --version` fails with:

```
Failed to load TAKT CLI. Have you run "npm run build"?
Cannot find module '.../node_modules/@opencode-ai/sdk/dist/v2/index.js'
import`@
```
Failed to load TAKT CLI. Have you run "npm run build"?
s