### PR TITLE
feat: opt-in auto_fetch and base_branch config for clone

### DIFF
--- a/src/__tests__/pipelineExecution.test.ts
+++ b/src/__tests__/pipelineExecution.test.ts
@@ -34,6 +34,7 @@ vi.mock('../features/tasks/index.js', () => ({
 const mockResolveConfigValues = vi.fn();
 vi.mock('../infra/config/index.js', () => ({
   resolveConfigValues: mockResolveConfigValues,
+  resolveConfigValue: vi.fn(() => undefined),
 }));
 
 // Mock execFileSync for git operations

--- a/src/core/models/persisted-global-config.ts
+++ b/src/core/models/persisted-global-config.ts
@@ -123,6 +123,10 @@ export interface PersistedGlobalConfig {
   concurrency: number;
   /** Polling interval in ms for picking up new tasks during takt run (default: 500, range: 100-5000) */
   taskPollIntervalMs: number;
+  /** Opt-in: fetch remote before cloning to keep clones up-to-date (default: false) */
+  autoFetch?: boolean;
+  /** Base branch to clone from (default: current branch) */
+  baseBranch?: string;
 }
 
 /** Project-level configuration */
@@ -132,4 +136,6 @@ export interface ProjectConfig {
   providerOptions?: MovementProviderOptions;
   /** Provider-specific permission profiles */
   providerProfiles?: ProviderPermissionProfiles;
+  /** Base branch to clone from (overrides global baseBranch) */
+  baseBranch?: string;
 }

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -481,6 +481,10 @@ export const GlobalConfigSchema = z.object({
   concurrency: z.number().int().min(1).max(10).optional().default(1),
   /** Polling interval in ms for picking up new tasks during takt run (default: 500, range: 100-5000) */
   task_poll_interval_ms: z.number().int().min(100).max(5000).optional().default(500),
+  /** Opt-in: fetch remote before cloning to keep clones up-to-date (default: false) */
+  auto_fetch: z.boolean().optional().default(false),
+  /** Base branch to clone from (default: current branch) */
+  base_branch: z.string().optional(),
 });
 
 /** Project config schema */
@@ -489,4 +493,6 @@ export const ProjectConfigSchema = z.object({
   provider: z.enum(['claude', 'codex', 'opencode', 'mock']).optional(),
   provider_options: MovementProviderOptionsSchema,
   provider_profiles: ProviderPermissionProfilesSchema,
+  /** Base branch to clone from (overrides global base_branch) */
+  base_branch: z.string().optional(),
 });

--- a/src/features/pipeline/execute.ts
+++ b/src/features/pipeline/execute.ts
@@ -19,7 +19,7 @@ import {
   buildPrBody,
   type GitHubIssue,
 } from '../../infra/github/index.js';
-import { stageAndCommit, getCurrentBranch } from '../../infra/task/index.js';
+import { stageAndCommit, resolveBaseBranch } from '../../infra/task/index.js';
 import { executeTask, type TaskExecutionOptions, type PipelineExecutionOptions } from '../tasks/index.js';
 import { resolveConfigValues } from '../../infra/config/index.js';
 import { info, error, success, status, blankLine } from '../../shared/ui/index.js';
@@ -134,11 +134,12 @@ export async function executePipeline(options: PipelineExecutionOptions): Promis
     return EXIT_ISSUE_FETCH_FAILED;
   }
 
-  // --- Step 2: Create branch (skip if --skip-git) ---
+  // --- Step 2: Sync & create branch (skip if --skip-git) ---
   let branch: string | undefined;
   let baseBranch: string | undefined;
   if (!skipGit) {
-    baseBranch = getCurrentBranch(cwd);
+    const resolved = resolveBaseBranch(cwd);
+    baseBranch = resolved.branch;
     branch = options.branch ?? generatePipelineBranchName(pipelineConfig, options.issueNumber);
     info(`Creating branch: ${branch}`);
     try {

--- a/src/infra/config/env/config-env-overrides.ts
+++ b/src/infra/config/env/config-env-overrides.ts
@@ -124,6 +124,8 @@ const GLOBAL_ENV_SPECS: readonly EnvSpec[] = [
   { path: 'verbose', type: 'boolean' },
   { path: 'concurrency', type: 'number' },
   { path: 'task_poll_interval_ms', type: 'number' },
+  { path: 'auto_fetch', type: 'boolean' },
+  { path: 'base_branch', type: 'string' },
 ];
 
 const PROJECT_ENV_SPECS: readonly EnvSpec[] = [
@@ -140,6 +142,7 @@ const PROJECT_ENV_SPECS: readonly EnvSpec[] = [
   { path: 'provider_options.claude.sandbox.allow_unsandboxed_commands', type: 'boolean' },
   { path: 'provider_options.claude.sandbox.excluded_commands', type: 'json' },
   { path: 'provider_profiles', type: 'json' },
+  { path: 'base_branch', type: 'string' },
 ];
 
 export function applyGlobalConfigEnvOverrides(target: Record<string, unknown>): void {

--- a/src/infra/config/global/globalConfig.ts
+++ b/src/infra/config/global/globalConfig.ts
@@ -220,6 +220,8 @@ export class GlobalConfigManager {
       verbose: parsed.verbose,
       concurrency: parsed.concurrency,
       taskPollIntervalMs: parsed.task_poll_interval_ms,
+      autoFetch: parsed.auto_fetch,
+      baseBranch: parsed.base_branch,
     };
     validateProviderModelCompatibility(config.provider, config.model);
     this.cachedConfig = config;
@@ -349,6 +351,12 @@ export class GlobalConfigManager {
     }
     if (config.taskPollIntervalMs !== undefined && config.taskPollIntervalMs !== 500) {
       raw.task_poll_interval_ms = config.taskPollIntervalMs;
+    }
+    if (config.autoFetch !== undefined) {
+      raw.auto_fetch = config.autoFetch;
+    }
+    if (config.baseBranch) {
+      raw.base_branch = config.baseBranch;
     }
     writeFileSync(configPath, stringifyYaml(raw), 'utf-8');
     this.invalidateCache();

--- a/src/infra/config/resolveConfigValue.ts
+++ b/src/infra/config/resolveConfigValue.ts
@@ -79,6 +79,8 @@ const RESOLUTION_REGISTRY: Partial<{ [K in ConfigParameterKey]: ResolutionRule<K
   draftPr: { layers: ['local', 'global'] },
   analytics: { layers: ['local', 'global'], mergeMode: 'analytics' },
   verbose: { layers: ['local', 'global'], defaultValue: false },
+  autoFetch: { layers: ['global'], defaultValue: false },
+  baseBranch: { layers: ['local', 'global'] },
 };
 
 function resolveAnalyticsMerged(
@@ -128,6 +130,8 @@ function getLocalLayerValue<K extends ConfigParameterKey>(
       return project.providerOptions as LoadedConfig[K] | undefined;
     case 'providerProfiles':
       return project.providerProfiles as LoadedConfig[K] | undefined;
+    case 'baseBranch':
+      return (project as Record<string, unknown>).base_branch as LoadedConfig[K] | undefined;
     default:
       return undefined;
   }

--- a/src/infra/task/index.ts
+++ b/src/infra/task/index.ts
@@ -44,6 +44,7 @@ export {
   saveCloneMeta,
   removeCloneMeta,
   cleanupOrphanedClone,
+  resolveBaseBranch,
 } from './clone.js';
 export {
   detectDefaultBranch,


### PR DESCRIPTION
## Summary

Replace the always-on `syncDefaultBranch` with opt-in `resolveBaseBranch`.

Addresses the review feedback: opt-in behavior, no local branch modifications, configurable base branch.

## Changes

| Item | Before | After |
|---|---|---|
| Default | Always sync | **Opt-in** (`auto_fetch: true`) |
| Local branches | `merge --ff-only` / ref overwrite | **Fetch only** (`git fetch origin`), local refs untouched |
| Base branch | Remote default (`symbolic-ref`) | Config `base_branch` → **current branch** fallback |
| Clone start point | Updated local branch | `git reset --hard <fetched_hash>` in clone |

## Config

```yaml
# ~/.takt/config.yaml (global) or .takt/config.yaml (project)
auto_fetch: true        # opt-in remote fetch before clone
base_branch: develop    # base branch for cloning (default: current branch)
```

`base_branch` supports project-level override (e.g., develop-based repos can set it in `.takt/config.yaml`).

## How it works

1. `resolveBaseBranch(projectDir)` determines the base branch:
   - Config `base_branch` → current branch (fallback)
2. If `auto_fetch: true`:
   - `git fetch origin` (no local branch changes)
   - `git rev-parse origin/<baseBranch>` to get the latest commit hash
3. Clone from the base branch, then `git reset --hard <hash>` to the fetched commit
4. All failures are non-fatal — continues with local state

## Files changed (10)

- `src/core/models/schemas.ts` — Add `auto_fetch`, `base_branch` to GlobalConfigSchema and ProjectConfigSchema
- `src/core/models/persisted-global-config.ts` — Add `autoFetch`, `baseBranch` to PersistedGlobalConfig and ProjectConfig
- `src/infra/config/global/globalConfig.ts` — Load/save `autoFetch`, `baseBranch`
- `src/infra/config/resolveConfigValue.ts` — Register `autoFetch` (global-only) and `baseBranch` (local+global)
- `src/infra/config/env/config-env-overrides.ts` — Add env override support
- `src/infra/task/clone.ts` — Replace `syncDefaultBranch` with `resolveBaseBranch`
- `src/infra/task/index.ts` — Update export
- `src/features/pipeline/execute.ts` — Use `resolveBaseBranch`
- `src/__tests__/clone.test.ts` — Rewrite tests for new behavior
- `src/__tests__/pipelineExecution.test.ts` — Add `resolveConfigValue` mock

## Testing

All 2621 unit tests pass.
