### PR TITLE
fix: gate piece stdio MCP servers by config

### DIFF
--- a/src/__tests__/it-piece-loader.test.ts
+++ b/src/__tests__/it-piece-loader.test.ts
@@ -588,6 +588,40 @@ movements:
     expect(() => loadPiece('with-mcp', testDir)).toThrow();
   });
 
+  it('should allow piece that defines remote mcp_servers by default', () => {
+    const piecesDir = join(testDir, '.takt', 'pieces');
+    mkdirSync(piecesDir, { recursive: true });
+
+    writeFileSync(join(piecesDir, 'remote-mcp.yaml'), `
+name: remote-mcp
+max_movements: 5
+initial_movement: test
+
+movements:
+  - name: test
+    persona: coder
+    mcp_servers:
+      remote-api:
+        type: http
+        url: http://localhost:3000/mcp
+    rules:
+      - condition: Done
+        next: COMPLETE
+    instruction: "Run tests"
+`);
+
+    const config = loadPiece('remote-mcp', testDir);
+
+    expect(config).not.toBeNull();
+    const testStep = config!.movements.find((s) => s.name === 'test');
+    expect(testStep?.mcpServers).toEqual({
+      'remote-api': {
+        type: 'http',
+        url: 'http://localhost:3000/mcp',
+      },
+    });
+  });
+
   it('should allow movement without mcp_servers', () => {
     const piecesDir = join(testDir, '.takt', 'pieces');
     mkdirSync(piecesDir, { recursive: true });
@@ -644,6 +678,47 @@ movements:
 `);
 
     expect(() => loadPiece('multi-mcp', testDir)).toThrow();
+  });
+
+  it('should allow stdio mcp_servers when explicitly enabled in project config', () => {
+    const configDir = join(testDir, '.takt');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.yaml'), [
+      'piece_mcp_servers:',
+      '  stdio: true',
+    ].join('\n'));
+
+    const piecesDir = join(testDir, '.takt', 'pieces');
+    mkdirSync(piecesDir, { recursive: true });
+
+    writeFileSync(join(piecesDir, 'with-mcp.yaml'), `
+name: with-mcp
+max_movements: 5
+initial_movement: e2e-test
+
+movements:
+  - name: e2e-test
+    persona: coder
+    mcp_servers:
+      playwright:
+        command: npx
+        args: ["-y", "@anthropic-ai/mcp-server-playwright"]
+    rules:
+      - condition: Done
+        next: COMPLETE
+    instruction: "Run E2E tests"
+`);
+
+    const config = loadPiece('with-mcp', testDir);
+
+    expect(config).not.toBeNull();
+    const e2eStep = config!.movements.find((s) => s.name === 'e2e-test');
+    expect(e2eStep?.mcpServers).toEqual({
+      playwright: {
+        command: 'npx',
+        args: ['-y', '@anthropic-ai/mcp-server-playwright'],
+      },
+    });
   });
 });
 

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -348,7 +348,7 @@ describe('PieceConfigRawSchema', () => {
     expect(() => PieceConfigRawSchema.parse(config)).toThrow();
   });
 
-  it('should reject movement with stdio mcp_servers', () => {
+  it('should parse movement with stdio mcp_servers', () => {
     const config = {
       name: 'test-piece',
       movements: [
@@ -371,10 +371,16 @@ describe('PieceConfigRawSchema', () => {
       ],
     };
 
-    expect(() => PieceConfigRawSchema.parse(config)).toThrow();
+    const result = PieceConfigRawSchema.parse(config);
+    expect(result.movements![0]?.mcp_servers).toEqual({
+      playwright: {
+        command: 'npx',
+        args: ['-y', '@anthropic-ai/mcp-server-playwright'],
+      },
+    });
   });
 
-  it('should reject movement with sse mcp_servers', () => {
+  it('should parse movement with sse mcp_servers', () => {
     const config = {
       name: 'test-piece',
       movements: [
@@ -393,10 +399,17 @@ describe('PieceConfigRawSchema', () => {
       ],
     };
 
-    expect(() => PieceConfigRawSchema.parse(config)).toThrow();
+    const result = PieceConfigRawSchema.parse(config);
+    expect(result.movements![0]?.mcp_servers).toEqual({
+      remote: {
+        type: 'sse',
+        url: 'http://localhost:8080/sse',
+        headers: { Authorization: 'Bearer token' },
+      },
+    });
   });
 
-  it('should reject movement with http mcp_servers', () => {
+  it('should parse movement with http mcp_servers', () => {
     const config = {
       name: 'test-piece',
       movements: [
@@ -414,7 +427,13 @@ describe('PieceConfigRawSchema', () => {
       ],
     };
 
-    expect(() => PieceConfigRawSchema.parse(config)).toThrow();
+    const result = PieceConfigRawSchema.parse(config);
+    expect(result.movements![0]?.mcp_servers).toEqual({
+      api: {
+        type: 'http',
+        url: 'http://localhost:3000/mcp',
+      },
+    });
   });
 
   it('should allow omitting mcp_servers', () => {
@@ -467,6 +486,23 @@ describe('PieceConfigRawSchema', () => {
     };
 
     expect(() => PieceConfigRawSchema.parse(config)).toThrow();
+  });
+
+  it('should accept piece_mcp_servers config in project/global schemas', () => {
+    const project = ProjectConfigSchema.parse({
+      piece_mcp_servers: {
+        stdio: true,
+        sse: false,
+      },
+    });
+    const global = GlobalConfigSchema.parse({
+      piece_mcp_servers: {
+        http: false,
+      },
+    });
+
+    expect(project.piece_mcp_servers).toEqual({ stdio: true, sse: false });
+    expect(global.piece_mcp_servers).toEqual({ http: false });
   });
 
   it('should reject movement-level allowed_tools', () => {

--- a/src/core/models/config-types.ts
+++ b/src/core/models/config-types.ts
@@ -82,6 +82,16 @@ export interface PipelineConfig {
   prBodyTemplate?: string;
 }
 
+/** Piece-level MCP transport policy */
+export interface PieceMcpServersConfig {
+  /** Allow stdio MCP servers from piece YAML (default: false) */
+  stdio?: boolean;
+  /** Allow SSE MCP servers from piece YAML (default: true) */
+  sse?: boolean;
+  /** Allow HTTP MCP servers from piece YAML (default: true) */
+  http?: boolean;
+}
+
 /** Notification sound toggles per event timing */
 export interface NotificationSoundEventsConfig {
   /** Warning when iteration limit is reached */
@@ -142,6 +152,8 @@ export interface ProjectConfig {
   pieceOverrides?: PieceOverrides;
   /** Runtime environment configuration (project-level override) */
   runtime?: PieceRuntimeConfig;
+  /** Piece-level MCP transport policy */
+  pieceMcpServers?: PieceMcpServersConfig;
 }
 
 /**

--- a/src/core/models/mcp-schemas.ts
+++ b/src/core/models/mcp-schemas.ts
@@ -36,5 +36,12 @@ export const McpServerConfigSchema = z.union([
   McpHttpServerSchema,
 ]);
 
+/** Piece-level MCP server configuration (remote transports only) */
+export const PieceMcpServerConfigSchema = z.union([
+  McpSseServerSchema,
+  McpHttpServerSchema,
+]);
+
 /** MCP servers map: server name → config */
 export const McpServersSchema = z.record(z.string(), McpServerConfigSchema).optional();
+export const PieceMcpServersSchema = z.record(z.string(), PieceMcpServerConfigSchema).optional();

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -6,10 +6,11 @@
 
 import { z } from 'zod/v4';
 import { DEFAULT_LANGUAGE } from '../../shared/constants.js';
+import { McpServersSchema } from './mcp-schemas.js';
 import { INTERACTIVE_MODES } from './interactive-mode.js';
 import { STATUS_VALUES } from './status.js';
 
-export { McpServerConfigSchema, McpServersSchema } from './mcp-schemas.js';
+export { McpServerConfigSchema, McpServersSchema, PieceMcpServerConfigSchema, PieceMcpServersSchema } from './mcp-schemas.js';
 
 /** Agent model schema (opus, sonnet, haiku) */
 export const AgentModelSchema = z.enum(['opus', 'sonnet', 'haiku']).default('sonnet');
@@ -297,7 +298,7 @@ export const ParallelSubMovementRawSchema = z.object({
   /** Knowledge reference(s) — key name(s) from piece-level knowledge map */
   knowledge: z.union([z.string(), z.array(z.string())]).optional(),
   allowed_tools: z.never().optional(),
-  mcp_servers: z.never().optional(),
+  mcp_servers: McpServersSchema,
   provider: ProviderReferenceSchema.optional(),
   model: z.string().optional(),
   /** Deprecated alias */
@@ -330,7 +331,7 @@ export const PieceMovementRawSchema = z.object({
   /** Knowledge reference(s) — key name(s) from piece-level knowledge map */
   knowledge: z.union([z.string(), z.array(z.string())]).optional(),
   allowed_tools: z.never().optional(),
-  mcp_servers: z.never().optional(),
+  mcp_servers: McpServersSchema,
   provider: ProviderReferenceSchema.optional(),
   model: z.string().optional(),
   /** Deprecated alias */
@@ -480,6 +481,13 @@ export const PipelineConfigSchema = z.object({
   pr_body_template: z.string().optional(),
 }).strict();
 
+/** Piece-level MCP transport policy schema */
+export const PieceMcpServersConfigSchema = z.object({
+  stdio: z.boolean().optional(),
+  sse: z.boolean().optional(),
+  http: z.boolean().optional(),
+}).strict().optional();
+
 /** Piece category config schema (recursive) */
 export type PieceCategoryConfigNode = {
   pieces?: string[];
@@ -515,6 +523,8 @@ export const ProjectConfigSchema = z.object({
   provider_profiles: ProviderPermissionProfilesSchema,
   /** Project-level runtime environment configuration */
   runtime: RuntimeConfigSchema,
+  /** Piece-level MCP transport policy */
+  piece_mcp_servers: PieceMcpServersConfigSchema,
   /** Number of tasks to run concurrently in takt run (default from global: 1, max: 10) */
   concurrency: z.number().int().min(1).max(10).optional(),
   /** Polling interval in ms for picking up new tasks during takt run (default: 500, range: 100-5000) */

--- a/src/infra/config/env/config-env-overrides.ts
+++ b/src/infra/config/env/config-env-overrides.ts
@@ -139,6 +139,10 @@ const GLOBAL_ENV_SPECS: readonly EnvSpec[] = [
   { path: 'provider_profiles', type: 'json' },
   { path: 'runtime', type: 'json' },
   { path: 'runtime.prepare', type: 'json' },
+  { path: 'piece_mcp_servers', type: 'json' },
+  { path: 'piece_mcp_servers.stdio', type: 'boolean' },
+  { path: 'piece_mcp_servers.sse', type: 'boolean' },
+  { path: 'piece_mcp_servers.http', type: 'boolean' },
   { path: 'prevent_sleep', type: 'boolean' },
   { path: 'notification_sound', type: 'boolean' },
   { path: 'notification_sound_events', type: 'json' },
@@ -174,6 +178,10 @@ const PROJECT_ENV_SPECS: readonly EnvSpec[] = [
   { path: 'provider_options.claude.sandbox.allow_unsandboxed_commands', type: 'boolean' },
   { path: 'provider_options.claude.sandbox.excluded_commands', type: 'json' },
   { path: 'provider_profiles', type: 'json' },
+  { path: 'piece_mcp_servers', type: 'json' },
+  { path: 'piece_mcp_servers.stdio', type: 'boolean' },
+  { path: 'piece_mcp_servers.sse', type: 'boolean' },
+  { path: 'piece_mcp_servers.http', type: 'boolean' },
   { path: 'base_branch', type: 'string' },
 ];
 

--- a/src/infra/config/global/globalConfigCore.ts
+++ b/src/infra/config/global/globalConfigCore.ts
@@ -123,6 +123,7 @@ export class GlobalConfigManager {
       providerOptions: normalizedProvider.providerOptions,
       providerProfiles: normalizeProviderProfiles(parsed.provider_profiles as Record<string, { default_permission_mode: unknown; movement_permission_overrides?: Record<string, unknown> }> | undefined),
       runtime: normalizeRuntime(parsed.runtime),
+      pieceMcpServers: parsed.piece_mcp_servers as GlobalConfig['pieceMcpServers'],
       preventSleep: parsed.prevent_sleep,
       notificationSound: parsed.notification_sound,
       notificationSoundEvents: parsed.notification_sound_events ? {

--- a/src/infra/config/global/globalConfigSerializer.ts
+++ b/src/infra/config/global/globalConfigSerializer.ts
@@ -116,6 +116,9 @@ export function serializeGlobalConfig(config: GlobalConfig): Record<string, unkn
       prepare: [...new Set(config.runtime.prepare)],
     };
   }
+  if (config.pieceMcpServers && Object.keys(config.pieceMcpServers).length > 0) {
+    raw.piece_mcp_servers = config.pieceMcpServers;
+  }
   if (config.preventSleep !== undefined) {
     raw.prevent_sleep = config.preventSleep;
   }

--- a/src/infra/config/loaders/pieceParser.ts
+++ b/src/infra/config/loaders/pieceParser.ts
@@ -27,7 +27,7 @@ import {
 type RawStep = z.output<typeof PieceMovementRawSchema>;
 import type { MovementProviderOptions } from '../../../core/models/piece-types.js';
 import { normalizeRuntime } from '../configNormalizers.js';
-import type { PieceOverrides } from '../../../core/models/config-types.js';
+import type { PieceMcpServersConfig, PieceOverrides } from '../../../core/models/config-types.js';
 import { applyQualityGateOverrides } from './qualityGateOverrides.js';
 import { loadProjectConfig } from '../project/projectConfig.js';
 import { loadGlobalConfig } from '../global/globalConfig.js';
@@ -241,6 +241,7 @@ function normalizeStepFromRaw(
   context?: FacetResolutionContext,
   projectOverrides?: PieceOverrides,
   globalOverrides?: PieceOverrides,
+  pieceMcpServersPolicy?: PieceMcpServersConfig,
 ): PieceMovement {
   const rules: PieceRule[] | undefined = step.rules?.map(normalizeRule);
 
@@ -278,6 +279,8 @@ function normalizeStepFromRaw(
   const expandedLegacyInstruction = step.instruction_template
     ? resolveRefToContent(step.instruction_template, sections.resolvedInstructions, pieceDir, 'instructions', context)
     : undefined;
+
+  validatePieceMcpServers(step.name, step.mcp_servers, pieceMcpServersPolicy);
 
   const result: PieceMovement = {
     name: step.name,
@@ -320,6 +323,7 @@ function normalizeStepFromRaw(
         context,
         projectOverrides,
         globalOverrides,
+        pieceMcpServersPolicy,
       ),
     );
   }
@@ -379,6 +383,34 @@ function normalizeLoopMonitors(
   }));
 }
 
+function isPieceMcpTransportAllowed(
+  serverConfig: NonNullable<PieceMovement['mcpServers']>[string],
+  policy: PieceMcpServersConfig | undefined,
+): boolean {
+  const transport = serverConfig.type ?? 'stdio';
+  if (transport === 'stdio') return policy?.stdio ?? false;
+  if (transport === 'sse') return policy?.sse ?? true;
+  if (transport === 'http') return policy?.http ?? true;
+  return false;
+}
+
+function validatePieceMcpServers(
+  movementName: string,
+  mcpServers: PieceMovement['mcpServers'] | undefined,
+  policy: PieceMcpServersConfig | undefined,
+): void {
+  if (!mcpServers) return;
+  for (const [serverName, serverConfig] of Object.entries(mcpServers)) {
+    if (!isPieceMcpTransportAllowed(serverConfig, policy)) {
+      const transport = serverConfig.type ?? 'stdio';
+      throw new Error(
+        `Movement "${movementName}" uses mcp_servers.${serverName} with disallowed transport "${transport}". ` +
+        'Configure piece_mcp_servers in project/global config to allow it.'
+      );
+    }
+  }
+}
+
 /** Convert raw YAML piece config to internal format. */
 export function normalizePieceConfig(
   raw: unknown,
@@ -386,6 +418,7 @@ export function normalizePieceConfig(
   context?: FacetResolutionContext,
   projectOverrides?: PieceOverrides,
   globalOverrides?: PieceOverrides,
+  pieceMcpServersPolicy?: PieceMcpServersConfig,
 ): PieceConfig {
   const parsed = PieceConfigRawSchema.parse(raw);
 
@@ -413,7 +446,18 @@ export function normalizePieceConfig(
   const pieceRuntime = normalizeRuntime(parsed.piece_config?.runtime);
 
   const movements: PieceMovement[] = parsed.movements.map((step) =>
-    normalizeStepFromRaw(step, pieceDir, sections, pieceProvider, pieceModel, pieceProviderOptions, context, projectOverrides, globalOverrides),
+    normalizeStepFromRaw(
+      step,
+      pieceDir,
+      sections,
+      pieceProvider,
+      pieceModel,
+      pieceProviderOptions,
+      context,
+      projectOverrides,
+      globalOverrides,
+      pieceMcpServersPolicy,
+    ),
   );
 
   // Schema guarantees movements.min(1)
@@ -463,6 +507,7 @@ export function loadPieceFromFile(filePath: string, projectDir: string): PieceCo
   const globalConfig = loadGlobalConfig();
   const projectOverrides = projectConfig.pieceOverrides;
   const globalOverrides = globalConfig.pieceOverrides;
+  const pieceMcpServersPolicy = projectConfig.pieceMcpServers ?? globalConfig.pieceMcpServers;
 
-  return normalizePieceConfig(raw, pieceDir, context, projectOverrides, globalOverrides);
+  return normalizePieceConfig(raw, pieceDir, context, projectOverrides, globalOverrides, pieceMcpServersPolicy);
 }

--- a/src/infra/config/project/projectConfig.ts
+++ b/src/infra/config/project/projectConfig.ts
@@ -90,6 +90,7 @@ export function loadProjectConfig(projectDir: string): ProjectConfig {
     interactive_preview_movements,
     piece_overrides,
     runtime,
+    piece_mcp_servers,
   } = parsedConfig;
   const normalizedProvider = normalizeConfigProviderReference(
     provider as RawProviderReference,
@@ -140,6 +141,7 @@ export function loadProjectConfig(projectDir: string): ProjectConfig {
       } | undefined
     ),
     runtime: normalizeRuntime(runtime),
+    pieceMcpServers: piece_mcp_servers as ProjectConfig['pieceMcpServers'],
   };
 }
 
@@ -242,6 +244,12 @@ export function saveProjectConfig(projectDir: string, config: ProjectConfig): vo
     savePayload.runtime = normalizedRuntime;
   } else {
     delete savePayload.runtime;
+  }
+
+  if (config.pieceMcpServers && Object.keys(config.pieceMcpServers).length > 0) {
+    savePayload.piece_mcp_servers = config.pieceMcpServers;
+  } else {
+    delete savePayload.piece_mcp_servers;
   }
 
   const content = stringify(savePayload, { indent: 2 });


### PR DESCRIPTION
**The response policy for this will vary depending on takt's anomaly model. Such considerations may not be necessary if a user with appropriate permissions executes the command.**

## Summary
- keep piece-level remote MCP servers (`http`, `sse`) enabled by default
- disable piece-level `stdio` MCP servers by default because they can spawn local commands
- add `piece_mcp_servers` config so project/global config can explicitly allow or deny `stdio`, `http`, and `sse`
- enforce the policy in the piece loader so raw YAML remains parseable but execution-facing loading applies the transport gate

## Why this draft exists
This is a middle-ground security proposal for piece-level MCP configuration.

The original concern is valid: `mcp_servers` in piece YAML can reach the SDK and, for `stdio`, that means spawning arbitrary local commands. That is a very different risk level from remote `http`/`sse` transports. At the same time, banning all piece-level MCP configuration is probably too strong if pieces are expected to use remote MCP servers as integration points.

## Why this middle ground may be the right boundary
This draft separates the transports by actual risk:
- `stdio` can spawn local processes, so it is disabled by default for piece YAML
- `http` and `sse` connect to remote MCP endpoints, so they remain enabled by default

If an operator really wants to allow piece-level `stdio`, they can opt in explicitly in project/global config:

```yaml
piece_mcp_servers:
  stdio: true
```

The same config can also disable `http` or `sse` if a deployment wants a stricter policy.

## What can go wrong without this fix
Without this change, an untrusted or insufficiently reviewed piece can use `mcp_servers` with `stdio` transport to launch arbitrary local commands under the operator account. That bypasses the mental model many users will have from `permission_mode` or `allowed_tools`, because the process is started as MCP infrastructure rather than as an ordinary Bash tool call.

## Defaults in this draft
- `stdio`: default `false`
- `http`: default `true`
- `sse`: default `true`

## Testing
- `npm run build`
- `npm test -- --run src/__tests__/models.test.ts src/__tests__/it-piece-loader.test.ts src/__tests__/projectConfig.test.ts src/__tests__/globalConfig-defaults.test.ts src/__tests__/permission-mode.test.ts`

## Tag
- #14_Untrusted pieces can launch arbitrary MCP server commands.txt