### PR TITLE
Release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.24.0] - 2026-02-24
+
+### Added
+
+- AskUserQuestion support: AI agents can now ask interactive questions during execution with single-select, multi-select, and free-text input via TTY UI; automatically denied during piece execution to maintain agent autonomy (#161, #369)
+- `review` builtin piece with 3-mode auto-detection: automatically selects PR mode (by PR number), branch mode (by branch name), or working diff mode (by free text) for multi-perspective parallel review
+- `testing-reviewer` and `requirements-reviewer` builtin personas for specialized review perspectives
+- `testing` policy: integration test requirement criteria (3+ module data flow, state merging into workflows, option propagation through call chains)
+- `gather-review` instruction and `review-gather` output contract for the new review piece gather movement
+- `requirements-review` instruction and output contract for requirements-focused review
+- `testing-review` output contract for testing-focused review
+- `settingSources: ['project']` in SDK options: delegates CLAUDE.md loading to the Claude SDK for proper project-level settings resolution
+
+### Changed
+
+- **BREAKING:** `review-only` piece renamed to `review`; `review-fix-minimal` piece removed — users referencing these piece names must update to `review`
+- `write-tests-first` instruction now includes integration test decision criteria instead of a generic "Write E2E tests if appropriate"
+
+### Fixed
+
+- Planner persona: added bug fix propagation check rule (grep for same pattern in related files) and prohibited deferring decidable questions to Open Questions
+
+### Internal
+
+- Docs: fixed music metaphor origin description, catalog gaps, broken links, orphaned documents, event names, API Key references, eject descriptions, removed stale personas section map from YAML example, aligned legacy terminology with current codebase
+- New test suites: `StreamDisplay`, `ask-user-question-handler`, `pieceExecution-ask-user-question`, `review-piece`, `opencode-client-cleanup`
+- Removed legacy `review-only-piece` test and `loadProjectContext` from session module (CLAUDE.md loading now delegated to SDK)
+
 ## [0.23.0] - 2026-02-23
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,34 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.24.0] - 2026-02-24
+
+### Added
+
+- AskUserQuestion 対応: AI エージェントが実行中に対話的にユーザーへ質問可能に。単一選択・複数選択・自由入力の TTY UI を提供。ピース実行中は自動的に拒否しエージェントの自律性を維持 (#161, #369)
+- `review` ビルトインピースを3モード自動判定に拡張: PR 番号・ブランチ名・フリーテキストから自動でレビューモード（PR/ブランチ/作業中差分）を判定し、5並列レビュー（arch/security/qa/testing/requirements）を実行
+- `testing-reviewer` と `requirements-reviewer` ビルトインペルソナを追加（専門レビュー観点）
+- `testing` ポリシー: インテグレーションテスト必要条件を追加（3+モジュールのデータフロー、ワークフローへの状態マージ、コールチェーンを通じたオプション伝搬）
+- `gather-review` インストラクションと `review-gather` 出力契約を追加（review ピースの gather ムーブメント用）
+- `requirements-review` インストラクションと出力契約を追加（要件レビュー用）
+- `testing-review` 出力契約を追加（テストレビュー用）
+- SDK オプションに `settingSources: ['project']` を追加: CLAUDE.md の読み込みを Claude SDK に委譲し、プロジェクトレベル設定を適切に解決
+
+### Changed
+
+- **BREAKING:** `review-only` ピースを `review` にリネーム、`review-fix-minimal` ピースを削除 — これらのピース名を参照しているユーザーは `review` に更新が必要
+- `write-tests-first` インストラクションに具体的なインテグレーションテスト判断基準を追加（「適宜 E2E テストを作成」から置き換え）
+
+### Fixed
+
+- planner ペルソナ: バグ修正の波及確認ルール（関連ファイルで同一パターンを grep）と、確認事項の判断保留禁止を追加
+
+### Internal
+
+- ドキュメント整備: 音楽メタファーの由来説明追加、カタログ漏れ・リンク切れ・孤立ドキュメント・イベント名・API Key 参照・eject 説明を修正、YAML 例から不要な personas セクションマップを削除、レガシー用語をコードベースの実態に合わせて修正
+- 新規テストスイート: `StreamDisplay`、`ask-user-question-handler`、`pieceExecution-ask-user-question`、`review-piece`、`opencode-client-cleanup`
+- レガシー `review-only-piece` テストと session モジュールの `loadProjectContext` を削除（CLAUDE.md 読み込みは SDK に委譲）
+
 ## [0.23.0] - 2026-02-23
 
 ### Added

--- a/docs/builtin-catalog.ja.md
+++ b/docs/builtin-catalog.ja.md
@@ -36,8 +36,7 @@ TAKT に同梱されているすべてのビルトイン piece と persona の�
 | 🔧 エキスパート | `expert` | フルスタック開発 piece: architecture、frontend、security、QA レビューと修正ループ付き。 |
 | | `expert-cqrs` | フルスタック開発 piece (CQRS+ES 特化): CQRS+ES、frontend、security、QA レビューと修正ループ付き。 |
 | 🛠️ リファクタリング | `structural-reform` | プロジェクト全体のレビューと構造改革: 段階的なファイル分割による反復的なコードベース再構築。 |
-| 🔍 レビュー | `review-fix-minimal` | レビュー特化 piece: review -> fix -> supervisor。レビューフィードバックに基づく反復改善向け。 |
-| | `review-only` | 変更を加えない読み取り専用のコードレビュー piece。 |
+| 🔍 レビュー | `review` | 多角コードレビュー: PR/ブランチ/作業中の差分を自動判定し、5つの並列観点（arch/security/QA/testing/requirements）からレビューして統合結果を出力。 |
 | 🧪 テスト | `unit-test` | ユニットテスト特化 piece: テスト分析 -> テスト実装 -> レビュー -> 修正。 |
 | | `e2e-test` | E2E テスト特化 piece: E2E 分析 -> E2E 実装 -> レビュー -> 修正 (Vitest ベースの E2E フロー)。 |
 | その他 | `research` | リサーチ piece: planner -> digger -> supervisor。質問せずに自律的にリサーチを実行。 |
@@ -68,6 +67,8 @@ TAKT に同梱されているすべてのビルトイン piece と persona の�
 | **research-digger** | 深掘り調査と情報収集 |
 | **research-supervisor** | リサーチ品質の検証と完全性の評価 |
 | **test-planner** | テスト戦略の分析と包括的なテスト計画 |
+| **testing-reviewer** | テスト重視のコードレビューとインテグレーションテスト要件分析 |
+| **requirements-reviewer** | 要件仕様と準拠性のレビュー |
 | **pr-commenter** | レビュー結果を GitHub PR コメントとして投稿 |
 
 ## カスタム Persona

--- a/docs/builtin-catalog.md
+++ b/docs/builtin-catalog.md
@@ -36,8 +36,7 @@ Organized by category.
 | 🔧 Expert | `expert` | Full-stack development piece: architecture, frontend, security, QA reviews with fix loops. |
 | | `expert-cqrs` | Full-stack development piece (CQRS+ES specialized): CQRS+ES, frontend, security, QA reviews with fix loops. |
 | 🛠️ Refactoring | `structural-reform` | Full project review and structural reform: iterative codebase restructuring with staged file splits. |
-| 🔍 Review | `review-fix-minimal` | Review-focused piece: review -> fix -> supervisor. For iterative improvement based on review feedback. |
-| | `review-only` | Read-only code review piece that makes no changes. |
+| 🔍 Review | `review` | Multi-perspective code review: auto-detects PR/branch/working diff, reviews from 5 parallel perspectives (arch/security/QA/testing/requirements), outputs consolidated results. |
 | 🧪 Testing | `unit-test` | Unit test focused piece: test analysis -> test implementation -> review -> fix. |
 | | `e2e-test` | E2E test focused piece: E2E analysis -> E2E implementation -> review -> fix (Vitest-based E2E flow). |
 | Others | `research` | Research piece: planner -> digger -> supervisor. Autonomously executes research without asking questions. |
@@ -68,6 +67,8 @@ Use `takt switch` to switch pieces interactively.
 | **research-digger** | Deep investigation and information gathering |
 | **research-supervisor** | Research quality validation and completeness assessment |
 | **test-planner** | Test strategy analysis and comprehensive test planning |
+| **testing-reviewer** | Testing-focused code review with integration test requirements analysis |
+| **requirements-reviewer** | Requirements specification and compliance review |
 | **pr-commenter** | Posts review findings as GitHub PR comments |
 
 ## Custom Personas

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- AskUserQuestion support: AI agents can now ask interactive questions during execution with single-select, multi-select, and free-text input via TTY UI; automatically denied during piece execution to maintain agent autonomy (#161, #369)
- `review` builtin piece with 3-mode auto-detection: automatically selects PR mode (by PR number), branch mode (by branch name), or working diff mode (by free text) for multi-perspective parallel review
- `testing-reviewer` and `requirements-reviewer` builtin personas for specialized review perspectives
- `testing` policy: integration test requirement criteria (3+ module data flow, state merging into workflows, option propagation through call chains)
- `gather-review` instruction and `review-gather` output contract for the new review piece gather movement
- `requirements-review` instruction and output contract for requirements-focused review
- `testing-review` output contract for testing-focused review
- `settingSources: ['project']` in SDK options: delegates CLAUDE.md loading to the Claude SDK for proper project-level settings resolution

### Changed

- **BREAKING:** `review-only` piece renamed to `review`; `review-fix-minimal` piece removed — users referencing these piece names must update to `review`
- `write-tests-first` instruction now includes integration test decision criteria instead of a generic "Write E2E tests if appropriate"

### Fixed

- Planner persona: added bug fix propagation check rule (grep for same pattern in related files) and prohibited deferring decidable questions to Open Questions

### Internal

- Docs: fixed music metaphor origin description, catalog gaps, broken links, orphaned documents, event names, API Key references, eject descriptions, removed stale personas section map from YAML example, aligned legacy terminology with current codebase
- New test suites: `StreamDisplay`, `ask-user-question-handler`, `pieceExecution-ask-user-question`, `review-piece`, `opencode-client-cleanup`
- Removed legacy `review-only-piece` test and `loadProjectContext` from session module (CLAUDE.md loading now delegated to SDK)

## Commits

- a49d3af settingSources に project を追加し、CLAUDE.md の読み込みを SDK に委譲
- cc7f73d review ピースに拡張: PR/ブランチ/現在の差分の3モード自動判定に対応
- c44477d pr-review ピース追加: 5並列レビュー（arch/security/qa/testing/requirements）で PR を多角的にレビュー
- 41d92a3 テスト系のファセット強化
- 40c372d fix: planner ペルソナにバグ修正の波及確認ルールと確認事項の判断保留禁止を追加
- c6e5a70 docs: 音楽メタファーの由来説明追加、カタログ漏れ・リンク切れ・孤立ドキュメントを修正
- b59b93d docs: README のイベント名・API Key・ドキュメント一覧・eject 説明を修正
- a1bfc2c docs: README の YAML 例から不要な personas セクションマップを削除
- 43c26d7 docs: 古い用語・構造をコードベースの実態に合わせて修正
- dfc9263 Merge pull request #369 from KentarouTakeda/support-ask-user-question
- 61959f6 feat: AskUserQuestion 対応 (#161)