### PR TITLE
fix: GitLab セルフホスト環境で、Git provider 経由の glab 実行に project/worktree の cwd が伝搬されていなかった問題を修正

### DIFF
--- a/src/__tests__/addTask.test.ts
+++ b/src/__tests__/addTask.test.ts
@@ -240,7 +240,7 @@ describe('addTask', () => {
     expect(mockInteractiveMode).not.toHaveBeenCalled();
     expect(mockIsIssueReference).toHaveBeenCalledWith('#99');
     expect(mockParseIssueNumbers).toHaveBeenCalledWith(['#99']);
-    expect(mockResolveIssueTask).toHaveBeenCalledWith('#99');
+    expect(mockResolveIssueTask).toHaveBeenCalledWith('#99', testDir);
     expect(mockCheckCliStatus).not.toHaveBeenCalled();
     const task = loadTasks(testDir).tasks[0]!;
     expect(task.content).toBeUndefined();
@@ -256,11 +256,11 @@ describe('addTask', () => {
 
     await addTaskWithPrOption(testDir, 'placeholder', 456);
 
-    expect(mockCheckCliStatus).toHaveBeenCalled();
+    expect(mockCheckCliStatus).toHaveBeenCalledWith(testDir);
     expect(mockCheckCliStatus.mock.invocationCallOrder[0]).toBeLessThan(
       mockFetchPrReviewComments.mock.invocationCallOrder[0],
     );
-    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456);
+    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456, testDir);
     expect(mockFormatPrReviewAsTask).toHaveBeenCalledWith(prReview);
     expect(mockIsIssueReference).not.toHaveBeenCalled();
     expect(mockParseIssueNumbers).not.toHaveBeenCalled();
@@ -296,7 +296,7 @@ describe('addTask', () => {
     await addTaskWithPrOption(testDir, 'placeholder', 456);
 
     expect(mockCheckCliStatus).toHaveBeenCalled();
-    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456);
+    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456, testDir);
     expect(mockFormatPrReviewAsTask).not.toHaveBeenCalled();
     expect(mockDeterminePiece).not.toHaveBeenCalled();
     expect(mockError).toHaveBeenCalled();
@@ -309,7 +309,7 @@ describe('addTask', () => {
     await addTaskWithPrOption(testDir, 'placeholder', 456);
 
     expect(mockCheckCliStatus).toHaveBeenCalled();
-    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456);
+    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456, testDir);
     expect(mockFormatPrReviewAsTask).not.toHaveBeenCalled();
     expect(mockDeterminePiece).not.toHaveBeenCalled();
     expect(mockError).toHaveBeenCalledWith(expect.stringContaining('network timeout'));
@@ -341,7 +341,7 @@ describe('addTask', () => {
     expect(mockParseIssueNumbers).not.toHaveBeenCalled();
     expect(mockResolveIssueTask).not.toHaveBeenCalled();
     expect(mockCheckCliStatus).toHaveBeenCalled();
-    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456);
+    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456, testDir);
     expect(mockFormatPrReviewAsTask).toHaveBeenCalledWith(prReview);
     const task = loadTasks(testDir).tasks[0]!;
     expect(task.content).toBeUndefined();
@@ -367,7 +367,7 @@ describe('addTask', () => {
     await addTaskWithPrOption(testDir, 'placeholder', 456);
 
     expect(mockCheckCliStatus).toHaveBeenCalled();
-    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456);
+    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456, testDir);
     expect(mockFormatPrReviewAsTask).toHaveBeenCalledWith(prReview);
     expect(mockDeterminePiece).toHaveBeenCalledTimes(1);
     expect(fs.existsSync(path.join(testDir, '.takt', 'tasks.yaml'))).toBe(false);

--- a/src/__tests__/cli-routing-issue-resolve.test.ts
+++ b/src/__tests__/cli-routing-issue-resolve.test.ts
@@ -235,7 +235,7 @@ describe('Issue resolution in routing', () => {
       await executeDefaultAction();
 
       // Then: issue should be fetched
-      expect(mockFetchIssue).toHaveBeenCalledWith(131);
+      expect(mockFetchIssue).toHaveBeenCalledWith(131, undefined);
 
       // Then: interactive mode should receive the formatted issue as initial input
       expect(mockInteractiveMode).toHaveBeenCalledWith(

--- a/src/__tests__/cli-routing-pr-resolve.test.ts
+++ b/src/__tests__/cli-routing-pr-resolve.test.ts
@@ -180,7 +180,7 @@ describe('PR resolution in routing', () => {
       await executeDefaultAction();
 
       // Then
-      expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456);
+      expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456, undefined);
       expect(mockInteractiveMode).toHaveBeenCalledWith(
         '/test/cwd',
         expect.stringContaining('## PR #456 Review Comments:'),

--- a/src/__tests__/createIssue.test.ts
+++ b/src/__tests__/createIssue.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../shared/utils/index.js', async (importOriginal) => ({
   }),
 }));
 
-import { createIssue, checkGhCli } from '../infra/github/issue.js';
+import { createIssue } from '../infra/github/issue.js';
 
 const mockExecFileSync = vi.mocked(execFileSync);
 
@@ -38,7 +38,7 @@ describe('createIssue', () => {
       .mockReturnValueOnce('https://github.com/owner/repo/issues/42\n' as unknown as Buffer);
 
     // When
-    const result = createIssue({ title: 'Test issue', body: 'Test body' });
+    const result = createIssue({ title: 'Test issue', body: 'Test body' }, '/project');
 
     // Then
     expect(result.success).toBe(true);
@@ -52,7 +52,7 @@ describe('createIssue', () => {
       .mockReturnValueOnce('https://github.com/owner/repo/issues/1\n' as unknown as Buffer);
 
     // When
-    createIssue({ title: 'My Title', body: 'My Body' });
+    createIssue({ title: 'My Title', body: 'My Body' }, '/project');
 
     // Then: verify the second call (issue create) has correct args
     const issueCreateCall = mockExecFileSync.mock.calls[1];
@@ -70,7 +70,7 @@ describe('createIssue', () => {
       .mockReturnValueOnce('https://github.com/owner/repo/issues/1\n' as unknown as Buffer);
 
     // When
-    createIssue({ title: 'Bug', body: 'Fix it', labels: ['bug', 'priority:high'] });
+    createIssue({ title: 'Bug', body: 'Fix it', labels: ['bug', 'priority:high'] }, '/project');
 
     // Then
     const issueCreateCall = mockExecFileSync.mock.calls[2];
@@ -88,7 +88,7 @@ describe('createIssue', () => {
       .mockReturnValueOnce('https://github.com/owner/repo/issues/1\n' as unknown as Buffer);
 
     // When
-    createIssue({ title: 'Bug', body: 'Fix it', labels: ['bug', 'Docs'] });
+    createIssue({ title: 'Bug', body: 'Fix it', labels: ['bug', 'Docs'] }, '/project');
 
     // Then
     const issueCreateCall = mockExecFileSync.mock.calls[2];
@@ -105,7 +105,7 @@ describe('createIssue', () => {
       .mockReturnValueOnce('https://github.com/owner/repo/issues/1\n' as unknown as Buffer);
 
     // When
-    createIssue({ title: 'Title', body: 'Body', labels: [] });
+    createIssue({ title: 'Title', body: 'Body', labels: [] }, '/project');
 
     // Then
     const issueCreateCall = mockExecFileSync.mock.calls[1];
@@ -120,7 +120,7 @@ describe('createIssue', () => {
       .mockReturnValueOnce('https://github.com/owner/repo/issues/1\n' as unknown as Buffer);
 
     // When
-    createIssue({ title: 'Title', body: 'Body', labels: ['Docs', 'Chore'] });
+    createIssue({ title: 'Title', body: 'Body', labels: ['Docs', 'Chore'] }, '/project');
 
     // Then
     const issueCreateCall = mockExecFileSync.mock.calls[2];
@@ -134,7 +134,7 @@ describe('createIssue', () => {
       .mockReturnValueOnce(Buffer.from('gh version 2.0.0'));
 
     // When
-    const result = createIssue({ title: 'Test', body: 'Body' });
+    const result = createIssue({ title: 'Test', body: 'Body' }, '/project');
 
     // Then
     expect(result.success).toBe(false);
@@ -148,11 +148,27 @@ describe('createIssue', () => {
       .mockImplementationOnce(() => { throw new Error('command not found'); });
 
     // When
-    const result = createIssue({ title: 'Test', body: 'Body' });
+    const result = createIssue({ title: 'Test', body: 'Body' }, '/project');
 
     // Then
     expect(result.success).toBe(false);
     expect(result.error).toContain('not installed');
+  });
+
+  it('should pass cwd to execFileSync for all gh commands', () => {
+    // Given
+    mockExecFileSync
+      .mockReturnValueOnce(Buffer.from('')) // gh auth status
+      .mockReturnValueOnce('bug\n' as unknown as Buffer) // gh label list
+      .mockReturnValueOnce('https://github.com/owner/repo/issues/1\n' as unknown as Buffer);
+
+    // When
+    createIssue({ title: 'Title', body: 'Body', labels: ['bug'] }, '/worktree/clone');
+
+    // Then: all execFileSync calls should include cwd
+    for (const call of mockExecFileSync.mock.calls) {
+      expect(call[2]).toEqual(expect.objectContaining({ cwd: '/worktree/clone' }));
+    }
   });
 
   it('should return error when gh issue create fails', () => {
@@ -162,7 +178,7 @@ describe('createIssue', () => {
       .mockImplementationOnce(() => { throw new Error('repo not found'); });
 
     // When
-    const result = createIssue({ title: 'Test', body: 'Body' });
+    const result = createIssue({ title: 'Test', body: 'Body' }, '/project');
 
     // Then
     expect(result.success).toBe(false);

--- a/src/__tests__/createIssueFromTask.test.ts
+++ b/src/__tests__/createIssueFromTask.test.ts
@@ -54,10 +54,10 @@ describe('createIssueFromTask', () => {
       createIssueFromTask(title99);
 
       // Then: title passed without truncation
-      expect(mockCreateIssue).toHaveBeenCalledWith({
-        title: title99,
-        body: title99,
-      });
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: title99, body: title99 },
+        undefined,
+      );
     });
 
     it('should use title as-is when exactly 100 characters', () => {
@@ -69,10 +69,10 @@ describe('createIssueFromTask', () => {
       createIssueFromTask(title100);
 
       // Then: title passed without truncation
-      expect(mockCreateIssue).toHaveBeenCalledWith({
-        title: title100,
-        body: title100,
-      });
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: title100, body: title100 },
+        undefined,
+      );
     });
 
     it('should truncate title to 97 chars + ellipsis when 101 characters', () => {
@@ -86,10 +86,10 @@ describe('createIssueFromTask', () => {
       // Then: title truncated to 97 chars + "..."
       const expectedTitle = `${'a'.repeat(97)}...`;
       expect(expectedTitle).toHaveLength(100);
-      expect(mockCreateIssue).toHaveBeenCalledWith({
-        title: expectedTitle,
-        body: title101,
-      });
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: expectedTitle, body: title101 },
+        undefined,
+      );
     });
   });
 
@@ -164,9 +164,39 @@ describe('createIssueFromTask', () => {
     createIssueFromTask(task);
 
     // Then: first line → title, full text → body
-    expect(mockCreateIssue).toHaveBeenCalledWith({
-      title: 'First line title',
-      body: task,
+    expect(mockCreateIssue).toHaveBeenCalledWith(
+      { title: 'First line title', body: task },
+      undefined,
+    );
+  });
+
+  describe('cwd propagation', () => {
+    it('cwd を指定した場合は createIssue に cwd を渡す', () => {
+      // Given
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/owner/repo/issues/1' });
+
+      // When
+      createIssueFromTask('Test task', { cwd: '/worktree/clone' });
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: 'Test task', body: 'Test task' },
+        '/worktree/clone',
+      );
+    });
+
+    it('cwd 省略時は createIssue に undefined を渡す', () => {
+      // Given
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/owner/repo/issues/1' });
+
+      // When
+      createIssueFromTask('Test task');
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: 'Test task', body: 'Test task' },
+        undefined,
+      );
     });
   });
 
@@ -179,11 +209,10 @@ describe('createIssueFromTask', () => {
       createIssueFromTask('Test task', { labels: ['bug'] });
 
       // Then
-      expect(mockCreateIssue).toHaveBeenCalledWith({
-        title: 'Test task',
-        body: 'Test task',
-        labels: ['bug'],
-      });
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: 'Test task', body: 'Test task', labels: ['bug'] },
+        undefined,
+      );
     });
 
     it('should not include labels key when options is undefined', () => {
@@ -194,10 +223,10 @@ describe('createIssueFromTask', () => {
       createIssueFromTask('Test task');
 
       // Then
-      expect(mockCreateIssue).toHaveBeenCalledWith({
-        title: 'Test task',
-        body: 'Test task',
-      });
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: 'Test task', body: 'Test task' },
+        undefined,
+      );
     });
 
     it('should not include labels key when labels is empty array', () => {
@@ -208,10 +237,10 @@ describe('createIssueFromTask', () => {
       createIssueFromTask('Test task', { labels: [] });
 
       // Then
-      expect(mockCreateIssue).toHaveBeenCalledWith({
-        title: 'Test task',
-        body: 'Test task',
-      });
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: 'Test task', body: 'Test task' },
+        undefined,
+      );
     });
 
     it('should filter out empty string labels', () => {
@@ -222,11 +251,10 @@ describe('createIssueFromTask', () => {
       createIssueFromTask('Test task', { labels: ['bug', '', 'enhancement'] });
 
       // Then
-      expect(mockCreateIssue).toHaveBeenCalledWith({
-        title: 'Test task',
-        body: 'Test task',
-        labels: ['bug', 'enhancement'],
-      });
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: 'Test task', body: 'Test task', labels: ['bug', 'enhancement'] },
+        undefined,
+      );
     });
   });
 });

--- a/src/__tests__/git-cwd-propagation.test.ts
+++ b/src/__tests__/git-cwd-propagation.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Integration tests for cwd propagation through GitProvider call chain.
+ *
+ * Verifies that cwd is correctly propagated from high-level callers
+ * (routing-inputs, pipeline/steps, tasks/add) through to the
+ * GitProvider methods. This ensures worktree execution works correctly
+ * even when process.cwd() differs from the project directory.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockCheckCliStatus,
+  mockFetchIssue,
+  mockCreateIssue,
+  mockFetchPrReviewComments,
+  mockFindExistingPr,
+  mockCreatePullRequest,
+  mockCommentOnPr,
+} = vi.hoisted(() => ({
+  mockCheckCliStatus: vi.fn(),
+  mockFetchIssue: vi.fn(),
+  mockCreateIssue: vi.fn(),
+  mockFetchPrReviewComments: vi.fn(),
+  mockFindExistingPr: vi.fn(),
+  mockCreatePullRequest: vi.fn(),
+  mockCommentOnPr: vi.fn(),
+}));
+
+vi.mock('../infra/git/index.js', () => ({
+  getGitProvider: () => ({
+    checkCliStatus: (...args: unknown[]) => mockCheckCliStatus(...args),
+    fetchIssue: (...args: unknown[]) => mockFetchIssue(...args),
+    createIssue: (...args: unknown[]) => mockCreateIssue(...args),
+    fetchPrReviewComments: (...args: unknown[]) => mockFetchPrReviewComments(...args),
+    findExistingPr: (...args: unknown[]) => mockFindExistingPr(...args),
+    createPullRequest: (...args: unknown[]) => mockCreatePullRequest(...args),
+    commentOnPr: (...args: unknown[]) => mockCommentOnPr(...args),
+  }),
+  formatIssueAsTask: vi.fn((issue: { number: number; title: string }) => `## Issue #${issue.number}: ${issue.title}`),
+  parseIssueNumbers: vi.fn(() => []),
+  isIssueReference: vi.fn(),
+  resolveIssueTask: vi.fn(),
+  formatPrReviewAsTask: vi.fn((pr: { number: number; title: string }) => `## PR #${pr.number}: ${pr.title}`),
+  buildPrBody: vi.fn(() => 'pr-body'),
+  createPullRequestSafely: vi.fn(),
+}));
+
+vi.mock('../shared/ui/index.js', () => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  success: vi.fn(),
+  withProgress: vi.fn(async (_start: unknown, _done: unknown, operation: () => unknown) => operation()),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCheckCliStatus.mockReturnValue({ available: true });
+});
+
+describe('cwd propagation: routing-inputs', () => {
+  describe('resolveIssueInput', () => {
+    it('cwd を指定した場合は checkCliStatus と fetchIssue に cwd を渡す', async () => {
+      // Given
+      const issue = { number: 42, title: 'Test', body: 'Body', labels: [], comments: [] };
+      mockFetchIssue.mockReturnValue(issue);
+
+      const { resolveIssueInput } = await import('../app/cli/routing-inputs.js');
+
+      // When
+      await resolveIssueInput(42, undefined, '/worktree/clone');
+
+      // Then
+      expect(mockCheckCliStatus).toHaveBeenCalledWith('/worktree/clone');
+      expect(mockFetchIssue).toHaveBeenCalledWith(42, '/worktree/clone');
+    });
+
+    it('cwd 省略時は checkCliStatus と fetchIssue に cwd を渡さない', async () => {
+      // Given
+      const issue = { number: 10, title: 'Issue', body: '', labels: [], comments: [] };
+      mockFetchIssue.mockReturnValue(issue);
+
+      const { resolveIssueInput } = await import('../app/cli/routing-inputs.js');
+
+      // When
+      await resolveIssueInput(10, undefined);
+
+      // Then: cwd is not passed (provider's fallback handles it)
+      expect(mockCheckCliStatus).toHaveBeenCalledTimes(1);
+      expect(mockFetchIssue).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('resolvePrInput', () => {
+    it('cwd を指定した場合は checkCliStatus と fetchPrReviewComments に cwd を渡す', async () => {
+      // Given
+      const prReview = {
+        number: 456,
+        title: 'Fix bug',
+        body: 'Description',
+        url: 'https://github.com/org/repo/pull/456',
+        headRefName: 'fix/bug',
+        comments: [],
+        reviews: [],
+        files: [],
+      };
+      mockFetchPrReviewComments.mockReturnValue(prReview);
+
+      const { resolvePrInput } = await import('../app/cli/routing-inputs.js');
+
+      // When
+      await resolvePrInput(456, '/worktree/clone');
+
+      // Then
+      expect(mockCheckCliStatus).toHaveBeenCalledWith('/worktree/clone');
+      expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456, '/worktree/clone');
+    });
+
+    it('cwd 省略時は checkCliStatus と fetchPrReviewComments に cwd を渡さない', async () => {
+      // Given
+      const prReview = {
+        number: 100,
+        title: 'PR',
+        body: '',
+        url: 'https://github.com/org/repo/pull/100',
+        headRefName: 'feat/x',
+        comments: [],
+        reviews: [],
+        files: [],
+      };
+      mockFetchPrReviewComments.mockReturnValue(prReview);
+
+      const { resolvePrInput } = await import('../app/cli/routing-inputs.js');
+
+      // When
+      await resolvePrInput(100);
+
+      // Then
+      expect(mockCheckCliStatus).toHaveBeenCalledTimes(1);
+      expect(mockFetchPrReviewComments).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('cwd propagation: GitProvider pattern A interface consistency', () => {
+  it('findExistingPr は branch が第1引数、cwd が第2引数（オプショナル）', () => {
+    // Given
+    const pr = { number: 1, url: 'https://github.com/org/repo/pull/1' };
+    mockFindExistingPr.mockReturnValue(pr);
+
+    // When: パターンA（末尾オプショナル）で呼び出す
+    const provider = {
+      findExistingPr: (branch: string, cwd?: string) =>
+        mockFindExistingPr(branch, cwd),
+    };
+    const result = provider.findExistingPr('feat/branch', '/project');
+
+    // Then: 引数順が (branch, cwd) であること
+    expect(mockFindExistingPr).toHaveBeenCalledWith('feat/branch', '/project');
+    expect(result).toBe(pr);
+  });
+
+  it('createPullRequest は options が第1引数、cwd が第2引数（オプショナル）', () => {
+    // Given
+    const prResult = { success: true, url: 'https://github.com/org/repo/pull/1' };
+    mockCreatePullRequest.mockReturnValue(prResult);
+
+    // When: パターンA（末尾オプショナル）で呼び出す
+    const provider = {
+      createPullRequest: (options: { branch: string; title: string; body: string }, cwd?: string) =>
+        mockCreatePullRequest(options, cwd),
+    };
+    const opts = { branch: 'feat/x', title: 'PR', body: 'body' };
+    const result = provider.createPullRequest(opts, '/project');
+
+    // Then: 引数順が (options, cwd) であること
+    expect(mockCreatePullRequest).toHaveBeenCalledWith(opts, '/project');
+    expect(result).toBe(prResult);
+  });
+
+  it('commentOnPr は prNumber が第1引数、body が第2引数、cwd が第3引数（オプショナル）', () => {
+    // Given
+    const commentResult = { success: true };
+    mockCommentOnPr.mockReturnValue(commentResult);
+
+    // When: パターンA（末尾オプショナル）で呼び出す
+    const provider = {
+      commentOnPr: (prNumber: number, body: string, cwd?: string) =>
+        mockCommentOnPr(prNumber, body, cwd),
+    };
+    const result = provider.commentOnPr(42, 'Updated!', '/project');
+
+    // Then: 引数順が (prNumber, body, cwd) であること
+    expect(mockCommentOnPr).toHaveBeenCalledWith(42, 'Updated!', '/project');
+    expect(result).toBe(commentResult);
+  });
+
+  it('findExistingPr の cwd 省略時は undefined が渡される（provider側で process.cwd() にフォールバック）', () => {
+    // Given
+    mockFindExistingPr.mockReturnValue(undefined);
+
+    // When: cwd を省略して呼び出す
+    const provider = {
+      findExistingPr: (branch: string, cwd?: string) =>
+        mockFindExistingPr(branch, cwd),
+    };
+    provider.findExistingPr('feat/branch');
+
+    // Then: cwd は undefined
+    expect(mockFindExistingPr).toHaveBeenCalledWith('feat/branch', undefined);
+  });
+
+  it('createPullRequest の cwd 省略時は undefined が渡される', () => {
+    // Given
+    mockCreatePullRequest.mockReturnValue({ success: true, url: 'https://github.com/org/repo/pull/1' });
+
+    // When
+    const provider = {
+      createPullRequest: (options: { branch: string; title: string; body: string }, cwd?: string) =>
+        mockCreatePullRequest(options, cwd),
+    };
+    provider.createPullRequest({ branch: 'feat/x', title: 'PR', body: 'body' });
+
+    // Then
+    expect(mockCreatePullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ branch: 'feat/x' }),
+      undefined,
+    );
+  });
+
+  it('commentOnPr の cwd 省略時は undefined が渡される', () => {
+    // Given
+    mockCommentOnPr.mockReturnValue({ success: true });
+
+    // When
+    const provider = {
+      commentOnPr: (prNumber: number, body: string, cwd?: string) =>
+        mockCommentOnPr(prNumber, body, cwd),
+    };
+    provider.commentOnPr(42, 'body');
+
+    // Then
+    expect(mockCommentOnPr).toHaveBeenCalledWith(42, 'body', undefined);
+  });
+});
+
+describe('cwd propagation: addTask wiring', () => {
+  it('addTask の PR 取得フローは cwd を checkCliStatus と fetchPrReviewComments に渡す', async () => {
+    // Given
+    const prReview = {
+      number: 10,
+      title: 'PR',
+      body: '',
+      url: 'https://github.com/org/repo/pull/10',
+      headRefName: 'feat/x',
+      comments: [{ author: 'a', body: 'fix' }],
+      reviews: [{ author: 'b', body: 'ok' }],
+      files: [],
+    };
+    mockFetchPrReviewComments.mockReturnValue(prReview);
+
+    vi.mock('../infra/task/index.js', () => ({
+      TaskRunner: vi.fn().mockImplementation(() => ({ addTask: vi.fn(() => ({ name: 'task-1' })) })),
+      summarizeTaskName: vi.fn(async () => 'slug'),
+    }));
+    vi.mock('../features/tasks/execute/selectAndExecute.js', () => ({
+      determinePiece: vi.fn(async () => 'default'),
+    }));
+    vi.mock('../infra/task/naming.js', () => ({
+      firstLine: vi.fn(() => 'line'),
+    }));
+    vi.mock('../features/tasks/add/worktree-settings.js', () => ({
+      displayTaskCreationResult: vi.fn(),
+      promptWorktreeSettings: vi.fn(),
+    }));
+    vi.mock('node:fs', () => ({
+      existsSync: vi.fn(() => false),
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+    }));
+    vi.mock('../shared/i18n/index.js', () => ({
+      getLabel: vi.fn(() => ''),
+    }));
+    vi.mock('../shared/prompt/index.js', () => ({
+      promptInput: vi.fn(),
+      confirm: vi.fn(),
+      selectOption: vi.fn(),
+    }));
+
+    const { addTask } = await import('../features/tasks/add/index.js');
+
+    // When
+    await addTask('/worktree/clone', undefined, { prNumber: 10 });
+
+    // Then
+    expect(mockCheckCliStatus).toHaveBeenCalledWith('/worktree/clone');
+    expect(mockFetchPrReviewComments).toHaveBeenCalledWith(10, '/worktree/clone');
+  });
+});
+
+describe('cwd propagation: string型引数の位置逆転による誤用検出', () => {
+  it('findExistingPr に旧シグネチャ (cwd, branch) で渡すと意味が逆転する', () => {
+    // Given: 旧パターン B の引数順で呼んでしまった場合
+    mockFindExistingPr.mockReturnValue(undefined);
+
+    // When: 間違った順番で呼ぶ（cwd が branch 位置に入る）
+    const wrongCall = () => {
+      // 実装後: findExistingPr(branch, cwd?) なので、
+      // 旧パターンの findExistingPr('/project', 'feat/x') は
+      // branch='/project', cwd='feat/x' として解釈される
+      mockFindExistingPr('/project', 'feat/x');
+    };
+    wrongCall();
+
+    // Then: 第1引数が branch として使われるため、
+    // '/project' がブランチ名として渡されてしまう
+    // この検証はテストケースのドキュメントとして機能する
+    expect(mockFindExistingPr).toHaveBeenCalledWith('/project', 'feat/x');
+    // ↑ これは意図的に "間違った" 呼び出しの記録。
+    // 実装者はこのケースに注意すること。
+  });
+});

--- a/src/__tests__/git-detect.test.ts
+++ b/src/__tests__/git-detect.test.ts
@@ -313,6 +313,47 @@ describe('detectVcsProvider', () => {
       expect(result).toBe('gitlab');
     });
   });
+
+  describe('cwd パラメータ', () => {
+    it('cwd を指定した場合は getRemoteHostname にそのまま渡す', () => {
+      // Given
+      mockExecFileSync.mockReturnValue('https://github.com/org/repo.git\n');
+
+      // When
+      const result = detectVcsProvider('/worktree/clone');
+
+      // Then
+      expect(result).toBe('github');
+      const call = mockExecFileSync.mock.calls[0];
+      expect(call[2]).toHaveProperty('cwd', '/worktree/clone');
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして使用する', () => {
+      // Given
+      mockExecFileSync.mockReturnValue('https://gitlab.com/org/repo.git\n');
+
+      // When
+      const result = detectVcsProvider();
+
+      // Then
+      expect(result).toBe('gitlab');
+      const call = mockExecFileSync.mock.calls[0];
+      expect(call[2]).toHaveProperty('cwd', process.cwd());
+    });
+
+    it('worktree パスを渡した場合にそのリポジトリのリモートで検出する', () => {
+      // Given: worktree ではセルフホストGitLab
+      mockExecFileSync.mockReturnValue('https://gitlab.company.com/org/repo.git\n');
+
+      // When
+      const result = detectVcsProvider('/tmp/worktree');
+
+      // Then: セルフホストは undefined
+      expect(result).toBeUndefined();
+      const call = mockExecFileSync.mock.calls[0];
+      expect(call[2]).toHaveProperty('cwd', '/tmp/worktree');
+    });
+  });
 });
 
 describe('VCS_PROVIDER_TYPES', () => {

--- a/src/__tests__/git-factory.test.ts
+++ b/src/__tests__/git-factory.test.ts
@@ -53,6 +53,7 @@ vi.mock('../infra/gitlab/index.js', () => ({
 let getGitProvider: typeof import('../infra/git/index.js').getGitProvider;
 let initGitProvider: typeof import('../infra/git/index.js').initGitProvider;
 let createPullRequestSafely: typeof import('../infra/git/index.js').createPullRequestSafely;
+let resolveIssueTask: typeof import('../infra/git/index.js').resolveIssueTask;
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -61,6 +62,7 @@ beforeEach(async () => {
   getGitProvider = mod.getGitProvider;
   initGitProvider = mod.initGitProvider;
   createPullRequestSafely = mod.createPullRequestSafely;
+  resolveIssueTask = mod.resolveIssueTask;
 });
 
 describe('getGitProvider', () => {
@@ -167,7 +169,7 @@ describe('initGitProvider', () => {
 
     // Then
     expect((provider as unknown as { _type: string })._type).toBe('gitlab');
-    expect(mockDetectVcsProvider).toHaveBeenCalled();
+    expect(mockDetectVcsProvider).toHaveBeenCalledWith('/project');
   });
 
   it('設定が自動検出より優先される', () => {
@@ -238,15 +240,67 @@ describe('createPullRequestSafely', () => {
       throw new Error('boom');
     });
 
-    const result = createPullRequestSafely(gitProvider, '/project', {
+    const result = createPullRequestSafely(gitProvider, {
       branch: 'feature/test',
       title: 'Test',
       body: 'Body',
-    });
+    }, '/project');
 
     expect(result).toEqual({
       success: false,
       error: 'boom',
     });
+  });
+
+  it('cwd を指定した場合は createPullRequest にそのまま転送する', () => {
+    mockDetectVcsProvider.mockReturnValue('github');
+    const gitProvider = getGitProvider();
+    const createPullRequestMock = vi.mocked(gitProvider.createPullRequest);
+    createPullRequestMock.mockReturnValue({ success: true, url: 'https://github.com/org/repo/pull/1' });
+
+    const opts = { branch: 'feat/test', title: 'Test', body: 'Body' };
+    createPullRequestSafely(gitProvider, opts, '/worktree/clone');
+
+    expect(createPullRequestMock).toHaveBeenCalledWith(opts, '/worktree/clone');
+  });
+
+  it('cwd 省略時も createPullRequest を正しく呼び出す', () => {
+    mockDetectVcsProvider.mockReturnValue('github');
+    const gitProvider = getGitProvider();
+    const createPullRequestMock = vi.mocked(gitProvider.createPullRequest);
+    createPullRequestMock.mockReturnValue({ success: true, url: 'https://github.com/org/repo/pull/2' });
+
+    const opts = { branch: 'feat/test', title: 'Test', body: 'Body' };
+    const result = createPullRequestSafely(gitProvider, opts);
+
+    expect(result.success).toBe(true);
+    expect(createPullRequestMock).toHaveBeenCalledWith(opts, undefined);
+  });
+});
+
+describe('resolveIssueTask with cwd', () => {
+  it('cwd を指定した場合は checkCliStatus と fetchIssue に cwd を渡す', () => {
+    mockDetectVcsProvider.mockReturnValue('github');
+    const gitProvider = getGitProvider();
+    const checkCliStatusMock = vi.mocked(gitProvider.checkCliStatus);
+    const fetchIssueMock = vi.mocked(gitProvider.fetchIssue);
+
+    checkCliStatusMock.mockReturnValue({ available: true });
+    fetchIssueMock.mockReturnValue({
+      number: 42,
+      title: 'Test Issue',
+      body: 'Body',
+      labels: [],
+      comments: [],
+    });
+
+    // resolveIssueTask is a module-level function using getGitProvider()
+    // After implementation, it should accept cwd? and pass to provider methods
+    const mod = { resolveIssueTask } as { resolveIssueTask: (task: string, cwd?: string) => string };
+    const result = mod.resolveIssueTask('#42', '/worktree/clone');
+
+    expect(checkCliStatusMock).toHaveBeenCalledWith('/worktree/clone');
+    expect(fetchIssueMock).toHaveBeenCalledWith(42, '/worktree/clone');
+    expect(result).toContain('Test Issue');
   });
 });

--- a/src/__tests__/github-pr.test.ts
+++ b/src/__tests__/github-pr.test.ts
@@ -31,7 +31,7 @@ describe('findExistingPr', () => {
   it('オープンな PR がある場合はその PR を返す', () => {
     mockExecFileSync.mockReturnValue(JSON.stringify([{ number: 42, url: 'https://github.com/org/repo/pull/42' }]));
 
-    const result = findExistingPr('/project', 'task/fix-bug');
+    const result = findExistingPr('task/fix-bug', '/project');
 
     expect(result).toEqual({ number: 42, url: 'https://github.com/org/repo/pull/42' });
   });
@@ -39,7 +39,7 @@ describe('findExistingPr', () => {
   it('PR がない場合は undefined を返す', () => {
     mockExecFileSync.mockReturnValue(JSON.stringify([]));
 
-    const result = findExistingPr('/project', 'task/fix-bug');
+    const result = findExistingPr('task/fix-bug', '/project');
 
     expect(result).toBeUndefined();
   });
@@ -47,7 +47,7 @@ describe('findExistingPr', () => {
   it('gh CLI が失敗した場合は undefined を返す', () => {
     mockExecFileSync.mockImplementation(() => { throw new Error('gh: command not found'); });
 
-    const result = findExistingPr('/project', 'task/fix-bug');
+    const result = findExistingPr('task/fix-bug', '/project');
 
     expect(result).toBeUndefined();
   });
@@ -61,12 +61,12 @@ describe('createPullRequest', () => {
   it('draft: true の場合、args に --draft が含まれる', () => {
     mockExecFileSync.mockReturnValue('https://github.com/org/repo/pull/1\n');
 
-    createPullRequest('/project', {
+    createPullRequest({
       branch: 'feat/my-branch',
       title: 'My PR',
       body: 'PR body',
       draft: true,
-    });
+    }, '/project');
 
     const call = mockExecFileSync.mock.calls[0];
     expect(call[1]).toContain('--draft');
@@ -75,12 +75,12 @@ describe('createPullRequest', () => {
   it('draft: false の場合、args に --draft が含まれない', () => {
     mockExecFileSync.mockReturnValue('https://github.com/org/repo/pull/2\n');
 
-    createPullRequest('/project', {
+    createPullRequest({
       branch: 'feat/my-branch',
       title: 'My PR',
       body: 'PR body',
       draft: false,
-    });
+    }, '/project');
 
     const call = mockExecFileSync.mock.calls[0];
     expect(call[1]).not.toContain('--draft');
@@ -89,11 +89,11 @@ describe('createPullRequest', () => {
   it('draft が未指定の場合、args に --draft が含まれない', () => {
     mockExecFileSync.mockReturnValue('https://github.com/org/repo/pull/3\n');
 
-    createPullRequest('/project', {
+    createPullRequest({
       branch: 'feat/my-branch',
       title: 'My PR',
       body: 'PR body',
-    });
+    }, '/project');
 
     const call = mockExecFileSync.mock.calls[0];
     expect(call[1]).not.toContain('--draft');
@@ -211,7 +211,7 @@ describe('fetchPrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
 
     // When
-    const result = fetchPrReviewComments(456);
+    const result = fetchPrReviewComments(456, '/project');
 
     // Then
     expect(mockExecFileSync).toHaveBeenCalledWith(
@@ -255,7 +255,7 @@ describe('fetchPrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify([]));
 
     // When
-    const result = fetchPrReviewComments(10);
+    const result = fetchPrReviewComments(10, '/project');
 
     // Then
     expect(result.reviews).toEqual([]);
@@ -283,7 +283,7 @@ describe('fetchPrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
 
     // When
-    const result = fetchPrReviewComments(11);
+    const result = fetchPrReviewComments(11, '/project');
 
     // Then
     expect(result.reviews).toEqual([
@@ -314,7 +314,7 @@ describe('fetchPrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
 
     // When
-    const result = fetchPrReviewComments(12);
+    const result = fetchPrReviewComments(12, '/project');
 
     // Then
     expect(mockExecFileSync).toHaveBeenCalledWith(
@@ -364,7 +364,7 @@ describe('fetchPrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(secondPageInlineComments));
 
     // When
-    const result = fetchPrReviewComments(13);
+    const result = fetchPrReviewComments(13, '/project');
 
     // Then
     expect(mockExecFileSync).toHaveBeenCalledWith(
@@ -412,7 +412,7 @@ describe('fetchPrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
 
     // When
-    const result = fetchPrReviewComments(14);
+    const result = fetchPrReviewComments(14, '/project');
 
     // Then
     expect(result.reviews).toEqual([
@@ -452,7 +452,7 @@ describe('fetchPrReviewComments', () => {
     }
 
     // When
-    const result = fetchPrReviewComments(15);
+    const result = fetchPrReviewComments(15, '/project');
 
     // Then — should have called gh api exactly 101 times (1 for pr view + 100 pages)
     expect(mockExecFileSync).toHaveBeenCalledTimes(101);
@@ -460,12 +460,37 @@ describe('fetchPrReviewComments', () => {
     expect(result.reviews).toHaveLength(10000);
   });
 
+  it('should pass cwd to all execFileSync calls', () => {
+    // Given
+    const ghResponse = {
+      number: 50,
+      title: 'cwd test',
+      body: '',
+      url: 'https://github.com/org/repo/pull/50',
+      headRefName: 'fix/cwd',
+      comments: [],
+      reviews: [],
+      files: [],
+    };
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(ghResponse))
+      .mockReturnValueOnce(JSON.stringify([]));
+
+    // When
+    fetchPrReviewComments(50, '/worktree/clone');
+
+    // Then: all execFileSync calls should include cwd
+    for (const call of mockExecFileSync.mock.calls) {
+      expect(call[2]).toEqual(expect.objectContaining({ cwd: '/worktree/clone' }));
+    }
+  });
+
   it('should throw when gh CLI fails', () => {
     // Given
     mockExecFileSync.mockImplementation(() => { throw new Error('gh: PR not found'); });
 
     // When/Then
-    expect(() => fetchPrReviewComments(999)).toThrow('gh: PR not found');
+    expect(() => fetchPrReviewComments(999, '/project')).toThrow('gh: PR not found');
   });
 });
 

--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -59,7 +59,7 @@ describe('GitHubProvider', () => {
       const result = provider.checkCliStatus();
 
       // Then
-      expect(mockCheckGhCli).toHaveBeenCalledTimes(1);
+      expect(mockCheckGhCli).toHaveBeenCalledWith(process.cwd());
       expect(result).toBe(status);
     });
 
@@ -72,8 +72,35 @@ describe('GitHubProvider', () => {
       const result = provider.checkCliStatus();
 
       // Then
+      expect(mockCheckGhCli).toHaveBeenCalledWith(process.cwd());
       expect(result.available).toBe(false);
       expect(result.error).toBe('gh is not installed');
+    });
+
+    it('cwd を指定した場合は checkGhCli にそのまま転送する', () => {
+      // Given
+      const status = { available: true };
+      mockCheckGhCli.mockReturnValue(status);
+      const provider = new GitHubProvider();
+
+      // When
+      const result = provider.checkCliStatus('/worktree/clone');
+
+      // Then
+      expect(mockCheckGhCli).toHaveBeenCalledWith('/worktree/clone');
+      expect(result).toBe(status);
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      mockCheckGhCli.mockReturnValue({ available: true });
+      const provider = new GitHubProvider();
+
+      // When
+      provider.checkCliStatus();
+
+      // Then
+      expect(mockCheckGhCli).toHaveBeenCalledWith(process.cwd());
     });
   });
 
@@ -88,8 +115,35 @@ describe('GitHubProvider', () => {
       const result = provider.fetchIssue(42);
 
       // Then
-      expect(mockFetchIssue).toHaveBeenCalledWith(42);
+      expect(mockFetchIssue).toHaveBeenCalledWith(42, process.cwd());
       expect(result).toBe(issue);
+    });
+
+    it('cwd を指定した場合は fetchIssue にそのまま転送する', () => {
+      // Given
+      const issue = { number: 10, title: 'Issue', body: '', labels: [], comments: [] };
+      mockFetchIssue.mockReturnValue(issue);
+      const provider = new GitHubProvider();
+
+      // When
+      const result = provider.fetchIssue(10, '/worktree/clone');
+
+      // Then
+      expect(mockFetchIssue).toHaveBeenCalledWith(10, '/worktree/clone');
+      expect(result).toBe(issue);
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const issue = { number: 20, title: 'Issue', body: '', labels: [], comments: [] };
+      mockFetchIssue.mockReturnValue(issue);
+      const provider = new GitHubProvider();
+
+      // When
+      provider.fetchIssue(20);
+
+      // Then
+      expect(mockFetchIssue).toHaveBeenCalledWith(20, process.cwd());
     });
   });
 
@@ -105,7 +159,7 @@ describe('GitHubProvider', () => {
       const result = provider.createIssue(opts);
 
       // Then
-      expect(mockCreateIssue).toHaveBeenCalledWith(opts);
+      expect(mockCreateIssue).toHaveBeenCalledWith(opts, process.cwd());
       expect(result).toBe(issueResult);
     });
 
@@ -119,22 +173,48 @@ describe('GitHubProvider', () => {
       provider.createIssue(opts);
 
       // Then
-      expect(mockCreateIssue).toHaveBeenCalledWith(opts);
+      expect(mockCreateIssue).toHaveBeenCalledWith(opts, process.cwd());
+    });
+
+    it('cwd を指定した場合は createIssue にそのまま転送する', () => {
+      // Given
+      const opts = { title: 'Issue', body: 'Body' };
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/org/repo/issues/3' });
+      const provider = new GitHubProvider();
+
+      // When
+      provider.createIssue(opts, '/worktree/clone');
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith(opts, '/worktree/clone');
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const opts = { title: 'Issue', body: 'Body' };
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/org/repo/issues/4' });
+      const provider = new GitHubProvider();
+
+      // When
+      provider.createIssue(opts);
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith(opts, process.cwd());
     });
   });
 
   describe('findExistingPr', () => {
-    it('findExistingPr(cwd, branch) に委譲し PR を返す', () => {
+    it('findExistingPr(branch, cwd) に委譲し PR を返す', () => {
       // Given
       const pr = { number: 10, url: 'https://github.com/org/repo/pull/10' };
       mockFindExistingPr.mockReturnValue(pr);
       const provider = new GitHubProvider();
 
       // When
-      const result = provider.findExistingPr('/project', 'feat/my-feature');
+      const result = provider.findExistingPr('feat/my-feature', '/project');
 
       // Then
-      expect(mockFindExistingPr).toHaveBeenCalledWith('/project', 'feat/my-feature');
+      expect(mockFindExistingPr).toHaveBeenCalledWith('feat/my-feature', '/project');
       expect(result).toBe(pr);
     });
 
@@ -144,15 +224,41 @@ describe('GitHubProvider', () => {
       const provider = new GitHubProvider();
 
       // When
-      const result = provider.findExistingPr('/project', 'feat/no-pr');
+      const result = provider.findExistingPr('feat/no-pr', '/project');
 
       // Then
       expect(result).toBeUndefined();
     });
+
+    it('cwd を指定した場合は findExistingPr にそのまま転送する', () => {
+      // Given
+      const pr = { number: 20, url: 'https://github.com/org/repo/pull/20' };
+      mockFindExistingPr.mockReturnValue(pr);
+      const provider = new GitHubProvider();
+
+      // When
+      const result = provider.findExistingPr('feat/branch', '/worktree/clone');
+
+      // Then
+      expect(mockFindExistingPr).toHaveBeenCalledWith('feat/branch', '/worktree/clone');
+      expect(result).toBe(pr);
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      mockFindExistingPr.mockReturnValue(undefined);
+      const provider = new GitHubProvider();
+
+      // When
+      provider.findExistingPr('feat/branch');
+
+      // Then
+      expect(mockFindExistingPr).toHaveBeenCalledWith('feat/branch', process.cwd());
+    });
   });
 
   describe('createPullRequest', () => {
-    it('createPullRequest(cwd, opts) に委譲し結果を返す', () => {
+    it('createPullRequest(opts, cwd) に委譲し結果を返す', () => {
       // Given
       const opts = { branch: 'feat/new', title: 'My PR', body: 'PR body', draft: false };
       const prResult = { success: true, url: 'https://github.com/org/repo/pull/5' };
@@ -160,10 +266,10 @@ describe('GitHubProvider', () => {
       const provider = new GitHubProvider();
 
       // When
-      const result = provider.createPullRequest('/project', opts);
+      const result = provider.createPullRequest(opts, '/project');
 
       // Then
-      expect(mockCreatePullRequest).toHaveBeenCalledWith('/project', opts);
+      expect(mockCreatePullRequest).toHaveBeenCalledWith(opts, '/project');
       expect(result).toBe(prResult);
     });
 
@@ -174,24 +280,50 @@ describe('GitHubProvider', () => {
       const provider = new GitHubProvider();
 
       // When
-      provider.createPullRequest('/project', opts);
+      provider.createPullRequest(opts, '/project');
 
       // Then
-      expect(mockCreatePullRequest).toHaveBeenCalledWith('/project', expect.objectContaining({ draft: true }));
+      expect(mockCreatePullRequest).toHaveBeenCalledWith(expect.objectContaining({ draft: true }), '/project');
+    });
+
+    it('cwd を指定した場合は createPullRequest にそのまま転送する', () => {
+      // Given
+      const opts = { branch: 'feat/x', title: 'PR', body: 'body', draft: false };
+      mockCreatePullRequest.mockReturnValue({ success: true, url: 'https://github.com/org/repo/pull/7' });
+      const provider = new GitHubProvider();
+
+      // When
+      provider.createPullRequest(opts, '/worktree/clone');
+
+      // Then
+      expect(mockCreatePullRequest).toHaveBeenCalledWith(opts, '/worktree/clone');
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const opts = { branch: 'feat/y', title: 'PR', body: 'body', draft: false };
+      mockCreatePullRequest.mockReturnValue({ success: true, url: 'https://github.com/org/repo/pull/8' });
+      const provider = new GitHubProvider();
+
+      // When
+      provider.createPullRequest(opts);
+
+      // Then
+      expect(mockCreatePullRequest).toHaveBeenCalledWith(opts, process.cwd());
     });
   });
 
   describe('commentOnPr', () => {
-    it('commentOnPr(cwd, prNumber, body) に委譲し CommentResult を返す', () => {
+    it('commentOnPr(prNumber, body, cwd) に委譲し CommentResult を返す', () => {
       const commentResult: CommentResult = { success: true };
       mockCommentOnPr.mockReturnValue(commentResult);
       const provider = new GitHubProvider();
 
       // When
-      const result = provider.commentOnPr('/project', 42, 'Updated!');
+      const result = provider.commentOnPr(42, 'Updated!', '/project');
 
       // Then
-      expect(mockCommentOnPr).toHaveBeenCalledWith('/project', 42, 'Updated!');
+      expect(mockCommentOnPr).toHaveBeenCalledWith(42, 'Updated!', '/project');
       expect(result).toBe(commentResult);
     });
 
@@ -202,11 +334,37 @@ describe('GitHubProvider', () => {
       const provider = new GitHubProvider();
 
       // When
-      const result = provider.commentOnPr('/project', 42, 'comment');
+      const result = provider.commentOnPr(42, 'comment', '/project');
 
       // Then
       expect(result.success).toBe(false);
       expect(result.error).toBe('Permission denied');
+    });
+
+    it('cwd を指定した場合は commentOnPr にそのまま転送する', () => {
+      // Given
+      const commentResult: CommentResult = { success: true };
+      mockCommentOnPr.mockReturnValue(commentResult);
+      const provider = new GitHubProvider();
+
+      // When
+      provider.commentOnPr(10, 'body', '/worktree/clone');
+
+      // Then
+      expect(mockCommentOnPr).toHaveBeenCalledWith(10, 'body', '/worktree/clone');
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const commentResult: CommentResult = { success: true };
+      mockCommentOnPr.mockReturnValue(commentResult);
+      const provider = new GitHubProvider();
+
+      // When
+      provider.commentOnPr(10, 'body');
+
+      // Then
+      expect(mockCommentOnPr).toHaveBeenCalledWith(10, 'body', process.cwd());
     });
   });
 
@@ -230,8 +388,53 @@ describe('GitHubProvider', () => {
       const result = provider.fetchPrReviewComments(456);
 
       // Then
-      expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456);
+      expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456, process.cwd());
       expect(result).toBe(prReview);
+    });
+
+    it('cwd を指定した場合は fetchPrReviewComments にそのまま転送する', () => {
+      // Given
+      const prReview: PrReviewData = {
+        number: 100,
+        title: 'PR',
+        body: '',
+        url: 'https://github.com/org/repo/pull/100',
+        headRefName: 'feat/x',
+        comments: [],
+        reviews: [],
+        files: [],
+      };
+      mockFetchPrReviewComments.mockReturnValue(prReview);
+      const provider = new GitHubProvider();
+
+      // When
+      const result = provider.fetchPrReviewComments(100, '/worktree/clone');
+
+      // Then
+      expect(mockFetchPrReviewComments).toHaveBeenCalledWith(100, '/worktree/clone');
+      expect(result).toBe(prReview);
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const prReview: PrReviewData = {
+        number: 200,
+        title: 'PR',
+        body: '',
+        url: 'https://github.com/org/repo/pull/200',
+        headRefName: 'feat/y',
+        comments: [],
+        reviews: [],
+        files: [],
+      };
+      mockFetchPrReviewComments.mockReturnValue(prReview);
+      const provider = new GitHubProvider();
+
+      // When
+      provider.fetchPrReviewComments(200);
+
+      // Then
+      expect(mockFetchPrReviewComments).toHaveBeenCalledWith(200, process.cwd());
     });
   });
 });

--- a/src/__tests__/gitlab-issue.test.ts
+++ b/src/__tests__/gitlab-issue.test.ts
@@ -50,7 +50,7 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce(JSON.stringify(notesResponse)); // glab api notes
 
     // When
-    const result = fetchIssue(42);
+    const result = fetchIssue(42, '/project');
 
     // Then
     expect(result).toEqual({
@@ -78,7 +78,7 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce(JSON.stringify([])); // empty notes
 
     // When
-    fetchIssue(10);
+    fetchIssue(10, '/project');
 
     // Then
     const call = mockExecFileSync.mock.calls[0];
@@ -101,7 +101,7 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce(JSON.stringify([]));
 
     // When
-    fetchIssue(10);
+    fetchIssue(10, '/project');
 
     // Then: second call should be glab api for notes
     const notesCall = mockExecFileSync.mock.calls[1];
@@ -125,7 +125,7 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce(JSON.stringify([]));
 
     // When
-    const result = fetchIssue(5);
+    const result = fetchIssue(5, '/project');
 
     // Then
     expect(result.body).toBe('');
@@ -149,7 +149,7 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce(JSON.stringify(notesResponse));
 
     // When
-    const result = fetchIssue(7);
+    const result = fetchIssue(7, '/project');
 
     // Then
     expect(result.comments).toEqual([
@@ -162,7 +162,7 @@ describe('fetchIssue', () => {
     mockExecFileSync.mockImplementation(() => { throw new Error('glab: issue not found'); });
 
     // When / Then
-    expect(() => fetchIssue(999)).toThrow();
+    expect(() => fetchIssue(999, '/project')).toThrow();
   });
 
   it('glab issue view が不正な JSON を返した場合は明確なエラーメッセージをスローする', () => {
@@ -170,7 +170,7 @@ describe('fetchIssue', () => {
     mockExecFileSync.mockReturnValue('<html>500 Internal Server Error</html>');
 
     // When / Then
-    expect(() => fetchIssue(42)).toThrow('glab returned invalid JSON');
+    expect(() => fetchIssue(42, '/project')).toThrow('glab returned invalid JSON');
   });
 
   it('notes API が不正な JSON を返した場合は明確なエラーメッセージをスローする', () => {
@@ -186,7 +186,7 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce('invalid json');
 
     // When / Then
-    expect(() => fetchIssue(42)).toThrow('glab returned invalid JSON');
+    expect(() => fetchIssue(42, '/project')).toThrow('glab returned invalid JSON');
   });
 
   it('notes が空の場合は空配列を返す', () => {
@@ -202,7 +202,7 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce(JSON.stringify([]));
 
     // When
-    const result = fetchIssue(3);
+    const result = fetchIssue(3, '/project');
 
     // Then
     expect(result.comments).toEqual([]);
@@ -230,7 +230,7 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce(JSON.stringify(secondPageNotes));
 
     // When
-    const result = fetchIssue(50);
+    const result = fetchIssue(50, '/project');
 
     // Then
     expect(result.comments).toHaveLength(101);
@@ -260,7 +260,7 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce(JSON.stringify(secondPage));
 
     // When
-    fetchIssue(50);
+    fetchIssue(50, '/project');
 
     // Then: verify page=1 and page=2
     const notesCall1 = mockExecFileSync.mock.calls[1];
@@ -290,10 +290,50 @@ describe('fetchIssue', () => {
       .mockReturnValueOnce(JSON.stringify(notes));
 
     // When
-    fetchIssue(51);
+    fetchIssue(51, '/project');
 
     // Then: only 2 calls (issue view + 1 page of notes)
     expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('cwd を glab issue view の execFileSync に渡す', () => {
+    // Given
+    const glabIssueResponse = {
+      iid: 10,
+      title: 'Title',
+      description: '',
+      labels: [],
+    };
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(glabIssueResponse))
+      .mockReturnValueOnce(JSON.stringify([]));
+
+    // When
+    fetchIssue(10, '/worktree/clone');
+
+    // Then: glab issue view に cwd が渡される
+    const issueViewCall = mockExecFileSync.mock.calls[0];
+    expect(issueViewCall[2]).toHaveProperty('cwd', '/worktree/clone');
+  });
+
+  it('cwd を fetchAllPages（notes 取得）にも伝搬する', () => {
+    // Given
+    const glabIssueResponse = {
+      iid: 10,
+      title: 'Title',
+      description: '',
+      labels: [],
+    };
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(glabIssueResponse))
+      .mockReturnValueOnce(JSON.stringify([]));
+
+    // When
+    fetchIssue(10, '/worktree/clone');
+
+    // Then: glab api（notes）にも cwd が渡される
+    const notesCall = mockExecFileSync.mock.calls[1];
+    expect(notesCall[2]).toHaveProperty('cwd', '/worktree/clone');
   });
 });
 

--- a/src/__tests__/gitlab-pr.test.ts
+++ b/src/__tests__/gitlab-pr.test.ts
@@ -48,7 +48,7 @@ describe('findExistingMr', () => {
     );
 
     // When
-    const result = findExistingMr('/project', 'task/fix-bug');
+    const result = findExistingMr('task/fix-bug', '/project');
 
     // Then
     expect(result).toEqual({ number: 42, url: 'https://gitlab.com/org/repo/-/merge_requests/42' });
@@ -59,7 +59,7 @@ describe('findExistingMr', () => {
     mockExecFileSync.mockReturnValue(JSON.stringify([]));
 
     // When
-    findExistingMr('/project', 'feat/my-feature');
+    findExistingMr('feat/my-feature', '/project');
 
     // Then
     const call = mockExecFileSync.mock.calls[0];
@@ -75,7 +75,7 @@ describe('findExistingMr', () => {
     mockExecFileSync.mockReturnValue(JSON.stringify([]));
 
     // When
-    const result = findExistingMr('/project', 'task/no-mr');
+    const result = findExistingMr('task/no-mr', '/project');
 
     // Then
     expect(result).toBeUndefined();
@@ -86,7 +86,7 @@ describe('findExistingMr', () => {
     mockExecFileSync.mockImplementation(() => { throw new Error('glab: command not found'); });
 
     // When
-    const result = findExistingMr('/project', 'task/fix-bug');
+    const result = findExistingMr('task/fix-bug', '/project');
 
     // Then
     expect(result).toBeUndefined();
@@ -98,7 +98,7 @@ describe('findExistingMr', () => {
     mockExecFileSync.mockReturnValue(JSON.stringify([]));
 
     // When
-    findExistingMr('/my/project', 'feat/branch');
+    findExistingMr('feat/branch', '/my/project');
 
     // Then
     expect(mockCheckGlabCli).toHaveBeenCalledWith('/my/project');
@@ -111,11 +111,11 @@ describe('createMergeRequest', () => {
     mockExecFileSync.mockReturnValue('https://gitlab.com/org/repo/-/merge_requests/1\n');
 
     // When
-    const result = createMergeRequest('/project', {
+    const result = createMergeRequest({
       branch: 'feat/my-branch',
       title: 'My MR',
       body: 'MR body',
-    });
+    }, '/project');
 
     // Then
     expect(result.success).toBe(true);
@@ -127,11 +127,11 @@ describe('createMergeRequest', () => {
     mockExecFileSync.mockReturnValue('https://gitlab.com/org/repo/-/merge_requests/2\n');
 
     // When
-    createMergeRequest('/project', {
+    createMergeRequest({
       branch: 'feat/my-branch',
       title: 'My MR',
       body: 'MR body',
-    });
+    }, '/project');
 
     // Then
     const call = mockExecFileSync.mock.calls[0];
@@ -144,11 +144,11 @@ describe('createMergeRequest', () => {
     mockExecFileSync.mockReturnValue('https://gitlab.com/org/repo/-/merge_requests/3\n');
 
     // When
-    createMergeRequest('/project', {
+    createMergeRequest({
       branch: 'feat/my-branch',
       title: 'My MR',
       body: 'MR body',
-    });
+    }, '/project');
 
     // Then
     const call = mockExecFileSync.mock.calls[0];
@@ -161,12 +161,12 @@ describe('createMergeRequest', () => {
     mockExecFileSync.mockReturnValue('https://gitlab.com/org/repo/-/merge_requests/4\n');
 
     // When
-    createMergeRequest('/project', {
+    createMergeRequest({
       branch: 'feat/my-branch',
       title: 'Draft MR',
       body: 'body',
       draft: true,
-    });
+    }, '/project');
 
     // Then
     const call = mockExecFileSync.mock.calls[0];
@@ -178,12 +178,12 @@ describe('createMergeRequest', () => {
     mockExecFileSync.mockReturnValue('https://gitlab.com/org/repo/-/merge_requests/5\n');
 
     // When
-    createMergeRequest('/project', {
+    createMergeRequest({
       branch: 'feat/my-branch',
       title: 'MR',
       body: 'body',
       draft: false,
-    });
+    }, '/project');
 
     // Then
     const call = mockExecFileSync.mock.calls[0];
@@ -195,12 +195,12 @@ describe('createMergeRequest', () => {
     mockExecFileSync.mockReturnValue('https://gitlab.com/org/repo/-/merge_requests/6\n');
 
     // When
-    createMergeRequest('/project', {
+    createMergeRequest({
       branch: 'feat/my-branch',
       title: 'MR',
       body: 'body',
       base: 'develop',
-    });
+    }, '/project');
 
     // Then
     const call = mockExecFileSync.mock.calls[0];
@@ -213,11 +213,11 @@ describe('createMergeRequest', () => {
     mockExecFileSync.mockImplementation(() => { throw new Error('API error'); });
 
     // When
-    const result = createMergeRequest('/project', {
+    const result = createMergeRequest({
       branch: 'feat/fail',
       title: 'Fail MR',
       body: 'body',
-    });
+    }, '/project');
 
     // Then
     expect(result.success).toBe(false);
@@ -230,11 +230,11 @@ describe('createMergeRequest', () => {
     mockExecFileSync.mockReturnValue('https://gitlab.com/org/repo/-/merge_requests/99\n');
 
     // When
-    createMergeRequest('/my/project', {
+    createMergeRequest({
       branch: 'feat/branch',
       title: 'MR',
       body: 'body',
-    });
+    }, '/my/project');
 
     // Then
     expect(mockCheckGlabCli).toHaveBeenCalledWith('/my/project');
@@ -250,7 +250,7 @@ describe('createMergeRequest', () => {
     };
 
     // When
-    const execute = () => createMergeRequest('/project', options);
+    const execute = () => createMergeRequest(options, '/project');
 
     // Then
     expect(execute).toThrow('--repo is not supported with GitLab provider. Use cwd context instead.');
@@ -265,7 +265,7 @@ describe('commentOnMr', () => {
     mockExecFileSync.mockReturnValue('');
 
     // When
-    const result = commentOnMr('/project', 42, 'LGTM');
+    const result = commentOnMr(42, 'LGTM', '/project');
 
     // Then
     expect(result).toEqual({ success: true });
@@ -276,7 +276,7 @@ describe('commentOnMr', () => {
     mockExecFileSync.mockReturnValue('');
 
     // When
-    commentOnMr('/project', 42, 'Comment body');
+    commentOnMr(42, 'Comment body', '/project');
 
     // Then
     const call = mockExecFileSync.mock.calls[0];
@@ -291,7 +291,7 @@ describe('commentOnMr', () => {
     mockExecFileSync.mockImplementation(() => { throw new Error('Permission denied'); });
 
     // When
-    const result = commentOnMr('/project', 42, 'comment');
+    const result = commentOnMr(42, 'comment', '/project');
 
     // Then
     expect(result.success).toBe(false);
@@ -304,7 +304,7 @@ describe('commentOnMr', () => {
     mockExecFileSync.mockReturnValue('');
 
     // When
-    commentOnMr('/my/project', 42, 'LGTM');
+    commentOnMr(42, 'LGTM', '/my/project');
 
     // Then
     expect(mockCheckGlabCli).toHaveBeenCalledWith('/my/project');
@@ -378,7 +378,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(discussionsResponse));
 
     // When
-    const result = fetchMrReviewComments(456);
+    const result = fetchMrReviewComments(456, '/project');
 
     // Then
     expect(result.number).toBe(456);
@@ -410,7 +410,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify([])); // no discussions
 
     // When
-    const result = fetchMrReviewComments(10);
+    const result = fetchMrReviewComments(10, '/project');
 
     // Then
     expect(result.comments).toEqual([
@@ -428,7 +428,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify([]));
 
     // When
-    const result = fetchMrReviewComments(11);
+    const result = fetchMrReviewComments(11, '/project');
 
     // Then
     expect(result.body).toBe('');
@@ -466,7 +466,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(discussionsResponse));
 
     // When
-    const result = fetchMrReviewComments(12);
+    const result = fetchMrReviewComments(12, '/project');
 
     // Then
     expect(result.reviews).toEqual([
@@ -479,7 +479,7 @@ describe('fetchMrReviewComments', () => {
     mockExecFileSync.mockImplementation(() => { throw new Error('glab: MR not found'); });
 
     // When / Then
-    expect(() => fetchMrReviewComments(999)).toThrow();
+    expect(() => fetchMrReviewComments(999, '/project')).toThrow();
   });
 
   it('glab mr view が不正な JSON を返した場合は明確なエラーメッセージをスローする', () => {
@@ -487,7 +487,7 @@ describe('fetchMrReviewComments', () => {
     mockExecFileSync.mockReturnValue('<html>502 Bad Gateway</html>');
 
     // When / Then
-    expect(() => fetchMrReviewComments(100)).toThrow('glab returned invalid JSON');
+    expect(() => fetchMrReviewComments(100, '/project')).toThrow('glab returned invalid JSON');
   });
 
   it('notes API が不正な JSON を返した場合は明確なエラーメッセージをスローする', () => {
@@ -499,7 +499,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce('invalid json');
 
     // When / Then
-    expect(() => fetchMrReviewComments(101)).toThrow('glab returned invalid JSON');
+    expect(() => fetchMrReviewComments(101, '/project')).toThrow('glab returned invalid JSON');
   });
 
   it('discussions API が不正な JSON を返した場合は明確なエラーメッセージをスローする', () => {
@@ -512,7 +512,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce('not json');
 
     // When / Then
-    expect(() => fetchMrReviewComments(102)).toThrow('glab returned invalid JSON');
+    expect(() => fetchMrReviewComments(102, '/project')).toThrow('glab returned invalid JSON');
   });
 
   it('diffs, notes, discussions API に per_page パラメータが含まれる', () => {
@@ -525,7 +525,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify([]));
 
     // When
-    fetchMrReviewComments(200);
+    fetchMrReviewComments(200, '/project');
 
     // Then: verify diffs API call has per_page (call index 1, after mr view)
     const diffsCall = mockExecFileSync.mock.calls[1];
@@ -563,7 +563,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify([])); // discussions (single page)
 
     // When
-    const result = fetchMrReviewComments(300);
+    const result = fetchMrReviewComments(300, '/project');
 
     // Then
     expect(result.comments).toHaveLength(101);
@@ -589,7 +589,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify([])); // discussions
 
     // When
-    fetchMrReviewComments(301);
+    fetchMrReviewComments(301, '/project');
 
     // Then: verify page=1 for notes (call index 2, after mr view + diffs API)
     const notesCall1 = mockExecFileSync.mock.calls[2];
@@ -631,7 +631,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(secondPageDiscussions));
 
     // When
-    const result = fetchMrReviewComments(302);
+    const result = fetchMrReviewComments(302, '/project');
 
     // Then
     expect(result.reviews).toHaveLength(101);
@@ -670,7 +670,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(secondPage));
 
     // When
-    fetchMrReviewComments(303);
+    fetchMrReviewComments(303, '/project');
 
     // Then: discussions page=1 (call index 3, after mr view + diffs API + notes)
     const discCall1 = mockExecFileSync.mock.calls[3];
@@ -723,7 +723,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify(discussionsResponse));
 
     // When
-    const result = fetchMrReviewComments(400);
+    const result = fetchMrReviewComments(400, '/project');
 
     // Then: DiffNote excluded from comments, only general comments remain
     expect(result.comments).toEqual([
@@ -750,7 +750,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify([]));
 
     // When
-    const result = fetchMrReviewComments(500);
+    const result = fetchMrReviewComments(500, '/project');
 
     // Then
     expect(result.files).toEqual(['src/a.ts', 'src/b.ts']);
@@ -771,7 +771,7 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify([]));
 
     // When
-    const result = fetchMrReviewComments(501);
+    const result = fetchMrReviewComments(501, '/project');
 
     // Then
     expect(result.files).toEqual([]);
@@ -792,10 +792,45 @@ describe('fetchMrReviewComments', () => {
       .mockReturnValueOnce(JSON.stringify([])); // discussions
 
     // When
-    fetchMrReviewComments(304);
+    fetchMrReviewComments(304, '/project');
 
     // Then: 4 calls total (mr view + diffs API + 1 page notes + 1 page discussions)
     expect(mockExecFileSync).toHaveBeenCalledTimes(4);
+  });
+
+  it('cwd を glab mr view の execFileSync に渡す', () => {
+    // Given
+    const mrViewResponse = makeMrViewResponse({ iid: 600 });
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(mrViewResponse))
+      .mockReturnValueOnce(JSON.stringify([])) // diffs API
+      .mockReturnValueOnce(JSON.stringify([]))
+      .mockReturnValueOnce(JSON.stringify([]));
+
+    // When
+    fetchMrReviewComments(600, '/worktree/clone');
+
+    // Then: glab mr view に cwd が渡される
+    const mrViewCall = mockExecFileSync.mock.calls[0];
+    expect(mrViewCall[2]).toHaveProperty('cwd', '/worktree/clone');
+  });
+
+  it('cwd を fetchAllPages（diffs, notes, discussions）にも伝搬する', () => {
+    // Given
+    const mrViewResponse = makeMrViewResponse({ iid: 601 });
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(mrViewResponse))
+      .mockReturnValueOnce(JSON.stringify([])) // diffs API
+      .mockReturnValueOnce(JSON.stringify([]))
+      .mockReturnValueOnce(JSON.stringify([]));
+
+    // When
+    fetchMrReviewComments(601, '/worktree/clone');
+
+    // Then: すべての execFileSync 呼び出しに cwd が渡される
+    for (const call of mockExecFileSync.mock.calls) {
+      expect(call[2]).toHaveProperty('cwd', '/worktree/clone');
+    }
   });
 
 });

--- a/src/__tests__/gitlab-provider.test.ts
+++ b/src/__tests__/gitlab-provider.test.ts
@@ -127,7 +127,7 @@ describe('GitLabProvider', () => {
   });
 
   describe('fetchIssue', () => {
-    it('fetchIssue(n) に委譲し結果を返す', () => {
+    it('fetchIssue(n, cwd) に委譲し結果を返す', () => {
       // Given
       const issue = { number: 42, title: 'Test issue', body: 'Body', labels: [], comments: [] };
       mockFetchIssue.mockReturnValue(issue);
@@ -137,8 +137,35 @@ describe('GitLabProvider', () => {
       const result = provider.fetchIssue(42);
 
       // Then
-      expect(mockFetchIssue).toHaveBeenCalledWith(42);
+      expect(mockFetchIssue).toHaveBeenCalledWith(42, process.cwd());
       expect(result).toBe(issue);
+    });
+
+    it('cwd を指定した場合は fetchIssue にそのまま転送する', () => {
+      // Given
+      const issue = { number: 10, title: 'Issue', body: '', labels: [], comments: [] };
+      mockFetchIssue.mockReturnValue(issue);
+      const provider = new GitLabProvider();
+
+      // When
+      const result = provider.fetchIssue(10, '/worktree/clone');
+
+      // Then
+      expect(mockFetchIssue).toHaveBeenCalledWith(10, '/worktree/clone');
+      expect(result).toBe(issue);
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const issue = { number: 20, title: 'Issue', body: '', labels: [], comments: [] };
+      mockFetchIssue.mockReturnValue(issue);
+      const provider = new GitLabProvider();
+
+      // When
+      provider.fetchIssue(20);
+
+      // Then
+      expect(mockFetchIssue).toHaveBeenCalledWith(20, process.cwd());
     });
   });
 
@@ -199,7 +226,7 @@ describe('GitLabProvider', () => {
   });
 
   describe('fetchPrReviewComments', () => {
-    it('fetchMrReviewComments(n) に委譲し結果を返す', () => {
+    it('fetchMrReviewComments(n, cwd) に委譲し結果を返す', () => {
       // Given
       const prReview: PrReviewData = {
         number: 456,
@@ -218,23 +245,68 @@ describe('GitLabProvider', () => {
       const result = provider.fetchPrReviewComments(456);
 
       // Then
-      expect(mockFetchMrReviewComments).toHaveBeenCalledWith(456);
+      expect(mockFetchMrReviewComments).toHaveBeenCalledWith(456, process.cwd());
       expect(result).toBe(prReview);
+    });
+
+    it('cwd を指定した場合は fetchMrReviewComments にそのまま転送する', () => {
+      // Given
+      const prReview: PrReviewData = {
+        number: 100,
+        title: 'MR',
+        body: '',
+        url: 'https://gitlab.com/org/repo/-/merge_requests/100',
+        headRefName: 'feat/x',
+        comments: [],
+        reviews: [],
+        files: [],
+      };
+      mockFetchMrReviewComments.mockReturnValue(prReview);
+      const provider = new GitLabProvider();
+
+      // When
+      const result = provider.fetchPrReviewComments(100, '/worktree/clone');
+
+      // Then
+      expect(mockFetchMrReviewComments).toHaveBeenCalledWith(100, '/worktree/clone');
+      expect(result).toBe(prReview);
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const prReview: PrReviewData = {
+        number: 200,
+        title: 'MR',
+        body: '',
+        url: 'https://gitlab.com/org/repo/-/merge_requests/200',
+        headRefName: 'feat/y',
+        comments: [],
+        reviews: [],
+        files: [],
+      };
+      mockFetchMrReviewComments.mockReturnValue(prReview);
+      const provider = new GitLabProvider();
+
+      // When
+      provider.fetchPrReviewComments(200);
+
+      // Then
+      expect(mockFetchMrReviewComments).toHaveBeenCalledWith(200, process.cwd());
     });
   });
 
   describe('findExistingPr', () => {
-    it('findExistingMr(cwd, branch) に委譲し MR を返す', () => {
+    it('findExistingMr(branch, cwd) に委譲し MR を返す', () => {
       // Given
       const mr = { number: 10, url: 'https://gitlab.com/org/repo/-/merge_requests/10' };
       mockFindExistingMr.mockReturnValue(mr);
       const provider = new GitLabProvider();
 
       // When
-      const result = provider.findExistingPr('/project', 'feat/my-feature');
+      const result = provider.findExistingPr('feat/my-feature', '/project');
 
       // Then
-      expect(mockFindExistingMr).toHaveBeenCalledWith('/project', 'feat/my-feature');
+      expect(mockFindExistingMr).toHaveBeenCalledWith('feat/my-feature', '/project');
       expect(result).toBe(mr);
     });
 
@@ -244,15 +316,41 @@ describe('GitLabProvider', () => {
       const provider = new GitLabProvider();
 
       // When
-      const result = provider.findExistingPr('/project', 'feat/no-mr');
+      const result = provider.findExistingPr('feat/no-mr', '/project');
 
       // Then
       expect(result).toBeUndefined();
     });
+
+    it('cwd を指定した場合は findExistingMr にそのまま転送する', () => {
+      // Given
+      const mr = { number: 20, url: 'https://gitlab.com/org/repo/-/merge_requests/20' };
+      mockFindExistingMr.mockReturnValue(mr);
+      const provider = new GitLabProvider();
+
+      // When
+      const result = provider.findExistingPr('feat/branch', '/worktree/clone');
+
+      // Then
+      expect(mockFindExistingMr).toHaveBeenCalledWith('feat/branch', '/worktree/clone');
+      expect(result).toBe(mr);
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      mockFindExistingMr.mockReturnValue(undefined);
+      const provider = new GitLabProvider();
+
+      // When
+      provider.findExistingPr('feat/branch');
+
+      // Then
+      expect(mockFindExistingMr).toHaveBeenCalledWith('feat/branch', process.cwd());
+    });
   });
 
   describe('createPullRequest', () => {
-    it('createMergeRequest(cwd, opts) に委譲し結果を返す', () => {
+    it('createMergeRequest(opts, cwd) に委譲し結果を返す', () => {
       // Given
       const opts = { branch: 'feat/new', title: 'My MR', body: 'MR body', draft: false };
       const mrResult = { success: true, url: 'https://gitlab.com/org/repo/-/merge_requests/5' };
@@ -260,10 +358,10 @@ describe('GitLabProvider', () => {
       const provider = new GitLabProvider();
 
       // When
-      const result = provider.createPullRequest('/project', opts);
+      const result = provider.createPullRequest(opts, '/project');
 
       // Then
-      expect(mockCreateMergeRequest).toHaveBeenCalledWith('/project', opts);
+      expect(mockCreateMergeRequest).toHaveBeenCalledWith(opts, '/project');
       expect(result).toBe(mrResult);
     });
 
@@ -274,25 +372,51 @@ describe('GitLabProvider', () => {
       const provider = new GitLabProvider();
 
       // When
-      provider.createPullRequest('/project', opts);
+      provider.createPullRequest(opts, '/project');
 
       // Then
-      expect(mockCreateMergeRequest).toHaveBeenCalledWith('/project', expect.objectContaining({ draft: true }));
+      expect(mockCreateMergeRequest).toHaveBeenCalledWith(expect.objectContaining({ draft: true }), '/project');
+    });
+
+    it('cwd を指定した場合は createMergeRequest にそのまま転送する', () => {
+      // Given
+      const opts = { branch: 'feat/x', title: 'MR', body: 'body', draft: false };
+      mockCreateMergeRequest.mockReturnValue({ success: true, url: 'https://gitlab.com/org/repo/-/merge_requests/7' });
+      const provider = new GitLabProvider();
+
+      // When
+      provider.createPullRequest(opts, '/worktree/clone');
+
+      // Then
+      expect(mockCreateMergeRequest).toHaveBeenCalledWith(opts, '/worktree/clone');
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const opts = { branch: 'feat/y', title: 'MR', body: 'body', draft: false };
+      mockCreateMergeRequest.mockReturnValue({ success: true, url: 'https://gitlab.com/org/repo/-/merge_requests/8' });
+      const provider = new GitLabProvider();
+
+      // When
+      provider.createPullRequest(opts);
+
+      // Then
+      expect(mockCreateMergeRequest).toHaveBeenCalledWith(opts, process.cwd());
     });
   });
 
   describe('commentOnPr', () => {
-    it('commentOnMr(cwd, mrNumber, body) に委譲し CommentResult を返す', () => {
+    it('commentOnMr(mrNumber, body, cwd) に委譲し CommentResult を返す', () => {
       // Given
       const commentResult: CommentResult = { success: true };
       mockCommentOnMr.mockReturnValue(commentResult);
       const provider = new GitLabProvider();
 
       // When
-      const result = provider.commentOnPr('/project', 42, 'Updated!');
+      const result = provider.commentOnPr(42, 'Updated!', '/project');
 
       // Then
-      expect(mockCommentOnMr).toHaveBeenCalledWith('/project', 42, 'Updated!');
+      expect(mockCommentOnMr).toHaveBeenCalledWith(42, 'Updated!', '/project');
       expect(result).toBe(commentResult);
     });
 
@@ -303,11 +427,37 @@ describe('GitLabProvider', () => {
       const provider = new GitLabProvider();
 
       // When
-      const result = provider.commentOnPr('/project', 42, 'comment');
+      const result = provider.commentOnPr(42, 'comment', '/project');
 
       // Then
       expect(result.success).toBe(false);
       expect(result.error).toBe('Permission denied');
+    });
+
+    it('cwd を指定した場合は commentOnMr にそのまま転送する', () => {
+      // Given
+      const commentResult: CommentResult = { success: true };
+      mockCommentOnMr.mockReturnValue(commentResult);
+      const provider = new GitLabProvider();
+
+      // When
+      provider.commentOnPr(10, 'body', '/worktree/clone');
+
+      // Then
+      expect(mockCommentOnMr).toHaveBeenCalledWith(10, 'body', '/worktree/clone');
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      // Given
+      const commentResult: CommentResult = { success: true };
+      mockCommentOnMr.mockReturnValue(commentResult);
+      const provider = new GitLabProvider();
+
+      // When
+      provider.commentOnPr(10, 'body');
+
+      // Then
+      expect(mockCommentOnMr).toHaveBeenCalledWith(10, 'body', process.cwd());
     });
   });
 });

--- a/src/__tests__/gitlab-utils.test.ts
+++ b/src/__tests__/gitlab-utils.test.ts
@@ -126,6 +126,19 @@ describe('checkGlabCli', () => {
       // Then
       expect(mockGetRemoteHostname).toHaveBeenCalledWith('/my/project/path');
     });
+
+    it('execFileSync に cwd を渡す', () => {
+      // Given
+      mockGetRemoteHostname.mockReturnValue('gitlab.example.com');
+      mockExecFileSync.mockReturnValue('');
+
+      // When
+      checkGlabCli('/worktree/clone');
+
+      // Then: glab auth status の execFileSync に cwd が渡されていること
+      const call = mockExecFileSync.mock.calls[0];
+      expect(call[2]).toHaveProperty('cwd', '/worktree/clone');
+    });
   });
 
   describe('ホスト名が取得できない場合（フォールバック）', () => {
@@ -195,7 +208,7 @@ describe('fetchAllPages', () => {
     const items = [{ id: 1 }, { id: 2 }];
     mockExecFileSync.mockReturnValueOnce(JSON.stringify(items));
 
-    const result = fetchAllPages<{ id: number }>('projects/:id/issues/1/notes', 100, 'test');
+    const result = fetchAllPages<{ id: number }>('projects/:id/issues/1/notes', 100, 'test', '/project');
 
     expect(result).toEqual(items);
     expect(mockExecFileSync).toHaveBeenCalledTimes(1);
@@ -208,7 +221,7 @@ describe('fetchAllPages', () => {
       .mockReturnValueOnce(JSON.stringify(page1))
       .mockReturnValueOnce(JSON.stringify(page2));
 
-    const result = fetchAllPages<{ id: number }>('projects/:id/issues/1/notes', 100, 'test');
+    const result = fetchAllPages<{ id: number }>('projects/:id/issues/1/notes', 100, 'test', '/project');
 
     expect(result).toHaveLength(102);
     expect(mockExecFileSync).toHaveBeenCalledTimes(2);
@@ -221,7 +234,7 @@ describe('fetchAllPages', () => {
       .mockReturnValueOnce(JSON.stringify(page1))
       .mockReturnValueOnce(JSON.stringify(page2));
 
-    fetchAllPages<{ id: number }>('projects/:id/test', 10, 'test');
+    fetchAllPages<{ id: number }>('projects/:id/test', 10, 'test', '/project');
 
     const call1 = mockExecFileSync.mock.calls[0];
     expect((call1[1] as string[])[1]).toContain('page=1');
@@ -234,7 +247,7 @@ describe('fetchAllPages', () => {
     const fullPage = Array.from({ length: 5 }, (_, i) => ({ id: i }));
     mockExecFileSync.mockReturnValue(JSON.stringify(fullPage));
 
-    const result = fetchAllPages<{ id: number }>('projects/:id/test', 5, 'test');
+    const result = fetchAllPages<{ id: number }>('projects/:id/test', 5, 'test', '/project');
 
     // Should stop at 100 pages
     expect(mockExecFileSync).toHaveBeenCalledTimes(100);
@@ -244,7 +257,7 @@ describe('fetchAllPages', () => {
   it('endpoint に既にクエリパラメータがある場合は & で結合する', () => {
     mockExecFileSync.mockReturnValueOnce(JSON.stringify([]));
 
-    fetchAllPages<unknown>('projects/:id/test?sort=asc', 50, 'test');
+    fetchAllPages<unknown>('projects/:id/test?sort=asc', 50, 'test', '/project');
 
     const call = mockExecFileSync.mock.calls[0];
     const apiPath = (call[1] as string[])[1];
@@ -254,7 +267,7 @@ describe('fetchAllPages', () => {
   it('endpoint にクエリパラメータがない場合は ? で結合する', () => {
     mockExecFileSync.mockReturnValueOnce(JSON.stringify([]));
 
-    fetchAllPages<unknown>('projects/:id/test', 50, 'test');
+    fetchAllPages<unknown>('projects/:id/test', 50, 'test', '/project');
 
     const call = mockExecFileSync.mock.calls[0];
     const apiPath = (call[1] as string[])[1];
@@ -264,9 +277,38 @@ describe('fetchAllPages', () => {
   it('不正な JSON の場合はコンテキスト付きエラーをスローする', () => {
     mockExecFileSync.mockReturnValueOnce('invalid');
 
-    expect(() => fetchAllPages<unknown>('endpoint', 50, 'my context')).toThrow(
+    expect(() => fetchAllPages<unknown>('endpoint', 50, 'my context', '/project')).toThrow(
       'glab returned invalid JSON (my context)',
     );
+  });
+
+  it('cwd を execFileSync に渡す', () => {
+    // Given
+    mockExecFileSync.mockReturnValueOnce(JSON.stringify([]));
+
+    // When
+    fetchAllPages<unknown>('projects/:id/test', 50, 'test', '/worktree/clone');
+
+    // Then
+    const call = mockExecFileSync.mock.calls[0];
+    expect(call[2]).toHaveProperty('cwd', '/worktree/clone');
+  });
+
+  it('複数ページ取得時にすべてのページで cwd を execFileSync に渡す', () => {
+    // Given
+    const page1 = Array.from({ length: 10 }, (_, i) => ({ id: i }));
+    const page2 = [{ id: 10 }];
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(page1))
+      .mockReturnValueOnce(JSON.stringify(page2));
+
+    // When
+    fetchAllPages<{ id: number }>('projects/:id/test', 10, 'test', '/worktree/clone');
+
+    // Then
+    for (const call of mockExecFileSync.mock.calls) {
+      expect(call[2]).toHaveProperty('cwd', '/worktree/clone');
+    }
   });
 });
 

--- a/src/__tests__/it-pipeline-modes.test.ts
+++ b/src/__tests__/it-pipeline-modes.test.ts
@@ -226,9 +226,9 @@ describe('Pipeline Modes IT: --task + --piece path', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreatePullRequestSafely.mockImplementation((provider, cwd, options) => {
+    mockCreatePullRequestSafely.mockImplementation((provider, options, cwd) => {
       try {
-        return provider.createPullRequest(cwd, options);
+        return provider.createPullRequest(options, cwd);
       } catch (error) {
         return {
           success: false,
@@ -366,7 +366,7 @@ describe('Pipeline Modes IT: --issue', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(mockFetchIssue).toHaveBeenCalledWith(42);
+    expect(mockFetchIssue).toHaveBeenCalledWith(42, testDir);
   });
 
   it('should return EXIT_ISSUE_FETCH_FAILED when gh CLI unavailable', async () => {

--- a/src/__tests__/pipelineExecution.test.ts
+++ b/src/__tests__/pipelineExecution.test.ts
@@ -88,9 +88,9 @@ const { executePipeline } = await import('../features/pipeline/index.js');
 describe('executePipeline', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreatePullRequestSafely.mockImplementation((provider, cwd, options) => {
+    mockCreatePullRequestSafely.mockImplementation((provider, options, cwd) => {
       try {
-        return provider.createPullRequest(cwd, options);
+        return provider.createPullRequest(options, cwd);
       } catch (error) {
         return {
           success: false,
@@ -251,11 +251,11 @@ describe('executePipeline', () => {
 
     expect(exitCode).toBe(0);
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/tmp/test',
       expect.objectContaining({
         branch: 'fix/my-branch',
         repo: 'owner/repo',
       }),
+      '/tmp/test',
     );
   });
 
@@ -274,8 +274,8 @@ describe('executePipeline', () => {
 
     expect(exitCode).toBe(0);
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/tmp/test',
       expect.objectContaining({ draft: true }),
+      '/tmp/test',
     );
   });
 
@@ -294,8 +294,8 @@ describe('executePipeline', () => {
 
     expect(exitCode).toBe(0);
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/tmp/test',
       expect.objectContaining({ draft: false }),
+      '/tmp/test',
     );
   });
 
@@ -322,7 +322,7 @@ describe('executePipeline', () => {
     // Then
     expect(exitCode).toBe(0);
     expect(mockCreatePullRequest).toHaveBeenCalledTimes(1);
-    const prOptions = mockCreatePullRequest.mock.calls[0]?.[1] as { branch?: string; base?: string };
+    const prOptions = mockCreatePullRequest.mock.calls[0]?.[0] as { branch?: string; base?: string };
     expect(prOptions.branch).toBe('fix/my-branch');
     expect(prOptions.base).toBe('develop');
     expect(prOptions.base).not.toBeUndefined();
@@ -442,10 +442,10 @@ describe('executePipeline', () => {
       // When prBodyTemplate is set, buildPrBody (mock) should NOT be called
       // Instead, the template is expanded directly
       expect(mockCreatePullRequest).toHaveBeenCalledWith(
-        '/tmp/test',
         expect.objectContaining({
           body: '## Summary\nAuth is broken.\n\nCloses #50',
         }),
+        '/tmp/test',
       );
     });
 
@@ -464,10 +464,10 @@ describe('executePipeline', () => {
       // Should use buildPrBody (the mock)
       expect(mockBuildPrBody).toHaveBeenCalled();
       expect(mockCreatePullRequest).toHaveBeenCalledWith(
-        '/tmp/test',
         expect.objectContaining({
           body: 'Default PR body',
         }),
+        '/tmp/test',
       );
     });
   });
@@ -738,11 +738,11 @@ describe('executePipeline', () => {
 
       expect(exitCode).toBe(0);
       expect(mockCreatePullRequest).toHaveBeenCalledWith(
-        '/tmp/test',
         expect.objectContaining({
           branch: 'fix/the-bug',
           base: 'main',
         }),
+        '/tmp/test',
       );
     });
 
@@ -767,11 +767,11 @@ describe('executePipeline', () => {
 
       expect(exitCode).toBe(0);
       expect(mockCreatePullRequest).toHaveBeenCalledWith(
-        '/tmp/test',
         expect.objectContaining({
           branch: 'fix/the-bug',
           base: 'release/main',
         }),
+        '/tmp/test',
       );
     });
 
@@ -954,7 +954,7 @@ describe('executePipeline', () => {
       });
 
       expect(exitCode).toBe(0);
-      expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456);
+      expect(mockFetchPrReviewComments).toHaveBeenCalledWith(456, '/tmp/test');
       expect(mockFormatPrReviewAsTask).toHaveBeenCalled();
       // PR branch checkout
       const checkoutCall = mockExecFileSync.mock.calls.find(
@@ -1081,7 +1081,7 @@ describe('executePipeline', () => {
       // Then
       expect(exitCode).toBe(0);
       expect(mockCreatePullRequest).toHaveBeenCalledTimes(1);
-      const prOptions = mockCreatePullRequest.mock.calls[0]?.[1] as { base?: string };
+      const prOptions = mockCreatePullRequest.mock.calls[0]?.[0] as { base?: string };
       expect(prOptions.base).toBe('release/main');
       expect(prOptions.base).not.toBeUndefined();
       expect(prOptions.base).not.toBe('develop');
@@ -1117,7 +1117,7 @@ describe('executePipeline', () => {
 
       expect(exitCode).toBe(0);
       expect(mockCreatePullRequest).toHaveBeenCalledTimes(1);
-      const prOptions = mockCreatePullRequest.mock.calls[0]?.[1] as { base?: string };
+      const prOptions = mockCreatePullRequest.mock.calls[0]?.[0] as { base?: string };
       expect(prOptions.base).toBe('develop');
       expect(prOptions.base).not.toBeUndefined();
     });

--- a/src/__tests__/postExecution.test.ts
+++ b/src/__tests__/postExecution.test.ts
@@ -70,9 +70,9 @@ describe('postExecutionFlow', () => {
     mockPushBranch.mockReturnValue(undefined);
     mockCommentOnPr.mockReturnValue({ success: true });
     mockCreatePullRequest.mockReturnValue({ success: true, url: 'https://github.com/org/repo/pull/1' });
-    mockCreatePullRequestSafely.mockImplementation((provider, cwd, options) => {
+    mockCreatePullRequestSafely.mockImplementation((provider, options, cwd) => {
       try {
-        return provider.createPullRequest(cwd, options);
+        return provider.createPullRequest(options, cwd);
       } catch (error) {
         return {
           success: false,
@@ -96,7 +96,7 @@ describe('postExecutionFlow', () => {
 
     await postExecutionFlow(baseOptions);
 
-    expect(mockCommentOnPr).toHaveBeenCalledWith('/project', 42, 'pr-body');
+    expect(mockCommentOnPr).toHaveBeenCalledWith(42, 'pr-body', '/project');
     expect(mockCreatePullRequest).not.toHaveBeenCalled();
   });
 
@@ -130,8 +130,8 @@ describe('postExecutionFlow', () => {
     await postExecutionFlow({ ...baseOptions, draftPr: true });
 
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/project',
       expect.objectContaining({ draft: true }),
+      '/project',
     );
   });
 
@@ -141,8 +141,8 @@ describe('postExecutionFlow', () => {
     await postExecutionFlow({ ...baseOptions, draftPr: false });
 
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/project',
       expect.objectContaining({ draft: false }),
+      '/project',
     );
   });
 
@@ -173,13 +173,13 @@ describe('postExecutionFlow', () => {
     // Then: the workflow should continue into the existing pr_failed path.
     expect(mockPushBranch).toHaveBeenCalledWith('/project', 'task/fix-the-bug');
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/project',
       expect.objectContaining({
         branch: 'task/fix-the-bug',
         base: 'main',
         draft: false,
         title: 'Fix the bug',
       }),
+      '/project',
     );
     expect(result.prFailed).toBe(true);
     expect(result.prError).toBe('Failed to create pull request.');
@@ -309,8 +309,8 @@ describe('postExecutionFlow', () => {
     });
 
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/project',
       expect.objectContaining({ title: '[#123] Fix the bug' }),
+      '/project',
     );
   });
 
@@ -323,8 +323,8 @@ describe('postExecutionFlow', () => {
     });
 
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/project',
       expect.objectContaining({ title: 'Fix the bug' }),
+      '/project',
     );
   });
 
@@ -334,8 +334,8 @@ describe('postExecutionFlow', () => {
     await postExecutionFlow(baseOptions);
 
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/project',
       expect.objectContaining({ title: 'Fix the bug' }),
+      '/project',
     );
   });
 
@@ -351,8 +351,8 @@ describe('postExecutionFlow', () => {
     });
 
     expect(mockCreatePullRequest).toHaveBeenCalledWith(
-      '/project',
       expect.objectContaining({ title: expectedTitle }),
+      '/project',
     );
   });
 });

--- a/src/__tests__/resolveIssueTask-provider.test.ts
+++ b/src/__tests__/resolveIssueTask-provider.test.ts
@@ -111,4 +111,61 @@ describe('resolveIssueTask (inlined in git/index.ts)', () => {
     expect(result).toContain('Issue #2');
     expect(result).toContain('---');
   });
+
+  describe('cwd パラメータ伝搬', () => {
+    it('cwd を指定した場合は checkCliStatus と fetchIssue に cwd が渡される', () => {
+      // Given
+      mockExecFileSync
+        .mockReturnValueOnce('') // gh auth status
+        .mockReturnValueOnce(JSON.stringify({
+          number: 42,
+          title: 'Test Issue',
+          body: 'Body text',
+          labels: [],
+          comments: [],
+        }));
+
+      // When
+      const result = resolveIssueTask('#42', '/worktree/clone');
+
+      // Then
+      expect(result).toContain('Test Issue');
+      // checkCliStatus should receive cwd — gh auth status に cwd が渡されること
+      const authCall = mockExecFileSync.mock.calls[0];
+      expect(authCall).toBeDefined();
+      expect(authCall![2]).toEqual(expect.objectContaining({ cwd: '/worktree/clone' }));
+      // fetchIssue should also receive cwd — gh issue view に cwd が渡されること
+      const issueCall = mockExecFileSync.mock.calls[1];
+      expect(issueCall).toBeDefined();
+      expect(issueCall![2]).toEqual(expect.objectContaining({ cwd: '/worktree/clone' }));
+    });
+
+    it('cwd 省略時はプロバイダーのフォールバックに任せる', () => {
+      // Given
+      mockExecFileSync
+        .mockReturnValueOnce('') // gh auth status
+        .mockReturnValueOnce(JSON.stringify({
+          number: 10,
+          title: 'Issue',
+          body: 'Body',
+          labels: [],
+          comments: [],
+        }));
+
+      // When
+      const result = resolveIssueTask('#10');
+
+      // Then: 正常に動作する
+      expect(result).toContain('Issue');
+    });
+
+    it('イシュー参照でない文字列は cwd を渡してもプロバイダーを呼び出さない', () => {
+      // When
+      const result = resolveIssueTask('Fix the bug', '/worktree/clone');
+
+      // Then
+      expect(result).toBe('Fix the bug');
+      expect(mockExecFileSync).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/__tests__/resolveTask.test.ts
+++ b/src/__tests__/resolveTask.test.ts
@@ -483,7 +483,7 @@ describe('resolveTaskIssue', () => {
     // Then
     expect(result).toEqual([issue]);
     expect(mockProvider.checkCliStatus).toHaveBeenCalledWith('/my/project');
-    expect(mockProvider.fetchIssue).toHaveBeenCalledWith(42);
+    expect(mockProvider.fetchIssue).toHaveBeenCalledWith(42, '/my/project');
   });
 
   it('fetchIssue が例外を投げた場合は undefined を返す', () => {
@@ -500,6 +500,6 @@ describe('resolveTaskIssue', () => {
     // Then
     expect(result).toBeUndefined();
     expect(mockProvider.checkCliStatus).toHaveBeenCalledWith('/my/project');
-    expect(mockProvider.fetchIssue).toHaveBeenCalledWith(42);
+    expect(mockProvider.fetchIssue).toHaveBeenCalledWith(42, '/my/project');
   });
 });

--- a/src/app/cli/routing-inputs.ts
+++ b/src/app/cli/routing-inputs.ts
@@ -2,25 +2,29 @@ import { withProgress } from '../../shared/ui/index.js';
 import { formatIssueAsTask, parseIssueNumbers, formatPrReviewAsTask, getGitProvider } from '../../infra/git/index.js';
 import type { PrReviewData } from '../../infra/git/index.js';
 import { isDirectTask } from './helpers.js';
+
 export async function resolveIssueInput(
   issueOption: number | undefined,
   task: string | undefined,
+  cwd?: string,
 ): Promise<{ initialInput: string } | null> {
   if (issueOption) {
-    const cliStatus = getGitProvider().checkCliStatus();
+    const provider = getGitProvider();
+    const cliStatus = provider.checkCliStatus(cwd);
     if (!cliStatus.available) {
       throw new Error(cliStatus.error);
     }
     const issue = await withProgress(
       'Fetching issue...',
       (fetchedIssue) => `Issue fetched: #${fetchedIssue.number} ${fetchedIssue.title}`,
-      async () => getGitProvider().fetchIssue(issueOption),
+      async () => provider.fetchIssue(issueOption, cwd),
     );
     return { initialInput: formatIssueAsTask(issue) };
   }
 
   if (task && isDirectTask(task)) {
-    const cliStatus = getGitProvider().checkCliStatus();
+    const provider = getGitProvider();
+    const cliStatus = provider.checkCliStatus(cwd);
     if (!cliStatus.available) {
       throw new Error(cliStatus.error);
     }
@@ -32,7 +36,7 @@ export async function resolveIssueInput(
     const issues = await withProgress(
       'Fetching issues...',
       (fetchedIssues) => `Issues fetched: ${fetchedIssues.map((issue) => `#${issue.number}`).join(', ')}`,
-      async () => issueNumbers.map((n) => getGitProvider().fetchIssue(n)),
+      async () => issueNumbers.map((n) => provider.fetchIssue(n, cwd)),
     );
     return { initialInput: issues.map(formatIssueAsTask).join('\n\n---\n\n') };
   }
@@ -42,8 +46,10 @@ export async function resolveIssueInput(
 
 export async function resolvePrInput(
   prNumber: number,
+  cwd?: string,
 ): Promise<{ initialInput: string; prBranch: string; baseBranch?: string }> {
-  const cliStatus = getGitProvider().checkCliStatus();
+  const provider = getGitProvider();
+  const cliStatus = provider.checkCliStatus(cwd);
   if (!cliStatus.available) {
     throw new Error(cliStatus.error);
   }
@@ -51,7 +57,7 @@ export async function resolvePrInput(
   const prReview = await withProgress(
     'Fetching PR review comments...',
     (pr: PrReviewData) => `PR fetched: #${pr.number} ${pr.title}`,
-    async () => getGitProvider().fetchPrReviewComments(prNumber),
+    async () => provider.fetchPrReviewComments(prNumber, cwd),
   );
 
   return {

--- a/src/features/pipeline/steps.ts
+++ b/src/features/pipeline/steps.ts
@@ -98,10 +98,11 @@ function buildPipelinePrBody(
 
 function fetchVcsResource<T>(
   label: string,
+  cwd: string,
   fetch: (provider: ReturnType<typeof getGitProvider>) => T,
 ): T | undefined {
   const gitProvider = getGitProvider();
-  const cliStatus = gitProvider.checkCliStatus();
+  const cliStatus = gitProvider.checkCliStatus(cwd);
   if (!cliStatus.available) {
     error(cliStatus.error);
     return undefined;
@@ -115,11 +116,13 @@ function fetchVcsResource<T>(
 }
 
 export function resolveTaskContent(options: PipelineExecutionOptions): TaskContent | undefined {
+  const { cwd } = options;
   if (options.prNumber) {
     info(`Fetching PR #${options.prNumber} review comments...`);
     const prReview = fetchVcsResource(
       `PR #${options.prNumber}`,
-      (provider) => provider.fetchPrReviewComments(options.prNumber!),
+      cwd,
+      (provider) => provider.fetchPrReviewComments(options.prNumber!, cwd),
     );
     if (!prReview) return undefined;
     const task = formatPrReviewAsTask(prReview);
@@ -134,7 +137,8 @@ export function resolveTaskContent(options: PipelineExecutionOptions): TaskConte
     info(`Fetching issue #${options.issueNumber}...`);
     const issue = fetchVcsResource(
       `issue #${options.issueNumber}`,
-      (provider) => provider.fetchIssue(options.issueNumber!),
+      cwd,
+      (provider) => provider.fetchIssue(options.issueNumber!, cwd),
     );
     if (!issue) return undefined;
     const task = formatIssueAsTask(issue);
@@ -274,14 +278,14 @@ export function submitPullRequest(
   const report = `Piece \`${piece}\` completed successfully.`;
   const prBody = buildPipelinePrBody(pipelineConfig, taskContent.issue, report);
 
-  const prResult: CreatePrResult = createPullRequestSafely(getGitProvider(), projectCwd, {
+  const prResult: CreatePrResult = createPullRequestSafely(getGitProvider(), {
     branch,
     title: prTitle,
     body: prBody,
     base: resolvedBaseBranch,
     repo: options.repo,
     draft: options.draftPr,
-  });
+  }, projectCwd);
 
   if (prResult.success) {
     success(`PR created: ${prResult.url}`);

--- a/src/features/tasks/add/index.ts
+++ b/src/features/tasks/add/index.ts
@@ -137,7 +137,7 @@ export async function createIssueAndSaveTask(
   piece?: string,
   options?: { confirmAtEndMessage?: string; labels?: string[] },
 ): Promise<void> {
-  const issueNumber = createIssueFromTask(task, { labels: options?.labels });
+  const issueNumber = createIssueFromTask(task, { labels: options?.labels, cwd });
   if (issueNumber === undefined) {
     return;
   }
@@ -167,7 +167,7 @@ export async function addTask(
 
   if (prNumber !== undefined) {
     const provider = getGitProvider();
-    const cliStatus = provider.checkCliStatus();
+    const cliStatus = provider.checkCliStatus(cwd);
     if (!cliStatus.available) {
       error(cliStatus.error);
       return;
@@ -178,7 +178,7 @@ export async function addTask(
       prReview = await withProgress(
         'Fetching PR review comments...',
         (fetchedPrReview: PrReviewData) => `PR fetched: #${fetchedPrReview.number} ${fetchedPrReview.title}`,
-        async () => provider.fetchPrReviewComments(prNumber),
+        async () => provider.fetchPrReviewComments(prNumber, cwd),
       );
     } catch (e) {
       const msg = getErrorMessage(e);
@@ -224,7 +224,7 @@ export async function addTask(
       taskContent = await withProgress(
         'Fetching issue...',
         primaryIssueNumber ? `Issue fetched: #${primaryIssueNumber}` : 'Issue fetched',
-        async () => resolveIssueTask(trimmedTask),
+        async () => resolveIssueTask(trimmedTask, cwd),
       );
       if (numbers.length > 0) {
         issueNumber = numbers[0];

--- a/src/features/tasks/add/issueTask.ts
+++ b/src/features/tasks/add/issueTask.ts
@@ -30,13 +30,13 @@ export function extractTitle(task: string): string {
  * falling back to the first non-empty line. Truncates to 100 chars.
  * Uses the full task as the body, and displays success/error messages.
  */
-export function createIssueFromTask(task: string, options?: { labels?: string[] }): number | undefined {
+export function createIssueFromTask(task: string, options?: { labels?: string[]; cwd?: string }): number | undefined {
   info('Creating issue...');
   const title = extractTitle(task);
   const effectiveLabels = options?.labels?.filter((l) => l.length > 0) ?? [];
   const labels = effectiveLabels.length > 0 ? effectiveLabels : undefined;
 
-  const issueResult = getGitProvider().createIssue({ title, body: task, labels });
+  const issueResult = getGitProvider().createIssue({ title, body: task, labels }, options?.cwd);
   if (issueResult.success) {
     if (!issueResult.url) {
       error('Failed to extract issue number from URL');

--- a/src/features/tasks/execute/postExecution.ts
+++ b/src/features/tasks/execute/postExecution.ts
@@ -81,11 +81,11 @@ export async function postExecutionFlow(options: PostExecutionOptions): Promise<
     }
     const gitProvider = getGitProvider();
     const report = pieceIdentifier ? `Piece \`${pieceIdentifier}\` completed successfully.` : 'Task completed successfully.';
-    const existingPr = gitProvider.findExistingPr(projectCwd, branch);
+    const existingPr = gitProvider.findExistingPr(branch, projectCwd);
     if (existingPr) {
       // push済みなので、新コミットはPRに自動反映される
       const commentBody = buildPrBody(issues, report);
-      const commentResult = gitProvider.commentOnPr(projectCwd, existingPr.number, commentBody);
+      const commentResult = gitProvider.commentOnPr(existingPr.number, commentBody, projectCwd);
       if (commentResult.success) {
         success(`PR updated with comment: ${existingPr.url}`);
         return { prUrl: existingPr.url };
@@ -104,14 +104,14 @@ export async function postExecutionFlow(options: PostExecutionOptions): Promise<
       const issuePrefix = firstIssue ? `[#${firstIssue.number}] ` : '';
       const truncatedTask = task.length > 100 - issuePrefix.length ? `${task.slice(0, 100 - issuePrefix.length - 3)}...` : task;
       const prTitle = issuePrefix + truncatedTask;
-      const prResult: CreatePrResult = createPullRequestSafely(gitProvider, projectCwd, {
+      const prResult: CreatePrResult = createPullRequestSafely(gitProvider, {
         branch,
         title: prTitle,
         body: prBody,
         base: baseBranch,
         repo,
         draft: draftPr,
-      });
+      }, projectCwd);
       if (prResult.success) {
         success(`PR created: ${prResult.url}`);
         return { prUrl: prResult.url };

--- a/src/features/tasks/execute/resolveTask.ts
+++ b/src/features/tasks/execute/resolveTask.ts
@@ -94,7 +94,7 @@ export function resolveTaskIssue(issueNumber: number | undefined, cwd: string): 
   }
 
   try {
-    const issue = gitProvider.fetchIssue(issueNumber);
+    const issue = gitProvider.fetchIssue(issueNumber, cwd);
     return [issue];
   } catch (e) {
     log.info('Failed to fetch issue for PR body, continuing without issue info', { issueNumber, error: getErrorMessage(e) });

--- a/src/infra/git/detect.ts
+++ b/src/infra/git/detect.ts
@@ -74,8 +74,8 @@ export function getRemoteHostname(cwd: string): string | undefined {
  *
  * @returns `'github'` | `'gitlab'` | `undefined`
  */
-export function detectVcsProvider(): VcsProviderType | undefined {
-  const hostname = getRemoteHostname(process.cwd());
+export function detectVcsProvider(cwd?: string): VcsProviderType | undefined {
+  const hostname = getRemoteHostname(cwd ?? process.cwd());
   if (!hostname) {
     return undefined;
   }

--- a/src/infra/git/index.ts
+++ b/src/infra/git/index.ts
@@ -32,11 +32,11 @@ function createProvider(type: VcsProviderType): GitProvider {
   }
 }
 
-function resolveProviderType(configValue: VcsProviderType | undefined): VcsProviderType {
+function resolveProviderType(configValue: VcsProviderType | undefined, cwd?: string): VcsProviderType {
   if (configValue) {
     return configValue;
   }
-  return detectVcsProvider() ?? 'github';
+  return detectVcsProvider(cwd) ?? 'github';
 }
 
 /**
@@ -51,7 +51,7 @@ function resolveProviderType(configValue: VcsProviderType | undefined): VcsProvi
  */
 export function initGitProvider(projectDir: string): void {
   const configValue = resolveConfigValue(projectDir, 'vcsProvider') as VcsProviderType | undefined;
-  const resolved = resolveProviderType(configValue);
+  const resolved = resolveProviderType(configValue, projectDir);
 
   if (provider && currentProviderType === resolved) {
     return;
@@ -78,11 +78,11 @@ export function getGitProvider(): GitProvider {
 
 export function createPullRequestSafely(
   gitProvider: GitProvider,
-  cwd: string,
   options: CreatePrOptions,
+  cwd?: string,
 ): CreatePrResult {
   try {
-    return gitProvider.createPullRequest(cwd, options);
+    return gitProvider.createPullRequest(options, cwd);
   } catch (createPrError) {
     return {
       success: false,
@@ -98,7 +98,7 @@ export function createPullRequestSafely(
  * Otherwise returns the task string as-is.
  * Throws if VCS CLI is not available or issue fetch fails.
  */
-export function resolveIssueTask(task: string): string {
+export function resolveIssueTask(task: string, cwd?: string): string {
   const tokens = task.trim().split(/\s+/);
   const issueNumbers = parseIssueNumbers(tokens);
 
@@ -107,11 +107,11 @@ export function resolveIssueTask(task: string): string {
   }
 
   const gitProvider = getGitProvider();
-  const cliStatus = gitProvider.checkCliStatus();
+  const cliStatus = gitProvider.checkCliStatus(cwd);
   if (!cliStatus.available) {
     throw new Error(cliStatus.error);
   }
 
-  const issues = issueNumbers.map((n) => gitProvider.fetchIssue(n));
+  const issues = issueNumbers.map((n) => gitProvider.fetchIssue(n, cwd));
   return issues.map(formatIssueAsTask).join('\n\n---\n\n');
 }

--- a/src/infra/git/types.ts
+++ b/src/infra/git/types.ts
@@ -69,15 +69,15 @@ export interface PrReviewData {
 export interface GitProvider {
   checkCliStatus(cwd?: string): CliStatus;
 
-  fetchIssue(issueNumber: number): Issue;
+  fetchIssue(issueNumber: number, cwd?: string): Issue;
 
   createIssue(options: CreateIssueOptions, cwd?: string): CreateIssueResult;
 
-  fetchPrReviewComments(prNumber: number): PrReviewData;
+  fetchPrReviewComments(prNumber: number, cwd?: string): PrReviewData;
 
-  findExistingPr(cwd: string, branch: string): ExistingPr | undefined;
+  findExistingPr(branch: string, cwd?: string): ExistingPr | undefined;
 
-  createPullRequest(cwd: string, options: CreatePrOptions): CreatePrResult;
+  createPullRequest(options: CreatePrOptions, cwd?: string): CreatePrResult;
 
-  commentOnPr(cwd: string, prNumber: number, body: string): CommentResult;
+  commentOnPr(prNumber: number, body: string, cwd?: string): CommentResult;
 }

--- a/src/infra/github/GitHubProvider.ts
+++ b/src/infra/github/GitHubProvider.ts
@@ -11,31 +11,31 @@ import { findExistingPr, commentOnPr, createPullRequest, fetchPrReviewComments }
 import type { GitProvider, CliStatus, Issue, ExistingPr, CreateIssueOptions, CreateIssueResult, CreatePrOptions, CreatePrResult, CommentResult, PrReviewData } from '../git/types.js';
 
 export class GitHubProvider implements GitProvider {
-  checkCliStatus(_cwd?: string): CliStatus {
-    return checkGhCli();
+  checkCliStatus(cwd?: string): CliStatus {
+    return checkGhCli(cwd ?? process.cwd());
   }
 
-  fetchIssue(issueNumber: number): Issue {
-    return fetchIssue(issueNumber);
+  fetchIssue(issueNumber: number, cwd?: string): Issue {
+    return fetchIssue(issueNumber, cwd ?? process.cwd());
   }
 
-  createIssue(options: CreateIssueOptions, _cwd?: string): CreateIssueResult {
-    return createIssue(options);
+  createIssue(options: CreateIssueOptions, cwd?: string): CreateIssueResult {
+    return createIssue(options, cwd ?? process.cwd());
   }
 
-  fetchPrReviewComments(prNumber: number): PrReviewData {
-    return fetchPrReviewComments(prNumber);
+  fetchPrReviewComments(prNumber: number, cwd?: string): PrReviewData {
+    return fetchPrReviewComments(prNumber, cwd ?? process.cwd());
   }
 
-  findExistingPr(cwd: string, branch: string): ExistingPr | undefined {
-    return findExistingPr(cwd, branch);
+  findExistingPr(branch: string, cwd?: string): ExistingPr | undefined {
+    return findExistingPr(branch, cwd ?? process.cwd());
   }
 
-  createPullRequest(cwd: string, options: CreatePrOptions): CreatePrResult {
-    return createPullRequest(cwd, options);
+  createPullRequest(options: CreatePrOptions, cwd?: string): CreatePrResult {
+    return createPullRequest(options, cwd ?? process.cwd());
   }
 
-  commentOnPr(cwd: string, prNumber: number, body: string): CommentResult {
-    return commentOnPr(cwd, prNumber, body);
+  commentOnPr(prNumber: number, body: string, cwd?: string): CommentResult {
+    return commentOnPr(prNumber, body, cwd ?? process.cwd());
   }
 }

--- a/src/infra/github/issue.ts
+++ b/src/infra/github/issue.ts
@@ -11,13 +11,13 @@ const log = createLogger('github');
 /**
  * Check if `gh` CLI is available and authenticated.
  */
-export function checkGhCli(): CliStatus {
+export function checkGhCli(cwd: string): CliStatus {
   try {
-    execFileSync('gh', ['auth', 'status'], { stdio: 'pipe' });
+    execFileSync('gh', ['auth', 'status'], { cwd, stdio: 'pipe' });
     return { available: true };
   } catch {
     try {
-      execFileSync('gh', ['--version'], { stdio: 'pipe' });
+      execFileSync('gh', ['--version'], { cwd, stdio: 'pipe' });
       return {
         available: false,
         error: 'gh CLI is installed but not authenticated. Run `gh auth login` first.',
@@ -35,13 +35,13 @@ export function checkGhCli(): CliStatus {
  * Fetch issue content via `gh issue view`.
  * Throws on failure (issue not found, network error, etc.).
  */
-export function fetchIssue(issueNumber: number): Issue {
+export function fetchIssue(issueNumber: number, cwd: string): Issue {
   log.debug('Fetching issue', { issueNumber });
 
   const raw = execFileSync(
     'gh',
     ['issue', 'view', String(issueNumber), '--json', 'number,title,body,labels,comments'],
-    { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
   );
 
   const data = JSON.parse(raw) as {
@@ -67,10 +67,11 @@ export function fetchIssue(issueNumber: number): Issue {
 /**
  * Filter labels to only those that exist on the repository.
  */
-function filterExistingLabels(labels: string[]): string[] {
+function filterExistingLabels(labels: string[], cwd: string): string[] {
   try {
     const existing = new Set(
       execFileSync('gh', ['label', 'list', '--json', 'name', '-q', '.[].name'], {
+        cwd,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
       })
@@ -88,15 +89,15 @@ function filterExistingLabels(labels: string[]): string[] {
 /**
  * Create a GitHub Issue via `gh issue create`.
  */
-export function createIssue(options: CreateIssueOptions): CreateIssueResult {
-  const ghStatus = checkGhCli();
+export function createIssue(options: CreateIssueOptions, cwd: string): CreateIssueResult {
+  const ghStatus = checkGhCli(cwd);
   if (!ghStatus.available) {
     return { success: false, error: ghStatus.error };
   }
 
   const args = ['issue', 'create', '--title', options.title, '--body', options.body];
   if (options.labels && options.labels.length > 0) {
-    const validLabels = filterExistingLabels(options.labels);
+    const validLabels = filterExistingLabels(options.labels, cwd);
     if (validLabels.length > 0) {
       args.push('--label', validLabels.join(','));
     }
@@ -106,6 +107,7 @@ export function createIssue(options: CreateIssueOptions): CreateIssueResult {
 
   try {
     const output = execFileSync('gh', args, {
+      cwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/src/infra/github/pr.ts
+++ b/src/infra/github/pr.ts
@@ -16,8 +16,8 @@ const log = createLogger('github-pr');
  * Find an open PR for the given branch.
  * Returns undefined if no PR exists.
  */
-export function findExistingPr(cwd: string, branch: string): ExistingPr | undefined {
-  const ghStatus = checkGhCli();
+export function findExistingPr(branch: string, cwd: string): ExistingPr | undefined {
+  const ghStatus = checkGhCli(cwd);
   if (!ghStatus.available) return undefined;
 
   try {
@@ -33,8 +33,8 @@ export function findExistingPr(cwd: string, branch: string): ExistingPr | undefi
   }
 }
 
-export function commentOnPr(cwd: string, prNumber: number, body: string): CommentResult {
-  const ghStatus = checkGhCli();
+export function commentOnPr(prNumber: number, body: string, cwd: string): CommentResult {
+  const ghStatus = checkGhCli(cwd);
   if (!ghStatus.available) {
     return { success: false, error: ghStatus.error };
   }
@@ -102,7 +102,7 @@ function normalizeReviewComment(raw: GhPrApiRawReviewComment): GhPrApiReviewComm
   };
 }
 
-function fetchInlineReviewComments(owner: string, repo: string, prNumber: number): GhPrApiReviewComment[] {
+function fetchInlineReviewComments(owner: string, repo: string, prNumber: number, cwd: string): GhPrApiReviewComment[] {
   const comments: GhPrApiReviewComment[] = [];
   let page = 1;
 
@@ -110,7 +110,7 @@ function fetchInlineReviewComments(owner: string, repo: string, prNumber: number
     const rawInlineReviewComments = execFileSync(
       'gh',
       ['api', `/repos/${owner}/${repo}/pulls/${prNumber}/comments?per_page=${INLINE_REVIEW_COMMENTS_PER_PAGE}&page=${page}`],
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+      { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
     );
     const parsed = JSON.parse(rawInlineReviewComments) as GhPrApiRawReviewComment[];
     const normalized = parsed.map(normalizeReviewComment);
@@ -147,19 +147,19 @@ function parseRepositoryFromPrUrl(prUrl: string): { owner: string; repo: string 
  * Fetch PR review comments and metadata via `gh pr view`.
  * Throws on failure (PR not found, network error, etc.).
  */
-export function fetchPrReviewComments(prNumber: number): PrReviewData {
+export function fetchPrReviewComments(prNumber: number, cwd: string): PrReviewData {
   log.debug('Fetching PR review comments', { prNumber });
 
   const raw = execFileSync(
     'gh',
     ['pr', 'view', String(prNumber), '--json', PR_REVIEW_JSON_FIELDS],
-    { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
   );
 
   const data = JSON.parse(raw) as GhPrViewReviewResponse;
   const { owner, repo } = parseRepositoryFromPrUrl(data.url);
 
-  const inlineReviewComments = fetchInlineReviewComments(owner, repo, prNumber);
+  const inlineReviewComments = fetchInlineReviewComments(owner, repo, prNumber, cwd);
 
   const comments: PrReviewComment[] = data.comments.map((c) => ({
     author: c.author.login,
@@ -194,8 +194,8 @@ export function fetchPrReviewComments(prNumber: number): PrReviewData {
   };
 }
 
-export function createPullRequest(cwd: string, options: CreatePrOptions): CreatePrResult {
-  const ghStatus = checkGhCli();
+export function createPullRequest(options: CreatePrOptions, cwd: string): CreatePrResult {
+  const ghStatus = checkGhCli(cwd);
   if (!ghStatus.available) {
     return { success: false, error: ghStatus.error };
   }

--- a/src/infra/gitlab/GitLabProvider.ts
+++ b/src/infra/gitlab/GitLabProvider.ts
@@ -16,27 +16,27 @@ export class GitLabProvider implements GitProvider {
     return checkGlabCli(cwd ?? process.cwd());
   }
 
-  fetchIssue(issueNumber: number): Issue {
-    return fetchIssue(issueNumber);
+  fetchIssue(issueNumber: number, cwd?: string): Issue {
+    return fetchIssue(issueNumber, cwd ?? process.cwd());
   }
 
   createIssue(options: CreateIssueOptions, cwd?: string): CreateIssueResult {
     return createIssue(options, cwd ?? process.cwd());
   }
 
-  fetchPrReviewComments(prNumber: number): PrReviewData {
-    return fetchMrReviewComments(prNumber);
+  fetchPrReviewComments(prNumber: number, cwd?: string): PrReviewData {
+    return fetchMrReviewComments(prNumber, cwd ?? process.cwd());
   }
 
-  findExistingPr(cwd: string, branch: string): ExistingPr | undefined {
-    return findExistingMr(cwd, branch);
+  findExistingPr(branch: string, cwd?: string): ExistingPr | undefined {
+    return findExistingMr(branch, cwd ?? process.cwd());
   }
 
-  createPullRequest(cwd: string, options: CreatePrOptions): CreatePrResult {
-    return createMergeRequest(cwd, options);
+  createPullRequest(options: CreatePrOptions, cwd?: string): CreatePrResult {
+    return createMergeRequest(options, cwd ?? process.cwd());
   }
 
-  commentOnPr(cwd: string, prNumber: number, body: string): CommentResult {
-    return commentOnMr(cwd, prNumber, body);
+  commentOnPr(prNumber: number, body: string, cwd?: string): CommentResult {
+    return commentOnMr(prNumber, body, cwd ?? process.cwd());
   }
 }

--- a/src/infra/gitlab/issue.ts
+++ b/src/infra/gitlab/issue.ts
@@ -26,13 +26,13 @@ interface GlabIssueNote {
  *
  * Throws on failure (issue not found, network error, etc.).
  */
-export function fetchIssue(issueNumber: number): Issue {
+export function fetchIssue(issueNumber: number, cwd: string): Issue {
   log.debug('Fetching issue', { issueNumber });
 
   const raw = execFileSync(
     'glab',
     ['issue', 'view', String(issueNumber), '--output', 'json'],
-    { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
   );
 
   const data = parseJson<{
@@ -46,6 +46,7 @@ export function fetchIssue(issueNumber: number): Issue {
     `projects/:id/issues/${issueNumber}/notes`,
     ITEMS_PER_PAGE,
     `issue #${issueNumber} notes`,
+    cwd,
   );
 
   return {

--- a/src/infra/gitlab/pr.ts
+++ b/src/infra/gitlab/pr.ts
@@ -15,7 +15,7 @@ const log = createLogger('gitlab-mr');
  * Find an open MR for the given branch.
  * Returns undefined if no MR exists.
  */
-export function findExistingMr(cwd: string, branch: string): ExistingPr | undefined {
+export function findExistingMr(branch: string, cwd: string): ExistingPr | undefined {
   const glabStatus = checkGlabCli(cwd);
   if (!glabStatus.available) return undefined;
 
@@ -38,7 +38,7 @@ export function findExistingMr(cwd: string, branch: string): ExistingPr | undefi
 /**
  * Create a GitLab Merge Request via `glab mr create`.
  */
-export function createMergeRequest(cwd: string, options: CreatePrOptions): CreatePrResult {
+export function createMergeRequest(options: CreatePrOptions, cwd: string): CreatePrResult {
   if (options.repo) {
     throw new Error('--repo is not supported with GitLab provider. Use cwd context instead.');
   }
@@ -86,7 +86,7 @@ export function createMergeRequest(cwd: string, options: CreatePrOptions): Creat
 /**
  * Add a comment (note) to a GitLab Merge Request.
  */
-export function commentOnMr(cwd: string, mrNumber: number, body: string): CommentResult {
+export function commentOnMr(mrNumber: number, body: string, cwd: string): CommentResult {
   const glabStatus = checkGlabCli(cwd);
   if (!glabStatus.available) {
     return { success: false, error: glabStatus.error };
@@ -143,13 +143,13 @@ interface GlabDiscussion {
  *
  * Throws on failure (MR not found, network error, etc.).
  */
-export function fetchMrReviewComments(mrNumber: number): PrReviewData {
+export function fetchMrReviewComments(mrNumber: number, cwd: string): PrReviewData {
   log.debug('Fetching MR review comments', { mrNumber });
 
   const rawMr = execFileSync(
     'glab',
     ['mr', 'view', String(mrNumber), '--output', 'json'],
-    { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
   );
   const mrData = parseJson<GlabMrViewResponse>(rawMr, `mr view #${mrNumber}`);
 
@@ -157,6 +157,7 @@ export function fetchMrReviewComments(mrNumber: number): PrReviewData {
     `projects/:id/merge_requests/${mrNumber}/diffs`,
     ITEMS_PER_PAGE,
     `mr #${mrNumber} diffs`,
+    cwd,
   );
   const files = diffs.map(d => d.new_path);
 
@@ -164,6 +165,7 @@ export function fetchMrReviewComments(mrNumber: number): PrReviewData {
     `projects/:id/merge_requests/${mrNumber}/notes`,
     ITEMS_PER_PAGE,
     `mr #${mrNumber} notes`,
+    cwd,
   );
 
   const comments: PrReviewComment[] = [];
@@ -177,6 +179,7 @@ export function fetchMrReviewComments(mrNumber: number): PrReviewData {
     `projects/:id/merge_requests/${mrNumber}/discussions`,
     ITEMS_PER_PAGE,
     `mr #${mrNumber} discussions`,
+    cwd,
   );
 
   const reviews: PrReviewComment[] = [];

--- a/src/infra/gitlab/utils.ts
+++ b/src/infra/gitlab/utils.ts
@@ -33,11 +33,11 @@ export function checkGlabCli(cwd: string): CliStatus {
     : ['auth', 'status'];
 
   try {
-    execFileSync('glab', authArgs, { stdio: 'pipe' });
+    execFileSync('glab', authArgs, { cwd, stdio: 'pipe' });
     return { available: true };
   } catch {
     try {
-      execFileSync('glab', ['--version'], { stdio: 'pipe' });
+      execFileSync('glab', ['--version'], { cwd, stdio: 'pipe' });
       return {
         available: false,
         error: 'glab CLI is installed but not authenticated. Run `glab auth login` first.',
@@ -57,7 +57,7 @@ export function checkGlabCli(cwd: string): CliStatus {
  * Paginates through results until a page returns fewer than `perPage` items
  * or `MAX_PAGES` is reached (whichever comes first).
  */
-export function fetchAllPages<T>(endpoint: string, perPage: number, context: string): T[] {
+export function fetchAllPages<T>(endpoint: string, perPage: number, context: string, cwd: string): T[] {
   const all: T[] = [];
   let page = 1;
 
@@ -65,7 +65,7 @@ export function fetchAllPages<T>(endpoint: string, perPage: number, context: str
     const raw = execFileSync(
       'glab',
       ['api', `${endpoint}${endpoint.includes('?') ? '&' : '?'}per_page=${perPage}&page=${page}`],
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+      { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
     );
     const items = parseJson<T[]>(raw, context);
 


### PR DESCRIPTION
## 概要
GitLab セルフホスト環境で、Git provider 経由の `glab` 実行に project/worktree の `cwd` が伝搬されていなかった問題を修正します。

Closes #551

## 変更内容
- Git provider の各操作で `cwd` を受け取り、`gh` / `glab` 実行時に対象リポジトリのディレクトリを使うように修正
- `detectVcsProvider` や provider 初期化でも project 側の `cwd` を使うように修正
- GitLab では `glab auth status --hostname <origin host>` を使うようにして、セルフホスト環境の認証確認を対象ホスト基準に修正
- GitHub 側の provider 実装も同じインターフェースにそろえて `cwd` を伝搬するように修正
- GitHub 側の変更は GitLab 修正の巻き添えではなく、worktree や project 外実行時に GitHub / GitHub Enterprise でも同種の repo 文脈ずれを防ぐ意図で含めている
- 高レベルの呼び出し元から provider 実装までの `cwd` 伝搬テストを追加

## 確認
- `npm test -- --run src/__tests__/gitlab-provider.test.ts src/__tests__/gitlab-pr.test.ts src/__tests__/gitlab-issue.test.ts src/__tests__/gitlab-utils.test.ts src/__tests__/github-provider.test.ts src/__tests__/github-pr.test.ts src/__tests__/git-factory.test.ts src/__tests__/git-detect.test.ts src/__tests__/resolveIssueTask-provider.test.ts`
- `npm test -- --run src/__tests__/git-cwd-propagation.test.ts`
