### PR TITLE
[#390] github-issue-390-to-no-provide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `--task` オプションでの直接実行時に tasks.yaml へ不要な記録がされる問題を修正
 - `--task` でワークツリー作成時は tasks.yaml に記録するよう修正（`takt list` でのブランチ管理に必要）
 - Provider resolution: removed implicit fallback to `claude` and switched to fail-fast when provider cannot be resolved (#386)
+- Provider resolution: unified display and execution provider/model resolution via `movement:start` event providerInfo, ensuring displayed provider always matches execution provider (#390)
 - E2E テスト config-priority の不安定性を修正 (#388)
 
 ### Internal

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -28,6 +28,7 @@
 - `--task` オプションでの直接実行時に tasks.yaml へ不要な記録がされる問題を修正
 - `--task` でワークツリー作成時は tasks.yaml に記録するよう修正（`takt list` でのブランチ管理に必要）
 - プロバイダー解決: 暗黙の `claude` フォールバックを廃止し、プロバイダーを解決できない場合は Fail Fast で終了するよう修正 (#386)
+- プロバイダー解決: 表示用と実行用の provider/model 解決を `movement:start` イベントの providerInfo に一元化し、表示されるプロバイダーと実行プロバイダーの一致を構造的に保証 (#390)
 - E2E テスト config-priority の不安定性を修正 (#388)
 
 ### Internal

--- a/src/__tests__/options-builder.test.ts
+++ b/src/__tests__/options-builder.test.ts
@@ -114,6 +114,86 @@ describe('OptionsBuilder.buildBaseOptions', () => {
   });
 });
 
+describe('OptionsBuilder.resolveStepProviderModel', () => {
+  it('should return engine-level provider and model when step has no overrides', () => {
+    const step = createMovement();
+    const builder = createBuilder(step, { provider: 'claude', model: 'sonnet' });
+
+    const result = builder.resolveStepProviderModel(step);
+
+    expect(result.provider).toBe('claude');
+    expect(result.model).toBe('sonnet');
+  });
+
+  it('should prioritize persona providers over engine-level provider', () => {
+    const step = createMovement({ personaDisplayName: 'coder' });
+    const builder = createBuilder(step, {
+      provider: 'claude',
+      model: 'sonnet',
+      personaProviders: { coder: { provider: 'codex', model: 'o3-mini' } },
+    });
+
+    const result = builder.resolveStepProviderModel(step);
+
+    expect(result.provider).toBe('codex');
+    expect(result.model).toBe('o3-mini');
+  });
+
+  it('should prioritize step-level provider over engine-level provider', () => {
+    const step = createMovement({ provider: 'opencode' as 'opencode' });
+    const builder = createBuilder(step, { provider: 'claude' });
+
+    const result = builder.resolveStepProviderModel(step);
+
+    expect(result.provider).toBe('opencode');
+  });
+
+  it('should prioritize persona providers over step-level provider', () => {
+    const step = createMovement({ personaDisplayName: 'coder', provider: 'claude' as 'claude' });
+    const builder = createBuilder(step, {
+      provider: 'mock',
+      personaProviders: { coder: { provider: 'codex' } },
+    });
+
+    const result = builder.resolveStepProviderModel(step);
+
+    expect(result.provider).toBe('codex');
+  });
+
+  it('should return undefined model when no model is configured', () => {
+    const step = createMovement();
+    const builder = createBuilder(step, { provider: 'claude', model: undefined });
+
+    const result = builder.resolveStepProviderModel(step);
+
+    expect(result.model).toBeUndefined();
+  });
+
+  it('should return undefined provider when no provider is configured', () => {
+    const step = createMovement();
+    const builder = createBuilder(step, { provider: undefined });
+
+    const result = builder.resolveStepProviderModel(step);
+
+    expect(result.provider).toBeUndefined();
+  });
+
+  it('should match buildBaseOptions stepProvider and stepModel', () => {
+    const step = createMovement({ personaDisplayName: 'coder' });
+    const builder = createBuilder(step, {
+      provider: 'claude',
+      model: 'sonnet',
+      personaProviders: { coder: { provider: 'codex', model: 'o3-mini' } },
+    });
+
+    const providerInfo = builder.resolveStepProviderModel(step);
+    const baseOptions = builder.buildBaseOptions(step);
+
+    expect(providerInfo.provider).toBe(baseOptions.stepProvider);
+    expect(providerInfo.model).toBe(baseOptions.stepModel);
+  });
+});
+
 describe('OptionsBuilder.buildResumeOptions', () => {
   it('should enforce readonly permission and empty allowedTools for report/status phases', () => {
     // Given

--- a/src/__tests__/pieceExecution-ask-user-question.test.ts
+++ b/src/__tests__/pieceExecution-ask-user-question.test.ts
@@ -31,7 +31,7 @@ const { MockPieceEngine } = vi.hoisted(() => {
     async run(): Promise<{ status: string; iteration: number }> {
       const firstStep = this.config.movements[0];
       if (firstStep) {
-        this.emit('movement:start', firstStep, 1, firstStep.instructionTemplate);
+        this.emit('movement:start', firstStep, 1, firstStep.instructionTemplate, { provider: undefined, model: undefined });
       }
       this.emit('piece:complete', { status: 'completed', iteration: 1 });
       return { status: 'completed', iteration: 1 };

--- a/src/__tests__/pieceExecution-debug-prompts.test.ts
+++ b/src/__tests__/pieceExecution-debug-prompts.test.ts
@@ -33,7 +33,8 @@ const { mockIsDebugEnabled, mockWritePromptLog, MockPieceEngine } = vi.hoisted((
       const shouldAbort = this.task === 'abort-task';
 
       const shouldRepeatMovement = this.task === 'repeat-movement-task';
-      this.emit('movement:start', step, 1, 'movement instruction');
+      const providerInfo = { provider: undefined, model: undefined };
+      this.emit('movement:start', step, 1, 'movement instruction', providerInfo);
       this.emit('phase:start', step, 1, 'execute', 'phase prompt');
       this.emit('phase:complete', step, 1, 'execute', 'phase response', 'done');
       this.emit(
@@ -48,7 +49,7 @@ const { mockIsDebugEnabled, mockWritePromptLog, MockPieceEngine } = vi.hoisted((
         'movement instruction'
       );
       if (shouldRepeatMovement) {
-        this.emit('movement:start', step, 2, 'movement instruction repeat');
+        this.emit('movement:start', step, 2, 'movement instruction repeat', providerInfo);
         this.emit(
           'movement:complete',
           step,

--- a/src/__tests__/pieceExecution-session-loading.test.ts
+++ b/src/__tests__/pieceExecution-session-loading.test.ts
@@ -15,6 +15,19 @@ const { MockPieceEngine, mockLoadPersonaSessions, mockLoadWorktreeSessions } = v
   const mockLoadPersonaSessions = vi.fn().mockReturnValue({ coder: 'saved-session-id' });
   const mockLoadWorktreeSessions = vi.fn().mockReturnValue({ coder: 'worktree-session-id' });
 
+  type PersonaProviderMap = Record<string, { provider?: string; model?: string }>;
+
+  function resolveProviderInfo(
+    step: { personaDisplayName?: string; provider?: string; model?: string },
+    opts: Record<string, unknown>,
+  ): { provider: string | undefined; model: string | undefined } {
+    const personaProviders = opts.personaProviders as PersonaProviderMap | undefined;
+    const personaEntry = personaProviders?.[step.personaDisplayName ?? ''];
+    const provider = personaEntry?.provider ?? step.provider ?? opts.provider as string | undefined;
+    const model = personaEntry?.model ?? step.model ?? opts.model as string | undefined;
+    return { provider, model };
+  }
+
   class MockPieceEngine extends EE {
     static lastInstance: MockPieceEngine;
     readonly receivedOptions: Record<string, unknown>;
@@ -32,7 +45,8 @@ const { MockPieceEngine, mockLoadPersonaSessions, mockLoadWorktreeSessions } = v
     async run(): Promise<{ status: string; iteration: number }> {
       const firstStep = this.config.movements[0];
       if (firstStep) {
-        this.emit('movement:start', firstStep, 1, firstStep.instructionTemplate);
+        const providerInfo = resolveProviderInfo(firstStep, this.receivedOptions);
+        this.emit('movement:start', firstStep, 1, firstStep.instructionTemplate, providerInfo);
       }
       this.emit('piece:complete', { status: 'completed', iteration: 1 });
       return { status: 'completed', iteration: 1 };

--- a/src/core/piece/engine/PieceEngine.ts
+++ b/src/core/piece/engine/PieceEngine.ts
@@ -39,6 +39,7 @@ const log = createLogger('engine');
 
 export type {
   PieceEvents,
+  MovementProviderInfo,
   UserInputRequest,
   IterationLimitRequest,
   SessionUpdateCallback,
@@ -492,7 +493,7 @@ export class PieceEngine extends EventEmitter {
       judgeMovement, movementIteration, this.state, this.task, this.config.maxMovements,
     );
 
-    this.emit('movement:start', judgeMovement, this.state.iteration, prebuiltInstruction);
+    this.emit('movement:start', judgeMovement, this.state.iteration, prebuiltInstruction, this.optionsBuilder.resolveStepProviderModel(judgeMovement));
 
     const { response, instruction } = await this.movementExecutor.runNormalMovement(
       judgeMovement,
@@ -579,7 +580,7 @@ export class PieceEngine extends EventEmitter {
           movement, movementIteration, this.state, this.task, this.config.maxMovements,
         );
       }
-      this.emit('movement:start', movement, this.state.iteration, prebuiltInstruction ?? '');
+      this.emit('movement:start', movement, this.state.iteration, prebuiltInstruction ?? '', this.optionsBuilder.resolveStepProviderModel(movement));
 
       try {
         const { response, instruction } = await this.runMovement(movement, prebuiltInstruction);

--- a/src/core/piece/index.ts
+++ b/src/core/piece/index.ts
@@ -18,6 +18,7 @@ export { AskUserQuestionDeniedError, createDenyAskUserQuestionHandler } from './
 export type {
   PieceEvents,
   PhaseName,
+  MovementProviderInfo,
   UserInputRequest,
   IterationLimitRequest,
   SessionUpdateCallback,

--- a/src/core/piece/types.ts
+++ b/src/core/piece/types.ts
@@ -110,9 +110,15 @@ export type AiJudgeCaller = (
 
 export type PhaseName = 'execute' | 'report' | 'judge';
 
+/** Provider and model info resolved for a movement */
+export interface MovementProviderInfo {
+  provider: ProviderType | undefined;
+  model: string | undefined;
+}
+
 /** Events emitted by piece engine */
 export interface PieceEvents {
-  'movement:start': (step: PieceMovement, iteration: number, instruction: string) => void;
+  'movement:start': (step: PieceMovement, iteration: number, instruction: string, providerInfo: MovementProviderInfo) => void;
   'movement:complete': (step: PieceMovement, response: AgentResponse, instruction: string) => void;
   'movement:report': (step: PieceMovement, filePath: string, fileName: string) => void;
   'movement:blocked': (step: PieceMovement, response: AgentResponse) => void;

--- a/src/features/tasks/execute/pieceExecution.ts
+++ b/src/features/tasks/execute/pieceExecution.ts
@@ -71,7 +71,6 @@ import { getLabel } from '../../../shared/i18n/index.js';
 import { EXIT_SIGINT } from '../../../shared/exitCodes.js';
 import { ShutdownManager } from './shutdownManager.js';
 import { buildRunPaths } from '../../../core/piece/run/run-paths.js';
-import { resolveMovementProviderModel } from '../../../core/piece/provider-resolution.js';
 import { resolveRuntimeConfig } from '../../../core/runtime/runtime-environment.js';
 import { writeFileAtomic, ensureDir } from '../../../infra/config/index.js';
 import { getGlobalConfigDir } from '../../../infra/config/paths.js';
@@ -540,7 +539,7 @@ export async function executePiece(
     }
   });
 
-    engine.on('movement:start', (step, iteration, instruction) => {
+    engine.on('movement:start', (step, iteration, instruction, providerInfo) => {
     log.debug('Movement starting', { step: step.name, persona: step.personaDisplayName, iteration });
     currentIteration = iteration;
     const movementIteration = (movementIterations.get(step.name) ?? 0) + 1;
@@ -552,15 +551,8 @@ export async function executePiece(
       movementIteration,
     });
     out.info(`[${iteration}/${pieceConfig.maxMovements}] ${step.name} (${step.personaDisplayName})`);
-    const resolved = resolveMovementProviderModel({
-      step,
-      provider: options.provider,
-      model: options.model,
-      personaProviders: options.personaProviders,
-    });
-    const movementProvider = resolved.provider ?? options.provider ?? currentProvider;
-    const resolvedModel = resolved.model;
-    const movementModel = resolvedModel ?? '(default)';
+    const movementProvider = providerInfo.provider ?? currentProvider;
+    const movementModel = providerInfo.model ?? '(default)';
     currentMovementProvider = movementProvider;
     currentMovementModel = movementModel;
     providerEventLogger.setMovement(step.name);


### PR DESCRIPTION
## Summary

## 背景

#386 の修正で `defaultValue: 'claude'` を削除し、movement-level provider が正しく優先されるようになった。
しかし、provider の解決ロジックが2箇所に分かれている構造自体は残っている。

## 現状

| 箇所 | 用途 | 解決ロジック |
|------|------|-------------|
| `pieceExecution.ts:558` | ログ表示・analytics | `resolveMovementProviderModel()` |
| `runner.ts:32-37` | 実際のエージェント実行 | `resolveProviderModelCandidates()` |

両者は同じ優先順位を意図しているが、独立した実装のため将来的にズレるリスクがある。

## 提案

`AgentRunner.resolveProviderAndModel()` を static public にし、`pieceExecution.ts` の表示側からも同じメソッドを呼ぶようにする。
これにより「表示された provider = 実行に使われる provider」が構造的に保証される。

## Execution Report

Piece `default` completed successfully.

Closes #390