### PR TITLE
tasuku-issue-notaitoru-wo-shi

### DIFF
--- a/src/app/cli/routing.ts
+++ b/src/app/cli/routing.ts
@@ -216,7 +216,7 @@ export async function executeDefaultAction(task?: string): Promise<void> {
       await selectAndExecuteTask(resolvedCwd, confirmedTask, selectOptions, agentOverrides);
     },
     create_issue: async ({ task: confirmedTask }) => {
-      const issueNumber = createIssueFromTask(confirmedTask);
+      const issueNumber = await createIssueFromTask(confirmedTask, { cwd: resolvedCwd });
       if (issueNumber !== undefined) {
         await saveTaskFromInteractive(resolvedCwd, confirmedTask, pieceId, {
           issue: issueNumber,

--- a/src/infra/github/index.ts
+++ b/src/infra/github/index.ts
@@ -12,6 +12,7 @@ export {
   isIssueReference,
   resolveIssueTask,
   createIssue,
+  generateIssueTitle,
 } from './issue.js';
 
 export type { ExistingPr } from './pr.js';

--- a/src/shared/prompts/en/issue_title_system_prompt.md
+++ b/src/shared/prompts/en/issue_title_system_prompt.md
@@ -1,0 +1,20 @@
+<!--
+  template: issue_title_system_prompt
+  role: system prompt for GitHub issue title generation
+  vars: (none - task is passed as user message)
+  caller: infra/github/issue
+-->
+You are a GitHub issue title generator. Given a task description, generate a concise and descriptive title suitable for a GitHub issue.
+
+Guidelines:
+- Keep titles short but informative (under 100 characters)
+- Use clear, action-oriented language
+- Include key nouns (what is being changed/fixed)
+- Avoid unnecessary words like "the", "a", "an"
+- Start with a verb when possible: Fix, Add, Update, Implement, Remove, etc.
+
+Examples:
+Task → Title:
+"認証 기능을 추가해야 합니다. 사용자가 이메일을 통해 인증할 수 있어야 합니다." → Add email authentication
+"Fix the login bug where users cannot sign in with Google" → Fix Google login bug
+"データベースの接続設定を環境ごとに設定できるようにする" → Add environment-specific database config

--- a/src/shared/prompts/en/issue_title_user_prompt.md
+++ b/src/shared/prompts/en/issue_title_user_prompt.md
@@ -1,0 +1,12 @@
+<!--
+  template: issue_title_user_prompt
+  role: user prompt for GitHub issue title generation
+  vars: taskDescription
+  caller: infra/github/issue
+-->
+Generate a GitHub issue title from the task description below.
+Output ONLY the title text (no explanation, no quotes).
+
+<task_description>
+{{taskDescription}}
+</task_description>

--- a/src/shared/prompts/ja/issue_title_system_prompt.md
+++ b/src/shared/prompts/ja/issue_title_system_prompt.md
@@ -1,0 +1,20 @@
+<!--
+  template: issue_title_system_prompt
+  role: system prompt for GitHub issue title generation
+  vars: (none - task is passed as user message)
+  caller: infra/github/issue
+-->
+You are a GitHub issue title generator. Given a task description, generate a concise and descriptive title suitable for a GitHub issue.
+
+Guidelines:
+- Keep titles short but informative (under 100 characters)
+- Use clear, action-oriented language
+- Include key nouns (what is being changed/fixed)
+- Avoid unnecessary words like "the", "a", "an"
+- Start with a verb when possible: Fix, Add, Update, Implement, Remove, etc.
+
+Examples:
+Task → Title:
+"認証 기능을 추가해야 합니다. 사용자가 이메일을 통해 인증할 수 있어야 합니다." → Add email authentication
+"Fix the login bug where users cannot sign in with Google" → Fix Google login bug
+"データベースの接続設定を環境ごとに設定できるようにする" → Add environment-specific database config

--- a/src/shared/prompts/ja/issue_title_user_prompt.md
+++ b/src/shared/prompts/ja/issue_title_user_prompt.md
@@ -1,0 +1,12 @@
+<!--
+  template: issue_title_user_prompt
+  role: user prompt for GitHub issue title generation
+  vars: taskDescription
+  caller: infra/github/issue
+-->
+Generate a GitHub issue title from the task description below.
+Output ONLY the title text (no explanation, no quotes).
+
+<task_description>
+{{taskDescription}}
+</task_description>


### PR DESCRIPTION
## Summary

# タスク指示書

## 概要
Issue作成時のタイトル生成処理を変更し、タスク指示書の全文をそのままタイトルにするのではなく、Issueにふさわしい要約タイトルを生成させる。

## 背景
現在、Issue作成時にAIがタスク指示書の全文をそのままタイトルに設定してしまう問題がある。GitHubのIssueタイトルとして適切な長さ・内容の名前に要約する機能が求められている。

## 変更要件

### 優先度高
- Issue作成フローの特定
  - どこでタイトルが設定されているか調査
  - 関連するファイル・モジュールを特定

### 優先度中
- タイトル生成ロジックの実装
  - タスク指示書を要約し、Issueにふさわしいタイトルを生成
  - 要約は簡潔かつ内容がわかるもの（GitHubのIssueタイトルとして適切）

### 優先度低
- テスト追加
  - 新しいタイトル生成ロジックのテスト

## 制約
- ユーザーが明示したタイトル入力がない場合（自動生成時）のみ対象
- ユーザー指定のタイトルがある場合はその値を優先

## Open Questions
- Structured Output如何使用するか確認が必要（モデル依存）
- 要約の長さは何文字程度が適切か確認が必要

## Execution Report

Piece `default` completed successfully.

Closes #333