### PR TITLE
Bug: `takt add` で存在するブランチが「Base branch does not exist」と誤判定される

### DIFF
--- a/src/__tests__/clone-base-branch.test.ts
+++ b/src/__tests__/clone-base-branch.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../infra/config/index.js', () => ({
+  resolveConfigValue: vi.fn(),
+}));
+
+vi.mock('../infra/task/branchList.js', () => ({
+  detectDefaultBranch: vi.fn().mockReturnValue('main'),
+}));
+
+import { execFileSync } from 'node:child_process';
+import { resolveConfigValue } from '../infra/config/index.js';
+import { branchExists, resolveBaseBranch } from '../infra/task/clone-base-branch.js';
+
+const mockExecFileSync = vi.mocked(execFileSync);
+const mockResolveConfigValue = vi.mocked(resolveConfigValue);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('branchExists — check-ref-format argument correctness', () => {
+  it('should call check-ref-format with --branch and ref only (no --)', () => {
+    // Given: both check-ref-format and rev-parse succeed
+    const checkRefFormatCalls: string[][] = [];
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        checkRefFormatCalls.push([...argsArr]);
+        return Buffer.from('feature/my-branch\n');
+      }
+      if (argsArr[0] === 'rev-parse') {
+        return Buffer.from('abc123\n');
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    branchExists('/project', 'feature/my-branch');
+
+    // Then: check-ref-format was called with exactly ['check-ref-format', '--branch', 'feature/my-branch']
+    expect(checkRefFormatCalls.length).toBeGreaterThanOrEqual(1);
+    expect(checkRefFormatCalls[0]).toEqual(['check-ref-format', '--branch', 'feature/my-branch']);
+  });
+
+  it('should not include -- in check-ref-format arguments for origin/ prefixed ref', () => {
+    // Given: local branch check fails, remote check succeeds
+    const checkRefFormatCalls: string[][] = [];
+    let callCount = 0;
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        checkRefFormatCalls.push([...argsArr]);
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'rev-parse') {
+        callCount++;
+        // First rev-parse (local) fails, second (origin/) succeeds
+        if (callCount <= 1) {
+          throw new Error('branch not found');
+        }
+        return Buffer.from('abc123\n');
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    branchExists('/project', 'feature/my-branch');
+
+    // Then: both check-ref-format calls should not contain '--'
+    expect(checkRefFormatCalls).toHaveLength(2);
+    expect(checkRefFormatCalls[0]).toEqual(['check-ref-format', '--branch', 'feature/my-branch']);
+    expect(checkRefFormatCalls[1]).toEqual(['check-ref-format', '--branch', 'origin/feature/my-branch']);
+  });
+});
+
+describe('resolveBaseBranch — assertValidBranchRef argument correctness', () => {
+  it('should call check-ref-format without -- when explicit baseBranch is provided', () => {
+    // Given: explicit baseBranch triggers assertValidBranchRef
+    const checkRefFormatCalls: string[][] = [];
+
+    mockResolveConfigValue.mockReturnValue(undefined);
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        checkRefFormatCalls.push([...argsArr]);
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--verify') {
+        return Buffer.from('abc123\n');
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    resolveBaseBranch('/project', 'release/v2');
+
+    // Then: check-ref-format was called without '--'
+    expect(checkRefFormatCalls.length).toBeGreaterThanOrEqual(1);
+    const assertCall = checkRefFormatCalls[0]!;
+    expect(assertCall).toEqual(['check-ref-format', '--branch', 'release/v2']);
+  });
+
+  it('should throw Invalid base branch when check-ref-format fails for explicit baseBranch', () => {
+    // Given: check-ref-format throws for invalid ref
+    mockResolveConfigValue.mockReturnValue(undefined);
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        throw new Error('invalid ref');
+      }
+      return Buffer.from('');
+    });
+
+    // When / Then
+    expect(() => resolveBaseBranch('/project', 'invalid..ref')).toThrow(
+      'Invalid base branch: invalid..ref',
+    );
+  });
+
+  it('should throw Base branch does not exist when branch does not exist', () => {
+    // Given: check-ref-format succeeds but rev-parse fails (branch not found)
+    mockResolveConfigValue.mockReturnValue(undefined);
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'rev-parse') {
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    // When / Then
+    expect(() => resolveBaseBranch('/project', 'missing/branch')).toThrow(
+      'Base branch does not exist: missing/branch',
+    );
+  });
+
+  it('should not call assertValidBranchRef when no explicit baseBranch is provided', () => {
+    // Given: no explicit baseBranch, autoFetch off
+    mockResolveConfigValue.mockReturnValue(undefined);
+    const checkRefFormatCalls: string[][] = [];
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        checkRefFormatCalls.push([...argsArr]);
+        return Buffer.from('');
+      }
+      return Buffer.from('');
+    });
+
+    // When
+    resolveBaseBranch('/project');
+
+    // Then: check-ref-format should not be called (no assertValidBranchRef)
+    expect(checkRefFormatCalls).toHaveLength(0);
+  });
+});
+

--- a/src/infra/task/clone-base-branch.ts
+++ b/src/infra/task/clone-base-branch.ts
@@ -7,7 +7,7 @@ const log = createLogger('clone');
 
 function gitRefExists(projectDir: string, ref: string): boolean {
   try {
-    execFileSync('git', ['check-ref-format', '--branch', '--', ref], {
+    execFileSync('git', ['check-ref-format', '--branch', ref], {
       cwd: projectDir,
       stdio: 'pipe',
     });
@@ -38,7 +38,7 @@ function resolveConfiguredBaseBranch(projectDir: string, explicitBaseBranch?: st
 
 function assertValidBranchRef(projectDir: string, ref: string): void {
   try {
-    execFileSync('git', ['check-ref-format', '--branch', '--', ref], {
+    execFileSync('git', ['check-ref-format', '--branch', ref], {
       cwd: projectDir,
       stdio: 'pipe',
     });


### PR DESCRIPTION
closes #480

## Summary

- `git check-ref-format --branch` コマンドに不要な `--` が含まれていたため、`branchExists()` が常に `false` を返すバグを修正
- `gitRefExists()` と `assertValidBranchRef()` の2箇所から `--` を除去
- バグの回帰防止テスト（`clone-base-branch.test.ts`）を新規追加

## Background

`--branch` モードは `<branchname-shorthand>` を1つだけ受け取る独立したサブコマンド形式。`--` を挟むと引数が2つになり usage error（exit 129）が発生し、`takt add` の base branch 検証が事実上破綻していた。

Related issue: `docs/takt_git_check_ref_format_bug.md`

## Changes

| File | Change |
|------|--------|
| `src/infra/task/clone-base-branch.ts` | `--branch` の後の `--` を除去（2箇所） |
| `src/__tests__/clone-base-branch.test.ts` | check-ref-format 引数の正確性を検証する回帰テストを新規追加 |

## Test plan

- [x] `branchExists` が `check-ref-format --branch <ref>` を `--` なしで呼ぶことを検証
- [x] `origin/` プレフィックス付きリモートブランチでも `--` が含まれないことを検証
- [x] `resolveBaseBranch` の明示的 baseBranch 指定時に `--` なしで呼ぶことを検証
- [x] 無効なrefやブランチ不存在のエラーケースを検証
- [x] vitest 全テスト通過確認済み


<details><summary>Report: review-summary.md</summary>
<p>

# レビューサマリー

## 総合判定: APPROVE

## サマリー
`git check-ref-format --branch` コマンドの引数から不正な `--`（オプション終端マーカー）を除去するバグ修正。プロダクションコード2箇所の最小限の修正（+2 -2）と、引数正確性を直接検証する6件のリグレッションテスト（+177行）が追加されている。全5レビュー観点（アーキテクチャ・セキュリティ・QA・テスト・要件充足）でブロッキング問題なし、全レビュアーがAPPROVE判定。

## レビュー結果
| レビュー | 結果 | 主要な発見 |
|---------|------|-----------|
| アーキテクチャ | APPROVE | 2行の最小限修正。モジュール構造・依存方向・公開範囲・関数設計すべて適切。スコープ逸脱なし |
| セキュリティ | APPROVE | `execFileSync` で配列引数使用（シェルインジェクションなし）。認証・認可・データ保護に該当なし |
| QA | APPROVE | 修正2箇所に対し6テストでカバー。正常系・異常系・ネガティブケースを網羅。技術的負債パターンなし |
| テスト | APPROVE | Given-When-Then構造、明確な命名、モック分離が適切。テスト独立性・再現性を確保 |
| 要件充足 | APPROVE | 4要件すべて充足（`gitRefExists`の修正、`assertValidBranchRef`の修正、全使用箇所の漏れなし確認、リグレッションテスト追加） |

## 今回の指摘（new）

該当なし

## 継続指摘（persists）

該当なし

## 解消済み（resolved）

該当なし（前回open findingsなし）

## 改善提案

該当なし — 変更は最小限かつ正確であり、追加の改善提案はない。

## REJECT判定条件
- `new`：0件
- `persists`：0件
- いずれも0件のため **APPROVE**

</p>
</details> 