### PR TITLE
Release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.23.0] - 2026-02-23
+
+### Added
+
+- `default-test-first-mini` builtin piece for test-first development workflow
+- `auto_fetch` global config: opt-in remote fetch before cloning to keep clones up-to-date (`default: false`)
+- `base_branch` config (global/project): specify the base branch for clone creation (defaults to remote default branch)
+- `model` project config: override model at the project level (`.takt/config.yaml`)
+- `concurrency` project config: set parallel task count per project for `takt run`
+- `--create-worktree` support in pipeline mode for worktree-based execution
+- `skipTaskList` option: interactive "Execute" action skips adding to `tasks.yaml`
+- `takt list` now displays GitHub Issue numbers alongside task names
+- Retry failed tasks now offers to reuse the previous piece before prompting piece selection
+- Pipeline mode Slack notifications: sends run summary with task details, duration, branch, and PR URL
+- CI workflow: lint, test, and e2e:mock checks run automatically on PRs (#364)
+
+### Changed
+
+- Provider/model resolution unified via `resolveProviderModelCandidates()` — single resolution function used in both `AgentRunner` and `resolveMovementProviderModel`
+- Pipeline execution refactored into thin orchestrator (`execute.ts`) + step implementations (`steps.ts`)
+- Clone directory default changed from `takt-worktree` (singular) to `takt-worktrees` (plural) with auto-migration of legacy directory
+- PR titles now include issue number prefix (e.g., `[#6] Fix the bug`)
+- Task status now reflects PR creation failure — previously only piece execution success was tracked
+- `auto-tag.yml` tags PR head SHA instead of merge commit for correct hotfix code publishing
+- Session reader falls back to JSONL file scanning when `sessions-index.json` is missing or invalid
+- `ProjectLocalConfig` type normalized to camelCase (`auto_pr`→`autoPr`, `draft_pr`→`draftPr`) — YAML snake_case preserved
+- `getLocalLayerValue` simplified from switch-case to dynamic property lookup
+
+### Fixed
+
+- `repertoire add` pipe stdin: multiple `confirm()` calls failed when reading from piped stdin due to readline destroying buffered lines (#334)
+- Movement provider override precedence in `AgentRunner`: step provider was incorrectly overridden by global config
+- Project-level `model` config was silently ignored — `getLocalLayerValue` was missing the `model` case
+- PR creation failure now properly propagated as task failure with error message (#345)
+- Claude session resume candidates now fall back to JSONL file scanning when `sessions-index.json` is unavailable
+
+### Internal
+
+- CI: PR checks for lint, test, e2e:mock (`ci.yml`)
+- Expanded e2e test coverage for repertoire (#364)
+- New test suites: clone, config, postExecution, session-reader, selectAndExecute-skipTaskList, taskStatusLabel, pipelineExecution
+- Refactored: project config case normalization (#358), clone manager (#359), pipeline steps extraction, confirm pipe reader singleton, provider resolution (#362)
+
 ## [0.22.0] - 2026-02-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Rules determine the next movement. `COMPLETE` ends the piece successfully, `ABOR
 | Piece | Use Case |
 |-------|----------|
 | `default-mini` | Quick fixes. Lightweight plan → implement → parallel review → fix loop. |
+| `default-test-first-mini` | Test-first development. Write tests first, then implement to pass them. |
 | `frontend-mini` | Frontend-focused mini configuration. |
 | `backend-mini` | Backend-focused mini configuration. |
 | `expert-mini` | Expert-level mini configuration. |

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,49 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.23.0] - 2026-02-23
+
+### Added
+
+- `default-test-first-mini` ビルトインピースを追加（テストファースト開発ワークフロー）
+- `auto_fetch` グローバル設定: クローン作成前にリモートを fetch してクローンを最新に保つオプション（`default: false`）
+- `base_branch` 設定（グローバル/プロジェクト）: クローン作成のベースブランチを指定（デフォルトはリモートのデフォルトブランチ）
+- `model` プロジェクト設定: プロジェクトレベルでモデルを上書き（`.takt/config.yaml`）
+- `concurrency` プロジェクト設定: プロジェクトごとに `takt run` の並列タスク数を設定
+- パイプラインモードで `--create-worktree` をサポート（worktree ベースの実行）
+- `skipTaskList` オプション: 対話モードの「実行する」アクションで `tasks.yaml` への追加をスキップ
+- `takt list` でタスク名の横に GitHub Issue 番号を表示
+- 失敗タスクのリトライ時、ピース選択の前に前回使用したピースの再利用を提案
+- パイプラインモードの Slack 通知: タスク詳細、実行時間、ブランチ、PR URL を含むサマリを送信
+- CI ワークフロー: PR に対して lint、test、e2e:mock チェックを自動実行 (#364)
+
+### Changed
+
+- Provider/Model 解決を `resolveProviderModelCandidates()` に一元化 — `AgentRunner` と `resolveMovementProviderModel` で同一の解決関数を使用
+- パイプライン実行を薄いオーケストレーター (`execute.ts`) + ステップ実装 (`steps.ts`) にリファクタリング
+- クローンディレクトリのデフォルト名を `takt-worktree`（単数）から `takt-worktrees`（複数）に変更（レガシーディレクトリの自動マイグレーション付き）
+- PR タイトルに Issue 番号プレフィックスを追加（例: `[#6] Fix the bug`）
+- タスクステータスが PR 作成失敗を反映するよう改善 — 以前はピース実行の成功のみを追跡
+- `auto-tag.yml` がマージコミットではなく PR head SHA にタグを付与（ホットフィックスの正しいコード publish のため）
+- セッションリーダーが `sessions-index.json` が欠損・不正な場合に JSONL ファイルスキャンにフォールバック
+- `ProjectLocalConfig` 型をキャメルケースに正規化（`auto_pr`→`autoPr`、`draft_pr`→`draftPr`）— YAML のスネークケースは維持
+- `getLocalLayerValue` を switch-case から動的プロパティルックアップに簡素化
+
+### Fixed
+
+- `repertoire add` のパイプ stdin: readline がバッファ済み行を破棄するため複数の `confirm()` 呼び出しが失敗する問題を修正 (#334)
+- `AgentRunner` での movement provider 上書き優先順位: step provider がグローバル設定に誤って上書きされていた問題を修正
+- プロジェクトレベルの `model` 設定が無視されていた問題 — `getLocalLayerValue` に `model` ケースが欠落していた
+- PR 作成失敗がタスク失敗として適切に伝搬されるよう修正（エラーメッセージ付き）(#345)
+- Claude セッション resume 候補が `sessions-index.json` 利用不可時に JSONL ファイルスキャンにフォールバック
+
+### Internal
+
+- CI: PR チェック用に lint、test、e2e:mock を追加（`ci.yml`）
+- repertoire の e2e テストカバレッジを拡充 (#364)
+- 新規テストスイート: clone、config、postExecution、session-reader、selectAndExecute-skipTaskList、taskStatusLabel、pipelineExecution
+- リファクタリング: プロジェクト設定のケース正規化 (#358)、クローンマネージャー (#359)、パイプラインステップ抽出、confirm パイプリーダーシングルトン、provider 解決 (#362)
+
 ## [0.22.0] - 2026-02-22
 
 ### Added

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -140,6 +140,7 @@ movements:
 | Piece | 用途 |
 |-------|------|
 | `default-mini` | ちょっとした修正向けです。計画 → 実装 → 並列レビュー → 修正の軽量構成です。 |
+| `default-test-first-mini` | テストファースト開発向けです。テストを先に書き、それを通す実装を行います。 |
 | `frontend-mini` | フロントエンド向けの mini 構成です。 |
 | `backend-mini` | バックエンド向けの mini 構成です。 |
 | `expert-mini` | エキスパート向けの mini 構成です。 |

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -27,6 +27,8 @@ notification_sound_events:    # イベントごとの通知音切り替え（省
 concurrency: 1                # takt run の並列タスク数（1-10、デフォルト: 1 = 逐次実行）
 task_poll_interval_ms: 500    # takt run での新規タスクポーリング間隔（100-5000、デフォルト: 500）
 interactive_preview_movements: 3  # インタラクティブモードでの movement プレビュー数（0-10、デフォルト: 3）
+# auto_fetch: false            # クローン作成前にリモートを fetch（デフォルト: false）
+# base_branch: main            # クローン作成のベースブランチ（デフォルト: リモートのデフォルトブランチ）
 
 # ランタイム環境デフォルト（piece_config.runtime で上書きしない限りすべての piece に適用）
 # runtime:
@@ -111,6 +113,8 @@ interactive_preview_movements: 3  # インタラクティブモードでの move
 | `disabled_builtins` | string[] | `[]` | 無効化する特定のビルトイン piece |
 | `pipeline` | object | - | pipeline テンプレート設定 |
 | `bookmarks_file` | string | - | ブックマークファイルのパス |
+| `auto_fetch` | boolean | `false` | クローン作成前にリモートを fetch してクローンを最新に保つ |
+| `base_branch` | string | - | クローン作成のベースブランチ（デフォルトはリモートのデフォルトブランチ） |
 | `piece_categories_file` | string | - | piece カテゴリファイルのパス |
 
 ## プロジェクト設定
@@ -121,9 +125,11 @@ interactive_preview_movements: 3  # インタラクティブモードでの move
 # .takt/config.yaml
 piece: default                # このプロジェクトの現在の piece
 provider: claude              # このプロジェクトの provider 上書き
+model: sonnet                 # このプロジェクトのモデル上書き
 auto_pr: true                 # worktree 実行後に PR を自動作成
 verbose: false                # 詳細出力モード
 concurrency: 2                # このプロジェクトでの takt run 並列タスク数（1-10）
+# base_branch: main           # クローン作成のベースブランチ（グローバルを上書き、デフォルト: リモートのデフォルトブランチ）
 
 # provider 固有オプション（グローバルを上書き、piece/movement で上書き可能）
 # provider_options:
@@ -144,9 +150,11 @@ concurrency: 2                # このプロジェクトでの takt run 並列�
 |-----------|------|---------|------|
 | `piece` | string | `"default"` | このプロジェクトの現在の piece 名 |
 | `provider` | `"claude"` \| `"codex"` \| `"opencode"` \| `"mock"` | - | provider 上書き |
+| `model` | string | - | モデル名の上書き（provider にそのまま渡される） |
 | `auto_pr` | boolean | - | worktree 実行後に PR を自動作成 |
 | `verbose` | boolean | - | 詳細出力モード |
 | `concurrency` | number (1-10) | `1`（global 設定由来） | `takt run` の並列タスク数 |
+| `base_branch` | string | - | クローン作成のベースブランチ（グローバルを上書き、デフォルト: リモートのデフォルトブランチ） |
 | `provider_options` | object | - | provider 固有オプション |
 | `provider_profiles` | object | - | provider 固有のパーミッションプロファイル |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,8 @@ notification_sound_events:    # Optional per-event toggles
 concurrency: 1                # Parallel task count for takt run (1-10, default: 1 = sequential)
 task_poll_interval_ms: 500    # Polling interval for new tasks during takt run (100-5000, default: 500)
 interactive_preview_movements: 3  # Movement previews in interactive mode (0-10, default: 3)
+# auto_fetch: false            # Fetch remote before cloning (default: false)
+# base_branch: main            # Base branch for clone creation (default: remote default branch)
 
 # Runtime environment defaults (applies to all pieces unless piece_config.runtime overrides)
 # runtime:
@@ -111,6 +113,8 @@ interactive_preview_movements: 3  # Movement previews in interactive mode (0-10,
 | `disabled_builtins` | string[] | `[]` | Specific builtin pieces to disable |
 | `pipeline` | object | - | Pipeline template settings |
 | `bookmarks_file` | string | - | Path to bookmarks file |
+| `auto_fetch` | boolean | `false` | Fetch remote before cloning to keep clones up-to-date |
+| `base_branch` | string | - | Base branch for clone creation (defaults to remote default branch) |
 | `piece_categories_file` | string | - | Path to piece categories file |
 
 ## Project Configuration
@@ -121,9 +125,11 @@ Configure project-specific settings in `.takt/config.yaml`. This file is created
 # .takt/config.yaml
 piece: default                # Current piece for this project
 provider: claude              # Override provider for this project
+model: sonnet                 # Override model for this project
 auto_pr: true                 # Auto-create PR after worktree execution
 verbose: false                # Verbose output mode
 concurrency: 2                # Parallel task count for takt run in this project (1-10)
+# base_branch: main           # Base branch for clone creation (overrides global, default: remote default branch)
 
 # Provider-specific options (overrides global, overridden by piece/movement)
 # provider_options:
@@ -144,9 +150,11 @@ concurrency: 2                # Parallel task count for takt run in this project
 |-------|------|---------|-------------|
 | `piece` | string | `"default"` | Current piece name for this project |
 | `provider` | `"claude"` \| `"codex"` \| `"opencode"` \| `"mock"` | - | Override provider |
+| `model` | string | - | Override model name (passed to provider as-is) |
 | `auto_pr` | boolean | - | Auto-create PR after worktree execution |
 | `verbose` | boolean | - | Verbose output mode |
 | `concurrency` | number (1-10) | `1` (from global) | Parallel task count for `takt run` |
+| `base_branch` | string | - | Base branch for clone creation (overrides global, default: remote default branch) |
 | `provider_options` | object | - | Provider-specific options |
 | `provider_profiles` | object | - | Provider-specific permission profiles |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- `default-test-first-mini` builtin piece for test-first development workflow
- `auto_fetch` global config: opt-in remote fetch before cloning to keep clones up-to-date (`default: false`)
- `base_branch` config (global/project): specify the base branch for clone creation (defaults to remote default branch)
- `model` project config: override model at the project level (`.takt/config.yaml`)
- `concurrency` project config: set parallel task count per project for `takt run`
- `--create-worktree` support in pipeline mode for worktree-based execution
- `skipTaskList` option: interactive "Execute" action skips adding to `tasks.yaml`
- `takt list` now displays GitHub Issue numbers alongside task names
- Retry failed tasks now offers to reuse the previous piece before prompting piece selection
- Pipeline mode Slack notifications: sends run summary with task details, duration, branch, and PR URL
- CI workflow: lint, test, and e2e:mock checks run automatically on PRs (#364)

### Changed

- Provider/model resolution unified via `resolveProviderModelCandidates()` — single resolution function used in both `AgentRunner` and `resolveMovementProviderModel`
- Pipeline execution refactored into thin orchestrator (`execute.ts`) + step implementations (`steps.ts`)
- Clone directory default changed from `takt-worktree` (singular) to `takt-worktrees` (plural) with auto-migration of legacy directory
- PR titles now include issue number prefix (e.g., `[#6] Fix the bug`)
- Task status now reflects PR creation failure — previously only piece execution success was tracked
- `auto-tag.yml` tags PR head SHA instead of merge commit for correct hotfix code publishing
- Session reader falls back to JSONL file scanning when `sessions-index.json` is missing or invalid
- `ProjectLocalConfig` type normalized to camelCase (`auto_pr`→`autoPr`, `draft_pr`→`draftPr`) — YAML snake_case preserved
- `getLocalLayerValue` simplified from switch-case to dynamic property lookup

### Fixed

- `repertoire add` pipe stdin: multiple `confirm()` calls failed when reading from piped stdin due to readline destroying buffered lines (#334)
- Movement provider override precedence in `AgentRunner`: step provider was incorrectly overridden by global config
- Project-level `model` config was silently ignored — `getLocalLayerValue` was missing the `model` case
- PR creation failure now properly propagated as task failure with error message (#345)
- Claude session resume candidates now fall back to JSONL file scanning when `sessions-index.json` is unavailable

### Internal

- CI: PR checks for lint, test, e2e:mock (`ci.yml`)
- Expanded e2e test coverage for repertoire (#364)
- New test suites: clone, config, postExecution, session-reader, selectAndExecute-skipTaskList, taskStatusLabel, pipelineExecution
- Refactored: project config case normalization (#358), clone manager (#359), pipeline steps extraction, confirm pipe reader singleton, provider resolution (#362)

## Commits

- 69a941a Release v0.23.0
- f2ca01f refactor: provider/model resolution precedenceを一元化
- 3970b6b fix: repertoire add のパイプ stdin で複数 confirm が失敗する問題を修正
- 69f1328 fix: movement provider override precedence in AgentRunner
- 95cd360 feat: ProjectLocalConfig に concurrency を追加
- 6a28929 fix: 通知ユーティリティのテストモック追加と check:release の通知対応
- 4ee69f8 add-e2e-coverage (#364)
- e5902b8 takt: Execute アクションで tasks.yaml への追加をスキップする skipTaskList オプション (#334)
- f307ed8 takt: tasuku-takt-list-komandoni-iss (#335)
- 4a7dea4 takt: tasuku-taktga-surupull-request (#336)
- b309233 takt: github-issue-328-tasuku-ritora (#340)
- 9e68f08 takt: refactor-project-config-case (#358)
- c066db4 takt: refactor-clone-manager (#359)
- e75e024 feat: default-test-first-mini ピースを追加
- 1acd991 feat: pipeline モードでの Slack 通知を強化 (#346) (#347)
- a08adad fix: PR creation failure handling + use default branch for base (#345)
- 4a4a8ef policy: enforce abstraction level consistency in orchestration functions (#362)
- f557db0 feat: support --create-worktree in pipeline mode (#361)
- a5e2bad fix: Claude resume候補をjsonlフォールバックで取得
- 134b666 Merge pull request #350 from tomohisa/fix/worktree-dir-plural
- 077d19a Merge pull request #355 from s-kikuchi/takt/20260222T0402-tasuku-purojekuto-takt-config
- 1d6770c Merge pull request #344 from tomohisa/feat/auto-sync-before-clone
- 2a3ff22 ci: PR時にlint, test, e2e:mockを必須チェックとして実行
- 753deb6 fix: Project-level model config ignored — getLocalLayerValue missing model case
- e57612d ci: tag PR head SHA instead of merge commit for hotfix support
- 717afd2 fix: remove non-existent ensemble→repertoire breaking change from CHANGELOG
- 1d73369 feat: opt-in auto_fetch and base_branch config for clone
- 2e72054 fix: use plural 'takt-worktrees' as default clone directory name