### PR TITLE
fix: fallback to normal clone when reference repository is shallow

### DIFF
--- a/src/infra/task/clone.ts
+++ b/src/infra/task/clone.ts
@@ -219,17 +219,33 @@ export class CloneManager {
 
     fs.mkdirSync(path.dirname(clonePath), { recursive: true });
 
-    const cloneArgs = ['clone', '--reference', referenceRepo, '--dissociate'];
-    cloneArgs.push(...cloneSubmoduleOptions.args);
+    const commonArgs: string[] = [...cloneSubmoduleOptions.args];
     if (branch) {
-      cloneArgs.push('--branch', branch);
+      commonArgs.push('--branch', branch);
     }
-    cloneArgs.push(projectDir, clonePath);
+    commonArgs.push(projectDir, clonePath);
 
-    execFileSync('git', cloneArgs, {
-      cwd: projectDir,
-      stdio: 'pipe',
-    });
+    const referenceCloneArgs = ['clone', '--reference', referenceRepo, '--dissociate', ...commonArgs];
+    const fallbackCloneArgs = ['clone', ...commonArgs];
+
+    try {
+      execFileSync('git', referenceCloneArgs, {
+        cwd: projectDir,
+        stdio: 'pipe',
+      });
+    } catch (err) {
+      const stderr = ((err as { stderr?: Buffer }).stderr ?? Buffer.alloc(0)).toString();
+      if (stderr.includes('reference repository is shallow')) {
+        log.info('Reference repository is shallow, retrying clone without --reference', { referenceRepo });
+        try { fs.rmSync(clonePath, { recursive: true, force: true }); } catch (e) { log.debug('Failed to cleanup partial clone before retry', { clonePath, error: String(e) }); }
+        execFileSync('git', fallbackCloneArgs, {
+          cwd: projectDir,
+          stdio: 'pipe',
+        });
+      } else {
+        throw err;
+      }
+    }
 
     execFileSync('git', ['remote', 'remove', 'origin'], {
       cwd: clonePath,


### PR DESCRIPTION
## Summary

Fixes #376 （taktで修正してます）

In shallow clone environments (e.g., DevContainer), `git clone --reference` fails with `fatal: reference repository is shallow`. This PR adds fallback logic to `src/infra/task/clone.ts`:

1. First attempts `git clone --reference <repo> --dissociate` (existing behavior)
2. If the error contains `reference repository is shallow`, retries without `--reference`
3. All other clone errors propagate as-is (no fallback)

## Changes

- **`src/infra/task/clone.ts`**: Added try-catch around clone with shallow detection and fallback
- **`src/__tests__/clone.test.ts`**: Added 3 test cases covering shallow fallback, non-shallow error propagation, and reference-first attempt

## Test plan

- [x] Shallow clone error triggers fallback to normal clone
- [x] Non-shallow errors propagate without fallback
- [x] `--reference --dissociate` is attempted first
- [x] Build passes
- [x] All existing + new tests pass