### PR TITLE
fix: Cursor prompt のオプション注入を防止

### DIFF
--- a/src/__tests__/cursor-client.test.ts
+++ b/src/__tests__/cursor-client.test.ts
@@ -101,10 +101,29 @@ describe('callCursor', () => {
       '--resume',
       'sess-prev',
       '--force',
+      '--',
       'implement feature',
     ]);
     expect(options.env?.CURSOR_API_KEY).toBe('cursor-key');
     expect(options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+  });
+
+  it('should pass prompt after end-of-options marker', async () => {
+    mockSpawnWithScenario({
+      stdout: JSON.stringify({ content: 'done' }),
+      code: 0,
+    });
+
+    const result = await callCursor('coder', '--workspace=/', {
+      cwd: '/repo',
+    });
+
+    expect(result.status).toBe('done');
+
+    const [, args] = mockSpawn.mock.calls[0] as [string, string[]];
+    expect(args).toContain('--');
+    expect(args.at(-2)).toBe('--');
+    expect(args.at(-1)).toBe('--workspace=/');
   });
 
   it('should not inject CURSOR_API_KEY when cursorApiKey is undefined', async () => {

--- a/src/infra/cursor/client.ts
+++ b/src/infra/cursor/client.ts
@@ -63,7 +63,7 @@ function buildArgs(prompt: string, options: CursorCallOptions): string[] {
     args.push('--force');
   }
 
-  args.push(buildPrompt(prompt, options.systemPrompt));
+  args.push('--', buildPrompt(prompt, options.systemPrompt));
   return args;
 }
 


### PR DESCRIPTION
## 概要
- Cursor provider で prompt を CLI 引数として渡す際に `--` 終端を追加し、先頭 `-` の prompt がオプションとして解釈されないように修正
- `--workspace=/` のような入力が prompt として末尾に保持されることを回帰テストで追加

## この対策がない場合の問題
- issue / PR / piece などの外部入力に `--force` や `--workspace=/` のような文字列が含まれると、prompt ではなく `cursor-agent` のオプションとして解釈される可能性がある
- その結果、本来の permission mode を迂回して強い権限で実行されたり、意図しない workspace を対象に処理されたりする
- `--output-format=text` のような注入で出力形式が変わると、呼び出し元が期待する JSON 応答が崩れ、異常系や安全制御の前提も壊れうる

## 変更内容
- `src/infra/cursor/client.ts` の `buildArgs` で prompt の直前に `--` を挿入
- `src/__tests__/cursor-client.test.ts` で通常ケースの期待値を更新
- option 風の prompt を渡しても end-of-options marker の後ろに載ることを検証するテストを追加

## テスト
- `npm test`
