### PR TITLE
fix: sanitize movement names in snapshot filenames to prevent path traversal

### DIFF
--- a/src/__tests__/engine-blocked.test.ts
+++ b/src/__tests__/engine-blocked.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
 // --- Mock setup (must be before imports that use these modules) ---
@@ -42,6 +42,8 @@ import {
   mockDetectMatchedRuleSequence,
   createTestTmpDir,
   applyDefaultMocks,
+  makeMovement,
+  makeRule,
 } from './engine-test-helpers.js';
 
 describe('PieceEngine Integration: Blocked Handling', () => {
@@ -178,6 +180,50 @@ describe('PieceEngine Integration: Blocked Handling', () => {
 
     expect(readFileSync(snapshotPath, 'utf-8')).toBe('Need clarification');
     expect(readFileSync(latestPath, 'utf-8')).toBe('Need clarification');
+    expect(onUserInput).toHaveBeenCalledOnce();
+  });
+
+  it('should sanitize movement name containing path separators when writing snapshot', async () => {
+    const config = buildDefaultPieceConfig({
+      initialMovement: '../../escape',
+      movements: [
+        makeMovement('../../escape', {
+          rules: [makeRule('done', 'ABORT')],
+        }),
+      ],
+    });
+
+    const onUserInput = vi.fn().mockResolvedValueOnce(null);
+    const engine = new PieceEngine(config, tmpDir, 'test task', { projectCwd: tmpDir, onUserInput });
+
+    mockRunAgentSequence([
+      makeResponse({ persona: 'escape', status: 'blocked', content: 'Need clarification' }),
+    ]);
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('aborted');
+    expect(state.lastOutput?.status).toBe('blocked');
+    // slugify('../../escape') === 'escape'
+    expect(state.previousResponseSourcePath).toMatch(
+      /^\.takt\/runs\/test-report-dir\/context\/previous_responses\/escape\.1\.\d{8}T\d{6}Z\.md$/,
+    );
+
+    const snapshotPath = join(tmpDir, state.previousResponseSourcePath!);
+    const latestPath = join(
+      tmpDir,
+      '.takt',
+      'runs',
+      'test-report-dir',
+      'context',
+      'previous_responses',
+      'latest.md',
+    );
+
+    expect(readFileSync(snapshotPath, 'utf-8')).toBe('Need clarification');
+    expect(readFileSync(latestPath, 'utf-8')).toBe('Need clarification');
+    // 上位ディレクトリにパストラバーサルでファイルが書き込まれていないことを確認
+    expect(readdirSync(tmpDir).some(name => /^escape\.1\.\d{8}T\d{6}Z\.md$/.test(name))).toBe(false);
     expect(onUserInput).toHaveBeenCalledOnce();
   });
 

--- a/src/core/piece/engine/MovementExecutor.ts
+++ b/src/core/piece/engine/MovementExecutor.ts
@@ -22,7 +22,7 @@ import { detectMatchedRule } from '../evaluation/index.js';
 import type { StatusJudgmentPhaseResult } from '../phase-runner.js';
 import { buildSessionKey } from '../session-key.js';
 import { incrementMovementIteration, getPreviousOutput } from './state-manager.js';
-import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
+import { createLogger, getErrorMessage, slugify } from '../../../shared/utils/index.js';
 import type { OptionsBuilder } from './OptionsBuilder.js';
 import type { RunPaths } from '../run/run-paths.js';
 
@@ -84,6 +84,15 @@ export class MovementExecutor {
     return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
   }
 
+  private static buildSnapshotFileName(
+    movementName: string,
+    movementIteration: number,
+    timestamp: string,
+  ): string {
+    const safeMovementName = slugify(movementName) || 'movement';
+    return `${safeMovementName}.${movementIteration}.${timestamp}.md`;
+  }
+
   private writeSnapshot(
     content: string,
     directoryRel: string,
@@ -110,7 +119,7 @@ export class MovementExecutor {
     const sourcePath = this.writeSnapshot(
       merged,
       directoryRel,
-      `${movementName}.${movementIteration}.${timestamp}.md`,
+      MovementExecutor.buildSnapshotFileName(movementName, movementIteration, timestamp),
     );
     return { content: [merged], sourcePath };
   }
@@ -123,7 +132,7 @@ export class MovementExecutor {
     if (!state.lastOutput || state.previousResponseSourcePath) return;
     const timestamp = MovementExecutor.buildTimestamp();
     const runPaths = this.deps.getRunPaths();
-    const fileName = `${movementName}.${movementIteration}.${timestamp}.md`;
+    const fileName = MovementExecutor.buildSnapshotFileName(movementName, movementIteration, timestamp);
     const sourcePath = this.writeSnapshot(
       state.lastOutput.content,
       runPaths.contextPreviousResponsesRel,
@@ -145,7 +154,7 @@ export class MovementExecutor {
   ): void {
     const timestamp = MovementExecutor.buildTimestamp();
     const runPaths = this.deps.getRunPaths();
-    const fileName = `${movementName}.${movementIteration}.${timestamp}.md`;
+    const fileName = MovementExecutor.buildSnapshotFileName(movementName, movementIteration, timestamp);
     const sourcePath = this.writeSnapshot(content, runPaths.contextPreviousResponsesRel, fileName);
     this.writeSnapshot(content, runPaths.contextPreviousResponsesRel, 'latest.md');
     state.previousResponseSourcePath = sourcePath;


### PR DESCRIPTION
## Summary

- **脆弱性**: movement name に `../` を含む値を設定すると、スナップショットファイルの書き込みが `.takt/runs` ディレクトリ外に逸脱する任意ファイル書き込みが可能だった
- **修正**: `MovementExecutor` 内でスナップショットファイル名を構築する前に、既存の `slugify()` でmovement nameをサニタイズするようにした（`writeFacetSnapshot`、`ensurePreviousResponseSnapshot`、`persistPreviousResponseSnapshot` の3箇所）
- **テスト**: `../../escape` という名前のmovementがパストラバーサルを起こさず `escape.1.{timestamp}.md` に正規化されることを確認するリグレッションテストを追加

## 変更ファイル

- `src/core/piece/engine/MovementExecutor.ts`: `slugify` のインポート追加、`buildSnapshotFileName` 静的メソッド追加、3箇所のファイル名構築を置き換え
- `src/__tests__/engine-blocked.test.ts`: パストラバーサルのリグレッションテストを追加

## テスト

```
✓ src/__tests__/engine-blocked.test.ts (6 tests)
```

## 関連

- Security finding: Path traversal in run context snapshot filenames (commit 9c44089)

🤖 Generated with [Claude Code](https://claude.com/claude-code)