### PR TITLE
tasuku-takt-list-komandoni-iss

### DIFF
--- a/src/__tests__/taskStatusLabel.test.ts
+++ b/src/__tests__/taskStatusLabel.test.ts
@@ -37,6 +37,30 @@ describe('formatTaskStatusLabel', () => {
     const task = makeTask({ kind: 'running', name: 'my-task' });
     expect(formatTaskStatusLabel(task)).toBe('[running] my-task');
   });
+
+  it('should include issue number when present', () => {
+    const task = makeTask({
+      kind: 'pending',
+      name: 'implement-feature',
+      issueNumber: 32,
+    });
+    expect(formatTaskStatusLabel(task)).toBe('[pending] implement-feature #32');
+  });
+
+  it('should include issue number with branch when both present', () => {
+    const task = makeTask({
+      kind: 'completed',
+      name: 'fix-bug',
+      issueNumber: 42,
+      branch: 'takt/42/fix-bug',
+    });
+    expect(formatTaskStatusLabel(task)).toBe('[completed] fix-bug #42 (takt/42/fix-bug)');
+  });
+
+  it('should not include issue number when absent', () => {
+    const task = makeTask({ kind: 'pending', name: 'my-task' });
+    expect(formatTaskStatusLabel(task)).toBe('[pending] my-task');
+  });
 });
 
 describe('formatShortDate', () => {

--- a/src/features/tasks/list/taskStatusLabel.ts
+++ b/src/features/tasks/list/taskStatusLabel.ts
@@ -8,7 +8,10 @@ const TASK_STATUS_BY_KIND: Record<TaskListItem['kind'], string> = {
 };
 
 export function formatTaskStatusLabel(task: TaskListItem): string {
-  const status = `[${TASK_STATUS_BY_KIND[task.kind]}] ${task.name}`;
+  let status = `[${TASK_STATUS_BY_KIND[task.kind]}] ${task.name}`;
+  if (task.issueNumber !== undefined) {
+    status += ` #${task.issueNumber}`;
+  }
   if (task.branch) {
     return `${status} (${task.branch})`;
   }

--- a/src/infra/task/mapper.ts
+++ b/src/infra/task/mapper.ts
@@ -127,6 +127,7 @@ function toBaseTaskListItem(projectDir: string, tasksFile: string, task: TaskRec
     completedAt: task.completed_at ?? undefined,
     ownerPid: task.owner_pid ?? undefined,
     data: toTaskData(projectDir, task),
+    issueNumber: task.issue,
   };
 }
 

--- a/src/infra/task/types.ts
+++ b/src/infra/task/types.ts
@@ -92,4 +92,5 @@ export interface TaskListItem {
   startedAt?: string;
   completedAt?: string;
   ownerPid?: number;
+  issueNumber?: number;
 }


### PR DESCRIPTION
## Summary

`takt list` コマンドに Issue 番号を表示する機能を追加する。

### 変更内容

- `TaskListItem` に `issueNumber` フィールドを追加
- タスクマッパーで `task.issue` を `issueNumber` にマッピング
- `formatTaskStatusLabel` で Issue 番号を表示（例: `[pending] my-task #32`）
- テスト 3 ケース追加

### 背景

現在 `takt list` の出力に Issue 番号が表示されておらず、タスクの由来がわかりにくい。Issue から作成したタスクについては Issue 番号を表示し、Issue に紐づかないタスクには表示しない。

Closes #331