### PR TITLE
fix: worktree_path 再利用時のパス検証を追加

### DIFF
--- a/src/__tests__/resolveTask.test.ts
+++ b/src/__tests__/resolveTask.test.ts
@@ -237,7 +237,7 @@ describe('resolveTaskExecution', () => {
 
   it('should preserve base_branch when reusing an existing worktree path', async () => {
     const root = createTempProjectDir();
-    const worktreePath = path.join(root, 'existing-worktree');
+    const worktreePath = path.join(root, '.takt', 'worktrees', 'existing-worktree');
     fs.mkdirSync(worktreePath, { recursive: true });
 
     const task = createTask({
@@ -272,7 +272,7 @@ describe('resolveTaskExecution', () => {
 
   it('should prefer base_branch over legacy baseBranch when reusing an existing worktree path', async () => {
     const root = createTempProjectDir();
-    const worktreePath = path.join(root, 'existing-worktree');
+    const worktreePath = path.join(root, '.takt', 'worktrees', 'existing-worktree');
     fs.mkdirSync(worktreePath, { recursive: true });
 
     const task = createTask({
@@ -309,7 +309,7 @@ describe('resolveTaskExecution', () => {
 
   it('should ignore legacy baseBranch when reusing an existing worktree path', async () => {
     const root = createTempProjectDir();
-    const worktreePath = path.join(root, 'existing-worktree');
+    const worktreePath = path.join(root, '.takt', 'worktrees', 'existing-worktree');
     fs.mkdirSync(worktreePath, { recursive: true });
 
     const task = createTask({
@@ -338,6 +338,76 @@ describe('resolveTaskExecution', () => {
     expect(result.execCwd).toBe(worktreePath);
     expect(result.isWorktree).toBe(true);
     expect(result.baseBranch).toBe('develop');
+
+    mockCreateSharedClone.mockRestore();
+    mockResolveBaseBranch.mockRestore();
+  });
+
+  it('should not reuse existing worktree path outside clone base directory', async () => {
+    const root = createTempProjectDir();
+    const outsidePath = path.join(os.tmpdir(), `takt-outside-${Date.now()}`);
+    fs.mkdirSync(outsidePath, { recursive: true });
+
+    const task = createTask({
+      data: ({
+        task: 'Run task with untrusted worktree path',
+        worktree: true,
+        branch: 'feature/outside-worktree',
+      } as unknown) as NonNullable<TaskInfo['data']>,
+      worktreePath: outsidePath,
+      status: 'pending',
+    });
+
+    const safeClonePath = path.join(root, '.takt', 'worktrees', 'safe-clone');
+    const mockResolveBaseBranch = vi.spyOn(infraTask, 'resolveBaseBranch').mockReturnValue({
+      branch: 'main',
+    });
+    const mockCreateSharedClone = vi.spyOn(infraTask, 'createSharedClone').mockReturnValue({
+      path: safeClonePath,
+      branch: 'feature/outside-worktree',
+    });
+
+    const result = await resolveTaskExecutionWithPiece(task, root);
+
+    expect(mockCreateSharedClone).toHaveBeenCalled();
+    expect(result.execCwd).toBe(safeClonePath);
+    expect(result.worktreePath).toBe(safeClonePath);
+    expect(result.isWorktree).toBe(true);
+
+    mockCreateSharedClone.mockRestore();
+    mockResolveBaseBranch.mockRestore();
+    fs.rmSync(outsidePath, { recursive: true, force: true });
+  });
+
+  it('should reuse existing worktree path within clone base directory', async () => {
+    const root = createTempProjectDir();
+    const worktreePath = path.join(root, '.takt', 'worktrees', 'existing-safe-worktree');
+    fs.mkdirSync(worktreePath, { recursive: true });
+
+    const task = createTask({
+      data: ({
+        task: 'Run task with safe worktree path',
+        worktree: true,
+        branch: 'feature/safe-worktree',
+      } as unknown) as NonNullable<TaskInfo['data']>,
+      worktreePath,
+      status: 'pending',
+    });
+
+    const mockResolveBaseBranch = vi.spyOn(infraTask, 'resolveBaseBranch').mockReturnValue({
+      branch: 'main',
+    });
+    const mockCreateSharedClone = vi.spyOn(infraTask, 'createSharedClone').mockReturnValue({
+      path: worktreePath,
+      branch: 'feature/safe-worktree',
+    });
+
+    const result = await resolveTaskExecutionWithPiece(task, root);
+
+    expect(mockCreateSharedClone).not.toHaveBeenCalled();
+    expect(result.execCwd).toBe(worktreePath);
+    expect(result.worktreePath).toBe(worktreePath);
+    expect(result.isWorktree).toBe(true);
 
     mockCreateSharedClone.mockRestore();
     mockResolveBaseBranch.mockRestore();

--- a/src/__tests__/worktree-exceeded-requeue.test.ts
+++ b/src/__tests__/worktree-exceeded-requeue.test.ts
@@ -235,8 +235,9 @@ describe('シナリオ3・4: requeue → re-execution passes exceeded metadata t
     vi.clearAllMocks();
     applyDefaultMocks();
     testDir = createTestDir();
-    // cloneDir simulates a pre-existing worktree clone (fs.existsSync check will pass)
-    cloneDir = createTestDir();
+    // cloneDir simulates a pre-existing worktree clone inside the managed worktree directory
+    cloneDir = join(testDir, '.takt', 'worktrees', `existing-${randomUUID()}`);
+    mkdirSync(cloneDir, { recursive: true });
     runner = new TaskRunner(testDir);
   });
 

--- a/src/features/tasks/execute/resolveTask.ts
+++ b/src/features/tasks/execute/resolveTask.ts
@@ -1,13 +1,31 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { resolvePieceConfigValue } from '../../../infra/config/index.js';
-import { type TaskInfo, buildTaskInstruction, createSharedClone, resolveBaseBranch, branchExists, summarizeTaskName } from '../../../infra/task/index.js';
+import {
+  type TaskInfo,
+  buildTaskInstruction,
+  createSharedClone,
+  resolveBaseBranch,
+  resolveCloneBaseDir,
+  branchExists,
+  summarizeTaskName,
+} from '../../../infra/task/index.js';
 import { getGitProvider, type Issue } from '../../../infra/git/index.js';
 import { withProgress } from '../../../shared/ui/index.js';
-import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
+import { createLogger, getErrorMessage, isPathInside } from '../../../shared/utils/index.js';
 import { getTaskSlugFromTaskDir } from '../../../shared/utils/taskPaths.js';
 
 const log = createLogger('task');
+
+function canReuseWorktreePath(projectDir: string, candidatePath: string): boolean {
+  if (!fs.existsSync(candidatePath)) {
+    return false;
+  }
+
+  const cloneBaseDir = resolveCloneBaseDir(projectDir);
+  const fallbackCloneBaseDir = path.join(projectDir, '.takt', 'worktrees');
+  return isPathInside(cloneBaseDir, candidatePath) || isPathInside(fallbackCloneBaseDir, candidatePath);
+}
 
 function resolveTaskDataBaseBranch(taskData: TaskInfo['data']): string | undefined {
   return taskData?.base_branch;
@@ -125,7 +143,7 @@ export async function resolveTaskExecution(
       ? resolveTaskBaseBranch(defaultCwd, data)
       : preferredBaseBranch;
 
-    if (task.worktreePath && fs.existsSync(task.worktreePath)) {
+    if (task.worktreePath && canReuseWorktreePath(defaultCwd, task.worktreePath)) {
       execCwd = task.worktreePath;
       branch = data.branch;
       worktreePath = task.worktreePath;

--- a/src/infra/task/clone.ts
+++ b/src/infra/task/clone.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { createLogger } from '../../shared/utils/index.js';
+import { createLogger, isPathInside } from '../../shared/utils/index.js';
 import { resolveConfigValue } from '../config/index.js';
 import type { WorktreeOptions, WorktreeResult } from './types.js';
 import { localBranchExists, remoteBranchExists, resolveBaseBranch as resolveBaseBranchInternal } from './clone-base-branch.js';
@@ -18,7 +18,7 @@ export class CloneManager {
     return new Date().toISOString().replace(/[-:.]/g, '').slice(0, 13);
   }
 
-  private static resolveCloneBaseDir(projectDir: string): string {
+  static resolveCloneBaseDir(projectDir: string): string {
     const worktreeDir = resolveConfigValue(projectDir, 'worktreeDir');
     if (worktreeDir) {
       return path.isAbsolute(worktreeDir)
@@ -165,7 +165,7 @@ export class CloneManager {
     }
     const cloneBaseDir = path.resolve(CloneManager.resolveCloneBaseDir(projectDir));
     const resolvedClonePath = path.resolve(meta.clonePath);
-    if (!resolvedClonePath.startsWith(cloneBaseDir + path.sep)) {
+    if (!isPathInside(cloneBaseDir, resolvedClonePath)) {
       log.error('Refusing to remove clone outside of clone base directory', {
         branch,
         clonePath: meta.clonePath,
@@ -212,4 +212,8 @@ export function resolveBaseBranch(
   explicitBaseBranch?: string,
 ): { branch: string; fetchedCommit?: string } {
   return CloneManager.resolveBaseBranch(projectDir, explicitBaseBranch);
+}
+
+export function resolveCloneBaseDir(projectDir: string): string {
+  return CloneManager.resolveCloneBaseDir(projectDir);
 }

--- a/src/infra/task/index.ts
+++ b/src/infra/task/index.ts
@@ -45,6 +45,7 @@ export {
   removeCloneMeta,
   cleanupOrphanedClone,
   resolveBaseBranch,
+  resolveCloneBaseDir,
   branchExists,
 } from './clone.js';
 export {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -5,6 +5,7 @@
 export * from './debug.js';
 export * from './error.js';
 export * from './notification.js';
+export * from './pathBoundary.js';
 export * from './providerEventLogger.js';
 export * from './reportDir.js';
 export * from './slackWebhook.js';

--- a/src/shared/utils/pathBoundary.ts
+++ b/src/shared/utils/pathBoundary.ts
@@ -1,0 +1,12 @@
+import * as path from 'node:path';
+
+export function isPathInside(basePath: string, candidatePath: string): boolean {
+  const resolvedBase = path.resolve(basePath);
+  const resolvedCandidate = path.resolve(candidatePath);
+
+  if (resolvedBase === resolvedCandidate) {
+    return true;
+  }
+
+  return resolvedCandidate.startsWith(resolvedBase + path.sep);
+}


### PR DESCRIPTION
## 概要
- 既存 `worktree_path` の再利用時に、管理対象の worktree ディレクトリ配下かを検証するよう修正
- clone/worktree のパス境界チェックを共通化し、既存の orphan cleanup と同じ判定ロジックを利用
- 外部ディレクトリを `worktree_path` に指定しても再利用されない回帰テストを追加

## この対策がない場合の問題
- `tasks.yaml` の `worktree_path` はタスクメタデータ経由で与えられるため、攻撃者が既存ディレクトリを任意指定できる
- worktree 再利用ロジックが存在確認だけで `execCwd` に採用すると、`/tmp` やホーム配下などリポジトリ外のディレクトリでタスク実行されうる
- その結果、Read/Bash などのツールが意図しない場所を対象に動作し、秘密情報の参照や外部ディレクトリ改変につながる
- exceeded/requeue/instruct のように保存済み `worktreePath` を再利用する経路でも同じ問題が波及する

## 変更内容
- `src/shared/utils/pathBoundary.ts` にパス境界判定の共通関数 `isPathInside` を追加
- `src/infra/task/clone.ts` の orphan cleanup 判定を共通関数ベースに置き換え
- `src/features/tasks/execute/resolveTask.ts` で `worktree_path` 再利用前に clone base dir 配下かを検証
- `src/__tests__/resolveTask.test.ts` に安全な worktree 再利用 / 外部パス拒否のテストを追加
- `src/__tests__/worktree-exceeded-requeue.test.ts` の前提を、管理対象 worktree 配下を使う形に調整

## テスト
- `npm test`
