### PR TITLE
Fix #268: OpenCode providerを指定してtaktを起動するとバリデーションエラーになる。providerに'opencode'を指定した場合、modelが'provider/model'形式でなくてもエラーにしないようにする。OpenCodeプロバイダーのバリデーションロジックを修正する。

### DIFF
--- a/src/__tests__/globalConfig-defaults.test.ts
+++ b/src/__tests__/globalConfig-defaults.test.ts
@@ -559,7 +559,7 @@ describe('loadGlobalConfig', () => {
         'utf-8',
       );
 
-      expect(() => loadGlobalConfig()).toThrow(/requires model/);
+      expect(() => loadGlobalConfig()).toThrow(/requires a model/);
     });
 
     it('should not throw when persona entry has opencode provider with compatible model', () => {
@@ -740,10 +740,10 @@ describe('loadGlobalConfig', () => {
         'utf-8',
       );
 
-      expect(() => loadGlobalConfig()).toThrow(/provider 'opencode' requires model in 'provider\/model' format/i);
+      expect(() => loadGlobalConfig()).toThrow(/provider 'opencode' requires a model/i);
     });
 
-    it('should throw when provider is opencode and model is not provider/model format', () => {
+    it('should allow any model string when provider is opencode', () => {
       const taktDir = join(testHomeDir, '.takt');
       mkdirSync(taktDir, { recursive: true });
       writeFileSync(
@@ -752,7 +752,7 @@ describe('loadGlobalConfig', () => {
         'utf-8',
       );
 
-      expect(() => loadGlobalConfig()).toThrow(/must be in 'provider\/model' format/i);
+      expect(() => loadGlobalConfig()).not.toThrow();
     });
   });
 });

--- a/src/__tests__/pipelineExecution.test.ts
+++ b/src/__tests__/pipelineExecution.test.ts
@@ -283,6 +283,55 @@ describe('executePipeline', () => {
     );
   });
 
+  it('issue 番号が指定された場合、PR title に issue 番号を含む', async () => {
+    mockExecuteTask.mockResolvedValueOnce(true);
+    mockCreatePullRequest.mockReturnValueOnce({ success: true, url: 'https://github.com/test/pr/1' });
+    mockFetchIssue.mockReturnValueOnce({
+      number: 123,
+      title: 'Test Issue Title',
+      body: 'Issue body',
+      labels: [],
+      comments: [],
+    });
+
+    const exitCode = await executePipeline({
+      piece: 'default',
+      issueNumber: 123,
+      branch: 'fix/my-branch',
+      autoPr: true,
+      cwd: '/tmp/test',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mockCreatePullRequest).toHaveBeenCalledWith(
+      '/tmp/test',
+      expect.objectContaining({
+        title: 'Test Issue Title (#123)',
+      }),
+    );
+  });
+
+  it('issue 番号がない場合、task が PR title に使用される', async () => {
+    mockExecuteTask.mockResolvedValueOnce(true);
+    mockCreatePullRequest.mockReturnValueOnce({ success: true, url: 'https://github.com/test/pr/1' });
+
+    const exitCode = await executePipeline({
+      task: 'Custom task title',
+      piece: 'default',
+      branch: 'fix/my-branch',
+      autoPr: true,
+      cwd: '/tmp/test',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(mockCreatePullRequest).toHaveBeenCalledWith(
+      '/tmp/test',
+      expect.objectContaining({
+        title: 'Custom task title',
+      }),
+    );
+  });
+
   it('should use --task when both --task and positional task are provided', async () => {
     mockExecuteTask.mockResolvedValueOnce(true);
 

--- a/src/__tests__/postExecution.test.ts
+++ b/src/__tests__/postExecution.test.ts
@@ -141,6 +141,64 @@ describe('postExecutionFlow', () => {
       expect.objectContaining({ draft: false }),
     );
   });
+
+  it('issues が指定されている場合、PR title に issue 番号を含む', async () => {
+    mockFindExistingPr.mockReturnValue(undefined);
+
+    await postExecutionFlow({
+      ...baseOptions,
+      issues: [{ number: 123, title: 'Test Issue', body: '', labels: [], comments: [] }],
+    });
+
+    expect(mockCreatePullRequest).toHaveBeenCalledWith(
+      '/project',
+      expect.objectContaining({ title: 'Fix the bug (#123)' }),
+    );
+  });
+
+  it('issues が空の配列の場合、PR title に issue 番号を追加しない', async () => {
+    mockFindExistingPr.mockReturnValue(undefined);
+
+    await postExecutionFlow({
+      ...baseOptions,
+      issues: [],
+    });
+
+    expect(mockCreatePullRequest).toHaveBeenCalledWith(
+      '/project',
+      expect.objectContaining({ title: 'Fix the bug' }),
+    );
+  });
+
+  it('issues が undefined の場合、PR title に issue 番号を追加しない', async () => {
+    mockFindExistingPr.mockReturnValue(undefined);
+
+    await postExecutionFlow({
+      ...baseOptions,
+      issues: undefined,
+    });
+
+    expect(mockCreatePullRequest).toHaveBeenCalledWith(
+      '/project',
+      expect.objectContaining({ title: 'Fix the bug' }),
+    );
+  });
+
+  it('task が 100 文字以上の場合、PR title は省略され issue 番号が追加される', async () => {
+    mockFindExistingPr.mockReturnValue(undefined);
+    const longTask = 'A'.repeat(120);
+
+    await postExecutionFlow({
+      ...baseOptions,
+      task: longTask,
+      issues: [{ number: 456, title: 'Test Issue', body: '', labels: [], comments: [] }],
+    });
+
+    expect(mockCreatePullRequest).toHaveBeenCalledWith(
+      '/project',
+      expect.objectContaining({ title: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA... (#456)' }),
+    );
+  });
 });
 
 describe('resolveDraftPr', () => {

--- a/src/__tests__/runAllTasks-concurrency.test.ts
+++ b/src/__tests__/runAllTasks-concurrency.test.ts
@@ -467,6 +467,12 @@ describe('runAllTasks concurrency', () => {
         .mockReturnValueOnce([task1, task2, task3])
         .mockReturnValueOnce([]);
 
+      mockListAllTaskItems.mockReturnValueOnce([
+        { kind: 'completed', name: 'pass-1', filePath: '', content: '', createdAt: '' },
+        { kind: 'failed', name: 'fail-1', filePath: '', content: '', createdAt: '' },
+        { kind: 'completed', name: 'pass-2', filePath: '', content: '', createdAt: '' },
+      ]);
+
       // When
       await runAllTasks('/project');
 
@@ -476,6 +482,10 @@ describe('runAllTasks concurrency', () => {
       expect(mockStatus).toHaveBeenCalledWith('Failed', '1', 'red');
       expect(mockNotifySuccess).not.toHaveBeenCalled();
       expect(mockNotifyError).toHaveBeenCalledTimes(1);
+      // Task summary shows failed tasks first with ✗, then successful tasks with ✓
+      expect(mockInfo).toHaveBeenCalledWith('fail-1 ✗');
+      expect(mockInfo).toHaveBeenCalledWith('pass-1 ✓');
+      expect(mockInfo).toHaveBeenCalledWith('pass-2 ✓');
     });
 
     it('should persist failure reason and movement when piece aborts', async () => {

--- a/src/features/pipeline/execute.ts
+++ b/src/features/pipeline/execute.ts
@@ -200,7 +200,7 @@ export async function executePipeline(options: PipelineExecutionOptions): Promis
       info('--auto-pr is ignored when --skip-git is specified (no push was performed)');
     } else if (branch) {
       info('Creating pull request...');
-      const prTitle = issue ? issue.title : (options.task ?? 'Pipeline task');
+      const prTitle = issue ? `${issue.title} (#${issue.number})` : (options.task ?? 'Pipeline task');
       const report = `Piece \`${piece}\` completed successfully.`;
       const prBody = buildPipelinePrBody(pipelineConfig, issue, report);
 

--- a/src/features/tasks/execute/postExecution.ts
+++ b/src/features/tasks/execute/postExecution.ts
@@ -100,9 +100,16 @@ export async function postExecutionFlow(options: PostExecutionOptions): Promise<
     } else {
       info('Creating pull request...');
       const prBody = buildPrBody(issues, report);
+      const prTitle = (() => {
+        const baseTitle = task.length > 100 ? `${task.slice(0, 97)}...` : task;
+        if (issues && issues.length > 0 && issues[0]) {
+          return `${baseTitle} (#${issues[0].number})`;
+        }
+        return baseTitle;
+      })();
       const prResult = createPullRequest(projectCwd, {
         branch,
-        title: task.length > 100 ? `${task.slice(0, 97)}...` : task,
+        title: prTitle,
         body: prBody,
         base: baseBranch,
         repo,

--- a/src/infra/config/global/globalConfig.ts
+++ b/src/infra/config/global/globalConfig.ts
@@ -15,7 +15,6 @@ import type { ProviderPermissionProfiles } from '../../../core/models/provider-p
 import { normalizeProviderOptions } from '../loaders/pieceParser.js';
 import { getGlobalConfigPath } from '../paths.js';
 import { DEFAULT_LANGUAGE } from '../../../shared/constants.js';
-import { parseProviderModel } from '../../../shared/utils/providerModel.js';
 import { applyGlobalConfigEnvOverrides, envVarNameFromPath } from '../env/config-env-overrides.js';
 import { invalidateAllResolvedConfigCache } from '../resolutionCache.js';
 
@@ -63,7 +62,7 @@ function validateProviderModelCompatibility(provider: string | undefined, model:
 
   if (provider === 'opencode' && !model) {
     throw new Error(
-      "Configuration error: provider 'opencode' requires model in 'provider/model' format (e.g. 'opencode/big-pickle')."
+      "Configuration error: provider 'opencode' requires a model."
     );
   }
 
@@ -76,9 +75,7 @@ function validateProviderModelCompatibility(provider: string | undefined, model:
     );
   }
 
-  if (provider === 'opencode') {
-    parseProviderModel(model, "Configuration error: model");
-  }
+
 }
 
 function normalizePersonaProviders(

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -384,7 +384,11 @@ export class OpenCodeClient {
         const diag = createStreamDiagnostics('opencode-sdk', { agentType, model: options.model, attempt });
         diagRef = diag;
 
-        const parsedModel = parseProviderModel(options.model, 'OpenCode model');
+        let modelToUse = options.model;
+        if (!modelToUse.includes('/')) {
+          modelToUse = `opencode/${modelToUse}`;
+        }
+        const parsedModel = parseProviderModel(modelToUse, 'OpenCode model');
         const fullModel = `${parsedModel.providerID}/${parsedModel.modelID}`;
 
         const acquired = await acquireClient(fullModel, options.opencodeApiKey);

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -9,7 +9,7 @@ import type { AgentSetup, Provider, ProviderAgent, ProviderCallOptions } from '.
 
 function toOpenCodeOptions(options: ProviderCallOptions): OpenCodeCallOptions {
   if (!options.model) {
-    throw new Error("OpenCode provider requires model in 'provider/model' format (e.g. 'opencode/big-pickle').");
+    throw new Error("OpenCode provider requires a model.");
   }
 
   return {


### PR DESCRIPTION
## Summary

## Execution Report

Piece `default` completed successfully.