### PR TITLE
Release v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.20.1] - 2026-02-20
+
+### Fixed
+
+- Pin `@opencode-ai/sdk` to `<1.2.7` to fix broken v2 exports that caused `Cannot find module` errors on `npm install -g takt` (#329)
+
 ## [0.20.0] - 2026-02-19
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.20.1] - 2026-02-20
+
+### Fixed
+
+- `@opencode-ai/sdk` を `<1.2.7` にピン留め — v1.2.7 以降のビルド成果物で v2 exports が壊れており、`npm install -g takt` 時に `Cannot find module` エラーが発生する問題を修正 (#329)
+
 ## [0.20.0] - 2026-02-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "takt",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.47",
         "@openai/codex-sdk": "^0.103.0",
-        "@opencode-ai/sdk": "^1.1.53",
+        "@opencode-ai/sdk": ">=1.1.53 <1.2.7",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "update-notifier": "^7.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Fixed

- Pin `@opencode-ai/sdk` to `<1.2.7` to fix broken v2 exports that caused `Cannot find module` errors on `npm install -g takt` (#329)

## Commits

- 26372c0 fix: pin @opencode-ai/sdk to <1.2.7 to fix broken v2 exports
- 3624636 Release v0.20.1

## Closes

Closes #329