### PR TITLE
[#489] fix-pr-review-comments-fetch

### DIFF
--- a/src/__tests__/github-pr.test.ts
+++ b/src/__tests__/github-pr.test.ts
@@ -221,7 +221,7 @@ describe('fetchPrReviewComments', () => {
     );
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'gh',
-      ['api', '/repos/org/repo/pulls/456/comments'],
+      ['api', '/repos/org/repo/pulls/456/comments?per_page=100&page=1'],
       expect.objectContaining({ encoding: 'utf-8' }),
     );
     expect(result.number).toBe(456);
@@ -288,6 +288,140 @@ describe('fetchPrReviewComments', () => {
     // Then
     expect(result.reviews).toEqual([
       { author: 'reviewer3', body: 'Address this edge case', path: 'src/index.ts', line: 7 },
+    ]);
+  });
+
+  it('should fetch all inline review comments when total comments exceed one default page', () => {
+    // Given
+    const ghResponse = {
+      number: 12,
+      title: 'Many inline comments',
+      body: '',
+      url: 'https://github.com/org/repo/pull/12',
+      headRefName: 'fix/many-inline-comments',
+      comments: [],
+      reviews: [],
+      files: [],
+    };
+    const inlineCommentsResponse = Array.from({ length: 31 }, (_, i) => ({
+      body: `Inline comment ${i + 1}`,
+      path: 'src/index.ts',
+      line: i + 1,
+      user: { login: 'reviewer-pagination' },
+    }));
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(ghResponse))
+      .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
+
+    // When
+    const result = fetchPrReviewComments(12);
+
+    // Then
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'gh',
+      ['api', '/repos/org/repo/pulls/12/comments?per_page=100&page=1'],
+      expect.objectContaining({ encoding: 'utf-8' }),
+    );
+    expect(result.reviews).toHaveLength(31);
+    expect(result.reviews[0]).toEqual({
+      author: 'reviewer-pagination',
+      body: 'Inline comment 1',
+      path: 'src/index.ts',
+      line: 1,
+    });
+    expect(result.reviews[30]).toEqual({
+      author: 'reviewer-pagination',
+      body: 'Inline comment 31',
+      path: 'src/index.ts',
+      line: 31,
+    });
+  });
+
+  it('should request additional pages when inline review comments exceed per_page', () => {
+    // Given
+    const ghResponse = {
+      number: 13,
+      title: 'Paginated inline comments',
+      body: '',
+      url: 'https://github.com/org/repo/pull/13',
+      headRefName: 'fix/paginated-inline-comments',
+      comments: [],
+      reviews: [],
+      files: [],
+    };
+    const firstPageInlineComments = Array.from({ length: 100 }, (_, i) => ({
+      body: `Inline comment ${i + 1}`,
+      path: 'src/index.ts',
+      line: i + 1,
+      user: { login: 'reviewer-pagination' },
+    }));
+    const secondPageInlineComments = [
+      { body: 'Inline comment 101', path: 'src/index.ts', line: 101, user: { login: 'reviewer-pagination' } },
+    ];
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(ghResponse))
+      .mockReturnValueOnce(JSON.stringify(firstPageInlineComments))
+      .mockReturnValueOnce(JSON.stringify(secondPageInlineComments));
+
+    // When
+    const result = fetchPrReviewComments(13);
+
+    // Then
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'gh',
+      ['api', '/repos/org/repo/pulls/13/comments?per_page=100&page=1'],
+      expect.objectContaining({ encoding: 'utf-8' }),
+    );
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'gh',
+      ['api', '/repos/org/repo/pulls/13/comments?per_page=100&page=2'],
+      expect.objectContaining({ encoding: 'utf-8' }),
+    );
+    expect(result.reviews).toHaveLength(101);
+    expect(result.reviews[100]).toEqual({
+      author: 'reviewer-pagination',
+      body: 'Inline comment 101',
+      path: 'src/index.ts',
+      line: 101,
+    });
+  });
+
+  it('should fallback to original_line when line is null', () => {
+    // Given
+    const ghResponse = {
+      number: 14,
+      title: 'Keep original line',
+      body: '',
+      url: 'https://github.com/org/repo/pull/14',
+      headRefName: 'fix/original-line',
+      comments: [],
+      reviews: [],
+      files: [],
+    };
+    const inlineCommentsResponse = [
+      {
+        body: 'Line moved after suggestion',
+        path: 'src/index.ts',
+        line: null,
+        original_line: 27,
+        user: { login: 'reviewer-original-line' },
+      },
+    ];
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(ghResponse))
+      .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
+
+    // When
+    const result = fetchPrReviewComments(14);
+
+    // Then
+    expect(result.reviews).toEqual([
+      {
+        author: 'reviewer-original-line',
+        body: 'Line moved after suggestion',
+        path: 'src/index.ts',
+        line: 27,
+      },
     ]);
   });
 

--- a/src/infra/github/pr.ts
+++ b/src/infra/github/pr.ts
@@ -75,7 +75,32 @@ interface GhPrApiReviewCommentResponse {
   body: string;
   path: string;
   line: number | null;
+  original_line?: number | null;
   user: { login: string };
+}
+
+const INLINE_REVIEW_COMMENTS_PER_PAGE = 100;
+
+function fetchInlineReviewComments(owner: string, repo: string, prNumber: number): GhPrApiReviewCommentResponse[] {
+  const comments: GhPrApiReviewCommentResponse[] = [];
+  let page = 1;
+
+  while (true) {
+    const rawInlineReviewComments = execFileSync(
+      'gh',
+      ['api', `/repos/${owner}/${repo}/pulls/${prNumber}/comments?per_page=${INLINE_REVIEW_COMMENTS_PER_PAGE}&page=${page}`],
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    const inlineReviewComments = JSON.parse(rawInlineReviewComments) as GhPrApiReviewCommentResponse[];
+
+    comments.push(...inlineReviewComments);
+
+    if (inlineReviewComments.length < INLINE_REVIEW_COMMENTS_PER_PAGE) {
+      return comments;
+    }
+
+    page += 1;
+  }
 }
 
 function parseRepositoryFromPrUrl(prUrl: string): { owner: string; repo: string } {
@@ -110,12 +135,7 @@ export function fetchPrReviewComments(prNumber: number): PrReviewData {
   const data = JSON.parse(raw) as GhPrViewReviewResponse;
   const { owner, repo } = parseRepositoryFromPrUrl(data.url);
 
-  const rawInlineReviewComments = execFileSync(
-    'gh',
-    ['api', `/repos/${owner}/${repo}/pulls/${prNumber}/comments`],
-    { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-  );
-  const inlineReviewComments = JSON.parse(rawInlineReviewComments) as GhPrApiReviewCommentResponse[];
+  const inlineReviewComments = fetchInlineReviewComments(owner, repo, prNumber);
 
   const comments: PrReviewComment[] = data.comments.map((c) => ({
     author: c.author.login,
@@ -133,7 +153,7 @@ export function fetchPrReviewComments(prNumber: number): PrReviewData {
       author: comment.user.login,
       body: comment.body,
       path: comment.path,
-      line: comment.line ?? undefined,
+      line: comment.line ?? comment.original_line ?? undefined,
     });
   }
 


### PR DESCRIPTION
## Summary

## 概要

`takt --pr <PR番号>` を実行すると、`review.comments is not iterable` エラーで失敗します。

## エラーメッセージ

```
[INFO] Fetching PR review comments...
[ERROR] review.comments is not iterable
```

## 原因

`src/infra/github/pr.ts` の `fetchPrReviewComments` 関数で、`gh pr view --json reviews` のレスポンス構造と実際のデータが一致していません。

taktのコードは `review.comments` を配列として期待しています：

```typescript
for (const review of data.reviews) {
  if (review.body) {
    reviews.push({ author: review.author.login, body: review.body });
  }
  for (const comment of review.comments) {  // ← ここでエラー
    reviews.push({ ... });
  }
}
```

しかし `gh pr view --json reviews` のレスポンスには、各 review オブジェクトに `comments` フィールドが含まれません：

```json
"reviews": [{
  "author": {"login": "user"},
  "body": "",
  "state": "COMMENTED"
}]
```

インラインレビューコメント（ファイルの特定行へのコメント）は `reviews[].comments` には含まれず、別の手段で取得する必要があります。

## 問題の影響

クラッシュを防ぐだけの修正（`review.comments ?? []`）では不十分です。インラインレビューコメントが取得されないため、`takt --pr` の本来の目的（レビューコメントに基づく自動修正）が機能しません。

## 修正案

インラインレビューコメントを正しく取得するために、以下のいずれかの対応が必要です：

1. `gh pr view --json` の `reviewComments` フィールドを追加で取得する（`PR_REVIEW_JSON_FIELDS` に `reviewComments` を追加）
2. REST API（`GET /repos/{owner}/{repo}/pulls/{number}/comments`）を使用してインラインレビューコメントを取得する

## 再現手順

1. PRにインラインレビューコメント（ファイルの特定行へのコメント）を付ける
2. `takt --pr <PR番号>` を実行
3. `review.comments is not iterable` エラーで失敗することを確認

## Execution Report

Piece `takt-default` completed successfully.

Closes #489