### PR TITLE
feat: add allow_git_commit option to piece movements

### DIFF
--- a/src/__tests__/postExecution.test.ts
+++ b/src/__tests__/postExecution.test.ts
@@ -6,10 +6,11 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockAutoCommitAndPush, mockPushBranch, mockFindExistingPr, mockCommentOnPr, mockCreatePullRequest, mockBuildPrBody } =
+const { mockAutoCommitAndPush, mockPushBranch, mockHasCommitsAhead, mockFindExistingPr, mockCommentOnPr, mockCreatePullRequest, mockBuildPrBody } =
   vi.hoisted(() => ({
     mockAutoCommitAndPush: vi.fn(),
     mockPushBranch: vi.fn(),
+    mockHasCommitsAhead: vi.fn(),
     mockFindExistingPr: vi.fn(),
     mockCommentOnPr: vi.fn(),
     mockCreatePullRequest: vi.fn(),
@@ -19,6 +20,7 @@ const { mockAutoCommitAndPush, mockPushBranch, mockFindExistingPr, mockCommentOn
 vi.mock('../infra/task/index.js', () => ({
   autoCommitAndPush: (...args: unknown[]) => mockAutoCommitAndPush(...args),
   pushBranch: (...args: unknown[]) => mockPushBranch(...args),
+  hasCommitsAhead: (...args: unknown[]) => mockHasCommitsAhead(...args),
 }));
 
 vi.mock('../infra/git/index.js', () => ({
@@ -66,6 +68,7 @@ describe('postExecutionFlow', () => {
     vi.clearAllMocks();
     mockAutoCommitAndPush.mockReturnValue({ success: true, commitHash: 'abc123' });
     mockPushBranch.mockReturnValue(undefined);
+    mockHasCommitsAhead.mockReturnValue(false);
     mockCommentOnPr.mockReturnValue({ success: true });
     mockCreatePullRequest.mockReturnValue({ success: true, url: 'https://github.com/org/repo/pull/1' });
   });
@@ -96,13 +99,26 @@ describe('postExecutionFlow', () => {
     expect(mockCreatePullRequest).not.toHaveBeenCalled();
   });
 
-  it('commit がない場合は PR 関連処理をスキップする', async () => {
+  it('commit がなく先行コミットもない場合は PR 関連処理をスキップする', async () => {
     mockAutoCommitAndPush.mockReturnValue({ success: true, commitHash: undefined });
+    mockHasCommitsAhead.mockReturnValue(false);
 
     await postExecutionFlow(baseOptions);
 
     expect(mockFindExistingPr).not.toHaveBeenCalled();
     expect(mockCreatePullRequest).not.toHaveBeenCalled();
+  });
+
+  it('autoCommit が空振りでも先行コミットがあれば PR を作成する', async () => {
+    mockAutoCommitAndPush.mockReturnValue({ success: true, commitHash: undefined });
+    mockHasCommitsAhead.mockReturnValue(true);
+    mockFindExistingPr.mockReturnValue(undefined);
+
+    const result = await postExecutionFlow(baseOptions);
+
+    expect(mockHasCommitsAhead).toHaveBeenCalledWith('/clone', 'task/fix-the-bug', 'main');
+    expect(mockCreatePullRequest).toHaveBeenCalledTimes(1);
+    expect(result.prUrl).toBe('https://github.com/org/repo/pull/1');
   });
 
   it('branch がない場合は PR 関連処理をスキップする', async () => {

--- a/src/core/models/piece-types.ts
+++ b/src/core/models/piece-types.ts
@@ -144,6 +144,8 @@ export interface PieceMovement {
   providerOptions?: MovementProviderOptions;
   /** Whether this movement is allowed to edit project files (true=allowed, false=prohibited, undefined=no prompt) */
   edit?: boolean;
+  /** Whether this movement is allowed to run git commit/add (default: false, system handles commits) */
+  allowGitCommit?: boolean;
   instructionTemplate: string;
   /** Rules for movement routing */
   rules?: PieceRule[];

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -312,6 +312,8 @@ export const ParallelSubMovementRawSchema = z.object({
   required_permission_mode: PermissionModeSchema.optional(),
   provider_options: MovementProviderOptionsSchema,
   edit: z.boolean().optional(),
+  /** Whether this movement is allowed to run git commit/add */
+  allow_git_commit: z.boolean().optional(),
   instruction: z.string().optional(),
   instruction_template: z.string().optional(),
   rules: z.array(PieceRuleSchema).optional(),
@@ -348,6 +350,8 @@ export const PieceMovementRawSchema = z.object({
   provider_options: MovementProviderOptionsSchema,
   /** Whether this movement is allowed to edit project files */
   edit: z.boolean().optional(),
+  /** Whether this movement is allowed to run git commit/add */
+  allow_git_commit: z.boolean().optional(),
   instruction: z.string().optional(),
   instruction_template: z.string().optional(),
   /** Rules for movement routing */

--- a/src/core/piece/instruction/InstructionBuilder.ts
+++ b/src/core/piece/instruction/InstructionBuilder.ts
@@ -164,6 +164,7 @@ export class InstructionBuilder {
     return loadTemplate('perform_phase1_message', language, {
       workingDirectory: this.context.cwd,
       editRule,
+      allowGitCommit: !!this.step.allowGitCommit,
       pieceName,
       pieceDescription,
       hasPieceDescription,

--- a/src/core/piece/instruction/ReportInstructionBuilder.ts
+++ b/src/core/piece/instruction/ReportInstructionBuilder.ts
@@ -92,6 +92,7 @@ export class ReportInstructionBuilder {
 
     return loadTemplate('perform_phase2_message', language, {
       workingDirectory: this.context.cwd,
+      allowGitCommit: !!this.step.allowGitCommit,
       reportContext,
       hasLastResponse: this.context.lastResponse != null && this.context.lastResponse.trim().length > 0,
       lastResponse: this.context.lastResponse ?? '',

--- a/src/features/tasks/execute/postExecution.ts
+++ b/src/features/tasks/execute/postExecution.ts
@@ -5,7 +5,7 @@
  * instructBranch (takt list).
  */
 
-import { autoCommitAndPush, pushBranch } from '../../../infra/task/index.js';
+import { autoCommitAndPush, pushBranch, hasCommitsAhead } from '../../../infra/task/index.js';
 import { info, error, success } from '../../../shared/ui/index.js';
 import { createLogger } from '../../../shared/utils/index.js';
 import { buildPrBody } from '../../../infra/github/index.js';
@@ -47,7 +47,14 @@ export async function postExecutionFlow(options: PostExecutionOptions): Promise<
     error(`Auto-commit failed: ${commitResult.message}`);
   }
 
-  if (commitResult.success && commitResult.commitHash && branch && shouldCreatePr) {
+  // Determine if there are commits to create a PR for:
+  // Either autoCommit created a new commit, or prior commits exist ahead of baseBranch
+  // (e.g. when allow_git_commit movement already committed during piece execution).
+  const hasNewCommit = commitResult.success && !!commitResult.commitHash;
+  const hasPriorCommits = !hasNewCommit && branch && baseBranch && hasCommitsAhead(execCwd, branch, baseBranch);
+  const canCreatePr = (hasNewCommit || hasPriorCommits) && branch && shouldCreatePr;
+
+  if (canCreatePr) {
     try {
       pushBranch(projectCwd, branch);
     } catch (pushError) {

--- a/src/infra/config/loaders/pieceParser.ts
+++ b/src/infra/config/loaders/pieceParser.ts
@@ -286,6 +286,7 @@ function normalizeStepFromRaw(
     requiredPermissionMode: step.required_permission_mode,
     providerOptions: mergeProviderOptions(inheritedProviderOptions, normalizedProvider.providerOptions),
     edit: step.edit,
+    allowGitCommit: step.allow_git_commit,
     instructionTemplate: (step.instruction_template
       ? resolveRefToContent(step.instruction_template, sections.resolvedInstructions, pieceDir, 'instructions', context)
       : undefined) || expandedInstruction || '{task}',

--- a/src/infra/task/git.ts
+++ b/src/infra/task/git.ts
@@ -59,3 +59,19 @@ export function pushBranch(cwd: string, branch: string): void {
     stdio: 'pipe',
   });
 }
+
+/**
+ * Returns true if `branch` has commits ahead of `baseBranch`.
+ */
+export function hasCommitsAhead(cwd: string, branch: string, baseBranch: string): boolean {
+  try {
+    const count = execFileSync('git', ['rev-list', '--count', `${baseBranch}..${branch}`], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    }).trim();
+    return Number.parseInt(count, 10) > 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/infra/task/index.ts
+++ b/src/infra/task/index.ts
@@ -56,7 +56,7 @@ export {
   getOriginalInstruction,
   buildListItems,
 } from './branchList.js';
-export { stageAndCommit, getCurrentBranch, pushBranch, checkoutBranch } from './git.js';
+export { stageAndCommit, getCurrentBranch, pushBranch, checkoutBranch, hasCommitsAhead } from './git.js';
 export { buildTaskInstruction } from './instruction.js';
 export { autoCommitAndPush, type AutoCommitResult } from './autoCommit.js';
 export { summarizeTaskName } from './summarize.js';

--- a/src/shared/prompts/en/perform_phase1_message.md
+++ b/src/shared/prompts/en/perform_phase1_message.md
@@ -1,7 +1,7 @@
 <!--
   template: perform_phase1_message
   phase: 1 (main execution)
-  vars: workingDirectory, editRule, pieceName, pieceDescription, hasPieceDescription,
+  vars: workingDirectory, editRule, allowGitCommit, pieceName, pieceDescription, hasPieceDescription,
         pieceStructure, iteration, movementIteration, movement, hasReport, reportInfo,
         phaseNote, hasTaskSection, userRequest, hasPreviousResponse, previousResponse,
         hasUserInputs, userInputs, hasRetryNote, retryNote, hasPolicy, policyContent,
@@ -12,9 +12,9 @@
 - Working Directory: {{workingDirectory}}
 
 ## Execution Rules
-- **Do NOT run git commit.** Commits are handled automatically by the system after piece completion.
+{{#if allowGitCommit}}{{else}}- **Do NOT run git commit.** Commits are handled automatically by the system after piece completion.
 - **Do NOT run git add.** Staging is also handled automatically by the system. Untracked files (`??`) are normal.
-- **Do NOT use `cd` in Bash commands.** Your working directory is already set correctly. Run commands directly without changing directories.
+{{/if}}- **Do NOT use `cd` in Bash commands.** Your working directory is already set correctly. Run commands directly without changing directories.
 {{#if editRule}}- {{editRule}}
 {{/if}}
 Note: This section is metadata. Follow the language used in the rest of the prompt.

--- a/src/shared/prompts/en/perform_phase2_message.md
+++ b/src/shared/prompts/en/perform_phase2_message.md
@@ -1,7 +1,7 @@
 <!--
   template: perform_phase2_message
   phase: 2 (report output)
-  vars: workingDirectory, reportContext, hasLastResponse, lastResponse, hasReportOutput, reportOutput,
+  vars: workingDirectory, allowGitCommit, reportContext, hasLastResponse, lastResponse, hasReportOutput, reportOutput,
         hasOutputContract, outputContract
   builder: ReportInstructionBuilder
 -->
@@ -9,8 +9,8 @@
 - Working Directory: {{workingDirectory}}
 
 ## Execution Rules
-- **Do NOT run git commit.** Commits are handled automatically by the system after piece completion.
-- **Do NOT use `cd` in Bash commands.** Your working directory is already set correctly. Run commands directly without changing directories.
+{{#if allowGitCommit}}{{else}}- **Do NOT run git commit.** Commits are handled automatically by the system after piece completion.
+{{/if}}- **Do NOT use `cd` in Bash commands.** Your working directory is already set correctly. Run commands directly without changing directories.
 - **Do NOT modify project source files.** Only respond with the report content.
 - **Use only the Report Directory files listed below.** Do not search or open reports outside that directory.
 Note: This section is metadata. Follow the language used in the rest of the prompt.

--- a/src/shared/prompts/ja/perform_phase1_message.md
+++ b/src/shared/prompts/ja/perform_phase1_message.md
@@ -1,7 +1,7 @@
 <!--
   template: perform_phase1_message
   phase: 1 (main execution)
-  vars: workingDirectory, editRule, pieceName, pieceDescription, hasPieceDescription,
+  vars: workingDirectory, editRule, allowGitCommit, pieceName, pieceDescription, hasPieceDescription,
         pieceStructure, iteration, movementIteration, movement, hasReport, reportInfo,
         phaseNote, hasTaskSection, userRequest, hasPreviousResponse, previousResponse,
         hasUserInputs, userInputs, hasRetryNote, retryNote, hasPolicy, policyContent,
@@ -12,9 +12,9 @@
 - 作業ディレクトリ: {{workingDirectory}}
 
 ## 実行ルール
-- **git commit を実行しないでください。** コミットはピース完了後にシステムが自動で行います。
+{{#if allowGitCommit}}{{else}}- **git commit を実行しないでください。** コミットはピース完了後にシステムが自動で行います。
 - **git add を実行しないでください。** ステージングもシステムが自動で行います。新規ファイルが未追跡（`??`）でも正常です。
-- **Bashコマンドで `cd` を使用しないでください。** 作業ディレクトリは既に正しく設定されています。ディレクトリを変更せずにコマンドを実行してください。
+{{/if}}- **Bashコマンドで `cd` を使用しないでください。** 作業ディレクトリは既に正しく設定されています。ディレクトリを変更せずにコマンドを実行してください。
 {{#if editRule}}- {{editRule}}
 {{/if}}
 {{#if hasKnowledge}}

--- a/src/shared/prompts/ja/perform_phase2_message.md
+++ b/src/shared/prompts/ja/perform_phase2_message.md
@@ -1,7 +1,7 @@
 <!--
   template: perform_phase2_message
   phase: 2 (report output)
-  vars: workingDirectory, reportContext, hasLastResponse, lastResponse, hasReportOutput, reportOutput,
+  vars: workingDirectory, allowGitCommit, reportContext, hasLastResponse, lastResponse, hasReportOutput, reportOutput,
         hasOutputContract, outputContract
   builder: ReportInstructionBuilder
 -->
@@ -9,8 +9,8 @@
 - 作業ディレクトリ: {{workingDirectory}}
 
 ## 実行ルール
-- **git commit を実行しないでください。** コミットはピース完了後にシステムが自動で行います。
-- **Bashコマンドで `cd` を使用しないでください。** 作業ディレクトリは既に正しく設定されています。ディレクトリを変更せずにコマンドを実行してください。
+{{#if allowGitCommit}}{{else}}- **git commit を実行しないでください。** コミットはピース完了後にシステムが自動で行います。
+{{/if}}- **Bashコマンドで `cd` を使用しないでください。** 作業ディレクトリは既に正しく設定されています。ディレクトリを変更せずにコマンドを実行してください。
 - **プロジェクトのソースファイルを変更しないでください。** レポート内容のみを回答してください。
 - **Report Directory内のファイルのみ使用してください。** 他のレポートディレクトリは検索/参照しないでください。
 


### PR DESCRIPTION
## Summary

- Add `allow_git_commit` field to `PieceMovement` schema, enabling movements to opt into running `git commit`/`git add` during execution
- When enabled, the "Do NOT run git commit" rule is suppressed in phase 1/phase 2 prompts (EN/JA)
- Add `hasCommitsAhead()` utility to detect prior commits for PR creation when `autoCommit` produces no new commit (e.g. movement already committed during piece execution)

## Changed files

- `src/core/models/piece-types.ts` / `schemas.ts` — add `allowGitCommit` / `allow_git_commit` field
- `src/core/piece/instruction/InstructionBuilder.ts` / `ReportInstructionBuilder.ts` — pass flag to templates
- `src/infra/config/loaders/pieceParser.ts` — parse `allow_git_commit` from YAML
- `src/infra/task/git.ts` / `index.ts` — add and export `hasCommitsAhead()`
- `src/features/tasks/execute/postExecution.ts` — use `hasCommitsAhead` for PR creation logic
- `src/shared/prompts/{en,ja}/perform_phase{1,2}_message.md` — conditional git commit rule

## Test plan

- [x] `postExecution.test.ts` updated with new test case for prior commits scenario