### PR TITLE
feat: Parallel Movementにconcurrency制御を追加

### DIFF
--- a/src/__tests__/engine-parallel.test.ts
+++ b/src/__tests__/engine-parallel.test.ts
@@ -272,4 +272,93 @@ describe('PieceEngine Integration: Parallel Movement Aggregation', () => {
       () => new PieceEngine(config, tmpDir, 'test task', { projectCwd: tmpDir, taskPrefix: 'override-persona-provider' })
     ).toThrow('taskPrefix and taskColorIndex must be provided together');
   });
+
+  it('should respect concurrency limit on parallel sub-movements', async () => {
+    // Track concurrent execution count
+    let currentConcurrency = 0;
+    let maxObservedConcurrency = 0;
+
+    const config = buildDefaultPieceConfig();
+    // Set concurrency to 1 on the reviewers movement
+    const reviewersMovement = config.movements.find(m => m.name === 'reviewers')!;
+    reviewersMovement.concurrency = 1;
+
+    const engine = new PieceEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+
+    vi.mocked(runAgent).mockImplementation(async (persona, task, options) => {
+      // Track concurrency for parallel sub-movements only
+      const isSubMovement = persona === '../personas/arch-review.md' || persona === '../personas/security-review.md';
+      if (isSubMovement) {
+        currentConcurrency++;
+        maxObservedConcurrency = Math.max(maxObservedConcurrency, currentConcurrency);
+        // Small delay to make concurrency observable
+        await new Promise(resolve => setTimeout(resolve, 10));
+        currentConcurrency--;
+      }
+
+      options.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({ persona: persona ?? 'unknown', content: `${persona} done` });
+    });
+
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' },  // plan
+      { index: 0, method: 'phase1_tag' },  // implement
+      { index: 0, method: 'phase1_tag' },  // ai_review
+      { index: 0, method: 'phase1_tag' },  // arch-review
+      { index: 0, method: 'phase1_tag' },  // security-review
+      { index: 0, method: 'aggregate' },   // reviewers
+      { index: 0, method: 'phase1_tag' },  // supervise
+    ]);
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+    // With concurrency=1, max observed should be 1
+    expect(maxObservedConcurrency).toBe(1);
+  });
+
+  it('should run all sub-movements simultaneously when concurrency is not set', async () => {
+    let currentConcurrency = 0;
+    let maxObservedConcurrency = 0;
+
+    const config = buildDefaultPieceConfig();
+    // No concurrency set — default behavior (all simultaneous)
+
+    const engine = new PieceEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+
+    vi.mocked(runAgent).mockImplementation(async (persona, task, options) => {
+      const isSubMovement = persona === '../personas/arch-review.md' || persona === '../personas/security-review.md';
+      if (isSubMovement) {
+        currentConcurrency++;
+        maxObservedConcurrency = Math.max(maxObservedConcurrency, currentConcurrency);
+        await new Promise(resolve => setTimeout(resolve, 10));
+        currentConcurrency--;
+      }
+
+      options.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({ persona: persona ?? 'unknown', content: `${persona} done` });
+    });
+
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'aggregate' },
+      { index: 0, method: 'phase1_tag' },
+    ]);
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+    // Without concurrency limit, both should run simultaneously
+    expect(maxObservedConcurrency).toBe(2);
+  });
 });

--- a/src/core/models/piece-types.ts
+++ b/src/core/models/piece-types.ts
@@ -164,6 +164,8 @@ export interface PieceMovement {
   passPreviousResponse: boolean;
   /** Sub-movements to execute in parallel. When set, this movement runs all sub-movements concurrently. */
   parallel?: PieceMovement[];
+  /** Maximum number of parallel sub-movements to execute concurrently. When omitted, all run simultaneously. */
+  concurrency?: number;
   /** Arpeggio configuration for data-driven batch processing. When set, this movement reads from a data source, expands templates, and calls LLM per batch. */
   arpeggio?: ArpeggioMovementConfig;
   /** Team leader configuration for dynamic part decomposition + parallel execution */

--- a/src/core/models/schemas.ts
+++ b/src/core/models/schemas.ts
@@ -363,6 +363,8 @@ export const PieceMovementRawSchema = z.object({
   pass_previous_response: z.boolean().optional().default(true),
   /** Sub-movements to execute in parallel */
   parallel: z.array(ParallelSubMovementRawSchema).optional(),
+  /** Maximum number of parallel sub-movements to execute concurrently (default: unlimited) */
+  concurrency: z.number().int().min(1).optional(),
   /** Arpeggio configuration for data-driven batch processing */
   arpeggio: ArpeggioConfigRawSchema.optional(),
   /** Team leader configuration for dynamic part decomposition */

--- a/src/core/piece/engine/ParallelRunner.ts
+++ b/src/core/piece/engine/ParallelRunner.ts
@@ -25,6 +25,37 @@ import type { ParallelLoggerOptions } from './parallel-logger.js';
 
 const log = createLogger('parallel-runner');
 
+/**
+ * Simple semaphore for controlling concurrency.
+ * Limits the number of concurrent async operations.
+ * Same implementation as ArpeggioRunner's Semaphore.
+ */
+class Semaphore {
+  private running = 0;
+  private readonly waiting: Array<() => void> = [];
+
+  constructor(private readonly maxConcurrency: number) {}
+
+  async acquire(): Promise<void> {
+    if (this.running < this.maxConcurrency) {
+      this.running++;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.waiting.push(resolve);
+    });
+  }
+
+  release(): void {
+    if (this.waiting.length > 0) {
+      const next = this.waiting.shift()!;
+      next();
+    } else {
+      this.running--;
+    }
+  }
+}
+
 export interface ParallelRunnerDeps {
   readonly optionsBuilder: OptionsBuilder;
   readonly movementExecutor: MovementExecutor;
@@ -107,9 +138,22 @@ export class ParallelRunner {
       callAiJudge: this.deps.callAiJudge,
     };
 
+    // Create semaphore for concurrency control (if configured)
+    const semaphore = step.concurrency != null
+      ? new Semaphore(step.concurrency)
+      : undefined;
+    if (semaphore) {
+      log.debug('Concurrency limit enabled', { movement: step.name, concurrency: step.concurrency });
+    }
+
     // Run all sub-movements concurrently (failures are captured, not thrown)
+    // When semaphore is set, at most `concurrency` sub-movements execute simultaneously.
     const settled = await Promise.allSettled(
       subMovements.map(async (subMovement, index) => {
+        if (semaphore) {
+          await semaphore.acquire();
+        }
+        try {
         const subIteration = incrementMovementIteration(state, subMovement.name);
         const subInstruction = this.deps.movementExecutor.buildInstruction(subMovement, subIteration, state, task, maxMovements);
         const parentIteration = state.iteration;
@@ -181,6 +225,11 @@ export class ParallelRunner {
         this.deps.movementExecutor.emitMovementReports(subMovement);
 
         return { subMovement, response: finalResponse, instruction: subInstruction };
+        } finally {
+          if (semaphore) {
+            semaphore.release();
+          }
+        }
       }),
     );
 

--- a/src/infra/config/loaders/pieceParser.ts
+++ b/src/infra/config/loaders/pieceParser.ts
@@ -323,6 +323,9 @@ function normalizeStepFromRaw(
         pieceMcpServersPolicy,
       ),
     );
+    if (step.concurrency != null) {
+      result.concurrency = step.concurrency;
+    }
   }
 
   const arpeggioConfig = normalizeArpeggio(step.arpeggio, pieceDir);


### PR DESCRIPTION
## 概要

Parallel Movementに `concurrency` フィールドを追加し、同時に起動するCLIエージェントの数を制御できるようにしました。

## 背景・動機

従来のParallel Movementでは、定義したsub-movementの数＝同時実行数でした。たとえば5つのsub-movementを定義すると、5つのCLIエージェントが同時に起動します。

この変更により、**定義の多重度と実行の多重度を分離**できます。ワークフローとして5つのレビュー観点を定義しつつ、リソース制約に応じて同時実行を3つに絞る、といった運用が可能になります。

## 仕組み

- セマフォを使い、`await semaphore.acquire()` が `executeAgent()` の**手前**でゲートとして機能
- `concurrency: 3` の場合、最初の3つのsub-movementだけCLIエージェントが起動し、残りは起動すらされない
- 先行のsub-movementが完了して `release()` されると、待機中の次のsub-movementが初めて起動する
- `concurrency` 未指定の場合は従来どおり全sub-movementが同時起動（セマフォなし）

## 使用例

```yaml
movements:
  - name: reviewers
    parallel:
      - name: arch-review
        persona: reviewer
      - name: security-review
        persona: security-reviewer
      - name: perf-review
        persona: perf-reviewer
    concurrency: 2  # 3つ定義しているが、同時起動は最大2つ
```

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `ParallelRunner.ts` | Semaphoreクラス追加、acquire/releaseによる並行度制御 |
| `piece-types.ts` | `PieceMovement`に`concurrency`フィールド追加 |
| `schemas.ts` | Zodスキーマに`concurrency`バリデーション追加 |
| `pieceParser.ts` | YAML→内部モデル変換時の`concurrency`伝播 |
| `engine-parallel.test.ts` | concurrency制限の遵守テスト、未指定時の全同時起動テスト |

## Test plan

- [x] `concurrency: 1` で最大同時実行数が1であることを検証するテスト
- [x] `concurrency` 未指定で全sub-movementが同時起動することを検証するテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)