### PR TITLE
[#526] fix-autocommit-pr-failed

### DIFF
--- a/src/__tests__/autoCommit.test.ts
+++ b/src/__tests__/autoCommit.test.ts
@@ -15,6 +15,20 @@ vi.mock('../infra/config/index.js', () => ({
   resolveConfigValue: (...args: unknown[]) => mockResolveConfigValue(...args),
 }));
 
+const { mockLogInfo, mockLogError } = vi.hoisted(() => ({
+  mockLogInfo: vi.fn(),
+  mockLogError: vi.fn(),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({
+    info: (...args: unknown[]) => mockLogInfo(...args),
+    error: (...args: unknown[]) => mockLogError(...args),
+    debug: vi.fn(),
+  }),
+}));
+
 import { execFileSync } from 'node:child_process';
 const mockExecFileSync = vi.mocked(execFileSync);
 
@@ -143,6 +157,54 @@ describe('autoCommitAndPush', () => {
     expect(result.message).toContain('not a git repository');
   });
 
+  it('should keep commitHash when push to projectDir fails after commit creation', () => {
+    // Given: commit creation succeeds, but the local push back to projectDir fails.
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (includesCommand(argsArr, 'status')) {
+        return 'M src/index.ts\n';
+      }
+      if (includesCommand(argsArr, 'rev-parse')) {
+        return 'abc1234\n';
+      }
+      if (includesCommand(argsArr, 'config')) {
+        return '';
+      }
+      if (includesCommand(argsArr, 'push')) {
+        throw new Error('refusing to update checked out branch');
+      }
+      return Buffer.from('');
+    });
+
+    // When: auto-commit runs in clone mode.
+    const result = autoCommitAndPush('/tmp/clone', 'my-task', '/project');
+
+    // Then: the created commit should still be reported so postExecution can continue.
+    expect(result.success).toBe(true);
+    expect(result.commitHash).toBe('abc1234');
+    expect(result.localPushFailed).toBe(true);
+    expect(result.message).toContain('abc1234');
+    expect(result.message).not.toContain('Auto-commit failed');
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['push', '/project', 'HEAD'],
+      expect.objectContaining({ cwd: '/tmp/clone' })
+    );
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      'Push to main repo failed after commit creation',
+      {
+        projectDir: '/project',
+        outcome: 'Push to main repo failed after commit creation.',
+      }
+    );
+    expect(mockLogInfo).not.toHaveBeenCalledWith(
+      'Push to main repo failed after commit creation',
+      expect.objectContaining({
+        error: expect.anything(),
+      })
+    );
+  });
+
   it('should not include co-author in commit message', () => {
     mockExecFileSync.mockImplementation((_cmd, args) => {
       const argsArr = args as string[];
@@ -229,5 +291,24 @@ describe('autoCommitAndPush', () => {
     expect(
       mockExecFileSync.mock.calls.some(call => includesCommand(call[1] as string[], 'config'))
     ).toBe(false);
+  });
+
+  it('should not pass raw git errors to logger data when auto-commit fails', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('fatal: could not read Password for https://token@example.com/org/repo from /tmp/project');
+    });
+
+    const result = autoCommitAndPush('/tmp/clone', 'my-task', '/project');
+
+    expect(result.success).toBe(false);
+    expect(mockLogError).toHaveBeenCalledWith('Auto-commit failed', {
+      outcome: 'Auto-commit failed.',
+    });
+    expect(mockLogError).not.toHaveBeenCalledWith(
+      'Auto-commit failed',
+      expect.objectContaining({
+        error: expect.anything(),
+      })
+    );
   });
 });

--- a/src/__tests__/postExecution.test.ts
+++ b/src/__tests__/postExecution.test.ts
@@ -6,10 +6,10 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockAutoCommitAndPush, mockPushBranch, mockFindExistingPr, mockCommentOnPr, mockCreatePullRequest, mockBuildPrBody, mockCreatePullRequestSafely } =
+const { mockAutoCommitAndPush, mockPushHeadToOriginBranch, mockFindExistingPr, mockCommentOnPr, mockCreatePullRequest, mockBuildPrBody, mockCreatePullRequestSafely } =
   vi.hoisted(() => ({
     mockAutoCommitAndPush: vi.fn(),
-    mockPushBranch: vi.fn(),
+    mockPushHeadToOriginBranch: vi.fn(),
     mockFindExistingPr: vi.fn(),
     mockCommentOnPr: vi.fn(),
     mockCreatePullRequest: vi.fn(),
@@ -19,7 +19,10 @@ const { mockAutoCommitAndPush, mockPushBranch, mockFindExistingPr, mockCommentOn
 
 vi.mock('../infra/task/index.js', () => ({
   autoCommitAndPush: (...args: unknown[]) => mockAutoCommitAndPush(...args),
-  pushBranch: (...args: unknown[]) => mockPushBranch(...args),
+}));
+
+vi.mock('../infra/task/git.js', () => ({
+  pushHeadToOriginBranch: (...args: unknown[]) => mockPushHeadToOriginBranch(...args),
 }));
 
 vi.mock('../infra/git/index.js', () => ({
@@ -64,7 +67,7 @@ describe('postExecutionFlow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAutoCommitAndPush.mockReturnValue({ success: true, commitHash: 'abc123' });
-    mockPushBranch.mockReturnValue(undefined);
+    mockPushHeadToOriginBranch.mockReturnValue(undefined);
     mockCommentOnPr.mockReturnValue({ success: true });
     mockCreatePullRequest.mockReturnValue({ success: true, url: 'https://github.com/org/repo/pull/1' });
     mockCreatePullRequestSafely.mockImplementation((provider, cwd, options) => {
@@ -150,8 +153,103 @@ describe('postExecutionFlow', () => {
     const result = await postExecutionFlow(baseOptions);
 
     expect(result.prFailed).toBe(true);
-    expect(result.prError).toBe('Base ref must be a branch');
+    expect(result.prError).toBe('Failed to create pull request.');
     expect(result.prUrl).toBeUndefined();
+  });
+
+  it('ローカルpush失敗後も commitHash があれば PR 作成失敗を prFailed として返す', async () => {
+    // Given: autoCommit keeps the commitHash even though its local push already failed.
+    mockAutoCommitAndPush.mockReturnValue({
+      success: true,
+      commitHash: 'abc123',
+      message: 'Committed locally; local push failed',
+    });
+    mockFindExistingPr.mockReturnValue(undefined);
+    mockCreatePullRequest.mockReturnValue({ success: false, error: 'Base ref must be a branch' });
+
+    // When: post-execution continues with origin push and PR creation.
+    const result = await postExecutionFlow(baseOptions);
+
+    // Then: the workflow should continue into the existing pr_failed path.
+    expect(mockPushHeadToOriginBranch).toHaveBeenCalledWith('/clone', 'task/fix-the-bug');
+    expect(mockCreatePullRequest).toHaveBeenCalledWith(
+      '/project',
+      expect.objectContaining({
+        branch: 'task/fix-the-bug',
+        base: 'main',
+        draft: false,
+        title: 'Fix the bug',
+      }),
+    );
+    expect(result.prFailed).toBe(true);
+    expect(result.prError).toBe('Failed to create pull request.');
+  });
+
+  it('origin への push 失敗時は PR 処理へ進まず prFailed: true を返す', async () => {
+    mockPushHeadToOriginBranch.mockImplementation(() => {
+      throw new Error('fatal: could not read Password for https://example.com/repo.git');
+    });
+
+    const result = await postExecutionFlow(baseOptions);
+
+    expect(mockPushHeadToOriginBranch).toHaveBeenCalledWith('/clone', 'task/fix-the-bug');
+    expect(mockFindExistingPr).not.toHaveBeenCalled();
+    expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    expect(result.prFailed).toBe(true);
+    expect(result.prError).toBe('Failed to push branch to origin.');
+  });
+
+  it('auto-commit 失敗時は通常失敗を返し、PR 処理へ進まない', async () => {
+    mockAutoCommitAndPush.mockReturnValue({
+      success: false,
+      message: 'Auto-commit failed: fatal: refusing to update checked out branch /tmp/project',
+    });
+
+    const result = await postExecutionFlow(baseOptions);
+
+    expect(mockPushHeadToOriginBranch).not.toHaveBeenCalled();
+    expect(mockFindExistingPr).not.toHaveBeenCalled();
+    expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    expect(result.prFailed).toBeUndefined();
+    expect(result.prError).toBeUndefined();
+    expect(result.taskFailed).toBe(true);
+    expect(result.taskError).toBe('Auto-commit failed before PR creation.');
+  });
+
+  it('shouldCreatePr が false かつ auto-commit 失敗時は pr_failed を返さない', async () => {
+    mockAutoCommitAndPush.mockReturnValue({
+      success: false,
+      message: 'Auto-commit failed: fatal: refusing to update checked out branch /tmp/project',
+    });
+
+    const result = await postExecutionFlow({ ...baseOptions, shouldCreatePr: false });
+
+    expect(mockPushHeadToOriginBranch).not.toHaveBeenCalled();
+    expect(mockFindExistingPr).not.toHaveBeenCalled();
+    expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    expect(result.prFailed).toBeUndefined();
+    expect(result.prError).toBeUndefined();
+    expect(result.taskFailed).toBe(true);
+    expect(result.taskError).toBe('Auto-commit failed before PR creation.');
+  });
+
+  it('shouldCreatePr が false かつローカル push 失敗時は completed にせず通常失敗を返す', async () => {
+    mockAutoCommitAndPush.mockReturnValue({
+      success: true,
+      commitHash: 'abc123',
+      localPushFailed: true,
+      message: 'Committed: abc123 - takt: Fix the bug',
+    });
+
+    const result = await postExecutionFlow({ ...baseOptions, shouldCreatePr: false });
+
+    expect(mockPushHeadToOriginBranch).not.toHaveBeenCalled();
+    expect(mockFindExistingPr).not.toHaveBeenCalled();
+    expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    expect(result.prFailed).toBeUndefined();
+    expect(result.prError).toBeUndefined();
+    expect(result.taskFailed).toBe(true);
+    expect(result.taskError).toBe('Push to main repo failed after commit creation.');
   });
 
   it('createPullRequest が例外を投げた場合も prFailed: true を返す', async () => {
@@ -163,7 +261,7 @@ describe('postExecutionFlow', () => {
     const result = await postExecutionFlow(baseOptions);
 
     expect(result.prFailed).toBe(true);
-    expect(result.prError).toBe('--repo is not supported with GitLab provider. Use cwd context instead.');
+    expect(result.prError).toBe('Failed to create pull request.');
     expect(result.prUrl).toBeUndefined();
   });
 
@@ -174,8 +272,21 @@ describe('postExecutionFlow', () => {
     const result = await postExecutionFlow(baseOptions);
 
     expect(result.prFailed).toBe(true);
-    expect(result.prError).toBe('Permission denied');
+    expect(result.prError).toBe('Failed to update pull request comment.');
     expect(result.prUrl).toBeUndefined();
+  });
+
+  it('PRプロバイダーの詳細エラーは UI 用 prError に露出しない', async () => {
+    mockFindExistingPr.mockReturnValue({ number: 42, url: 'https://github.com/org/repo/pull/42' });
+    mockCommentOnPr.mockReturnValue({
+      success: false,
+      error: 'fatal: could not read Password for https://token@example.com/org/repo from /tmp/project',
+    });
+
+    const result = await postExecutionFlow(baseOptions);
+
+    expect(result.prFailed).toBe(true);
+    expect(result.prError).toBe('Failed to update pull request comment.');
   });
 
   it('PR作成成功時は prFailed を返さない', async () => {

--- a/src/__tests__/taskExecution.test.ts
+++ b/src/__tests__/taskExecution.test.ts
@@ -5,13 +5,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { TaskInfo } from '../infra/task/index.js';
 
-const { mockResolveTaskExecution, mockExecutePiece, mockLoadPieceByIdentifier, mockResolvePieceConfigValues, mockResolveConfigValueWithSource, mockBuildTaskResult, mockPersistTaskResult, mockPersistPrFailedTaskResult, mockPersistTaskError, mockPostExecutionFlow } =
+const { mockResolveTaskExecution, mockExecutePiece, mockLoadPieceByIdentifier, mockResolvePieceConfigValues, mockResolveConfigValueWithSource, mockBuildBooleanTaskResult, mockBuildTaskResult, mockPersistTaskResult, mockPersistPrFailedTaskResult, mockPersistTaskError, mockPostExecutionFlow } =
   vi.hoisted(() => ({
     mockResolveTaskExecution: vi.fn(),
     mockExecutePiece: vi.fn(),
     mockLoadPieceByIdentifier: vi.fn(),
     mockResolvePieceConfigValues: vi.fn(),
     mockResolveConfigValueWithSource: vi.fn(),
+    mockBuildBooleanTaskResult: vi.fn(),
     mockBuildTaskResult: vi.fn(),
     mockPersistTaskResult: vi.fn(),
     mockPersistPrFailedTaskResult: vi.fn(),
@@ -29,6 +30,7 @@ vi.mock('../features/tasks/execute/pieceExecution.js', () => ({
 }));
 
 vi.mock('../features/tasks/execute/taskResultHandler.js', () => ({
+  buildBooleanTaskResult: (...args: unknown[]) => mockBuildBooleanTaskResult(...args),
   buildTaskResult: (...args: unknown[]) => mockBuildTaskResult(...args),
   persistTaskResult: (...args: unknown[]) => mockPersistTaskResult(...args),
   persistPrFailedTaskResult: (...args: unknown[]) => mockPersistPrFailedTaskResult(...args),
@@ -113,6 +115,7 @@ describe('executeAndCompleteTask', () => {
       },
       source: 'project',
     });
+    mockBuildBooleanTaskResult.mockReturnValue({ success: false });
     mockBuildTaskResult.mockReturnValue({ success: true });
     mockResolveTaskExecution.mockResolvedValue({
       execCwd: '/project',
@@ -286,5 +289,85 @@ describe('executeAndCompleteTask', () => {
         prUrl: 'https://github.com/org/repo/pull/1',
       }),
     );
+  });
+
+  it('should mark task as failed when postExecution returns a non-PR failure', async () => {
+    const task = createTask('task-with-autocommit-failure');
+    mockResolveTaskExecution.mockResolvedValue({
+      execCwd: '/worktree/clone',
+      execPiece: 'default',
+      isWorktree: true,
+      autoPr: false,
+      draftPr: false,
+      taskPrompt: undefined,
+      reportDirName: undefined,
+      branch: 'takt/task-with-autocommit-failure',
+      worktreePath: '/worktree/clone',
+      baseBranch: 'main',
+      startMovement: undefined,
+      retryNote: undefined,
+      issueNumber: undefined,
+    });
+    mockExecutePiece.mockResolvedValue({ success: true });
+    mockPostExecutionFlow.mockResolvedValue({
+      taskFailed: true,
+      taskError: 'Auto-commit failed before PR creation.',
+    });
+
+    const result = await executeAndCompleteTaskWithoutPiece(task, {} as never, '/project');
+
+    expect(result).toBe(false);
+    expect(mockBuildBooleanTaskResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task,
+        taskSuccess: false,
+        failureResponse: 'Auto-commit failed before PR creation.',
+        branch: 'takt/task-with-autocommit-failure',
+        worktreePath: '/worktree/clone',
+      }),
+    );
+    expect(mockPersistTaskResult).toHaveBeenCalledTimes(1);
+    expect(mockPersistPrFailedTaskResult).not.toHaveBeenCalled();
+    expect(mockBuildTaskResult).not.toHaveBeenCalled();
+  });
+
+  it('should mark task as failed when local push fails for a worktree task without PR creation', async () => {
+    const task = createTask('task-with-local-push-failure');
+    mockResolveTaskExecution.mockResolvedValue({
+      execCwd: '/worktree/clone',
+      execPiece: 'default',
+      isWorktree: true,
+      autoPr: false,
+      draftPr: false,
+      taskPrompt: undefined,
+      reportDirName: undefined,
+      branch: 'takt/task-with-local-push-failure',
+      worktreePath: '/worktree/clone',
+      baseBranch: 'main',
+      startMovement: undefined,
+      retryNote: undefined,
+      issueNumber: undefined,
+    });
+    mockExecutePiece.mockResolvedValue({ success: true });
+    mockPostExecutionFlow.mockResolvedValue({
+      taskFailed: true,
+      taskError: 'Push to main repo failed after commit creation.',
+    });
+
+    const result = await executeAndCompleteTaskWithoutPiece(task, {} as never, '/project');
+
+    expect(result).toBe(false);
+    expect(mockBuildBooleanTaskResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task,
+        taskSuccess: false,
+        failureResponse: 'Push to main repo failed after commit creation.',
+        branch: 'takt/task-with-local-push-failure',
+        worktreePath: '/worktree/clone',
+      }),
+    );
+    expect(mockPersistTaskResult).toHaveBeenCalledTimes(1);
+    expect(mockPersistPrFailedTaskResult).not.toHaveBeenCalled();
+    expect(mockBuildTaskResult).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/taskGit.test.ts
+++ b/src/__tests__/taskGit.test.ts
@@ -20,7 +20,7 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
 import { execFileSync } from 'node:child_process';
 const mockExecFileSync = vi.mocked(execFileSync);
 
-import { pushBranch } from '../infra/task/git.js';
+import { pushBranch, pushHeadToOriginBranch } from '../infra/task/git.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -51,6 +51,20 @@ describe('pushBranch', () => {
     // When / Then
     expect(() => pushBranch('/project', 'feature/my-branch')).toThrow(
       'error: failed to push some refs',
+    );
+  });
+});
+
+describe('pushHeadToOriginBranch', () => {
+  it('should call git push origin HEAD:refs/heads/<branch>', () => {
+    mockExecFileSync.mockReturnValue(Buffer.from(''));
+
+    pushHeadToOriginBranch('/clone', 'feature/my-branch');
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['push', 'origin', 'HEAD:refs/heads/feature/my-branch'],
+      { cwd: '/clone', stdio: 'pipe' },
     );
   });
 });

--- a/src/features/tasks/execute/postExecution.ts
+++ b/src/features/tasks/execute/postExecution.ts
@@ -5,13 +5,20 @@
  * instructBranch (takt list).
  */
 
-import { autoCommitAndPush, pushBranch } from '../../../infra/task/index.js';
+import { autoCommitAndPush } from '../../../infra/task/index.js';
+import { pushHeadToOriginBranch } from '../../../infra/task/git.js';
 import { info, error, success } from '../../../shared/ui/index.js';
 import { createLogger } from '../../../shared/utils/index.js';
 import { buildPrBody, createPullRequestSafely, getGitProvider } from '../../../infra/git/index.js';
 import type { Issue, CreatePrResult } from '../../../infra/git/index.js';
 
 const log = createLogger('postExecution');
+
+const AUTO_COMMIT_FAILURE_MESSAGE = 'Auto-commit failed before PR creation.';
+const LOCAL_PUSH_FAILURE_MESSAGE = 'Push to main repo failed after commit creation.';
+const BRANCH_PUSH_FAILURE_MESSAGE = 'Failed to push branch to origin.';
+const PR_COMMENT_FAILURE_MESSAGE = 'Failed to update pull request comment.';
+const PR_CREATION_FAILURE_MESSAGE = 'Failed to create pull request.';
 
 
 export interface PostExecutionOptions {
@@ -31,6 +38,8 @@ export interface PostExecutionResult {
   prUrl?: string;
   prFailed?: boolean;
   prError?: string;
+  taskFailed?: boolean;
+  taskError?: string;
 }
 
 /**
@@ -40,17 +49,35 @@ export async function postExecutionFlow(options: PostExecutionOptions): Promise<
   const { execCwd, projectCwd, task, branch, baseBranch, shouldCreatePr, draftPr, pieceIdentifier, issues, repo } = options;
 
   const commitResult = autoCommitAndPush(execCwd, task, projectCwd);
-  if (commitResult.success && commitResult.commitHash) {
-    success(`Auto-committed & pushed: ${commitResult.commitHash}`);
+  if (commitResult.commitHash) {
+    success(`Auto-committed: ${commitResult.commitHash}`);
   } else if (!commitResult.success) {
-    error(`Auto-commit failed: ${commitResult.message}`);
+    log.error('Auto-commit failed before PR handling', {
+      outcome: AUTO_COMMIT_FAILURE_MESSAGE,
+    });
+    error(AUTO_COMMIT_FAILURE_MESSAGE);
+    return { taskFailed: true, taskError: AUTO_COMMIT_FAILURE_MESSAGE };
   }
 
-  if (commitResult.success && commitResult.commitHash && branch && shouldCreatePr) {
+  if (commitResult.localPushFailed && !shouldCreatePr) {
+    log.error('Local push failed for task without PR creation', {
+      outcome: LOCAL_PUSH_FAILURE_MESSAGE,
+    });
+    error(LOCAL_PUSH_FAILURE_MESSAGE);
+    return { taskFailed: true, taskError: LOCAL_PUSH_FAILURE_MESSAGE };
+  }
+
+  if (commitResult.commitHash && branch && shouldCreatePr) {
     try {
-      pushBranch(projectCwd, branch);
+      pushHeadToOriginBranch(execCwd, branch);
     } catch (pushError) {
-      log.info('Branch push from project cwd failed (may already exist)', { error: pushError });
+      void pushError;
+      log.error('Branch push from execution cwd failed', {
+        branch,
+        outcome: BRANCH_PUSH_FAILURE_MESSAGE,
+      });
+      error(BRANCH_PUSH_FAILURE_MESSAGE);
+      return { prFailed: true, prError: BRANCH_PUSH_FAILURE_MESSAGE };
     }
     const gitProvider = getGitProvider();
     const report = pieceIdentifier ? `Piece \`${pieceIdentifier}\` completed successfully.` : 'Task completed successfully.';
@@ -63,8 +90,12 @@ export async function postExecutionFlow(options: PostExecutionOptions): Promise<
         success(`PR updated with comment: ${existingPr.url}`);
         return { prUrl: existingPr.url };
       } else {
-        error(`PR comment failed: ${commentResult.error}`);
-        return { prFailed: true, prError: commentResult.error };
+        log.error('PR comment failed', {
+          prNumber: existingPr.number,
+          outcome: PR_COMMENT_FAILURE_MESSAGE,
+        });
+        error(PR_COMMENT_FAILURE_MESSAGE);
+        return { prFailed: true, prError: PR_COMMENT_FAILURE_MESSAGE };
       }
     } else {
       info('Creating pull request...');
@@ -85,8 +116,13 @@ export async function postExecutionFlow(options: PostExecutionOptions): Promise<
         success(`PR created: ${prResult.url}`);
         return { prUrl: prResult.url };
       } else {
-        error(`PR creation failed: ${prResult.error}`);
-        return { prFailed: true, prError: prResult.error };
+        log.error('PR creation failed', {
+          branch,
+          baseBranch,
+          outcome: PR_CREATION_FAILURE_MESSAGE,
+        });
+        error(PR_CREATION_FAILURE_MESSAGE);
+        return { prFailed: true, prError: PR_CREATION_FAILURE_MESSAGE };
       }
     }
   }

--- a/src/features/tasks/execute/taskExecution.ts
+++ b/src/features/tasks/execute/taskExecution.ts
@@ -18,7 +18,7 @@ import type { TaskExecutionOptions, ExecuteTaskOptions, PieceExecutionResult } f
 import { runWithWorkerPool } from './parallelExecution.js';
 import { resolveTaskExecution, resolveTaskIssue } from './resolveTask.js';
 import { postExecutionFlow } from './postExecution.js';
-import { buildTaskResult, persistExceededTaskResult, persistTaskError, persistPrFailedTaskResult, persistTaskResult } from './taskResultHandler.js';
+import { buildBooleanTaskResult, buildTaskResult, persistExceededTaskResult, persistTaskError, persistPrFailedTaskResult, persistTaskResult } from './taskResultHandler.js';
 import { generateRunId, toSlackTaskDetail } from './slackSummaryAdapter.js';
 
 export type { TaskExecutionOptions, ExecuteTaskOptions };
@@ -182,6 +182,7 @@ export async function executeAndCompleteTask(
 
     let prUrl: string | undefined;
     let prFailedError: string | undefined;
+    let postExecutionTaskError: string | undefined;
     if (taskSuccess && isWorktree) {
       const issues = resolveTaskIssue(issueNumber);
       const postResult = await postExecutionFlow({
@@ -199,6 +200,24 @@ export async function executeAndCompleteTask(
       if (postResult.prFailed) {
         prFailedError = postResult.prError;
       }
+      if (postResult.taskFailed) {
+        postExecutionTaskError = postResult.taskError;
+      }
+    }
+
+    if (postExecutionTaskError !== undefined) {
+      const taskResult = buildBooleanTaskResult({
+        task,
+        taskSuccess: false,
+        startedAt,
+        completedAt,
+        successResponse: 'Task completed successfully',
+        failureResponse: postExecutionTaskError,
+        branch,
+        worktreePath,
+      });
+      persistTaskResult(taskRunner, taskResult);
+      return false;
     }
 
     const taskResult = buildTaskResult({

--- a/src/infra/task/autoCommit.ts
+++ b/src/infra/task/autoCommit.ts
@@ -13,12 +13,16 @@ import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
 import { stageAndCommit } from './git.js';
 
 const log = createLogger('autoCommit');
+const AUTO_COMMIT_PUSH_FAILURE_MESSAGE = 'Push to main repo failed after commit creation.';
+const AUTO_COMMIT_FAILURE_MESSAGE = 'Auto-commit failed.';
 
 export interface AutoCommitResult {
   /** Whether the commit was created successfully */
   success: boolean;
   /** The short commit hash (if committed) */
   commitHash?: string;
+  /** Whether the local push back to the main repo failed after commit creation */
+  localPushFailed?: boolean;
   /** Human-readable message */
   message: string;
 }
@@ -53,21 +57,35 @@ export class AutoCommitter {
 
       log.info('Auto-commit created', { commitHash, message: commitMessage });
 
-      execFileSync('git', ['push', projectDir, 'HEAD'], {
-        cwd: cloneCwd,
-        stdio: 'pipe',
-      });
+      try {
+        execFileSync('git', ['push', projectDir, 'HEAD'], {
+          cwd: cloneCwd,
+          stdio: 'pipe',
+        });
+        log.info('Pushed to main repo', { projectDir });
+      } catch (pushError) {
+        void pushError;
+        log.info('Push to main repo failed after commit creation', {
+          projectDir,
+          outcome: AUTO_COMMIT_PUSH_FAILURE_MESSAGE,
+        });
 
-      log.info('Pushed to main repo', { projectDir });
+        return {
+          success: true,
+          commitHash,
+          localPushFailed: true,
+          message: `Committed: ${commitHash} - ${commitMessage}`,
+        };
+      }
 
       return {
         success: true,
         commitHash,
-        message: `Committed & pushed: ${commitHash} - ${commitMessage}`,
+        message: `Committed: ${commitHash} - ${commitMessage}`,
       };
     } catch (err) {
       const errorMessage = getErrorMessage(err);
-      log.error('Auto-commit failed', { error: errorMessage });
+      log.error('Auto-commit failed', { outcome: AUTO_COMMIT_FAILURE_MESSAGE });
 
       return {
         success: false,

--- a/src/infra/task/git.ts
+++ b/src/infra/task/git.ts
@@ -122,3 +122,14 @@ export function pushBranch(cwd: string, branch: string): void {
     stdio: 'pipe',
   });
 }
+
+/**
+ * Pushes the current HEAD to the target origin branch. Throws on failure.
+ */
+export function pushHeadToOriginBranch(cwd: string, branch: string): void {
+  log.info('Pushing HEAD to origin branch', { branch });
+  execFileSync('git', ['push', 'origin', `HEAD:refs/heads/${branch}`], {
+    cwd,
+    stdio: 'pipe',
+  });
+}


### PR DESCRIPTION
## Summary

## 概要

`autoCommitAndPush` が失敗した場合（例：git worktreeロックによる push エラー）、タスクが `pr_failed` ではなく `completed` としてマークされる。その結果、originへのpushもPR作成も行われないまま、ユーザーに何も通知されない。

## 原因

`autoCommit.js` で `git push <projectDir> HEAD` が例外をスローすると、メソッドは `{ success: false }` を返す。

`postExecution.js` では PR作成ブロックが `commitResult.success && commitResult.commitHash` で制御されているため、`success: false` の場合はスキップされる：

```js
const commitResult = autoCommitAndPush(execCwd, task, projectCwd);

if (commitResult.success && commitResult.commitHash && branch && shouldCreatePr) {
    // origin への push と PR 作成 → success: false の場合はスキップ
}

return {}; // prFailed がセットされないまま返る
```

`prFailed` がセットされないため、`taskExecution.js` は `persistPrFailedTaskResult` ではなく `persistTaskResult`（`status: 'completed'`）を呼び出す。

## 再現シナリオ

1. ホストマシンでブランチ `feature-X` を git worktree としてチェックアウト
2. ホストと sandbox が同じ `.git/` ディレクトリを共有している（例：Docker bind mount）
3. sandbox 上で `takt` を実行し、`feature-X` ブランチを対象とするタスクを処理
4. takt がクローンを作成してコミットを作成
5. `git push <projectDir> HEAD` が失敗：`refusing to update checked out branch`
6. タスクは `completed` としてマークされる — push なし、PR なし、エラー表示なし

## 影響

- ユーザーには `[INFO] Task "..." completed` と表示されるが PR は作成されない
- 依存タスク（例：step-2 を base とする step-3）のPR作成が、step-2 が origin に push されていないために失敗する
- 失敗が完全にサイレント — `pr_failed` にならないため `takt list` からリトライもできない

## 期待される動作

auto-commit の push が失敗した場合、他の PR 作成失敗と同様に `pr_failed` としてマークされるべき。

## 修正案

`autoCommit.js` でコミット処理と push 処理を分離し、push 失敗時でも `commitHash` が返るようにする：

```js
const commitHash = stageAndCommit(cloneCwd, commitMessage, { ... });
if (!commitHash) {
    return { success: true, message: 'No changes to commit' };
}

try {
    execFileSync('git', ['push', projectDir, 'HEAD'], { cwd: cloneCwd, stdio: 'pipe' });
} catch (localPushErr) {
    log.warn('ローカルpushに失敗。postExecution経由でorigin pushを試みます', {
        error: getErrorMessage(localPushErr)
    });
}

return { success: true, commitHash, message: `...` };
```

これにより `postExecution.js` が origin への push と PR 作成を試み、それらが失敗した場合に正しく `pr_failed` をセットできる。

## バージョン

- takt: 0.32.1


## Execution Report

Piece `takt-default` completed successfully.

Closes #526