### PR TITLE
Release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.28.0] - 2026-03-02
+
+### Added
+
+- GitHub Copilot CLI プロバイダーを追加: `copilot` プロバイダーとして GitHub Copilot CLI を利用可能に。セッション継続、パーミッション制御（readonly/edit/full）に対応。`copilotCliPath` / `TAKT_COPILOT_CLI_PATH` で CLI パスを指定、`copilotGithubToken` / `TAKT_COPILOT_GITHUB_TOKEN` で認証トークンを設定 (#425)
+- `--pr` オプションを追加: PR のレビューコメントを取得してタスクとして実行。パイプラインモードとインタラクティブモードの両方で利用可能 (#421)
+- `takt add --pr N` で PR のレビューコメントをタスクとして追加可能に。PR のブランチ名で worktree を自動作成し、レビュー指摘の修正タスクとしてキューイング (#426)
+- `takt list` に「Pull from remote」アクションを追加: リモートの変更を worktree に取り込み、再プッシュ可能に (#395)
+- プロジェクト単位の CLI パス設定: `.takt/config.yaml` で `claudeCliPath` / `cursorCliPath` / `codexCliPath` / `copilotCliPath` をプロジェクトごとに設定可能に (#413)
+- インタラクティブモードのスラッシュコマンドを行末でも認識可能に（例: `タスクの内容 /go`）(#406)
+- takt-default / takt-default-team-leader ビルトインピースを追加（TAKT 自己開発用のワークフロー定義）
+- TAKT ナレッジファセット（`takt.md`）を追加: TAKT のアーキテクチャとコード規約を体系化
+- ai-antipattern ポリシーに冗長な条件分岐パターン検出を追加: 同一関数を if/else で呼び分けるコードを検出し、三項演算子やスプレッド構文での統一を促す
+
+### Fixed
+
+- 不正な `tasks.yaml` を検出した場合、ファイルを削除せず保持してエラーメッセージで停止するよう修正 (#418)
+- shallow clone リポジトリで worktree 作成が失敗する問題を修正: `--reference` 付きクローンが失敗した場合に通常クローンへフォールバック (#376, #409)
+- グローバル/プロジェクト設定の `model` がモデルログに反映されない不具合を修正 (#417)
+- fork PR レビュー時に `GH_REPO` を設定して正しいリポジトリの issue を参照するよう修正
+- takt-review ワークフローの PR コメント投稿ステップにも `GH_REPO` を設定
+
+### Internal
+
+- `resolveConfigValue` の不要な `defaultValue` 引数を削除し、設定解決ロジックを簡素化 (#391)
+- PRコメント `/resolve` でコンフリクト解決・レビュー指摘修正を行う GitHub Actions ワークフロー（cc-resolve）を追加
+- takt-review ワークフローを `pull_request_target` に変更し、fork PR でもシークレットを利用可能に
+- CI に `ready_for_review` / `reopened` トリガーを追加
+- CONTRIBUTING にレビューモードの例を追加、日本語版（`CONTRIBUTING.ja.md`）を追加
+
 ## [0.28.0-alpha.1] - 2026-02-28
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,36 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.28.0] - 2026-03-02
+
+### Added
+
+- GitHub Copilot CLI プロバイダーを追加: `copilot` プロバイダーとして GitHub Copilot CLI を利用可能に。セッション継続、パーミッション制御（readonly/edit/full）に対応。`copilotCliPath` / `TAKT_COPILOT_CLI_PATH` で CLI パスを指定、`copilotGithubToken` / `TAKT_COPILOT_GITHUB_TOKEN` で認証トークンを設定 (#425)
+- `--pr` オプションを追加: PR のレビューコメントを取得してタスクとして実行。パイプラインモードとインタラクティブモードの両方で利用可能 (#421)
+- `takt add --pr N` で PR のレビューコメントをタスクとして追加可能に。PR のブランチ名で worktree を自動作成し、レビュー指摘の修正タスクとしてキューイング (#426)
+- `takt list` に「Pull from remote」アクションを追加: リモートの変更を worktree に取り込み、再プッシュ可能に (#395)
+- プロジェクト単位の CLI パス設定: `.takt/config.yaml` で `claudeCliPath` / `cursorCliPath` / `codexCliPath` / `copilotCliPath` をプロジェクトごとに設定可能に (#413)
+- インタラクティブモードのスラッシュコマンドを行末でも認識可能に（例: `タスクの内容 /go`）(#406)
+- takt-default / takt-default-team-leader ビルトインピースを追加（TAKT 自己開発用のワークフロー定義）
+- TAKT ナレッジファセット（`takt.md`）を追加: TAKT のアーキテクチャとコード規約を体系化
+- ai-antipattern ポリシーに冗長な条件分岐パターン検出を追加: 同一関数を if/else で呼び分けるコードを検出し、三項演算子やスプレッド構文での統一を促す
+
+### Fixed
+
+- 不正な `tasks.yaml` を検出した場合、ファイルを削除せず保持してエラーメッセージで停止するよう修正 (#418)
+- shallow clone リポジトリで worktree 作成が失敗する問題を修正: `--reference` 付きクローンが失敗した場合に通常クローンへフォールバック (#376, #409)
+- グローバル/プロジェクト設定の `model` がモデルログに反映されない不具合を修正 (#417)
+- fork PR レビュー時に `GH_REPO` を設定して正しいリポジトリの issue を参照するよう修正
+- takt-review ワークフローの PR コメント投稿ステップにも `GH_REPO` を設定
+
+### Internal
+
+- `resolveConfigValue` の不要な `defaultValue` 引数を削除し、設定解決ロジックを簡素化 (#391)
+- PRコメント `/resolve` でコンフリクト解決・レビュー指摘修正を行う GitHub Actions ワークフロー（cc-resolve）を追加
+- takt-review ワークフローを `pull_request_target` に変更し、fork PR でもシークレットを利用可能に
+- CI に `ready_for_review` / `reopened` トリガーを追加
+- CONTRIBUTING にレビューモードの例を追加、日本語版（`CONTRIBUTING.ja.md`）を追加
+
 ## [0.28.0-alpha.1] - 2026-02-28
 
 ### Added

--- a/docs/builtin-catalog.ja.md
+++ b/docs/builtin-catalog.ja.md
@@ -35,10 +35,13 @@ TAKT に同梱されているすべてのビルトイン piece と persona の�
 | | `backend-cqrs` | CQRS+ES 特化バックエンド開発 piece。CQRS+ES、セキュリティ、QA エキスパートレビュー付き。 |
 | 🔧 エキスパート | `expert` | フルスタック開発 piece: architecture、frontend、security、QA レビューと修正ループ付き。 |
 | | `expert-cqrs` | フルスタック開発 piece (CQRS+ES 特化): CQRS+ES、frontend、security、QA レビューと修正ループ付き。 |
+| 🏗️ インフラストラクチャ | `terraform` | Terraform IaC 開発 piece: plan → implement → 並列レビュー → supervisor 検証 → 修正 → 完了。 |
 | 🛠️ リファクタリング | `structural-reform` | プロジェクト全体のレビューと構造改革: 段階的なファイル分割による反復的なコードベース再構築。 |
 | 🔍 レビュー | `review` | 多角コードレビュー: PR/ブランチ/作業中の差分を自動判定し、5つの並列観点（arch/security/QA/testing/requirements）からレビューして統合結果を出力。 |
 | 🧪 テスト | `unit-test` | ユニットテスト特化 piece: テスト分析 -> テスト実装 -> レビュー -> 修正。 |
 | | `e2e-test` | E2E テスト特化 piece: E2E 分析 -> E2E 実装 -> レビュー -> 修正 (Vitest ベースの E2E フロー)。 |
+| 🎵 TAKT 開発 | `takt-default` | TAKT 開発 piece: plan → テスト作成 → implement → AI レビュー → 5並列レビュー → 修正 → supervise → 完了。 |
+| | `takt-default-team-leader` | TAKT 開発 piece (team leader 版): plan → テスト作成 → team-leader implement → AI レビュー → 5並列レビュー → 修正 → supervise → 完了。 |
 | その他 | `research` | リサーチ piece: planner -> digger -> supervisor。質問せずに自律的にリサーチを実行。 |
 | | `deep-research` | ディープリサーチ piece: plan -> dig -> analyze -> supervise。発見駆動型の調査で、浮上した疑問を多角的に分析。 |
 | | `magi` | エヴァンゲリオンにインスパイアされた合議システム。3つの AI persona (MELCHIOR, BALTHASAR, CASPER) が分析・投票。 |

--- a/docs/builtin-catalog.md
+++ b/docs/builtin-catalog.md
@@ -35,10 +35,13 @@ Organized by category.
 | | `backend-cqrs` | CQRS+ES-specialized backend development piece with CQRS+ES, security, and QA expert reviews. |
 | 🔧 Expert | `expert` | Full-stack development piece: architecture, frontend, security, QA reviews with fix loops. |
 | | `expert-cqrs` | Full-stack development piece (CQRS+ES specialized): CQRS+ES, frontend, security, QA reviews with fix loops. |
+| 🏗️ Infrastructure | `terraform` | Terraform IaC development piece: plan → implement → parallel review → supervisor validation → fix → complete. |
 | 🛠️ Refactoring | `structural-reform` | Full project review and structural reform: iterative codebase restructuring with staged file splits. |
 | 🔍 Review | `review` | Multi-perspective code review: auto-detects PR/branch/working diff, reviews from 5 parallel perspectives (arch/security/QA/testing/requirements), outputs consolidated results. |
 | 🧪 Testing | `unit-test` | Unit test focused piece: test analysis -> test implementation -> review -> fix. |
 | | `e2e-test` | E2E test focused piece: E2E analysis -> E2E implementation -> review -> fix (Vitest-based E2E flow). |
+| 🎵 TAKT Development | `takt-default` | TAKT development piece: plan → write tests → implement → AI review → 5-parallel review → fix → supervise → complete. |
+| | `takt-default-team-leader` | TAKT development piece with team leader: plan → write tests → team-leader implement → AI review → 5-parallel review → fix → supervise → complete. |
 | Others | `research` | Research piece: planner -> digger -> supervisor. Autonomously executes research without asking questions. |
 | | `deep-research` | Deep research piece: plan -> dig -> analyze -> supervise. Discovery-driven investigation that follows emerging questions with multi-perspective analysis. |
 | | `magi` | Deliberation system inspired by Evangelion. Three AI personas (MELCHIOR, BALTHASAR, CASPER) analyze and vote. |

--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -13,13 +13,14 @@
 | `-i, --issue <N>` | GitHub Issue 番号（インタラクティブモードでの `#N` と同等） |
 | `-w, --piece <name or path>` | Piece 名または piece YAML ファイルのパス |
 | `-b, --branch <name>` | ブランチ名を指定（省略時は自動生成） |
+| `--pr <number>` | PR 番号を指定してレビューコメントを取得し修正を実行 |
 | `--auto-pr` | PR を作成（インタラクティブ: 確認スキップ、pipeline: PR 有効化） |
-| `--draft-pr` | PR をドラフトとして作成 |
+| `--draft` | PR をドラフトとして作成（`--auto-pr` または `auto_pr` 設定が必要） |
 | `--skip-git` | ブランチ作成、コミット、プッシュをスキップ（pipeline モード、piece のみ実行） |
 | `--repo <owner/repo>` | リポジトリを指定（PR 作成用） |
 | `--create-worktree <yes\|no>` | worktree 確認プロンプトをスキップ |
 | `-q, --quiet` | 最小出力モード: AI 出力を抑制（CI 向け） |
-| `--provider <name>` | エージェント provider を上書き（claude\|codex\|opencode\|cursor\|mock） |
+| `--provider <name>` | エージェント provider を上書き（claude\|codex\|opencode\|cursor\|copilot\|mock） |
 | `--model <name>` | エージェントモデルを上書き |
 | `--config <path>` | グローバル設定ファイルのパス（デフォルト: `~/.takt/config.yaml`） |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,13 +13,14 @@ This document provides a complete reference for all TAKT CLI commands and option
 | `-i, --issue <N>` | GitHub issue number (same as `#N` in interactive mode) |
 | `-w, --piece <name or path>` | Piece name or path to piece YAML file |
 | `-b, --branch <name>` | Specify branch name (auto-generated if omitted) |
+| `--pr <number>` | PR number to fetch review comments and fix |
 | `--auto-pr` | Create PR (interactive: skip confirmation, pipeline: enable PR) |
-| `--draft-pr` | Create PR as draft |
+| `--draft` | Create PR as draft (requires `--auto-pr` or `auto_pr` config) |
 | `--skip-git` | Skip branch creation, commit, and push (pipeline mode, piece-only) |
 | `--repo <owner/repo>` | Specify repository (for PR creation) |
 | `--create-worktree <yes\|no>` | Skip worktree confirmation prompt |
 | `-q, --quiet` | Minimal output mode: suppress AI output (for CI) |
-| `--provider <name>` | Override agent provider (claude\|codex\|opencode\|cursor\|mock) |
+| `--provider <name>` | Override agent provider (claude\|codex\|opencode\|cursor\|copilot\|mock) |
 | `--model <name>` | Override agent model |
 | `--config <path>` | Path to global config file (default: `~/.takt/config.yaml`) |
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -13,7 +13,7 @@
 language: en                  # UI 言語: 'en' または 'ja'
 default_piece: default        # 新規プロジェクトのデフォルト piece
 log_level: info               # ログレベル: debug, info, warn, error
-provider: claude              # デフォルト provider: claude, codex, opencode, または cursor
+provider: claude              # デフォルト provider: claude, codex, opencode, cursor, または copilot
 model: sonnet                 # デフォルトモデル（省略可、provider にそのまま渡される）
 branch_name_strategy: romaji  # ブランチ名生成方式: 'romaji'（高速）または 'ai'（低速）
 prevent_sleep: false          # 実行中に macOS のアイドルスリープを防止（caffeinate）
@@ -56,16 +56,20 @@ interactive_preview_movements: 3  # インタラクティブモードでの move
 #     default_permission_mode: edit
 
 # API キー設定（省略可）
-# 環境変数 TAKT_ANTHROPIC_API_KEY / TAKT_OPENAI_API_KEY / TAKT_OPENCODE_API_KEY / TAKT_CURSOR_API_KEY で上書き可能
+# 環境変数 TAKT_ANTHROPIC_API_KEY / TAKT_OPENAI_API_KEY / TAKT_OPENCODE_API_KEY / TAKT_CURSOR_API_KEY / TAKT_COPILOT_GITHUB_TOKEN で上書き可能
 # anthropic_api_key: sk-ant-...  # Claude（Anthropic）用
 # openai_api_key: sk-...         # Codex（OpenAI）用
 # opencode_api_key: ...          # OpenCode 用
 # cursor_api_key: ...            # Cursor Agent 用（省略時は login セッションにフォールバック）
+# copilot_github_token: ...      # Copilot 用（GitHub トークン）
 
-# Codex CLI パス上書き（省略可）
-# Codex SDK が使用する Codex CLI バイナリを上書き（実行可能ファイルの絶対パスが必要）
-# 環境変数 TAKT_CODEX_CLI_PATH で上書き可能
+# CLI パス上書き（省略可）
+# provider の CLI バイナリを上書き（実行可能ファイルの絶対パスが必要）
+# 環境変数 TAKT_CLAUDE_CLI_PATH / TAKT_CODEX_CLI_PATH / TAKT_CURSOR_CLI_PATH / TAKT_COPILOT_CLI_PATH で上書き可能
+# claude_cli_path: /usr/local/bin/claude
 # codex_cli_path: /usr/local/bin/codex
+# cursor_cli_path: /usr/local/bin/cursor-agent
+# copilot_cli_path: /usr/local/bin/github-copilot-cli
 
 # ビルトイン piece フィルタリング（省略可）
 # builtin_pieces_enabled: true           # false ですべてのビルトインを無効化
@@ -89,7 +93,7 @@ interactive_preview_movements: 3  # インタラクティブモードでの move
 | `language` | `"en"` \| `"ja"` | `"en"` | UI 言語 |
 | `default_piece` | string | `"default"` | 新規プロジェクトのデフォルト piece |
 | `log_level` | `"debug"` \| `"info"` \| `"warn"` \| `"error"` | `"info"` | ログレベル |
-| `provider` | `"claude"` \| `"codex"` \| `"opencode"` \| `"cursor"` | `"claude"` | デフォルト AI provider |
+| `provider` | `"claude"` \| `"codex"` \| `"opencode"` \| `"cursor"` \| `"copilot"` | `"claude"` | デフォルト AI provider |
 | `model` | string | - | デフォルトモデル名（provider にそのまま渡される） |
 | `branch_name_strategy` | `"romaji"` \| `"ai"` | `"romaji"` | ブランチ名生成方式 |
 | `prevent_sleep` | boolean | `false` | macOS アイドルスリープ防止（caffeinate） |
@@ -110,7 +114,11 @@ interactive_preview_movements: 3  # インタラクティブモードでの move
 | `openai_api_key` | string | - | Codex 用 OpenAI API キー |
 | `opencode_api_key` | string | - | OpenCode API キー |
 | `cursor_api_key` | string | - | Cursor API キー（省略時は login セッションへフォールバック） |
+| `copilot_github_token` | string | - | Copilot 認証用 GitHub トークン |
+| `claude_cli_path` | string | - | Claude Code CLI バイナリパス上書き（絶対パス） |
 | `codex_cli_path` | string | - | Codex CLI バイナリパス上書き（絶対パス） |
+| `cursor_cli_path` | string | - | Cursor Agent CLI バイナリパス上書き（絶対パス） |
+| `copilot_cli_path` | string | - | Copilot CLI バイナリパス上書き（絶対パス） |
 | `enable_builtin_pieces` | boolean | `true` | ビルトイン piece の有効化 |
 | `disabled_builtins` | string[] | `[]` | 無効化する特定のビルトイン piece |
 | `pipeline` | object | - | pipeline テンプレート設定 |
@@ -151,7 +159,7 @@ concurrency: 2                # このプロジェクトでの takt run 並列�
 | フィールド | 型 | デフォルト | 説明 |
 |-----------|------|---------|------|
 | `piece` | string | `"default"` | このプロジェクトの現在の piece 名 |
-| `provider` | `"claude"` \| `"codex"` \| `"opencode"` \| `"cursor"` \| `"mock"` | - | provider 上書き |
+| `provider` | `"claude"` \| `"codex"` \| `"opencode"` \| `"cursor"` \| `"copilot"` \| `"mock"` | - | provider 上書き |
 | `model` | string | - | モデル名の上書き（provider にそのまま渡される） |
 | `auto_pr` | boolean | - | worktree 実行後に PR を自動作成 |
 | `verbose` | boolean | - | 詳細出力モード |
@@ -164,7 +172,7 @@ concurrency: 2                # このプロジェクトでの takt run 並列�
 
 ## API キー設定
 
-TAKT は4つの provider をサポートしています。Claude/Codex/OpenCode は API キーを使い、Cursor は API キーまたは `cursor-agent login` セッションで認証できます。
+TAKT は5つの provider をサポートしています。Claude/Codex/OpenCode は API キーを使い、Cursor は API キーまたは `cursor-agent login` セッションで認証でき、Copilot は GitHub トークンで認証します。
 
 ### 環境変数（推奨）
 
@@ -180,6 +188,9 @@ export TAKT_OPENCODE_API_KEY=...
 
 # Cursor Agent 用（cursor-agent login 済みなら省略可）
 export TAKT_CURSOR_API_KEY=...
+
+# Copilot 用（GitHub トークン）
+export TAKT_COPILOT_GITHUB_TOKEN=...
 ```
 
 ### 設定ファイル
@@ -190,6 +201,7 @@ anthropic_api_key: sk-ant-...  # Claude 用
 openai_api_key: sk-...         # Codex 用
 opencode_api_key: ...          # OpenCode 用
 cursor_api_key: ...            # Cursor Agent 用（省略可）
+copilot_github_token: ...      # Copilot 用（GitHub トークン）
 ```
 
 ### 優先順位
@@ -202,6 +214,7 @@ cursor_api_key: ...            # Cursor Agent 用（省略可）
 | Codex (OpenAI) | `TAKT_OPENAI_API_KEY` | `openai_api_key` |
 | OpenCode | `TAKT_OPENCODE_API_KEY` | `opencode_api_key` |
 | Cursor Agent | `TAKT_CURSOR_API_KEY` | `cursor_api_key` |
+| Copilot | `TAKT_COPILOT_GITHUB_TOKEN` | `copilot_github_token` |
 
 ### セキュリティ
 
@@ -211,20 +224,33 @@ cursor_api_key: ...            # Cursor Agent 用（省略可）
 - Cursor provider は `cursor-agent login` が済んでいれば API キーなしでも動作できます。
 - API キーを設定すれば、対応する CLI ツール（Claude Code、Codex、OpenCode）のインストールは不要です。TAKT が対応する API を直接呼び出します。
 
-### Codex CLI パス上書き
+### CLI パス上書き
 
-Codex CLI バイナリパスは環境変数または設定ファイルで上書きできます。
+provider の CLI バイナリパスは環境変数または設定ファイルで上書きできます。
 
 ```bash
+export TAKT_CLAUDE_CLI_PATH=/usr/local/bin/claude
 export TAKT_CODEX_CLI_PATH=/usr/local/bin/codex
+export TAKT_CURSOR_CLI_PATH=/usr/local/bin/cursor-agent
+export TAKT_COPILOT_CLI_PATH=/usr/local/bin/github-copilot-cli
 ```
 
 ```yaml
 # ~/.takt/config.yaml
+claude_cli_path: /usr/local/bin/claude
 codex_cli_path: /usr/local/bin/codex
+cursor_cli_path: /usr/local/bin/cursor-agent
+copilot_cli_path: /usr/local/bin/github-copilot-cli
 ```
 
-パスは実行可能ファイルの絶対パスである必要があります。`TAKT_CODEX_CLI_PATH` は設定ファイルの値よりも優先されます。
+| Provider | 環境変数 | 設定キー |
+|----------|---------|---------|
+| Claude | `TAKT_CLAUDE_CLI_PATH` | `claude_cli_path` |
+| Codex | `TAKT_CODEX_CLI_PATH` | `codex_cli_path` |
+| Cursor Agent | `TAKT_CURSOR_CLI_PATH` | `cursor_cli_path` |
+| Copilot | `TAKT_COPILOT_CLI_PATH` | `copilot_cli_path` |
+
+パスは実行可能ファイルの絶対パスである必要があります。環境変数は設定ファイルの値よりも優先されます。プロジェクトレベルの `.takt/config.yaml` でも設定可能です。
 
 ## モデル解決
 
@@ -243,6 +269,8 @@ codex_cli_path: /usr/local/bin/codex
 **OpenCode** は `provider/model` 形式のモデル（例: `opencode/big-pickle`）が必要です。OpenCode provider でモデルを省略すると設定エラーになります。
 
 **Cursor Agent** は `model` を `cursor-agent --model <model>` にそのまま渡します。省略時は Cursor CLI のデフォルトが使用されます。
+
+**Copilot** は `model` を Copilot CLI の `--model <model>` フラグにそのまま渡します。省略時は Copilot CLI のデフォルトが使用されます。
 
 ### 設定例
 
@@ -271,11 +299,11 @@ Provider プロファイルを使用すると、各 provider にデフォルト�
 
 TAKT は provider 非依存の3つのパーミッションモードを使用します。
 
-| モード | 説明 | Claude | Codex | OpenCode | Cursor Agent |
-|--------|------|--------|-------|----------|--------------|
-| `readonly` | 読み取り専用、ファイル変更不可 | `default` | `read-only` | `read-only` | デフォルトフラグ（`--force` なし） |
-| `edit` | 確認付きでファイル編集を許可 | `acceptEdits` | `workspace-write` | `workspace-write` | デフォルトフラグ（`--force` なし） |
-| `full` | すべてのパーミッションチェックをバイパス | `bypassPermissions` | `danger-full-access` | `danger-full-access` | `--force` |
+| モード | 説明 | Claude | Codex | OpenCode | Cursor Agent | Copilot |
+|--------|------|--------|-------|----------|--------------|---------|
+| `readonly` | 読み取り専用、ファイル変更不可 | `default` | `read-only` | `read-only` | デフォルトフラグ（`--force` なし） | フラグなし |
+| `edit` | 確認付きでファイル編集を許可 | `acceptEdits` | `workspace-write` | `workspace-write` | デフォルトフラグ（`--force` なし） | `--allow-all-tools --no-ask-user` |
+| `full` | すべてのパーミッションチェックをバイパス | `bypassPermissions` | `danger-full-access` | `danger-full-access` | `--force` | `--yolo` |
 
 ### 設定方法
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.28.0-alpha.1",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.28.0-alpha.1",
+      "version": "0.28.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.28.0-alpha.1",
+  "version": "0.28.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- GitHub Copilot CLI プロバイダーを追加: `copilot` プロバイダーとして GitHub Copilot CLI を利用可能に。セッション継続、パーミッション制御（readonly/edit/full）に対応。`copilotCliPath` / `TAKT_COPILOT_CLI_PATH` で CLI パスを指定、`copilotGithubToken` / `TAKT_COPILOT_GITHUB_TOKEN` で認証トークンを設定 (#425)
- `--pr` オプションを追加: PR のレビューコメントを取得してタスクとして実行。パイプラインモードとインタラクティブモードの両方で利用可能 (#421)
- `takt add --pr N` で PR のレビューコメントをタスクとして追加可能に。PR のブランチ名で worktree を自動作成し、レビュー指摘の修正タスクとしてキューイング (#426)
- `takt list` に「Pull from remote」アクションを追加: リモートの変更を worktree に取り込み、再プッシュ可能に (#395)
- プロジェクト単位の CLI パス設定: `.takt/config.yaml` で `claudeCliPath` / `cursorCliPath` / `codexCliPath` / `copilotCliPath` をプロジェクトごとに設定可能に (#413)
- インタラクティブモードのスラッシュコマンドを行末でも認識可能に（例: `タスクの内容 /go`）(#406)
- takt-default / takt-default-team-leader ビルトインピースを追加（TAKT 自己開発用のワークフロー定義）
- TAKT ナレッジファセット（`takt.md`）を追加: TAKT のアーキテクチャとコード規約を体系化
- ai-antipattern ポリシーに冗長な条件分岐パターン検出を追加

### Fixed

- 不正な `tasks.yaml` を検出した場合、ファイルを削除せず保持してエラーメッセージで停止するよう修正 (#418)
- shallow clone リポジトリで worktree 作成が失敗する問題を修正 (#376, #409)
- グローバル/プロジェクト設定の `model` がモデルログに反映されない不具合を修正 (#417)
- fork PR レビュー時に `GH_REPO` を設定して正しいリポジトリの issue を参照するよう修正
- takt-review ワークフローの PR コメント投稿ステップにも `GH_REPO` を設定

### Internal

- `resolveConfigValue` の不要な `defaultValue` 引数を削除し、設定解決ロジックを簡素化 (#391)
- cc-resolve / takt-review ワークフローの改善
- CI トリガーの追加、CONTRIBUTING の更新
- ドキュメント更新: CLI リファレンス、設定ガイド、ビルトインカタログに Copilot プロバイダー情報を追加

## Commits

- 3acd30c Release v0.28.0
- 501639f Merge pull request #433 from nrslib/release/v0.28.0-alpha.1
- 9ce4358 Release v0.28.0-alpha.1
- 8f0f546 [#426] add-pr-review-task (#427)
- 2be824b fix: PRコメント投稿ステップにも GH_REPO を設定
- 17232f9 feat: add GitHub Copilot CLI as a new provider (#425)
- 4566334 feat: ai-antipattern ポリシーに冗長な条件分岐パターン検出を追加
- ff31d9c fix: fork PR レビュー時に GH_REPO を設定して正しいリポジトリの issue を参照
- 5fd9022 fix: takt-review を pull_request_target に変更して fork PR でもシークレットを利用可能に
- e5665ed fix: takt-review のトリガーに reopened を追加
- 929557a fix: takt-review が fork PR で失敗する問題を修正
- fb0b343 ci: pull_request の ready_for_review でもCIが走るように修正
- 9ba05d8 [#395] github-issue-395-add-pull-from (#397)
- 2d0dc12 refactor: cc-resolve をコンフリクト解決専用に変更
- 88455b7 fix: cc-resolve でマージコミットがあれば常に push するように修正
- 8bb9ea4 fix: cc-resolve の Resolve ステップに GH_TOKEN を追加
- d05cb43 fix: cc-resolve で Claude にフル権限を付与
- 2a8cc50 fix: cc-resolve でフォークPRをスキップ
- e4af465 fix: cc-resolve の checkout 前ステップに --repo を追加
- f6d59f4 fix: cc-resolve の checkout 前ステップに --repo を追加
- fe0b723 fix: 不正なtasks.yamlで削除せず停止するように修正 (#418)
- ac4cb9c fix: fallback to normal clone when reference repository is shallow (#376) (#409)
- e77cb50 feat: インタラクティブモードのスラッシュコマンドを行末でも認識可能にする (#406)
- 09fda82 ci: PRコメント /resolve でコンフリクト解決・レビュー指摘修正を行うワークフローを追加
- 252c337 fix: Global/ProjectのmodelがModelログに反映されない不具合を修正 (#417)
- 7494149 [#421] github-issue-421-feat-pr-opush (#422)
- e256db8 takt: github-issue-398-branchexists (#401)
- ae74c0d takt: #391 resolveConfigValue の無意味な defaultValue を撲滅する (#392)
- 6d50221 ci: PRに対するTAKT Reviewワークフローを追加
- 4e9c020 feat: add takt-default pieces and TAKT knowledge facet for self-development
- c7389a5 docs: add review mode examples to CONTRIBUTING
- b8b64f8 feat: プロジェクト単位のCLIパス設定(Claude/Cursor/Codex) (#413)
- 52c5e29 docs: require takt review before submitting PRs