### PR TITLE
refactor: instruction_template の後方互換コードを削除

### DIFF
--- a/e2e/fixtures/pieces/mock-cycle-detect.yaml
+++ b/e2e/fixtures/pieces/mock-cycle-detect.yaml
@@ -23,7 +23,7 @@ loop_monitors:
 movements:
   - name: review
     persona: ../agents/test-reviewer-a.md
-    instruction_template: |
+    instruction: |
       Review the code.
     rules:
       - condition: approved
@@ -34,7 +34,7 @@ movements:
     persona: ../agents/test-coder.md
     edit: true
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       Fix the issues found in review.
     rules:
       - condition: fixed

--- a/e2e/fixtures/pieces/mock-max-iter.yaml
+++ b/e2e/fixtures/pieces/mock-max-iter.yaml
@@ -13,7 +13,7 @@ movements:
     edit: true
     persona: ../agents/test-coder.md
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: Done
@@ -22,7 +22,7 @@ movements:
     edit: true
     persona: ../agents/test-coder.md
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       Continue the task.
     rules:
       - condition: Done

--- a/e2e/fixtures/pieces/mock-no-match.yaml
+++ b/e2e/fixtures/pieces/mock-no-match.yaml
@@ -12,7 +12,7 @@ movements:
     edit: true
     persona: ../agents/test-coder.md
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: SpecificMatchThatWillNotOccur

--- a/e2e/fixtures/pieces/mock-single-step.yaml
+++ b/e2e/fixtures/pieces/mock-single-step.yaml
@@ -18,7 +18,7 @@ movements:
           - Write
           - Edit
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: Done

--- a/e2e/fixtures/pieces/mock-slow-multi-step.yaml
+++ b/e2e/fixtures/pieces/mock-slow-multi-step.yaml
@@ -12,7 +12,7 @@ movements:
   - name: step-1
     edit: true
     persona: ../agents/test-coder.md
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: Done
@@ -20,7 +20,7 @@ movements:
   - name: step-2
     edit: true
     persona: ../agents/test-coder.md
-    instruction_template: |
+    instruction: |
       Continue task execution.
     rules:
       - condition: Done
@@ -28,7 +28,7 @@ movements:
   - name: step-3
     edit: true
     persona: ../agents/test-coder.md
-    instruction_template: |
+    instruction: |
       Continue task execution.
     rules:
       - condition: Done
@@ -36,7 +36,7 @@ movements:
   - name: step-4
     edit: true
     persona: ../agents/test-coder.md
-    instruction_template: |
+    instruction: |
       Continue task execution.
     rules:
       - condition: Done
@@ -44,7 +44,7 @@ movements:
   - name: step-5
     edit: true
     persona: ../agents/test-coder.md
-    instruction_template: |
+    instruction: |
       Continue task execution.
     rules:
       - condition: Done
@@ -52,7 +52,7 @@ movements:
   - name: step-6
     edit: true
     persona: ../agents/test-coder.md
-    instruction_template: |
+    instruction: |
       Continue task execution.
     rules:
       - condition: Done
@@ -60,7 +60,7 @@ movements:
   - name: step-7
     edit: true
     persona: ../agents/test-coder.md
-    instruction_template: |
+    instruction: |
       Continue task execution.
     rules:
       - condition: Done
@@ -68,7 +68,7 @@ movements:
   - name: step-8
     edit: true
     persona: ../agents/test-coder.md
-    instruction_template: |
+    instruction: |
       Finalize task execution.
     rules:
       - condition: Done

--- a/e2e/fixtures/pieces/mock-two-step.yaml
+++ b/e2e/fixtures/pieces/mock-two-step.yaml
@@ -13,7 +13,7 @@ movements:
     edit: true
     persona: ../agents/test-coder.md
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: Done
@@ -22,7 +22,7 @@ movements:
     edit: true
     persona: ../agents/test-coder.md
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       Continue the task.
     rules:
       - condition: Done

--- a/e2e/fixtures/pieces/multi-step-parallel.yaml
+++ b/e2e/fixtures/pieces/multi-step-parallel.yaml
@@ -13,7 +13,7 @@ movements:
     persona: ../agents/test-coder.md
     edit: true
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       Create a plan for the task.
     rules:
       - condition: Plan complete
@@ -22,14 +22,14 @@ movements:
     parallel:
       - name: arch-review
         persona: ../agents/test-reviewer-a.md
-        instruction_template: |
+        instruction: |
           Review the architecture.
         rules:
           - condition: approved
           - condition: needs_fix
       - name: security-review
         persona: ../agents/test-reviewer-b.md
-        instruction_template: |
+        instruction: |
           Review security.
         rules:
           - condition: approved
@@ -43,7 +43,7 @@ movements:
     persona: ../agents/test-coder.md
     edit: true
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       Fix the issues found in review.
     rules:
       - condition: Fix applied

--- a/e2e/fixtures/pieces/report-judge.yaml
+++ b/e2e/fixtures/pieces/report-judge.yaml
@@ -22,7 +22,7 @@ movements:
       report:
         - name: report.md
           format: report
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: Done

--- a/e2e/fixtures/pieces/simple.yaml
+++ b/e2e/fixtures/pieces/simple.yaml
@@ -18,7 +18,7 @@ movements:
           - Write
           - Edit
     required_permission_mode: edit
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: Task completed

--- a/e2e/fixtures/pieces/structured-output.yaml
+++ b/e2e/fixtures/pieces/structured-output.yaml
@@ -12,7 +12,7 @@ movements:
     edit: false
     persona: ../agents/test-coder.md
     required_permission_mode: readonly
-    instruction_template: |
+    instruction: |
       Reply with exactly: "Task completed successfully."
       Do not do anything else.
     rules:

--- a/e2e/fixtures/pieces/team-leader-refill-threshold.yaml
+++ b/e2e/fixtures/pieces/team-leader-refill-threshold.yaml
@@ -21,7 +21,7 @@ movements:
         - Read
         - Write
         - Edit
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: Task completed

--- a/e2e/fixtures/pieces/team-leader-worker-pool.yaml
+++ b/e2e/fixtures/pieces/team-leader-worker-pool.yaml
@@ -20,7 +20,7 @@ movements:
         - Read
         - Write
         - Edit
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: Task completed

--- a/e2e/fixtures/pieces/team-leader.yaml
+++ b/e2e/fixtures/pieces/team-leader.yaml
@@ -20,7 +20,7 @@ movements:
         - Read
         - Write
         - Edit
-    instruction_template: |
+    instruction: |
       {task}
     rules:
       - condition: Task completed

--- a/e2e/specs/codex-permission-mode.e2e.ts
+++ b/e2e/specs/codex-permission-mode.e2e.ts
@@ -30,7 +30,7 @@ describe('E2E: Codex permission mode readonly/full', () => {
         '        allowed_tools:',
         '          - Bash',
         '    required_permission_mode: readonly',
-        '    instruction_template: |',
+        '    instruction: |',
         '      Run this exact command in repository root:',
         '      /bin/sh -lc \'printf "ok\\n" > epperm-check.txt\'',
         '      If file creation succeeds, reply exactly: COMPLETE',

--- a/e2e/specs/piece-selection-branches.e2e.ts
+++ b/e2e/specs/piece-selection-branches.e2e.ts
@@ -39,7 +39,7 @@ function writeMinimalPiece(piecePath: string): void {
       '          - Write',
       '          - Edit',
       '    required_permission_mode: edit',
-      '    instruction_template: |',
+      '    instruction: |',
       '      {task}',
       '    rules:',
       '      - condition: Done',

--- a/e2e/specs/runtime-config-provider.e2e.ts
+++ b/e2e/specs/runtime-config-provider.e2e.ts
@@ -84,7 +84,7 @@ describe('E2E: runtime.prepare with provider', () => {
         '          - Read',
         '          - Bash',
         '    required_permission_mode: edit',
-        '    instruction_template: |',
+        '    instruction: |',
         '      {task}',
         '    rules:',
         '      - condition: Task completed',

--- a/src/__tests__/arpeggio-schema.test.ts
+++ b/src/__tests__/arpeggio-schema.test.ts
@@ -297,7 +297,7 @@ describe('PieceMovementRawSchema with arpeggio', () => {
     const raw = {
       name: 'normal-step',
       persona: 'coder.md',
-      instruction_template: 'Do work',
+      instruction: 'Do work',
     };
 
     const result = PieceMovementRawSchema.safeParse(raw);

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -71,7 +71,7 @@ describe('getBuiltinPiece', () => {
     expect(piece!.name).toBe('default');
   });
 
-  it('should resolve builtin instruction_template without projectCwd', () => {
+  it('should resolve builtin instruction without projectCwd', () => {
     const piece = getBuiltinPiece('default', process.cwd());
     expect(piece).not.toBeNull();
 

--- a/src/__tests__/facet-resolution.test.ts
+++ b/src/__tests__/facet-resolution.test.ts
@@ -509,7 +509,7 @@ describe('normalizePieceConfig with layer resolution', () => {
     expect(config.movements[0]!.knowledgeContents![0]).toBe('# Domain Knowledge');
   });
 
-  it('should resolve instruction_template from section map before layer resolution', () => {
+  it('should resolve instruction from section map before layer resolution', () => {
     const raw = {
       name: 'test-piece',
       instructions: {
@@ -519,7 +519,7 @@ describe('normalizePieceConfig with layer resolution', () => {
         {
           name: 'step1',
           persona: 'coder',
-          instruction_template: 'implement',
+          instruction: 'implement',
         },
       ],
     };
@@ -530,7 +530,7 @@ describe('normalizePieceConfig with layer resolution', () => {
     expect(config.movements[0]!.instruction).toBe('Mapped instruction template');
   });
 
-  it('should resolve instruction_template by name via layer resolution', () => {
+  it('should resolve instruction by name via layer resolution', () => {
     const instructionsDir = join(projectDir, '.takt', 'facets', 'instructions');
     mkdirSync(instructionsDir, { recursive: true });
     writeFileSync(join(instructionsDir, 'implement.md'), 'Project implement template');
@@ -541,7 +541,7 @@ describe('normalizePieceConfig with layer resolution', () => {
         {
           name: 'step1',
           persona: 'coder',
-          instruction_template: 'implement',
+          instruction: 'implement',
         },
       ],
     };
@@ -552,7 +552,7 @@ describe('normalizePieceConfig with layer resolution', () => {
     expect(config.movements[0]!.instruction).toBe('Project implement template');
   });
 
-  it('should keep inline instruction_template when no facet is found', () => {
+  it('should keep inline instruction when no facet is found', () => {
     const inlineTemplate = `Use this inline template.
 Second line remains inline.`;
     const raw = {
@@ -561,7 +561,7 @@ Second line remains inline.`;
         {
           name: 'step1',
           persona: 'coder',
-          instruction_template: inlineTemplate,
+          instruction: inlineTemplate,
         },
       ],
     };
@@ -572,7 +572,7 @@ Second line remains inline.`;
     expect(config.movements[0]!.instruction).toBe(inlineTemplate);
   });
 
-  it('should resolve loop monitor judge instruction_template via layer resolution', () => {
+  it('should resolve loop monitor judge instruction via layer resolution', () => {
     const instructionsDir = join(projectDir, '.takt', 'facets', 'instructions');
     mkdirSync(instructionsDir, { recursive: true });
     writeFileSync(join(instructionsDir, 'judge-template.md'), 'Project judge template');
@@ -599,7 +599,7 @@ Second line remains inline.`;
           threshold: 2,
           judge: {
             persona: 'coder',
-            instruction_template: 'judge-template',
+            instruction: 'judge-template',
             rules: [{ condition: 'continue', next: 'step2' }],
           },
         },

--- a/src/__tests__/instruction-template-removal.test.ts
+++ b/src/__tests__/instruction-template-removal.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+import {
+  PieceConfigRawSchema,
+  LoopMonitorJudgeSchema,
+  ParallelSubMovementRawSchema,
+  PieceMovementRawSchema,
+} from '../core/models/index.js';
+import { normalizePieceConfig } from '../infra/config/loaders/pieceParser.js';
+
+const pieceDir = join(process.cwd(), 'src', '__tests__');
+
+function expectFailurePath(
+  result:
+    | ReturnType<typeof PieceMovementRawSchema.safeParse>
+    | ReturnType<typeof ParallelSubMovementRawSchema.safeParse>
+    | ReturnType<typeof LoopMonitorJudgeSchema.safeParse>
+    | ReturnType<typeof PieceConfigRawSchema.safeParse>,
+  expectedPath: Array<string | number>,
+): void {
+  expect(result.success).toBe(false);
+  if (result.success) {
+    return;
+  }
+
+  expect(result.error.issues.some((issue) => issue.path.join('.') === expectedPath.join('.'))).toBe(true);
+}
+
+describe('instruction_template removal', () => {
+  it('movement schema should reject instruction_template', () => {
+    const raw = {
+      name: 'implement',
+      instruction_template: 'Legacy instruction',
+    };
+
+    const result = PieceMovementRawSchema.safeParse(raw);
+
+    expectFailurePath(result, ['instruction_template']);
+  });
+
+  it('parallel sub-movement schema should reject instruction_template', () => {
+    const raw = {
+      name: 'review',
+      instruction_template: 'Legacy review instruction',
+    };
+
+    const result = ParallelSubMovementRawSchema.safeParse(raw);
+
+    expectFailurePath(result, ['instruction_template']);
+  });
+
+  it('loop monitor judge schema should reject instruction_template', () => {
+    const raw = {
+      persona: 'reviewer',
+      instruction_template: 'Legacy judge instruction',
+      rules: [{ condition: 'continue', next: 'ai_fix' }],
+    };
+
+    const result = LoopMonitorJudgeSchema.safeParse(raw);
+
+    expectFailurePath(result, ['instruction_template']);
+  });
+
+  it('piece config schema should reject instruction_template on a movement', () => {
+    const raw = {
+      name: 'test-piece',
+      movements: [
+        {
+          name: 'implement',
+          persona: 'coder',
+          instruction_template: 'Legacy movement instruction',
+        },
+      ],
+    };
+
+    const result = PieceConfigRawSchema.safeParse(raw);
+
+    expectFailurePath(result, ['movements', 0, 'instruction_template']);
+  });
+
+  it('piece config schema should reject instruction_template on a parallel sub-movement', () => {
+    const raw = {
+      name: 'test-piece',
+      movements: [
+        {
+          name: 'review',
+          parallel: [
+            {
+              name: 'security',
+              persona: 'reviewer',
+              instruction_template: 'Legacy parallel instruction',
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = PieceConfigRawSchema.safeParse(raw);
+
+    expectFailurePath(result, ['movements', 0, 'parallel', 0, 'instruction_template']);
+  });
+
+  it('piece config schema should reject instruction_template on a loop monitor judge', () => {
+    const raw = {
+      name: 'test-piece',
+      movements: [
+        {
+          name: 'step1',
+          persona: 'coder',
+          instruction: '{task}',
+          rules: [{ condition: 'done', next: 'COMPLETE' }],
+        },
+      ],
+      loop_monitors: [
+        {
+          cycle: ['step1', 'step1'],
+          threshold: 2,
+          judge: {
+            persona: 'reviewer',
+            instruction_template: 'Legacy judge instruction',
+            rules: [{ condition: 'continue', next: 'step1' }],
+          },
+        },
+      ],
+    };
+
+    const result = PieceConfigRawSchema.safeParse(raw);
+
+    expectFailurePath(result, ['loop_monitors', 0, 'judge', 'instruction_template']);
+  });
+
+  it('normalizePieceConfig should fail fast without deprecation warning when a movement uses instruction_template', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const raw = {
+        name: 'test-piece',
+        movements: [
+          {
+            name: 'implement',
+            persona: 'coder',
+            instruction_template: 'Legacy movement instruction',
+          },
+        ],
+      };
+
+      expect(() => normalizePieceConfig(raw, pieceDir)).toThrow();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('normalizePieceConfig should fail fast without deprecation warning when a loop monitor judge uses instruction_template', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const raw = {
+        name: 'test-piece',
+        movements: [
+          {
+            name: 'step1',
+            persona: 'coder',
+            instruction: '{task}',
+            rules: [{ condition: 'next', next: 'step2' }],
+          },
+          {
+            name: 'step2',
+            persona: 'coder',
+            instruction: '{task}',
+            rules: [{ condition: 'done', next: 'COMPLETE' }],
+          },
+        ],
+        loop_monitors: [
+          {
+            cycle: ['step1', 'step2'],
+            threshold: 2,
+            judge: {
+              persona: 'reviewer',
+              instruction_template: 'Legacy judge instruction',
+              rules: [{ condition: 'continue', next: 'step2' }],
+            },
+          },
+        ],
+      };
+
+      expect(() => normalizePieceConfig(raw, pieceDir)).toThrow();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/src/__tests__/instructionBuilder.test.ts
+++ b/src/__tests__/instructionBuilder.test.ts
@@ -700,7 +700,7 @@ describe('instruction-builder', () => {
       expect(result).not.toContain('Custom order instruction');
     });
 
-    it('should still replace {report:filename} in instruction_template', () => {
+    it('should still replace {report:filename} in instruction', () => {
       const step = createMinimalStep('Write to {report:00-plan.md}');
       const context = createMinimalContext({
         reportDir: '/project/.takt/runs/20260129-test/reports',

--- a/src/__tests__/knowledge.test.ts
+++ b/src/__tests__/knowledge.test.ts
@@ -129,7 +129,7 @@ describe('ParallelSubMovementRawSchema knowledge field', () => {
       name: 'sub-step',
       persona: 'reviewer.md',
       knowledge: 'security',
-      instruction_template: 'Review security',
+      instruction: 'Review security',
     };
 
     const result = ParallelSubMovementRawSchema.safeParse(raw);
@@ -144,7 +144,7 @@ describe('ParallelSubMovementRawSchema knowledge field', () => {
       name: 'sub-step',
       persona: 'reviewer.md',
       knowledge: ['security', 'performance'],
-      instruction_template: 'Review',
+      instruction: 'Review',
     };
 
     const result = ParallelSubMovementRawSchema.safeParse(raw);
@@ -238,7 +238,7 @@ describe('normalizePieceConfig knowledge resolution', () => {
               name: 'sec-review',
               persona: 'reviewer.md',
               knowledge: 'security',
-              instruction_template: 'Review security',
+              instruction: 'Review security',
             },
           ],
           rules: [{ condition: 'approved', next: 'COMPLETE' }],

--- a/src/__tests__/parallel-and-loader.test.ts
+++ b/src/__tests__/parallel-and-loader.test.ts
@@ -1,12 +1,3 @@
-/**
- * Tests for parallel movement execution and ai() condition loader
- *
- * Covers:
- * - Schema validation for parallel sub-movements
- * - Piece loader normalization of ai() conditions and parallel movements
- * - Engine parallel movement aggregation logic
- */
-
 import { describe, it, expect } from 'vitest';
 import {
   PieceConfigRawSchema,
@@ -20,17 +11,17 @@ describe('ParallelSubMovementRawSchema', () => {
     const raw = {
       name: 'arch-review',
       persona: '~/.takt/agents/default/reviewer.md',
-      instruction_template: 'Review architecture',
+      instruction: 'Review architecture',
     };
 
     const result = ParallelSubMovementRawSchema.safeParse(raw);
     expect(result.success).toBe(true);
   });
 
-  it('should accept a sub-movement without persona (instruction_template only)', () => {
+  it('should accept a sub-movement without persona', () => {
     const raw = {
       name: 'no-agent-step',
-      instruction_template: 'Do something',
+      instruction: 'Do something',
     };
 
     const result = ParallelSubMovementRawSchema.safeParse(raw);
@@ -38,36 +29,25 @@ describe('ParallelSubMovementRawSchema', () => {
   });
 
   it('should accept a sub-movement with instruction field', () => {
-    // Given: a parallel sub-movement that uses the new canonical field
     const raw = {
       name: 'no-agent-step',
       instruction: 'Do something',
     };
 
-    // When: validating the sub-movement schema
     const result = ParallelSubMovementRawSchema.safeParse(raw);
 
-    // Then: it is accepted
     expect(result.success).toBe(true);
   });
 
-  it('should accept a sub-movement when instruction and instruction_template are both provided', () => {
-    // Given: both canonical and deprecated fields are present during migration
+  it('should reject a sub-movement when instruction_template is provided', () => {
     const raw = {
       name: 'dual-field-sub-step',
-      instruction: 'Canonical instruction',
       instruction_template: 'Legacy instruction',
     };
 
-    // When: validating the sub-movement schema
     const result = ParallelSubMovementRawSchema.safeParse(raw);
 
-    // Then: schema keeps backward compatibility and accepts both fields
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect((result.data as unknown as Record<string, unknown>).instruction).toBe('Canonical instruction');
-      expect((result.data as unknown as Record<string, unknown>).instruction_template).toBe('Legacy instruction');
-    }
+    expect(result.success).toBe(false);
   });
 
   it('should accept optional fields', () => {
@@ -82,7 +62,7 @@ describe('ParallelSubMovementRawSchema', () => {
       },
       model: 'haiku',
       edit: false,
-      instruction_template: 'Do work',
+      instruction: 'Do work',
       report: '01-report.md',
       pass_previous_response: false,
     };
@@ -104,7 +84,7 @@ describe('ParallelSubMovementRawSchema', () => {
         model: 'gpt-5.3',
         network_access: true,
       },
-      instruction_template: 'Review',
+      instruction: 'Review',
     };
 
     const result = ParallelSubMovementRawSchema.safeParse(raw);
@@ -118,7 +98,7 @@ describe('ParallelSubMovementRawSchema', () => {
         type: 'claude',
         network_access: true,
       },
-      instruction_template: 'Review',
+      instruction: 'Review',
     };
 
     const result = ParallelSubMovementRawSchema.safeParse(raw);
@@ -129,7 +109,7 @@ describe('ParallelSubMovementRawSchema', () => {
     const raw = {
       name: 'reviewed',
       persona: '~/.takt/agents/default/reviewer.md',
-      instruction_template: 'Review',
+      instruction: 'Review',
       rules: [
         { condition: 'No issues', next: 'COMPLETE' },
         { condition: 'Issues found', next: 'fix' },
@@ -147,7 +127,7 @@ describe('ParallelSubMovementRawSchema', () => {
     const raw = {
       name: 'invalid-sub-step',
       allowed_tools: ['Read'],
-      instruction_template: 'Review',
+      instruction: 'Review',
     };
 
     const result = ParallelSubMovementRawSchema.safeParse(raw);
@@ -160,8 +140,8 @@ describe('PieceMovementRawSchema with parallel', () => {
     const raw = {
       name: 'parallel-review',
       parallel: [
-        { name: 'arch-review', persona: 'reviewer.md', instruction_template: 'Review arch' },
-        { name: 'sec-review', persona: 'security.md', instruction_template: 'Review security' },
+        { name: 'arch-review', persona: 'reviewer.md', instruction: 'Review arch' },
+        { name: 'sec-review', persona: 'security.md', instruction: 'Review security' },
       ],
       rules: [
         { condition: 'All pass', next: 'COMPLETE' },
@@ -172,10 +152,10 @@ describe('PieceMovementRawSchema with parallel', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should accept a movement with neither agent nor parallel (instruction_template only)', () => {
+  it('should accept a movement with neither agent nor parallel', () => {
     const raw = {
       name: 'orphan-step',
-      instruction_template: 'Do something',
+      instruction: 'Do something',
     };
 
     const result = PieceMovementRawSchema.safeParse(raw);
@@ -183,43 +163,32 @@ describe('PieceMovementRawSchema with parallel', () => {
   });
 
   it('should accept a movement with instruction only', () => {
-    // Given: a movement that only uses instruction
     const raw = {
       name: 'orphan-step',
       instruction: 'Do something',
     };
 
-    // When: validating the movement schema
     const result = PieceMovementRawSchema.safeParse(raw);
 
-    // Then: it is accepted
     expect(result.success).toBe(true);
   });
 
-  it('should accept a movement when instruction and instruction_template are both provided', () => {
-    // Given: movement includes both canonical and deprecated instruction fields
+  it('should reject a movement when instruction_template is provided', () => {
     const raw = {
       name: 'orphan-step',
-      instruction: 'Canonical movement instruction',
       instruction_template: 'Legacy movement instruction',
     };
 
-    // When: validating the movement schema
     const result = PieceMovementRawSchema.safeParse(raw);
 
-    // Then: schema accepts both fields for deprecation window
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect((result.data as unknown as Record<string, unknown>).instruction).toBe('Canonical movement instruction');
-      expect((result.data as unknown as Record<string, unknown>).instruction_template).toBe('Legacy movement instruction');
-    }
+    expect(result.success).toBe(false);
   });
 
   it('should accept a movement with persona (no parallel)', () => {
     const raw = {
       name: 'normal-step',
       persona: 'coder.md',
-      instruction_template: 'Code something',
+      instruction: 'Code something',
     };
 
     const result = PieceMovementRawSchema.safeParse(raw);
@@ -243,7 +212,7 @@ describe('PieceMovementRawSchema with parallel', () => {
         {
           name: 'arch-review',
           provider: 'codex',
-          instruction_template: 'Review architecture',
+          instruction: 'Review architecture',
         },
       ],
     };
@@ -255,41 +224,30 @@ describe('PieceMovementRawSchema with parallel', () => {
 
 describe('LoopMonitorJudgeSchema', () => {
   it('should accept judge configuration with instruction field', () => {
-    // Given: a loop monitor judge with canonical instruction
     const raw = {
       persona: 'reviewer',
       instruction: 'Judge loop health',
       rules: [{ condition: 'continue', next: 'ai_fix' }],
     };
 
-    // When: validating judge schema
     const result = LoopMonitorJudgeSchema.safeParse(raw);
 
-    // Then: it is accepted
     expect(result.success).toBe(true);
     if (result.success) {
       expect((result.data as unknown as Record<string, unknown>).instruction).toBe('Judge loop health');
     }
   });
 
-  it('should accept judge configuration during deprecation window when both fields exist', () => {
-    // Given: judge config with both new and deprecated fields
+  it('should reject judge configuration when instruction_template exists', () => {
     const raw = {
       persona: 'reviewer',
-      instruction: 'Judge loop health',
       instruction_template: 'legacy judge instruction',
       rules: [{ condition: 'continue', next: 'ai_fix' }],
     };
 
-    // When: validating judge schema
     const result = LoopMonitorJudgeSchema.safeParse(raw);
 
-    // Then: it is accepted for backward compatibility
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect((result.data as unknown as Record<string, unknown>).instruction).toBe('Judge loop health');
-      expect((result.data as unknown as Record<string, unknown>).instruction_template).toBe('legacy judge instruction');
-    }
+    expect(result.success).toBe(false);
   });
 });
 
@@ -306,8 +264,8 @@ describe('PieceConfigRawSchema with parallel movements', () => {
         {
           name: 'review',
           parallel: [
-            { name: 'arch-review', persona: 'arch-reviewer.md', instruction_template: 'Review architecture' },
-            { name: 'sec-review', persona: 'sec-reviewer.md', instruction_template: 'Review security' },
+            { name: 'arch-review', persona: 'arch-reviewer.md', instruction: 'Review architecture' },
+            { name: 'sec-review', persona: 'sec-reviewer.md', instruction: 'Review security' },
           ],
           rules: [
             { condition: 'All approved', next: 'COMPLETE' },
@@ -475,7 +433,7 @@ describe('all()/any() condition in PieceMovementRawSchema', () => {
     const raw = {
       name: 'parallel-review',
       parallel: [
-        { name: 'arch-review', persona: 'reviewer.md', instruction_template: 'Review' },
+        { name: 'arch-review', persona: 'reviewer.md', instruction: 'Review' },
       ],
       rules: [
         { condition: 'all("approved")', next: 'COMPLETE' },

--- a/src/__tests__/policy-persona.test.ts
+++ b/src/__tests__/policy-persona.test.ts
@@ -9,7 +9,7 @@
  * - File-based policy content loading via resolveContentPath
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -601,7 +601,7 @@ describe('section reference resolution', () => {
     expect(config.movements[0]!.persona).toBe('nonexistent');
   });
 
-  it('should prefer instruction over instruction_template when both are provided', () => {
+  it('should resolve instruction field from instructions section', () => {
     const raw = {
       name: 'test-piece',
       instructions: { implement: './instructions/implement.md' },
@@ -609,7 +609,6 @@ describe('section reference resolution', () => {
         name: 'impl',
         persona: 'coder',
         instruction: 'implement',
-        instruction_template: 'Inline template takes priority.',
       }],
     };
 
@@ -617,73 +616,53 @@ describe('section reference resolution', () => {
     expect(config.movements[0]!.instruction).toBe('Implement the feature.');
   });
 
-  it('should emit deprecation warning when movement uses instruction_template', () => {
-    // Given: deprecated instruction_template is used on a movement
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const raw = {
-        name: 'test-piece',
-        movements: [{
-          name: 'impl',
+  it('should fail fast when movement uses instruction_template', () => {
+    const raw = {
+      name: 'test-piece',
+      movements: [{
+        name: 'impl',
+        persona: 'coder',
+        instruction_template: 'Legacy movement instruction',
+      }],
+    };
+
+    expect(() => normalizePieceConfig(raw, testDir)).toThrow();
+  });
+
+  it('should fail fast when loop monitor judge uses instruction_template', () => {
+    const raw = {
+      name: 'test-piece',
+      movements: [
+        {
+          name: 'step1',
           persona: 'coder',
-          instruction_template: 'Legacy movement instruction',
-        }],
-      };
+          instruction: '{task}',
+          rules: [{ condition: 'next', next: 'step2' }],
+        },
+        {
+          name: 'step2',
+          persona: 'coder',
+          instruction: '{task}',
+          rules: [{ condition: 'done', next: 'COMPLETE' }],
+        },
+      ],
+      loop_monitors: [
+        {
+          cycle: ['step1', 'step2'],
+          threshold: 2,
+          judge: {
+            persona: 'coder',
+            instruction_template: 'Legacy judge instruction',
+            rules: [{ condition: 'continue', next: 'step2' }],
+          },
+        },
+      ],
+    };
 
-      // When: normalizing piece config
-      normalizePieceConfig(raw, testDir);
-
-      // Then: deprecation warning is emitted
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('instruction_template'));
-    } finally {
-      warnSpy.mockRestore();
-    }
+    expect(() => normalizePieceConfig(raw, testDir)).toThrow();
   });
 
-  it('should emit deprecation warning when loop monitor judge uses instruction_template', () => {
-    // Given: deprecated instruction_template is used on loop monitor judge
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const raw = {
-        name: 'test-piece',
-        movements: [
-          {
-            name: 'step1',
-            persona: 'coder',
-            instruction: '{task}',
-            rules: [{ condition: 'next', next: 'step2' }],
-          },
-          {
-            name: 'step2',
-            persona: 'coder',
-            instruction: '{task}',
-            rules: [{ condition: 'done', next: 'COMPLETE' }],
-          },
-        ],
-        loop_monitors: [
-          {
-            cycle: ['step1', 'step2'],
-            threshold: 2,
-            judge: {
-              persona: 'coder',
-              instruction_template: 'Legacy judge instruction',
-              rules: [{ condition: 'continue', next: 'step2' }],
-            },
-          },
-        ],
-      };
-
-      // When: normalizing piece config
-      normalizePieceConfig(raw, testDir);
-
-      // Then: deprecation warning is emitted
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('instruction_template'));
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('should prefer loop monitor judge instruction over instruction_template when both are provided', () => {
+  it('should resolve loop monitor judge instruction from instructions section', () => {
     const raw = {
       name: 'test-piece',
       instructions: { judge_template: './instructions/implement.md' },
@@ -708,7 +687,6 @@ describe('section reference resolution', () => {
           judge: {
             persona: 'coder',
             instruction: 'judge_template',
-            instruction_template: 'Legacy judge template',
             rules: [{ condition: 'continue', next: 'step2' }],
           },
         },

--- a/src/__tests__/team-leader-schema-loader.test.ts
+++ b/src/__tests__/team-leader-schema-loader.test.ts
@@ -12,7 +12,7 @@ describe('team_leader schema', () => {
         max_parts: 3,
         timeout_ms: 120000,
       },
-      instruction_template: 'decompose',
+      instruction: 'decompose',
     };
 
     const result = PieceMovementRawSchema.safeParse(raw);
@@ -25,7 +25,7 @@ describe('team_leader schema', () => {
       team_leader: {
         max_parts: 4,
       },
-      instruction_template: 'decompose',
+      instruction: 'decompose',
     };
 
     const result = PieceMovementRawSchema.safeParse(raw);
@@ -39,7 +39,7 @@ describe('team_leader schema', () => {
         max_parts: 2,
         refill_threshold: 3,
       },
-      instruction_template: 'decompose',
+      instruction: 'decompose',
     };
 
     const result = PieceMovementRawSchema.safeParse(raw);
@@ -49,11 +49,11 @@ describe('team_leader schema', () => {
   it('parallel と team_leader の同時指定は拒否する', () => {
     const raw = {
       name: 'implement',
-      parallel: [{ name: 'sub', instruction_template: 'x' }],
+      parallel: [{ name: 'sub', instruction: 'x' }],
       team_leader: {
         max_parts: 2,
       },
-      instruction_template: 'decompose',
+      instruction: 'decompose',
     };
 
     const result = PieceMovementRawSchema.safeParse(raw);
@@ -71,7 +71,7 @@ describe('team_leader schema', () => {
       team_leader: {
         max_parts: 2,
       },
-      instruction_template: 'decompose',
+      instruction: 'decompose',
     };
 
     const result = PieceMovementRawSchema.safeParse(raw);
@@ -96,7 +96,7 @@ describe('normalizePieceConfig team_leader', () => {
             part_edit: true,
             part_permission_mode: 'edit',
           },
-          instruction_template: 'decompose',
+          instruction: 'decompose',
         },
       ],
     };

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -309,7 +309,7 @@ export const ParallelSubMovementRawSchema = z.object({
   provider_options: MovementProviderOptionsSchema,
   edit: z.boolean().optional(),
   instruction: z.string().optional(),
-  instruction_template: z.string().optional(),
+  instruction_template: z.never().optional(),
   rules: z.array(PieceRuleSchema).optional(),
   /** Output contracts for this movement (report definitions) */
   output_contracts: OutputContractsFieldSchema,
@@ -345,7 +345,7 @@ export const PieceMovementRawSchema = z.object({
   /** Whether this movement is allowed to edit project files */
   edit: z.boolean().optional(),
   instruction: z.string().optional(),
-  instruction_template: z.string().optional(),
+  instruction_template: z.never().optional(),
   /** Rules for movement routing */
   rules: z.array(PieceRuleSchema).optional(),
   /** Output contracts for this movement (report definitions) */
@@ -381,8 +381,7 @@ export const LoopMonitorJudgeSchema = z.object({
   persona: z.string().optional(),
   /** Custom judge instruction */
   instruction: z.string().optional(),
-  /** Deprecated alias */
-  instruction_template: z.string().optional(),
+  instruction_template: z.never().optional(),
   /** Rules for the judge's decision */
   rules: z.array(LoopMonitorRuleSchema).min(1),
 });

--- a/src/infra/config/loaders/pieceParser.ts
+++ b/src/infra/config/loaders/pieceParser.ts
@@ -275,12 +275,6 @@ function normalizeStepFromRaw(
   const expandedInstruction = step.instruction
     ? resolveRefToContent(step.instruction, sections.resolvedInstructions, pieceDir, 'instructions', context)
     : undefined;
-  if (step.instruction_template !== undefined) {
-    console.warn(`Movement "${step.name}" uses deprecated field "instruction_template". Use "instruction" instead.`);
-  }
-  const expandedLegacyInstruction = step.instruction_template
-    ? resolveRefToContent(step.instruction_template, sections.resolvedInstructions, pieceDir, 'instructions', context)
-    : undefined;
   validatePieceArpeggio(step.name, step.arpeggio, pieceArpeggioPolicy);
   validatePieceMcpServers(step.name, step.mcp_servers, pieceMcpServersPolicy);
 
@@ -297,7 +291,7 @@ function normalizeStepFromRaw(
     requiredPermissionMode: step.required_permission_mode,
     providerOptions: mergeProviderOptions(inheritedProviderOptions, normalizedProvider.providerOptions),
     edit: step.edit,
-    instruction: expandedInstruction || expandedLegacyInstruction || '{task}',
+    instruction: expandedInstruction || '{task}',
     rules,
     outputContracts: normalizeOutputContracts(step.output_contracts, pieceDir, sections.resolvedReportFormats, context),
     qualityGates: applyQualityGateOverrides(
@@ -346,20 +340,15 @@ function normalizeStepFromRaw(
 
 /** Normalize a raw loop monitor judge from YAML into internal format. */
 function normalizeLoopMonitorJudge(
-  raw: { persona?: string; instruction?: string; instruction_template?: string; rules: Array<{ condition: string; next: string }> },
+  raw: { persona?: string; instruction?: string; rules: Array<{ condition: string; next: string }> },
   pieceDir: string,
   sections: PieceSections,
   context?: FacetResolutionContext,
 ): LoopMonitorJudge {
   const { personaSpec, personaPath } = resolvePersona(raw.persona, sections, pieceDir, context);
-  if (raw.instruction_template !== undefined) {
-    console.warn('loop_monitors judge uses deprecated field "instruction_template". Use "instruction" instead.');
-  }
   const resolvedInstruction = raw.instruction
     ? resolveRefToContent(raw.instruction, sections.resolvedInstructions, pieceDir, 'instructions', context)
-    : raw.instruction_template
-      ? resolveRefToContent(raw.instruction_template, sections.resolvedInstructions, pieceDir, 'instructions', context)
-      : undefined;
+    : undefined;
 
   return {
     persona: personaSpec,
@@ -373,7 +362,7 @@ function normalizeLoopMonitorJudge(
  * Normalize raw loop monitors from YAML into internal format.
  */
 function normalizeLoopMonitors(
-  raw: Array<{ cycle: string[]; threshold: number; judge: { persona?: string; instruction?: string; instruction_template?: string; rules: Array<{ condition: string; next: string }> } }> | undefined,
+  raw: Array<{ cycle: string[]; threshold: number; judge: { persona?: string; instruction?: string; rules: Array<{ condition: string; next: string }> } }> | undefined,
   pieceDir: string,
   sections: PieceSections,
   context?: FacetResolutionContext,


### PR DESCRIPTION
## Summary
- `instruction_template` の後方互換フィールドとパース処理を削除
- piece YAML スキーマから `instruction_template` を除去し、`instruction` に統一
- E2E fixtures・テストを更新、削除検証用テスト `instruction-template-removal.test.ts` を追加

Closes #490