### PR TITLE
fix: GitLabセルフホスト環境において、gitlab.comへの認証をしていない状態だとタスク完了後のMR作成に必ず失敗するバグの修正

### DIFF
--- a/src/__tests__/git-detect.test.ts
+++ b/src/__tests__/git-detect.test.ts
@@ -11,11 +11,145 @@ vi.mock('node:child_process', () => ({
   execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }));
 
-import { detectVcsProvider, VCS_PROVIDER_TYPES } from '../infra/git/detect.js';
-import type { VcsProviderType } from '../infra/git/detect.js';
+import { detectVcsProvider, getRemoteHostname, VCS_PROVIDER_TYPES } from '../infra/git/detect.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe('getRemoteHostname — hostname extraction (indirect extractHostname tests)', () => {
+  it('HTTPS URL からホスト名を抽出する', () => {
+    // Given
+    mockExecFileSync.mockReturnValue('https://gitlab.example.com/owner/repo.git\n');
+
+    // When / Then
+    expect(getRemoteHostname('/project')).toBe('gitlab.example.com');
+  });
+
+  it('HTTPS URL（.git なし）からホスト名を抽出する', () => {
+    // Given
+    mockExecFileSync.mockReturnValue('https://gitlab.example.com/owner/repo\n');
+
+    // When / Then
+    expect(getRemoteHostname('/project')).toBe('gitlab.example.com');
+  });
+
+  it('SSH URL からホスト名を抽出する', () => {
+    // Given
+    mockExecFileSync.mockReturnValue('git@gitlab.example.com:owner/repo.git\n');
+
+    // When / Then
+    expect(getRemoteHostname('/project')).toBe('gitlab.example.com');
+  });
+
+  it('SSH URL（.git なし）からホスト名を抽出する', () => {
+    // Given
+    mockExecFileSync.mockReturnValue('git@gitlab.example.com:owner/repo\n');
+
+    // When / Then
+    expect(getRemoteHostname('/project')).toBe('gitlab.example.com');
+  });
+
+  it('github.com の HTTPS URL からホスト名を抽出する', () => {
+    mockExecFileSync.mockReturnValue('https://github.com/owner/repo.git\n');
+    expect(getRemoteHostname('/project')).toBe('github.com');
+  });
+
+  it('github.com の SSH URL からホスト名を抽出する', () => {
+    mockExecFileSync.mockReturnValue('git@github.com:owner/repo.git\n');
+    expect(getRemoteHostname('/project')).toBe('github.com');
+  });
+
+  it('サブグループを含む gitlab.com URL からホスト名を抽出する', () => {
+    mockExecFileSync.mockReturnValue('https://gitlab.com/group/subgroup/repo.git\n');
+    expect(getRemoteHostname('/project')).toBe('gitlab.com');
+  });
+
+  it('ポート番号付き HTTPS URL からホスト名を抽出する', () => {
+    mockExecFileSync.mockReturnValue('https://gitlab.example.com:8443/owner/repo.git\n');
+    expect(getRemoteHostname('/project')).toBe('gitlab.example.com');
+  });
+
+  it('不正な文字列の場合は undefined を返す', () => {
+    mockExecFileSync.mockReturnValue('not-a-url\n');
+    expect(getRemoteHostname('/project')).toBeUndefined();
+  });
+
+  it('空文字列の場合は undefined を返す', () => {
+    mockExecFileSync.mockReturnValue('\n');
+    expect(getRemoteHostname('/project')).toBeUndefined();
+  });
+});
+
+describe('getRemoteHostname', () => {
+  it('HTTPS remote URL からホスト名を返す', () => {
+    // Given
+    mockExecFileSync.mockReturnValue('https://gitlab.example.com/owner/repo.git\n');
+
+    // When
+    const result = getRemoteHostname('/project');
+
+    // Then
+    expect(result).toBe('gitlab.example.com');
+  });
+
+  it('SSH remote URL からホスト名を返す', () => {
+    // Given
+    mockExecFileSync.mockReturnValue('git@gitlab.example.com:owner/repo.git\n');
+
+    // When
+    const result = getRemoteHostname('/project');
+
+    // Then
+    expect(result).toBe('gitlab.example.com');
+  });
+
+  it('cwd を git コマンドのオプションとして渡す', () => {
+    // Given
+    mockExecFileSync.mockReturnValue('https://gitlab.example.com/owner/repo.git\n');
+
+    // When
+    getRemoteHostname('/my/project');
+
+    // Then
+    const call = mockExecFileSync.mock.calls[0];
+    expect(call[0]).toBe('git');
+    expect(call[1]).toEqual(['remote', 'get-url', 'origin']);
+    expect(call[2]).toHaveProperty('cwd', '/my/project');
+  });
+
+  it('git remote get-url origin が失敗した場合は undefined を返す', () => {
+    // Given
+    mockExecFileSync.mockImplementation(() => { throw new Error('not a git repository'); });
+
+    // When
+    const result = getRemoteHostname('/not-a-repo');
+
+    // Then
+    expect(result).toBeUndefined();
+  });
+
+  it('remote URL が空の場合は undefined を返す', () => {
+    // Given
+    mockExecFileSync.mockReturnValue('\n');
+
+    // When
+    const result = getRemoteHostname('/project');
+
+    // Then
+    expect(result).toBeUndefined();
+  });
+
+  it('remote URL がパース不能な場合は undefined を返す', () => {
+    // Given
+    mockExecFileSync.mockReturnValue('not-a-url\n');
+
+    // When
+    const result = getRemoteHostname('/project');
+
+    // Then
+    expect(result).toBeUndefined();
+  });
 });
 
 describe('detectVcsProvider', () => {

--- a/src/__tests__/gitlab-issue.test.ts
+++ b/src/__tests__/gitlab-issue.test.ts
@@ -299,13 +299,14 @@ describe('fetchIssue', () => {
 
 describe('createIssue', () => {
   it('成功時は success: true と URL を返す', () => {
-    // Given: checkGlabCli succeeds (first call), then createIssue succeeds
+    // Given: getRemoteHostname (git remote), checkGlabCli (glab auth), then createIssue
     mockExecFileSync
+      .mockReturnValueOnce('https://gitlab.com/org/repo.git\n') // git remote get-url origin
       .mockReturnValueOnce('') // glab auth status
       .mockReturnValueOnce('https://gitlab.com/org/repo/-/issues/1\n');
 
     // When
-    const result = createIssue({ title: 'New issue', body: 'Description' });
+    const result = createIssue({ title: 'New issue', body: 'Description' }, '/my/project');
 
     // Then
     expect(result.success).toBe(true);
@@ -315,14 +316,15 @@ describe('createIssue', () => {
   it('--description オプションで body を渡す（--body ではない）', () => {
     // Given
     mockExecFileSync
+      .mockReturnValueOnce('https://gitlab.com/org/repo.git\n') // git remote get-url origin
       .mockReturnValueOnce('') // glab auth status
       .mockReturnValueOnce('https://gitlab.com/org/repo/-/issues/2\n');
 
     // When
-    createIssue({ title: 'Title', body: 'Body text' });
+    createIssue({ title: 'Title', body: 'Body text' }, '/my/project');
 
     // Then
-    const createCall = mockExecFileSync.mock.calls[1];
+    const createCall = mockExecFileSync.mock.calls[2];
     expect(createCall[1]).toContain('--description');
     expect(createCall[1]).not.toContain('--body');
   });
@@ -330,25 +332,27 @@ describe('createIssue', () => {
   it('ラベル付きの場合 --label オプションを使う', () => {
     // Given
     mockExecFileSync
+      .mockReturnValueOnce('https://gitlab.com/org/repo.git\n') // git remote get-url origin
       .mockReturnValueOnce('') // glab auth status
       .mockReturnValueOnce('https://gitlab.com/org/repo/-/issues/3\n');
 
     // When
-    createIssue({ title: 'Bug', body: 'Details', labels: ['bug', 'urgent'] });
+    createIssue({ title: 'Bug', body: 'Details', labels: ['bug', 'urgent'] }, '/my/project');
 
     // Then
-    const createCall = mockExecFileSync.mock.calls[1];
+    const createCall = mockExecFileSync.mock.calls[2];
     expect(createCall[1]).toContain('--label');
   });
 
   it('glab CLI が利用不可の場合は success: false を返す', () => {
     // Given
     mockExecFileSync
+      .mockReturnValueOnce('https://gitlab.com/org/repo.git\n') // git remote get-url origin
       .mockImplementationOnce(() => { throw new Error('not logged in'); })
       .mockImplementationOnce(() => { throw new Error('command not found'); });
 
     // When
-    const result = createIssue({ title: 'Title', body: 'Body' });
+    const result = createIssue({ title: 'Title', body: 'Body' }, '/my/project');
 
     // Then
     expect(result.success).toBe(false);
@@ -358,14 +362,34 @@ describe('createIssue', () => {
   it('glab issue create が失敗した場合は success: false を返す', () => {
     // Given
     mockExecFileSync
+      .mockReturnValueOnce('https://gitlab.com/org/repo.git\n') // git remote get-url origin
       .mockReturnValueOnce('') // glab auth status
       .mockImplementationOnce(() => { throw new Error('API error'); });
 
     // When
-    const result = createIssue({ title: 'Title', body: 'Body' });
+    const result = createIssue({ title: 'Title', body: 'Body' }, '/my/project');
 
     // Then
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
+  });
+
+  it('cwd を checkGlabCli に転送する', () => {
+    // Given
+    mockExecFileSync
+      .mockReturnValueOnce('https://gitlab.com/org/repo.git\n') // git remote get-url origin
+      .mockReturnValueOnce('') // glab auth status
+      .mockReturnValueOnce('https://gitlab.com/org/repo/-/issues/5\n');
+
+    // When
+    createIssue({ title: 'Test', body: 'Body' }, '/specific/dir');
+
+    // Then: first call is getRemoteHostname which receives cwd via execFileSync options
+    const remoteCall = mockExecFileSync.mock.calls[0];
+    expect(remoteCall[2]).toHaveProperty('cwd', '/specific/dir');
+
+    // Then: third call is glab issue create which also receives cwd
+    const createCall = mockExecFileSync.mock.calls[2];
+    expect(createCall[2]).toHaveProperty('cwd', '/specific/dir');
   });
 });

--- a/src/__tests__/gitlab-pr.test.ts
+++ b/src/__tests__/gitlab-pr.test.ts
@@ -91,6 +91,18 @@ describe('findExistingMr', () => {
     // Then
     expect(result).toBeUndefined();
   });
+
+  it('checkGlabCli に cwd を渡す', () => {
+    // Given
+    mockCheckGlabCli.mockReturnValue({ available: true });
+    mockExecFileSync.mockReturnValue(JSON.stringify([]));
+
+    // When
+    findExistingMr('/my/project', 'feat/branch');
+
+    // Then
+    expect(mockCheckGlabCli).toHaveBeenCalledWith('/my/project');
+  });
 });
 
 describe('createMergeRequest', () => {
@@ -212,6 +224,22 @@ describe('createMergeRequest', () => {
     expect(result.error).toBeDefined();
   });
 
+  it('checkGlabCli に cwd を渡す', () => {
+    // Given
+    mockCheckGlabCli.mockReturnValue({ available: true });
+    mockExecFileSync.mockReturnValue('https://gitlab.com/org/repo/-/merge_requests/99\n');
+
+    // When
+    createMergeRequest('/my/project', {
+      branch: 'feat/branch',
+      title: 'MR',
+      body: 'body',
+    });
+
+    // Then
+    expect(mockCheckGlabCli).toHaveBeenCalledWith('/my/project');
+  });
+
   it('repo が指定された場合、明示エラーを throw する', () => {
     // Given
     const options = {
@@ -268,6 +296,18 @@ describe('commentOnMr', () => {
     // Then
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
+  });
+
+  it('checkGlabCli に cwd を渡す', () => {
+    // Given
+    mockCheckGlabCli.mockReturnValue({ available: true });
+    mockExecFileSync.mockReturnValue('');
+
+    // When
+    commentOnMr('/my/project', 42, 'LGTM');
+
+    // Then
+    expect(mockCheckGlabCli).toHaveBeenCalledWith('/my/project');
   });
 });
 

--- a/src/__tests__/gitlab-provider.test.ts
+++ b/src/__tests__/gitlab-provider.test.ts
@@ -64,7 +64,7 @@ describe('GitLabProvider', () => {
       const result = provider.checkCliStatus();
 
       // Then
-      expect(mockCheckGlabCli).toHaveBeenCalledTimes(1);
+      expect(mockCheckGlabCli).toHaveBeenCalledWith(process.cwd());
       expect(result).toBe(status);
     });
 
@@ -77,6 +77,7 @@ describe('GitLabProvider', () => {
       const result = provider.checkCliStatus();
 
       // Then
+      expect(mockCheckGlabCli).toHaveBeenCalledWith(process.cwd());
       expect(result.available).toBe(false);
       expect(result.error).toBe('glab is not installed');
     });
@@ -93,8 +94,35 @@ describe('GitLabProvider', () => {
       const result = provider.checkCliStatus();
 
       // Then
+      expect(mockCheckGlabCli).toHaveBeenCalledWith(process.cwd());
       expect(result.available).toBe(false);
       expect(result.error).toContain('not authenticated');
+    });
+
+    it('cwd を指定した場合は checkGlabCli にそのまま転送する', () => {
+      // Given
+      const status = { available: true };
+      mockCheckGlabCli.mockReturnValue(status);
+      const provider = new GitLabProvider();
+
+      // When
+      const result = provider.checkCliStatus('/my/project');
+
+      // Then
+      expect(mockCheckGlabCli).toHaveBeenCalledWith('/my/project');
+      expect(result).toBe(status);
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      mockCheckGlabCli.mockReturnValue({ available: true });
+      const provider = new GitLabProvider();
+
+      // When
+      provider.checkCliStatus();
+
+      // Then
+      expect(mockCheckGlabCli).toHaveBeenCalledWith(process.cwd());
     });
   });
 
@@ -126,7 +154,7 @@ describe('GitLabProvider', () => {
       const result = provider.createIssue(opts);
 
       // Then
-      expect(mockCreateIssue).toHaveBeenCalledWith(opts);
+      expect(mockCreateIssue).toHaveBeenCalledWith(opts, process.cwd());
       expect(result).toBe(issueResult);
     });
 
@@ -140,7 +168,33 @@ describe('GitLabProvider', () => {
       provider.createIssue(opts);
 
       // Then
-      expect(mockCreateIssue).toHaveBeenCalledWith(opts);
+      expect(mockCreateIssue).toHaveBeenCalledWith(opts, process.cwd());
+    });
+
+    it('cwd を指定した場合は createIssue にそのまま転送する', () => {
+      // Given
+      const opts = { title: 'Issue', body: 'Body' };
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://gitlab.com/org/repo/-/issues/3' });
+      const provider = new GitLabProvider();
+
+      // When
+      provider.createIssue(opts, '/my/project');
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith(opts, '/my/project');
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const opts = { title: 'Issue', body: 'Body' };
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://gitlab.com/org/repo/-/issues/4' });
+      const provider = new GitLabProvider();
+
+      // When
+      provider.createIssue(opts);
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith(opts, process.cwd());
     });
   });
 

--- a/src/__tests__/gitlab-utils.test.ts
+++ b/src/__tests__/gitlab-utils.test.ts
@@ -11,6 +11,13 @@ vi.mock('node:child_process', () => ({
   execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }));
 
+const { mockGetRemoteHostname } = vi.hoisted(() => ({
+  mockGetRemoteHostname: vi.fn(),
+}));
+vi.mock('../infra/git/detect.js', () => ({
+  getRemoteHostname: (...args: unknown[]) => mockGetRemoteHostname(...args),
+}));
+
 import { parseJson, checkGlabCli, fetchAllPages } from '../infra/gitlab/utils.js';
 
 beforeEach(() => {
@@ -31,28 +38,155 @@ describe('parseJson', () => {
 });
 
 describe('checkGlabCli', () => {
-  it('glab auth status が成功する場合は available: true を返す', () => {
-    mockExecFileSync.mockReturnValue('');
-    const result = checkGlabCli();
-    expect(result).toEqual({ available: true });
+  describe('ホスト名が取得できる場合（ホスト単位判定）', () => {
+    it('対象ホストが認証済みの場合は available: true を返す', () => {
+      // Given: remote URL から gitlab.example.com が取得できる
+      mockGetRemoteHostname.mockReturnValue('gitlab.example.com');
+      // glab auth status --hostname gitlab.example.com が成功
+      mockExecFileSync.mockReturnValue('');
+
+      // When
+      const result = checkGlabCli('/project');
+
+      // Then
+      expect(result).toEqual({ available: true });
+    });
+
+    it('glab auth status に --hostname オプションを付与して呼び出す', () => {
+      // Given
+      mockGetRemoteHostname.mockReturnValue('gitlab.example.com');
+      mockExecFileSync.mockReturnValue('');
+
+      // When
+      checkGlabCli('/project');
+
+      // Then
+      const call = mockExecFileSync.mock.calls[0];
+      expect(call[0]).toBe('glab');
+      expect(call[1]).toContain('auth');
+      expect(call[1]).toContain('status');
+      expect(call[1]).toContain('--hostname');
+      expect(call[1]).toContain('gitlab.example.com');
+    });
+
+    it('対象ホストが認証済み、別ホストが未認証でも available: true を返す（最重要ケース）', () => {
+      // Given: remote URL から対象ホストが取得できる
+      mockGetRemoteHostname.mockReturnValue('gitlab.example.com');
+      // glab auth status --hostname gitlab.example.com は成功（ホスト限定なので別ホストの状態は無関係）
+      mockExecFileSync.mockReturnValue('');
+
+      // When
+      const result = checkGlabCli('/project');
+
+      // Then
+      expect(result).toEqual({ available: true });
+    });
+
+    it('対象ホストが未認証の場合は available: false と認証エラーを返す', () => {
+      // Given
+      mockGetRemoteHostname.mockReturnValue('gitlab.example.com');
+      // glab auth status --hostname gitlab.example.com が失敗
+      mockExecFileSync
+        .mockImplementationOnce(() => { throw new Error('not logged in'); })
+        // glab --version は成功（インストール済み）
+        .mockReturnValueOnce('glab version 1.36.0');
+
+      // When
+      const result = checkGlabCli('/project');
+
+      // Then
+      expect(result.available).toBe(false);
+      expect(result.error).toContain('not authenticated');
+    });
+
+    it('glab 未インストールの場合は available: false とインストールエラーを返す', () => {
+      // Given
+      mockGetRemoteHostname.mockReturnValue('gitlab.example.com');
+      // glab auth status と glab --version の両方が失敗
+      mockExecFileSync
+        .mockImplementationOnce(() => { throw new Error('command not found'); })
+        .mockImplementationOnce(() => { throw new Error('command not found'); });
+
+      // When
+      const result = checkGlabCli('/project');
+
+      // Then
+      expect(result.available).toBe(false);
+      expect(result.error).toContain('not installed');
+    });
+
+    it('cwd を getRemoteHostname に渡す', () => {
+      // Given
+      mockGetRemoteHostname.mockReturnValue('gitlab.example.com');
+      mockExecFileSync.mockReturnValue('');
+
+      // When
+      checkGlabCli('/my/project/path');
+
+      // Then
+      expect(mockGetRemoteHostname).toHaveBeenCalledWith('/my/project/path');
+    });
   });
 
-  it('glab auth status が失敗し glab --version が成功する場合は認証エラーを返す', () => {
-    mockExecFileSync
-      .mockImplementationOnce(() => { throw new Error('not logged in'); })
-      .mockReturnValueOnce('glab version 1.36.0');
-    const result = checkGlabCli();
-    expect(result.available).toBe(false);
-    expect(result.error).toContain('not authenticated');
-  });
+  describe('ホスト名が取得できない場合（フォールバック）', () => {
+    it('glab auth status（全体）にフォールバックし、成功すれば available: true を返す', () => {
+      // Given: ホスト名取得に失敗
+      mockGetRemoteHostname.mockReturnValue(undefined);
+      // glab auth status（引数なし）が成功
+      mockExecFileSync.mockReturnValue('');
 
-  it('両方失敗する場合はインストールエラーを返す', () => {
-    mockExecFileSync
-      .mockImplementationOnce(() => { throw new Error('command not found'); })
-      .mockImplementationOnce(() => { throw new Error('command not found'); });
-    const result = checkGlabCli();
-    expect(result.available).toBe(false);
-    expect(result.error).toContain('not installed');
+      // When
+      const result = checkGlabCli('/project');
+
+      // Then
+      expect(result).toEqual({ available: true });
+    });
+
+    it('フォールバック時に --hostname オプションを付与しない', () => {
+      // Given
+      mockGetRemoteHostname.mockReturnValue(undefined);
+      mockExecFileSync.mockReturnValue('');
+
+      // When
+      checkGlabCli('/project');
+
+      // Then
+      const call = mockExecFileSync.mock.calls[0];
+      expect(call[0]).toBe('glab');
+      expect(call[1]).toContain('auth');
+      expect(call[1]).toContain('status');
+      expect(call[1]).not.toContain('--hostname');
+    });
+
+    it('フォールバック時に認証失敗すれば認証エラーを返す', () => {
+      // Given
+      mockGetRemoteHostname.mockReturnValue(undefined);
+      mockExecFileSync
+        .mockImplementationOnce(() => { throw new Error('not logged in'); })
+        .mockReturnValueOnce('glab version 1.36.0');
+
+      // When
+      const result = checkGlabCli('/project');
+
+      // Then
+      expect(result.available).toBe(false);
+      expect(result.error).toContain('not authenticated');
+    });
+
+    it('フォールバック時に glab 未インストールならインストールエラーを返す', () => {
+      // Given
+      mockGetRemoteHostname.mockReturnValue(undefined);
+      mockExecFileSync
+        .mockImplementationOnce(() => { throw new Error('command not found'); })
+        .mockImplementationOnce(() => { throw new Error('command not found'); });
+
+      // When
+      const result = checkGlabCli('/project');
+
+      // Then
+      expect(result.available).toBe(false);
+      expect(result.error).toContain('not installed');
+    });
   });
 });
 

--- a/src/__tests__/resolveTask.test.ts
+++ b/src/__tests__/resolveTask.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { TaskInfo } from '../infra/task/index.js';
 import * as infraTask from '../infra/task/index.js';
-import { resolveTaskExecution } from '../features/tasks/execute/resolveTask.js';
+
+const mockGetGitProvider = vi.hoisted(() => vi.fn());
+
+vi.mock('../infra/git/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getGitProvider: mockGetGitProvider,
+}));
+
+import { resolveTaskExecution, resolveTaskIssue } from '../features/tasks/execute/resolveTask.js';
 
 const tempRoots = new Set<string>();
 
@@ -427,5 +435,71 @@ describe('resolveTaskExecution', () => {
 
     expect(result.draftPr).toBe(true);
     expect(result.autoPr).toBe(true);
+  });
+});
+
+describe('resolveTaskIssue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('issueNumber が undefined の場合は undefined を返す', () => {
+    // When
+    const result = resolveTaskIssue(undefined, '/tmp/test');
+
+    // Then
+    expect(result).toBeUndefined();
+  });
+
+  it('CLI が利用不可の場合は undefined を返し、cwd を checkCliStatus に渡す', () => {
+    // Given
+    const mockProvider = {
+      checkCliStatus: vi.fn().mockReturnValue({ available: false, error: 'not installed' }),
+      fetchIssue: vi.fn(),
+    };
+    mockGetGitProvider.mockReturnValue(mockProvider);
+
+    // When
+    const result = resolveTaskIssue(42, '/my/project');
+
+    // Then
+    expect(result).toBeUndefined();
+    expect(mockProvider.checkCliStatus).toHaveBeenCalledWith('/my/project');
+    expect(mockProvider.fetchIssue).not.toHaveBeenCalled();
+  });
+
+  it('fetchIssue が成功した場合は issue 配列を返す', () => {
+    // Given
+    const issue = { number: 42, title: 'Test', body: 'Body', labels: [], comments: [] };
+    const mockProvider = {
+      checkCliStatus: vi.fn().mockReturnValue({ available: true }),
+      fetchIssue: vi.fn().mockReturnValue(issue),
+    };
+    mockGetGitProvider.mockReturnValue(mockProvider);
+
+    // When
+    const result = resolveTaskIssue(42, '/my/project');
+
+    // Then
+    expect(result).toEqual([issue]);
+    expect(mockProvider.checkCliStatus).toHaveBeenCalledWith('/my/project');
+    expect(mockProvider.fetchIssue).toHaveBeenCalledWith(42);
+  });
+
+  it('fetchIssue が例外を投げた場合は undefined を返す', () => {
+    // Given
+    const mockProvider = {
+      checkCliStatus: vi.fn().mockReturnValue({ available: true }),
+      fetchIssue: vi.fn().mockImplementation(() => { throw new Error('API error'); }),
+    };
+    mockGetGitProvider.mockReturnValue(mockProvider);
+
+    // When
+    const result = resolveTaskIssue(42, '/my/project');
+
+    // Then
+    expect(result).toBeUndefined();
+    expect(mockProvider.checkCliStatus).toHaveBeenCalledWith('/my/project');
+    expect(mockProvider.fetchIssue).toHaveBeenCalledWith(42);
   });
 });

--- a/src/features/tasks/execute/resolveTask.ts
+++ b/src/features/tasks/execute/resolveTask.ts
@@ -81,15 +81,15 @@ function throwIfAborted(signal?: AbortSignal): void {
   }
 }
 
-export function resolveTaskIssue(issueNumber: number | undefined): Issue[] | undefined {
+export function resolveTaskIssue(issueNumber: number | undefined, cwd: string): Issue[] | undefined {
   if (issueNumber === undefined) {
     return undefined;
   }
 
   const gitProvider = getGitProvider();
-  const cliStatus = gitProvider.checkCliStatus();
+  const cliStatus = gitProvider.checkCliStatus(cwd);
   if (!cliStatus.available) {
-    log.info('gh CLI unavailable, skipping issue resolution for PR body', { issueNumber });
+    log.info('VCS CLI unavailable, skipping issue resolution for PR body', { issueNumber });
     return undefined;
   }
 

--- a/src/features/tasks/execute/taskExecution.ts
+++ b/src/features/tasks/execute/taskExecution.ts
@@ -184,7 +184,7 @@ export async function executeAndCompleteTask(
     let prFailedError: string | undefined;
     let postExecutionTaskError: string | undefined;
     if (taskSuccess && isWorktree) {
-      const issues = resolveTaskIssue(issueNumber);
+      const issues = resolveTaskIssue(issueNumber, execCwd);
       const postResult = await postExecutionFlow({
         execCwd,
         projectCwd: cwd,

--- a/src/infra/git/detect.ts
+++ b/src/infra/git/detect.ts
@@ -42,15 +42,17 @@ function extractHostname(url: string): string | undefined {
 }
 
 /**
- * Detect VCS provider from the `origin` remote URL.
+ * Get the hostname of the `origin` remote URL.
  *
- * @returns `'github'` | `'gitlab'` | `undefined`
+ * @param cwd - Working directory for the git command
+ * @returns hostname string or `undefined` if unavailable
  */
-export function detectVcsProvider(): VcsProviderType | undefined {
+export function getRemoteHostname(cwd: string): string | undefined {
   let output: string;
   try {
     output = String(
       execFileSync('git', ['remote', 'get-url', 'origin'], {
+        cwd,
         encoding: 'utf-8',
         stdio: ['ignore', 'pipe', 'ignore'],
       }),
@@ -64,7 +66,16 @@ export function detectVcsProvider(): VcsProviderType | undefined {
     return undefined;
   }
 
-  const hostname = extractHostname(url);
+  return extractHostname(url);
+}
+
+/**
+ * Detect VCS provider from the `origin` remote URL.
+ *
+ * @returns `'github'` | `'gitlab'` | `undefined`
+ */
+export function detectVcsProvider(): VcsProviderType | undefined {
+  const hostname = getRemoteHostname(process.cwd());
   if (!hostname) {
     return undefined;
   }

--- a/src/infra/git/types.ts
+++ b/src/infra/git/types.ts
@@ -67,11 +67,11 @@ export interface PrReviewData {
 }
 
 export interface GitProvider {
-  checkCliStatus(): CliStatus;
+  checkCliStatus(cwd?: string): CliStatus;
 
   fetchIssue(issueNumber: number): Issue;
 
-  createIssue(options: CreateIssueOptions): CreateIssueResult;
+  createIssue(options: CreateIssueOptions, cwd?: string): CreateIssueResult;
 
   fetchPrReviewComments(prNumber: number): PrReviewData;
 

--- a/src/infra/github/GitHubProvider.ts
+++ b/src/infra/github/GitHubProvider.ts
@@ -11,7 +11,7 @@ import { findExistingPr, commentOnPr, createPullRequest, fetchPrReviewComments }
 import type { GitProvider, CliStatus, Issue, ExistingPr, CreateIssueOptions, CreateIssueResult, CreatePrOptions, CreatePrResult, CommentResult, PrReviewData } from '../git/types.js';
 
 export class GitHubProvider implements GitProvider {
-  checkCliStatus(): CliStatus {
+  checkCliStatus(_cwd?: string): CliStatus {
     return checkGhCli();
   }
 
@@ -19,7 +19,7 @@ export class GitHubProvider implements GitProvider {
     return fetchIssue(issueNumber);
   }
 
-  createIssue(options: CreateIssueOptions): CreateIssueResult {
+  createIssue(options: CreateIssueOptions, _cwd?: string): CreateIssueResult {
     return createIssue(options);
   }
 

--- a/src/infra/gitlab/GitLabProvider.ts
+++ b/src/infra/gitlab/GitLabProvider.ts
@@ -12,16 +12,16 @@ import { findExistingMr, commentOnMr, createMergeRequest, fetchMrReviewComments 
 import type { GitProvider, CliStatus, Issue, ExistingPr, CreateIssueOptions, CreateIssueResult, CreatePrOptions, CreatePrResult, CommentResult, PrReviewData } from '../git/types.js';
 
 export class GitLabProvider implements GitProvider {
-  checkCliStatus(): CliStatus {
-    return checkGlabCli();
+  checkCliStatus(cwd?: string): CliStatus {
+    return checkGlabCli(cwd ?? process.cwd());
   }
 
   fetchIssue(issueNumber: number): Issue {
     return fetchIssue(issueNumber);
   }
 
-  createIssue(options: CreateIssueOptions): CreateIssueResult {
-    return createIssue(options);
+  createIssue(options: CreateIssueOptions, cwd?: string): CreateIssueResult {
+    return createIssue(options, cwd ?? process.cwd());
   }
 
   fetchPrReviewComments(prNumber: number): PrReviewData {

--- a/src/infra/gitlab/issue.ts
+++ b/src/infra/gitlab/issue.ts
@@ -65,8 +65,8 @@ export function fetchIssue(issueNumber: number): Issue {
 /**
  * Create a GitLab Issue via `glab issue create`.
  */
-export function createIssue(options: CreateIssueOptions): CreateIssueResult {
-  const glabStatus = checkGlabCli();
+export function createIssue(options: CreateIssueOptions, cwd: string): CreateIssueResult {
+  const glabStatus = checkGlabCli(cwd);
   if (!glabStatus.available) {
     return { success: false, error: glabStatus.error };
   }
@@ -80,6 +80,7 @@ export function createIssue(options: CreateIssueOptions): CreateIssueResult {
 
   try {
     const output = execFileSync('glab', args, {
+      cwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/src/infra/gitlab/pr.ts
+++ b/src/infra/gitlab/pr.ts
@@ -16,7 +16,7 @@ const log = createLogger('gitlab-mr');
  * Returns undefined if no MR exists.
  */
 export function findExistingMr(cwd: string, branch: string): ExistingPr | undefined {
-  const glabStatus = checkGlabCli();
+  const glabStatus = checkGlabCli(cwd);
   if (!glabStatus.available) return undefined;
 
   try {
@@ -43,7 +43,7 @@ export function createMergeRequest(cwd: string, options: CreatePrOptions): Creat
     throw new Error('--repo is not supported with GitLab provider. Use cwd context instead.');
   }
 
-  const glabStatus = checkGlabCli();
+  const glabStatus = checkGlabCli(cwd);
   if (!glabStatus.available) {
     return { success: false, error: glabStatus.error };
   }
@@ -87,7 +87,7 @@ export function createMergeRequest(cwd: string, options: CreatePrOptions): Creat
  * Add a comment (note) to a GitLab Merge Request.
  */
 export function commentOnMr(cwd: string, mrNumber: number, body: string): CommentResult {
-  const glabStatus = checkGlabCli();
+  const glabStatus = checkGlabCli(cwd);
   if (!glabStatus.available) {
     return { success: false, error: glabStatus.error };
   }

--- a/src/infra/gitlab/utils.ts
+++ b/src/infra/gitlab/utils.ts
@@ -6,6 +6,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { MAX_PAGES } from '../git/constants.js';
+import { getRemoteHostname } from '../git/detect.js';
 import type { CliStatus } from '../git/types.js';
 
 export const ITEMS_PER_PAGE = 100;
@@ -20,10 +21,19 @@ export function parseJson<T>(raw: string, context: string): T {
 
 /**
  * Check if `glab` CLI is available and authenticated.
+ *
+ * When `cwd` is provided, the hostname of the `origin` remote is extracted
+ * and `glab auth status --hostname <host>` is used so that only the
+ * target host's authentication state is evaluated (not all configured hosts).
  */
-export function checkGlabCli(): CliStatus {
+export function checkGlabCli(cwd: string): CliStatus {
+  const hostname = getRemoteHostname(cwd);
+  const authArgs = hostname
+    ? ['auth', 'status', '--hostname', hostname]
+    : ['auth', 'status'];
+
   try {
-    execFileSync('glab', ['auth', 'status'], { stdio: 'pipe' });
+    execFileSync('glab', authArgs, { stdio: 'pipe' });
     return { available: true };
   } catch {
     try {


### PR DESCRIPTION
 ## 概要
  GitLab セルフホスト環境のリポジトリで、`gitlab.com` に未ログインでもタスク完了後の Issue / Merge Request 作成が失敗しないように修正しました。

  従来は `glab auth status` で全ホストの認証状態を見ていたため、対象プロジェクトの GitLab インスタンスにはログイン済みでも、`gitlab.com` の認証がないだけで
  CLI 利用不可と判定されていました。

  ## 変更内容
  - `origin` remote URL からホスト名を取得する `getRemoteHostname(cwd)` を追加
  - GitLab CLI の認証確認を `glab auth status --hostname <remote-host>` ベースに変更
  - GitLab Provider の `checkCliStatus` / `createIssue` に `cwd` を渡せるようにして、対象リポジトリの remote 情報を使って判定するよう修正
  - MR の検索・作成・コメント、Issue 作成で `checkGlabCli(cwd)` を使うように統一
  - タスク完了後フローで Issue 解決処理に実行ディレクトリを渡すよう修正
  - GitLab セルフホスト URL、SSH/HTTPS、ポート付き URL、`cwd` 伝搬に関するテストを追加

  ## 動作確認
  - GitLab 関連のユニットテストを追加し、セルフホスト環境の remote hostname を使って認証確認する挙動を検証
  - `gitlab.com` に未ログインでも、対象の GitLab セルフホスト環境に対する Issue / MR 操作がブロックされないことをテストで確認

  ## 影響範囲
  - GitLab Provider を使う Issue / Merge Request 作成、およびタスク完了後の自動 PR/MR 作成フロー
  - GitHub Provider には互換目的のシグネチャ調整のみで、実動作の変更はなし

  ## リスク・懸念点
  - remote URL からホスト名を取得できない特殊な Git 設定では、従来どおり `glab auth status` の汎用判定にフォールバックします
  - GitLab CLI のホスト別認証状態に依存するため、`origin` が想定外のホストを向いている場合は期待と異なる判定になる可能性があります

  ## 補足
  - 修正対象は `fix-gitlab-selfhosted-merge-request-bug`
  - 主な変更ファイル: `src/infra/git/detect.ts`, `src/infra/gitlab/utils.ts`, `src/infra/gitlab/issue.ts`, `src/infra/gitlab/pr.ts`

closed. https://github.com/nrslib/takt/issues/544
