### PR TITLE
fix: remove forced full permission from terraform piece

### DIFF
--- a/builtins/en/pieces/terraform.yaml
+++ b/builtins/en/pieces/terraform.yaml
@@ -51,7 +51,6 @@ movements:
           - Bash
           - WebSearch
           - WebFetch
-    required_permission_mode: full
     quality_gates:
       - terraform fmt -check passes without errors
       - terraform validate succeeds
@@ -176,7 +175,6 @@ movements:
               - Bash
               - WebSearch
               - WebFetch
-        required_permission_mode: full
         rules:
           - condition: AI issue fix complete
           - condition: No fix needed (target file/spec verified)
@@ -198,7 +196,6 @@ movements:
               - Bash
               - WebSearch
               - WebFetch
-        required_permission_mode: full
         rules:
           - condition: Supervisor's findings have been fixed
           - condition: Cannot proceed with fix
@@ -225,7 +222,6 @@ movements:
           - Bash
           - WebSearch
           - WebFetch
-    required_permission_mode: full
     pass_previous_response: false
     rules:
       - condition: AI issue fix complete
@@ -252,7 +248,6 @@ movements:
           - Bash
           - WebSearch
           - WebFetch
-    required_permission_mode: full
     pass_previous_response: false
     rules:
       - condition: Supervisor's findings have been fixed

--- a/builtins/ja/pieces/terraform.yaml
+++ b/builtins/ja/pieces/terraform.yaml
@@ -51,7 +51,6 @@ movements:
           - Bash
           - WebSearch
           - WebFetch
-    required_permission_mode: full
     quality_gates:
       - terraform fmt -check がエラーなし
       - terraform validate が成功
@@ -176,7 +175,6 @@ movements:
               - Bash
               - WebSearch
               - WebFetch
-        required_permission_mode: full
         rules:
           - condition: AI問題の修正完了
           - condition: 修正不要（指摘対象ファイル/仕様の確認済み）
@@ -198,7 +196,6 @@ movements:
               - Bash
               - WebSearch
               - WebFetch
-        required_permission_mode: full
         rules:
           - condition: 監督者の指摘に対する修正が完了した
           - condition: 修正を進行できない
@@ -225,7 +222,6 @@ movements:
           - Bash
           - WebSearch
           - WebFetch
-    required_permission_mode: full
     pass_previous_response: false
     rules:
       - condition: AI問題の修正完了
@@ -252,7 +248,6 @@ movements:
           - Bash
           - WebSearch
           - WebFetch
-    required_permission_mode: full
     pass_previous_response: false
     rules:
       - condition: 監督者の指摘に対する修正が完了した


### PR DESCRIPTION
## 概要
- Terraform piece の implement / fix 系 movement から `required_permission_mode: full` を削除
- provider profile の `default_permission_mode` / `movement_permission_overrides` をそのまま尊重する挙動に戻す
- これにより、Terraform task 実行時に `danger-full-access` / `bypassPermissions` が強制される経路を解消

## 何が問題だったか
Terraform piece では implement と fix movement に `required_permission_mode: full` が設定されていました。

`resolveMovementPermissionMode` は `required_permission_mode` を minimum floor として適用するため、オペレータが provider profile で `edit` や `readonly` を設定していても、Terraform piece では最終的に `full` が選ばれます。

Codex では `full` が `danger-full-access` に対応するため、untrusted な issue / task 入力を Terraform piece で処理した場合に、ワークスペース外のファイル参照や任意コマンド実行のリスクが不必要に上がっていました。

## 対応内容
- `builtins/en/pieces/terraform.yaml` の `required_permission_mode: full` を削除
- `builtins/ja/pieces/terraform.yaml` も同様に削除
- permission floor ロジック自体は変更せず、問題の原因だった Terraform piece 側の強制設定のみを除去

これにより、強い権限が本当に必要な環境ではオペレータが provider profile 側で明示的に `full` を選べます。一方で、piece 定義だけで unsandboxed 実行が固定されることはなくなります。

## テスト
- `npm run build`
