### PR TITLE
Release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.34.0] - 2026-04-03
+
+### Added
+
+- StructuredCaller インターフェースを導入: プロバイダーのネイティブ構造化出力（Structured Output）をサポートし、ステータス判定・条件評価・タスク分解でテキストパースに代わる JSON ベースの応答抽出が可能に (#570)
+- Traced Config を導入: `traced-config` パッケージによる設定値の出所追跡（環境変数・設定ファイル・デフォルト値）をサポート (#558)
+- 並列ステップに `concurrency` フィールドを追加: セマフォベースの同時実行数制御が可能に
+- 無効なワークフロー YAML のロード時に警告を表示するようになった（スキーマバリデーションエラーの詳細を表示） (#540)
+- 計画・レビュー用ファセットを強化: planner・requirements-reviewer・supervisor のペルソナ、plan・requirements-review・supervisor-validation の出力契約、coding ポリシーを新規追加
+- `takt add` コマンドで `--workflow` オプションによるワークフロー指定に対応
+
+### Changed
+
+- **BREAKING:** ワークフロー YAML のキーをリネーム: `movements` → `steps`、`initial_movement` → `initial_step`、`max_movements` → `max_steps`、`piece_config` → `workflow_config`。旧キーは互換エイリアスとして引き続き使用可能 (#576)
+- **BREAKING:** ビルトインワークフローのディレクトリを `builtins/{lang}/pieces/` から `builtins/{lang}/workflows/` に移動。設定キーも `piece_categories` → `workflow_categories`、`enable_builtin_pieces` → `enable_builtin_workflows` にリネーム。旧キーは互換エイリアスとして引き続き使用可能 (#571, #561)
+- **BREAKING:** CLI オプション `-w, --piece` を `-w, --workflow` にリネーム。`--piece` はレガシーエイリアスとして使用可能 (#576)
+- **BREAKING:** ワークフロー YAML の `instruction_template` フィールドを削除。`instruction` フィールドを使用すること (#539)
+- `takt-default` ワークフローの `max_steps` を 50 に増加（`default` は 30 のまま）
+- 設定キーのエイリアス解決時に旧キーと新キーの両方が異なる値で存在する場合はエラーを発生させるよう変更
+
+### Fixed
+
+- Claude SDK のエラーペイロードが正しく処理されない問題を修正
+- ワークフロー用語の統一: CLI ヘルプ、エラーメッセージ、ドキュメントを `workflow` / `step` 用語に更新
+- ワークツリーモードで PR の Issue 解決がプロジェクト cwd から正しく行われるよう修正
+- Cursor Agent のヘッドレスワークツリー実行で `--trust` フラグが渡されるよう修正
+- ワークツリー環境下で `runtime.prepare` が設定されている場合にセルフホスト GitLab の `glab` CLI 認証が失敗する問題を修正 (#563)
+- ピースプロバイダー解決の統一化
+
+### Internal
+
+- Zod スキーマを `schemas.ts` から `schema-base.ts`・`workflow-schemas.ts`・`config-schemas.ts` に分割
+- 環境変数オーバーライドを spec ベースの宣言的定義にリファクタリング
+- レガシーの `step_provider`・`step_model` フィールドを削除
+- TeamLeader のパートタイムアウト処理を簡素化
+- `yaml` パッケージを v2.8.3 に更新
+- ドキュメント（README、CLI リファレンス、設定ガイド等）をワークフロー用語に全面更新
+
 ## [0.33.2] - 2026-03-26
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,44 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.34.0] - 2026-04-03
+
+### Added
+
+- StructuredCaller インターフェースを導入: プロバイダーのネイティブ構造化出力（Structured Output）をサポートし、ステータス判定・条件評価・タスク分解でテキストパースに代わる JSON ベースの応答抽出が可能に (#570)
+- Traced Config を導入: `traced-config` パッケージによる設定値の出所追跡（環境変数・設定ファイル・デフォルト値）をサポート (#558)
+- 並列ステップに `concurrency` フィールドを追加: セマフォベースの同時実行数制御が可能に
+- 無効なワークフロー YAML のロード時に警告を表示するようになった（スキーマバリデーションエラーの詳細を表示） (#540)
+- 計画・レビュー用ファセットを強化: planner・requirements-reviewer・supervisor のペルソナ、plan・requirements-review・supervisor-validation の出力契約、coding ポリシーを新規追加
+- `takt add` コマンドで `--workflow` オプションによるワークフロー指定に対応
+
+### Changed
+
+- **BREAKING:** ワークフロー YAML のキーをリネーム: `movements` → `steps`、`initial_movement` → `initial_step`、`max_movements` → `max_steps`、`piece_config` → `workflow_config`。旧キーは互換エイリアスとして引き続き使用可能 (#576)
+- **BREAKING:** ビルトインワークフローのディレクトリを `builtins/{lang}/pieces/` から `builtins/{lang}/workflows/` に移動。設定キーも `piece_categories` → `workflow_categories`、`enable_builtin_pieces` → `enable_builtin_workflows` にリネーム。旧キーは互換エイリアスとして引き続き使用可能 (#571, #561)
+- **BREAKING:** CLI オプション `-w, --piece` を `-w, --workflow` にリネーム。`--piece` はレガシーエイリアスとして使用可能 (#576)
+- **BREAKING:** ワークフロー YAML の `instruction_template` フィールドを削除。`instruction` フィールドを使用すること (#539)
+- `takt-default` ワークフローの `max_steps` を 50 に増加（`default` は 30 のまま）
+- 設定キーのエイリアス解決時に旧キーと新キーの両方が異なる値で存在する場合はエラーを発生させるよう変更
+
+### Fixed
+
+- Claude SDK のエラーペイロードが正しく処理されない問題を修正
+- ワークフロー用語の統一: CLI ヘルプ、エラーメッセージ、ドキュメントを `workflow` / `step` 用語に更新
+- ワークツリーモードで PR の Issue 解決がプロジェクト cwd から正しく行われるよう修正
+- Cursor Agent のヘッドレスワークツリー実行で `--trust` フラグが渡されるよう修正
+- ワークツリー環境下で `runtime.prepare` が設定されている場合にセルフホスト GitLab の `glab` CLI 認証が失敗する問題を修正 (#563)
+- ピースプロバイダー解決の統一化
+
+### Internal
+
+- Zod スキーマを `schemas.ts` から `schema-base.ts`・`workflow-schemas.ts`・`config-schemas.ts` に分割
+- 環境変数オーバーライドを spec ベースの宣言的定義にリファクタリング
+- レガシーの `step_provider`・`step_model` フィールドを削除
+- TeamLeader のパートタイムアウト処理を簡素化
+- `yaml` パッケージを v2.8.3 に更新
+- ドキュメント（README、CLI リファレンス、設定ガイド等）をワークフロー用語に全面更新
+
 ## [0.33.2] - 2026-03-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.33.2",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.33.2",
+      "version": "0.34.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.71",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.33.2",
+  "version": "0.34.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- StructuredCaller インターフェースを導入: プロバイダーのネイティブ構造化出力（Structured Output）をサポートし、ステータス判定・条件評価・タスク分解でテキストパースに代わる JSON ベースの応答抽出が可能に (#570)
- Traced Config を導入: `traced-config` パッケージによる設定値の出所追跡（環境変数・設定ファイル・デフォルト値）をサポート (#558)
- 並列ステップに `concurrency` フィールドを追加: セマフォベースの同時実行数制御が可能に
- 無効なワークフロー YAML のロード時に警告を表示するようになった（スキーマバリデーションエラーの詳細を表示） (#540)
- 計画・レビュー用ファセットを強化: planner・requirements-reviewer・supervisor のペルソナ、plan・requirements-review・supervisor-validation の出力契約、coding ポリシーを新規追加
- `takt add` コマンドで `--workflow` オプションによるワークフロー指定に対応

### Changed

- **BREAKING:** ワークフロー YAML のキーをリネーム: `movements` → `steps`、`initial_movement` → `initial_step`、`max_movements` → `max_steps`、`piece_config` → `workflow_config`。旧キーは互換エイリアスとして引き続き使用可能 (#576)
- **BREAKING:** ビルトインワークフローのディレクトリを `builtins/{lang}/pieces/` から `builtins/{lang}/workflows/` に移動。設定キーも `piece_categories` → `workflow_categories`、`enable_builtin_pieces` → `enable_builtin_workflows` にリネーム。旧キーは互換エイリアスとして引き続き使用可能 (#571, #561)
- **BREAKING:** CLI オプション `-w, --piece` を `-w, --workflow` にリネーム。`--piece` はレガシーエイリアスとして使用可能 (#576)
- **BREAKING:** ワークフロー YAML の `instruction_template` フィールドを削除。`instruction` フィールドを使用すること (#539)
- `takt-default` ワークフローの `max_steps` を 50 に増加（`default` は 30 のまま）
- 設定キーのエイリアス解決時に旧キーと新キーの両方が異なる値で存在する場合はエラーを発生させるよう変更

### Fixed

- Claude SDK のエラーペイロードが正しく処理されない問題を修正
- ワークフロー用語の統一: CLI ヘルプ、エラーメッセージ、ドキュメントを `workflow` / `step` 用語に更新
- ワークツリーモードで PR の Issue 解決がプロジェクト cwd から正しく行われるよう修正
- Cursor Agent のヘッドレスワークツリー実行で `--trust` フラグが渡されるよう修正
- ワークツリー環境下で `runtime.prepare` が設定されている場合にセルフホスト GitLab の `glab` CLI 認証が失敗する問題を修正 (#563)
- ピースプロバイダー解決の統一化

### Internal

- Zod スキーマを `schemas.ts` から `schema-base.ts`・`workflow-schemas.ts`・`config-schemas.ts` に分割
- 環境変数オーバーライドを spec ベースの宣言的定義にリファクタリング
- レガシーの `step_provider`・`step_model` フィールドを削除
- TeamLeader のパートタイムアウト処理を簡素化
- `yaml` パッケージを v2.8.3 に更新
- ドキュメント（README、CLI リファレンス、設定ガイド等）をワークフロー用語に全面更新

## Commits

- 93d41b85 Release v0.34.0
- 1ea2e4bc takt: rename-piece-movement-keys (#576)
- 3b072320 fix: revert default max_steps, increase takt-default max_steps to 50
- 64a698f2 chore: increase default piece max_steps from 30 to 50
- 6abf5ebb Add manuscript review workflow and concurrency handling. (#573)
- 637cb278 refactor: remove legacy step provider fields
- 985b675a [#565] rename-builtin-workflows (#571)
- 7dc919df fix: simplify team leader part timeout handling
- 3552a8e7 docs: add resolution and phase-separation guidance
- 176ac3d0 fix: unify piece provider resolution
- 75a8d8e0 implement-structured-caller (#570)
- dc614adc fix: handle Claude SDK result error payloads
- b874cde9 test: log Claude rate limit stream events
- c6c2dcb1 fix: CQRS知識からSubscription Query・Subscribingプロセッサを排除し、PubSub+リアクティブポーリングパターンに更新
- 0365dfdf fix: resolve PR issues from project cwd in worktree mode
- 5d0c33b9 fix: pass --trust to cursor-agent for headless worktree execution
- 71fef186 fix: takt worktree環境下でruntime.prepareが設定されている、かつセルフホスト環境でglab CLI認証が失敗する問題の修正 (#563)
- 4ce7265b update-workflow-terms (#561)
- 1045a022 feat: strengthen planning and review facets
- 5410971c implement-traced-config (#558)
- e683729e feat: dual ピースにデザイン忠実再現の強化
- c7f30427 fix: update project dotgitignore facet paths
- 14118eab feat: 無効なピースYAMLの警告表示 (#540)
- 487bb442 docs: remove default_piece from configuration docs
- 0427214e Merge pull request #539 from nrslib/takt/490/remove-instruction-fallback
- f9b65b21 Merge pull request #554 from nrslib/release/v0.33.2
- a6ea5fe0 takt: remove-instruction-fallback