### PR TITLE
fix: align dotgitignore facet paths with actual directory structure

### DIFF
--- a/builtins/project/dotgitignore
+++ b/builtins/project/dotgitignore
@@ -10,13 +10,14 @@
 # Facets and pieces (version-controlled)
 !pieces/
 !pieces/**
-!personas/
-!personas/**
-!policies/
-!policies/**
-!knowledge/
-!knowledge/**
-!instructions/
-!instructions/**
-!output-contracts/
-!output-contracts/**
+!facets/
+!facets/personas/
+!facets/personas/**
+!facets/policies/
+!facets/policies/**
+!facets/knowledge/
+!facets/knowledge/**
+!facets/instructions/
+!facets/instructions/**
+!facets/output-contracts/
+!facets/output-contracts/**

--- a/src/__tests__/it-dotgitignore.test.ts
+++ b/src/__tests__/it-dotgitignore.test.ts
@@ -11,6 +11,8 @@ import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
+import { getProjectPiecesDir, getProjectFacetDir } from '../infra/config/paths.js';
+import { VALID_FACET_TYPES, parseFacetType } from '../features/config/ejectBuiltin.js';
 
 function gitTrackedFiles(cwd: string): string[] {
   const output = execFileSync('git', ['ls-files', '.takt/'], { cwd, encoding: 'utf-8' });
@@ -56,23 +58,36 @@ describe('dotgitignore patterns', () => {
   });
 
   it('should track facet directories', () => {
-    const facets = ['pieces', 'personas', 'policies', 'knowledge', 'instructions', 'output-contracts'];
-    for (const facet of facets) {
-      mkdirSync(join(testDir, '.takt', facet), { recursive: true });
-      writeFileSync(join(testDir, '.takt', facet, 'test.md'), `# ${facet}`);
+    // pieces directory
+    const piecesDir = getProjectPiecesDir(testDir);
+    mkdirSync(piecesDir, { recursive: true });
+    writeFileSync(join(piecesDir, 'test.md'), '# pieces');
+
+    // facet type directories — derived from VALID_FACET_TYPES
+    for (const singular of VALID_FACET_TYPES) {
+      const facetType = parseFacetType(singular)!;
+      const facetDir = getProjectFacetDir(testDir, facetType);
+      mkdirSync(facetDir, { recursive: true });
+      writeFileSync(join(facetDir, 'test.md'), `# ${facetType}`);
     }
 
     execFileSync('git', ['add', '.takt/'], { cwd: testDir });
     const tracked = gitTrackedFiles(testDir);
 
-    for (const facet of facets) {
-      expect(tracked).toContain(`.takt/${facet}/test.md`);
+    // Assert pieces tracked
+    expect(tracked).toContain('.takt/pieces/test.md');
+
+    // Assert all facet types tracked
+    for (const singular of VALID_FACET_TYPES) {
+      const facetType = parseFacetType(singular)!;
+      expect(tracked).toContain(`.takt/facets/${facetType}/test.md`);
     }
   });
 
   it('should track nested files in facet directories', () => {
-    mkdirSync(join(testDir, '.takt', 'pieces', 'sub'), { recursive: true });
-    writeFileSync(join(testDir, '.takt', 'pieces', 'sub', 'nested.yaml'), 'name: test');
+    const subDir = join(getProjectPiecesDir(testDir), 'sub');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(join(subDir, 'nested.yaml'), 'name: test');
 
     execFileSync('git', ['add', '.takt/'], { cwd: testDir });
     const tracked = gitTrackedFiles(testDir);


### PR DESCRIPTION
## Summary

The `.takt/.gitignore` template listed facet types (personas, policies, etc.) without the `facets/` prefix, so files ejected to `.takt/facets/{type}/` were not tracked by git.

Add the `facets/` prefix to each allowlist entry and update the integration test to derive facet directories from `getProjectFacetDir` and `VALID_FACET_TYPES` instead of hardcoded values.

Closes #513

---

# Takt Review Summary

## Overall Verdict: APPROVE

## Summary
All five reviewers unanimously approved this change. The fix correctly aligns `.takt/.gitignore` facet path patterns with the actual directory structure (`.takt/facets/{type}/` instead of `.takt/{type}/`), and the tests now derive expected paths from canonical source-of-truth functions (`getProjectFacetDir`, `VALID_FACET_TYPES`), eliminating hardcoded values and preventing this class of bug from recurring.

## Review Results
| Review | Result | Key Findings |
|--------|--------|--------------|
| Architecture | APPROVE | Clean, well-scoped bugfix; tests derive from canonical source of truth |
| Security | APPROVE | No security concerns; tighter gitignore scoping improves data protection |
| QA | APPROVE | All 4 integration tests pass; `parseFacetType()!` non-null assertion safe in test context |
| Testing | APPROVE | Proper regression coverage; real git operations against isolated temp repos |
| Requirements | APPROVE | All 3 requirements satisfied; no scope creep detected |

## Current Iteration Findings (new)
_None_

## Carry-over Findings (persists)
_None_

## Resolved Findings (resolved)
_None_

## Improvement Suggestions
- None — the change is minimal, well-tested, and correctly scoped.

## Rejection Gate
- No findings exist in `new` or `persists`. APPROVE is valid.
