### PR TITLE
fix: restrict piece runtime.prepare to built-in presets

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -307,6 +307,25 @@ describe('PieceConfigRawSchema', () => {
     });
   });
 
+  it('should reject non-preset piece-level piece_config.runtime.prepare entries', () => {
+    const config = {
+      name: 'test-piece',
+      piece_config: {
+        runtime: {
+          prepare: ['./setup.sh'],
+        },
+      },
+      movements: [
+        {
+          name: 'implement',
+          instruction: '{task}',
+        },
+      ],
+    };
+
+    expect(() => PieceConfigRawSchema.parse(config)).toThrow();
+  });
+
   it('should allow omitting required_permission_mode', () => {
     const config = {
       name: 'test-piece',

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -139,15 +139,19 @@ export const RuntimePrepareEntrySchema = z.union([
 ]);
 
 /** Piece-level runtime settings */
+export const PieceRuntimeConfigSchema = z.object({
+  prepare: z.array(RuntimePreparePresetSchema).optional(),
+}).optional();
+
+/** Piece-level provider options schema */
 export const RuntimeConfigSchema = z.object({
   prepare: z.array(RuntimePrepareEntrySchema).optional(),
 }).optional();
 
-/** Piece-level provider options schema */
 export const PieceProviderOptionsSchema = z.object({
   provider: ProviderReferenceSchema.optional(),
   provider_options: MovementProviderOptionsSchema,
-  runtime: RuntimeConfigSchema,
+  runtime: PieceRuntimeConfigSchema,
 }).optional();
 
 /**


### PR DESCRIPTION
## Summary
- restrict piece-level `piece_config.runtime.prepare` to built-in presets only (`gradle`, `node`)
- keep broader runtime normalization and execution behavior unchanged for global/project config in this draft
- present this as a middle-ground trust-boundary change rather than a full runtime feature removal

## Why this draft exists
This draft is intended to make the trust boundary for distributed pieces safer without removing local runtime setup capabilities across the board.

Today, a piece can supply arbitrary script paths in `piece_config.runtime.prepare`, and those scripts are executed locally via `bash` before normal provider sandboxing or permission controls apply. If third-party pieces or repertoire packages are treated as untrusted or semi-trusted inputs, that gives portable artifacts an arbitrary local script execution surface.

## Why this is the proposed middle ground
The security problem is strongest at the piece boundary, because pieces are easier to distribute and reuse than local config.

This draft keeps the common setup/cache use cases for pieces by allowing only built-in presets such as `gradle` and `node`, while leaving local project/global configuration behavior unchanged for now. That means:
- portable pieces lose the most dangerous capability
- local operators still retain explicit control over broader runtime setup in trusted config
- the change is narrower than removing arbitrary runtime preparation everywhere

## What this draft changes
- piece YAML may use built-in presets such as `gradle` and `node`
- piece YAML may no longer provide arbitrary script paths
- global/project runtime configuration is intentionally left unchanged in this draft so the decision stays scoped to the portable piece boundary

## What can go wrong without this fix
Without this change, a malicious or compromised piece can execute arbitrary local scripts with the operator's privileges during piece initialization. That can bypass normal provider permission expectations and lead to file access, secret exposure, or other local environment compromise.

## Alternatives
- Weaker option: keep current behavior and document that `runtime.prepare` in pieces is trusted-input-only
- Middle ground in this PR: allow only built-in presets in piece YAML, keep local config behavior unchanged
- Stronger option: remove arbitrary script paths from runtime preparation entirely

## Testing
- `npm test -- --run src/__tests__/models.test.ts src/__tests__/provider-options-piece-parser.test.ts src/__tests__/normalizeRuntime.test.ts src/__tests__/runtime-environment.test.ts`

## Tag

- #10_Untrusted piece runtime.prepare enables arbitrary script execution.txt