### PR TITLE
feat: project configでsubmodule取得を制御可能にする

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1205,6 +1205,95 @@ describe('loadProjectConfig snake_case normalization', () => {
   });
 });
 
+describe('loadProjectConfig submodules', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `takt-test-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should normalize case-insensitive submodules all to canonical all', () => {
+    const projectConfigDir = getProjectConfigDir(testDir);
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(projectConfigDir, 'config.yaml'), 'submodules: ALL\n');
+
+    const config = loadProjectConfig(testDir);
+
+    expect(config.submodules).toBe('all');
+    expect(config.withSubmodules).toBeUndefined();
+  });
+
+  it('should keep explicit submodule path list as target set', () => {
+    const projectConfigDir = getProjectConfigDir(testDir);
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(projectConfigDir, 'config.yaml'), [
+      'submodules:',
+      '  - path/a',
+      '  - path/b',
+    ].join('\n'));
+
+    const config = loadProjectConfig(testDir);
+
+    expect(config.submodules).toEqual(['path/a', 'path/b']);
+    expect(config.withSubmodules).toBeUndefined();
+  });
+
+  it('should reject wildcard-only path in submodules', () => {
+    const projectConfigDir = getProjectConfigDir(testDir);
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(projectConfigDir, 'config.yaml'), [
+      'submodules:',
+      '  - "*"',
+    ].join('\n'));
+
+    expect(() => loadProjectConfig(testDir)).toThrow('Invalid submodules');
+  });
+
+  it('should reject wildcard-like path in submodules', () => {
+    const projectConfigDir = getProjectConfigDir(testDir);
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(projectConfigDir, 'config.yaml'), [
+      'submodules:',
+      '  - libs/*',
+    ].join('\n'));
+
+    expect(() => loadProjectConfig(testDir)).toThrow('Invalid submodules');
+  });
+
+  it('should prefer submodules over with_submodules', () => {
+    const projectConfigDir = getProjectConfigDir(testDir);
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(projectConfigDir, 'config.yaml'), [
+      'submodules:',
+      '  - path/a',
+      'with_submodules: true',
+    ].join('\n'));
+
+    const config = loadProjectConfig(testDir);
+
+    expect(config.submodules).toEqual(['path/a']);
+    expect(config.withSubmodules).toBeUndefined();
+  });
+
+  it('should treat with_submodules true as fallback full acquisition when submodules is unset', () => {
+    const projectConfigDir = getProjectConfigDir(testDir);
+    mkdirSync(projectConfigDir, { recursive: true });
+    writeFileSync(join(projectConfigDir, 'config.yaml'), 'with_submodules: true\n');
+
+    const config = loadProjectConfig(testDir);
+
+    expect(config.submodules).toBeUndefined();
+    expect(config.withSubmodules).toBe(true);
+  });
+});
+
 describe('saveProjectConfig snake_case denormalization', () => {
   let testDir: string;
 
@@ -1246,6 +1335,28 @@ describe('saveProjectConfig snake_case denormalization', () => {
     expect((saved as Record<string, unknown>).base_branch).toBeUndefined();
   });
 
+  it('should persist withSubmodules as with_submodules and reload correctly', () => {
+    saveProjectConfig(testDir, { piece: 'default', withSubmodules: true });
+
+    const saved = loadProjectConfig(testDir);
+
+    expect(saved.withSubmodules).toBe(true);
+    expect((saved as Record<string, unknown>).with_submodules).toBeUndefined();
+  });
+
+  it('should persist submodules and ignore with_submodules when both are provided', () => {
+    saveProjectConfig(testDir, { piece: 'default', submodules: ['path/a'], withSubmodules: true });
+
+    const projectConfigDir = getProjectConfigDir(testDir);
+    const content = readFileSync(join(projectConfigDir, 'config.yaml'), 'utf-8');
+    const saved = loadProjectConfig(testDir);
+
+    expect(content).toContain('submodules:');
+    expect(content).not.toContain('with_submodules:');
+    expect(saved.submodules).toEqual(['path/a']);
+    expect(saved.withSubmodules).toBeUndefined();
+  });
+
   it('should persist concurrency and reload correctly', () => {
     saveProjectConfig(testDir, { piece: 'default', concurrency: 3 });
 
@@ -1263,6 +1374,7 @@ describe('saveProjectConfig snake_case denormalization', () => {
     expect(content).toContain('auto_pr:');
     expect(content).toContain('draft_pr:');
     expect(content).toContain('base_branch:');
+    expect(content).not.toContain('withSubmodules:');
     expect(content).not.toContain('autoPr:');
     expect(content).not.toContain('draftPr:');
     expect(content).not.toContain('baseBranch:');

--- a/src/__tests__/opencode-config.test.ts
+++ b/src/__tests__/opencode-config.test.ts
@@ -41,6 +41,29 @@ describe('Schemas accept opencode provider', () => {
     expect(result.concurrency).toBe(3);
   });
 
+  it('should accept submodules all in ProjectConfigSchema', () => {
+    const result = ProjectConfigSchema.parse({ submodules: 'ALL' });
+    expect(result.submodules).toBe('ALL');
+  });
+
+  it('should accept explicit submodule path list in ProjectConfigSchema', () => {
+    const result = ProjectConfigSchema.parse({ submodules: ['path/a', 'path/b'] });
+    expect(result.submodules).toEqual(['path/a', 'path/b']);
+  });
+
+  it('should accept with_submodules in ProjectConfigSchema', () => {
+    const result = ProjectConfigSchema.parse({ with_submodules: true });
+    expect(result.with_submodules).toBe(true);
+  });
+
+  it('should reject wildcard path in ProjectConfigSchema submodules', () => {
+    expect(() => ProjectConfigSchema.parse({ submodules: ['libs/*'] })).toThrow();
+  });
+
+  it('should reject non-all string in ProjectConfigSchema submodules', () => {
+    expect(() => ProjectConfigSchema.parse({ submodules: 'libs' })).toThrow();
+  });
+
   it('should accept opencode in CustomAgentConfigSchema', () => {
     const result = CustomAgentConfigSchema.parse({
       name: 'test',

--- a/src/core/models/persisted-global-config.ts
+++ b/src/core/models/persisted-global-config.ts
@@ -38,6 +38,9 @@ export interface AnalyticsConfig {
   retentionDays?: number;
 }
 
+/** Project-level submodule acquisition selection */
+export type SubmoduleSelection = 'all' | string[];
+
 /** Language setting for takt */
 export type Language = 'en' | 'ja';
 
@@ -141,4 +144,8 @@ export interface ProjectConfig {
   concurrency?: number;
   /** Base branch to clone from (overrides global baseBranch) */
   baseBranch?: string;
+  /** Compatibility flag for full submodule acquisition when submodules is unset */
+  withSubmodules?: boolean;
+  /** Submodule acquisition mode (all or explicit path list) */
+  submodules?: SubmoduleSelection;
 }

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -498,4 +498,15 @@ export const ProjectConfigSchema = z.object({
   concurrency: z.number().int().min(1).max(10).optional(),
   /** Base branch to clone from (overrides global base_branch) */
   base_branch: z.string().optional(),
+  /** Submodule acquisition mode (all or explicit path list) */
+  submodules: z.union([
+    z.string().refine((value) => value.trim().toLowerCase() === 'all', {
+      message: 'submodules string value must be "all"',
+    }),
+    z.array(z.string().min(1)).refine((paths) => paths.every((path) => !path.includes('*')), {
+      message: 'submodules path entries must not include wildcard "*"',
+    }),
+  ]).optional(),
+  /** Compatibility flag for full submodule acquisition when submodules is unset */
+  with_submodules: z.boolean().optional(),
 });

--- a/src/infra/config/types.ts
+++ b/src/infra/config/types.ts
@@ -4,7 +4,7 @@
 
 import type { MovementProviderOptions } from '../../core/models/piece-types.js';
 import type { ProviderPermissionProfiles } from '../../core/models/provider-profiles.js';
-import type { AnalyticsConfig } from '../../core/models/persisted-global-config.js';
+import type { AnalyticsConfig, SubmoduleSelection } from '../../core/models/persisted-global-config.js';
 
 /** Project configuration stored in .takt/config.yaml */
 export interface ProjectLocalConfig {
@@ -18,6 +18,10 @@ export interface ProjectLocalConfig {
   draftPr?: boolean;
   /** Base branch to clone from (overrides global baseBranch) */
   baseBranch?: string;
+  /** Submodule acquisition mode (all or explicit path list) */
+  submodules?: SubmoduleSelection;
+  /** Compatibility flag for full submodule acquisition when submodules is unset */
+  withSubmodules?: boolean;
   /** Verbose output mode */
   verbose?: boolean;
   /** Number of tasks to run concurrently in takt run (1-10) */


### PR DESCRIPTION
## 概要
project config（.takt/config.yaml）で submodule 取得を制御できるようにしました。

## 変更内容
- `submodules` / `with_submodules` を project config に追加
- `submodules: all` の正規化（大小無視）
- `submodules` が配列の場合のワイルドカード（`*`）拒否
- `submodules` 優先、`with_submodules` は未指定時のみ補助として有効
- clone 実行時に `--recurse-submodules` / `--recurse-submodules=<path>` を付与
- clone開始ログに submodule モードと対象（targets）を表示

## テスト
- npm run build
- npm run test -- src/__tests__/config.test.ts src/__tests__/clone.test.ts src/__tests__/opencode-config.test.ts
- npm run test -- src/__tests__/clone.test.ts
