### PR TITLE
[#444] fix-phase3-fallback-bypass

### DIFF
--- a/src/__tests__/engine-error.test.ts
+++ b/src/__tests__/engine-error.test.ts
@@ -37,7 +37,7 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
 import { PieceEngine } from '../core/piece/index.js';
 import { runAgent } from '../agents/runner.js';
 import { detectMatchedRule } from '../core/piece/evaluation/index.js';
-import { runReportPhase } from '../core/piece/phase-runner.js';
+import { needsStatusJudgmentPhase, runReportPhase, runStatusJudgmentPhase } from '../core/piece/phase-runner.js';
 import {
   makeResponse,
   makeMovement,
@@ -111,6 +111,45 @@ describe('PieceEngine Integration: Error Handling', () => {
       expect(reason).toContain('API connection failed');
     });
 
+  });
+
+  // =====================================================
+  // 2.5 Phase 3 fallback
+  // =====================================================
+  describe('Phase 3 fallback', () => {
+    it('should continue with phase1 rule evaluation when status judgment throws', async () => {
+      const config = buildDefaultPieceConfig({
+        initialMovement: 'plan',
+        movements: [
+          makeMovement('plan', {
+            rules: [makeRule('continue', 'COMPLETE')],
+          }),
+        ],
+      });
+      const engine = new PieceEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+
+      vi.mocked(needsStatusJudgmentPhase).mockReturnValue(true);
+      vi.mocked(runStatusJudgmentPhase).mockRejectedValueOnce(new Error('Phase 3 failed'));
+
+      mockRunAgentSequence([
+        makeResponse({ persona: 'plan', content: '[STEP:1] continue' }),
+      ]);
+      mockDetectMatchedRuleSequence([
+        { index: 0, method: 'phase1_tag' },
+      ]);
+
+      const state = await engine.run();
+
+      expect(state.status).toBe('completed');
+      expect(runStatusJudgmentPhase).toHaveBeenCalledOnce();
+      expect(detectMatchedRule).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'plan' }),
+        '[STEP:1] continue',
+        '',
+        expect.any(Object),
+      );
+      expect(state.movementOutputs.get('plan')?.matchedRuleMethod).toBe('phase1_tag');
+    });
   });
 
   // =====================================================

--- a/src/__tests__/engine-parallel-failure.test.ts
+++ b/src/__tests__/engine-parallel-failure.test.ts
@@ -36,6 +36,7 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
 import { PieceEngine } from '../core/piece/index.js';
 import { runAgent } from '../agents/runner.js';
 import { detectMatchedRule } from '../core/piece/evaluation/index.js';
+import { needsStatusJudgmentPhase, runStatusJudgmentPhase } from '../core/piece/phase-runner.js';
 import {
   makeResponse,
   makeMovement,
@@ -214,5 +215,60 @@ describe('PieceEngine Integration: Parallel Movement Partial Failure', () => {
     expect(archReviewOutput).toBeDefined();
     expect(archReviewOutput!.error).toBe('Session resume failed');
     expect(archReviewOutput!.content).toBe('');
+  });
+
+  it('should fallback to phase1 rule evaluation when sub-movement phase3 throws', async () => {
+    const config = buildParallelOnlyConfig();
+    const engine = new PieceEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+
+    vi.mocked(needsStatusJudgmentPhase).mockImplementation((movement) => {
+      return movement.name === 'arch-review' || movement.name === 'security-review';
+    });
+    vi.mocked(runStatusJudgmentPhase).mockImplementation(async (movement) => {
+      if (movement.name === 'arch-review') {
+        throw new Error('Phase 3 failed for arch-review');
+      }
+      return { tag: '', ruleIndex: 0, method: 'auto_select' };
+    });
+
+    const mock = vi.mocked(runAgent);
+    mock.mockImplementationOnce(async (persona, task, options) => {
+      options?.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({ persona: 'arch-review', content: '[STEP:1] done' });
+    });
+    mock.mockImplementationOnce(async (persona, task, options) => {
+      options?.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({ persona: 'security-review', content: '[STEP:1] done' });
+    });
+    mock.mockImplementationOnce(async (persona, task, options) => {
+      options?.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({ persona: 'done', content: 'completed' });
+    });
+
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' }, // arch-review fallback
+      { index: 0, method: 'aggregate' },  // reviewers aggregate
+      { index: 0, method: 'phase1_tag' }, // done -> COMPLETE
+    ]);
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+    expect(state.movementOutputs.get('arch-review')?.status).toBe('done');
+    expect(state.movementOutputs.get('arch-review')?.matchedRuleMethod).toBe('phase1_tag');
+    expect(
+      vi.mocked(detectMatchedRule).mock.calls.some(([movement, content, tagContent]) => {
+        return movement.name === 'arch-review' && content === '[STEP:1] done' && tagContent === '';
+      }),
+    ).toBe(true);
   });
 });

--- a/src/core/piece/engine/MovementExecutor.ts
+++ b/src/core/piece/engine/MovementExecutor.ts
@@ -19,9 +19,10 @@ import { executeAgent } from '../../../agents/agent-usecases.js';
 import { InstructionBuilder } from '../instruction/InstructionBuilder.js';
 import { needsStatusJudgmentPhase, runReportPhase, runStatusJudgmentPhase } from '../phase-runner.js';
 import { detectMatchedRule } from '../evaluation/index.js';
+import type { StatusJudgmentPhaseResult } from '../phase-runner.js';
 import { buildSessionKey } from '../session-key.js';
 import { incrementMovementIteration, getPreviousOutput } from './state-manager.js';
-import { createLogger } from '../../../shared/utils/index.js';
+import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
 import type { OptionsBuilder } from './OptionsBuilder.js';
 import type { RunPaths } from '../run/run-paths.js';
 
@@ -237,9 +238,17 @@ export class MovementExecutor {
     }
 
     // Phase 3: status judgment (new session, no tools, determines matched rule)
-    const phase3Result = needsStatusJudgmentPhase(step)
-      ? await runStatusJudgmentPhase(step, phaseCtx)
-      : undefined;
+    let phase3Result: StatusJudgmentPhaseResult | undefined;
+    try {
+      phase3Result = needsStatusJudgmentPhase(step)
+        ? await runStatusJudgmentPhase(step, phaseCtx)
+        : undefined;
+    } catch (error) {
+      log.info('Phase 3 status judgment failed, falling back to phase1 rule evaluation', {
+        movement: step.name,
+        error: getErrorMessage(error),
+      });
+    }
 
     if (phase3Result) {
       log.debug('Rule matched (Phase 3)', {

--- a/src/core/piece/engine/ParallelRunner.ts
+++ b/src/core/piece/engine/ParallelRunner.ts
@@ -14,6 +14,7 @@ import { executeAgent } from '../../../agents/agent-usecases.js';
 import { ParallelLogger } from './parallel-logger.js';
 import { needsStatusJudgmentPhase, runReportPhase, runStatusJudgmentPhase } from '../phase-runner.js';
 import { detectMatchedRule } from '../evaluation/index.js';
+import type { StatusJudgmentPhaseResult } from '../phase-runner.js';
 import { incrementMovementIteration } from './state-manager.js';
 import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
 import { buildSessionKey } from '../session-key.js';
@@ -154,9 +155,17 @@ export class ParallelRunner {
         }
 
         // Phase 3: status judgment for sub-movement
-        const subPhase3 = needsStatusJudgmentPhase(subMovement)
-          ? await runStatusJudgmentPhase(subMovement, phaseCtx)
-          : undefined;
+        let subPhase3: StatusJudgmentPhaseResult | undefined;
+        try {
+          subPhase3 = needsStatusJudgmentPhase(subMovement)
+            ? await runStatusJudgmentPhase(subMovement, phaseCtx)
+            : undefined;
+        } catch (error) {
+          log.info('Phase 3 status judgment failed for sub-movement, falling back to phase1 rule evaluation', {
+            movement: subMovement.name,
+            error: getErrorMessage(error),
+          });
+        }
 
         let finalResponse: AgentResponse;
         if (subPhase3) {


### PR DESCRIPTION
## Summary

## 概要

Phase 3 (status judgment) が失敗したとき、`judgeStatus()` が例外を throw するため、MovementExecutor / ParallelRunner に既に実装されている Phase 1 出力ベースの RuleEvaluator フォールバックに到達しない。結果として、Phase 3 エラー = movement 全体のエラーとなり、ピースが ABORT する。

## 現状の問題

### MovementExecutor (L212-248)

```typescript
// Phase 3 が throw するとここで死ぬ
const phase3Result = needsStatusJudgmentPhase(step)
  ? await runStatusJudgmentPhase(step, phaseCtx)  // ← throws
  : undefined;

if (phase3Result) { return ...; }

// ↓ このフォールバックに到達しない
const match = await detectMatchedRule(step, nextResponse.content, '', { ... });
```

### ParallelRunner (L117-129)

```typescript
// 同じ問題
const subPhase3 = needsStatusJudgmentPhase(subMovement)
  ? await runStatusJudgmentPhase(subMovement, phaseCtx)  // ← throws
  : undefined;

// ↓ このフォールバックに到達しない
if (!subPhase3) {
  const match = await detectMatchedRule(subMovement, subResponse.content, '', ruleCtx);
}
```

### throw の発生元

`status-judgment-phase.ts` (L100-103) で `judgeStatus()` の例外をそのまま re-throw している。

```typescript
} catch (error) {
  const errorMsg = error instanceof Error ? error.message : String(error);
  ctx.onPhaseComplete?.(step, 3, 'judge', '', 'error', errorMsg);
  throw error;  // ← re-throw
}
```

`judgeStatus()` (`agent-usecases.ts` L207-279) は3ステージのフォールバック（structured output → tag detection → AI judge）を持つが、3つとも Claude SDK のプロセスエラー等で応答が得られない場合は全ステージ失敗し、`"Status not found for movement X"` を throw する。

## 実際の障害ログからの示唆

`takt-default-team-leader` ピースで Issue #429 を実行中に発生。

### 障害の経緯

1. iteration 5 以降、`reviewers ↔ fix` が交互に20回繰り返し
2. 最終 iteration (24) で `reviewers` の並列サブムーブメント5つ全てが Phase 3 で失敗
3. `"All parallel sub-movements failed"` → Piece ABORT

### ログから得られた数値

| 指標 | 値 |
|------|-----|
| 総クエリ数 | 324 |
| 成功 (success: true) | 295 |
| 失敗 (success: false, hasResultMessage: true) | 10 |
| post-completion error (exit code 1 だが結果取得済み) | 19 |

### Phase 3 失敗時の contentLength 推移

Phase 3 の judge クエリで返された contentLength:

```
7,497 → 8,109 → 39,168 → 43,758 → 178,908
```

Phase 3 は `maxTurns: 3` の readonly conductor で `[STEP:N]` タグを出すだけの仕事だが、**175KB もの出力**を返している。セッションコンテキストが肥大化し、conductor が正常に判定できなくなっている。

### Phase 3 の3ステージが全滅する構造的理由

Phase 3 の3ステージは「AIの回答フォーマットが想定外だった場合のフォールバック」として設計されている。しかし provider レベルの障害（プロセス死亡、セッション肥大、レート制限等）では3ステージすべてが等しく失敗する。各ステージが独立に `runAgent('conductor', ...)` を呼ぶため、同じ状況で同じように失敗する。

### サイクル検出が効かなかった理由

- **CycleDetector**: 成功した movement 遷移のみ記録 → `reviewers` が throw で失敗するためサイクル履歴に載らない
- **LoopDetector**: 同一 movement の連続繰り返しのみ検出 → `reviewers → fix → reviewers → fix` の交互パターンは非対応

## 修正方針

MovementExecutor と ParallelRunner の Phase 3 呼び出しを try-catch で囲み、失敗時は `phase3Result = undefined` として既存の RuleEvaluator フォールバックに落とす。

```typescript
let phase3Result: StatusJudgmentPhaseResult | undefined;
try {
  phase3Result = needsStatusJudgmentPhase(step)
    ? await runStatusJudgmentPhase(step, phaseCtx)
    : undefined;
} catch (error) {
  log.warn('Phase 3 status judgment failed, falling back to rule evaluator', {
    movement: step.name,
    error: getErrorMessage(error),
  });
}
```

## やること

- [ ] `MovementExecutor.applyPostExecutionPhases()` に Phase 3 try-catch 追加
- [ ] `ParallelRunner` のサブムーブメント Phase 3 に try-catch 追加
- [ ] Phase 3 フォールバック動作のテスト追加

## Execution Report

Piece `takt-default-team-leader` completed successfully.

Closes #444