### PR TITLE
Release v0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.28.1] - 2026-03-02
+
+### Changed
+
+- BREAKING: `expert` / `expert-mini` / `expert-cqrs` / `expert-cqrs-mini` ピースを `dual` / `dual-mini` / `dual-cqrs` / `dual-cqrs-mini` にリネーム。カスタマイズしている場合はピース名を更新が必要
+- `default-mini` / `default-test-first-mini` ピースを `default` に統合。`default` ピースが「テスト優先モード」を内包するよう拡張
+- `coding-pitfalls` ナレッジの主要項目を `coding` ポリシーに移動し、ポリシーとして実際に適用されるよう強化
+- `implement` / `plan` インストラクションにセルフチェック・コーダー指針を追加
+
+### Removed
+
+- `passthrough` ピースを削除
+- `structural-reform` ピースを削除
+
+### Internal
+
+- `expert-supervisor` ペルソナを `dual-supervisor` にリネーム
+- ビルトインカタログに不足していた `terraform`、`takt-default` 系、`deep-research` を追加
+- カテゴリ設定に `deep-research` を追加
+- 全ドキュメントに `copilot` プロバイダーの説明を追加し、Claude Code 寄りの記述をプロバイダー中立に修正
+
 ## [0.28.0] - 2026-03-02
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,27 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.28.1] - 2026-03-02
+
+### Changed
+
+- BREAKING: `expert` / `expert-mini` / `expert-cqrs` / `expert-cqrs-mini` ピースを `dual` / `dual-mini` / `dual-cqrs` / `dual-cqrs-mini` にリネーム。カスタマイズしている場合はピース名の更新が必要
+- `default-mini` / `default-test-first-mini` ピースを `default` に統合。`default` ピースが「テスト優先モード」を内包するよう拡張
+- `coding-pitfalls` ナレッジの主要項目を `coding` ポリシーに移動し、ポリシーとして実際に適用されるよう強化
+- `implement` / `plan` インストラクションにセルフチェック・コーダー指針を追加
+
+### Removed
+
+- `passthrough` ピースを削除
+- `structural-reform` ピースを削除
+
+### Internal
+
+- `expert-supervisor` ペルソナを `dual-supervisor` にリネーム
+- ビルトインカタログに不足していた `terraform`、`takt-default` 系、`deep-research` を追加
+- カテゴリ設定に `deep-research` を追加
+- 全ドキュメントに `copilot` プロバイダーの説明を追加し、Claude Code 寄りの記述をプロバイダー中立に修正
+
 ## [0.28.0] - 2026-03-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Changed

- BREAKING: `expert` / `expert-mini` / `expert-cqrs` / `expert-cqrs-mini` ピースを `dual` / `dual-mini` / `dual-cqrs` / `dual-cqrs-mini` にリネーム。カスタマイズしている場合はピース名の更新が必要
- `default-mini` / `default-test-first-mini` ピースを `default` に統合。`default` ピースが「テスト優先モード」を内包するよう拡張
- `coding-pitfalls` ナレッジの主要項目を `coding` ポリシーに移動し、ポリシーとして実際に適用されるよう強化
- `implement` / `plan` インストラクションにセルフチェック・コーダー指針を追加

### Removed

- `passthrough` ピースを削除
- `structural-reform` ピースを削除

### Internal

- `expert-supervisor` ペルソナを `dual-supervisor` にリネーム
- ビルトインカタログに不足していた `terraform`、`takt-default` 系、`deep-research` を追加
- カテゴリ設定に `deep-research` を追加
- 全ドキュメントに `copilot` プロバイダーの説明を追加し、Claude Code 寄りの記述をプロバイダー中立に修正

## Commits

- 0201056f docs: 全ドキュメントに copilot プロバイダーを追加し、Claude Code 寄りの記述をプロバイダー中立に修正
- 532b1961 refactor: expert → dual リネーム、未使用ピース削除、default 統合