### PR TITLE
feat: スラッシュコマンドの補完メニューを実装

### DIFF
--- a/src/__tests__/completionMenu.test.ts
+++ b/src/__tests__/completionMenu.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for slash command completion: registry filtering and menu rendering
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { filterSlashCommands, getAllSlashCommands } from '../features/interactive/slashCommandRegistry.js';
+import { renderCompletionMenu, writeCompletionMenu, clearCompletionMenu } from '../features/interactive/completionMenu.js';
+import { stripAnsi } from '../shared/utils/text.js';
+import { parseInputData, type InputCallbacks } from '../features/interactive/lineEditor.js';
+
+// --- slashCommandRegistry tests ---
+
+describe('filterSlashCommands', () => {
+  it('should return all commands when prefix is "/"', () => {
+    const result = filterSlashCommands('/');
+    expect(result.length).toBe(6);
+  });
+
+  it('should filter by prefix "/p"', () => {
+    const result = filterSlashCommands('/p');
+    const commands = result.map((e) => e.command);
+    expect(commands).toContain('/play');
+    expect(commands).not.toContain('/go');
+    expect(commands).not.toContain('/cancel');
+  });
+
+  it('should filter by prefix "/ca"', () => {
+    const result = filterSlashCommands('/ca');
+    expect(result.length).toBe(1);
+    expect(result[0]!.command).toBe('/cancel');
+  });
+
+  it('should return empty array for non-matching prefix', () => {
+    const result = filterSlashCommands('/xyz');
+    expect(result.length).toBe(0);
+  });
+
+  it('should return all commands for empty string prefix', () => {
+    const result = filterSlashCommands('');
+    expect(result.length).toBe(6);
+  });
+
+  it('should not match prefix without leading slash', () => {
+    const result = filterSlashCommands('go');
+    expect(result.length).toBe(0);
+  });
+
+  it('should be case-insensitive', () => {
+    const result = filterSlashCommands('/P');
+    const commands = result.map((e) => e.command);
+    expect(commands).toContain('/play');
+  });
+
+  it('should return "/re" prefix matches (retry, replay, resume)', () => {
+    const result = filterSlashCommands('/re');
+    const commands = result.map((e) => e.command);
+    expect(commands).toContain('/retry');
+    expect(commands).toContain('/replay');
+    expect(commands).toContain('/resume');
+    expect(commands.length).toBe(3);
+  });
+
+  it('should return descriptions in the specified language', () => {
+    const resultEn = filterSlashCommands('/play');
+    expect(resultEn[0]!.description.en).toBe('Run a task immediately');
+
+    const resultJa = filterSlashCommands('/play');
+    expect(resultJa[0]!.description.ja).toBe('タスクを即実行する');
+  });
+});
+
+describe('getAllSlashCommands', () => {
+  it('should return all 6 commands', () => {
+    const all = getAllSlashCommands();
+    expect(all.length).toBe(6);
+  });
+
+  it('should contain all expected commands', () => {
+    const all = getAllSlashCommands();
+    const commands = all.map((e) => e.command);
+    expect(commands).toContain('/play');
+    expect(commands).toContain('/go');
+    expect(commands).toContain('/retry');
+    expect(commands).toContain('/replay');
+    expect(commands).toContain('/cancel');
+    expect(commands).toContain('/resume');
+  });
+});
+
+// --- completionMenu rendering tests ---
+
+describe('renderCompletionMenu', () => {
+  it('should return separator + one line per candidate', () => {
+    const candidates = filterSlashCommands('/');
+    const lines = renderCompletionMenu(candidates, 0, 80, 'en');
+    expect(lines.length).toBe(candidates.length + 1);
+  });
+
+  it('should include command name in each line', () => {
+    const candidates = filterSlashCommands('/');
+    const lines = renderCompletionMenu(candidates, 0, 80, 'en');
+    const stripped = lines.map(stripAnsi);
+    expect(stripped[1]).toContain('/play');
+    expect(stripped[2]).toContain('/go');
+  });
+
+  it('should include description in each line', () => {
+    const candidates = filterSlashCommands('/play');
+    const lines = renderCompletionMenu(candidates, 0, 80, 'en');
+    const stripped = lines.map(stripAnsi);
+    expect(stripped[1]).toContain('Run a task immediately');
+  });
+
+  it('should include Japanese description when lang is ja', () => {
+    const candidates = filterSlashCommands('/play');
+    const lines = renderCompletionMenu(candidates, 0, 80, 'ja');
+    const stripped = lines.map(stripAnsi);
+    expect(stripped[1]).toContain('タスクを即実行する');
+  });
+
+  it('should render separator as first line', () => {
+    const candidates = filterSlashCommands('/');
+    const lines = renderCompletionMenu(candidates, 0, 80, 'en');
+    const stripped = stripAnsi(lines[0]!);
+    expect(stripped).toMatch(/^─+$/);
+    expect(stripped.length).toBe(80);
+  });
+
+  it('should handle empty candidates', () => {
+    const lines = renderCompletionMenu([], 0, 80, 'en');
+    expect(lines.length).toBe(1);
+  });
+
+  it('should handle narrow terminal width', () => {
+    const candidates = filterSlashCommands('/play');
+    const lines = renderCompletionMenu(candidates, 0, 30, 'en');
+    expect(lines.length).toBe(2);
+  });
+
+  it('should always include all candidate commands regardless of selectedIndex', () => {
+    const candidates = filterSlashCommands('/');
+    const lines0 = renderCompletionMenu(candidates, 0, 80, 'en').map(stripAnsi);
+    const lines2 = renderCompletionMenu(candidates, 2, 80, 'en').map(stripAnsi);
+    expect(lines0[1]).toContain('/play');
+    expect(lines2[1]).toContain('/play');
+    expect(lines0[3]).toContain('/retry');
+    expect(lines2[3]).toContain('/retry');
+  });
+
+  it('should omit description when terminal width is very narrow', () => {
+    const candidates = filterSlashCommands('/play');
+    const lines = renderCompletionMenu(candidates, 0, 26, 'en');
+    const stripped = stripAnsi(lines[1]!);
+    expect(stripped).toContain('/play');
+    expect(stripped).not.toContain('Run a task');
+  });
+});
+
+// --- writeCompletionMenu / clearCompletionMenu terminal output tests ---
+
+describe('writeCompletionMenu', () => {
+  let savedWrite: typeof process.stdout.write;
+  let writtenData: string[];
+
+  beforeEach(() => {
+    savedWrite = process.stdout.write;
+    writtenData = [];
+    process.stdout.write = vi.fn((data: string | Uint8Array) => {
+      writtenData.push(typeof data === 'string' ? data : data.toString());
+      return true;
+    }) as unknown as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = savedWrite;
+  });
+
+  it('should write menu lines to stdout', () => {
+    const lines = ['separator', 'item1', 'item2'];
+    writeCompletionMenu(lines, 0);
+    const output = writtenData.join('');
+    expect(output).toContain('separator\nitem1\nitem2');
+  });
+
+  it('should move cursor down when rowsBelowCursor > 0', () => {
+    writeCompletionMenu(['line'], 3);
+    expect(writtenData[0]).toBe('\x1B[3B');
+  });
+
+  it('should erase below and restore cursor position', () => {
+    writeCompletionMenu(['line'], 0);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[J');
+    expect(output).toContain('\x1B[1A');
+  });
+
+  it('should restore cursor by total lines when multiple lines written', () => {
+    writeCompletionMenu(['sep', 'item1', 'item2', 'item3'], 0);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[4A');
+  });
+
+  it('should restore cursor by lines + rowsBelowCursor combined', () => {
+    writeCompletionMenu(['sep', 'item1', 'item2'], 2);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[2B');
+    expect(output).toContain('\x1B[5A');
+  });
+});
+
+describe('clearCompletionMenu', () => {
+  let savedWrite: typeof process.stdout.write;
+  let writtenData: string[];
+
+  beforeEach(() => {
+    savedWrite = process.stdout.write;
+    writtenData = [];
+    process.stdout.write = vi.fn((data: string | Uint8Array) => {
+      writtenData.push(typeof data === 'string' ? data : data.toString());
+      return true;
+    }) as unknown as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = savedWrite;
+  });
+
+  it('should erase below cursor', () => {
+    clearCompletionMenu(0);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[J');
+  });
+
+  it('should move cursor down when rowsBelowCursor > 0', () => {
+    clearCompletionMenu(2);
+    expect(writtenData[0]).toBe('\x1B[2B');
+  });
+
+  it('should restore cursor after clearing', () => {
+    clearCompletionMenu(0);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[1A');
+  });
+
+  it('should move up by rowsBelowCursor + 1 when clearing', () => {
+    clearCompletionMenu(2);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[3A');
+  });
+});
+
+// --- parseInputData onEsc callback tests ---
+
+describe('parseInputData onEsc', () => {
+  /**
+   * Create callbacks with onEsc tracking.
+   */
+  const createCallbacksWithEsc = (): InputCallbacks & { calls: string[] } => {
+    const calls: string[] = [];
+    return {
+      calls,
+      onPasteStart() { calls.push('pasteStart'); },
+      onPasteEnd() { calls.push('pasteEnd'); },
+      onShiftEnter() { calls.push('shiftEnter'); },
+      onArrowLeft() { calls.push('left'); },
+      onArrowRight() { calls.push('right'); },
+      onArrowUp() { calls.push('up'); },
+      onArrowDown() { calls.push('down'); },
+      onWordLeft() { calls.push('wordLeft'); },
+      onWordRight() { calls.push('wordRight'); },
+      onHome() { calls.push('home'); },
+      onEnd() { calls.push('end'); },
+      onEsc() { calls.push('esc'); },
+      onChar(ch: string) { calls.push(`char:${ch}`); },
+    };
+  };
+
+  it('should emit onEsc for bare escape key', () => {
+    const cb = createCallbacksWithEsc();
+    parseInputData('\x1B', cb);
+    expect(cb.calls).toEqual(['esc']);
+  });
+
+  it('should not emit onEsc for recognized escape sequences', () => {
+    const cb = createCallbacksWithEsc();
+    parseInputData('\x1B[A', cb);
+    expect(cb.calls).toEqual(['up']);
+    expect(cb.calls).not.toContain('esc');
+  });
+
+  it('should emit onEsc followed by char for escape then regular character', () => {
+    const cb = createCallbacksWithEsc();
+    parseInputData('\x1Ba\x1B[A', cb);
+    expect(cb.calls).toContain('esc');
+    expect(cb.calls).toContain('char:a');
+    expect(cb.calls).toContain('up');
+  });
+});

--- a/src/__tests__/lineEditor.test.ts
+++ b/src/__tests__/lineEditor.test.ts
@@ -20,6 +20,7 @@ function createCallbacks(): InputCallbacks & { calls: string[] } {
     onWordRight() { calls.push('wordRight'); },
     onHome() { calls.push('home'); },
     onEnd() { calls.push('end'); },
+    onEsc() { calls.push('esc'); },
     onChar(ch: string) { calls.push(`char:${ch}`); },
   };
 }
@@ -118,6 +119,26 @@ describe('parseInputData', () => {
       expect(cb.calls).toEqual(['wordLeft', 'wordRight']);
       expect(cb.calls).not.toContain('char:b');
       expect(cb.calls).not.toContain('char:f');
+    });
+  });
+
+  describe('bare Esc key detection', () => {
+    it('should fire onEsc for bare Esc', () => {
+      // Given
+      const cb = createCallbacks();
+      // When
+      parseInputData('\x1B', cb);
+      // Then
+      expect(cb.calls).toEqual(['esc']);
+    });
+
+    it('should fire onEsc then onChar for Esc followed by non-sequence char', () => {
+      // Given
+      const cb = createCallbacks();
+      // When
+      parseInputData('\x1Bx', cb);
+      // Then
+      expect(cb.calls).toEqual(['esc', 'char:x']);
     });
   });
 
@@ -241,9 +262,9 @@ describe('readMultilineInput cursor navigation', () => {
   });
 
   // We need to dynamically import after mocking stdin
-  async function callReadMultilineInput(prompt: string): Promise<string | null> {
+  async function callReadMultilineInput(prompt: string, options?: { lang?: 'en' | 'ja' }): Promise<string | null> {
     const { readMultilineInput } = await import('../features/interactive/lineEditor.js');
-    return readMultilineInput(prompt);
+    return readMultilineInput(prompt, options);
   }
 
   describe('left arrow line wrap', () => {
@@ -1057,6 +1078,120 @@ describe('readMultilineInput cursor navigation', () => {
 
       // Then
       expect(result).toBe('abc\ndef');
+    });
+  });
+
+  describe('completion menu integration', () => {
+    it('should submit selected command on Enter when menu is visible', async () => {
+      // Given: type "/" then Enter → default selectedIndex=0 is /play
+      setupRawStdin(['/\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('/play');
+    });
+
+    it('should submit command selected by arrow down on Enter', async () => {
+      // Given: "/" → ArrowDown (select /go, index=1) → Enter
+      setupRawStdin(['/\x1B[B\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('/go');
+    });
+
+    it('should apply completion on Tab and allow further editing', async () => {
+      // Given: "/g" → Tab (applies "/go ") → Enter
+      setupRawStdin(['/g\t\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('/go ');
+    });
+
+    it('should dismiss completion on Esc and keep buffer unchanged', async () => {
+      // Given: "/ca" → Esc (dismiss menu) → Enter
+      setupRawStdin(['/ca\x1B\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('/ca');
+    });
+
+    it('should not trigger completion for regular text', async () => {
+      // Given: "hello" → Enter (no "/" prefix, no completion)
+      setupRawStdin(['hello\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('hello');
+    });
+
+    it('should wrap selection on ArrowUp from first item', async () => {
+      // Given: "/" → ArrowUp (wrap to last item, /resume index=5) → Enter
+      setupRawStdin(['/\x1B[A\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('/resume');
+    });
+
+    it('should not show completion menu for multiline buffer starting with /', async () => {
+      // Given: "/" → Shift+Enter (newline) → "test" → Enter
+      // shouldShowCompletion() returns false when buffer includes \n
+      setupRawStdin(['/\x1B[13;2utest\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('/\ntest');
+    });
+
+    it('should apply Tab completion then allow backspace to delete', async () => {
+      // Given: "/g" → Tab (applies "/go ") → Backspace (delete space) → Enter
+      setupRawStdin(['/g\t\x7F\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('/go');
+    });
+
+    it('should wrap selection on ArrowDown from last item', async () => {
+      // Given: "/" → ArrowDown x6 (6 commands, wraps back to /play index=0) → Enter
+      setupRawStdin(['/\x1B[B\x1B[B\x1B[B\x1B[B\x1B[B\x1B[B\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('/play');
+    });
+
+    it('should clamp selectedIndex when candidates shrink', async () => {
+      // Given: "/re" → ArrowDown x2 (select /resume, index=2) → type "s" ("/res" → 1 candidate) → Enter
+      // selectedIndex is clamped to 0
+      setupRawStdin(['/re\x1B[B\x1B[Bs\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { lang: 'en' });
+
+      // Then
+      expect(result).toBe('/resume');
     });
   });
 });

--- a/src/features/interactive/completionMenu.ts
+++ b/src/features/interactive/completionMenu.ts
@@ -1,0 +1,93 @@
+/**
+ * Inline completion menu renderer for slash commands.
+ *
+ * Provides pure rendering functions and terminal drawing helpers
+ * for the slash command autocomplete menu displayed below the input line.
+ */
+
+import chalk from 'chalk';
+import { truncateText } from '../../shared/utils/text.js';
+import type { SlashCommandEntry } from './slashCommandRegistry.js';
+
+/** State of the visible completion menu */
+export interface CompletionState {
+  readonly candidates: readonly SlashCommandEntry[];
+  selectedIndex: number;
+}
+
+const SEPARATOR_CHAR = '─';
+const COMMAND_COLUMN_WIDTH = 24;
+const LEFT_PADDING = 2;
+
+/**
+ * Render completion menu lines (pure function).
+ *
+ * Returns an array of styled strings: separator line + one line per candidate.
+ */
+export const renderCompletionMenu = (
+  candidates: readonly SlashCommandEntry[],
+  selectedIndex: number,
+  termWidth: number,
+  lang: 'en' | 'ja',
+): readonly string[] => {
+  const separator = chalk.dim(SEPARATOR_CHAR.repeat(termWidth));
+  const descMaxWidth = termWidth - LEFT_PADDING - COMMAND_COLUMN_WIDTH - 2;
+
+  const lines = candidates.map((entry, i) => {
+    const isSelected = i === selectedIndex;
+    const command = entry.command.padEnd(COMMAND_COLUMN_WIDTH);
+    const desc = descMaxWidth > 0
+      ? truncateText(entry.description[lang], descMaxWidth)
+      : '';
+
+    if (isSelected) {
+      return `${' '.repeat(LEFT_PADDING)}${chalk.cyan.bold(command)}${chalk.gray(desc)}`;
+    }
+    return `${' '.repeat(LEFT_PADDING)}${chalk.gray(command)}${chalk.dim(desc)}`;
+  });
+
+  return [separator, ...lines];
+};
+
+/**
+ * Write the completion menu below the current cursor position.
+ *
+ * Moves cursor down to below the input, draws the menu,
+ * then restores cursor to original position.
+ */
+export const writeCompletionMenu = (
+  lines: readonly string[],
+  rowsBelowCursor: number,
+): void => {
+  if (rowsBelowCursor > 0) {
+    process.stdout.write(`\x1B[${rowsBelowCursor}B`);
+  }
+  process.stdout.write('\r\n');
+  process.stdout.write('\x1B[J');
+  process.stdout.write(lines.join('\n'));
+
+  const moveUp = lines.length + rowsBelowCursor;
+  if (moveUp > 0) {
+    process.stdout.write(`\x1B[${moveUp}A`);
+  }
+};
+
+/**
+ * Clear the completion menu from the terminal.
+ *
+ * Moves cursor below input, erases everything, then restores position.
+ */
+export const clearCompletionMenu = (
+  rowsBelowCursor: number,
+): void => {
+  if (rowsBelowCursor > 0) {
+    process.stdout.write(`\x1B[${rowsBelowCursor}B`);
+  }
+  process.stdout.write('\r\n');
+  process.stdout.write('\x1B[J');
+
+  const moveUp = 1 + rowsBelowCursor;
+  if (moveUp > 0) {
+    process.stdout.write(`\x1B[${moveUp}A`);
+  }
+};

--- a/src/features/interactive/conversationLoop.ts
+++ b/src/features/interactive/conversationLoop.ts
@@ -127,7 +127,7 @@ export async function runConversationLoop(
   }
 
   while (true) {
-    const input = await readMultilineInput(chalk.green('> '));
+    const input = await readMultilineInput(chalk.green('> '), { lang: ctx.lang });
 
     if (input === null) {
       blankLine();

--- a/src/features/interactive/lineEditor.ts
+++ b/src/features/interactive/lineEditor.ts
@@ -10,6 +10,13 @@
 import * as readline from 'node:readline';
 import { StringDecoder } from 'node:string_decoder';
 import { stripAnsi, getDisplayWidth } from '../../shared/utils/text.js';
+import { filterSlashCommands } from './slashCommandRegistry.js';
+import {
+  type CompletionState,
+  renderCompletionMenu,
+  writeCompletionMenu,
+  clearCompletionMenu,
+} from './completionMenu.js';
 
 /** Escape sequences for terminal protocol control */
 const PASTE_BRACKET_ENABLE = '\x1B[?2004h';
@@ -78,7 +85,13 @@ export interface InputCallbacks {
   onWordRight: () => void;
   onHome: () => void;
   onEnd: () => void;
+  onEsc: () => void;
   onChar: (ch: string) => void;
+}
+
+/** Options for readMultilineInput */
+export interface ReadMultilineInputOptions {
+  readonly lang?: 'en' | 'ja';
 }
 
 /**
@@ -185,7 +198,8 @@ export function parseInputData(data: string, callbacks: InputCallbacks): void {
           continue;
         }
       }
-      // Unrecognized escape: skip the \x1B
+      // Bare Esc (not part of a recognized sequence)
+      callbacks.onEsc();
       i++;
       continue;
     }
@@ -207,7 +221,7 @@ export function parseInputData(data: string, callbacks: InputCallbacks): void {
  *
  * Falls back to readline.question() in non-TTY environments.
  */
-export function readMultilineInput(prompt: string): Promise<string | null> {
+export function readMultilineInput(prompt: string, options?: ReadMultilineInputOptions): Promise<string | null> {
   if (!process.stdin.isTTY) {
     return new Promise((resolve) => {
       if (process.stdin.readable && !process.stdin.destroyed) {
@@ -239,6 +253,8 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
     let buffer = '';
     let cursorPos = 0;
     let state: InputState = 'normal';
+    let completionState: CompletionState | null = null;
+    const completionLang = options?.lang ?? 'en';
 
     const wasRaw = process.stdin.isRaw;
     process.stdin.setRawMode(true);
@@ -296,6 +312,139 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
 
     function getTermWidth(): number {
       return process.stdout.columns || 80;
+    }
+
+    // --- Completion menu helpers ---
+
+    /**
+     * Count total display rows from buffer start to end (for cursor math).
+     */
+    function countTotalDisplayRows(): number {
+      return countDisplayRowsBetweenPositions(0, buffer.length);
+    }
+
+    /**
+     * Count display rows from cursor position to end of buffer.
+     */
+    function countRowsBelowCursor(): number {
+      const cursorRow = countDisplayRowsBetweenPositions(0, cursorPos);
+      const totalRows = countTotalDisplayRows();
+      return totalRows - cursorRow;
+    }
+
+    /**
+     * Count display rows between two arbitrary buffer positions.
+     */
+    function countDisplayRowsBetweenPositions(from: number, to: number): number {
+      if (from >= to) return 0;
+      let rows = 0;
+      let pos = from;
+      while (pos < to) {
+        const rowEnd = getDisplayRowEnd(pos);
+        if (rowEnd >= to) break;
+        const nextChar = buffer[rowEnd];
+        if (nextChar === '\n') {
+          rows++;
+          pos = rowEnd + 1;
+        } else {
+          rows++;
+          pos = rowEnd;
+        }
+      }
+      return rows;
+    }
+
+    /**
+     * Check if the buffer starts with '/' (completion trigger).
+     */
+    function shouldShowCompletion(): boolean {
+      return buffer.startsWith('/') && !buffer.includes('\n');
+    }
+
+    /**
+     * Update completion menu state based on current buffer.
+     */
+    function updateCompletionMenu(): void {
+      if (!shouldShowCompletion()) {
+        hideCompletionMenu();
+        return;
+      }
+
+      const prefix = buffer;
+      const candidates = filterSlashCommands(prefix);
+
+      if (candidates.length === 0) {
+        hideCompletionMenu();
+        return;
+      }
+
+      if (completionState) {
+        const clampedIndex = Math.min(completionState.selectedIndex, candidates.length - 1);
+        completionState = { candidates, selectedIndex: clampedIndex };
+      } else {
+        completionState = { candidates, selectedIndex: 0 };
+      }
+
+      redrawCompletionMenu();
+    }
+
+    /**
+     * Render current completionState to the terminal and restore cursor column.
+     */
+    function redrawCompletionMenu(): void {
+      if (!completionState) return;
+      const termWidth = getTermWidth();
+      const rowsBelow = countRowsBelowCursor();
+      const lines = renderCompletionMenu(completionState.candidates, completionState.selectedIndex, termWidth, completionLang);
+      const termCol = getTerminalColumn(cursorPos);
+      writeCompletionMenu(lines, rowsBelow);
+      process.stdout.write(`\x1B[${termCol}G`);
+    }
+
+    /**
+     * Hide the completion menu if visible.
+     */
+    function hideCompletionMenu(): void {
+      if (!completionState) return;
+      const rowsBelow = countRowsBelowCursor();
+      const termCol = getTerminalColumn(cursorPos);
+      clearCompletionMenu(rowsBelow);
+      process.stdout.write(`\x1B[${termCol}G`);
+      completionState = null;
+    }
+
+    /**
+     * Move completion selection by delta (+1 = down, -1 = up) with wrap-around.
+     */
+    function moveCompletionSelection(delta: number): void {
+      if (!completionState || completionState.candidates.length === 0) return;
+      const len = completionState.candidates.length;
+      completionState.selectedIndex = ((completionState.selectedIndex + delta) % len + len) % len;
+      redrawCompletionMenu();
+    }
+
+    /**
+     * Apply the selected completion: replace buffer with the command + space.
+     */
+    function applyCompletion(): void {
+      if (!completionState) return;
+      const selected = completionState.candidates[completionState.selectedIndex];
+      if (!selected) return;
+
+      const newBuffer = `${selected.command} `;
+      const rowsBelow = countRowsBelowCursor();
+
+      clearCompletionMenu(rowsBelow);
+
+      // Use absolute positioning (clearCompletionMenu resets column to 1 via \n)
+      process.stdout.write(`\x1B[${promptWidth + 1}G`);
+
+      buffer = newBuffer;
+      cursorPos = newBuffer.length;
+      process.stdout.write(newBuffer);
+      process.stdout.write('\x1B[K');
+
+      completionState = null;
     }
 
     /** Buffer position of the display row start that contains `pos` */
@@ -392,6 +541,7 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
     }
 
     function cleanup(): void {
+      hideCompletionMenu();
       process.stdin.removeListener('data', onData);
       process.stdout.write(PASTE_BRACKET_DISABLE);
       process.stdout.write(KITTY_KB_DISABLE);
@@ -597,6 +747,10 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
           },
           onArrowUp() {
             if (state !== 'normal') return;
+            if (completionState && completionState.candidates.length > 0) {
+              moveCompletionSelection(-1);
+              return;
+            }
             const logicalLineStart = getLineStart();
             const displayRowStart = getDisplayRowStart(cursorPos);
             const displayCol = getDisplayRowColumn(cursorPos);
@@ -616,6 +770,10 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
           },
           onArrowDown() {
             if (state !== 'normal') return;
+            if (completionState && completionState.candidates.length > 0) {
+              moveCompletionSelection(1);
+              return;
+            }
             const logicalLineEnd = getLineEnd();
             const displayRowEnd = getDisplayRowEnd(cursorPos);
             const displayCol = getDisplayRowColumn(cursorPos);
@@ -662,6 +820,9 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
             if (state !== 'normal') return;
             moveCursorToLogicalLineEnd();
           },
+          onEsc() {
+            hideCompletionMenu();
+          },
           onChar(ch: string) {
             if (state === 'paste') {
               if (ch === '\r' || ch === '\n') {
@@ -676,8 +837,23 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
               return;
             }
 
+            // Tab: apply completion
+            if (ch === '\t') {
+              if (completionState && completionState.candidates.length > 0) {
+                applyCompletion();
+              }
+              return;
+            }
             // Submit
             if (ch === '\r') {
+              if (completionState && completionState.candidates.length > 0) {
+                const selected = completionState.candidates[completionState.selectedIndex];
+                if (selected) {
+                  buffer = selected.command;
+                  cursorPos = buffer.length;
+                }
+              }
+              hideCompletionMenu();
               process.stdout.write('\n');
               cleanup();
               resolve(buffer);
@@ -691,17 +867,18 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
               return;
             }
             // Editing
-            if (ch === '\x7F' || ch === '\x08') { deleteCharBefore(); return; }
+            if (ch === '\x7F' || ch === '\x08') { deleteCharBefore(); updateCompletionMenu(); return; }
             if (ch === '\x01') { moveCursorToDisplayRowStart(); return; }
             if (ch === '\x05') { moveCursorToDisplayRowEnd(); return; }
-            if (ch === '\x0B') { deleteToLineEnd(); return; }
-            if (ch === '\x15') { deleteToLineStart(); return; }
-            if (ch === '\x17') { deleteWord(); return; }
-            if (ch === '\x0A') { insertNewline(); return; }
+            if (ch === '\x0B') { deleteToLineEnd(); updateCompletionMenu(); return; }
+            if (ch === '\x15') { deleteToLineStart(); updateCompletionMenu(); return; }
+            if (ch === '\x17') { deleteWord(); updateCompletionMenu(); return; }
+            if (ch === '\x0A') { hideCompletionMenu(); insertNewline(); return; }
             // Ignore unknown control characters
             if (ch.charCodeAt(0) < 0x20) return;
             // Regular character
             insertChar(ch);
+            updateCompletionMenu();
           },
         });
       } catch {

--- a/src/features/interactive/passthroughMode.ts
+++ b/src/features/interactive/passthroughMode.ts
@@ -32,7 +32,7 @@ export async function passthroughMode(
   info(getLabel('interactive.ui.intro', lang));
   blankLine();
 
-  const input = await readMultilineInput(chalk.green('> '));
+  const input = await readMultilineInput(chalk.green('> '), { lang });
 
   if (input === null) {
     blankLine();

--- a/src/features/interactive/quietMode.ts
+++ b/src/features/interactive/quietMode.ts
@@ -54,7 +54,7 @@ export async function quietMode(
     info(getLabel('interactive.ui.intro', ctx.lang));
     blankLine();
 
-    const input = await readMultilineInput(chalk.green('> '));
+    const input = await readMultilineInput(chalk.green('> '), { lang: ctx.lang });
     if (input === null) {
       blankLine();
       info(getLabel('interactive.ui.cancelled', ctx.lang));

--- a/src/features/interactive/slashCommandRegistry.ts
+++ b/src/features/interactive/slashCommandRegistry.ts
@@ -1,0 +1,41 @@
+/**
+ * Slash command registry with metadata for inline completion.
+ *
+ * Defines all slash commands recognized in interactive mode,
+ * along with localized descriptions for the completion menu.
+ */
+
+import { SlashCommand } from '../../shared/constants.js';
+
+/** Slash command entry with localized description */
+export interface SlashCommandEntry {
+  readonly command: SlashCommand;
+  readonly description: Readonly<Record<'en' | 'ja', string>>;
+}
+
+/**
+ * Registry of all slash commands with their descriptions.
+ */
+const SLASH_COMMAND_REGISTRY: readonly SlashCommandEntry[] = [
+  { command: SlashCommand.Play, description: { en: 'Run a task immediately', ja: 'タスクを即実行する' } },
+  { command: SlashCommand.Go, description: { en: 'Create instruction & run', ja: '指示書を作成して実行' } },
+  { command: SlashCommand.Retry, description: { en: 'Rerun with previous order', ja: '前回の指示書を確認して再実行' } },
+  { command: SlashCommand.Replay, description: { en: 'Resubmit previous order', ja: '前回の指示書で即再実行' } },
+  { command: SlashCommand.Cancel, description: { en: 'Exit interactive mode', ja: '対話モードを終了' } },
+  { command: SlashCommand.Resume, description: { en: 'Load a previous session', ja: 'セッションを読み込む' } },
+] as const;
+
+/**
+ * Filter slash commands by prefix match.
+ */
+export const filterSlashCommands = (
+  prefix: string,
+): readonly SlashCommandEntry[] => {
+  const lower = prefix.toLowerCase();
+  return SLASH_COMMAND_REGISTRY.filter((entry) => entry.command.startsWith(lower));
+};
+
+/**
+ * Get all registered slash commands.
+ */
+export const getAllSlashCommands = (): readonly SlashCommandEntry[] => SLASH_COMMAND_REGISTRY;


### PR DESCRIPTION
## 概要

対話モードで `/` を入力するとスラッシュコマンドの候補が表示される補完メニューを実装する。

## 変更内容

- `/` 入力時に候補一覧をインライン表示
- 上下矢印キーで候補を選択（ハイライト表示）
- Tab で選択中のコマンドを補完（コマンド + スペース）
- Enter で選択中のコマンドを即実行
- Esc でメニューを閉じる（バッファは維持）
- 入力に応じて候補をリアルタイムフィルタリング
- `lang` オプションにより説明文を日英切り替え可能

## 追加ファイル

- `src/features/interactive/slashCommandRegistry.ts` — コマンドメタデータ（名前・説明）の定義とフィルタリング
- `src/features/interactive/completionMenu.ts` — メニューの描画・表示・クリア処理（純粋関数）

## 変更ファイル

- `src/features/interactive/lineEditor.ts` — 補完ステート管理、キーハンドラ拡張（Tab/Enter/Esc/矢印）
- `src/features/interactive/conversationLoop.ts`, `passthroughMode.ts`, `quietMode.ts` — `readMultilineInput` に `lang` オプションを渡すよう変更

## テスト

- `src/__tests__/completionMenu.test.ts` — registry・描画・端末出力・Escキーパースのテスト（32件）
- `src/__tests__/lineEditor.test.ts` — 補完メニューの統合テストを追加（+10件）