### PR TITLE
Release v0.28.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.28.0-alpha.1] - 2026-02-28
+
+### Added
+
+- GitHub Copilot CLI プロバイダーを追加: `copilot` プロバイダーとして GitHub Copilot CLI を利用可能に。セッション継続、パーミッション制御（readonly/edit/full）に対応。`copilotCliPath` / `TAKT_COPILOT_CLI_PATH` で CLI パスを指定、`copilotGithubToken` / `TAKT_COPILOT_GITHUB_TOKEN` で認証トークンを設定 (#425)
+- `--pr` オプションを追加: PR のレビューコメントを取得してタスクとして実行。パイプラインモードとインタラクティブモードの両方で利用可能 (#421)
+- `takt add --pr N` で PR のレビューコメントをタスクとして追加可能に。PR のブランチ名で worktree を自動作成し、レビュー指摘の修正タスクとしてキューイング (#426)
+- `takt list` に「Pull from remote」アクションを追加: リモートの変更を worktree に取り込み、再プッシュ可能に (#395)
+- プロジェクト単位の CLI パス設定: `.takt/config.yaml` で `claudeCliPath` / `cursorCliPath` / `codexCliPath` / `copilotCliPath` をプロジェクトごとに設定可能に (#413)
+- インタラクティブモードのスラッシュコマンドを行末でも認識可能に（例: `タスクの内容 /go`）(#406)
+- takt-default / takt-default-team-leader ビルトインピースを追加（TAKT 自己開発用のワークフロー定義）
+- TAKT ナレッジファセット（`takt.md`）を追加: TAKT のアーキテクチャとコード規約を体系化
+- ai-antipattern ポリシーに冗長な条件分岐パターン検出を追加: 同一関数を if/else で呼び分けるコードを検出し、三項演算子やスプレッド構文での統一を促す
+
+### Fixed
+
+- 不正な `tasks.yaml` を検出した場合、ファイルを削除せず保持してエラーメッセージで停止するよう修正 (#418)
+- shallow clone リポジトリで worktree 作成が失敗する問題を修正: `--reference` 付きクローンが失敗した場合に通常クローンへフォールバック (#376, #409)
+- グローバル/プロジェクト設定の `model` がモデルログに反映されない不具合を修正 (#417)
+- fork PR レビュー時に `GH_REPO` を設定して正しいリポジトリの issue を参照するよう修正
+- takt-review ワークフローの PR コメント投稿ステップにも `GH_REPO` を設定
+
+### Internal
+
+- `resolveConfigValue` の不要な `defaultValue` 引数を削除し、設定解決ロジックを簡素化 (#391)
+- PRコメント `/resolve` でコンフリクト解決・レビュー指摘修正を行う GitHub Actions ワークフロー（cc-resolve）を追加
+- takt-review ワークフローを `pull_request_target` に変更し、fork PR でもシークレットを利用可能に
+- CI に `ready_for_review` / `reopened` トリガーを追加
+- CONTRIBUTING にレビューモードの例を追加、日本語版（`CONTRIBUTING.ja.md`）を追加
+
 ## [0.27.0] - 2026-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **T**AKT **A**gent **K**oordination **T**opology — Give your AI coding agents structured review loops, managed prompts, and guardrails — so they deliver quality code, not just code.
 
-TAKT runs AI agents (Claude Code, Codex, OpenCode, Cursor) through YAML-defined workflows with built-in review cycles. You talk to AI to define what you want, queue tasks, and let TAKT handle the execution — planning, implementation, multi-stage review, and fix loops — all governed by declarative piece files.
+TAKT runs AI agents (Claude Code, Codex, OpenCode, Cursor, Copilot) through YAML-defined workflows with built-in review cycles. You talk to AI to define what you want, queue tasks, and let TAKT handle the execution — planning, implementation, multi-stage review, and fix loops — all governed by declarative piece files.
 
 TAKT is built with TAKT itself (dogfooding).
 
@@ -22,7 +22,7 @@ TAKT is built with TAKT itself (dogfooding).
 
 Choose one:
 
-- **Provider CLIs**: [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [OpenCode](https://opencode.ai), or [Cursor Agent](https://docs.cursor.com/) installed
+- **Provider CLIs**: [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [OpenCode](https://opencode.ai), [Cursor Agent](https://docs.cursor.com/), or [GitHub Copilot](https://github.com/features/copilot) installed
 - **Direct API**: Anthropic / OpenAI / OpenCode / Cursor API Key (no CLI required)
 
 Optional:
@@ -152,7 +152,7 @@ See the [CLI Reference](./docs/cli-reference.md) for all commands and options.
 Minimal `~/.takt/config.yaml`:
 
 ```yaml
-provider: claude    # claude, codex, opencode, or cursor
+provider: claude    # claude, codex, opencode, cursor, or copilot
 model: sonnet       # passed directly to provider
 language: en        # en or ja
 ```

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,36 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.28.0-alpha.1] - 2026-02-28
+
+### Added
+
+- GitHub Copilot CLI プロバイダーを追加: `copilot` プロバイダーとして GitHub Copilot CLI を利用可能に。セッション継続、パーミッション制御（readonly/edit/full）に対応。`copilotCliPath` / `TAKT_COPILOT_CLI_PATH` で CLI パスを指定、`copilotGithubToken` / `TAKT_COPILOT_GITHUB_TOKEN` で認証トークンを設定 (#425)
+- `--pr` オプションを追加: PR のレビューコメントを取得してタスクとして実行。パイプラインモードとインタラクティブモードの両方で利用可能 (#421)
+- `takt add --pr N` で PR のレビューコメントをタスクとして追加可能に。PR のブランチ名で worktree を自動作成し、レビュー指摘の修正タスクとしてキューイング (#426)
+- `takt list` に「Pull from remote」アクションを追加: リモートの変更を worktree に取り込み、再プッシュ可能に (#395)
+- プロジェクト単位の CLI パス設定: `.takt/config.yaml` で `claudeCliPath` / `cursorCliPath` / `codexCliPath` / `copilotCliPath` をプロジェクトごとに設定可能に (#413)
+- インタラクティブモードのスラッシュコマンドを行末でも認識可能に（例: `タスクの内容 /go`）(#406)
+- takt-default / takt-default-team-leader ビルトインピースを追加（TAKT 自己開発用のワークフロー定義）
+- TAKT ナレッジファセット（`takt.md`）を追加: TAKT のアーキテクチャとコード規約を体系化
+- ai-antipattern ポリシーに冗長な条件分岐パターン検出を追加: 同一関数を if/else で呼び分けるコードを検出し、三項演算子やスプレッド構文での統一を促す
+
+### Fixed
+
+- 不正な `tasks.yaml` を検出した場合、ファイルを削除せず保持してエラーメッセージで停止するよう修正 (#418)
+- shallow clone リポジトリで worktree 作成が失敗する問題を修正: `--reference` 付きクローンが失敗した場合に通常クローンへフォールバック (#376, #409)
+- グローバル/プロジェクト設定の `model` がモデルログに反映されない不具合を修正 (#417)
+- fork PR レビュー時に `GH_REPO` を設定して正しいリポジトリの issue を参照するよう修正
+- takt-review ワークフローの PR コメント投稿ステップにも `GH_REPO` を設定
+
+### Internal
+
+- `resolveConfigValue` の不要な `defaultValue` 引数を削除し、設定解決ロジックを簡素化 (#391)
+- PRコメント `/resolve` でコンフリクト解決・レビュー指摘修正を行う GitHub Actions ワークフロー（cc-resolve）を追加
+- takt-review ワークフローを `pull_request_target` に変更し、fork PR でもシークレットを利用可能に
+- CI に `ready_for_review` / `reopened` トリガーを追加
+- CONTRIBUTING にレビューモードの例を追加、日本語版（`CONTRIBUTING.ja.md`）を追加
+
 ## [0.27.0] - 2026-02-28
 
 ### Added

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -4,7 +4,7 @@
 
 **T**AKT **A**gent **K**oordination **T**opology — AI コーディングエージェントにレビューループ・プロンプト管理・ガードレールを与え、「とりあえず動くコード」ではなく「品質の高いコード」を出させるツールです。
 
-AI と会話してやりたいことを決め、タスクとして積み、`takt run` で実行します。計画・実装・レビュー・修正のループは YAML の piece ファイルで定義されており、エージェント任せにはしません。Claude Code、Codex、OpenCode、Cursor に対応しています。
+AI と会話してやりたいことを決め、タスクとして積み、`takt run` で実行します。計画・実装・レビュー・修正のループは YAML の piece ファイルで定義されており、エージェント任せにはしません。Claude Code、Codex、OpenCode、Cursor、Copilot に対応しています。
 
 TAKT は TAKT 自身で開発しています（ドッグフーディング）。
 
@@ -22,7 +22,7 @@ TAKT は TAKT 自身で開発しています（ドッグフーディング）。
 
 次のいずれかが必要です。
 
-- **プロバイダー CLI**: [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex](https://github.com/openai/codex)、[OpenCode](https://opencode.ai)、[Cursor Agent](https://docs.cursor.com/) のいずれか
+- **プロバイダー CLI**: [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex](https://github.com/openai/codex)、[OpenCode](https://opencode.ai)、[Cursor Agent](https://docs.cursor.com/)、[GitHub Copilot](https://github.com/features/copilot) のいずれか
 - **API Key 直接利用**: Anthropic / OpenAI / OpenCode / Cursor の API Key があれば CLI は不要です
 
 任意:
@@ -164,7 +164,7 @@ movements:
 最小限の `~/.takt/config.yaml` は次の通りです。
 
 ```yaml
-provider: claude    # claude, codex, opencode, or cursor
+provider: claude    # claude, codex, opencode, cursor, or copilot
 model: sonnet       # プロバイダーにそのまま渡されます
 language: ja        # en or ja
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.27.0",
+  "version": "0.28.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.27.0",
+      "version": "0.28.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.27.0",
+  "version": "0.28.0-alpha.1",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- GitHub Copilot CLI プロバイダーを追加 (#425)
- `--pr` オプションで PR レビューコメントを取得してタスクとして実行 (#421)
- `takt add --pr N` で PR レビューコメントをタスクとして追加 (#426)
- `takt list` に「Pull from remote」アクションを追加 (#395)
- プロジェクト単位の CLI パス設定（Claude/Cursor/Codex/Copilot）(#413)
- インタラクティブモードのスラッシュコマンドを行末でも認識可能に (#406)
- takt-default / takt-default-team-leader ビルトインピースを追加
- TAKT ナレッジファセット、ai-antipattern の冗長な条件分岐パターン検出を追加

### Fixed

- 不正な tasks.yaml で削除せず停止するよう修正 (#418)
- shallow clone リポジトリで worktree 作成失敗時に通常クローンへフォールバック (#376, #409)
- Global/Project の model がモデルログに反映されない不具合を修正 (#417)
- fork PR レビュー時の GH_REPO 設定修正

### Internal

- resolveConfigValue の defaultValue 整理 (#391)
- cc-resolve ワークフロー追加・改善
- takt-review ワークフロー fork PR 対応
- CONTRIBUTING 日本語版追加

## Commits

- 9ce4358e Release v0.28.0-alpha.1
- 8f0f5469 [#426] add-pr-review-task (#427)
- 2be824b2 fix: PRコメント投稿ステップにも GH_REPO を設定
- 17232f99 feat: add GitHub Copilot CLI as a new provider (#425)
- 45663342 feat: ai-antipattern ポリシーに冗長な条件分岐パターン検出を追加
- ff31d9cb fix: fork PR レビュー時に GH_REPO を設定して正しいリポジトリの issue を参照
- 5fd9022c fix: takt-review を pull_request_target に変更して fork PR でもシークレットを利用可能に
- e5665ed8 fix: takt-review のトリガーに reopened を追加
- 929557aa fix: takt-review が fork PR で失敗する問題を修正
- fb0b3438 ci: pull_request の ready_for_review でもCIが走るように修正
- 9ba05d85 [#395] github-issue-395-add-pull-from (#397)
- 2d0dc127 refactor: cc-resolve をコンフリクト解決専用に変更
- 88455b75 fix: cc-resolve でマージコミットがあれば常に push するように修正
- 8bb9ea4e fix: cc-resolve の Resolve ステップに GH_TOKEN を追加
- d05cb434 fix: cc-resolve で Claude にフル権限を付与
- 2a8cc50b fix: cc-resolve でフォークPRをスキップ
- e4af465d fix: cc-resolve の checkout 前ステップに --repo を追加
- f6d59f42 fix: cc-resolve の checkout 前ステップに --repo を追加
- fe0b7237 fix: 不正なtasks.yamlで削除せず停止するように修正 (#418)
- ac4cb9c8 fix: fallback to normal clone when reference repository is shallow (#376) (#409)
- e77cb50a feat: インタラクティブモードのスラッシュコマンドを行末でも認識可能にする (#406)
- 09fda826 ci: PRコメント /resolve でコンフリクト解決ワークフローを追加
- 252c3374 fix: Global/ProjectのmodelがModelログに反映されない不具合を修正 (#417)
- 7494149e [#421] github-issue-421-feat-pr-opush (#422)
- e256db8d takt: github-issue-398-branchexists (#401)
- ae74c0d5 takt: #391 resolveConfigValue の無意味な defaultValue を撲滅する (#392)
- 6d50221d ci: PRに対するTAKT Reviewワークフローを追加
- 4e9c0209 feat: add takt-default pieces and TAKT knowledge facet for self-development
- c7389a5b docs: add review mode examples to CONTRIBUTING
- b8b64f85 feat: プロジェクト単位のCLIパス設定(Claude/Cursor/Codex) (#413)
- 52c5e290 docs: require takt review before submitting PRs

## Closes

Closes #391