### PR TITLE
[#404] refactor-status-types

### DIFF
--- a/builtins/en/facets/knowledge/architecture.md
+++ b/builtins/en/facets/knowledge/architecture.md
@@ -121,8 +121,8 @@ Detect comments that simply restate code behavior in natural language.
 
 ```typescript
 // REJECT - Restates code (What)
-// If interrupted, abort immediately
-if (status === 'interrupted') {
+// If error, abort immediately
+if (status === 'error') {
   return ABORT_STEP;
 }
 
@@ -135,8 +135,8 @@ for (const transition of step.transitions) {
 export function matchesCondition(status: Status, condition: TransitionCondition): boolean {
 
 // OK - Design decision (Why)
-// User interruption takes priority over piece-defined transitions
-if (status === 'interrupted') {
+// Errors take priority over piece-defined transitions
+if (status === 'error') {
   return ABORT_STEP;
 }
 

--- a/builtins/ja/facets/knowledge/architecture.md
+++ b/builtins/ja/facets/knowledge/architecture.md
@@ -121,8 +121,8 @@ Vertical Slice の判定基準:
 
 ```typescript
 // REJECT - コードの言い換え（What）
-// If interrupted, abort immediately
-if (status === 'interrupted') {
+// If error, abort immediately
+if (status === 'error') {
   return ABORT_STEP;
 }
 
@@ -135,8 +135,8 @@ for (const transition of step.transitions) {
 export function matchesCondition(status: Status, condition: TransitionCondition): boolean {
 
 // OK - 設計判断の理由（Why）
-// ユーザー中断はピース定義のトランジションより優先する
-if (status === 'interrupted') {
+// エラーはピース定義のトランジションより優先する
+if (status === 'error') {
   return ABORT_STEP;
 }
 

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -27,19 +27,27 @@ describe('AgentTypeSchema', () => {
 });
 
 describe('StatusSchema', () => {
-  it('should accept valid statuses', () => {
-    expect(StatusSchema.parse('pending')).toBe('pending');
+  it('有効なステータス値（6種類）をすべて受容する', () => {
     expect(StatusSchema.parse('done')).toBe('done');
     expect(StatusSchema.parse('approved')).toBe('approved');
     expect(StatusSchema.parse('rejected')).toBe('rejected');
+    expect(StatusSchema.parse('improve')).toBe('improve');
     expect(StatusSchema.parse('blocked')).toBe('blocked');
     expect(StatusSchema.parse('error')).toBe('error');
-    expect(StatusSchema.parse('answer')).toBe('answer');
   });
 
-  it('should reject invalid statuses', () => {
-    expect(() => StatusSchema.parse('unknown')).toThrow();
-    expect(() => StatusSchema.parse('conditional')).toThrow();
+  it('廃止済みステータスは受理しない', () => {
+    for (const status of [
+      'pending',
+      'answer',
+      'cancelled',
+      'interrupted',
+      'unknown',
+      'conditional',
+    ]) {
+      const result = StatusSchema.safeParse(status);
+      expect(result.success).toBe(false);
+    }
   });
 });
 

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, readFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createSessionState } from '../core/models/session.js';
 import {
   initNdjsonLog,
   appendNdjsonLine,
@@ -659,5 +660,26 @@ describe('NDJSON log', () => {
       const result = extractFailureInfo(filepath);
       expect(result).toBeNull();
     });
+  });
+});
+
+describe('createSessionState', () => {
+  it('デフォルト値で SessionState を生成する', () => {
+    const state = createSessionState('タスク', '/project');
+
+    expect(state.task).toBe('タスク');
+    expect(state.projectDir).toBe('/project');
+    expect(state.iteration).toBe(0);
+    expect(state.maxMovements).toBe(10);
+    expect(state.history).toEqual([]);
+    expect(state.context).toBe('');
+  });
+
+  it('options で値を上書きできる', () => {
+    const state = createSessionState('task', '/dir', { iteration: 3, maxMovements: 20, context: 'ctx' });
+
+    expect(state.iteration).toBe(3);
+    expect(state.maxMovements).toBe(20);
+    expect(state.context).toBe('ctx');
   });
 });

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -45,16 +45,12 @@ export const AgentTypeSchema = z.enum(['coder', 'architect', 'supervisor', 'cust
 
 /** Status schema */
 export const StatusSchema = z.enum([
-  'pending',
   'done',
   'blocked',
   'error',
   'approved',
   'rejected',
   'improve',
-  'cancelled',
-  'interrupted',
-  'answer',
 ]);
 
 /** Permission mode schema for tool execution */

--- a/src/core/models/session.ts
+++ b/src/core/models/session.ts
@@ -3,7 +3,6 @@
  */
 
 import type { AgentResponse } from './response.js';
-import type { Status } from './status.js';
 
 /**
  * Session state for piece execution
@@ -13,9 +12,6 @@ export interface SessionState {
   projectDir: string;
   iteration: number;
   maxMovements: number;
-  coderStatus: Status;
-  architectStatus: Status;
-  supervisorStatus: Status;
   history: AgentResponse[];
   context: string;
 }
@@ -33,9 +29,6 @@ export function createSessionState(
     projectDir,
     iteration: 0,
     maxMovements: 10,
-    coderStatus: 'pending',
-    architectStatus: 'pending',
-    supervisorStatus: 'pending',
     history: [],
     context: '',
     ...options,

--- a/src/core/models/status.ts
+++ b/src/core/models/status.ts
@@ -7,16 +7,12 @@ export type AgentType = 'coder' | 'architect' | 'supervisor' | 'custom';
 
 /** Execution status for agents and pieces */
 export type Status =
-  | 'pending'
   | 'done'
   | 'blocked'
   | 'error'
   | 'approved'
   | 'rejected'
-  | 'improve'
-  | 'cancelled'
-  | 'interrupted'
-  | 'answer';
+  | 'improve';
 
 /** How a rule match was detected */
 export type RuleMatchMethod =

--- a/src/infra/claude/client.ts
+++ b/src/infra/claude/client.ts
@@ -22,15 +22,9 @@ const log = createLogger('client');
 export class ClaudeClient {
   /** Determine status from execution result */
   private static determineStatus(
-    result: { success: boolean; interrupted?: boolean; content: string; fullContent?: string },
+    result: { success: boolean; content: string; fullContent?: string },
   ): Status {
-    if (!result.success) {
-      if (result.interrupted) {
-        return 'interrupted';
-      }
-      return 'error';
-    }
-    return 'done';
+    return result.success ? 'done' : 'error';
   }
 
   /** Convert ClaudeCallOptions to ClaudeSpawnOptions */
@@ -152,7 +146,7 @@ export class ClaudeClient {
 
     return {
       persona: `skill:${skillName}`,
-      status: result.success ? 'done' : 'error',
+      status: ClaudeClient.determineStatus(result),
       content: result.content,
       timestamp: new Date(),
       sessionId: result.sessionId,

--- a/src/infra/claude/process.ts
+++ b/src/infra/claude/process.ts
@@ -64,7 +64,6 @@ export async function executeClaudeCli(
 export class ClaudeProcess {
   private options: ClaudeSpawnOptions;
   private currentSessionId?: string;
-  private interrupted = false;
 
   constructor(options: ClaudeSpawnOptions) {
     this.options = options;
@@ -72,18 +71,13 @@ export class ClaudeProcess {
 
   /** Execute a prompt */
   async execute(prompt: string): Promise<ClaudeResult> {
-    this.interrupted = false;
     const result = await executeClaudeCli(prompt, this.options);
     this.currentSessionId = result.sessionId;
-    if (result.interrupted) {
-      this.interrupted = true;
-    }
     return result;
   }
 
   /** Interrupt the running query */
   kill(): void {
-    this.interrupted = true;
     interruptCurrentProcess();
   }
 
@@ -95,10 +89,5 @@ export class ClaudeProcess {
   /** Get session ID */
   getSessionId(): string | undefined {
     return this.currentSessionId;
-  }
-
-  /** Check if query was interrupted */
-  wasInterrupted(): boolean {
-    return this.interrupted;
   }
 }


### PR DESCRIPTION
## Summary

## 概要

`Status` 型（`src/core/models/status.ts`）に定義されているステータスのうち、`PieceEngine.run()` で明示的にハンドリングされていないものがある。現状は `resolveNextMovement` で例外になるパスに依存しており、意図的な設計ではない。

## 現状

`PieceEngine.run()` のステータス分岐:

```typescript
if (response.status === 'blocked') { /* handleBlocked */ }
if (response.status === 'error') { /* abort */ }
// それ以外 → resolveNextMovement（matchedRuleIndex 必須）
```

`Status` 型の全値と PieceEngine での扱い:

| status | ハンドリング | 備考 |
|--------|------------|------|
| `done` | ✅ `resolveNextMovement` | 正常フロー |
| `error` | ✅ abort | プロバイダー障害 |
| `blocked` | ✅ `handleBlocked` | ユーザー入力待ち |
| `interrupted` | ❌ 例外パス | Claude provider が返す（`client.ts:29`） |
| `approved` | ❌ 例外パス | Mock provider が返せる |
| `rejected` | ❌ 例外パス | Mock provider が返せる |
| `improve` | ❌ 例外パス | Mock provider が返せる |
| `cancelled` | ❌ 例外パス | 使用箇所なし |
| `answer` | ❌ 例外パス | 使用箇所なし |
| `pending` | ❌ 例外パス | 使用箇所なし |

## 未使用コード

- `ClaudeProcess.wasInterrupted()` が定義されているが呼び出し元がない

## 検討事項

- `interrupted` を `error` に統一するか、PieceEngine に明示的ハンドリングを追加するか
- `approved` / `rejected` / `improve` はエンジンレベルで必要か、Mock 専用で十分か
- `cancelled` / `answer` / `pending` は AgentResponse として返る想定があるのか
- 不要なステータスを `Status` 型から削除するか

## 発見経緯

PR #403 のレビューで `status !== 'done'` ガードの影響範囲を調査した際に発見。

## Execution Report

Piece `takt-default-team-leader` completed successfully.

Closes #404