### PR TITLE
fix: review-takt-default から Bash 実行権限を除去

### DIFF
--- a/builtins/en/pieces/review-takt-default.yaml
+++ b/builtins/en/pieces/review-takt-default.yaml
@@ -19,7 +19,6 @@ movements:
           - Read
           - Glob
           - Grep
-          - Bash
           - WebSearch
           - WebFetch
     instruction: gather-review
@@ -52,7 +51,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-arch
@@ -75,7 +73,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-security
@@ -99,7 +96,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-qa
@@ -123,7 +119,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-test
@@ -147,7 +142,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: ai-review
@@ -169,7 +163,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-requirements

--- a/builtins/ja/pieces/review-takt-default.yaml
+++ b/builtins/ja/pieces/review-takt-default.yaml
@@ -19,7 +19,6 @@ movements:
           - Read
           - Glob
           - Grep
-          - Bash
           - WebSearch
           - WebFetch
     instruction: gather-review
@@ -52,7 +51,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-arch
@@ -75,7 +73,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-security
@@ -99,7 +96,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-qa
@@ -123,7 +119,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-test
@@ -147,7 +142,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: ai-review
@@ -169,7 +163,6 @@ movements:
               - Read
               - Glob
               - Grep
-              - Bash
               - WebSearch
               - WebFetch
         instruction: review-requirements

--- a/src/__tests__/review-takt-default-piece.test.ts
+++ b/src/__tests__/review-takt-default-piece.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { PieceConfigRawSchema } from '../core/models/index.js';
+
+const RESOURCES_DIR = join(import.meta.dirname, '../../builtins');
+
+function loadReviewTaktDefaultYaml(lang: 'en' | 'ja') {
+  const filePath = join(RESOURCES_DIR, lang, 'pieces', 'review-takt-default.yaml');
+  const content = readFileSync(filePath, 'utf-8');
+  return parseYaml(content);
+}
+
+type PieceMovementLike = {
+  name: string;
+  provider_options?: {
+    claude?: {
+      allowed_tools?: string[];
+    };
+  };
+  parallel?: PieceMovementLike[];
+};
+
+type PieceLike = {
+  movements: PieceMovementLike[];
+};
+
+function assertNoBashInReviewOnlyMovements(raw: PieceLike) {
+  const gather = raw.movements.find((movement: { name: string }) => movement.name === 'gather');
+  expect(gather.provider_options?.claude?.allowed_tools).not.toContain('Bash');
+
+  const reviewers = raw.movements.find((movement: { name: string }) => movement.name === 'reviewers');
+  for (const reviewer of reviewers.parallel ?? []) {
+    expect(reviewer.provider_options?.claude?.allowed_tools).not.toContain('Bash');
+  }
+}
+
+describe('review-takt-default piece', () => {
+  it.each(['en', 'ja'] as const)('should pass schema validation for %s', (lang) => {
+    const raw = loadReviewTaktDefaultYaml(lang);
+    const result = PieceConfigRawSchema.safeParse(raw);
+    expect(result.success).toBe(true);
+  });
+
+  it.each(['en', 'ja'] as const)('should not allow Bash in review-only gather and reviewer movements for %s', (lang) => {
+    const raw = loadReviewTaktDefaultYaml(lang) as PieceLike;
+    assertNoBashInReviewOnlyMovements(raw);
+  });
+});


### PR DESCRIPTION
別途判断が必要。そもそもBash権限を除去しても問題ないか要検討です。

## 概要
- `review-takt-default` のレビュー専用 movement から `Bash` を除去し、PR レビュー中にシェル実行できないように修正
- 英語版・日本語版の両方に同じ制約を適用
- 回帰テストを追加し、レビュー専用ピースで `Bash` が再び許可されないように固定

## この対策がない場合の問題
- 攻撃者が PR 本文や差分にプロンプト注入を仕込むと、レビュー中の LLM が `Bash` を使って任意コマンドを実行できる
- `required_permission_mode` 未指定のため既定の `edit` 権限が適用され、workspace-write 相当でリポジトリ変更やローカルファイル参照が可能になる
- `network_access: true` の provider 設定と組み合わさると、秘密情報の外部送信や意図しない環境調査の踏み台になる
- これは「レビュー専用ピースでテストやビルドをしない」という設計意図と明確に矛盾する

## 変更内容
- `builtins/en/pieces/review-takt-default.yaml` の `gather` と全 reviewer movement から `Bash` を削除
- `builtins/ja/pieces/review-takt-default.yaml` に同じ修正を反映
- `src/__tests__/review-takt-default-piece.test.ts` を追加し、英日両方で `Bash` が含まれないことを検証

## テスト
- `npm test`
