### PR TITLE
fix: takt worktree環境下でruntime.prepareが設定されているかつセルフホスト環境でglab CLI認証が失敗する問題の修正

### DIFF
--- a/src/__tests__/runtime-environment.test.ts
+++ b/src/__tests__/runtime-environment.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -16,6 +16,9 @@ describe('prepareRuntimeEnvironment', () => {
     'JAVA_TOOL_OPTIONS',
     'GRADLE_USER_HOME',
     'npm_config_cache',
+    'GH_CONFIG_DIR',
+    'GLAB_CONFIG_DIR',
+    'HOME',
   ] as const;
   const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
 
@@ -91,6 +94,159 @@ describe('prepareRuntimeEnvironment', () => {
     expect(result).toBeDefined();
     expect(result?.injectedEnv.CUSTOM_CACHE_DIR).toBe(join(cwd, '.takt', '.runtime', 'custom-cache'));
     expect(existsSync(join(cwd, '.takt', '.runtime', 'custom-cache'))).toBe(true);
+  });
+
+  it('should preserve GLAB_CONFIG_DIR when already set in environment', () => {
+    const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+    tempDirs.push(cwd);
+
+    const customGlabDir = '/custom/glab/config';
+    process.env['GLAB_CONFIG_DIR'] = customGlabDir;
+
+    const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+    expect(result).toBeDefined();
+    expect(result?.injectedEnv.GLAB_CONFIG_DIR).toBe(customGlabDir);
+  });
+
+  it.skipIf(process.platform !== 'darwin')(
+    'should use macOS Application Support path when it exists',
+    () => {
+      const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+      tempDirs.push(cwd);
+      const fakeHome = mkdtempSync(join(systemTmpDir, 'takt-fake-home-'));
+      tempDirs.push(fakeHome);
+
+      delete process.env['GLAB_CONFIG_DIR'];
+      process.env['HOME'] = fakeHome;
+      delete process.env['XDG_CONFIG_HOME'];
+
+      const macOsGlabDir = join(fakeHome, 'Library', 'Application Support', 'glab-cli');
+      mkdirSync(macOsGlabDir, { recursive: true });
+
+      const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+      expect(result).toBeDefined();
+      expect(result?.injectedEnv.GLAB_CONFIG_DIR).toBe(macOsGlabDir);
+    },
+  );
+
+  it('should use XDG_CONFIG_HOME/glab-cli when it exists', () => {
+    const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+    tempDirs.push(cwd);
+    const fakeHome = mkdtempSync(join(systemTmpDir, 'takt-fake-home-'));
+    tempDirs.push(fakeHome);
+    const fakeXdgConfig = mkdtempSync(join(systemTmpDir, 'takt-xdg-config-'));
+    tempDirs.push(fakeXdgConfig);
+
+    delete process.env['GLAB_CONFIG_DIR'];
+    process.env['HOME'] = fakeHome;
+    process.env['XDG_CONFIG_HOME'] = fakeXdgConfig;
+
+    const glabDir = join(fakeXdgConfig, 'glab-cli');
+    mkdirSync(glabDir, { recursive: true });
+
+    const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+    expect(result).toBeDefined();
+    expect(result?.injectedEnv.GLAB_CONFIG_DIR).toBe(glabDir);
+  });
+
+  it('should fallback to ~/.config/glab-cli when no other glab config exists', () => {
+    const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+    tempDirs.push(cwd);
+    const fakeHome = mkdtempSync(join(systemTmpDir, 'takt-fake-home-'));
+    tempDirs.push(fakeHome);
+
+    delete process.env['GLAB_CONFIG_DIR'];
+    delete process.env['XDG_CONFIG_HOME'];
+    process.env['HOME'] = fakeHome;
+
+    const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+    expect(result).toBeDefined();
+    expect(result?.injectedEnv.GLAB_CONFIG_DIR).toBe(join(fakeHome, '.config', 'glab-cli'));
+  });
+
+  it('should respect XDG_CONFIG_HOME in fallback when glab-cli dir does not exist', () => {
+    const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+    tempDirs.push(cwd);
+    const fakeHome = mkdtempSync(join(systemTmpDir, 'takt-fake-home-'));
+    tempDirs.push(fakeHome);
+    const fakeXdgConfig = mkdtempSync(join(systemTmpDir, 'takt-xdg-config-'));
+    tempDirs.push(fakeXdgConfig);
+
+    delete process.env['GLAB_CONFIG_DIR'];
+    process.env['HOME'] = fakeHome;
+    process.env['XDG_CONFIG_HOME'] = fakeXdgConfig;
+
+    // glab-cli dir does NOT exist under XDG_CONFIG_HOME — fallback should still use XDG_CONFIG_HOME
+    const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+    expect(result).toBeDefined();
+    expect(result?.injectedEnv.GLAB_CONFIG_DIR).toBe(join(fakeXdgConfig, 'glab-cli'));
+  });
+
+  it('should include GLAB_CONFIG_DIR in env.sh output', () => {
+    const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+    tempDirs.push(cwd);
+
+    const customGlabDir = '/custom/glab/config';
+    process.env['GLAB_CONFIG_DIR'] = customGlabDir;
+
+    const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+    expect(result).toBeDefined();
+    const envContent = readFileSync(result!.envFile, 'utf-8');
+    expect(envContent).toContain('export GLAB_CONFIG_DIR=');
+    expect(envContent).toContain(customGlabDir);
+  });
+
+  it.skipIf(process.platform !== 'darwin')(
+    'should prefer macOS Application Support over XDG_CONFIG_HOME for glab',
+    () => {
+      const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+      tempDirs.push(cwd);
+      const fakeHome = mkdtempSync(join(systemTmpDir, 'takt-fake-home-'));
+      tempDirs.push(fakeHome);
+      const fakeXdgConfig = mkdtempSync(join(systemTmpDir, 'takt-xdg-config-'));
+      tempDirs.push(fakeXdgConfig);
+
+      delete process.env['GLAB_CONFIG_DIR'];
+      process.env['HOME'] = fakeHome;
+      process.env['XDG_CONFIG_HOME'] = fakeXdgConfig;
+
+      // Both paths exist
+      const macOsGlabDir = join(fakeHome, 'Library', 'Application Support', 'glab-cli');
+      mkdirSync(macOsGlabDir, { recursive: true });
+      const xdgGlabDir = join(fakeXdgConfig, 'glab-cli');
+      mkdirSync(xdgGlabDir, { recursive: true });
+
+      const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+      expect(result).toBeDefined();
+      expect(result?.injectedEnv.GLAB_CONFIG_DIR).toBe(macOsGlabDir);
+    },
+  );
+
+  it('should prefer GLAB_CONFIG_DIR env over all other glab config paths', () => {
+    const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+    tempDirs.push(cwd);
+    const fakeXdgConfig = mkdtempSync(join(systemTmpDir, 'takt-xdg-config-'));
+    tempDirs.push(fakeXdgConfig);
+
+    const explicitDir = '/explicit/glab/config';
+    process.env['GLAB_CONFIG_DIR'] = explicitDir;
+    process.env['XDG_CONFIG_HOME'] = fakeXdgConfig;
+
+    // XDG path also exists, but env var should take precedence
+    const xdgGlabDir = join(fakeXdgConfig, 'glab-cli');
+    mkdirSync(xdgGlabDir, { recursive: true });
+
+    const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+    expect(result).toBeDefined();
+    expect(result?.injectedEnv.GLAB_CONFIG_DIR).toBe(explicitDir);
   });
 
 });

--- a/src/core/runtime/runtime-environment.ts
+++ b/src/core/runtime/runtime-environment.ts
@@ -28,8 +28,25 @@ function preserveToolConfigDir(envKey: string, xdgSubdir: string): string {
     ?? join(process.env['XDG_CONFIG_HOME'] ?? join(process.env['HOME']!, '.config'), xdgSubdir);
 }
 
+function resolveGlabConfigDir(): string {
+  if (process.env['GLAB_CONFIG_DIR']) {
+    return process.env['GLAB_CONFIG_DIR'];
+  }
+
+  if (process.platform === 'darwin') {
+    const macOsPath = join(process.env['HOME']!, 'Library', 'Application Support', 'glab-cli');
+    if (existsSync(macOsPath)) {
+      return macOsPath;
+    }
+  }
+
+  const xdgBase = process.env['XDG_CONFIG_HOME'] ?? join(process.env['HOME']!, '.config');
+  return join(xdgBase, 'glab-cli');
+}
+
 function createBaseEnvironment(runtimeRoot: string): Record<string, string> {
   const ghConfigDir = preserveToolConfigDir('GH_CONFIG_DIR', 'gh');
+  const glabConfigDir = resolveGlabConfigDir();
   return {
     TMPDIR: join(runtimeRoot, 'tmp'),
     XDG_CACHE_HOME: join(runtimeRoot, 'cache'),
@@ -37,6 +54,7 @@ function createBaseEnvironment(runtimeRoot: string): Record<string, string> {
     XDG_STATE_HOME: join(runtimeRoot, 'state'),
     CI: 'true',
     GH_CONFIG_DIR: ghConfigDir,
+    GLAB_CONFIG_DIR: glabConfigDir,
   };
 }
 


### PR DESCRIPTION
## 概要
`runtime.prepare` によって `XDG_CONFIG_HOME` がワークツリー配下の `.takt/.runtime/config` に切り替わる環境で、セルフホスト GitLab 利用時に `glab` CLI の既存認証設定を参照できず失敗する問題を修正します。

## 変更内容
- runtime 環境の注入変数に `GLAB_CONFIG_DIR` を追加
- `GLAB_CONFIG_DIR` が明示的に設定されている場合はその値を優先
- macOS では既存の `~/Library/Application Support/glab-cli` が存在する場合にそのパスを優先
- それ以外の環境では `XDG_CONFIG_HOME/glab-cli` または `~/.config/glab-cli` を利用するように調整
- 生成される `env.sh` にも `GLAB_CONFIG_DIR` を出力
- `runtime-environment` の単体テストを追加し、優先順位とフォールバック動作をカバー

## 動作確認
- テスト実行は未実施
- 以下の観点を確認する単体テストを追加
  - `GLAB_CONFIG_DIR` の明示指定を保持すること
  - macOS の `Application Support` 配下を優先すること
  - `XDG_CONFIG_HOME/glab-cli` を利用すること
  - フォールバック時に `~/.config/glab-cli` または `XDG_CONFIG_HOME/glab-cli` を使うこと
  - `env.sh` に `GLAB_CONFIG_DIR` が出力されること

## 影響範囲
- `runtime.prepare` を利用する実行環境の環境変数解決
- セルフホスト GitLab と `glab` CLI を併用するワークツリー実行フロー

## リスク・懸念点
- macOS では既存ディレクトリの有無で解決先が変わるため、ローカル環境差によるパス差分が発生する可能性があります
- `glab` の設定保存先が標準外に変更されている環境では、`GLAB_CONFIG_DIR` を明示指定していることが前提です

## 補足
- 既存の `GH_CONFIG_DIR` と同様に、CLI ごとの設定ディレクトリを runtime 環境へ引き継ぐ方針に合わせた修正です

Closes. https://github.com/nrslib/takt/issues/559