### PR TITLE
fix: validate git state before worktree clone creation

### DIFF
--- a/src/__tests__/cli-worktree-git-validation.test.ts
+++ b/src/__tests__/cli-worktree-git-validation.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Tests for git state validation in worktree creation flow
+ *
+ * Covers:
+ * - confirmAndCreateWorktree: git readiness check before clone creation
+ * - selectAndExecuteTask: null result handling when user declines fallback
+ * - resolveExecutionContext: pipeline mode fallback behavior
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---- Hoisted mocks ----
+
+const {
+  mockCheckGitCloneReadiness,
+  mockAddTask,
+  mockCompleteTask,
+  mockFailTask,
+  mockExecuteTask,
+} = vi.hoisted(() => ({
+  mockCheckGitCloneReadiness: vi.fn(),
+  mockAddTask: vi.fn(() => ({
+    name: 'test-task',
+    content: 'test task',
+    filePath: '/project/.takt/tasks.yaml',
+    createdAt: '2026-03-01T00:00:00.000Z',
+    status: 'pending',
+    data: { task: 'test task' },
+  })),
+  mockCompleteTask: vi.fn(),
+  mockFailTask: vi.fn(),
+  mockExecuteTask: vi.fn(),
+}));
+
+// ---- Module mocks ----
+
+vi.mock('../shared/prompt/index.js', () => ({
+  confirm: vi.fn(),
+  selectOptionWithDefault: vi.fn(),
+}));
+
+vi.mock('../infra/task/git.js', () => ({
+  stageAndCommit: vi.fn(),
+  getCurrentBranch: vi.fn(() => 'main'),
+  pushBranch: vi.fn(),
+  checkGitCloneReadiness: (...args: unknown[]) => mockCheckGitCloneReadiness(...args),
+}));
+
+vi.mock('../infra/task/clone.js', () => ({
+  createSharedClone: vi.fn(),
+  removeClone: vi.fn(),
+  resolveBaseBranch: vi.fn(() => ({ branch: 'main' })),
+}));
+
+vi.mock('../infra/task/branchList.js', () => ({
+  detectDefaultBranch: vi.fn(() => 'main'),
+  BranchManager: vi.fn(),
+}));
+
+vi.mock('../infra/task/autoCommit.js', () => ({
+  autoCommitAndPush: vi.fn(),
+}));
+
+vi.mock('../infra/task/summarize.js', () => ({
+  summarizeTaskName: vi.fn(),
+}));
+
+vi.mock('../infra/task/runner.js', () => ({
+  TaskRunner: vi.fn(() => ({
+    addTask: (...args: unknown[]) => mockAddTask(...args),
+    completeTask: (...args: unknown[]) => mockCompleteTask(...args),
+    failTask: (...args: unknown[]) => mockFailTask(...args),
+  })),
+}));
+
+vi.mock('../shared/ui/index.js', () => {
+  const info = vi.fn();
+  const warn = vi.fn();
+  return {
+    info,
+    warn,
+    error: vi.fn(),
+    success: vi.fn(),
+    header: vi.fn(),
+    status: vi.fn(),
+    setLogLevel: vi.fn(),
+    withProgress: vi.fn(async (start: string, done: unknown, operation: () => Promise<unknown>) => {
+      info(start);
+      const result = await operation();
+      info(typeof done === 'function' ? done(result) : done);
+      return result;
+    }),
+  };
+});
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+  initDebugLogger: vi.fn(),
+  setVerboseConsole: vi.fn(),
+  getDebugLogFile: vi.fn(),
+}));
+
+vi.mock('../infra/config/index.js', () => ({
+  initGlobalDirs: vi.fn(),
+  initProjectDirs: vi.fn(),
+  loadGlobalConfig: vi.fn(() => ({ logLevel: 'info' })),
+  resolvePieceConfigValue: vi.fn(),
+  listPieces: vi.fn(() => ['default']),
+  listPieceEntries: vi.fn(() => []),
+  loadPieceByIdentifier: vi.fn((identifier: string) => (identifier === 'default' ? { name: 'default' } : null)),
+  isPiecePath: vi.fn(() => false),
+  resolveConfigValue: vi.fn(() => undefined),
+}));
+
+vi.mock('../infra/config/paths.js', () => ({
+  clearPersonaSessions: vi.fn(),
+  isVerboseMode: vi.fn(() => false),
+}));
+
+vi.mock('../infra/config/loaders/pieceLoader.js', () => ({
+  listPieces: vi.fn(() => []),
+}));
+
+vi.mock('../shared/constants.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../shared/constants.js')>();
+  return {
+    ...actual,
+    DEFAULT_PIECE_NAME: 'default',
+  };
+});
+
+vi.mock('../infra/github/issue.js', () => ({
+  isIssueReference: vi.fn((s: string) => /^#\d+$/.test(s)),
+  resolveIssueTask: vi.fn(),
+}));
+
+vi.mock('../infra/github/index.js', () => ({
+  buildPrBody: vi.fn(),
+}));
+
+vi.mock('../features/tasks/execute/taskExecution.js', () => ({
+  executeTask: (...args: unknown[]) => mockExecuteTask(...args),
+}));
+
+vi.mock('../features/pieceSelection/index.js', () => ({
+  warnMissingPieces: vi.fn(),
+  selectPieceFromCategorizedPieces: vi.fn(),
+  selectPieceFromEntries: vi.fn(),
+  selectPiece: vi.fn(),
+}));
+
+// ---- Imports ----
+
+import { confirm } from '../shared/prompt/index.js';
+import { createSharedClone } from '../infra/task/clone.js';
+import { summarizeTaskName } from '../infra/task/summarize.js';
+import { warn } from '../shared/ui/index.js';
+import { confirmAndCreateWorktree, selectAndExecuteTask } from '../features/tasks/execute/selectAndExecute.js';
+
+const mockConfirm = vi.mocked(confirm);
+const mockCreateSharedClone = vi.mocked(createSharedClone);
+const mockSummarizeTaskName = vi.mocked(summarizeTaskName);
+const mockWarn = vi.mocked(warn);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExecuteTask.mockResolvedValue(true);
+});
+
+// ---- Tests: confirmAndCreateWorktree git validation ----
+
+describe('confirmAndCreateWorktree git state validation', () => {
+  describe('when git repo is not initialized (not_git_repo)', () => {
+    beforeEach(() => {
+      mockCheckGitCloneReadiness.mockReturnValue({ ready: false, reason: 'not_git_repo' });
+    });
+
+    it('should warn and offer fallback when interactive (no override)', async () => {
+      // Given: user confirms worktree creation, then accepts fallback
+      mockConfirm
+        .mockResolvedValueOnce(true)   // "Create worktree?"
+        .mockResolvedValueOnce(true);  // "Run in current directory instead?"
+
+      // When
+      const result = await confirmAndCreateWorktree('/project', 'fix bug');
+
+      // Then: falls back to in-place execution
+      expect(result).toEqual({ execCwd: '/project', isWorktree: false });
+      expect(mockWarn).toHaveBeenCalled();
+      expect(mockCreateSharedClone).not.toHaveBeenCalled();
+    });
+
+    it('should return null when user declines fallback in interactive mode', async () => {
+      // Given: user confirms worktree, then declines fallback
+      mockConfirm
+        .mockResolvedValueOnce(true)   // "Create worktree?"
+        .mockResolvedValueOnce(false); // "Run in current directory instead?" → No
+
+      // When
+      const result = await confirmAndCreateWorktree('/project', 'fix bug');
+
+      // Then: returns null (caller should save task and exit)
+      expect(result).toBeNull();
+      expect(mockCreateSharedClone).not.toHaveBeenCalled();
+    });
+
+    it('should auto-fallback when override is true (pipeline mode)', async () => {
+      // Given: override=true (pipeline mode, non-interactive)
+
+      // When
+      const result = await confirmAndCreateWorktree('/project', 'fix bug', true);
+
+      // Then: auto-fallback to in-place execution
+      expect(result).toEqual({ execCwd: '/project', isWorktree: false });
+      expect(mockWarn).toHaveBeenCalled();
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockCreateSharedClone).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when git repo has no commits (no_commits)', () => {
+    beforeEach(() => {
+      mockCheckGitCloneReadiness.mockReturnValue({ ready: false, reason: 'no_commits' });
+    });
+
+    it('should warn and offer fallback when interactive (no override)', async () => {
+      // Given: user confirms worktree creation, then accepts fallback
+      mockConfirm
+        .mockResolvedValueOnce(true)   // "Create worktree?"
+        .mockResolvedValueOnce(true);  // "Run in current directory instead?"
+
+      // When
+      const result = await confirmAndCreateWorktree('/project', 'add feature');
+
+      // Then: falls back to in-place execution
+      expect(result).toEqual({ execCwd: '/project', isWorktree: false });
+      expect(mockWarn).toHaveBeenCalled();
+      expect(mockCreateSharedClone).not.toHaveBeenCalled();
+    });
+
+    it('should return null when user declines fallback in interactive mode', async () => {
+      // Given: user confirms worktree, then declines fallback
+      mockConfirm
+        .mockResolvedValueOnce(true)   // "Create worktree?"
+        .mockResolvedValueOnce(false); // "Run in current directory instead?" → No
+
+      // When
+      const result = await confirmAndCreateWorktree('/project', 'add feature');
+
+      // Then
+      expect(result).toBeNull();
+    });
+
+    it('should auto-fallback when override is true (pipeline mode)', async () => {
+      // Given: override=true (pipeline mode)
+
+      // When
+      const result = await confirmAndCreateWorktree('/project', 'add feature', true);
+
+      // Then: auto-fallback
+      expect(result).toEqual({ execCwd: '/project', isWorktree: false });
+      expect(mockWarn).toHaveBeenCalled();
+      expect(mockConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when git repo is ready (normal case)', () => {
+    beforeEach(() => {
+      mockCheckGitCloneReadiness.mockReturnValue({ ready: true });
+    });
+
+    it('should proceed with clone creation when git is ready', async () => {
+      // Given: user confirms worktree, git is ready
+      mockConfirm.mockResolvedValueOnce(true);
+      mockSummarizeTaskName.mockResolvedValue('fix-auth');
+      mockCreateSharedClone.mockReturnValue({
+        path: '/project/../20260301T0000-fix-auth',
+        branch: 'takt/20260301T0000-fix-auth',
+      });
+
+      // When
+      const result = await confirmAndCreateWorktree('/project', 'fix auth');
+
+      // Then: clone is created normally
+      expect(result.isWorktree).toBe(true);
+      expect(result.execCwd).toBe('/project/../20260301T0000-fix-auth');
+      expect(mockCreateSharedClone).toHaveBeenCalled();
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it('should not check git readiness when user declines worktree', async () => {
+      // Given: user declines worktree creation
+      mockConfirm.mockResolvedValueOnce(false);
+
+      // When
+      const result = await confirmAndCreateWorktree('/project', 'fix auth');
+
+      // Then: no readiness check, returns cwd directly
+      expect(result).toEqual({ execCwd: '/project', isWorktree: false });
+      expect(mockCheckGitCloneReadiness).not.toHaveBeenCalled();
+    });
+
+    it('should not check git readiness when override is false', async () => {
+      // Given: override=false (worktree explicitly disabled)
+
+      // When
+      const result = await confirmAndCreateWorktree('/project', 'task', false);
+
+      // Then
+      expect(result).toEqual({ execCwd: '/project', isWorktree: false });
+      expect(mockCheckGitCloneReadiness).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---- Tests: selectAndExecuteTask null handling ----
+
+describe('selectAndExecuteTask with git validation', () => {
+  it('should save task and return when confirmAndCreateWorktree returns null', async () => {
+    // Given: git repo not ready, user declines fallback → confirmAndCreateWorktree returns null
+    mockCheckGitCloneReadiness.mockReturnValue({ ready: false, reason: 'not_git_repo' });
+    mockConfirm
+      .mockResolvedValueOnce(true)   // "Create worktree?"
+      .mockResolvedValueOnce(false); // "Run in current directory?" → No
+
+    // When
+    await selectAndExecuteTask('/project', 'fix bug', { piece: 'default' });
+
+    // Then: task is saved to queue and execution does not proceed
+    expect(mockAddTask).toHaveBeenCalledWith('fix bug', expect.objectContaining({
+      piece: 'default',
+    }));
+    expect(mockExecuteTask).not.toHaveBeenCalled();
+  });
+
+  it('should execute task in-place when user accepts fallback', async () => {
+    // Given: git repo not ready, user accepts fallback
+    mockCheckGitCloneReadiness.mockReturnValue({ ready: false, reason: 'no_commits' });
+    mockConfirm
+      .mockResolvedValueOnce(true)   // "Create worktree?"
+      .mockResolvedValueOnce(true);  // "Run in current directory?" → Yes
+
+    mockExecuteTask.mockResolvedValue(true);
+
+    // When
+    await selectAndExecuteTask('/project', 'fix bug', { piece: 'default' });
+
+    // Then: task executes in original cwd (not worktree)
+    expect(mockExecuteTask).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: '/project',
+      pieceIdentifier: 'default',
+    }));
+  });
+});
+
+// ---- Tests: resolveExecutionContext pipeline fallback ----
+
+describe('resolveExecutionContext pipeline git validation', () => {
+  // resolveExecutionContext uses confirmAndCreateWorktree with override=true,
+  // which triggers auto-fallback when git is not ready.
+  // We test this through the pipeline execution path.
+
+  it('should fall back to in-place execution when git is not ready in pipeline mode', async () => {
+    // Given: git repo not ready, pipeline mode with createWorktree=true
+    mockCheckGitCloneReadiness.mockReturnValue({ ready: false, reason: 'not_git_repo' });
+
+    // Import resolveExecutionContext to test directly
+    const { resolveExecutionContext } = await import('../features/pipeline/steps.js');
+
+    // When
+    const result = await resolveExecutionContext(
+      '/project',
+      'fix bug',
+      { createWorktree: true },
+      undefined,
+    );
+
+    // Then: falls back to in-place execution
+    expect(result.execCwd).toBe('/project');
+    expect(result.isWorktree).toBe(false);
+    expect(mockCreateSharedClone).not.toHaveBeenCalled();
+  });
+
+  it('should proceed normally when git is ready in pipeline mode', async () => {
+    // Given: git repo is ready, pipeline mode
+    mockCheckGitCloneReadiness.mockReturnValue({ ready: true });
+    mockSummarizeTaskName.mockResolvedValue('fix-bug');
+    mockCreateSharedClone.mockReturnValue({
+      path: '/tmp/worktree',
+      branch: 'takt/fix-bug',
+    });
+
+    const { resolveExecutionContext } = await import('../features/pipeline/steps.js');
+
+    // When
+    const result = await resolveExecutionContext(
+      '/project',
+      'fix bug',
+      { createWorktree: true },
+      undefined,
+    );
+
+    // Then: worktree is created normally
+    expect(result.isWorktree).toBe(true);
+    expect(result.execCwd).toBe('/tmp/worktree');
+    expect(mockCreateSharedClone).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/cli-worktree.test.ts
+++ b/src/__tests__/cli-worktree.test.ts
@@ -13,6 +13,7 @@ vi.mock('../shared/prompt/index.js', () => ({
 vi.mock('../infra/task/git.js', () => ({
   stageAndCommit: vi.fn(),
   getCurrentBranch: vi.fn(() => 'main'),
+  checkGitCloneReadiness: vi.fn(() => ({ ready: true })),
 }));
 
 vi.mock('../infra/task/clone.js', () => ({
@@ -38,6 +39,7 @@ vi.mock('../shared/ui/index.js', () => {
   const info = vi.fn();
   return {
     info,
+    warn: vi.fn(),
     error: vi.fn(),
     success: vi.fn(),
     header: vi.fn(),

--- a/src/__tests__/git-clone-readiness.test.ts
+++ b/src/__tests__/git-clone-readiness.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for checkGitCloneReadiness (git state validation before clone creation)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { execFileSync } from 'node:child_process';
+import { checkGitCloneReadiness } from '../infra/task/git.js';
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('checkGitCloneReadiness', () => {
+  it('should return ready when git repo is initialized and has commits', () => {
+    // Given: both git commands succeed
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--is-inside-work-tree') {
+        return 'true\n';
+      }
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === 'HEAD') {
+        return 'abc123\n';
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    const result = checkGitCloneReadiness('/project');
+
+    // Then
+    expect(result).toEqual({ ready: true });
+  });
+
+  it('should return not_git_repo when directory is not a git repository', () => {
+    // Given: git rev-parse --is-inside-work-tree fails
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--is-inside-work-tree') {
+        throw new Error('fatal: not a git repository');
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    const result = checkGitCloneReadiness('/not-a-repo');
+
+    // Then
+    expect(result).toEqual({ ready: false, reason: 'not_git_repo' });
+  });
+
+  it('should return no_commits when git repo has no commits', () => {
+    // Given: git is initialized but HEAD does not exist
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--is-inside-work-tree') {
+        return 'true\n';
+      }
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === 'HEAD') {
+        throw new Error('fatal: ambiguous argument \'HEAD\': unknown revision');
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    const result = checkGitCloneReadiness('/empty-repo');
+
+    // Then
+    expect(result).toEqual({ ready: false, reason: 'no_commits' });
+  });
+
+  it('should pass cwd to execFileSync for both checks', () => {
+    // Given: both commands succeed
+    mockExecFileSync.mockReturnValue(Buffer.from('true\n'));
+
+    // When
+    checkGitCloneReadiness('/my/project/dir');
+
+    // Then: both calls use the provided cwd
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['rev-parse', '--is-inside-work-tree'],
+      expect.objectContaining({ cwd: '/my/project/dir' }),
+    );
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['rev-parse', 'HEAD'],
+      expect.objectContaining({ cwd: '/my/project/dir' }),
+    );
+  });
+
+  it('should not check HEAD when not a git repo', () => {
+    // Given: not a git repo
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--is-inside-work-tree') {
+        throw new Error('fatal: not a git repository');
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    checkGitCloneReadiness('/not-a-repo');
+
+    // Then: only one call was made (not_git_repo short-circuits)
+    const revParseCalls = mockExecFileSync.mock.calls.filter(
+      (call) => call[0] === 'git',
+    );
+    expect(revParseCalls).toHaveLength(1);
+    expect((revParseCalls[0]![1] as string[])[1]).toBe('--is-inside-work-tree');
+  });
+});

--- a/src/__tests__/selectAndExecute-autoPr.test.ts
+++ b/src/__tests__/selectAndExecute-autoPr.test.ts
@@ -44,6 +44,7 @@ vi.mock('../infra/task/index.js', () => ({
   getCurrentBranch: vi.fn(() => 'main'),
   detectDefaultBranch: vi.fn(() => 'main'),
   resolveBaseBranch: vi.fn(() => ({ branch: 'main' })),
+  checkGitCloneReadiness: vi.fn(() => ({ ready: true })),
   TaskRunner: vi.fn(() => ({
     addTask: (...args: unknown[]) => mockAddTask(...args),
     completeTask: (...args: unknown[]) => mockCompleteTask(...args),
@@ -53,6 +54,7 @@ vi.mock('../infra/task/index.js', () => ({
 
 vi.mock('../shared/ui/index.js', () => ({
   info: vi.fn(),
+  warn: vi.fn(),
   error: vi.fn(),
   success: vi.fn(),
   withProgress: async <T>(

--- a/src/features/pipeline/steps.ts
+++ b/src/features/pipeline/steps.ts
@@ -144,6 +144,9 @@ export async function resolveExecutionContext(
 ): Promise<ExecutionContext> {
   if (options.createWorktree) {
     const result = await confirmAndCreateWorktree(cwd, task, options.createWorktree, prBranch);
+    if (!result) {
+      return { execCwd: cwd, isWorktree: false };
+    }
     if (result.isWorktree) {
       success(`Worktree created: ${result.execCwd}`);
     }

--- a/src/infra/task/git.ts
+++ b/src/infra/task/git.ts
@@ -50,3 +50,35 @@ export function pushBranch(cwd: string, branch: string): void {
     stdio: 'pipe',
   });
 }
+
+// ---- Git clone readiness check ----
+
+export type GitCloneReadiness =
+  | { ready: true }
+  | { ready: false; reason: 'not_git_repo' | 'no_commits' };
+
+/**
+ * Check if the directory is a git repository with at least one commit,
+ * which is required before creating a shared clone.
+ */
+export function checkGitCloneReadiness(cwd: string): GitCloneReadiness {
+  try {
+    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd,
+      stdio: 'pipe',
+    });
+  } catch {
+    return { ready: false, reason: 'not_git_repo' };
+  }
+
+  try {
+    execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      stdio: 'pipe',
+    });
+  } catch {
+    return { ready: false, reason: 'no_commits' };
+  }
+
+  return { ready: true };
+}

--- a/src/infra/task/index.ts
+++ b/src/infra/task/index.ts
@@ -55,7 +55,7 @@ export {
   getOriginalInstruction,
   buildListItems,
 } from './branchList.js';
-export { stageAndCommit, getCurrentBranch, pushBranch } from './git.js';
+export { stageAndCommit, getCurrentBranch, pushBranch, checkGitCloneReadiness, type GitCloneReadiness } from './git.js';
 export { autoCommitAndPush, type AutoCommitResult } from './autoCommit.js';
 export { summarizeTaskName } from './summarize.js';
 export { TaskWatcher, type TaskWatcherOptions } from './watcher.js';


### PR DESCRIPTION
## Summary
- worktree作成前にgitリポジトリの状態を検証する `checkGitCloneReadiness()` を追加
- gitリポジトリ未初期化 (`not_git_repo`) またはコミットなし (`no_commits`) の場合、`git clone --shared` が失敗する問題を事前に検出
- インタラクティブモードではフォールバック確認、パイプラインモードでは自動フォールバック

## Changes
- `src/infra/task/git.ts`: `checkGitCloneReadiness()` 関数を追加
- `src/features/tasks/execute/selectAndExecute.ts`: `confirmAndCreateWorktree()` にgit状態検証を追加、null返却時のタスク保存処理を追加
- `src/features/pipeline/steps.ts`: `resolveExecutionContext()` でnull結果のハンドリングを追加
- テスト3ファイル追加・2ファイル更新

## Test plan
- [ ] `npm run test` で既存テストがパスすることを確認
- [ ] 新規テスト `cli-worktree-git-validation.test.ts`, `git-clone-readiness.test.ts` がパスすることを確認
- [ ] gitリポジトリ未初期化のディレクトリでworktree作成を試みた場合のフォールバック動作を確認

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)