### PR TITLE
fix: global config piece not resolved in config layer chain

### DIFF
--- a/src/__tests__/resolveConfigValue-no-defaultValue.test.ts
+++ b/src/__tests__/resolveConfigValue-no-defaultValue.test.ts
@@ -51,15 +51,15 @@ describe('RESOLUTION_REGISTRY defaultValue removal', () => {
   });
 
   describe('piece', () => {
-    it('should resolve piece from project config DEFAULT_PROJECT_CONFIG when not explicitly set', () => {
+    it('should resolve piece as undefined when not set in project or global config', () => {
       const value = resolveConfigValue(projectDir, 'piece');
-      expect(value).toBe('default');
+      expect(value).toBeUndefined();
     });
 
-    it('should report source as project when piece comes from DEFAULT_PROJECT_CONFIG', () => {
+    it('should report source as default when piece is not set anywhere', () => {
       const result = resolveConfigValueWithSource(projectDir, 'piece');
-      expect(result.value).toBe('default');
-      expect(result.source).toBe('project');
+      expect(result.value).toBeUndefined();
+      expect(result.source).toBe('default');
     });
 
     it('should resolve explicit project piece over default', () => {
@@ -76,8 +76,8 @@ describe('RESOLUTION_REGISTRY defaultValue removal', () => {
       invalidateGlobalConfigCache();
 
       const result = resolveConfigValueWithSource(projectDir, 'piece');
-      expect(result.value).toBe('default');
-      expect(result.source).toBe('project');
+      expect(result.value).toBe('global-piece');
+      expect(result.source).toBe('global');
     });
   });
 

--- a/src/core/models/persisted-global-config.ts
+++ b/src/core/models/persisted-global-config.ts
@@ -87,6 +87,8 @@ export interface PersistedGlobalConfig {
   logLevel: 'debug' | 'info' | 'warn' | 'error';
   provider?: 'claude' | 'codex' | 'opencode' | 'cursor' | 'copilot' | 'mock';
   model?: string;
+  /** Default piece name for new tasks (resolved via config layers: project > global > 'default') */
+  piece?: string;
   observability?: ObservabilityConfig;
   analytics?: AnalyticsConfig;
   /** Directory for shared clones (worktree_dir in config). If empty, uses ../{clone-name} relative to project */

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -444,6 +444,8 @@ export const GlobalConfigSchema = z.object({
   log_level: z.enum(['debug', 'info', 'warn', 'error']).optional().default('info'),
   provider: z.enum(['claude', 'codex', 'opencode', 'cursor', 'copilot', 'mock']).optional().default('claude'),
   model: z.string().optional(),
+  /** Default piece name for new tasks */
+  piece: z.string().optional(),
   observability: ObservabilityConfigSchema.optional(),
   analytics: AnalyticsConfigSchema.optional(),
   /** Directory for shared clones (worktree_dir in config). If empty, uses ../{clone-name} relative to project */

--- a/src/infra/config/global/globalConfig.ts
+++ b/src/infra/config/global/globalConfig.ts
@@ -221,6 +221,7 @@ export class GlobalConfigManager {
       logLevel: parsed.log_level,
       provider: parsed.provider,
       model: parsed.model,
+      piece: parsed.piece,
       observability: parsed.observability ? {
         providerEvents: parsed.observability.provider_events,
       } : undefined,
@@ -288,6 +289,9 @@ export class GlobalConfigManager {
     };
     if (config.model) {
       raw.model = config.model;
+    }
+    if (config.piece) {
+      raw.piece = config.piece;
     }
     if (config.observability && config.observability.providerEvents !== undefined) {
       raw.observability = {

--- a/src/infra/config/project/projectConfig.ts
+++ b/src/infra/config/project/projectConfig.ts
@@ -18,9 +18,7 @@ import { invalidateResolvedConfigCache } from '../resolutionCache.js';
 export type { ProjectLocalConfig } from '../types.js';
 
 /** Default project configuration */
-const DEFAULT_PROJECT_CONFIG: ProjectLocalConfig = {
-  piece: 'default',
-};
+const DEFAULT_PROJECT_CONFIG: ProjectLocalConfig = {};
 
 const SUBMODULES_ALL = 'all';
 


### PR DESCRIPTION
## Summary

- `~/.takt/config.yaml` の `piece` 設定がプロジェクトのデフォルトピースとして反映されないバグを修正
- `DEFAULT_PROJECT_CONFIG` に `piece: 'default'` がハードコードされていたため、ローカル層が常に `'default'` を返し、グローバル層に到達しなかった
- `GlobalConfigSchema` と `PersistedGlobalConfig` に `piece` フィールドが定義されておらず、`~/.takt/config.yaml` の `piece` 値がパース時に無視されていた

## Changes

1. **`projectConfig.ts`**: `DEFAULT_PROJECT_CONFIG` から `piece: 'default'` を除去し、設定されていない場合は `undefined` を返すように変更
2. **`schemas.ts`**: `GlobalConfigSchema` に `piece: z.string().optional()` を追加
3. **`persisted-global-config.ts`**: `PersistedGlobalConfig` インターフェースに `piece?: string` を追加
4. **`globalConfig.ts`**: `load()` / `save()` で `piece` フィールドの読み書きを追加
5. **テスト更新**: `resolveConfigValue-no-defaultValue.test.ts` のexpectationsを修正

## Resolution order (after fix)

```
project .takt/config.yaml (piece: xxx)
  ↓ (undefined の場合)
global ~/.takt/config.yaml (piece: xxx)
  ↓ (undefined の場合)
undefined (piece selection UIでユーザーに選択を促す)
```

## Test plan

- [x] `npm run build` — ビルド成功
- [x] `npm test` — 全264ファイル・3380テスト通過
- [x] `resolveConfigValue-no-defaultValue.test.ts` のpiece関連テスト更新・通過