### PR TITLE
[#399] add-per-task-base-branch

### DIFF
--- a/src/__tests__/add-task-base-branch.test.ts
+++ b/src/__tests__/add-task-base-branch.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for base_branch support in task addition (Issue #399)
+ *
+ * Covers:
+ *   - saveTaskFile saves base_branch to tasks.yaml
+ *   - promptWorktreeSettings (via addTask/saveTaskFromInteractive):
+ *       - main/master branch: no base branch prompt
+ *       - feature branch, user confirms: saves base_branch
+ *       - feature branch, user declines: no base_branch
+ *   - addTask --pr: baseRefName from PR is saved as base_branch
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { parse as parseYaml } from 'yaml';
+
+// --- Hoisted mocks (must be before vi.mock calls) ---
+
+const {
+  mockGetCurrentBranch,
+  mockCheckCliStatus,
+  mockFetchPrReviewComments,
+  mockFormatPrReviewAsTask,
+  mockDeterminePiece,
+} = vi.hoisted(() => ({
+  mockGetCurrentBranch: vi.fn().mockReturnValue('main'),
+  mockCheckCliStatus: vi.fn().mockReturnValue({ available: true }),
+  mockFetchPrReviewComments: vi.fn(),
+  mockFormatPrReviewAsTask: vi.fn(),
+  mockDeterminePiece: vi.fn().mockResolvedValue('default'),
+}));
+
+// --- Module mocks ---
+
+vi.mock('../features/interactive/index.js', () => ({
+  interactiveMode: vi.fn(),
+}));
+
+vi.mock('../shared/prompt/index.js', () => ({
+  promptInput: vi.fn(),
+  confirm: vi.fn(),
+}));
+
+vi.mock('../shared/ui/index.js', () => ({
+  success: vi.fn(),
+  info: vi.fn(),
+  blankLine: vi.fn(),
+  error: vi.fn(),
+  withProgress: vi.fn(async (_start: unknown, _done: unknown, operation: () => Promise<unknown>) => operation()),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../features/tasks/execute/selectAndExecute.js', () => ({
+  determinePiece: (...args: unknown[]) => mockDeterminePiece(...args),
+}));
+
+vi.mock('../infra/task/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  summarizeTaskName: vi.fn().mockResolvedValue('test-task'),
+  // getCurrentBranch will be imported by add/index.ts after implementation
+  getCurrentBranch: (...args: unknown[]) => mockGetCurrentBranch(...args),
+}));
+
+vi.mock('../infra/git/index.js', () => ({
+  getGitProvider: () => ({
+    createIssue: vi.fn(),
+    checkCliStatus: (...args: unknown[]) => mockCheckCliStatus(...args),
+    fetchPrReviewComments: (...args: unknown[]) => mockFetchPrReviewComments(...args),
+  }),
+}));
+
+const mockIsIssueReference = vi.fn((s: string) => /^#\d+$/.test(s));
+const mockResolveIssueTask = vi.fn();
+const mockParseIssueNumbers = vi.fn();
+
+vi.mock('../infra/github/index.js', () => ({
+  isIssueReference: (...args: unknown[]) => mockIsIssueReference(...args),
+  resolveIssueTask: (...args: unknown[]) => mockResolveIssueTask(...args),
+  parseIssueNumbers: (...args: unknown[]) => mockParseIssueNumbers(...args),
+  formatPrReviewAsTask: (...args: unknown[]) => mockFormatPrReviewAsTask(...args),
+}));
+
+// --- Imports after mocks ---
+
+import { promptInput, confirm } from '../shared/prompt/index.js';
+import { saveTaskFile, addTask } from '../features/tasks/index.js';
+import type { PrReviewData } from '../infra/git/index.js';
+
+const mockPromptInput = vi.mocked(promptInput);
+const mockConfirm = vi.mocked(confirm);
+
+let testDir: string;
+
+function loadTasks(dir: string): { tasks: Array<Record<string, unknown>> } {
+  const raw = fs.readFileSync(path.join(dir, '.takt', 'tasks.yaml'), 'utf-8');
+  return parseYaml(raw) as { tasks: Array<Record<string, unknown>> };
+}
+
+/** Build a mock PrReviewData that includes baseRefName (added in implementation) */
+function createMockPrReview(
+  overrides: Partial<PrReviewData> & { baseRefName?: string } = {},
+): PrReviewData & { baseRefName: string } {
+  return {
+    number: 456,
+    title: 'Fix auth bug',
+    body: 'PR description',
+    url: 'https://github.com/org/repo/pull/456',
+    headRefName: 'feature/fix-auth-bug',
+    baseRefName: 'develop',
+    comments: [{ author: 'commenter', body: 'Please update tests' }],
+    reviews: [{ author: 'reviewer', body: 'Fix null check' }],
+    files: ['src/auth.ts'],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  testDir = fs.mkdtempSync(path.join(tmpdir(), 'takt-test-base-branch-'));
+  mockDeterminePiece.mockResolvedValue('default');
+  mockConfirm.mockResolvedValue(false);
+  mockCheckCliStatus.mockReturnValue({ available: true });
+  mockGetCurrentBranch.mockReturnValue('main');
+});
+
+afterEach(() => {
+  if (testDir && fs.existsSync(testDir)) {
+    fs.rmSync(testDir, { recursive: true });
+  }
+});
+
+// ---- saveTaskFile with baseBranch ----
+
+describe('saveTaskFile with baseBranch option', () => {
+  it('should save base_branch to tasks.yaml when baseBranch option is provided', async () => {
+    // Given: baseBranch option is set
+    await saveTaskFile(testDir, 'Implement feature X', {
+      worktree: true,
+      baseBranch: 'feat/base-feature',
+    });
+
+    // When: reading tasks.yaml
+    const task = loadTasks(testDir).tasks[0]!;
+
+    // Then: base_branch field is written
+    expect(task.base_branch).toBe('feat/base-feature');
+  });
+
+  it('should not write base_branch to tasks.yaml when baseBranch option is absent', async () => {
+    // Given: no baseBranch option
+    await saveTaskFile(testDir, 'Implement feature Y', {
+      worktree: true,
+    });
+
+    // When: reading tasks.yaml
+    const task = loadTasks(testDir).tasks[0]!;
+
+    // Then: base_branch field is absent
+    expect(task.base_branch).toBeUndefined();
+  });
+
+  it('should save base_branch alongside other task options', async () => {
+    // Given: multiple options including baseBranch
+    await saveTaskFile(testDir, 'Feature Z', {
+      piece: 'review',
+      worktree: true,
+      branch: 'feat/z-branch',
+      baseBranch: 'develop',
+    });
+
+    // When: reading tasks.yaml
+    const task = loadTasks(testDir).tasks[0]!;
+
+    // Then: all fields are saved correctly
+    expect(task.base_branch).toBe('develop');
+    expect(task.branch).toBe('feat/z-branch');
+    expect(task.piece).toBe('review');
+    expect(task.worktree).toBe(true);
+  });
+});
+
+// ---- promptWorktreeSettings via addTask ----
+
+describe('promptWorktreeSettings (via addTask): base branch behavior by current branch', () => {
+  it('should NOT prompt for base branch when on main', async () => {
+    // Given: user is on main branch
+    mockGetCurrentBranch.mockReturnValue('main');
+    mockPromptInput.mockResolvedValueOnce('').mockResolvedValueOnce('');
+    mockConfirm.mockResolvedValueOnce(false);  // auto-create PR?
+
+    // When
+    await addTask(testDir, 'Task on main');
+
+    // Then: confirm was NOT called with a base branch question
+    const baseBranchPrompt = mockConfirm.mock.calls.find(
+      ([msg]) => typeof msg === 'string' && (msg as string).toLowerCase().includes('base branch'),
+    );
+    expect(baseBranchPrompt).toBeUndefined();
+
+    // Then: no base_branch in tasks.yaml
+    const task = loadTasks(testDir).tasks[0]!;
+    expect(task.base_branch).toBeUndefined();
+  });
+
+  it('should NOT prompt for base branch when on master', async () => {
+    // Given: user is on master branch
+    mockGetCurrentBranch.mockReturnValue('master');
+    mockPromptInput.mockResolvedValueOnce('').mockResolvedValueOnce('');
+    mockConfirm.mockResolvedValueOnce(false);  // auto-create PR?
+
+    // When
+    await addTask(testDir, 'Task on master');
+
+    // Then: no base branch confirm prompt
+    const baseBranchPrompt = mockConfirm.mock.calls.find(
+      ([msg]) => typeof msg === 'string' && (msg as string).toLowerCase().includes('base branch'),
+    );
+    expect(baseBranchPrompt).toBeUndefined();
+
+    // Then: no base_branch in tasks.yaml
+    const task = loadTasks(testDir).tasks[0]!;
+    expect(task.base_branch).toBeUndefined();
+  });
+
+  it('should prompt and save base_branch when on feature branch and user confirms', async () => {
+    // Given: user is on feat/xxx branch and confirms using it as base
+    mockGetCurrentBranch.mockReturnValue('feat/xxx');
+    mockPromptInput.mockResolvedValueOnce('').mockResolvedValueOnce('');
+    // Confirm call order: auto-create PR? (false), then base branch confirm (true)
+    // Note: actual call order may vary by implementation; key assertion is result
+    mockConfirm.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    // When
+    await addTask(testDir, 'Task on feature branch confirmed');
+
+    // Then: base_branch is saved as feat/xxx
+    const task = loadTasks(testDir).tasks[0]!;
+    expect(task.base_branch).toBe('feat/xxx');
+  });
+
+  it('should not save base_branch when on feature branch and user declines', async () => {
+    // Given: user is on feat/xxx branch but declines using it as base
+    mockGetCurrentBranch.mockReturnValue('feat/xxx');
+    mockPromptInput.mockResolvedValueOnce('').mockResolvedValueOnce('');
+    // All confirms decline (covers auto-PR, draft, and base branch)
+    mockConfirm.mockResolvedValue(false);
+
+    // When
+    await addTask(testDir, 'Task on feature branch declined');
+
+    // Then: no base_branch in tasks.yaml
+    const task = loadTasks(testDir).tasks[0]!;
+    expect(task.base_branch).toBeUndefined();
+  });
+
+  it('should include current branch name in the base branch confirm message', async () => {
+    // Given: user is on feat/my-feature
+    mockGetCurrentBranch.mockReturnValue('feat/my-feature');
+    mockPromptInput.mockResolvedValueOnce('').mockResolvedValueOnce('');
+    mockConfirm.mockResolvedValue(false);
+
+    // When
+    await addTask(testDir, 'Task with named branch in prompt');
+
+    // Then: at least one confirm call included the branch name
+    const branchMentionedPrompt = mockConfirm.mock.calls.find(
+      ([msg]) => typeof msg === 'string' && (msg as string).includes('feat/my-feature'),
+    );
+    expect(branchMentionedPrompt).toBeDefined();
+  });
+});
+
+// ---- addTask --pr: baseRefName from PR → base_branch ----
+
+describe('addTask --pr: baseRefName saved as base_branch', () => {
+  it('should save baseRefName from PR as base_branch in tasks.yaml', async () => {
+    // Given: PR has baseRefName = 'develop'
+    const prReview = createMockPrReview({ baseRefName: 'develop' });
+    const formattedTask = '## PR #456 Review: Fix auth bug';
+    mockFetchPrReviewComments.mockReturnValue(prReview);
+    mockFormatPrReviewAsTask.mockReturnValue(formattedTask);
+
+    // When: addTask with --pr option
+    await addTask(testDir, 'placeholder', { prNumber: 456 });
+
+    // Then: base_branch is saved as 'develop'
+    const task = loadTasks(testDir).tasks[0]!;
+    expect(task.base_branch).toBe('develop');
+  });
+
+  it('should save base_branch from PR alongside headRefName as branch', async () => {
+    // Given: PR with headRefName and baseRefName
+    const prReview = createMockPrReview({
+      headRefName: 'feature/fix-auth-bug',
+      baseRefName: 'main',
+    });
+    const formattedTask = '## PR #456 Review: Fix auth bug';
+    mockFetchPrReviewComments.mockReturnValue(prReview);
+    mockFormatPrReviewAsTask.mockReturnValue(formattedTask);
+
+    // When
+    await addTask(testDir, 'placeholder', { prNumber: 456 });
+
+    // Then: branch = headRefName, base_branch = baseRefName
+    const task = loadTasks(testDir).tasks[0]!;
+    expect(task.branch).toBe('feature/fix-auth-bug');
+    expect(task.base_branch).toBe('main');
+  });
+
+  it('should not prompt for worktree settings when using --pr', async () => {
+    // Given: PR with review comments
+    const prReview = createMockPrReview();
+    const formattedTask = '## PR #456 Review: Fix auth bug';
+    mockFetchPrReviewComments.mockReturnValue(prReview);
+    mockFormatPrReviewAsTask.mockReturnValue(formattedTask);
+
+    // When
+    await addTask(testDir, 'placeholder', { prNumber: 456 });
+
+    // Then: no prompts for worktree settings (PR sets these automatically)
+    expect(mockPromptInput).not.toHaveBeenCalled();
+    // getCurrentBranch should NOT be called in PR flow (base branch comes from PR)
+    expect(mockGetCurrentBranch).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/agent-usecases.test.ts
+++ b/src/__tests__/agent-usecases.test.ts
@@ -232,6 +232,48 @@ describe('agent-usecases', () => {
       .rejects.toThrow('Team leader failed: bad output');
   });
 
+  it('decomposeTask は error と content が共に空の場合に status をフォールバックに使う', async () => {
+    // error が undefined、content が空文字 → ?? では '' が残る → 修正後は status フォールバック
+    vi.mocked(runAgent).mockResolvedValue({
+      persona: 'team-leader',
+      status: 'error',
+      content: '',
+      error: undefined,
+      timestamp: new Date('2026-02-12T00:00:00Z'),
+    });
+
+    await expect(decomposeTask('instruction', 2, { cwd: '/repo' }))
+      .rejects.toThrow('Team leader failed: status: error');
+  });
+
+  it('decomposeTask は error が空文字でも status フォールバックを使う', async () => {
+    // error が '' → ?? は空文字をフォールバックしない → 修正後は || で status にフォールバック
+    vi.mocked(runAgent).mockResolvedValue({
+      persona: 'team-leader',
+      status: 'error',
+      content: '',
+      error: '',
+      timestamp: new Date('2026-02-12T00:00:00Z'),
+    });
+
+    await expect(decomposeTask('instruction', 2, { cwd: '/repo' }))
+      .rejects.toThrow('Team leader failed: status: error');
+  });
+
+  it('decomposeTask は error が空文字で content がある場合 content を使う', async () => {
+    // error が '' → ?? は '' を採用するが、修正後の || は content にフォールバック
+    vi.mocked(runAgent).mockResolvedValue({
+      persona: 'team-leader',
+      status: 'error',
+      content: 'partial output',
+      error: '',
+      timestamp: new Date('2026-02-12T00:00:00Z'),
+    });
+
+    await expect(decomposeTask('instruction', 2, { cwd: '/repo' }))
+      .rejects.toThrow('Team leader failed: partial output');
+  });
+
   it('requestMoreParts は構造化出力をパースして返す', async () => {
     vi.mocked(runAgent).mockResolvedValue(doneResponse('x', {
       done: false,
@@ -276,5 +318,24 @@ describe('agent-usecases', () => {
       1,
       { cwd: '/repo', persona: 'team-leader' },
     )).rejects.toThrow('Team leader feedback failed: timeout');
+  });
+
+  it('requestMoreParts は error と content が共に空の場合に status をフォールバックに使う', async () => {
+    // error が undefined、content が空文字 → 修正後は status フォールバック
+    vi.mocked(runAgent).mockResolvedValue({
+      persona: 'team-leader',
+      status: 'error',
+      content: '',
+      error: undefined,
+      timestamp: new Date('2026-02-12T00:00:00Z'),
+    });
+
+    await expect(requestMoreParts(
+      'instruction',
+      [{ id: 'p1', title: 'Part 1', status: 'done', content: 'ok' }],
+      ['p1'],
+      1,
+      { cwd: '/repo', persona: 'team-leader' },
+    )).rejects.toThrow('Team leader feedback failed: status: error');
   });
 });

--- a/src/__tests__/cli-routing-issue-resolve.test.ts
+++ b/src/__tests__/cli-routing-issue-resolve.test.ts
@@ -14,9 +14,6 @@ vi.mock('../shared/ui/index.js', () => ({
   withProgress: vi.fn(async (_start, _done, operation) => operation()),
 }));
 
-vi.mock('../shared/prompt/index.js', () => ({
-}));
-
 vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   createLogger: () => ({
@@ -51,6 +48,7 @@ vi.mock('../features/tasks/index.js', () => ({
   saveTaskFromInteractive: vi.fn(),
   createIssueAndSaveTask: vi.fn(),
   promptLabelSelection: vi.fn().mockResolvedValue([]),
+  promptBaseBranchIfNeeded: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../features/pipeline/index.js', () => ({
@@ -115,7 +113,7 @@ vi.mock('../app/cli/helpers.js', () => ({
 }));
 
 import { formatIssueAsTask, parseIssueNumbers } from '../infra/github/issue.js';
-import { selectAndExecuteTask, determinePiece, createIssueAndSaveTask } from '../features/tasks/index.js';
+import { selectAndExecuteTask, determinePiece, createIssueAndSaveTask, promptBaseBranchIfNeeded } from '../features/tasks/index.js';
 import { interactiveMode } from '../features/interactive/index.js';
 import { resolveConfigValues, loadPersonaSessions } from '../infra/config/index.js';
 import { isDirectTask } from '../app/cli/helpers.js';
@@ -134,6 +132,7 @@ const mockResolveConfigValues = vi.mocked(resolveConfigValues);
 const mockIsDirectTask = vi.mocked(isDirectTask);
 const mockInfo = vi.mocked(info);
 const mockTaskRunnerListAllTaskItems = vi.mocked(mockListAllTaskItems);
+const mockPromptBaseBranchIfNeeded = vi.mocked(promptBaseBranchIfNeeded);
 
 function createMockIssue(number: number): Issue {
   return {
@@ -158,6 +157,7 @@ beforeEach(() => {
   mockParseIssueNumbers.mockReturnValue([]);
   mockTaskRunnerListAllTaskItems.mockReturnValue([]);
   mockIsStaleRunningTask.mockReturnValue(false);
+  mockPromptBaseBranchIfNeeded.mockResolvedValue(undefined);
 });
 
 describe('Issue resolution in routing', () => {
@@ -543,6 +543,43 @@ describe('Issue resolution in routing', () => {
         expect.anything(),
         undefined,
       );
+    });
+  });
+
+  describe('base branch prompt on execute action', () => {
+    it('should set baseBranch when promptBaseBranchIfNeeded returns a branch name', async () => {
+      // Given: feature branch confirmed by user
+      mockPromptBaseBranchIfNeeded.mockResolvedValue('feat/xxx');
+
+      // When
+      await executeDefaultAction();
+
+      // Then: baseBranch is passed to selectAndExecuteTask
+      expect(mockSelectAndExecuteTask).toHaveBeenCalledWith(
+        '/test/cwd',
+        'summarized task',
+        expect.objectContaining({ baseBranch: 'feat/xxx' }),
+        undefined,
+      );
+    });
+
+    it('should not set baseBranch when promptBaseBranchIfNeeded returns undefined', async () => {
+      // Given: user declined or on main/master (default mock returns undefined)
+
+      // When
+      await executeDefaultAction();
+
+      // Then: baseBranch is not set
+      const callArgs = mockSelectAndExecuteTask.mock.calls[0];
+      expect(callArgs?.[2]?.baseBranch).toBeUndefined();
+    });
+
+    it('should call promptBaseBranchIfNeeded with cwd', async () => {
+      // When
+      await executeDefaultAction();
+
+      // Then: promptBaseBranchIfNeeded receives the cwd
+      expect(mockPromptBaseBranchIfNeeded).toHaveBeenCalledWith('/test/cwd');
     });
   });
 });

--- a/src/__tests__/cli-routing-pr-resolve.test.ts
+++ b/src/__tests__/cli-routing-pr-resolve.test.ts
@@ -14,9 +14,6 @@ vi.mock('../shared/ui/index.js', () => ({
   withProgress: vi.fn(async (_start, _done, operation) => operation()),
 }));
 
-vi.mock('../shared/prompt/index.js', () => ({
-}));
-
 vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   createLogger: () => ({
@@ -53,6 +50,7 @@ vi.mock('../features/tasks/index.js', () => ({
   saveTaskFromInteractive: vi.fn(),
   createIssueAndSaveTask: vi.fn(),
   promptLabelSelection: vi.fn().mockResolvedValue([]),
+  promptBaseBranchIfNeeded: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../features/pipeline/index.js', () => ({
@@ -116,7 +114,7 @@ vi.mock('../app/cli/helpers.js', () => ({
   isDirectTask: vi.fn(() => false),
 }));
 
-import { selectAndExecuteTask, determinePiece } from '../features/tasks/index.js';
+import { selectAndExecuteTask, determinePiece, promptBaseBranchIfNeeded } from '../features/tasks/index.js';
 import { interactiveMode } from '../features/interactive/index.js';
 import { executePipeline } from '../features/pipeline/index.js';
 import { executeDefaultAction } from '../app/cli/routing.js';
@@ -128,6 +126,7 @@ const mockDeterminePiece = vi.mocked(determinePiece);
 const mockInteractiveMode = vi.mocked(interactiveMode);
 const mockExecutePipeline = vi.mocked(executePipeline);
 const mockLogError = vi.mocked(logError);
+const mockPromptBaseBranchIfNeeded = vi.mocked(promptBaseBranchIfNeeded);
 
 function createMockPrReview(overrides: Partial<PrReviewData> = {}): PrReviewData {
   return {
@@ -136,6 +135,7 @@ function createMockPrReview(overrides: Partial<PrReviewData> = {}): PrReviewData
     body: 'PR description',
     url: 'https://github.com/org/repo/pull/456',
     headRefName: 'fix/auth-bug',
+    baseRefName: 'main',
     comments: [{ author: 'commenter1', body: 'Update tests' }],
     reviews: [{ author: 'reviewer1', body: 'Fix null check' }],
     files: ['src/auth.ts'],
@@ -176,10 +176,10 @@ describe('PR resolution in routing', () => {
       );
     });
 
-    it('should set branch in selectOptions from PR headRefName', async () => {
+    it('should set branch and baseBranch in selectOptions from PR headRefName and baseRefName', async () => {
       // Given
       mockOpts.pr = 456;
-      const prReview = createMockPrReview({ headRefName: 'feat/my-pr-branch' });
+      const prReview = createMockPrReview({ headRefName: 'feat/my-pr-branch', baseRefName: 'main' });
       mockCheckCliStatus.mockReturnValue({ available: true });
       mockFetchPrReviewComments.mockReturnValue(prReview);
 
@@ -192,7 +192,28 @@ describe('PR resolution in routing', () => {
         'summarized task',
         expect.objectContaining({
           branch: 'feat/my-pr-branch',
+          baseBranch: 'main',
         }),
+        undefined,
+      );
+    });
+
+    it('should not call promptBaseBranchIfNeeded when baseBranch is already set from PR', async () => {
+      // Given: --pr sets baseBranch automatically from prBaseRefName
+      mockOpts.pr = 456;
+      const prReview = createMockPrReview({ baseRefName: 'develop' });
+      mockCheckCliStatus.mockReturnValue({ available: true });
+      mockFetchPrReviewComments.mockReturnValue(prReview);
+
+      // When
+      await executeDefaultAction();
+
+      // Then: promptBaseBranchIfNeeded should NOT be called since baseBranch is already set
+      expect(mockPromptBaseBranchIfNeeded).not.toHaveBeenCalled();
+      expect(mockSelectAndExecuteTask).toHaveBeenCalledWith(
+        '/test/cwd',
+        'summarized task',
+        expect.objectContaining({ baseBranch: 'develop' }),
         undefined,
       );
     });

--- a/src/__tests__/clone.test.ts
+++ b/src/__tests__/clone.test.ts
@@ -51,7 +51,7 @@ vi.mock('../infra/config/project/projectConfig.js', async (importOriginal) => ({
 import { execFileSync } from 'node:child_process';
 import { loadGlobalConfig } from '../infra/config/global/globalConfig.js';
 import { loadProjectConfig } from '../infra/config/project/projectConfig.js';
-import { createSharedClone, createTempCloneForBranch } from '../infra/task/clone.js';
+import { createSharedClone, createTempCloneForBranch, resolveBaseBranch } from '../infra/task/clone.js';
 
 const mockExecFileSync = vi.mocked(execFileSync);
 const mockLoadProjectConfig = vi.mocked(loadProjectConfig);
@@ -736,6 +736,176 @@ describe('branchExists remote tracking branch fallback', () => {
 
     // Then: no checkout -b was called (branch already exists locally)
     expect(checkoutCalls).toHaveLength(0);
+  });
+});
+
+describe('resolveBaseBranch with taskBaseBranch override', () => {
+  it('should return taskBaseBranch when local branch exists', () => {
+    // Given: taskBaseBranch is provided and the local branch exists
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--verify') {
+        // Local branch exists
+        return Buffer.from('abc123');
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    const result = resolveBaseBranch('/project', 'feat/xxx');
+
+    // Then: returns taskBaseBranch without looking up config or detectDefaultBranch
+    expect(result.branch).toBe('feat/xxx');
+  });
+
+  it('should return taskBaseBranch when only remote tracking branch exists', () => {
+    // Given: taskBaseBranch is provided; local branch missing, remote tracking branch exists
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--verify') {
+        const ref = argsArr[2] as string;
+        if (ref.startsWith('origin/')) {
+          return Buffer.from('abc123');  // remote tracking branch exists
+        }
+        throw new Error('branch not found');  // local branch missing
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    const result = resolveBaseBranch('/project', 'feat/remote-only');
+
+    // Then: returns the branch using remote tracking ref as fallback
+    expect(result.branch).toBe('feat/remote-only');
+  });
+
+  it('should throw when taskBaseBranch does not exist locally or remotely', () => {
+    // Given: neither local nor remote tracking branch exists
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--verify') {
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    // When / Then: error message contains the branch name for diagnostics
+    expect(() => resolveBaseBranch('/project', 'feat/nonexistent')).toThrow('feat/nonexistent');
+  });
+
+  it('should not fetch from remote when taskBaseBranch is specified', () => {
+    // Given: autoFetch is enabled but taskBaseBranch is provided
+    vi.mocked(loadGlobalConfig).mockReturnValue({ autoFetch: true } as ReturnType<typeof loadGlobalConfig>);
+
+    const fetchCalls: string[][] = [];
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'fetch') {
+        fetchCalls.push(argsArr);
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--verify') {
+        return Buffer.from('abc123');
+      }
+      return Buffer.from('');
+    });
+
+    // When: taskBaseBranch is explicitly given
+    resolveBaseBranch('/project', 'feat/explicit');
+
+    // Then: git fetch is NOT called (taskBaseBranch bypasses autoFetch)
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe('createSharedClone with baseBranch option', () => {
+  it('should use baseBranch option as the base when creating a new branch', () => {
+    // Given: baseBranch option provided; new task branch does not exist yet; feat/xxx exists locally
+    const cloneCalls: string[][] = [];
+    const checkoutCalls: string[][] = [];
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--verify') {
+        const ref = argsArr[2] as string;
+        // base branch exists locally
+        if (ref === 'feat/xxx' || ref === 'origin/feat/xxx') {
+          return Buffer.from('abc123');
+        }
+        // new task branch doesn't exist yet
+        throw new Error('branch not found');
+      }
+      if (argsArr[0] === 'clone') {
+        cloneCalls.push(argsArr);
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config') {
+        if (argsArr[1] === '--local') throw new Error('not set');
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'checkout') {
+        checkoutCalls.push(argsArr);
+        return Buffer.from('');
+      }
+      return Buffer.from('');
+    });
+
+    // When: createSharedClone with baseBranch set to feat/xxx
+    createSharedClone('/project', {
+      worktree: '/tmp/clone-base-branch-test',
+      taskSlug: 'new-feature-task',
+      baseBranch: 'feat/xxx',
+    });
+
+    // Then: git clone was called with --branch feat/xxx (the task-level base)
+    expect(cloneCalls).toHaveLength(1);
+    expect(cloneCalls[0]).toContain('--branch');
+    expect(cloneCalls[0]).toContain('feat/xxx');
+
+    // Then: checkout -b was called to create the task branch from feat/xxx
+    expect(checkoutCalls).toHaveLength(1);
+    expect(checkoutCalls[0][0]).toBe('checkout');
+    expect(checkoutCalls[0][1]).toBe('-b');
+  });
+
+  it('should not use baseBranch when the task branch already exists', () => {
+    // Given: task branch already exists (no new checkout needed)
+    const cloneCalls: string[][] = [];
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--verify') {
+        // Task branch exists; both local and baseBranch verify succeed
+        return Buffer.from('abc123');
+      }
+      if (argsArr[0] === 'clone') {
+        cloneCalls.push(argsArr);
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config') {
+        if (argsArr[1] === '--local') throw new Error('not set');
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'checkout') return Buffer.from('');
+      return Buffer.from('');
+    });
+
+    // When: createSharedClone with explicit branch that already exists
+    createSharedClone('/project', {
+      worktree: '/tmp/clone-existing-branch',
+      taskSlug: 'existing-task',
+      branch: 'existing-task-branch',
+      baseBranch: 'feat/xxx',
+    });
+
+    // Then: clone was called with --branch existing-task-branch (not baseBranch)
+    expect(cloneCalls).toHaveLength(1);
+    expect(cloneCalls[0]).toContain('--branch');
+    expect(cloneCalls[0]).toContain('existing-task-branch');
   });
 });
 

--- a/src/__tests__/engine-team-leader.test.ts
+++ b/src/__tests__/engine-team-leader.test.ts
@@ -157,6 +157,37 @@ describe('PieceEngine Integration: TeamLeaderRunner', () => {
     expect(output!.content).toContain('[ERROR] test failed');
   });
 
+  it('パート失敗時にerrorが空文字でもcontentの詳細をエラー表示に使う', async () => {
+    // error: '' は ?? では空文字を採用してしまうが、|| では content にフォールバックする
+    const config = buildTeamLeaderConfig();
+    const engine = new PieceEngine(config, tmpDir, 'implement feature', { projectCwd: tmpDir });
+
+    vi.mocked(runAgent)
+      .mockResolvedValueOnce(makeResponse({
+        persona: 'team-leader',
+        content: [
+          '```json',
+          '[{"id":"part-1","title":"API","instruction":"Implement API"},{"id":"part-2","title":"Test","instruction":"Add tests"}]',
+          '```',
+        ].join('\n'),
+      }))
+      .mockResolvedValueOnce(makeResponse({ persona: 'coder', status: 'error', error: '', content: 'api failed from content' }))
+      .mockResolvedValueOnce(makeResponse({ persona: 'coder', content: 'Tests done' }))
+      .mockResolvedValueOnce(makeResponse({
+        persona: 'team-leader',
+        structuredOutput: { done: true, reasoning: 'stop', parts: [] },
+      }));
+
+    vi.mocked(detectMatchedRule).mockResolvedValueOnce({ index: 0, method: 'phase1_tag' });
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+    const output = state.movementOutputs.get('implement');
+    expect(output).toBeDefined();
+    expect(output!.content).toContain('[ERROR] api failed from content');
+  });
+
   it('パート失敗時にerrorがなくてもcontentの詳細をエラー表示に使う', async () => {
     const config = buildTeamLeaderConfig();
     const engine = new PieceEngine(config, tmpDir, 'implement feature', { projectCwd: tmpDir });

--- a/src/__tests__/github-pr.test.ts
+++ b/src/__tests__/github-pr.test.ts
@@ -191,6 +191,7 @@ describe('fetchPrReviewComments', () => {
       body: 'PR description',
       url: 'https://github.com/org/repo/pull/456',
       headRefName: 'fix/auth-bug',
+      baseRefName: 'main',
       comments: [
         { author: { login: 'commenter1' }, body: 'Please update tests' },
       ],
@@ -221,12 +222,13 @@ describe('fetchPrReviewComments', () => {
     // Then
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'gh',
-      ['pr', 'view', '456', '--json', 'number,title,body,url,headRefName,comments,reviews,files'],
+      ['pr', 'view', '456', '--json', 'number,title,body,url,headRefName,baseRefName,comments,reviews,files'],
       expect.objectContaining({ encoding: 'utf-8' }),
     );
     expect(result.number).toBe(456);
     expect(result.title).toBe('Fix auth bug');
     expect(result.headRefName).toBe('fix/auth-bug');
+    expect(result.baseRefName).toBe('main');
     expect(result.comments).toEqual([{ author: 'commenter1', body: 'Please update tests' }]);
     expect(result.reviews).toEqual([
       { author: 'reviewer1', body: 'Looks mostly good' },
@@ -276,6 +278,7 @@ describe('formatPrReviewAsTask', () => {
       body: 'PR description text',
       url: 'https://github.com/org/repo/pull/456',
       headRefName: 'fix/auth-bug',
+      baseRefName: 'main',
       comments: [
         { author: 'commenter1', body: 'Can you also update the tests?' },
       ],
@@ -312,6 +315,7 @@ describe('formatPrReviewAsTask', () => {
       body: '',
       url: 'https://github.com/org/repo/pull/10',
       headRefName: 'fix/quick',
+      baseRefName: 'main',
       comments: [],
       reviews: [{ author: 'reviewer', body: 'Fix this' }],
       files: [],
@@ -333,6 +337,7 @@ describe('formatPrReviewAsTask', () => {
       body: '',
       url: 'https://github.com/org/repo/pull/20',
       headRefName: 'feat/empty',
+      baseRefName: 'main',
       comments: [],
       reviews: [{ author: 'reviewer', body: 'Add tests' }],
       files: [],
@@ -355,6 +360,7 @@ describe('formatPrReviewAsTask', () => {
       body: '',
       url: 'https://github.com/org/repo/pull/30',
       headRefName: 'feat/path-only',
+      baseRefName: 'main',
       comments: [],
       reviews: [{ author: 'reviewer', body: 'Fix this', path: 'src/index.ts' }],
       files: [],

--- a/src/__tests__/pipeline-pr-base-branch.test.ts
+++ b/src/__tests__/pipeline-pr-base-branch.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Integration tests for pipeline PR base branch support (Issue #399)
+ *
+ * Verifies:
+ *   - resolveTaskContent returns prBaseRefName from PR data
+ *   - resolveExecutionContext uses prBaseRefName as baseBranch when checking out PR branch
+ *   - resolveExecutionContext passes prBaseRefName to confirmAndCreateWorktree when using worktree
+ *
+ * Module chain (3+ modules):
+ *   resolveTaskContent (pipeline/steps.ts)
+ *     → fetchPrReviewComments (infra/github/pr.ts)
+ *       → PrReviewData.baseRefName (infra/git/types.ts)
+ *   resolveExecutionContext (pipeline/steps.ts)
+ *     → confirmAndCreateWorktree (features/tasks/execute/selectAndExecute.ts)
+ *       → createSharedClone with baseBranch (infra/task/clone.ts)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Hoisted mocks ---
+
+const {
+  mockCheckCliStatus,
+  mockFetchPrReviewComments,
+  mockFormatPrReviewAsTask,
+  mockConfirmAndCreateWorktree,
+  mockResolveBaseBranch,
+  mockExecFileSync,
+} = vi.hoisted(() => ({
+  mockCheckCliStatus: vi.fn().mockReturnValue({ available: true }),
+  mockFetchPrReviewComments: vi.fn(),
+  mockFormatPrReviewAsTask: vi.fn(),
+  mockConfirmAndCreateWorktree: vi.fn(),
+  mockResolveBaseBranch: vi.fn().mockReturnValue({ branch: 'main' }),
+  mockExecFileSync: vi.fn(),
+}));
+
+// --- Module mocks ---
+
+vi.mock('node:child_process', () => ({
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+}));
+
+vi.mock('../infra/git/index.js', () => ({
+  getGitProvider: () => ({
+    checkCliStatus: (...args: unknown[]) => mockCheckCliStatus(...args),
+    fetchPrReviewComments: (...args: unknown[]) => mockFetchPrReviewComments(...args),
+    fetchIssue: vi.fn(),
+    createPullRequest: vi.fn(),
+    findExistingPr: vi.fn(),
+  }),
+}));
+
+vi.mock('../infra/github/index.js', () => ({
+  formatIssueAsTask: vi.fn(),
+  formatPrReviewAsTask: (...args: unknown[]) => mockFormatPrReviewAsTask(...args),
+  buildPrBody: vi.fn().mockReturnValue('PR body'),
+}));
+
+vi.mock('../features/tasks/index.js', () => ({
+  executeTask: vi.fn(),
+  confirmAndCreateWorktree: (...args: unknown[]) => mockConfirmAndCreateWorktree(...args),
+}));
+
+vi.mock('../infra/task/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  stageAndCommit: vi.fn(),
+  pushBranch: vi.fn(),
+  resolveBaseBranch: (...args: unknown[]) => mockResolveBaseBranch(...args),
+}));
+
+vi.mock('../infra/config/index.js', () => ({
+  resolveConfigValue: vi.fn(() => undefined),
+  resolveConfigValues: vi.fn(() => ({})),
+}));
+
+vi.mock('../shared/ui/index.js', () => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+  getErrorMessage: (e: unknown) => String(e),
+}));
+
+// --- Import under test ---
+
+import { resolveTaskContent, resolveExecutionContext } from '../features/pipeline/steps.js';
+import type { PipelineExecutionOptions } from '../features/tasks/index.js';
+
+// --- Helpers ---
+
+/** Build mock PR review data including baseRefName (added in implementation) */
+function createMockPrReview(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    number: 456,
+    title: 'Fix auth bug',
+    body: 'PR description',
+    url: 'https://github.com/org/repo/pull/456',
+    headRefName: 'feature/fix-auth-bug',
+    baseRefName: 'develop',
+    comments: [{ author: 'commenter', body: 'Please update tests' }],
+    reviews: [{ author: 'reviewer', body: 'Fix null check' }],
+    files: ['src/auth.ts'],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCheckCliStatus.mockReturnValue({ available: true });
+  mockResolveBaseBranch.mockReturnValue({ branch: 'main' });
+});
+
+// ---- resolveTaskContent with PR ----
+
+describe('resolveTaskContent: includes prBaseRefName from PR', () => {
+  it('should include prBaseRefName in returned TaskContent when PR has baseRefName', () => {
+    // Given: PR has baseRefName = 'develop'
+    const prReview = createMockPrReview({ baseRefName: 'develop' });
+    mockFetchPrReviewComments.mockReturnValue(prReview);
+    mockFormatPrReviewAsTask.mockReturnValue('## PR Review task');
+
+    const options: PipelineExecutionOptions = {
+      prNumber: 456,
+      piece: 'default',
+      cwd: '/project',
+    };
+
+    // When
+    const result = resolveTaskContent(options);
+
+    // Then: prBaseRefName is included in the result
+    expect(result).not.toBeUndefined();
+    expect(result?.prBaseRefName).toBe('develop');
+  });
+
+  it('should include prBranch (headRefName) in returned TaskContent', () => {
+    // Given: PR with specific headRefName
+    const prReview = createMockPrReview({ headRefName: 'feature/fix-auth-bug', baseRefName: 'develop' });
+    mockFetchPrReviewComments.mockReturnValue(prReview);
+    mockFormatPrReviewAsTask.mockReturnValue('## PR Review task');
+
+    const options: PipelineExecutionOptions = {
+      prNumber: 456,
+      piece: 'default',
+      cwd: '/project',
+    };
+
+    // When
+    const result = resolveTaskContent(options);
+
+    // Then: both prBranch and prBaseRefName are included
+    expect(result?.prBranch).toBe('feature/fix-auth-bug');
+    expect(result?.prBaseRefName).toBe('develop');
+  });
+
+  it('should not include prBaseRefName when resolving non-PR task', () => {
+    // Given: task-based (no PR)
+    const options: PipelineExecutionOptions = {
+      task: 'Implement feature',
+      piece: 'default',
+      cwd: '/project',
+    };
+
+    // When
+    const result = resolveTaskContent(options);
+
+    // Then: no prBaseRefName
+    expect(result?.prBaseRefName).toBeUndefined();
+    expect(result?.prBranch).toBeUndefined();
+  });
+});
+
+// ---- resolveExecutionContext with prBaseRefName ----
+
+describe('resolveExecutionContext: uses prBaseRefName as baseBranch for PR branch checkout', () => {
+  it('should use prBaseRefName as baseBranch when checking out PR branch (no worktree)', async () => {
+    // Given: PR checkout path (prBranch set, no worktree, no skipGit)
+    mockExecFileSync.mockReturnValue(Buffer.from(''));
+
+    const options = {
+      createWorktree: false as boolean | undefined,
+      skipGit: false,
+      branch: undefined,
+      issueNumber: undefined,
+    };
+
+    // When: resolveExecutionContext with prBranch and prBaseRefName
+    const result = await resolveExecutionContext(
+      '/project',
+      'Fix auth bug task',
+      options,
+      undefined,
+      'feature/fix-auth-bug',   // prBranch
+      'develop',                 // prBaseRefName
+    );
+
+    // Then: baseBranch in result is 'develop' (from PR), NOT resolved from config
+    expect(result.baseBranch).toBe('develop');
+    // Then: resolveBaseBranch was NOT called (prBaseRefName bypasses it)
+    expect(mockResolveBaseBranch).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to resolveBaseBranch when prBaseRefName is undefined', async () => {
+    // Given: PR checkout path without prBaseRefName
+    mockExecFileSync.mockReturnValue(Buffer.from(''));
+    mockResolveBaseBranch.mockReturnValue({ branch: 'main' });
+
+    const options = {
+      createWorktree: false as boolean | undefined,
+      skipGit: false,
+      branch: undefined,
+      issueNumber: undefined,
+    };
+
+    // When: resolveExecutionContext with prBranch but no prBaseRefName
+    const result = await resolveExecutionContext(
+      '/project',
+      'Fix auth bug task',
+      options,
+      undefined,
+      'feature/fix-auth-bug',  // prBranch
+      // prBaseRefName not provided
+    );
+
+    // Then: baseBranch comes from resolveBaseBranch (config/default)
+    expect(result.baseBranch).toBe('main');
+    expect(mockResolveBaseBranch).toHaveBeenCalled();
+  });
+
+  it('should pass prBaseRefName to confirmAndCreateWorktree when using worktree', async () => {
+    // Given: worktree mode with prBaseRefName
+    mockConfirmAndCreateWorktree.mockResolvedValue({
+      execCwd: '/tmp/clone',
+      branch: 'feature/fix-auth-bug',
+      baseBranch: 'develop',
+      isWorktree: true,
+    });
+
+    const options = {
+      createWorktree: true as boolean | undefined,
+      skipGit: false,
+      branch: undefined,
+      issueNumber: undefined,
+    };
+
+    // When: resolveExecutionContext in worktree mode with prBaseRefName
+    await resolveExecutionContext(
+      '/project',
+      'Fix auth bug task',
+      options,
+      undefined,
+      'feature/fix-auth-bug',  // prBranch
+      'develop',               // prBaseRefName
+    );
+
+    // Then: confirmAndCreateWorktree was called with baseBranchOverride = 'develop'
+    expect(mockConfirmAndCreateWorktree).toHaveBeenCalledWith(
+      '/project',
+      'Fix auth bug task',
+      true,                     // createWorktreeOverride
+      'feature/fix-auth-bug',   // branchOverride (prBranch)
+      'develop',                // baseBranchOverride (prBaseRefName)
+    );
+  });
+});

--- a/src/__tests__/pipelineExecution.test.ts
+++ b/src/__tests__/pipelineExecution.test.ts
@@ -534,7 +534,7 @@ describe('executePipeline', () => {
       });
 
       expect(exitCode).toBe(0);
-      expect(mockConfirmAndCreateWorktree).toHaveBeenCalledWith('/tmp/test', 'Fix the bug', true, undefined);
+      expect(mockConfirmAndCreateWorktree).toHaveBeenCalledWith('/tmp/test', 'Fix the bug', true, undefined, undefined);
       expect(mockExecuteTask).toHaveBeenCalledWith({
         task: 'Fix the bug',
         cwd: '/tmp/test-worktree',

--- a/src/__tests__/resolve-task-base-branch.test.ts
+++ b/src/__tests__/resolve-task-base-branch.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Integration tests for resolveTaskExecution with base_branch (Issue #399)
+ *
+ * Verifies that base_branch from task data is propagated to createSharedClone
+ * as baseBranch option, crossing the following module chain:
+ *   resolveTaskExecution (execute/resolveTask.ts)
+ *     → createSharedClone (infra/task/clone.ts)
+ *       → CloneManager.resolveBaseBranch (infra/task/clone.ts)
+ *
+ * Tests follow the integration-test criteria:
+ *   - 3+ modules crossed in the call chain
+ *   - New option (base_branch) propagates from task data to clone creation
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { TaskInfo } from '../infra/task/index.js';
+
+// --- Hoisted mocks ---
+
+const { mockCreateSharedClone, mockWithProgress } = vi.hoisted(() => ({
+  mockCreateSharedClone: vi.fn(),
+  mockWithProgress: vi.fn(async (
+    _start: unknown,
+    _done: unknown,
+    operation: () => Promise<unknown>,
+  ) => operation()),
+}));
+
+// --- Module mocks ---
+
+vi.mock('../infra/task/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createSharedClone: (...args: unknown[]) => mockCreateSharedClone(...args),
+  summarizeTaskName: vi.fn().mockResolvedValue('test-task'),
+  detectDefaultBranch: vi.fn().mockReturnValue('main'),
+  resolveBaseBranch: vi.fn((_cwd: unknown, taskBranch?: string) => ({ branch: taskBranch ?? 'main' })),
+}));
+
+vi.mock('../shared/ui/index.js', () => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  success: vi.fn(),
+  withProgress: (...args: unknown[]) => mockWithProgress(...args),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../infra/config/index.js', () => ({
+  resolvePieceConfigValue: vi.fn(() => undefined),
+  resolveConfigValue: vi.fn(() => undefined),
+}));
+
+vi.mock('../infra/git/index.js', () => ({
+  getGitProvider: () => ({
+    checkCliStatus: vi.fn(() => ({ available: false })),
+    fetchIssue: vi.fn(),
+  }),
+}));
+
+// --- Import under test ---
+
+import { resolveTaskExecution } from '../features/tasks/execute/resolveTask.js';
+
+// --- Helpers ---
+
+const tempRoots = new Set<string>();
+
+afterEach(() => {
+  for (const root of tempRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  tempRoots.clear();
+});
+
+function createTempProjectDir(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-base-branch-test-'));
+  tempRoots.add(root);
+  return root;
+}
+
+function createTask(overrides: Partial<TaskInfo>): TaskInfo {
+  return {
+    filePath: '/tasks/task.yaml',
+    name: 'task-name',
+    content: 'Run task',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    status: 'pending',
+    data: { task: 'Run task' },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default: createSharedClone succeeds
+  mockCreateSharedClone.mockReturnValue({ path: '/tmp/clone', branch: 'takt/123/test-task' });
+});
+
+// ---- Integration tests ----
+
+describe('resolveTaskExecution propagates base_branch to createSharedClone', () => {
+  it('should pass base_branch from task data to createSharedClone as baseBranch option', async () => {
+    // Given: task has base_branch set in data
+    const root = createTempProjectDir();
+    const task = createTask({
+      data: {
+        task: 'Run task with base branch',
+        worktree: true,
+        base_branch: 'feat/xxx',
+      },
+    });
+
+    // When
+    await resolveTaskExecution(task, root, 'default');
+
+    // Then: createSharedClone was called with baseBranch option
+    expect(mockCreateSharedClone).toHaveBeenCalledWith(
+      root,
+      expect.objectContaining({
+        baseBranch: 'feat/xxx',
+      }),
+    );
+  });
+
+  it('should NOT pass baseBranch to createSharedClone when base_branch is absent', async () => {
+    // Given: task has no base_branch in data
+    const root = createTempProjectDir();
+    const task = createTask({
+      data: {
+        task: 'Run task without base branch',
+        worktree: true,
+      },
+    });
+
+    // When
+    await resolveTaskExecution(task, root, 'default');
+
+    // Then: createSharedClone was called without baseBranch (or with undefined)
+    const callArgs = mockCreateSharedClone.mock.calls[0];
+    const options = callArgs?.[1] as Record<string, unknown>;
+    // baseBranch should be absent or undefined — not a specific branch
+    expect(options?.baseBranch).toBeUndefined();
+  });
+
+  it('should reflect baseBranch from task data in resolved baseBranch output', async () => {
+    // Given: task specifies base_branch and createSharedClone succeeds
+    const root = createTempProjectDir();
+    const task = createTask({
+      data: {
+        task: 'Run task',
+        worktree: true,
+        base_branch: 'feat/feature-branch',
+      },
+    });
+    mockCreateSharedClone.mockReturnValue({ path: '/tmp/clone', branch: 'takt/123/run-task' });
+
+    // When
+    const result = await resolveTaskExecution(task, root, 'default');
+
+    // Then: the resolved baseBranch in the result matches the task's base_branch
+    expect(result.baseBranch).toBe('feat/feature-branch');
+  });
+
+  it('should still work when worktree is false and base_branch is set (base_branch ignored)', async () => {
+    // Given: worktree is disabled; base_branch is provided but irrelevant
+    const root = createTempProjectDir();
+    const task = createTask({
+      data: {
+        task: 'Run non-worktree task',
+        base_branch: 'feat/xxx',
+      },
+    });
+
+    // When
+    const result = await resolveTaskExecution(task, root, 'default');
+
+    // Then: execCwd is the project root (no worktree)
+    expect(result.execCwd).toBe(root);
+    expect(result.isWorktree).toBe(false);
+    // Then: createSharedClone is NOT called
+    expect(mockCreateSharedClone).not.toHaveBeenCalled();
+  });
+
+  it('should use task.base_branch over config default branch when resolving baseBranch', async () => {
+    // Given: both task.base_branch and resolveBaseBranch-from-config would return different values
+    const root = createTempProjectDir();
+    const task = createTask({
+      data: {
+        task: 'Run task with explicit base',
+        worktree: true,
+        base_branch: 'feat/explicit-base',
+      },
+    });
+
+    // When
+    await resolveTaskExecution(task, root, 'default');
+
+    // Then: createSharedClone received the explicit base_branch value
+    expect(mockCreateSharedClone).toHaveBeenCalledWith(
+      root,
+      expect.objectContaining({
+        baseBranch: 'feat/explicit-base',
+      }),
+    );
+    // Not the mock's detectDefaultBranch return value of 'main'
+    const callOptions = mockCreateSharedClone.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(callOptions?.baseBranch).not.toBe('main');
+  });
+});

--- a/src/__tests__/task-schema.test.ts
+++ b/src/__tests__/task-schema.test.ts
@@ -85,6 +85,28 @@ describe('TaskExecutionConfigSchema', () => {
   it('should reject non-integer issue number', () => {
     expect(() => TaskExecutionConfigSchema.parse({ issue: 1.5 })).toThrow();
   });
+
+  it('should accept base_branch as optional string', () => {
+    // Given: base_branch is a valid branch name
+    expect(() => TaskExecutionConfigSchema.parse({ base_branch: 'feat/xxx' })).not.toThrow();
+  });
+
+  it('should accept base_branch with slash in name', () => {
+    // Given: branch names commonly include slashes
+    expect(() => TaskExecutionConfigSchema.parse({ base_branch: 'feature/some-feature' })).not.toThrow();
+  });
+
+  it('should accept config without base_branch (optional field)', () => {
+    // Given: base_branch is not provided
+    const config = { worktree: true, branch: 'feat/x' };
+    const parsed = TaskExecutionConfigSchema.parse(config);
+    expect(parsed.base_branch).toBeUndefined();
+  });
+
+  it('should reject non-string base_branch', () => {
+    // Given: base_branch is a number instead of string
+    expect(() => TaskExecutionConfigSchema.parse({ base_branch: 123 })).toThrow();
+  });
 });
 
 describe('TaskFileSchema', () => {

--- a/src/__tests__/team-leader-aggregation.test.ts
+++ b/src/__tests__/team-leader-aggregation.test.ts
@@ -12,6 +12,27 @@ function makePart(id: string, title: string): PartDefinition {
 }
 
 describe('buildTeamLeaderAggregatedContent', () => {
+  it('errorが空文字でもcontentをエラー詳細として使う', () => {
+    // error: '' は ?? では採用されてしまうが、|| ではコンテンツにフォールバックする
+    const part = makePart('p1', 'API');
+    const partResults: PartResult[] = [
+      {
+        part,
+        response: {
+          persona: 'execute.p1',
+          status: 'error',
+          content: 'fallback error detail',
+          error: '',
+          timestamp: new Date(),
+        },
+      },
+    ];
+
+    const content = buildTeamLeaderAggregatedContent([part], partResults);
+
+    expect(content).toContain('[ERROR] fallback error detail');
+  });
+
   it('decomposition とパート結果を規定フォーマットで連結する', () => {
     const part1 = makePart('p1', 'API');
     const part2 = makePart('p2', 'Test');

--- a/src/app/cli/routing.ts
+++ b/src/app/cli/routing.ts
@@ -11,7 +11,7 @@ import { getLabel } from '../../shared/i18n/index.js';
 import { formatIssueAsTask, parseIssueNumbers, formatPrReviewAsTask } from '../../infra/github/index.js';
 import { getGitProvider } from '../../infra/git/index.js';
 import type { Issue, PrReviewData } from '../../infra/git/index.js';
-import { selectAndExecuteTask, determinePiece, saveTaskFromInteractive, createIssueAndSaveTask, promptLabelSelection, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
+import { selectAndExecuteTask, determinePiece, saveTaskFromInteractive, createIssueAndSaveTask, promptLabelSelection, promptBaseBranchIfNeeded, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
 import { executePipeline } from '../../features/pipeline/index.js';
 import {
   interactiveMode,
@@ -85,7 +85,7 @@ async function resolveIssueInput(
  */
 async function resolvePrInput(
   prNumber: number,
-): Promise<{ initialInput: string; prBranch: string }> {
+): Promise<{ initialInput: string; prBranch: string; prBaseRefName: string }> {
   const ghStatus = getGitProvider().checkCliStatus();
   if (!ghStatus.available) {
     throw new Error(ghStatus.error);
@@ -104,6 +104,7 @@ async function resolvePrInput(
   return {
     initialInput: formatPrReviewAsTask(prReview),
     prBranch: prReview.headRefName,
+    prBaseRefName: prReview.baseRefName,
   };
 }
 
@@ -185,6 +186,7 @@ export async function executeDefaultAction(task?: string): Promise<void> {
       const prResult = await resolvePrInput(prNumber);
       initialInput = prResult.initialInput;
       selectOptions.branch = prResult.prBranch;
+      selectOptions.baseBranch = prResult.prBaseRefName;
     } catch (e) {
       logError(getErrorMessage(e));
       process.exit(1);
@@ -275,6 +277,12 @@ export async function executeDefaultAction(task?: string): Promise<void> {
       selectOptions.piece = pieceId;
       selectOptions.interactiveMetadata = { confirmed: true, task: confirmedTask };
       selectOptions.skipTaskList = true;
+      if (!selectOptions.baseBranch) {
+        const baseBranch = await promptBaseBranchIfNeeded(resolvedCwd);
+        if (baseBranch) {
+          selectOptions.baseBranch = baseBranch;
+        }
+      }
       await selectAndExecuteTask(resolvedCwd, confirmedTask, selectOptions, agentOverrides);
     },
     create_issue: async ({ task: confirmedTask }) => {

--- a/src/core/piece/agent-usecases.ts
+++ b/src/core/piece/agent-usecases.ts
@@ -296,7 +296,7 @@ export async function decomposeTask(
   });
 
   if (response.status !== 'done') {
-    const detail = response.error ?? response.content;
+    const detail = response.error || response.content || `status: ${response.status}`;
     throw new Error(`Team leader failed: ${detail}`);
   }
 
@@ -336,7 +336,7 @@ export async function requestMoreParts(
   });
 
   if (response.status !== 'done') {
-    const detail = response.error ?? response.content;
+    const detail = response.error || response.content || `status: ${response.status}`;
     throw new Error(`Team leader feedback failed: ${detail}`);
   }
 

--- a/src/core/piece/engine/team-leader-common.ts
+++ b/src/core/piece/engine/team-leader-common.ts
@@ -9,7 +9,7 @@ export function summarizeParts(parts: PartDefinition[]): Array<{ id: string; tit
 }
 
 export function resolvePartErrorDetail(partResult: PartResult): string {
-  const detail = partResult.response.error ?? partResult.response.content;
+  const detail = partResult.response.error || partResult.response.content;
   if (!detail) {
     throw new Error(`Part "${partResult.part.id}" failed without error detail`);
   }

--- a/src/features/pipeline/execute.ts
+++ b/src/features/pipeline/execute.ts
@@ -59,7 +59,7 @@ async function runPipeline(options: PipelineExecutionOptions): Promise<PipelineO
   // Step 2: Prepare execution environment
   let context: ExecutionContext;
   try {
-    context = await resolveExecutionContext(cwd, taskContent.task, options, pipelineConfig, taskContent.prBranch);
+    context = await resolveExecutionContext(cwd, taskContent.task, options, pipelineConfig, taskContent.prBranch, taskContent.prBaseRefName);
   } catch (err) {
     error(`Failed to prepare execution environment: ${getErrorMessage(err)}`);
     return { exitCode: EXIT_GIT_OPERATION_FAILED, result: buildResult() };

--- a/src/features/pipeline/steps.ts
+++ b/src/features/pipeline/steps.ts
@@ -21,6 +21,8 @@ export interface TaskContent {
   issue?: Issue;
   /** PR head branch name (set when using --pr) */
   prBranch?: string;
+  /** PR base branch name (set when using --pr) */
+  prBaseRefName?: string;
 }
 
 export interface ExecutionContext {
@@ -113,7 +115,7 @@ export function resolveTaskContent(options: PipelineExecutionOptions): TaskConte
     }
     const task = formatPrReviewAsTask(prReview);
     success(`PR #${options.prNumber} fetched: "${prReview.title}"`);
-    return { task, prBranch: prReview.headRefName };
+    return { task, prBranch: prReview.headRefName, prBaseRefName: prReview.baseRefName };
   }
   if (options.issueNumber) {
     info(`Fetching issue #${options.issueNumber}...`);
@@ -141,9 +143,10 @@ export async function resolveExecutionContext(
   options: Pick<PipelineExecutionOptions, 'createWorktree' | 'skipGit' | 'branch' | 'issueNumber'>,
   pipelineConfig: PipelineConfig | undefined,
   prBranch?: string,
+  prBaseRefName?: string,
 ): Promise<ExecutionContext> {
   if (options.createWorktree) {
-    const result = await confirmAndCreateWorktree(cwd, task, options.createWorktree, prBranch);
+    const result = await confirmAndCreateWorktree(cwd, task, options.createWorktree, prBranch, prBaseRefName);
     if (result.isWorktree) {
       success(`Worktree created: ${result.execCwd}`);
     }
@@ -157,7 +160,8 @@ export async function resolveExecutionContext(
     execFileSync('git', ['fetch', 'origin', prBranch], { cwd, stdio: 'pipe' });
     execFileSync('git', ['checkout', prBranch], { cwd, stdio: 'pipe' });
     success(`Checked out PR branch: ${prBranch}`);
-    return { execCwd: cwd, branch: prBranch, baseBranch: resolveBaseBranch(cwd).branch, isWorktree: false };
+    const baseBranch = prBaseRefName ?? resolveBaseBranch(cwd).branch;
+    return { execCwd: cwd, branch: prBranch, baseBranch, isWorktree: false };
   }
   const resolved = resolveBaseBranch(cwd);
   const branch = options.branch ?? generatePipelineBranchName(pipelineConfig, options.issueNumber);

--- a/src/features/tasks/add/index.ts
+++ b/src/features/tasks/add/index.ts
@@ -10,7 +10,7 @@ import { promptInput, confirm, selectOption } from '../../../shared/prompt/index
 import { success, info, error, withProgress } from '../../../shared/ui/index.js';
 import { getLabel } from '../../../shared/i18n/index.js';
 import type { Language } from '../../../core/models/types.js';
-import { TaskRunner, type TaskFileData, summarizeTaskName } from '../../../infra/task/index.js';
+import { TaskRunner, type TaskFileData, summarizeTaskName, getCurrentBranch } from '../../../infra/task/index.js';
 import { determinePiece } from '../execute/selectAndExecute.js';
 import { createLogger, getErrorMessage, generateReportDir } from '../../../shared/utils/index.js';
 import { isIssueReference, resolveIssueTask, parseIssueNumbers, formatPrReviewAsTask } from '../../../infra/github/index.js';
@@ -42,7 +42,7 @@ function resolveUniqueTaskSlug(cwd: string, baseSlug: string): string {
 export async function saveTaskFile(
   cwd: string,
   taskContent: string,
-  options?: { piece?: string; issue?: number; worktree?: boolean | string; branch?: string; autoPr?: boolean; draftPr?: boolean },
+  options?: { piece?: string; issue?: number; worktree?: boolean | string; branch?: string; baseBranch?: string; autoPr?: boolean; draftPr?: boolean },
 ): Promise<{ taskName: string; tasksFile: string }> {
   const runner = new TaskRunner(cwd);
   const slug = await summarizeTaskName(taskContent, { cwd });
@@ -56,6 +56,7 @@ export async function saveTaskFile(
   const config: Omit<TaskFileData, 'task'> = {
     ...(options?.worktree !== undefined && { worktree: options.worktree }),
     ...(options?.branch && { branch: options.branch }),
+    ...(options?.baseBranch && { base_branch: options.baseBranch }),
     ...(options?.piece && { piece: options.piece }),
     ...(options?.issue !== undefined && { issue: options.issue }),
     ...(options?.autoPr !== undefined && { auto_pr: options.autoPr }),
@@ -75,6 +76,7 @@ export async function saveTaskFile(
 interface WorktreeSettings {
   worktree?: boolean | string;
   branch?: string;
+  baseBranch?: string;
   autoPr?: boolean;
   draftPr?: boolean;
 }
@@ -126,7 +128,24 @@ export async function promptLabelSelection(lang: Language): Promise<string[]> {
   return [selected];
 }
 
-async function promptWorktreeSettings(): Promise<WorktreeSettings> {
+/**
+ * Prompt user to use current non-default branch as base branch.
+ *
+ * Returns the current branch name if user confirms, undefined otherwise.
+ * Skips the prompt silently when on main or master.
+ */
+export async function promptBaseBranchIfNeeded(cwd: string): Promise<string | undefined> {
+  const currentBranch = getCurrentBranch(cwd);
+  if (currentBranch !== 'main' && currentBranch !== 'master') {
+    const useCurrentAsBase = await confirm(`Use ${currentBranch} as base branch?`, true);
+    if (useCurrentAsBase) {
+      return currentBranch;
+    }
+  }
+  return undefined;
+}
+
+async function promptWorktreeSettings(cwd: string): Promise<WorktreeSettings> {
   const customPath = await promptInput('Worktree path (Enter for auto)');
   const worktree: boolean | string = customPath || true;
 
@@ -136,7 +155,9 @@ async function promptWorktreeSettings(): Promise<WorktreeSettings> {
   const autoPr = await confirm('Auto-create PR?', true);
   const draftPr = autoPr ? await confirm('Create as draft?', true) : false;
 
-  return { worktree, branch, autoPr, draftPr };
+  const baseBranch = await promptBaseBranchIfNeeded(cwd);
+
+  return { worktree, branch, baseBranch, autoPr, draftPr };
 }
 
 /**
@@ -155,7 +176,7 @@ export async function saveTaskFromInteractive(
       return;
     }
   }
-  const settings = await promptWorktreeSettings();
+  const settings = await promptWorktreeSettings(cwd);
   const created = await saveTaskFile(cwd, task, { piece, issue: options?.issue, ...settings });
   displayTaskCreationResult(created, settings, piece);
 }
@@ -230,6 +251,7 @@ export async function addTask(
     const settings = {
       worktree: true,
       branch: prReview.headRefName,
+      baseBranch: prReview.baseRefName,
       autoPr: false,
     };
     const created = await saveTaskFile(cwd, taskContent, { piece, ...settings });
@@ -273,7 +295,7 @@ export async function addTask(
     return;
   }
 
-  const settings = await promptWorktreeSettings();
+  const settings = await promptWorktreeSettings(cwd);
 
   const created = await saveTaskFile(cwd, taskContent, {
     piece,

--- a/src/features/tasks/execute/resolveTask.ts
+++ b/src/features/tasks/execute/resolveTask.ts
@@ -5,7 +5,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { resolvePieceConfigValue } from '../../../infra/config/index.js';
-import { type TaskInfo, createSharedClone, summarizeTaskName, detectDefaultBranch } from '../../../infra/task/index.js';
+import { type TaskInfo, createSharedClone, summarizeTaskName, resolveBaseBranch } from '../../../infra/task/index.js';
 import { getGitProvider, type Issue } from '../../../infra/git/index.js';
 import { withProgress } from '../../../shared/ui/index.js';
 import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
@@ -125,7 +125,7 @@ export async function resolveTaskExecution(
 
   if (data.worktree) {
     throwIfAborted(abortSignal);
-    baseBranch = detectDefaultBranch(defaultCwd);
+    baseBranch = resolveBaseBranch(defaultCwd, data.base_branch).branch;
 
     if (task.worktreePath && fs.existsSync(task.worktreePath)) {
       // Reuse existing worktree (clone still on disk from previous execution)
@@ -149,6 +149,7 @@ export async function resolveTaskExecution(
           branch: data.branch,
           taskSlug,
           issueNumber: data.issue,
+          ...(data.base_branch ? { baseBranch: data.base_branch } : {}),
         }),
       );
       throwIfAborted(abortSignal);

--- a/src/features/tasks/execute/selectAndExecute.ts
+++ b/src/features/tasks/execute/selectAndExecute.ts
@@ -44,6 +44,7 @@ export async function confirmAndCreateWorktree(
   task: string,
   createWorktreeOverride?: boolean | undefined,
   branchOverride?: string,
+  baseBranchOverride?: string,
 ): Promise<WorktreeConfirmationResult> {
   const useWorktree =
     typeof createWorktreeOverride === 'boolean'
@@ -54,7 +55,7 @@ export async function confirmAndCreateWorktree(
     return { execCwd: cwd, isWorktree: false };
   }
 
-  const baseBranch = resolveBaseBranch(cwd).branch;
+  const baseBranch = baseBranchOverride ?? resolveBaseBranch(cwd).branch;
 
   const taskSlug = await withProgress(
     'Generating branch name...',
@@ -69,6 +70,7 @@ export async function confirmAndCreateWorktree(
       worktree: true,
       taskSlug,
       ...(branchOverride ? { branch: branchOverride } : {}),
+      ...(baseBranchOverride ? { baseBranch: baseBranchOverride } : {}),
     }),
   );
 
@@ -97,6 +99,7 @@ export async function selectAndExecuteTask(
     task,
     options?.createWorktree,
     options?.branch,
+    options?.baseBranch,
   );
 
   // Ask for PR creation BEFORE execution (only if worktree is enabled)

--- a/src/features/tasks/execute/types.ts
+++ b/src/features/tasks/execute/types.ts
@@ -143,6 +143,8 @@ export interface SelectAndExecuteOptions {
   createWorktree?: boolean | undefined;
   /** Override branch name (e.g., PR head branch for --pr) */
   branch?: string;
+  /** Override base branch (e.g., PR base branch for --pr, or current branch for interactive mode) */
+  baseBranch?: string;
   /** Enable interactive user input during step transitions */
   interactiveUserInput?: boolean;
   /** Interactive mode result metadata for NDJSON logging */

--- a/src/features/tasks/index.ts
+++ b/src/features/tasks/index.ts
@@ -16,7 +16,7 @@ export {
   type WorktreeConfirmationResult,
 } from './execute/selectAndExecute.js';
 export { resolveAutoPr, postExecutionFlow, type PostExecutionOptions } from './execute/postExecution.js';
-export { addTask, saveTaskFile, saveTaskFromInteractive, createIssueFromTask, createIssueAndSaveTask, promptLabelSelection } from './add/index.js';
+export { addTask, saveTaskFile, saveTaskFromInteractive, createIssueFromTask, createIssueAndSaveTask, promptLabelSelection, promptBaseBranchIfNeeded } from './add/index.js';
 export { watchTasks } from './watch/index.js';
 export {
   listTasks,

--- a/src/infra/git/types.ts
+++ b/src/infra/git/types.ts
@@ -87,6 +87,8 @@ export interface PrReviewData {
   url: string;
   /** Branch name of the PR head */
   headRefName: string;
+  /** Base branch the PR targets */
+  baseRefName: string;
   /** Conversation comments (non-review) */
   comments: PrReviewComment[];
   /** Review comments (from reviews) */

--- a/src/infra/github/pr.ts
+++ b/src/infra/github/pr.ts
@@ -53,7 +53,7 @@ export function commentOnPr(cwd: string, prNumber: number, body: string): Commen
 }
 
 /** JSON fields requested from `gh pr view` for review data */
-const PR_REVIEW_JSON_FIELDS = 'number,title,body,url,headRefName,comments,reviews,files';
+const PR_REVIEW_JSON_FIELDS = 'number,title,body,url,headRefName,baseRefName,comments,reviews,files';
 
 /** Raw shape returned by `gh pr view --json` for review data */
 interface GhPrViewReviewResponse {
@@ -62,6 +62,7 @@ interface GhPrViewReviewResponse {
   body: string;
   url: string;
   headRefName: string;
+  baseRefName: string;
   comments: Array<{ author: { login: string }; body: string }>;
   reviews: Array<{
     author: { login: string };
@@ -112,6 +113,7 @@ export function fetchPrReviewComments(prNumber: number): PrReviewData {
     body: data.body,
     url: data.url,
     headRefName: data.headRefName,
+    baseRefName: data.baseRefName,
     comments,
     reviews,
     files: data.files.map((f) => f.path),

--- a/src/infra/task/clone.ts
+++ b/src/infra/task/clone.ts
@@ -175,7 +175,12 @@ export class CloneManager {
   /**
    * Resolve the base branch for cloning and optionally fetch from remote.
    *
-   * When `auto_fetch` config is true:
+   * When `taskBaseBranch` is provided:
+   *   - Checks local then remote tracking branch existence
+   *   - Returns it immediately (bypasses config and autoFetch)
+   *   - Throws if neither local nor remote tracking branch exists
+   *
+   * When `auto_fetch` config is true (and no taskBaseBranch):
    *   1. Runs `git fetch origin` (without modifying local branches)
    *   2. Resolves base branch from config `base_branch` → remote default branch fallback
    *   3. Returns the branch name and the fetched commit hash of `origin/<baseBranch>`
@@ -185,7 +190,33 @@ export class CloneManager {
    *
    * Any failure (network, no remote, etc.) is non-fatal.
    */
-  static resolveBaseBranch(projectDir: string): { branch: string; fetchedCommit?: string } {
+  static resolveBaseBranch(projectDir: string, taskBaseBranch?: string): { branch: string; fetchedCommit?: string } {
+    if (taskBaseBranch !== undefined) {
+      // Check local branch
+      try {
+        execFileSync('git', ['rev-parse', '--verify', taskBaseBranch], {
+          cwd: projectDir,
+          stdio: 'pipe',
+        });
+        log.info('Task base branch found locally', { branch: taskBaseBranch });
+        return { branch: taskBaseBranch };
+      } catch {
+        // not found locally — fall through to remote check
+      }
+      // Check remote tracking branch
+      try {
+        execFileSync('git', ['rev-parse', '--verify', `origin/${taskBaseBranch}`], {
+          cwd: projectDir,
+          stdio: 'pipe',
+        });
+        log.info('Task base branch found as remote tracking ref', { branch: taskBaseBranch });
+        return { branch: taskBaseBranch };
+      } catch {
+        // not found remotely either
+      }
+      throw new Error(`Base branch not found locally or remotely: ${taskBaseBranch}`);
+    }
+
     const configBaseBranch = resolveConfigValue(projectDir, 'baseBranch');
     const autoFetch = resolveConfigValue(projectDir, 'autoFetch');
 
@@ -292,7 +323,7 @@ export class CloneManager {
 
   /** Create a git clone for a task */
   createSharedClone(projectDir: string, options: WorktreeOptions): WorktreeResult {
-    const { branch: baseBranch, fetchedCommit } = CloneManager.resolveBaseBranch(projectDir);
+    const { branch: baseBranch, fetchedCommit } = CloneManager.resolveBaseBranch(projectDir, options.baseBranch);
 
     const clonePath = CloneManager.resolveClonePath(projectDir, options);
     const branch = CloneManager.resolveBranchName(options);
@@ -412,6 +443,6 @@ export function cleanupOrphanedClone(projectDir: string, branch: string): void {
   defaultManager.cleanupOrphanedClone(projectDir, branch);
 }
 
-export function resolveBaseBranch(projectDir: string): { branch: string; fetchedCommit?: string } {
-  return CloneManager.resolveBaseBranch(projectDir);
+export function resolveBaseBranch(projectDir: string, taskBaseBranch?: string): { branch: string; fetchedCommit?: string } {
+  return CloneManager.resolveBaseBranch(projectDir, taskBaseBranch);
 }

--- a/src/infra/task/schema.ts
+++ b/src/infra/task/schema.ts
@@ -12,6 +12,7 @@ import { isValidTaskDir } from '../../shared/utils/taskPaths.js';
 export const TaskExecutionConfigSchema = z.object({
   worktree: z.union([z.boolean(), z.string()]).optional(),
   branch: z.string().optional(),
+  base_branch: z.string().optional(),
   piece: z.string().optional(),
   issue: z.number().int().positive().optional(),
   start_movement: z.string().optional(),

--- a/src/infra/task/types.ts
+++ b/src/infra/task/types.ts
@@ -42,6 +42,8 @@ export interface WorktreeOptions {
   taskSlug: string;
   /** GitHub Issue number (optional, for formatting branch/path) */
   issueNumber?: number;
+  /** Override base branch for clone (task-level base_branch takes precedence over config/default) */
+  baseBranch?: string;
 }
 
 export interface WorktreeResult {


### PR DESCRIPTION
## Summary

## 概要

インタラクティブモードおよび tasks.yaml でタスクごとに `base_branch` を指定できるようにする。main 以外のブランチ上で会話してタスクを積んだ場合、そのブランチをベースにして作業ブランチを切れるようにする。

## 背景

現在、ベースブランチは config.yaml のグローバル設定（`base_branch`）か `detectDefaultBranch`（main/master）で決まる。タスク単位での指定はできない。

`feat/xxx` ブランチ上でインタラクティブに会話してタスクを積んでも、実行時は main からブランチが切られるため、会話の文脈と実行環境がずれる。

## 仕様

### tasks.yaml に `base_branch` フィールドを追加

```yaml
- task: "..."
  slug: "fix-something"
  base_branch: "feat/xxx"    # 新規フィールド
  branch: "takt/398/fix-something"
```

### ベースブランチの解決順序

1. タスクに `base_branch` 指定あり → ローカル/リモート（`origin/<branch>`）を探す → **どちらにもなければエラー**
2. タスクに `base_branch` 指定なし → config.yaml の `base_branch` → `detectDefaultBranch`（今まで通り）

### インタラクティブモード（promptWorktreeSettings）

現在のブランチが main/master 以外の場合のみ、Base branch を確認する:

```
現在のブランチ: feat/xxx
Base branch として feat/xxx を使いますか？ (Y/n):
```

- Y（デフォルト）→ 現在のブランチを base_branch に設定
- n → config.yaml の base_branch / detectDefaultBranch に従う（従来通り）

main/master にいる場合はプロンプトを表示せず、従来通りの挙動を維持する。

### `--pr` 連携

`--pr` 指定時、PR の `baseRefName` を自動的に `base_branch` として使用する（#400 を吸収）。

- **`takt --pr N`（パイプライン/インタラクティブ）**: PR の `baseRefName` を `base_branch` に設定
- **`takt add --pr N`**: tasks.yaml に PR の `baseRefName` を `base_branch` として保存
- 明示的な tasks.yaml の `base_branch` が指定されている場合はそちらを優先

### 解決順序（全体）

1. タスクの `base_branch`（tasks.yaml / 明示指定）
2. `--pr` の場合 → PR の `baseRefName`
3. config.yaml の `base_branch`
4. `detectDefaultBranch`

### モード別のエラー挙動

| モード | base_branch が見つからない場合 |
|--------|-------------------------------|
| インタラクティブ（`takt` / `takt add`） | エラー表示 → 再入力を促す |
| パイプライン（`takt run` / `--pipeline`） | エラーで停止 |

## 関連

- #398 (branchExists のリモートブランチ対応)
- #400 (takt pr サブコマンド → `--pr` 拡張として本 Issue に統合、close 済み)

## Execution Report

Piece `takt-default-team-leader` completed successfully.

Closes #399