### PR TITLE
fix: stop auto-approving tools in sync conflict resolver

### DIFF
--- a/src/__tests__/taskSyncAction.test.ts
+++ b/src/__tests__/taskSyncAction.test.ts
@@ -180,7 +180,6 @@ describe('syncBranchWithRoot', () => {
         cwd: task.worktreePath,
         model: 'sonnet',
         permissionMode: 'edit',
-        onPermissionRequest: expect.any(Function),
         onStream: expect.any(Function),
       }),
     );

--- a/src/features/tasks/list/taskSyncAction.ts
+++ b/src/features/tasks/list/taskSyncAction.ts
@@ -82,7 +82,6 @@ export async function syncBranchWithRoot(
     cwd: worktreePath,
     model: config.model,
     permissionMode: 'edit',
-    onPermissionRequest: autoApproveBash,
     onStream: new StreamDisplay('conflict-resolver', false).createHandler(),
   });
 
@@ -98,11 +97,6 @@ export async function syncBranchWithRoot(
   abortMerge(worktreePath);
   logError('Failed to resolve conflicts. Merge aborted.');
   return false;
-}
-
-/** Auto-approve all tool invocations (agent runs in isolated worktree) */
-async function autoApproveBash(request: { toolName: string; input: Record<string, unknown> }) {
-  return { behavior: 'allow' as const, updatedInput: request.input };
 }
 
 function pushSynced(worktreePath: string, projectDir: string, target: BranchActionTarget): boolean {


### PR DESCRIPTION
## Summary
- remove the unconditional `onPermissionRequest` auto-approval from the sync conflict resolver
- keep AI-assisted conflict resolution, but let the provider enforce its normal permission flow
- update the sync conflict resolver test to match the safer call contract

## Why this change is needed
The sync conflict resolver currently bypasses the normal permission model by passing `onPermissionRequest` that blindly allows every tool invocation. That means the resolver does not honor the operator's configured permission safeguards in the same way as the regular piece engine.

This path also embeds the original task instruction directly into the resolver prompt. If that instruction comes from untrusted task or issue content, a prompt-injected conflict resolution run can request arbitrary tool usage and have it auto-approved.

## What can go wrong without this fix
Without this change, a merge-conflict resolution run can execute tools without human review or the expected provider-level permission gate. In practice, that can lead to unintended shell command execution, access to files outside the intended scope, or data exfiltration from the operator environment.

## Scope and behavior
This is a small security hardening change, not a large product behavior change. AI-based conflict resolution still runs, but it now follows the normal permission handling instead of silently bypassing it.

## Testing
- `npm test -- --run src/__tests__/taskSyncAction.test.ts`

## Tag
- #5_Conflict resolver auto-approves tool use, bypassing permissions