### PR TITLE
fix: interactive mode で issue 初期入力の事前 AI 実行を防止

### DIFF
--- a/src/__tests__/interactive-mode.test.ts
+++ b/src/__tests__/interactive-mode.test.ts
@@ -463,10 +463,10 @@ describe('personaMode', () => {
     );
   });
 
-  it('should process initialInput as first message', async () => {
+  it('should keep initialInput in local history until the user acts', async () => {
     // Given
     setupRawStdin(toRawInputs(['/go']));
-    setupMockProvider(['I analyzed the issue.', 'Task summary.']);
+    setupMockProvider(['Task summary.']);
     mockSelectOption.mockResolvedValue('execute');
 
     // When
@@ -475,9 +475,10 @@ describe('personaMode', () => {
     // Then
     expect(result.action).toBe('execute');
     const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
-    expect(mockProvider._call).toHaveBeenCalledTimes(2);
+    expect(mockProvider._call).toHaveBeenCalledTimes(1);
     const firstPrompt = mockProvider._call.mock.calls[0]?.[0] as string;
-    expect(firstPrompt).toBe('fix the login');
+    expect(firstPrompt).toContain('Conversation:');
+    expect(firstPrompt).toContain('User: fix the login');
   });
 
   it('should handle /play command', async () => {

--- a/src/__tests__/interactive.test.ts
+++ b/src/__tests__/interactive.test.ts
@@ -206,41 +206,41 @@ describe('interactiveMode', () => {
     expect(prompt).toContain('test message');
   });
 
-  it('should process initialInput as first message before entering loop', async () => {
+  it('should not auto-submit initialInput before user interaction', async () => {
     // Given: initialInput provided, then user types /go
     setupRawStdin(toRawInputs(['/go']));
-    setupMockProvider(['What do you mean by "a"?', 'Clarify task for "a".']);
+    setupMockProvider(['Clarify task for "a".']);
 
     // When
     const result = await interactiveMode('/project', 'a');
 
-    // Then: AI should have been called with initialInput (with policy injected)
+    // Then: initial input is kept in local history and only /go summary call reaches AI
     const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
-    expect(mockProvider._call).toHaveBeenCalledTimes(2);
+    expect(mockProvider._call).toHaveBeenCalledTimes(1);
     const firstPrompt = mockProvider._call.mock.calls[0]?.[0] as string;
-    expect(firstPrompt).toContain('## Policy');
-    expect(firstPrompt).toContain('a');
+    expect(firstPrompt).toContain('Conversation:');
+    expect(firstPrompt).toContain('User: a');
 
-    // /go should work because initialInput already started conversation
     expect(result.action).toBe('execute');
     expect(result.task).toBe('Clarify task for "a".');
   });
 
-  it('should send only current input for subsequent turns after initialInput', async () => {
+  it('should send only explicit user turns and include initialInput in summary context', async () => {
     // Given: initialInput, then follow-up, then /go
     setupRawStdin(toRawInputs(['fix the login page', '/go']));
-    setupMockProvider(['What about "a"?', 'Got it, fixing login page.', 'Fix login page with clarified scope.']);
+    setupMockProvider(['Got it, fixing login page.', 'Fix login page with clarified scope.']);
 
     // When
     const result = await interactiveMode('/project', 'a');
 
-    // Then: each call receives only its own input with policy (session handles history)
+    // Then: first AI call is from explicit follow-up input, second is /go summary
     const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
-    expect(mockProvider._call).toHaveBeenCalledTimes(3);
+    expect(mockProvider._call).toHaveBeenCalledTimes(2);
     const firstPrompt = mockProvider._call.mock.calls[0]?.[0] as string;
     const secondPrompt = mockProvider._call.mock.calls[1]?.[0] as string;
-    expect(firstPrompt).toContain('a');
-    expect(secondPrompt).toContain('fix the login page');
+    expect(firstPrompt).toContain('fix the login page');
+    expect(secondPrompt).toContain('User: a');
+    expect(secondPrompt).toContain('User: fix the login page');
 
     // Task still contains all history for downstream use
     expect(result.action).toBe('execute');
@@ -322,32 +322,18 @@ describe('interactiveMode', () => {
     expect(setupArgs.systemPrompt).not.toContain('Previous Run Reference');
   });
 
-  it('should abort in-flight provider call on SIGINT during initial input', async () => {
+  it('should not start provider call from initial input alone', async () => {
+    const mockCall = vi.fn();
     mockGetProvider.mockReturnValue({
       setup: () => ({
-        call: vi.fn((_prompt: string, options: { abortSignal?: AbortSignal }) => {
-          return new Promise((resolve) => {
-            options.abortSignal?.addEventListener('abort', () => {
-              resolve({
-                persona: 'interactive',
-                status: 'error',
-                content: 'aborted',
-                timestamp: new Date(),
-              });
-            }, { once: true });
-          });
-        }),
+        call: mockCall,
       }),
     } as unknown as ReturnType<typeof getProvider>);
 
-    const promise = interactiveMode('/project', 'trigger');
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
-
-    const listeners = process.rawListeners('SIGINT') as Array<() => void>;
-    listeners[listeners.length - 1]?.();
-
-    const result = await promise;
+    setupRawStdin(toRawInputs(['/cancel']));
+    const result = await interactiveMode('/project', 'trigger');
     expect(result.action).toBe('cancel');
+    expect(mockCall).not.toHaveBeenCalled();
   });
 
   it('should use saved sessionId from initializeSession when no sessionId parameter is given', async () => {

--- a/src/features/interactive/conversationLoop.ts
+++ b/src/features/interactive/conversationLoop.ts
@@ -127,21 +127,10 @@ export async function runConversationLoop(
 
   if (initialInput) {
     history.push({ role: 'user', content: initialInput });
-    log.debug('Processing initial input', { initialInput, sessionId });
-
-    const promptWithTransform = strategy.transformPrompt(initialInput);
-    const result = await doCallAI(promptWithTransform, strategy.systemPrompt, strategy.allowedTools);
-    if (result) {
-      if (!result.success) {
-        error(result.content);
-        blankLine();
-        return { action: 'cancel', task: '' };
-      }
-      history.push({ role: 'assistant', content: result.content });
-      blankLine();
-    } else {
-      history.pop();
-    }
+    log.debug('Loaded initial input into local history without auto-submitting to AI', {
+      initialInput,
+      sessionId,
+    });
   }
 
   async function handleSummaryAction(task: string): Promise<InteractiveModeResult | null> {


### PR DESCRIPTION
## 概要
- issue / PR 由来の `initialInput` を interactive mode 起動時に自動で AI 送信しないよう修正
- 初期入力は引き続きローカル履歴に保持し、ユーザーの明示操作後の会話や `/go` 要約には利用
- これにより、未確認の外部入力で Bash / WebFetch 付きの AI 呼び出しが先行する経路を解消

## 何が問題だったか
これまでは `--issue N` や `#N` で取り込んだ GitHub Issue 本文・コメントが、interactive mode 起動直後にそのまま AI へ送られていました。
Issue 本文は外部入力であり、prompt injection を含められます。にもかかわらず、この最初の AI 呼び出しでは `Bash` や `WebFetch` を含む強いツールが許可されていたため、ユーザーが実行意思を確認する前にローカルファイル参照や外部送信につながる余地がありました。

## 対応内容
- `initialInput` は会話履歴へ積むだけに変更
- AI 呼び出しは、ユーザーが追加入力するか `/go` を実行したときにだけ発生
- `/go` 要約時には `initialInput` も含めて task を生成するため、issue を初期コンテキストとして使う機能自体は維持
- 関連テストを更新し、事前自動送信が起きないことを固定

## テスト
- `npm test`
