### PR TITLE
fix: ProviderPermissionProfilesSchema に copilot が欠落していた問題を修正

### DIFF
--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -135,6 +135,7 @@ export const ProviderPermissionProfilesSchema = z.object({
   codex: ProviderPermissionProfileSchema.optional(),
   opencode: ProviderPermissionProfileSchema.optional(),
   cursor: ProviderPermissionProfileSchema.optional(),
+  copilot: ProviderPermissionProfileSchema.optional(),
   mock: ProviderPermissionProfileSchema.optional(),
 }).optional();
 


### PR DESCRIPTION
## Summary

- Copilot プロバイダー追加 PR (#425) で `ProviderProfileNameSchema`（enum）に `copilot` を追加したが、`ProviderPermissionProfilesSchema` への追加が漏れていた
- これにより `~/.takt/config.yaml` や `.takt/config.yaml` に `provider_profiles.copilot` を設定しても Zod のパース時に黙って破棄され、設定が無視される問題が発生していた

## Changes

1. **`schemas.ts`**: `ProviderPermissionProfilesSchema` に `copilot: ProviderPermissionProfileSchema.optional()` を追加

## Test plan

- [ ] `npm test` — 全テスト通過