### PR TITLE
[#562] fix-exceeded-worktree-path

### DIFF
--- a/src/__tests__/comment-policy-regression.test.ts
+++ b/src/__tests__/comment-policy-regression.test.ts
@@ -7,6 +7,15 @@ const TEST_FILES = [
   'globalConfig.test.ts',
 ] as const;
 
+const ISSUE_562_TASK_TEST_FILES = [
+  'task-exceed-service.test.ts',
+  'worktree-exceeded-requeue.test.ts',
+] as const;
+
+const ISSUE_562_POLICY_COMMENT_SOURCES = ['../features/tasks/execute/taskExecution.ts'] as const;
+
+const gwtLineComment = /^\s*\/\/\s*(Given|When|Then)(:|\/)/;
+
 describe('test comment policy regression', () => {
   it('should not contain Given/When/Then explanation comments in config-related tests', () => {
     for (const file of TEST_FILES) {
@@ -14,6 +23,44 @@ describe('test comment policy regression', () => {
       expect(content).not.toMatch(/\bGiven:\b/);
       expect(content).not.toMatch(/\bWhen:\b/);
       expect(content).not.toMatch(/\bThen:\b/);
+    }
+  });
+
+  it('should not contain Given/When/Then line comments in Issue #562 task tests (policy-comment)', () => {
+    for (const file of ISSUE_562_TASK_TEST_FILES) {
+      const lines = readFileSync(new URL(file, import.meta.url), 'utf-8').split('\n');
+      const offenders = lines
+        .map((line, i) => (gwtLineComment.test(line) ? i + 1 : null))
+        .filter((n): n is number => n !== null);
+      expect(offenders, file).toEqual([]);
+    }
+  });
+
+  it('should not contain procedural How comments in Issue #562 task tests (policy-comment)', () => {
+    const forbidden = [
+      /must be before imports that use these modules/i,
+      /Imports \(after mocks\)/i,
+      /writeExceededRecord must come first/i,
+      /addTask then reads and appends/i,
+    ] as const;
+    for (const file of ISSUE_562_TASK_TEST_FILES) {
+      const content = readFileSync(new URL(file, import.meta.url), 'utf-8');
+      for (const pattern of forbidden) {
+        expect(content, `${file}: ${String(pattern)}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('should not contain cwd/projectCwd What-How line comments in taskExecution (policy-comment)', () => {
+    const forbidden = [
+      /\bcwd is always the project root\b/i,
+      /pass it as projectCwd/i,
+    ] as const;
+    for (const rel of ISSUE_562_POLICY_COMMENT_SOURCES) {
+      const content = readFileSync(new URL(rel, import.meta.url), 'utf-8');
+      for (const pattern of forbidden) {
+        expect(content, `${rel}: ${String(pattern)}`).not.toMatch(pattern);
+      }
     }
   });
 });

--- a/src/__tests__/task-exceed-service.test.ts
+++ b/src/__tests__/task-exceed-service.test.ts
@@ -1,13 +1,3 @@
-/**
- * Unit tests for task exceed/requeue operations
- *
- * Covers:
- * - exceedTask: transitions running task to exceeded status with metadata
- * - requeueExceededTask: transitions exceeded task back to pending, preserving metadata
- * - deleteTask('exceeded'): removes exceeded task from the store
- * - listExceededTasks: returns exceeded tasks as TaskListItem list
- */
-
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, existsSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -57,7 +47,6 @@ describe('TaskRunner - exceedTask', () => {
   });
 
   it('should transition a running task to exceeded status', () => {
-    // Given: a running task
     runner.addTask('Task A');
     runner.claimNextTasks(1);
 
@@ -65,21 +54,18 @@ describe('TaskRunner - exceedTask', () => {
     const runningTask = beforeFile.tasks[0]!;
     const taskName = runningTask.name as string;
 
-    // When: exceedTask is called
     runner.exceedTask(taskName, {
       currentMovement: 'implement',
       newMaxMovements: 60,
       currentIteration: 30,
     });
 
-    // Then: task is now exceeded
     const afterFile = loadTasksFile(testDir);
     const exceededTask = afterFile.tasks[0]!;
     expect(exceededTask.status).toBe('exceeded');
   });
 
   it('should preserve started_at from the running state', () => {
-    // Given: a running task
     runner.addTask('Task A');
     runner.claimNextTasks(1);
 
@@ -88,33 +74,28 @@ describe('TaskRunner - exceedTask', () => {
     const taskName = runningTask.name as string;
     const originalStartedAt = runningTask.started_at as string;
 
-    // When: exceedTask is called
     runner.exceedTask(taskName, {
       currentMovement: 'plan',
       newMaxMovements: 60,
       currentIteration: 30,
     });
 
-    // Then: started_at is preserved from running state
     const afterFile = loadTasksFile(testDir);
     const exceededTask = afterFile.tasks[0]!;
     expect(exceededTask.started_at).toBe(originalStartedAt);
   });
 
   it('should set completed_at to a non-null timestamp', () => {
-    // Given: a running task
     runner.addTask('Task A');
     runner.claimNextTasks(1);
     const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
 
-    // When: exceedTask is called
     runner.exceedTask(taskName, {
       currentMovement: 'plan',
       newMaxMovements: 60,
       currentIteration: 30,
     });
 
-    // Then: completed_at is set
     const afterFile = loadTasksFile(testDir);
     const exceededTask = afterFile.tasks[0]!;
     expect(exceededTask.completed_at).toBeTruthy();
@@ -122,84 +103,70 @@ describe('TaskRunner - exceedTask', () => {
   });
 
   it('should clear owner_pid', () => {
-    // Given: a running task (has owner_pid)
     runner.addTask('Task A');
     runner.claimNextTasks(1);
     const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
 
-    // When: exceedTask is called
     runner.exceedTask(taskName, {
       currentMovement: 'plan',
       newMaxMovements: 60,
       currentIteration: 30,
     });
 
-    // Then: owner_pid is null
     const afterFile = loadTasksFile(testDir);
     const exceededTask = afterFile.tasks[0]!;
     expect(exceededTask.owner_pid).toBeNull();
   });
 
   it('should record the current movement as start_step', () => {
-    // Given: a running task
     runner.addTask('Task A');
     runner.claimNextTasks(1);
     const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
 
-    // When: exceedTask is called with currentMovement = 'reviewers'
     runner.exceedTask(taskName, {
       currentMovement: 'reviewers',
       newMaxMovements: 60,
       currentIteration: 30,
     });
 
-    // Then: start_step is set to 'reviewers'
     const afterFile = loadTasksFile(testDir);
     const exceededTask = afterFile.tasks[0]!;
     expect(exceededTask.start_step).toBe('reviewers');
   });
 
   it('should record exceeded_max_movements', () => {
-    // Given: a running task
     runner.addTask('Task A');
     runner.claimNextTasks(1);
     const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
 
-    // When: exceedTask is called with newMaxMovements = 60
     runner.exceedTask(taskName, {
       currentMovement: 'plan',
       newMaxMovements: 60,
       currentIteration: 30,
     });
 
-    // Then: exceeded_max_movements is 60
     const afterFile = loadTasksFile(testDir);
     const exceededTask = afterFile.tasks[0]!;
     expect(exceededTask.exceeded_max_movements).toBe(60);
   });
 
   it('should record exceeded_current_iteration', () => {
-    // Given: a running task
     runner.addTask('Task A');
     runner.claimNextTasks(1);
     const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
 
-    // When: exceedTask is called with currentIteration = 30
     runner.exceedTask(taskName, {
       currentMovement: 'plan',
       newMaxMovements: 60,
       currentIteration: 30,
     });
 
-    // Then: exceeded_current_iteration is 30
     const afterFile = loadTasksFile(testDir);
     const exceededTask = afterFile.tasks[0]!;
     expect(exceededTask.exceeded_current_iteration).toBe(30);
   });
 
   it('should throw when task is not found', () => {
-    // Given: no task exists
-    // When/Then: exceedTask throws
     expect(() => runner.exceedTask('nonexistent-task', {
       currentMovement: 'plan',
       newMaxMovements: 60,
@@ -208,16 +175,86 @@ describe('TaskRunner - exceedTask', () => {
   });
 
   it('should throw when task is pending (not running)', () => {
-    // Given: a pending task (not yet claimed)
     runner.addTask('Task A');
     const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
 
-    // When/Then: exceedTask throws for pending task
     expect(() => runner.exceedTask(taskName, {
       currentMovement: 'plan',
       newMaxMovements: 60,
       currentIteration: 0,
     })).toThrow(/not found/i);
+  });
+
+  it('should persist worktree_path when exceed options include worktreePath', () => {
+    runner.addTask('Task A');
+    runner.claimNextTasks(1);
+    const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
+    const wt = '/tmp/takt-wt-persist-test';
+
+    runner.exceedTask(taskName, {
+      currentMovement: 'plan',
+      newMaxMovements: 60,
+      currentIteration: 30,
+      worktreePath: wt,
+    });
+
+    const afterFile = loadTasksFile(testDir);
+    const exceededTask = afterFile.tasks[0]!;
+    expect(exceededTask.worktree_path).toBe(wt);
+  });
+
+  it('should persist branch when exceed options include branch', () => {
+    runner.addTask('Task A');
+    runner.claimNextTasks(1);
+    const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
+
+    runner.exceedTask(taskName, {
+      currentMovement: 'plan',
+      newMaxMovements: 60,
+      currentIteration: 30,
+      branch: 'takt/issue-562',
+    });
+
+    const afterFile = loadTasksFile(testDir);
+    const exceededTask = afterFile.tasks[0]!;
+    expect(exceededTask.branch).toBe('takt/issue-562');
+  });
+
+  it('Issue #562: persists worktree_path and branch when exceed options include both (typed literals)', () => {
+    runner.addTask('Task A');
+    runner.claimNextTasks(1);
+    const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
+    const wt = '/tmp/takt-wt-both';
+
+    runner.exceedTask(taskName, {
+      currentMovement: 'implement',
+      newMaxMovements: 55,
+      currentIteration: 20,
+      worktreePath: wt,
+      branch: 'takt/both',
+    });
+
+    const afterFile = loadTasksFile(testDir);
+    const exceededTask = afterFile.tasks[0]!;
+    expect(exceededTask.worktree_path).toBe(wt);
+    expect(exceededTask.branch).toBe('takt/both');
+  });
+
+  it('should not add worktree_path or branch when options omit them', () => {
+    runner.addTask('Task A');
+    runner.claimNextTasks(1);
+    const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
+
+    runner.exceedTask(taskName, {
+      currentMovement: 'plan',
+      newMaxMovements: 60,
+      currentIteration: 30,
+    });
+
+    const afterFile = loadTasksFile(testDir);
+    const exceededTask = afterFile.tasks[0]!;
+    expect(exceededTask.worktree_path).toBeUndefined();
+    expect(exceededTask.branch).toBeUndefined();
   });
 });
 
@@ -237,118 +274,105 @@ describe('TaskRunner - requeueExceededTask', () => {
   });
 
   it('should transition exceeded task to pending', () => {
-    // Given: an exceeded task in the store
     writeExceededRecord(testDir, { name: 'task-a' });
 
-    // When: requeueExceededTask is called
     runner.requeueExceededTask('task-a');
 
-    // Then: task is now pending
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.status).toBe('pending');
   });
 
   it('should clear started_at after requeue', () => {
-    // Given: an exceeded task (has started_at from execution)
     writeExceededRecord(testDir, { name: 'task-a' });
 
-    // When: requeueExceededTask is called
     runner.requeueExceededTask('task-a');
 
-    // Then: started_at is null
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.started_at).toBeNull();
   });
 
   it('should clear completed_at after requeue', () => {
-    // Given: an exceeded task (has completed_at from exceed time)
     writeExceededRecord(testDir, { name: 'task-a' });
 
-    // When: requeueExceededTask is called
     runner.requeueExceededTask('task-a');
 
-    // Then: completed_at is null
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.completed_at).toBeNull();
   });
 
   it('should clear owner_pid after requeue', () => {
-    // Given: an exceeded task
     writeExceededRecord(testDir, { name: 'task-a' });
 
-    // When: requeueExceededTask is called
     runner.requeueExceededTask('task-a');
 
-    // Then: owner_pid is null
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.owner_pid).toBeNull();
   });
 
   it('should preserve exceeded_max_movements for continuation', () => {
-    // Given: an exceeded task with exceeded_max_movements = 60
     writeExceededRecord(testDir, {
       name: 'task-a',
       exceeded_max_movements: 60,
       exceeded_current_iteration: 30,
     });
 
-    // When: requeueExceededTask is called
     runner.requeueExceededTask('task-a');
 
-    // Then: exceeded_max_movements is preserved (used by resolveTaskExecution)
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.exceeded_max_movements).toBe(60);
   });
 
   it('should preserve exceeded_current_iteration for continuation', () => {
-    // Given: an exceeded task with exceeded_current_iteration = 30
     writeExceededRecord(testDir, {
       name: 'task-a',
       exceeded_current_iteration: 30,
     });
 
-    // When: requeueExceededTask is called
     runner.requeueExceededTask('task-a');
 
-    // Then: exceeded_current_iteration is preserved
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.exceeded_current_iteration).toBe(30);
   });
 
   it('should preserve start_step for re-entry point', () => {
-    // Given: an exceeded task with start_step = 'reviewers'
     writeExceededRecord(testDir, {
       name: 'task-a',
       start_movement: 'reviewers',
     });
 
-    // When: requeueExceededTask is called
     runner.requeueExceededTask('task-a');
 
-    // Then: start_step is preserved
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.start_step).toBe('reviewers');
   });
 
+  it('should preserve worktree_path and branch through requeue when present on exceeded record', () => {
+    writeExceededRecord(testDir, {
+      name: 'task-a',
+      worktree_path: '/tmp/preserved-wt',
+      branch: 'takt/preserved-branch',
+    });
+
+    runner.requeueExceededTask('task-a');
+
+    const file = loadTasksFile(testDir);
+    expect(file.tasks[0]?.status).toBe('pending');
+    expect(file.tasks[0]?.worktree_path).toBe('/tmp/preserved-wt');
+    expect(file.tasks[0]?.branch).toBe('takt/preserved-branch');
+  });
+
   it('should throw when task is not in exceeded status', () => {
-    // Given: a pending task (not exceeded)
     runner.addTask('Task A');
     const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
 
-    // When/Then: requeueExceededTask throws
     expect(() => runner.requeueExceededTask(taskName)).toThrow(/not found/i);
   });
 
   it('should throw when task does not exist', () => {
-    // Given: no task exists
-    // When/Then: requeueExceededTask throws
     expect(() => runner.requeueExceededTask('nonexistent-task')).toThrow(/not found/i);
   });
 
   it('should not affect other tasks in the store', () => {
-    // Given: one exceeded and one pending task
-    // writeExceededRecord must come first because it overwrites tasks.yaml;
-    // addTask then reads and appends to the file.
     writeExceededRecord(testDir, { name: 'task-a' });
     runner.addTask('Task B');
 
@@ -356,10 +380,8 @@ describe('TaskRunner - requeueExceededTask', () => {
     const pendingTask = initialFile.tasks.find((t) => t.status === 'pending');
     expect(pendingTask).toBeDefined();
 
-    // When: requeueExceededTask is called for task-a
     runner.requeueExceededTask('task-a');
 
-    // Then: the other task is unaffected
     const afterFile = loadTasksFile(testDir);
     const stillPending = afterFile.tasks.find((t) => (t.name as string).includes('task-b'));
     expect(stillPending?.status).toBe('pending');
@@ -382,29 +404,22 @@ describe('TaskRunner - deleteTask (exceeded)', () => {
   });
 
   it('should delete an exceeded task', () => {
-    // Given: an exceeded task
     writeExceededRecord(testDir, { name: 'task-a' });
 
-    // When: deleteTask is called
     runner.deleteTask('task-a', 'exceeded');
 
-    // Then: task is removed
     const file = loadTasksFile(testDir);
     expect(file.tasks).toHaveLength(0);
   });
 
   it('should throw when task is not in exceeded status', () => {
-    // Given: a pending task
     runner.addTask('Task A');
     const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
 
-    // When/Then: deleteTask throws
     expect(() => runner.deleteTask(taskName, 'exceeded')).toThrow(/not found/i);
   });
 
   it('should throw when task does not exist', () => {
-    // Given: no task exists
-    // When/Then: deleteTask throws
     expect(() => runner.deleteTask('nonexistent-task', 'exceeded')).toThrow(/not found/i);
   });
 });
@@ -425,56 +440,42 @@ describe('TaskRunner - listExceededTasks', () => {
   });
 
   it('should return exceeded tasks as TaskListItems with exceeded kind', () => {
-    // Given: an exceeded task
     writeExceededRecord(testDir, { name: 'task-a' });
 
-    // When: listExceededTasks is called
     const exceeded = runner.listExceededTasks();
 
-    // Then: one item with kind 'exceeded'
     expect(exceeded).toHaveLength(1);
     expect(exceeded[0]?.kind).toBe('exceeded');
     expect(exceeded[0]?.name).toBe('task-a');
   });
 
   it('should return empty array when no exceeded tasks exist', () => {
-    // Given: only pending tasks
     runner.addTask('Task A');
 
-    // When: listExceededTasks is called
     const exceeded = runner.listExceededTasks();
 
-    // Then: empty array
     expect(exceeded).toHaveLength(0);
   });
 
   it('should not include non-exceeded tasks', () => {
-    // Given: one exceeded and one pending task
-    // writeExceededRecord must come first because it overwrites tasks.yaml;
-    // addTask then reads and appends to the file.
     writeExceededRecord(testDir, { name: 'task-a' });
     runner.addTask('Task B');
 
-    // When: listExceededTasks is called
     const exceeded = runner.listExceededTasks();
 
-    // Then: only the exceeded task
     expect(exceeded).toHaveLength(1);
     expect(exceeded[0]?.name).toBe('task-a');
   });
 
   it('should expose exceeded metadata in data field', () => {
-    // Given: an exceeded task with metadata
     writeExceededRecord(testDir, {
       name: 'task-a',
       exceeded_max_movements: 60,
       exceeded_current_iteration: 30,
     });
 
-    // When: listExceededTasks is called
     const exceeded = runner.listExceededTasks();
 
-    // Then: metadata is accessible via data
     const task = exceeded[0]!;
     expect(task.data?.exceeded_max_movements).toBe(60);
     expect(task.data?.exceeded_current_iteration).toBe(30);

--- a/src/__tests__/taskResultHandler.test.ts
+++ b/src/__tests__/taskResultHandler.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, existsSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { parse as parseYaml } from 'yaml';
 
 vi.mock('../shared/ui/index.js', () => ({
   info: vi.fn(),
@@ -8,45 +13,125 @@ vi.mock('../shared/ui/index.js', () => ({
 
 import { info } from '../shared/ui/index.js';
 import { persistExceededTaskResult } from '../features/tasks/execute/taskResultHandler.js';
-import type { TaskInfo } from '../infra/task/index.js';
+import { TaskRunner } from '../infra/task/runner.js';
 
 const mockInfo = vi.mocked(info);
 
-describe('persistExceededTaskResult', () => {
-  const taskRunner = {
-    exceedTask: vi.fn(),
-  };
+function loadTasksFile(testDir: string): { tasks: Array<Record<string, unknown>> } {
+  const raw = readFileSync(join(testDir, '.takt', 'tasks.yaml'), 'utf-8');
+  return parseYaml(raw) as { tasks: Array<Record<string, unknown>> };
+}
 
-  const task: TaskInfo = {
-    name: 'task-a',
-    content: 'Implement feature',
-    filePath: '/tmp/task-a.yaml',
-    createdAt: '2026-03-31T00:00:00.000Z',
-    status: 'running',
-    data: {
-      task: 'Implement feature',
-      piece: 'default',
-    },
-  };
+describe('persistExceededTaskResult', () => {
+  let testDir: string;
+  let runner: TaskRunner;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    testDir = join(tmpdir(), `takt-result-handler-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+    runner = new TaskRunner(testDir);
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
   });
 
   it('should record exceeded metadata and log the current step with canonical wording', () => {
-    persistExceededTaskResult(taskRunner as never, task, {
+    runner.addTask('Implement feature');
+    const [task] = runner.claimNextTasks(1);
+    if (!task) {
+      throw new Error('expected claimed task');
+    }
+
+    persistExceededTaskResult(runner, task, {
       currentMovement: 'reviewers',
       newMaxMovements: 60,
       currentIteration: 30,
     });
 
-    expect(taskRunner.exceedTask).toHaveBeenCalledWith('task-a', {
-      currentMovement: 'reviewers',
-      newMaxMovements: 60,
-      currentIteration: 30,
-    });
+    const { tasks } = loadTasksFile(testDir);
+    const row = tasks[0]!;
+    expect(row.status).toBe('exceeded');
+    expect(row.start_step).toBe('reviewers');
+    expect(row.exceeded_max_movements).toBe(60);
+    expect(row.exceeded_current_iteration).toBe(30);
     expect(mockInfo).toHaveBeenCalledWith(
-      'Task "task-a" exceeded iteration limit at step "reviewers"',
+      `Task "${task.name}" exceeded iteration limit at step "reviewers"`,
     );
+  });
+
+  it('Issue #562: persists worktree_path on first exceed when context provides worktreePath (requeue reuse)', () => {
+    runner.addTask('Implement feature');
+    const [task] = runner.claimNextTasks(1);
+    if (!task) {
+      throw new Error('expected claimed task');
+    }
+
+    persistExceededTaskResult(
+      runner,
+      task,
+      {
+        currentMovement: 'implement',
+        newMaxMovements: 60,
+        currentIteration: 30,
+      },
+      { worktreePath: '/clone/path', branch: 'takt/feature' },
+    );
+
+    const { tasks } = loadTasksFile(testDir);
+    const row = tasks[0]!;
+    expect(row.worktree_path).toBe('/clone/path');
+    expect(row.branch).toBe('takt/feature');
+  });
+
+  it('should forward only worktreePath when branch is omitted from context', () => {
+    runner.addTask('Implement feature');
+    const [task] = runner.claimNextTasks(1);
+    if (!task) {
+      throw new Error('expected claimed task');
+    }
+
+    persistExceededTaskResult(
+      runner,
+      task,
+      {
+        currentMovement: 'plan',
+        newMaxMovements: 40,
+        currentIteration: 5,
+      },
+      { worktreePath: '/wt-only' },
+    );
+
+    const { tasks } = loadTasksFile(testDir);
+    const row = tasks[0]!;
+    expect(row.worktree_path).toBe('/wt-only');
+    expect(row.branch).toBeUndefined();
+  });
+
+  it('should forward only branch when worktreePath is omitted from context', () => {
+    runner.addTask('Implement feature');
+    const [task] = runner.claimNextTasks(1);
+    if (!task) {
+      throw new Error('expected claimed task');
+    }
+
+    persistExceededTaskResult(
+      runner,
+      task,
+      {
+        currentMovement: 'fix',
+        newMaxMovements: 50,
+        currentIteration: 12,
+      },
+      { branch: 'takt/branch-only' },
+    );
+
+    const { tasks } = loadTasksFile(testDir);
+    const row = tasks[0]!;
+    expect(row.branch).toBe('takt/branch-only');
+    expect(row.worktree_path).toBeUndefined();
   });
 });

--- a/src/__tests__/worktree-exceeded-requeue.test.ts
+++ b/src/__tests__/worktree-exceeded-requeue.test.ts
@@ -1,20 +1,3 @@
-/**
- * Integration tests for worktree exceeded → requeue → re-execution flow.
- *
- * Scenarios:
- * 1. Worktree task reaches iteration limit → transitions to 'exceeded' status
- * 2. Exceeded task stores start_movement / exceeded_max_movements / exceeded_current_iteration
- * 3. After requeue, re-execution passes maxMovementsOverride and initialIterationOverride
- * 4. After requeue, re-execution starts from start_movement (re-entry point)
- *
- * Integration boundary:
- *   TaskRunner (real file I/O) →
- *   executeAndCompleteTask →
- *     resolveTaskExecution →
- *     executeTaskWithResult →
- *     executePiece (mocked, args captured)
- */
-
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, existsSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -22,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 
-// --- Mock setup (must be before imports that use these modules) ---
+// --- Mock setup ---
 
 vi.mock('../infra/config/index.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../infra/config/index.js')>();
@@ -76,12 +59,12 @@ vi.mock('../shared/ui/index.js', async (importOriginal) => ({
   ),
 }));
 
-// --- Imports (after mocks) ---
+// --- Imports ---
 
 import { executePiece } from '../features/tasks/execute/pieceExecution.js';
 import { postExecutionFlow } from '../features/tasks/execute/postExecution.js';
 import { loadPieceByIdentifier } from '../infra/config/index.js';
-import { detectDefaultBranch } from '../infra/task/index.js';
+import { createSharedClone, detectDefaultBranch, summarizeTaskName } from '../infra/task/index.js';
 import { withProgress } from '../shared/ui/index.js';
 import { executeAndCompleteTask } from '../features/tasks/execute/taskExecution.js';
 import { TaskRunner } from '../infra/task/runner.js';
@@ -143,8 +126,6 @@ function buildTestPieceConfig(): PieceConfig {
 }
 
 function applyDefaultMocks(): void {
-  // Re-apply mocks that are not set by the vi.mock factory
-  // (vi.clearAllMocks preserves factory implementations, but these are set per-suite)
   vi.mocked(loadPieceByIdentifier).mockReturnValue(buildTestPieceConfig());
   vi.mocked(detectDefaultBranch).mockReturnValue('main');
   vi.mocked(postExecutionFlow).mockResolvedValue({ prUrl: undefined, prFailed: false });
@@ -160,7 +141,6 @@ describe('シナリオ1・2: exceeded status transition via executeAndCompleteTa
   let runner: TaskRunner;
 
   beforeEach(() => {
-    // clearAllMocks clears call history but preserves factory implementations
     vi.clearAllMocks();
     applyDefaultMocks();
     testDir = createTestDir();
@@ -174,12 +154,10 @@ describe('シナリオ1・2: exceeded status transition via executeAndCompleteTa
   });
 
   it('scenario 1: task transitions to exceeded status when executePiece returns exceeded result', async () => {
-    // Given: a pending task
     runner.addTask('Do work', { piece: 'test-piece' });
     const [task] = runner.claimNextTasks(1);
     if (!task) throw new Error('No task claimed');
 
-    // executePiece simulates hitting iteration limit
     vi.mocked(executePiece).mockResolvedValueOnce({
       success: false,
       exceeded: true,
@@ -190,13 +168,10 @@ describe('シナリオ1・2: exceeded status transition via executeAndCompleteTa
       },
     });
 
-    // When: executeAndCompleteTask processes the exceeded result
     const result = await executeAndCompleteTask(task, runner, testDir);
 
-    // Then: returns false (task did not succeed)
     expect(result).toBe(false);
 
-    // Then: task is now in exceeded status
     const exceededTasks = runner.listExceededTasks();
     expect(exceededTasks).toHaveLength(1);
     expect(exceededTasks[0]?.kind).toBe('exceeded');
@@ -204,12 +179,10 @@ describe('シナリオ1・2: exceeded status transition via executeAndCompleteTa
   });
 
   it('scenario 2: exceeded metadata is recorded in tasks.yaml for resumption', async () => {
-    // Given: a pending task
     runner.addTask('Do work', { piece: 'test-piece' });
     const [task] = runner.claimNextTasks(1);
     if (!task) throw new Error('No task claimed');
 
-    // executePiece simulates hitting limit at 'implement' movement, producing 30/60 iterations
     vi.mocked(executePiece).mockResolvedValueOnce({
       success: false,
       exceeded: true,
@@ -220,16 +193,46 @@ describe('シナリオ1・2: exceeded status transition via executeAndCompleteTa
       },
     });
 
-    // When: executeAndCompleteTask records the exceeded result
     await executeAndCompleteTask(task, runner, testDir);
 
-    // Then: YAML contains the three resumption fields
     const file = loadTasksFile(testDir);
     const exceededRecord = file.tasks[0];
     expect(exceededRecord?.status).toBe('exceeded');
     expect(exceededRecord?.start_step).toBe('implement');
     expect(exceededRecord?.exceeded_max_movements).toBe(60);
     expect(exceededRecord?.exceeded_current_iteration).toBe(30);
+  });
+
+  it('scenario 5: first exceed on worktree task persists worktree_path and branch in tasks.yaml', async () => {
+    const cloneDir = join(testDir, '.takt', 'worktrees', `first-exceed-${randomUUID()}`);
+    mkdirSync(cloneDir, { recursive: true });
+    vi.mocked(summarizeTaskName).mockResolvedValueOnce('slug-562');
+    vi.mocked(createSharedClone).mockResolvedValueOnce({
+      path: cloneDir,
+      branch: 'takt/slug-562',
+    });
+
+    runner.addTask('Do work', { piece: 'test-piece', worktree: true });
+    const [task] = runner.claimNextTasks(1);
+    if (!task) throw new Error('No task claimed');
+
+    vi.mocked(executePiece).mockResolvedValueOnce({
+      success: false,
+      exceeded: true,
+      exceededInfo: {
+        currentMovement: 'implement',
+        newMaxMovements: 60,
+        currentIteration: 30,
+      },
+    });
+
+    await executeAndCompleteTask(task, runner, testDir);
+
+    const file = loadTasksFile(testDir);
+    const rec = file.tasks[0];
+    expect(rec?.status).toBe('exceeded');
+    expect(rec?.worktree_path).toBe(cloneDir);
+    expect(rec?.branch).toBe('takt/slug-562');
   });
 });
 
@@ -239,11 +242,9 @@ describe('シナリオ3・4: requeue → re-execution passes exceeded metadata t
   let runner: TaskRunner;
 
   beforeEach(() => {
-    // clearAllMocks clears call history but preserves factory implementations
     vi.clearAllMocks();
     applyDefaultMocks();
     testDir = createTestDir();
-    // cloneDir simulates a pre-existing worktree clone inside the managed worktree directory
     cloneDir = join(testDir, '.takt', 'worktrees', `existing-${randomUUID()}`);
     mkdirSync(cloneDir, { recursive: true });
     runner = new TaskRunner(testDir);
@@ -258,7 +259,6 @@ describe('シナリオ3・4: requeue → re-execution passes exceeded metadata t
   });
 
   it('scenario 3: maxMovementsOverride and initialIterationOverride are passed to executePiece after requeue', async () => {
-    // Given: an exceeded worktree task with pre-existing clone on disk
     writeExceededRecord(testDir, {
       worktree: true,
       worktree_path: cloneDir,
@@ -266,20 +266,15 @@ describe('シナリオ3・4: requeue → re-execution passes exceeded metadata t
       exceeded_current_iteration: 30,
     });
 
-    // Requeue → status back to pending, exceeded metadata and worktree_path preserved
     runner.requeueExceededTask('task-a');
 
-    // Claim the requeued task as running
     const [task] = runner.claimNextTasks(1);
     if (!task) throw new Error('No task claimed');
 
-    // executePiece returns success so we can capture args without side effects
     vi.mocked(executePiece).mockResolvedValueOnce({ success: true });
 
-    // When: executeAndCompleteTask runs the requeued task
     await executeAndCompleteTask(task, runner, testDir);
 
-    // Then: executePiece received the correct exceeded override options
     expect(vi.mocked(executePiece)).toHaveBeenCalledOnce();
     const capturedOptions = vi.mocked(executePiece).mock.calls[0]![3] as PieceExecutionOptions;
     expect(capturedOptions.maxMovementsOverride).toBe(60);
@@ -287,7 +282,6 @@ describe('シナリオ3・4: requeue → re-execution passes exceeded metadata t
   });
 
   it('scenario 4: startMovement is passed so re-execution resumes from the exceeded movement', async () => {
-    // Given: an exceeded worktree task with start_movement='implement'
     writeExceededRecord(testDir, {
       worktree: true,
       worktree_path: cloneDir,
@@ -296,20 +290,15 @@ describe('シナリオ3・4: requeue → re-execution passes exceeded metadata t
       start_movement: 'implement',
     });
 
-    // Requeue → pending, start_movement preserved
     runner.requeueExceededTask('task-a');
 
-    // Claim the requeued task as running
     const [task] = runner.claimNextTasks(1);
     if (!task) throw new Error('No task claimed');
 
-    // executePiece returns success so we can capture args without side effects
     vi.mocked(executePiece).mockResolvedValueOnce({ success: true });
 
-    // When: executeAndCompleteTask runs the requeued task
     await executeAndCompleteTask(task, runner, testDir);
 
-    // Then: executePiece received startMovement='implement' to resume from where it stopped
     expect(vi.mocked(executePiece)).toHaveBeenCalledOnce();
     const capturedOptions = vi.mocked(executePiece).mock.calls[0]![3] as PieceExecutionOptions;
     expect(capturedOptions.startMovement).toBe('implement');

--- a/src/features/tasks/execute/taskExecution.ts
+++ b/src/features/tasks/execute/taskExecution.ts
@@ -150,12 +150,12 @@ export async function executeAndCompleteTask(
       initialIterationOverride,
     } = await resolveTaskExecution(task, cwd, taskAbortSignal);
 
-    // cwd is always the project root; pass it as projectCwd so reports/sessions go there
+    const projectRootCwd = cwd;
     const taskRunResult = await executeTaskWithResult({
       task: taskPrompt ?? task.content,
       cwd: execCwd,
       pieceIdentifier: execPiece,
-      projectCwd: cwd,
+      projectCwd: projectRootCwd,
       agentOverrides: taskExecutionOptions,
       startMovement,
       retryNote,
@@ -169,7 +169,10 @@ export async function executeAndCompleteTask(
     });
 
     if (taskRunResult.exceeded && taskRunResult.exceededInfo) {
-      persistExceededTaskResult(taskRunner, task, taskRunResult.exceededInfo);
+      persistExceededTaskResult(taskRunner, task, taskRunResult.exceededInfo, {
+        worktreePath,
+        branch,
+      });
       return false;
     }
 
@@ -180,10 +183,10 @@ export async function executeAndCompleteTask(
     let prFailedError: string | undefined;
     let postExecutionTaskError: string | undefined;
     if (taskSuccess && isWorktree) {
-      const issues = resolveTaskIssue(issueNumber, cwd);
+      const issues = resolveTaskIssue(issueNumber, projectRootCwd);
       const postResult = await postExecutionFlow({
         execCwd,
-        projectCwd: cwd,
+        projectCwd: projectRootCwd,
         task: task.name,
         branch,
         baseBranch,

--- a/src/features/tasks/execute/taskResultHandler.ts
+++ b/src/features/tasks/execute/taskResultHandler.ts
@@ -113,11 +113,14 @@ export function persistExceededTaskResult(
   taskRunner: TaskRunner,
   task: TaskInfo,
   exceeded: ExceededInfo,
+  context?: { worktreePath?: string; branch?: string },
 ): void {
   taskRunner.exceedTask(task.name, {
     currentMovement: exceeded.currentMovement,
     newMaxMovements: exceeded.newMaxMovements,
     currentIteration: exceeded.currentIteration,
+    ...(context?.worktreePath ? { worktreePath: context.worktreePath } : {}),
+    ...(context?.branch ? { branch: context.branch } : {}),
   });
   info(`Task "${task.name}" exceeded iteration limit at step "${exceeded.currentMovement}"`);
 }

--- a/src/infra/task/taskExceedService.ts
+++ b/src/infra/task/taskExceedService.ts
@@ -6,6 +6,8 @@ export interface ExceedTaskOptions {
   currentMovement: string;
   newMaxMovements: number;
   currentIteration: number;
+  worktreePath?: string;
+  branch?: string;
 }
 
 export class TaskExceedService {
@@ -30,6 +32,8 @@ export class TaskExceedService {
         start_movement: options.currentMovement,
         exceeded_max_movements: options.newMaxMovements,
         exceeded_current_iteration: options.currentIteration,
+        ...(options.worktreePath ? { worktree_path: options.worktreePath } : {}),
+        ...(options.branch ? { branch: options.branch } : {}),
       };
 
       const tasks = [...current.tasks];


### PR DESCRIPTION
## Summary

## Summary

タスクが exceeded ステータスになった際、`worktree_path` が tasks.yaml に保存されない。
そのため requeue → 再実行すると新しいクローンがベースブランチから作成され、前回の worktree 内のコミット済み差分が全て失われる。

## Reproduction Steps

1. worktree 付きのタスクを `takt add` で追加し、`takt run` で実行する
2. タスクが `max_movements` の上限に達して `exceeded` ステータスになる
3. `takt list` から "Requeue" を選択して `pending` に戻す
4. `takt run` で再実行する

**Expected:** 前回の worktree ディレクトリが再利用され、コミット済みの変更が保持される
**Actual:** 新しいクローンがベースブランチから作成され、前回の worktree 内の変更が全て消失する

## Root Cause

### 1. `persistExceededTaskResult()` が `worktreePath` を渡していない

`taskResultHandler.ts` の `persistExceededTaskResult()` は `exceedTask()` に対して `worktreePath` と `branch` を渡していない:

```typescript
// taskResultHandler.ts L54-61
export function persistExceededTaskResult(taskRunner, task, exceeded) {
    taskRunner.exceedTask(task.name, {
        currentMovement: exceeded.currentMovement,
        newMaxMovements: exceeded.newMaxMovements,
        currentIteration: exceeded.currentIteration,
        // ← worktreePath が渡されていない
    });
}
```

比較: `persistTaskError()` は正しく `worktreePath` を渡している:

```typescript
// taskResultHandler.ts L62-78
export function persistTaskError(taskRunner, task, startedAt, completedAt, err) {
    taskRunner.failTask({
        ...
        ...(task.worktreePath ? { worktreePath: task.worktreePath } : {}),  // ← 渡している
    });
}
```

### 2. `exceedTask()` が `worktree_path` を明示的に保存しない

`taskExceedService.ts` の `exceedTask()` は `...target` スプレッドで既存フィールドを引き継ぐが、初回実行時の `target`（YAML レコード）にはそもそも `worktree_path` が存在しない:

```typescript
// taskExceedService.ts L7-27
exceedTask(taskName, options) {
    const updated = {
        ...target,  // ← target に worktree_path がない（初回実行時）
        status: 'exceeded',
        completed_at: nowIso(),
        owner_pid: null,
        failure: undefined,
        start_movement: options.currentMovement,
        exceeded_max_movements: options.newMaxMovements,
        exceeded_current_iteration: options.currentIteration,
        // ← worktree_path の明示的な保存なし
    };
}
```

### なぜ `target` に `worktree_path` がないのか

`worktree_path` が YAML に書き込まれるのは `completeTask()` または `failTask()` の実行時のみ:

```typescript
// taskLifecycleService.ts L103
worktree_path: result.worktreePath ?? target.worktree_path,  // completeTask()

// taskLifecycleService.ts L132
worktree_path: result.worktreePath ?? target.worktree_path,  // failTask()
```

`exceedTask()` はこれらより前に発火するため、初回実行では YAML に `worktree_path` が一度も書き込まれない。

### 影響の深刻さ

worktree クローンは `git clone --reference --dissociate` で作成され、`origin` リモートも削除されるため、クローン内のコミットはそのディレクトリにローカル。新しいクローンからはアクセス不可能であり、変更の復旧手段がない（手動で旧 worktree ディレクトリを見つける以外）。

## Flow Diagram

```
[初回実行]
  pending → running (claimNextTasks: worktree_path 未設定)
    → resolveTaskExecution(): worktree 作成、worktreePath をローカル変数に保持
    → executePiece(): タスク実行、コミット作成
    → exceeded 発生
    → persistExceededTaskResult(): worktreePath を渡さない
    → exceedTask(): ...target に worktree_path なし → YAML に未保存

[requeue]
  exceeded → pending (requeueExceededTask: ...target → worktree_path なし)

[再実行]
  pending → running
    → resolveTaskExecution(): task.worktreePath === undefined
    → canReuseWorktreePath() は評価されない
    → 新しいクローンをベースブランチから作成 ← 前回の差分消失
```

## Suggested Fix

`executeAndCompleteTask()` 内で exceeded 分岐でも `worktreePath` を保存する:

```typescript
// taskExecution.ts L109-111
if (taskRunResult.exceeded && taskRunResult.exceededInfo) {
    persistExceededTaskResult(taskRunner, task, taskRunResult.exceededInfo, {
        worktreePath,
        branch,
    });
    return false;
}
```

```typescript
// taskResultHandler.ts
export function persistExceededTaskResult(taskRunner, task, exceeded, context?) {
    taskRunner.exceedTask(task.name, {
        currentMovement: exceeded.currentMovement,
        newMaxMovements: exceeded.newMaxMovements,
        currentIteration: exceeded.currentIteration,
        worktreePath: context?.worktreePath,
        branch: context?.branch,
    });
}
```

```typescript
// taskExceedService.ts
exceedTask(taskName, options) {
    const updated = {
        ...target,
        status: 'exceeded',
        completed_at: nowIso(),
        owner_pid: null,
        failure: undefined,
        start_movement: options.currentMovement,
        exceeded_max_movements: options.newMaxMovements,
        exceeded_current_iteration: options.currentIteration,
        ...(options.worktreePath ? { worktree_path: options.worktreePath } : {}),
        ...(options.branch ? { branch: options.branch } : {}),
    };
}
```

## Workaround

requeue 前に tasks.yaml へ `worktree_path` を手動で追記することで回避可能:

```yaml
- name: my-task
  status: exceeded
  worktree_path: /absolute/path/to/takt-worktrees/20260331xxxx-slug
```

worktree ディレクトリは `../takt-worktrees/` 配下（または `worktree_dir` 設定先）に残っている。

## Related

- #366 -- exceeded / requeue システムの実装要件
- #374 -- exceeded / requeue の本実装（このバグの起点）
- #502 -- worktree_path 再利用時のパス検証追加（再利用ロジックは実装済みだが、保存の欠落は未対処）

## Environment

- takt v0.33.2


## Execution Report

Workflow `takt-default` completed successfully.

Closes #562