### PR TITLE
test: piece_arpeggio の env override / global config テスト追加

### DIFF
--- a/src/__tests__/config-env-overrides.test.ts
+++ b/src/__tests__/config-env-overrides.test.ts
@@ -133,6 +133,17 @@ describe('config env overrides', () => {
     });
   });
 
+  it('should apply TAKT_PIECE_ARPEGGIO_CUSTOM_MERGE_FILES override for global config', () => {
+    process.env.TAKT_PIECE_ARPEGGIO_CUSTOM_MERGE_FILES = 'true';
+
+    const raw: Record<string, unknown> = {};
+    applyGlobalConfigEnvOverrides(raw);
+
+    expect(raw.piece_arpeggio).toEqual({
+      custom_merge_files: true,
+    });
+  });
+
   it('should apply TAKT_PIECE_ARPEGGIO_CUSTOM_DATA_SOURCE_MODULES override for project config', () => {
     process.env.TAKT_PIECE_ARPEGGIO_CUSTOM_DATA_SOURCE_MODULES = 'false';
 

--- a/src/__tests__/globalConfig-defaults.test.ts
+++ b/src/__tests__/globalConfig-defaults.test.ts
@@ -915,12 +915,12 @@ describe('loadGlobalConfig', () => {
       writeFileSync(getGlobalConfigPath(), 'language: en\n', 'utf-8');
 
       const config = loadGlobalConfig();
-      config.pieceArpeggio = { customDataSourceModules: true, customMergeInlineJs: true };
+      config.pieceArpeggio = { customDataSourceModules: true, customMergeInlineJs: true, customMergeFiles: false };
       saveGlobalConfig(config);
       invalidateGlobalConfigCache();
 
       const reloaded = loadGlobalConfig();
-      expect(reloaded.pieceArpeggio).toEqual({ customDataSourceModules: true, customMergeInlineJs: true });
+      expect(reloaded.pieceArpeggio).toEqual({ customDataSourceModules: true, customMergeInlineJs: true, customMergeFiles: false });
     });
   });
 


### PR DESCRIPTION
## 概要
PR #521 (piece_arpeggio ポリシー) で不足していたテストカバレッジを追加。

- env override テスト (`TAKT_PIECE_ARPEGGIO` JSON / 個別 boolean、global / project)
- global config の load / save round-trip テスト

## 背景
PR #521 の Codex レビューで "non-blocking recommendation" として指摘されていた項目。
他の同種ポリシー (sync_conflict_resolver, piece_mcp_servers) では追加済みだが、
piece_arpeggio のみ漏れていた。

## テスト計画
- [x] `npx vitest run src/__tests__/config-env-overrides.test.ts` パス
- [x] `npx vitest run src/__tests__/globalConfig-defaults.test.ts` パス