### PR TITLE
feat: add safety_baseline flag to prepend safety preamble to system prompts

### DIFF
--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -218,7 +218,10 @@ export class AgentRunner {
     // 1. If personaPath is provided (resolved file exists), load prompt from file
     //    and wrap it through the perform_agent_system_prompt template
     if (options.personaPath) {
-      const agentDefinition = AgentRunner.loadPersonaPromptFromPath(options.personaPath);
+      const rawAgentDefinition = AgentRunner.loadPersonaPromptFromPath(options.personaPath);
+      const agentDefinition = options.safetyBaseline
+        ? `You must not generate, produce, or assist with creation of malware, exploits, or harmful code.\n\n${rawAgentDefinition}`
+        : rawAgentDefinition;
       const language = options.language ?? 'en';
       const templateVars: Record<string, string> = { agentDefinition };
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -50,4 +50,9 @@ export interface RunAgentOptions {
     systemPrompt: string;
     userInstruction: string;
   }) => void;
+  /**
+   * When true, a 1-line safety constraint is prepended before the persona definition
+   * in the system prompt. Set from PieceConfig.safetyBaseline via PieceEngineOptions.
+   */
+  safetyBaseline?: boolean;
 }

--- a/src/core/models/piece-types.ts
+++ b/src/core/models/piece-types.ts
@@ -268,6 +268,11 @@ export interface PieceConfig {
   answerAgent?: string;
   /** Default interactive mode for this piece (overrides user default) */
   interactiveMode?: InteractiveMode;
+  /**
+   * When true, a 1-line safety constraint is prepended before the persona definition
+   * in every movement system prompt. Defaults to false so existing pieces are unaffected.
+   */
+  safetyBaseline?: boolean;
 }
 
 /** Runtime state of a piece execution */

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -423,6 +423,11 @@ export const PieceConfigRawSchema = z.object({
   answer_agent: z.string().optional(),
   /** Default interactive mode for this piece (overrides user default) */
   interactive_mode: InteractiveModeSchema.optional(),
+  /**
+   * When true, prepends a 1-line safety constraint before the persona definition
+   * in every movement system prompt. Defaults to false so existing pieces are unaffected.
+   */
+  safety_baseline: z.boolean().optional().default(false),
 });
 
 export const PersonaProviderEntrySchema = z.object({

--- a/src/core/piece/engine/OptionsBuilder.ts
+++ b/src/core/piece/engine/OptionsBuilder.ts
@@ -106,6 +106,7 @@ export class OptionsBuilder {
         movementsList: movements,
         currentPosition,
       },
+      safetyBaseline: this.engineOptions.safetyBaseline,
     };
   }
 

--- a/src/core/piece/engine/PieceEngine.ts
+++ b/src/core/piece/engine/PieceEngine.ts
@@ -81,7 +81,8 @@ export class PieceEngine extends EventEmitter {
     this.projectCwd = options.projectCwd;
     this.cwd = cwd;
     this.task = task;
-    this.options = options;
+    // Merge piece-level safetyBaseline into options so OptionsBuilder can propagate it
+    this.options = config.safetyBaseline ? { ...options, safetyBaseline: true } : options;
     this.loopDetector = new LoopDetector(config.loopDetection);
     this.cycleDetector = new CycleDetector(config.loopMonitors ?? []);
     if (options.reportDirName !== undefined && !isValidReportDirName(options.reportDirName)) {

--- a/src/core/piece/types.ts
+++ b/src/core/piece/types.ts
@@ -220,6 +220,11 @@ export interface PieceEngineOptions {
   taskColorIndex?: number;
   /** Initial iteration count (for resuming exceeded tasks) */
   initialIteration?: number;
+  /**
+   * When true, a 1-line safety constraint is prepended before the persona definition
+   * in every movement system prompt. Propagated from PieceConfig.safetyBaseline.
+   */
+  safetyBaseline?: boolean;
 }
 
 /** Loop detection result */

--- a/src/infra/config/loaders/pieceParser.ts
+++ b/src/infra/config/loaders/pieceParser.ts
@@ -435,6 +435,7 @@ export function normalizePieceConfig(
     loopMonitors: normalizeLoopMonitors(parsed.loop_monitors, pieceDir, sections, context),
     answerAgent: parsed.answer_agent,
     interactiveMode: parsed.interactive_mode,
+    safetyBaseline: parsed.safety_baseline ?? false,
   };
 }
 


### PR DESCRIPTION
## Summary
- Added `safety_baseline` boolean flag to TAKT piece YAML schema
- When enabled, prepends 1-2 line safety constraint before persona in system prompts
- Existing pieces without the flag retain current behavior (backward compatible)

## Issues
- Closes #ptyctl-8f7mh (bd: ptyctl-8f7mh)

## Test plan
- [ ] Piece with `safety_baseline: true` prepends safety constraint
- [ ] Piece without flag or `safety_baseline: false` unchanged
- [ ] Type checks pass (`tsc --noEmit`)

Generated with [Claude Code](https://claude.com/claude-code)