### PR TITLE
Rename 'Sync with root' to 'Merge from root'

### DIFF
--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -177,7 +177,7 @@ takt list --non-interactive --action delete --branch takt/my-branch --yes
 takt list --non-interactive --format json
 ```
 
-インタラクティブモードでは **Sync with root** を選択でき、ルートリポジトリの HEAD をワークツリーブランチにマージします。コンフリクト発生時は AI が自動解決を試みます。
+インタラクティブモードでは **Merge from root** を選択でき、ルートリポジトリの HEAD をワークツリーブランチにマージします。コンフリクト発生時は AI が自動解決を試みます。
 
 ### タスクディレクトリワークフロー（作成 / 実行 / 確認）
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -164,7 +164,7 @@ takt watch
 
 ### takt list
 
-List task branches and perform actions (merge, delete, sync with root, etc.).
+List task branches and perform actions (merge, delete, merge from root, etc.).
 
 ```bash
 # List task branches (merge/delete)
@@ -177,7 +177,7 @@ takt list --non-interactive --action delete --branch takt/my-branch --yes
 takt list --non-interactive --format json
 ```
 
-In interactive mode, **Sync with root** merges the root repository HEAD into the worktree branch with AI-assisted conflict resolution.
+In interactive mode, **Merge from root** merges the root repository HEAD into the worktree branch with AI-assisted conflict resolution.
 
 ### Task Directory Workflow (Create / Run / Verify)
 

--- a/src/features/tasks/list/taskDiffActions.ts
+++ b/src/features/tasks/list/taskDiffActions.ts
@@ -66,7 +66,7 @@ export async function showDiffAndPromptActionForTask(
     [
       { label: 'View diff', value: 'diff', description: 'Show full diff in pager' },
       { label: 'Instruct', value: 'instruct', description: 'Craft additional instructions and requeue this task' },
-      { label: 'Sync with root', value: 'sync', description: 'Merge root HEAD into worktree branch; auto-resolve conflicts with AI' },
+      { label: 'Merge from root', value: 'sync', description: 'Merge root HEAD into worktree branch; auto-resolve conflicts with AI' },
       { label: 'Try merge', value: 'try', description: 'Squash merge (stage changes without commit)' },
       { label: 'Merge & cleanup', value: 'merge', description: 'Merge and delete branch' },
       { label: 'Delete', value: 'delete', description: 'Discard changes, delete branch' },


### PR DESCRIPTION
UIラベルとドキュメントの文言を「Sync with root」から「Merge from root」に変更。

動作（value: 'sync'）は変更なし。表示ラベルのみのリネーム。

変更箇所:
- `taskDiffActions.ts`: メニューラベル
- `cli-reference.md` / `cli-reference.ja.md`: ドキュメント