### PR TITLE
Release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.30.0] - 2026-03-05
+
+### Added
+
+- トレースレポートの自動生成: piece 実行完了時に movement の遷移・フェーズ・ルール評価結果を Markdown レポートとして `.takt/runs/` に自動出力。`logging.trace: true` で全文モード、デフォルトは redacted モード (#467)
+- 使用量イベントログ: プロバイダー呼び出しごとのトークン使用量を NDJSON 形式で記録。`logging.usage_events: true` で有効化 (#470)
+- タスクリトライ時のピース再利用確認: `takt list` からリトライ・追加指示する際に、前回と同じピースを使うか選び直すかを選択可能に (#468)
+
+### Changed
+
+- BREAKING: `takt switch` コマンドを削除。ピース選択はインタラクティブモード起動時（`takt`）に毎回行う方式に変更 (#465)
+- Claude プロバイダーの `allowed_tools` をビルトインピースの YAML 定義からエグゼキューター側に移動し、ピース YAML の簡素化と保守性を向上 (#469)
+- 設定構造をリファクタリング: `globalConfig.ts` を `globalConfigCore.ts`・`globalConfigAccessors.ts`・`globalConfigResolvers.ts`・`globalConfigSerializer.ts` に分割。プロジェクトローカル設定（`.takt/config.yaml`）のフォールバック優先度を明確化 (#460)
+- observability モジュールを `core/logging/` に再編成: `providerEventLogger` と `usageEventLogger` を統一的なログ基盤として整理 (#466)
+- レビュアー全体に `coder-decisions.md` の参照を追加し、コーダーの設計判断を考慮したレビューで誤検知を抑制
+- レビュー↔修正ループの収束を支援: レポート履歴の参照、ループモニター、修正方針のガイドラインを整備
+
+### Fixed
+
+- runtime 環境の `XDG_CONFIG_HOME` 上書きで `gh` CLI の認証が失敗する問題を修正。`GH_CONFIG_DIR` を元の設定から保持するよう変更
+- `.takt/config.yaml` に `runtime.prepare` を記述するとエラーになる問題を修正（プロジェクトレベルでの runtime 設定を許可） (#464)
+- インタラクティブモードで iteration limit 到達時にプロンプトが表示されず、exceeded 状態が保持されない問題を修正
+- PR 作成失敗時のタスクステータスを `failed` から `pr_failed` に分離し、実行成功だが PR 作成のみ失敗したケースを区別可能に
+- リトライ時にタスクにピース情報が引き継がれるよう修正
+- `.gitignore` の `.takt/` ディレクトリ ignore を削除し `.takt/.gitignore` に委譲（プロジェクト設定ファイルの追跡を可能に）
+- CI: push トリガーから `takt/**` を削除し二重実行を防止
+- `cc-resolve` ワークフローで push 後に CI を自動トリガーするよう修正
+
+### Internal
+
+- deprecated config マイグレーション処理を削除
+- プロジェクトローカル設定の優先度に関する統合テストを追加
+- テストヘルパーとテストセットアップの改善
+
 ## [0.29.0] - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ See the [Builtin Catalog](./docs/builtin-catalog.md) for all pieces and personas
 | `takt run` | Execute all pending tasks |
 | `takt list` | Manage task branches (merge, retry, instruct, delete) |
 | `takt #N` | Execute GitHub Issue as task |
-| `takt switch` | Switch active piece |
 | `takt eject` | Copy builtin pieces/facets for customization |
 | `takt repertoire add` | Install a repertoire package from GitHub |
 

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,40 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.30.0] - 2026-03-05
+
+### Added
+
+- トレースレポートの自動生成: piece 実行完了時に movement の遷移・フェーズ・ルール評価結果を Markdown レポートとして `.takt/runs/` に自動出力。`logging.trace: true` で全文モード、デフォルトは redacted モード (#467)
+- 使用量イベントログ: プロバイダー呼び出しごとのトークン使用量を NDJSON 形式で記録。`logging.usage_events: true` で有効化 (#470)
+- タスクリトライ時のピース再利用確認: `takt list` からリトライ・追加指示する際に、前回と同じピースを使うか選び直すかを選択可能に (#468)
+
+### Changed
+
+- BREAKING: `takt switch` コマンドを削除。ピース選択はインタラクティブモード起動時（`takt`）に毎回行う方式に変更 (#465)
+- Claude プロバイダーの `allowed_tools` をビルトインピースの YAML 定義からエグゼキューター側に移動し、ピース YAML の簡素化と保守性を向上 (#469)
+- 設定構造をリファクタリング: `globalConfig.ts` を `globalConfigCore.ts`・`globalConfigAccessors.ts`・`globalConfigResolvers.ts`・`globalConfigSerializer.ts` に分割。プロジェクトローカル設定（`.takt/config.yaml`）のフォールバック優先度を明確化 (#460)
+- observability モジュールを `core/logging/` に再編成: `providerEventLogger` と `usageEventLogger` を統一的なログ基盤として整理 (#466)
+- レビュアー全体に `coder-decisions.md` の参照を追加し、コーダーの設計判断を考慮したレビューで誤検知を抑制
+- レビュー↔修正ループの収束を支援: レポート履歴の参照、ループモニター、修正方針のガイドラインを整備
+
+### Fixed
+
+- runtime 環境の `XDG_CONFIG_HOME` 上書きで `gh` CLI の認証が失敗する問題を修正。`GH_CONFIG_DIR` を元の設定から保持するよう変更
+- `.takt/config.yaml` に `runtime.prepare` を記述するとエラーになる問題を修正（プロジェクトレベルでの runtime 設定を許可） (#464)
+- インタラクティブモードで iteration limit 到達時にプロンプトが表示されず、exceeded 状態が保持されない問題を修正
+- PR 作成失敗時のタスクステータスを `failed` から `pr_failed` に分離し、実行成功だが PR 作成のみ失敗したケースを区別可能に
+- リトライ時にタスクにピース情報が引き継がれるよう修正
+- `.gitignore` の `.takt/` ディレクトリ ignore を削除し `.takt/.gitignore` に委譲（プロジェクト設定ファイルの追跡を可能に）
+- CI: push トリガーから `takt/**` を削除し二重実行を防止
+- `cc-resolve` ワークフローで push 後に CI を自動トリガーするよう修正
+
+### Internal
+
+- deprecated config マイグレーション処理を削除
+- プロジェクトローカル設定の優先度に関する統合テストを追加
+- テストヘルパーとテストセットアップの改善
+
 ## [0.29.0] - 2026-03-04
 
 ### Added

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -153,7 +153,6 @@ movements:
 | `takt run` | 積まれたタスクをまとめて実行します |
 | `takt list` | タスクブランチを管理します（マージ、リトライ、追加指示、削除） |
 | `takt #N` | GitHub Issue をタスクとして実行します |
-| `takt switch` | 使う piece を切り替えます |
 | `takt eject` | ビルトインの piece/facet をコピーしてカスタマイズできます |
 | `takt repertoire add` | GitHub から repertoire パッケージをインストールします |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- トレースレポートの自動生成: piece 実行完了時に movement の遷移・フェーズ・ルール評価結果を Markdown レポートとして `.takt/runs/` に自動出力。`logging.trace: true` で全文モード、デフォルトは redacted モード (#467)
- 使用量イベントログ: プロバイダー呼び出しごとのトークン使用量を NDJSON 形式で記録。`logging.usage_events: true` で有効化 (#470)
- タスクリトライ時のピース再利用確認: `takt list` からリトライ・追加指示する際に、前回と同じピースを使うか選び直すかを選択可能に (#468)

### Changed

- BREAKING: `takt switch` コマンドを削除。ピース選択はインタラクティブモード起動時（`takt`）に毎回行う方式に変更 (#465)
- Claude プロバイダーの `allowed_tools` をビルトインピースの YAML 定義からエグゼキューター側に移動 (#469)
- 設定構造をリファクタリング: `globalConfig.ts` を分割し、プロジェクトローカル設定の優先度を明確化 (#460)
- observability モジュールを `core/logging/` に再編成 (#466)
- レビュアー全体に `coder-decisions.md` 参照を追加
- レビュー↔修正ループの収束支援を整備

### Fixed

- runtime 環境の `XDG_CONFIG_HOME` 上書きで `gh` CLI の認証が失敗する問題を修正
- `.takt/config.yaml` に `runtime.prepare` を記述するとエラーになる問題を修正 (#464)
- インタラクティブモードで iteration limit 到達時の問題を修正
- PR 作成失敗時のタスクステータスを `pr_failed` に分離
- リトライ時にタスクにピース情報が引き継がれるよう修正
- `.gitignore` の `.takt/` ディレクトリ ignore を `.takt/.gitignore` に委譲
- CI 関連の修正（二重実行防止、cc-resolve 後の自動トリガー）

## Commits

- 98607298 Release v0.30.0
- 76cfd771 takt: implement-usage-event-logging (#470)
- 2f268f6d [#320] move-allowed-tools-claude (#469)
- 2ce51aff fix: .gitignore の .takt/ ディレクトリ ignore を削除し .takt/.gitignore に委譲
- 3649ce40 takt: add-piece-reuse-confirm (#468)
- 8403a7c8 takt: add-trace-report-generation (#467)
- dbc22c76 fix: runtime環境のXDG_CONFIG_HOME上書きでgh認証が失敗する問題を修正
- 1cfae9f5 refactor: deprecated config マイグレーション処理を削除
- cb3bc5e4 fix: push トリガーから takt/** を削除し二重実行を防止
- 69dd8714 refactor: observability を logging に再編成し設定構造を体系化 (#466)
- 289a0fb9 .takt/config.yaml（プロジェクト設定）に runtime.prepare を記述するとエラーになる (#464)
- f733a7eb fix: cc-resolve push 後に CI を自動トリガー
- 4f02c20c Merge pull request #465 from nrslib/takt/420/remove-default-piece-switch
- 9fc8ab73 リトライ時でタスクにつめるようにする
- 8ffe0592 Merge pull request #460 from nrslib/takt/452/refactor-config-structure
- 7c1bc445 feat: PR作成失敗時のタスクステータスを failed から pr_failed に分離
- 2dc5cf11 feat: 全レビュアーに coder-decisions.md 参照を追加し設計判断の FP を抑制
- 204d84e3 takt: refactor-config-structure
- 4e89fe1c feat: reviewers↔fix ループ収束を支援するレポート履歴・ループ監視・参照方針の整備
- 6a3c64a0 fix: stop iteration limit prompt and persist exceeded in interactive run
- 54ecc38d Merge pull request #459 from nrslib/release/v0.29.0