### PR TITLE
feat: スラッシュコマンドの補完メニューを実装

### DIFF
--- a/src/__tests__/completionMenu.test.ts
+++ b/src/__tests__/completionMenu.test.ts
@@ -3,28 +3,22 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import chalk from 'chalk';
 import {
   renderCompletionMenu,
   writeCompletionMenu,
   clearCompletionMenu,
+  type CompletionCandidate,
 } from '../features/interactive/completionMenu.js';
 import { stripAnsi, getDisplayWidth } from '../shared/utils/text.js';
 
-const ENGLISH_CANDIDATES: readonly {
-  readonly value: string;
-  readonly description?: string;
-  readonly applyValue?: string;
-}[] = [
+const ENGLISH_CANDIDATES: readonly CompletionCandidate[] = [
   { value: '/play', description: 'Run a task immediately', applyValue: '/play ' },
   { value: '/go', description: 'Create instruction & run', applyValue: '/go ' },
   { value: '/retry', description: 'Review & rerun with previous instructions', applyValue: '/retry ' },
 ];
 
-const JAPANESE_CANDIDATES: readonly {
-  readonly value: string;
-  readonly description?: string;
-  readonly applyValue?: string;
-}[] = [
+const JAPANESE_CANDIDATES: readonly CompletionCandidate[] = [
   { value: '/play', description: 'タスクを即実行する', applyValue: '/play ' },
 ];
 
@@ -99,6 +93,19 @@ describe('renderCompletionMenu', () => {
     for (const line of lines) {
       const width = getDisplayWidth(stripAnsi(line));
       expect(width).toBeLessThanOrEqual(termWidth);
+    }
+  });
+
+  it('should apply different styles for selected vs unselected candidates', () => {
+    const prevLevel = chalk.level;
+    chalk.level = 1;
+    try {
+      const lines0 = renderCompletionMenu(ENGLISH_CANDIDATES, 0, 80);
+      const lines1 = renderCompletionMenu(ENGLISH_CANDIDATES, 1, 80);
+      expect(lines0[1]).not.toBe(lines1[1]);
+      expect(lines0[2]).not.toBe(lines1[2]);
+    } finally {
+      chalk.level = prevLevel;
     }
   });
 });

--- a/src/__tests__/completionMenu.test.ts
+++ b/src/__tests__/completionMenu.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for completion menu rendering and terminal output
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  renderCompletionMenu,
+  writeCompletionMenu,
+  clearCompletionMenu,
+} from '../features/interactive/completionMenu.js';
+import { stripAnsi } from '../shared/utils/text.js';
+
+const ENGLISH_CANDIDATES: readonly {
+  readonly value: string;
+  readonly description?: string;
+  readonly applyValue?: string;
+}[] = [
+  { value: '/play', description: 'Run a task immediately', applyValue: '/play ' },
+  { value: '/go', description: 'Create instruction & run', applyValue: '/go ' },
+  { value: '/retry', description: 'Review & rerun with previous instructions', applyValue: '/retry ' },
+];
+
+const JAPANESE_CANDIDATES: readonly {
+  readonly value: string;
+  readonly description?: string;
+  readonly applyValue?: string;
+}[] = [
+  { value: '/play', description: 'タスクを即実行する', applyValue: '/play ' },
+];
+
+describe('renderCompletionMenu', () => {
+  it('should return separator + one line per candidate', () => {
+    const lines = renderCompletionMenu(ENGLISH_CANDIDATES, 0, 80);
+    expect(lines.length).toBe(ENGLISH_CANDIDATES.length + 1);
+  });
+
+  it('should include command name in each line', () => {
+    const lines = renderCompletionMenu(ENGLISH_CANDIDATES, 0, 80);
+    const stripped = lines.map(stripAnsi);
+    expect(stripped[1]).toContain('/play');
+    expect(stripped[2]).toContain('/go');
+  });
+
+  it('should include description in each line', () => {
+    const lines = renderCompletionMenu([ENGLISH_CANDIDATES[0]!], 0, 80);
+    const stripped = lines.map(stripAnsi);
+    expect(stripped[1]).toContain('Run a task immediately');
+  });
+
+  it('should include Japanese description when provided', () => {
+    const lines = renderCompletionMenu(JAPANESE_CANDIDATES, 0, 80);
+    const stripped = lines.map(stripAnsi);
+    expect(stripped[1]).toContain('タスクを即実行する');
+  });
+
+  it('should render separator as first line', () => {
+    const lines = renderCompletionMenu(ENGLISH_CANDIDATES, 0, 80);
+    const stripped = stripAnsi(lines[0]!);
+    expect(stripped).toMatch(/^─+$/);
+    expect(stripped.length).toBe(80);
+  });
+
+  it('should handle empty candidates', () => {
+    const lines = renderCompletionMenu([], 0, 80);
+    expect(lines.length).toBe(1);
+  });
+
+  it('should handle narrow terminal width', () => {
+    const lines = renderCompletionMenu([ENGLISH_CANDIDATES[0]!], 0, 30);
+    expect(lines.length).toBe(2);
+  });
+
+  it('should always include all candidate commands regardless of selectedIndex', () => {
+    const lines0 = renderCompletionMenu(ENGLISH_CANDIDATES, 0, 80).map(stripAnsi);
+    const lines2 = renderCompletionMenu(ENGLISH_CANDIDATES, 2, 80).map(stripAnsi);
+    expect(lines0[1]).toContain('/play');
+    expect(lines2[1]).toContain('/play');
+    expect(lines0[3]).toContain('/retry');
+    expect(lines2[3]).toContain('/retry');
+  });
+
+  it('should omit description when terminal width is very narrow', () => {
+    const lines = renderCompletionMenu([ENGLISH_CANDIDATES[0]!], 0, 26);
+    const stripped = stripAnsi(lines[1]!);
+    expect(stripped).toContain('/play');
+    expect(stripped).not.toContain('Run a task');
+  });
+});
+
+// --- writeCompletionMenu / clearCompletionMenu terminal output tests ---
+
+describe('writeCompletionMenu', () => {
+  let savedWrite: typeof process.stdout.write;
+  let writtenData: string[];
+
+  beforeEach(() => {
+    savedWrite = process.stdout.write;
+    writtenData = [];
+    process.stdout.write = vi.fn((data: string | Uint8Array) => {
+      writtenData.push(typeof data === 'string' ? data : data.toString());
+      return true;
+    }) as unknown as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = savedWrite;
+  });
+
+  it('should write menu lines to stdout', () => {
+    const lines = ['separator', 'item1', 'item2'];
+    writeCompletionMenu(lines, 0);
+    const output = writtenData.join('');
+    expect(output).toContain('separator\nitem1\nitem2');
+  });
+
+  it('should move cursor down when rowsBelowCursor > 0', () => {
+    writeCompletionMenu(['line'], 3);
+    expect(writtenData[0]).toBe('\x1B[3B');
+  });
+
+  it('should erase below and restore cursor position', () => {
+    writeCompletionMenu(['line'], 0);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[J');
+    expect(output).toContain('\x1B[1A');
+  });
+
+  it('should restore cursor by total lines when multiple lines written', () => {
+    writeCompletionMenu(['sep', 'item1', 'item2', 'item3'], 0);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[4A');
+  });
+
+  it('should restore cursor by lines + rowsBelowCursor combined', () => {
+    writeCompletionMenu(['sep', 'item1', 'item2'], 2);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[2B');
+    expect(output).toContain('\x1B[5A');
+  });
+});
+
+describe('clearCompletionMenu', () => {
+  let savedWrite: typeof process.stdout.write;
+  let writtenData: string[];
+
+  beforeEach(() => {
+    savedWrite = process.stdout.write;
+    writtenData = [];
+    process.stdout.write = vi.fn((data: string | Uint8Array) => {
+      writtenData.push(typeof data === 'string' ? data : data.toString());
+      return true;
+    }) as unknown as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = savedWrite;
+  });
+
+  it('should erase below cursor', () => {
+    clearCompletionMenu(0);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[J');
+  });
+
+  it('should move cursor down when rowsBelowCursor > 0', () => {
+    clearCompletionMenu(2);
+    expect(writtenData[0]).toBe('\x1B[2B');
+  });
+
+  it('should restore cursor after clearing', () => {
+    clearCompletionMenu(0);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[1A');
+  });
+
+  it('should move up by rowsBelowCursor + 1 when clearing', () => {
+    clearCompletionMenu(2);
+    const output = writtenData.join('');
+    expect(output).toContain('\x1B[3A');
+  });
+});

--- a/src/__tests__/completionMenu.test.ts
+++ b/src/__tests__/completionMenu.test.ts
@@ -8,7 +8,7 @@ import {
   writeCompletionMenu,
   clearCompletionMenu,
 } from '../features/interactive/completionMenu.js';
-import { stripAnsi } from '../shared/utils/text.js';
+import { stripAnsi, getDisplayWidth } from '../shared/utils/text.js';
 
 const ENGLISH_CANDIDATES: readonly {
   readonly value: string;
@@ -80,10 +80,26 @@ describe('renderCompletionMenu', () => {
   });
 
   it('should omit description when terminal width is very narrow', () => {
-    const lines = renderCompletionMenu([ENGLISH_CANDIDATES[0]!], 0, 26);
+    const lines = renderCompletionMenu([ENGLISH_CANDIDATES[0]!], 0, 14);
     const stripped = stripAnsi(lines[1]!);
     expect(stripped).toContain('/play');
     expect(stripped).not.toContain('Run a task');
+  });
+
+  it.each([20, 26, 30, 40])('should not exceed termWidth=%i for English candidates', (termWidth) => {
+    const lines = renderCompletionMenu(ENGLISH_CANDIDATES, 0, termWidth);
+    for (const line of lines) {
+      const width = getDisplayWidth(stripAnsi(line));
+      expect(width).toBeLessThanOrEqual(termWidth);
+    }
+  });
+
+  it.each([20, 26, 30, 40])('should not exceed termWidth=%i for Japanese candidates', (termWidth) => {
+    const lines = renderCompletionMenu(JAPANESE_CANDIDATES, 0, termWidth);
+    for (const line of lines) {
+      const width = getDisplayWidth(stripAnsi(line));
+      expect(width).toBeLessThanOrEqual(termWidth);
+    }
   });
 });
 

--- a/src/__tests__/conversationLoop-resume.test.ts
+++ b/src/__tests__/conversationLoop-resume.test.ts
@@ -255,6 +255,40 @@ describe('/resume command', () => {
     expect(mockLogInfo).toHaveBeenCalledWith('/retry is not available in this mode.');
     expect(result.action).toBe('cancel');
   });
+
+  it('should complete /r to /resume when retry and replay are unavailable', async () => {
+    // Given: /r → Tab → Enter completes to /resume, then /cancel exits
+    setupRawStdin(toRawInputs(['/r\t', '/cancel']));
+    setupProvider([]);
+
+    const ctx = createSessionContext();
+
+    // When
+    const result = await runConversationLoop('/test', ctx, defaultStrategy, undefined, undefined);
+
+    // Then
+    expect(mockSelectRecentSession).toHaveBeenCalledWith('/test', 'en');
+    expect(result.action).toBe('cancel');
+  });
+
+  it('should complete /r to /retry when retry is available', async () => {
+    // Given: /r → Tab → Enter completes to /retry, then /cancel exits
+    setupRawStdin(toRawInputs(['/r\t', '/cancel']));
+    setupProvider([]);
+
+    const ctx = createSessionContext();
+
+    // When
+    const result = await runConversationLoop('/test', ctx, {
+      ...defaultStrategy,
+      enableRetryCommand: true,
+    }, undefined, undefined);
+
+    // Then
+    expect(mockLogInfo).toHaveBeenCalledWith('No previous order found.');
+    expect(mockSelectRecentSession).not.toHaveBeenCalled();
+    expect(result.action).toBe('cancel');
+  });
 });
 
 // =================================================================

--- a/src/__tests__/interactiveInput.test.ts
+++ b/src/__tests__/interactiveInput.test.ts
@@ -56,6 +56,60 @@ describe('interactiveInput', () => {
 
       expect(provider({ buffer: '/go\nnote' })).toEqual([]);
     });
+
+    it('should exclude /retry when enableRetryCommand is falsy', () => {
+      const provider = createSlashCommandCompletionProvider('en', { enableRetryCommand: false, hasPreviousOrder: true });
+      const values = provider({ buffer: '/' }).map((c) => c.value);
+
+      expect(values).not.toContain('/retry');
+      expect(values).toContain('/replay');
+    });
+
+    it('should include /retry when enableRetryCommand is true', () => {
+      const provider = createSlashCommandCompletionProvider('en', { enableRetryCommand: true, hasPreviousOrder: true });
+      const values = provider({ buffer: '/' }).map((c) => c.value);
+
+      expect(values).toContain('/retry');
+    });
+
+    it('should exclude /replay when hasPreviousOrder is falsy', () => {
+      const provider = createSlashCommandCompletionProvider('en', { enableRetryCommand: true, hasPreviousOrder: false });
+      const values = provider({ buffer: '/' }).map((c) => c.value);
+
+      expect(values).not.toContain('/replay');
+      expect(values).toContain('/retry');
+    });
+
+    it('should include /replay when hasPreviousOrder is true', () => {
+      const provider = createSlashCommandCompletionProvider('en', { hasPreviousOrder: true });
+      const values = provider({ buffer: '/' }).map((c) => c.value);
+
+      expect(values).toContain('/replay');
+    });
+
+    it('should exclude /retry and /replay when availability is explicitly set without them', () => {
+      const provider = createSlashCommandCompletionProvider('en', {});
+      const values = provider({ buffer: '/' }).map((c) => c.value);
+
+      expect(values).not.toContain('/retry');
+      expect(values).not.toContain('/replay');
+    });
+
+    it('should support suffix slash command form "text /go"', () => {
+      const provider = createSlashCommandCompletionProvider('en');
+      const results = provider({ buffer: 'fix the bug /g' });
+
+      expect(results.length).toBe(1);
+      expect(results[0]!.value).toBe('fix the bug /go');
+      expect(results[0]!.applyValue).toBe('fix the bug /go ');
+    });
+
+    it('should return empty for slash in middle of text', () => {
+      const provider = createSlashCommandCompletionProvider('en');
+      const results = provider({ buffer: 'fix /go more text' });
+
+      expect(results).toEqual([]);
+    });
   });
 
   describe('readInteractiveInput', () => {

--- a/src/__tests__/interactiveInput.test.ts
+++ b/src/__tests__/interactiveInput.test.ts
@@ -48,18 +48,18 @@ describe('interactiveInput', () => {
     it('should return empty candidates for non-slash input', () => {
       const provider = createSlashCommandCompletionProvider('en');
 
-      expect(provider({ buffer: 'hello' })).toEqual([]);
+      expect(provider({ buffer: 'hello', cursorPos: 5 })).toEqual([]);
     });
 
     it('should return empty candidates for multiline input', () => {
       const provider = createSlashCommandCompletionProvider('en');
 
-      expect(provider({ buffer: '/go\nnote' })).toEqual([]);
+      expect(provider({ buffer: '/go\nnote', cursorPos: 3 })).toEqual([]);
     });
 
     it('should exclude /retry when enableRetryCommand is falsy', () => {
       const provider = createSlashCommandCompletionProvider('en', { enableRetryCommand: false, hasPreviousOrder: true });
-      const values = provider({ buffer: '/' }).map((c) => c.value);
+      const values = provider({ buffer: '/', cursorPos: 1 }).map((c) => c.value);
 
       expect(values).not.toContain('/retry');
       expect(values).toContain('/replay');
@@ -67,14 +67,14 @@ describe('interactiveInput', () => {
 
     it('should include /retry when enableRetryCommand is true', () => {
       const provider = createSlashCommandCompletionProvider('en', { enableRetryCommand: true, hasPreviousOrder: true });
-      const values = provider({ buffer: '/' }).map((c) => c.value);
+      const values = provider({ buffer: '/', cursorPos: 1 }).map((c) => c.value);
 
       expect(values).toContain('/retry');
     });
 
     it('should exclude /replay when hasPreviousOrder is falsy', () => {
       const provider = createSlashCommandCompletionProvider('en', { enableRetryCommand: true, hasPreviousOrder: false });
-      const values = provider({ buffer: '/' }).map((c) => c.value);
+      const values = provider({ buffer: '/', cursorPos: 1 }).map((c) => c.value);
 
       expect(values).not.toContain('/replay');
       expect(values).toContain('/retry');
@@ -82,14 +82,14 @@ describe('interactiveInput', () => {
 
     it('should include /replay when hasPreviousOrder is true', () => {
       const provider = createSlashCommandCompletionProvider('en', { hasPreviousOrder: true });
-      const values = provider({ buffer: '/' }).map((c) => c.value);
+      const values = provider({ buffer: '/', cursorPos: 1 }).map((c) => c.value);
 
       expect(values).toContain('/replay');
     });
 
     it('should exclude /retry and /replay when availability is explicitly set without them', () => {
       const provider = createSlashCommandCompletionProvider('en', {});
-      const values = provider({ buffer: '/' }).map((c) => c.value);
+      const values = provider({ buffer: '/', cursorPos: 1 }).map((c) => c.value);
 
       expect(values).not.toContain('/retry');
       expect(values).not.toContain('/replay');
@@ -97,16 +97,36 @@ describe('interactiveInput', () => {
 
     it('should support suffix slash command form "text /go"', () => {
       const provider = createSlashCommandCompletionProvider('en');
-      const results = provider({ buffer: 'fix the bug /g' });
+      const results = provider({ buffer: 'fix the bug /g', cursorPos: 14 });
 
       expect(results.length).toBe(1);
       expect(results[0]!.value).toBe('fix the bug /go');
       expect(results[0]!.applyValue).toBe('fix the bug /go ');
     });
 
+    it('should return empty when cursor is outside the slash token', () => {
+      const provider = createSlashCommandCompletionProvider('en');
+      const results = provider({ buffer: 'fix the bug /g', cursorPos: 0 });
+
+      expect(results).toEqual([]);
+    });
+
+    it('should preserve trailing text when completing an in-place slash token', () => {
+      const provider = createSlashCommandCompletionProvider('en');
+      const results = provider({ buffer: 'fix /g later', cursorPos: 6 });
+
+      expect(results).toEqual([
+        {
+          value: 'fix /go later',
+          applyValue: 'fix /go later',
+          description: 'Create instruction & run',
+        },
+      ]);
+    });
+
     it('should return empty for slash in middle of text', () => {
       const provider = createSlashCommandCompletionProvider('en');
-      const results = provider({ buffer: 'fix /go more text' });
+      const results = provider({ buffer: 'fix /go more text', cursorPos: 17 });
 
       expect(results).toEqual([]);
     });
@@ -124,7 +144,7 @@ describe('interactiveInput', () => {
       const [prompt, options] = mockReadMultilineInput.mock.calls[0]!;
       expect(prompt).toBe('> ');
       expect(options?.completionProvider).toBeTypeOf('function');
-      expect(options?.completionProvider?.({ buffer: '/g' })).toEqual([
+      expect(options?.completionProvider?.({ buffer: '/g', cursorPos: 2 })).toEqual([
         {
           value: '/go',
           applyValue: '/go ',

--- a/src/__tests__/interactiveInput.test.ts
+++ b/src/__tests__/interactiveInput.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../features/interactive/lineEditor.js', () => ({
+  readMultilineInput: vi.fn(),
+}));
+
+import { readMultilineInput } from '../features/interactive/lineEditor.js';
+import {
+  createSlashCommandCompletionProvider,
+  getSlashCommandCompletions,
+  readInteractiveInput,
+} from '../features/interactive/interactiveInput.js';
+
+const mockReadMultilineInput = vi.mocked(readMultilineInput);
+
+describe('interactiveInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getSlashCommandCompletions', () => {
+    it('should return localized English descriptions with apply values', () => {
+      const result = getSlashCommandCompletions('/play', 'en');
+
+      expect(result).toEqual([
+        {
+          value: '/play',
+          applyValue: '/play ',
+          description: 'Run a task immediately',
+        },
+      ]);
+    });
+
+    it('should return localized Japanese descriptions', () => {
+      const result = getSlashCommandCompletions('/play', 'ja');
+
+      expect(result).toEqual([
+        {
+          value: '/play',
+          applyValue: '/play ',
+          description: 'タスクを即実行する',
+        },
+      ]);
+    });
+  });
+
+  describe('createSlashCommandCompletionProvider', () => {
+    it('should return empty candidates for non-slash input', () => {
+      const provider = createSlashCommandCompletionProvider('en');
+
+      expect(provider({ buffer: 'hello' })).toEqual([]);
+    });
+
+    it('should return empty candidates for multiline input', () => {
+      const provider = createSlashCommandCompletionProvider('en');
+
+      expect(provider({ buffer: '/go\nnote' })).toEqual([]);
+    });
+  });
+
+  describe('readInteractiveInput', () => {
+    it('should delegate to readMultilineInput with a slash command completion provider', async () => {
+      mockReadMultilineInput.mockResolvedValue('/go');
+
+      const result = await readInteractiveInput('> ', 'en');
+
+      expect(result).toBe('/go');
+      expect(mockReadMultilineInput).toHaveBeenCalledOnce();
+
+      const [prompt, options] = mockReadMultilineInput.mock.calls[0]!;
+      expect(prompt).toBe('> ');
+      expect(options?.completionProvider).toBeTypeOf('function');
+      expect(options?.completionProvider?.({ buffer: '/g' })).toEqual([
+        {
+          value: '/go',
+          applyValue: '/go ',
+          description: 'Create instruction & run',
+        },
+      ]);
+    });
+  });
+});

--- a/src/__tests__/lineEditor.test.ts
+++ b/src/__tests__/lineEditor.test.ts
@@ -20,9 +20,33 @@ function createCallbacks(): InputCallbacks & { calls: string[] } {
     onWordRight() { calls.push('wordRight'); },
     onHome() { calls.push('home'); },
     onEnd() { calls.push('end'); },
+    onEsc() { calls.push('esc'); },
     onChar(ch: string) { calls.push(`char:${ch}`); },
   };
 }
+
+const TEST_COMPLETION_VALUES = ['/play', '/go', '/retry', '/replay', '/cancel', '/resume'] as const;
+
+const testCompletionProvider = (
+  { buffer }: { buffer: string },
+): readonly {
+  readonly value: string;
+  readonly description?: string;
+  readonly applyValue?: string;
+}[] => {
+  if (!buffer.startsWith('/') || buffer.includes('\n')) {
+    return [];
+  }
+
+  const lower = buffer.toLowerCase();
+  return TEST_COMPLETION_VALUES
+    .filter((value) => value.startsWith(lower))
+    .map((value) => ({
+      value,
+      applyValue: `${value} `,
+      description: `Description for ${value}`,
+    }));
+};
 
 describe('parseInputData', () => {
   describe('arrow key detection', () => {
@@ -118,6 +142,26 @@ describe('parseInputData', () => {
       expect(cb.calls).toEqual(['wordLeft', 'wordRight']);
       expect(cb.calls).not.toContain('char:b');
       expect(cb.calls).not.toContain('char:f');
+    });
+  });
+
+  describe('bare Esc key detection', () => {
+    it('should fire onEsc for bare Esc', () => {
+      // Given
+      const cb = createCallbacks();
+      // When
+      parseInputData('\x1B', cb);
+      // Then
+      expect(cb.calls).toEqual(['esc']);
+    });
+
+    it('should fire onEsc then onChar for Esc followed by non-sequence char', () => {
+      // Given
+      const cb = createCallbacks();
+      // When
+      parseInputData('\x1Bx', cb);
+      // Then
+      expect(cb.calls).toEqual(['esc', 'char:x']);
     });
   });
 
@@ -241,9 +285,20 @@ describe('readMultilineInput cursor navigation', () => {
   });
 
   // We need to dynamically import after mocking stdin
-  async function callReadMultilineInput(prompt: string): Promise<string | null> {
+  async function callReadMultilineInput(
+    prompt: string,
+    options?: {
+      completionProvider?: (
+        context: { buffer: string },
+      ) => readonly {
+        readonly value: string;
+        readonly description?: string;
+        readonly applyValue?: string;
+      }[];
+    },
+  ): Promise<string | null> {
     const { readMultilineInput } = await import('../features/interactive/lineEditor.js');
-    return readMultilineInput(prompt);
+    return readMultilineInput(prompt, options);
   }
 
   describe('left arrow line wrap', () => {
@@ -1057,6 +1112,166 @@ describe('readMultilineInput cursor navigation', () => {
 
       // Then
       expect(result).toBe('abc\ndef');
+    });
+  });
+
+  describe('onEsc callback', () => {
+    it('should emit onEsc for bare escape key', () => {
+      const cb = createCallbacks();
+      parseInputData('\x1B', cb);
+      expect(cb.calls).toEqual(['esc']);
+    });
+
+    it('should not emit onEsc for recognized escape sequences', () => {
+      const cb = createCallbacks();
+      parseInputData('\x1B[A', cb);
+      expect(cb.calls).toEqual(['up']);
+      expect(cb.calls).not.toContain('esc');
+    });
+
+    it('should emit onEsc followed by char for escape then regular character', () => {
+      const cb = createCallbacks();
+      parseInputData('\x1Ba\x1B[A', cb);
+      expect(cb.calls).toContain('esc');
+      expect(cb.calls).toContain('char:a');
+      expect(cb.calls).toContain('up');
+    });
+
+    it('should emit onEsc for Kitty keyboard protocol ESC sequence with modifier', () => {
+      const cb = createCallbacks();
+      parseInputData('\x1B[27;1u', cb);
+      expect(cb.calls).toEqual(['esc']);
+    });
+
+    it('should emit onEsc for Kitty keyboard protocol ESC sequence without modifier', () => {
+      const cb = createCallbacks();
+      parseInputData('\x1B[27u', cb);
+      expect(cb.calls).toEqual(['esc']);
+    });
+  });
+
+  describe('completion menu integration', () => {
+    it('should not enable completion by default', async () => {
+      // Given: "/" → Enter with no completion provider
+      setupRawStdin(['/\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ');
+
+      // Then
+      expect(result).toBe('/');
+    });
+
+    it('should submit selected command on Enter when menu is visible', async () => {
+      // Given: type "/" then Enter → default selectedIndex=0 is /play
+      setupRawStdin(['/\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('/play');
+    });
+
+    it('should submit command selected by arrow down on Enter', async () => {
+      // Given: "/" → ArrowDown (select /go, index=1) → Enter
+      setupRawStdin(['/\x1B[B\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('/go');
+    });
+
+    it('should apply completion on Tab and allow further editing', async () => {
+      // Given: "/g" → Tab (applies "/go ") → Enter
+      setupRawStdin(['/g\t\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('/go ');
+    });
+
+    it('should dismiss completion on Esc and keep buffer unchanged', async () => {
+      // Given: "/ca" → Esc (dismiss menu) → Enter
+      setupRawStdin(['/ca\x1B\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('/ca');
+    });
+
+    it('should not trigger completion for regular text', async () => {
+      // Given: "hello" → Enter (no "/" prefix, no completion)
+      setupRawStdin(['hello\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('hello');
+    });
+
+    it('should wrap selection on ArrowUp from first item', async () => {
+      // Given: "/" → ArrowUp (wrap to last item, /resume index=5) → Enter
+      setupRawStdin(['/\x1B[A\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('/resume');
+    });
+
+    it('should not show completion menu for multiline buffer starting with /', async () => {
+      // Given: "/" → Shift+Enter (newline) → "test" → Enter
+      // shouldShowCompletion() returns false when buffer includes \n
+      setupRawStdin(['/\x1B[13;2utest\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('/\ntest');
+    });
+
+    it('should apply Tab completion then allow backspace to delete', async () => {
+      // Given: "/g" → Tab (applies "/go ") → Backspace (delete space) → Enter
+      setupRawStdin(['/g\t\x7F\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('/go');
+    });
+
+    it('should wrap selection on ArrowDown from last item', async () => {
+      // Given: "/" → ArrowDown x6 (6 commands, wraps back to /play index=0) → Enter
+      setupRawStdin(['/\x1B[B\x1B[B\x1B[B\x1B[B\x1B[B\x1B[B\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('/play');
+    });
+
+    it('should clamp selectedIndex when candidates shrink', async () => {
+      // Given: "/re" → ArrowDown x2 (select /resume, index=2) → type "s" ("/res" → 1 candidate) → Enter
+      // selectedIndex is clamped to 0
+      setupRawStdin(['/re\x1B[B\x1B[Bs\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then
+      expect(result).toBe('/resume');
     });
   });
 });

--- a/src/__tests__/lineEditor.test.ts
+++ b/src/__tests__/lineEditor.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { parseInputData, type InputCallbacks } from '../features/interactive/lineEditor.js';
+import { parseInputData, createEscapeParser, type InputCallbacks } from '../features/interactive/lineEditor.js';
 
 function createCallbacks(): InputCallbacks & { calls: string[] } {
   const calls: string[] = [];
@@ -1272,6 +1272,70 @@ describe('readMultilineInput cursor navigation', () => {
 
       // Then
       expect(result).toBe('/resume');
+    });
+
+    it('should hide completion on Shift+Enter and return multiline buffer', async () => {
+      // Given: "/" → Shift+Enter → Enter
+      setupRawStdin(['/\x1B[13;2u\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then — buffer should contain newline, not a selected command
+      expect(result).toBe('/\n');
+    });
+
+    it('should hide completion on paste start', async () => {
+      // Given: "/" → paste bracket start → "test" → paste bracket end → Enter
+      setupRawStdin(['/\x1B[200~test\x1B[201~\r']);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: testCompletionProvider });
+
+      // Then — paste content appended, no command selection on Enter
+      expect(result).toBe('/test');
+    });
+  });
+
+  describe('createEscapeParser', () => {
+    it('should resolve split escape sequence across chunks', () => {
+      const cb = createCallbacks();
+      const parser = createEscapeParser(cb);
+
+      parser.feed('\x1B');
+      parser.feed('[A');
+
+      expect(cb.calls).toEqual(['up']);
+    });
+
+    it('should emit onEsc for bare Esc on flush', () => {
+      const cb = createCallbacks();
+      const parser = createEscapeParser(cb);
+
+      parser.feed('\x1B');
+      parser.flush();
+
+      expect(cb.calls).toEqual(['esc']);
+    });
+
+    it('should emit onEsc for bare Esc after timeout', async () => {
+      const cb = createCallbacks();
+      const parser = createEscapeParser(cb);
+
+      parser.feed('\x1B');
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(cb.calls).toEqual(['esc']);
+    });
+
+    it('should handle normal characters without pending state', () => {
+      const cb = createCallbacks();
+      const parser = createEscapeParser(cb);
+
+      parser.feed('abc');
+
+      expect(cb.calls).toEqual(['char:a', 'char:b', 'char:c']);
     });
   });
 });

--- a/src/__tests__/lineEditor.test.ts
+++ b/src/__tests__/lineEditor.test.ts
@@ -1251,6 +1251,33 @@ describe('readMultilineInput cursor navigation', () => {
       expect(result).toBe('/go');
     });
 
+    it('should repaint wrapped suffix completion from the prompt row on Tab', async () => {
+      // Given: narrow terminal width wraps "note /g" before Tab applies "note /go "
+      const suffixCompletionProvider = ({ buffer }: { buffer: string }) =>
+        buffer === 'note /g'
+          ? [{
+              value: 'note /go',
+              applyValue: 'note /go ',
+              description: 'Description for /go',
+            }]
+          : [];
+      setupRawStdin(['note /g\t\r'], 8);
+
+      // When
+      const result = await callReadMultilineInput('> ', { completionProvider: suffixCompletionProvider });
+
+      // Then
+      expect(result).toBe('note /go ');
+      const appliedBufferIndex = stdoutCalls.lastIndexOf('note /go ');
+      expect(appliedBufferIndex).toBeGreaterThan(3);
+      expect(stdoutCalls.slice(appliedBufferIndex - 4, appliedBufferIndex)).toEqual([
+        '\r\n',
+        '\x1B[J',
+        expect.stringMatching(/^\x1B\[\d+A$/),
+        '\x1B[3G',
+      ]);
+    });
+
     it('should wrap selection on ArrowDown from last item', async () => {
       // Given: "/" → ArrowDown x6 (6 commands, wraps back to /play index=0) → Enter
       setupRawStdin(['/\x1B[B\x1B[B\x1B[B\x1B[B\x1B[B\x1B[B\r']);

--- a/src/__tests__/lineEditor.test.ts
+++ b/src/__tests__/lineEditor.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parseInputData, createEscapeParser, type InputCallbacks } from '../features/interactive/lineEditor.js';
-import type { CompletionCandidate } from '../features/interactive/completionMenu.js';
+import type { CompletionCandidate, CompletionProvider } from '../features/interactive/completionMenu.js';
 
 function createCallbacks(): InputCallbacks & { calls: string[] } {
   const calls: string[] = [];
@@ -29,7 +29,7 @@ function createCallbacks(): InputCallbacks & { calls: string[] } {
 const TEST_COMPLETION_VALUES = ['/play', '/go', '/retry', '/replay', '/cancel', '/resume'] as const;
 
 const testCompletionProvider = (
-  { buffer }: { buffer: string },
+  { buffer }: Parameters<CompletionProvider>[0],
 ): readonly CompletionCandidate[] => {
   if (!buffer.startsWith('/') || buffer.includes('\n')) {
     return [];
@@ -294,9 +294,7 @@ describe('readMultilineInput cursor navigation', () => {
   async function callReadMultilineInput(
     prompt: string,
     options?: {
-      completionProvider?: (
-        context: { buffer: string },
-      ) => readonly CompletionCandidate[];
+      completionProvider?: CompletionProvider;
     },
   ): Promise<string | null> {
     const { readMultilineInput } = await import('../features/interactive/lineEditor.js');
@@ -1173,6 +1171,7 @@ describe('readMultilineInput cursor navigation', () => {
 
       // Then
       expect(result).toBe('/play');
+      expect(stdoutCalls).toContain('/play');
     });
 
     it('should submit command selected by arrow down on Enter', async () => {
@@ -1255,8 +1254,8 @@ describe('readMultilineInput cursor navigation', () => {
 
     it('should repaint wrapped suffix completion from the prompt row on Tab', async () => {
       // Given: narrow terminal width wraps "note /g" before Tab applies "note /go "
-      const suffixCompletionProvider = ({ buffer }: { buffer: string }) =>
-        buffer === 'note /g'
+      const suffixCompletionProvider: CompletionProvider = ({ buffer, cursorPos }) =>
+        buffer === 'note /g' && cursorPos === buffer.length
           ? [{
               value: 'note /go',
               applyValue: 'note /go ',
@@ -1278,6 +1277,63 @@ describe('readMultilineInput cursor navigation', () => {
         expect.stringMatching(/^\x1B\[\d+A$/),
         '\x1B[3G',
       ]);
+    });
+
+    it('should not submit a stale completion after moving to Home', async () => {
+      const suffixCompletionProvider: CompletionProvider = ({ buffer, cursorPos }) =>
+        buffer === 'note /g' && cursorPos === buffer.length
+          ? [{
+              value: 'note /go',
+              applyValue: 'note /go ',
+              description: 'Description for /go',
+            }]
+          : [];
+      setupRawStdin(['note /g\x1B[H\r']);
+
+      const result = await callReadMultilineInput('> ', { completionProvider: suffixCompletionProvider });
+
+      expect(result).toBe('note /g');
+      expect(stdoutCalls).not.toContain('note /go');
+    });
+
+    it('should repaint wrapped suffix completion from the prompt row on Enter', async () => {
+      const suffixCompletionProvider: CompletionProvider = ({ buffer, cursorPos }) =>
+        buffer === 'note /g' && cursorPos === buffer.length
+          ? [{
+              value: 'note /go',
+              applyValue: 'note /go ',
+              description: 'Description for /go',
+            }]
+          : [];
+      setupRawStdin(['note /g\r'], 8);
+
+      const result = await callReadMultilineInput('> ', { completionProvider: suffixCompletionProvider });
+
+      expect(result).toBe('note /go');
+      const acceptedBufferIndex = stdoutCalls.lastIndexOf('note /go');
+      expect(acceptedBufferIndex).toBeGreaterThan(3);
+      expect(stdoutCalls.slice(acceptedBufferIndex - 4, acceptedBufferIndex)).toEqual([
+        '\r\n',
+        '\x1B[J',
+        expect.stringMatching(/^\x1B\[\d+A$/),
+        '\x1B[3G',
+      ]);
+    });
+
+    it('should restore completion after moving Home and back to End', async () => {
+      const suffixCompletionProvider: CompletionProvider = ({ buffer, cursorPos }) =>
+        buffer === 'note /g' && cursorPos === buffer.length
+          ? [{
+              value: 'note /go',
+              applyValue: 'note /go ',
+              description: 'Description for /go',
+            }]
+          : [];
+      setupRawStdin(['note /g\x1B[H\x1B[F\r']);
+
+      const result = await callReadMultilineInput('> ', { completionProvider: suffixCompletionProvider });
+
+      expect(result).toBe('note /go');
     });
 
     it('should wrap selection on ArrowDown from last item', async () => {

--- a/src/__tests__/lineEditor.test.ts
+++ b/src/__tests__/lineEditor.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parseInputData, createEscapeParser, type InputCallbacks } from '../features/interactive/lineEditor.js';
+import type { CompletionCandidate } from '../features/interactive/completionMenu.js';
 
 function createCallbacks(): InputCallbacks & { calls: string[] } {
   const calls: string[] = [];
@@ -29,11 +30,7 @@ const TEST_COMPLETION_VALUES = ['/play', '/go', '/retry', '/replay', '/cancel', 
 
 const testCompletionProvider = (
   { buffer }: { buffer: string },
-): readonly {
-  readonly value: string;
-  readonly description?: string;
-  readonly applyValue?: string;
-}[] => {
+): readonly CompletionCandidate[] => {
   if (!buffer.startsWith('/') || buffer.includes('\n')) {
     return [];
   }
@@ -163,6 +160,15 @@ describe('parseInputData', () => {
       // Then
       expect(cb.calls).toEqual(['esc', 'char:x']);
     });
+
+    it('should fire onEsc then char:[ for incomplete CSI at end of input', () => {
+      // Given
+      const cb = createCallbacks();
+      // When
+      parseInputData('\x1B[', cb);
+      // Then
+      expect(cb.calls).toEqual(['esc', 'char:[']);
+    });
   });
 
   describe('Ctrl+J key detection', () => {
@@ -290,11 +296,7 @@ describe('readMultilineInput cursor navigation', () => {
     options?: {
       completionProvider?: (
         context: { buffer: string },
-      ) => readonly {
-        readonly value: string;
-        readonly description?: string;
-        readonly applyValue?: string;
-      }[];
+      ) => readonly CompletionCandidate[];
     },
   ): Promise<string | null> {
     const { readMultilineInput } = await import('../features/interactive/lineEditor.js');

--- a/src/__tests__/lineEditor.test.ts
+++ b/src/__tests__/lineEditor.test.ts
@@ -1337,5 +1337,46 @@ describe('readMultilineInput cursor navigation', () => {
 
       expect(cb.calls).toEqual(['char:a', 'char:b', 'char:c']);
     });
+
+    it('should resolve CSI split across chunks (ESC+[ then A)', () => {
+      const cb = createCallbacks();
+      const parser = createEscapeParser(cb);
+
+      parser.feed('\x1B[');
+      parser.feed('A');
+
+      expect(cb.calls).toEqual(['up']);
+    });
+
+    it('should resolve CSI split across three chunks (ESC then [ then B)', () => {
+      const cb = createCallbacks();
+      const parser = createEscapeParser(cb);
+
+      parser.feed('\x1B');
+      parser.feed('[');
+      parser.feed('B');
+
+      expect(cb.calls).toEqual(['down']);
+    });
+
+    it('should handle text after resolved split escape sequence', () => {
+      const cb = createCallbacks();
+      const parser = createEscapeParser(cb);
+
+      parser.feed('\x1B[');
+      parser.feed('Cabc');
+
+      expect(cb.calls).toEqual(['right', 'char:a', 'char:b', 'char:c']);
+    });
+
+    it('should flush incomplete CSI fragment as bare Esc', () => {
+      const cb = createCallbacks();
+      const parser = createEscapeParser(cb);
+
+      parser.feed('\x1B[');
+      parser.flush();
+
+      expect(cb.calls).toEqual(['esc']);
+    });
   });
 });

--- a/src/__tests__/slashCommandRegistry.test.ts
+++ b/src/__tests__/slashCommandRegistry.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for slash command registry filtering
+ */
+
+import { describe, it, expect } from 'vitest';
+import { filterSlashCommands } from '../features/interactive/slashCommandRegistry.js';
+
+describe('filterSlashCommands', () => {
+  it('should return all commands when prefix is "/"', () => {
+    const result = filterSlashCommands('/');
+    expect(result.length).toBe(6);
+  });
+
+  it('should filter by prefix "/p"', () => {
+    const result = filterSlashCommands('/p');
+    const commands = result.map((e) => e.command);
+    expect(commands).toContain('/play');
+    expect(commands).not.toContain('/go');
+    expect(commands).not.toContain('/cancel');
+  });
+
+  it('should filter by prefix "/ca"', () => {
+    const result = filterSlashCommands('/ca');
+    expect(result.length).toBe(1);
+    expect(result[0]!.command).toBe('/cancel');
+  });
+
+  it('should return empty array for non-matching prefix', () => {
+    const result = filterSlashCommands('/xyz');
+    expect(result.length).toBe(0);
+  });
+
+  it('should return all commands for empty string prefix', () => {
+    const result = filterSlashCommands('');
+    expect(result.length).toBe(6);
+  });
+
+  it('should not match prefix without leading slash', () => {
+    const result = filterSlashCommands('go');
+    expect(result.length).toBe(0);
+  });
+
+  it('should be case-insensitive', () => {
+    const result = filterSlashCommands('/P');
+    const commands = result.map((e) => e.command);
+    expect(commands).toContain('/play');
+  });
+
+  it('should return "/re" prefix matches (retry, replay, resume)', () => {
+    const result = filterSlashCommands('/re');
+    const commands = result.map((e) => e.command);
+    expect(commands).toContain('/retry');
+    expect(commands).toContain('/replay');
+    expect(commands).toContain('/resume');
+    expect(commands.length).toBe(3);
+  });
+
+  it('should include labelKey for i18n lookup', () => {
+    const result = filterSlashCommands('/play');
+    expect(result[0]!.labelKey).toBe('interactive.commands.play');
+  });
+});

--- a/src/features/interactive/completionController.ts
+++ b/src/features/interactive/completionController.ts
@@ -1,0 +1,156 @@
+/**
+ * Completion menu state management and operations.
+ *
+ * Manages the lifecycle of the inline completion menu:
+ * filtering candidates, selection navigation, applying completions,
+ * and coordinating with the terminal renderer.
+ *
+ * Separated from lineEditor to keep input handling and completion
+ * logic as distinct concerns.
+ */
+
+import {
+  renderCompletionMenu,
+  writeCompletionMenu,
+  clearCompletionMenu,
+} from './completionMenu.js';
+
+/**
+ * Create a completion controller bound to a line editor instance.
+ */
+export const createCompletionController = (
+  accessors: {
+    getBuffer: () => string;
+    getCursorPos: () => number;
+    getTermWidth: () => number;
+    getTerminalColumn: (pos: number) => number;
+    countRowsBelowCursor: () => number;
+  },
+  mutators: {
+    setBuffer: (value: string) => void;
+    setCursorPos: (value: number) => void;
+  },
+  promptWidth: number,
+  completionProvider?: (
+    context: { buffer: string },
+  ) => readonly {
+    readonly value: string;
+    readonly description?: string;
+    readonly applyValue?: string;
+  }[],
+): {
+  readonly getState: () => {
+    readonly candidates: readonly {
+      readonly value: string;
+      readonly description?: string;
+      readonly applyValue?: string;
+    }[];
+    selectedIndex: number;
+  } | null;
+  readonly update: () => void;
+  readonly hide: () => void;
+  readonly moveSelection: (delta: number) => void;
+  readonly apply: () => void;
+} => {
+  let completionState: {
+    readonly candidates: readonly {
+      readonly value: string;
+      readonly description?: string;
+      readonly applyValue?: string;
+    }[];
+    selectedIndex: number;
+  } | null = null;
+
+  /**
+   * Render current completionState to the terminal and restore cursor column.
+   */
+  const redraw = (): void => {
+    if (!completionState) return;
+    const termWidth = accessors.getTermWidth();
+    const rowsBelow = accessors.countRowsBelowCursor();
+    const lines = renderCompletionMenu(completionState.candidates, completionState.selectedIndex, termWidth);
+    const termCol = accessors.getTerminalColumn(accessors.getCursorPos());
+    writeCompletionMenu(lines, rowsBelow);
+    process.stdout.write(`\x1B[${termCol}G`);
+  };
+
+  /**
+   * Hide the completion menu if visible.
+   */
+  const hide = (): void => {
+    if (!completionState) return;
+    const rowsBelow = accessors.countRowsBelowCursor();
+    const termCol = accessors.getTerminalColumn(accessors.getCursorPos());
+    clearCompletionMenu(rowsBelow);
+    process.stdout.write(`\x1B[${termCol}G`);
+    completionState = null;
+  };
+
+  /**
+   * Update completion menu state based on current buffer.
+   */
+  const update = (): void => {
+    if (!completionProvider) {
+      hide();
+      return;
+    }
+
+    const buffer = accessors.getBuffer();
+    const candidates = completionProvider({ buffer });
+
+    if (candidates.length === 0) {
+      hide();
+      return;
+    }
+
+    if (completionState) {
+      const clampedIndex = Math.min(completionState.selectedIndex, candidates.length - 1);
+      completionState = { candidates, selectedIndex: clampedIndex };
+    } else {
+      completionState = { candidates, selectedIndex: 0 };
+    }
+
+    redraw();
+  };
+
+  /**
+   * Move completion selection by delta (+1 = down, -1 = up) with wrap-around.
+   */
+  const moveSelection = (delta: number): void => {
+    if (!completionState || completionState.candidates.length === 0) return;
+    const len = completionState.candidates.length;
+    completionState.selectedIndex = ((completionState.selectedIndex + delta) % len + len) % len;
+    redraw();
+  };
+
+  /**
+   * Apply the selected completion value to the buffer.
+   */
+  const apply = (): void => {
+    if (!completionState) return;
+    const selected = completionState.candidates[completionState.selectedIndex];
+    if (!selected) return;
+
+    const newBuffer = selected.applyValue ?? selected.value;
+    const rowsBelow = accessors.countRowsBelowCursor();
+
+    clearCompletionMenu(rowsBelow);
+
+    process.stdout.write(`\x1B[${promptWidth + 1}G`);
+
+    mutators.setBuffer(newBuffer);
+    mutators.setCursorPos(newBuffer.length);
+    process.stdout.write(newBuffer);
+    process.stdout.write('\x1B[K');
+
+    completionState = null;
+  };
+
+  return {
+    getState: () => completionState,
+    update,
+    hide,
+    moveSelection,
+    apply,
+  };
+};

--- a/src/features/interactive/completionController.ts
+++ b/src/features/interactive/completionController.ts
@@ -13,6 +13,7 @@ import {
   renderCompletionMenu,
   writeCompletionMenu,
   clearCompletionMenu,
+  type CompletionCandidate,
 } from './completionMenu.js';
 
 /**
@@ -25,6 +26,7 @@ export const createCompletionController = (
     getTermWidth: () => number;
     getTerminalColumn: (pos: number) => number;
     countRowsBelowCursor: () => number;
+    getCursorRow: () => number;
   },
   mutators: {
     setBuffer: (value: string) => void;
@@ -33,18 +35,10 @@ export const createCompletionController = (
   promptWidth: number,
   completionProvider?: (
     context: { buffer: string },
-  ) => readonly {
-    readonly value: string;
-    readonly description?: string;
-    readonly applyValue?: string;
-  }[],
+  ) => readonly CompletionCandidate[],
 ): {
   readonly getState: () => {
-    readonly candidates: readonly {
-      readonly value: string;
-      readonly description?: string;
-      readonly applyValue?: string;
-    }[];
+    readonly candidates: readonly CompletionCandidate[];
     selectedIndex: number;
   } | null;
   readonly update: () => void;
@@ -53,11 +47,7 @@ export const createCompletionController = (
   readonly apply: () => void;
 } => {
   let completionState: {
-    readonly candidates: readonly {
-      readonly value: string;
-      readonly description?: string;
-      readonly applyValue?: string;
-    }[];
+    readonly candidates: readonly CompletionCandidate[];
     selectedIndex: number;
   } | null = null;
 
@@ -103,12 +93,10 @@ export const createCompletionController = (
       return;
     }
 
-    if (completionState) {
-      const clampedIndex = Math.min(completionState.selectedIndex, candidates.length - 1);
-      completionState = { candidates, selectedIndex: clampedIndex };
-    } else {
-      completionState = { candidates, selectedIndex: 0 };
-    }
+    const clampedIndex = completionState
+      ? Math.min(completionState.selectedIndex, candidates.length - 1)
+      : 0;
+    completionState = { candidates, selectedIndex: clampedIndex };
 
     redraw();
   };
@@ -133,15 +121,24 @@ export const createCompletionController = (
 
     const newBuffer = selected.applyValue ?? selected.value;
     const rowsBelow = accessors.countRowsBelowCursor();
+    const cursorRow = accessors.getCursorRow();
 
-    clearCompletionMenu(rowsBelow);
+    if (rowsBelow > 0) {
+      process.stdout.write(`\x1B[${rowsBelow}B`);
+    }
+    process.stdout.write('\r\n');
+    process.stdout.write('\x1B[J');
 
+    const moveUp = 1 + cursorRow + rowsBelow;
+    if (moveUp > 0) {
+      process.stdout.write(`\x1B[${moveUp}A`);
+    }
     process.stdout.write(`\x1B[${promptWidth + 1}G`);
 
     mutators.setBuffer(newBuffer);
     mutators.setCursorPos(newBuffer.length);
     process.stdout.write(newBuffer);
-    process.stdout.write('\x1B[K');
+    process.stdout.write('\x1B[J');
 
     completionState = null;
   };

--- a/src/features/interactive/completionController.ts
+++ b/src/features/interactive/completionController.ts
@@ -14,6 +14,7 @@ import {
   writeCompletionMenu,
   clearCompletionMenu,
   type CompletionCandidate,
+  type CompletionProvider,
 } from './completionMenu.js';
 
 /**
@@ -33,22 +34,21 @@ export const createCompletionController = (
     setCursorPos: (value: number) => void;
   },
   promptWidth: number,
-  completionProvider?: (
-    context: { buffer: string },
-  ) => readonly CompletionCandidate[],
+  completionProvider?: CompletionProvider,
 ): {
   readonly getState: () => {
     readonly candidates: readonly CompletionCandidate[];
-    selectedIndex: number;
+    readonly selectedIndex: number;
   } | null;
   readonly update: () => void;
   readonly hide: () => void;
   readonly moveSelection: (delta: number) => void;
   readonly apply: () => void;
+  readonly acceptSelection: () => boolean;
 } => {
   let completionState: {
     readonly candidates: readonly CompletionCandidate[];
-    selectedIndex: number;
+    readonly selectedIndex: number;
   } | null = null;
 
   /**
@@ -86,7 +86,10 @@ export const createCompletionController = (
     }
 
     const buffer = accessors.getBuffer();
-    const candidates = completionProvider({ buffer });
+    const candidates = completionProvider({
+      buffer,
+      cursorPos: accessors.getCursorPos(),
+    });
 
     if (candidates.length === 0) {
       hide();
@@ -107,19 +110,18 @@ export const createCompletionController = (
   const moveSelection = (delta: number): void => {
     if (!completionState || completionState.candidates.length === 0) return;
     const len = completionState.candidates.length;
-    completionState.selectedIndex = ((completionState.selectedIndex + delta) % len + len) % len;
+    const nextIndex = ((completionState.selectedIndex + delta) % len + len) % len;
+    completionState = {
+      ...completionState,
+      selectedIndex: nextIndex,
+    };
     redraw();
   };
 
   /**
-   * Apply the selected completion value to the buffer.
+   * Replace the active buffer from the prompt row and clear the menu.
    */
-  const apply = (): void => {
-    if (!completionState) return;
-    const selected = completionState.candidates[completionState.selectedIndex];
-    if (!selected) return;
-
-    const newBuffer = selected.applyValue ?? selected.value;
+  const replaceBuffer = (newBuffer: string): void => {
     const rowsBelow = accessors.countRowsBelowCursor();
     const cursorRow = accessors.getCursorRow();
 
@@ -143,11 +145,33 @@ export const createCompletionController = (
     completionState = null;
   };
 
+  /**
+   * Apply the selected completion value to the buffer.
+   */
+  const apply = (): void => {
+    if (!completionState) return;
+    const selected = completionState.candidates[completionState.selectedIndex];
+    if (!selected) return;
+    replaceBuffer(selected.applyValue ?? selected.value);
+  };
+
+  /**
+   * Accept the currently selected completion without adding trailing editing space.
+   */
+  const acceptSelection = (): boolean => {
+    if (!completionState) return false;
+    const selected = completionState.candidates[completionState.selectedIndex];
+    if (!selected) return false;
+    replaceBuffer(selected.value);
+    return true;
+  };
+
   return {
     getState: () => completionState,
     update,
     hide,
     moveSelection,
     apply,
+    acceptSelection,
   };
 };

--- a/src/features/interactive/completionMenu.ts
+++ b/src/features/interactive/completionMenu.ts
@@ -9,10 +9,18 @@ import chalk from 'chalk';
 import { getDisplayWidth, truncateText } from '../../shared/utils/text.js';
 
 const SEPARATOR_CHAR = '─';
-const DEFAULT_COMMAND_COLUMN_WIDTH = 24;
 const LEFT_PADDING = 2;
 const DESC_GAP = 2;
 const MIN_COMMAND_WIDTH = 8;
+
+/**
+ * A single completion candidate entry.
+ */
+export type CompletionCandidate = {
+  readonly value: string;
+  readonly description?: string;
+  readonly applyValue?: string;
+};
 
 /**
  * Render completion menu lines (pure function).
@@ -20,11 +28,7 @@ const MIN_COMMAND_WIDTH = 8;
  * Returns an array of styled strings: separator line + one line per candidate.
  */
 export const renderCompletionMenu = (
-  candidates: readonly {
-    readonly value: string;
-    readonly description?: string;
-    readonly applyValue?: string;
-  }[],
+  candidates: readonly CompletionCandidate[],
   selectedIndex: number,
   termWidth: number,
 ): readonly string[] => {
@@ -34,10 +38,7 @@ export const renderCompletionMenu = (
     (max, entry) => Math.max(max, getDisplayWidth(entry.value)),
     0,
   );
-  const commandColWidth = Math.min(
-    Math.max(maxCommandDisplayWidth + 2, MIN_COMMAND_WIDTH),
-    Math.max(DEFAULT_COMMAND_COLUMN_WIDTH, maxCommandDisplayWidth + 2),
-  );
+  const commandColWidth = Math.max(maxCommandDisplayWidth + 2, MIN_COMMAND_WIDTH);
   const availableForRow = Math.max(termWidth - LEFT_PADDING, 0);
   const clampedCommandCol = Math.min(commandColWidth, availableForRow);
   const descMaxWidth = availableForRow - clampedCommandCol - DESC_GAP;

--- a/src/features/interactive/completionMenu.ts
+++ b/src/features/interactive/completionMenu.ts
@@ -23,6 +23,21 @@ export interface CompletionCandidate {
 }
 
 /**
+ * Context passed to completion providers.
+ */
+export interface CompletionContext {
+  readonly buffer: string;
+  readonly cursorPos: number;
+}
+
+/**
+ * Function that returns completion candidates for the current input state.
+ */
+export type CompletionProvider = (
+  context: CompletionContext,
+) => readonly CompletionCandidate[];
+
+/**
  * Render completion menu lines (pure function).
  *
  * Returns an array of styled strings: separator line + one line per candidate.

--- a/src/features/interactive/completionMenu.ts
+++ b/src/features/interactive/completionMenu.ts
@@ -6,11 +6,13 @@
  */
 
 import chalk from 'chalk';
-import { truncateText } from '../../shared/utils/text.js';
+import { getDisplayWidth, truncateText } from '../../shared/utils/text.js';
 
 const SEPARATOR_CHAR = '─';
-const COMMAND_COLUMN_WIDTH = 24;
+const DEFAULT_COMMAND_COLUMN_WIDTH = 24;
 const LEFT_PADDING = 2;
+const DESC_GAP = 2;
+const MIN_COMMAND_WIDTH = 8;
 
 /**
  * Render completion menu lines (pure function).
@@ -27,11 +29,25 @@ export const renderCompletionMenu = (
   termWidth: number,
 ): readonly string[] => {
   const separator = chalk.dim(SEPARATOR_CHAR.repeat(termWidth));
-  const descMaxWidth = termWidth - LEFT_PADDING - COMMAND_COLUMN_WIDTH - 2;
+
+  const maxCommandDisplayWidth = candidates.reduce(
+    (max, entry) => Math.max(max, getDisplayWidth(entry.value)),
+    0,
+  );
+  const commandColWidth = Math.min(
+    Math.max(maxCommandDisplayWidth + 2, MIN_COMMAND_WIDTH),
+    Math.max(DEFAULT_COMMAND_COLUMN_WIDTH, maxCommandDisplayWidth + 2),
+  );
+  const availableForRow = Math.max(termWidth - LEFT_PADDING, 0);
+  const clampedCommandCol = Math.min(commandColWidth, availableForRow);
+  const descMaxWidth = availableForRow - clampedCommandCol - DESC_GAP;
 
   const lines = candidates.map((entry, i) => {
     const isSelected = i === selectedIndex;
-    const command = entry.value.padEnd(COMMAND_COLUMN_WIDTH);
+    const commandText = getDisplayWidth(entry.value) > clampedCommandCol
+      ? truncateText(entry.value, clampedCommandCol)
+      : entry.value;
+    const command = commandText.padEnd(clampedCommandCol);
     const desc = descMaxWidth > 0
       ? truncateText(entry.description ?? '', descMaxWidth)
       : '';

--- a/src/features/interactive/completionMenu.ts
+++ b/src/features/interactive/completionMenu.ts
@@ -16,11 +16,11 @@ const MIN_COMMAND_WIDTH = 8;
 /**
  * A single completion candidate entry.
  */
-export type CompletionCandidate = {
+export interface CompletionCandidate {
   readonly value: string;
   readonly description?: string;
   readonly applyValue?: string;
-};
+}
 
 /**
  * Render completion menu lines (pure function).

--- a/src/features/interactive/completionMenu.ts
+++ b/src/features/interactive/completionMenu.ts
@@ -1,0 +1,87 @@
+/**
+ * Inline completion menu renderer.
+ *
+ * Provides pure rendering functions and terminal drawing helpers
+ * for the slash command autocomplete menu displayed below the input line.
+ */
+
+import chalk from 'chalk';
+import { truncateText } from '../../shared/utils/text.js';
+
+const SEPARATOR_CHAR = '─';
+const COMMAND_COLUMN_WIDTH = 24;
+const LEFT_PADDING = 2;
+
+/**
+ * Render completion menu lines (pure function).
+ *
+ * Returns an array of styled strings: separator line + one line per candidate.
+ */
+export const renderCompletionMenu = (
+  candidates: readonly {
+    readonly value: string;
+    readonly description?: string;
+    readonly applyValue?: string;
+  }[],
+  selectedIndex: number,
+  termWidth: number,
+): readonly string[] => {
+  const separator = chalk.dim(SEPARATOR_CHAR.repeat(termWidth));
+  const descMaxWidth = termWidth - LEFT_PADDING - COMMAND_COLUMN_WIDTH - 2;
+
+  const lines = candidates.map((entry, i) => {
+    const isSelected = i === selectedIndex;
+    const command = entry.value.padEnd(COMMAND_COLUMN_WIDTH);
+    const desc = descMaxWidth > 0
+      ? truncateText(entry.description ?? '', descMaxWidth)
+      : '';
+
+    if (isSelected) return `${' '.repeat(LEFT_PADDING)}${chalk.cyan.bold(command)}${chalk.gray(desc)}`;
+    return `${' '.repeat(LEFT_PADDING)}${chalk.gray(command)}${chalk.dim(desc)}`;
+  });
+
+  return [separator, ...lines];
+};
+
+/**
+ * Write the completion menu below the current cursor position.
+ *
+ * Moves cursor down to below the input, draws the menu,
+ * then restores cursor to original position.
+ */
+export const writeCompletionMenu = (
+  lines: readonly string[],
+  rowsBelowCursor: number,
+): void => {
+  if (rowsBelowCursor > 0) {
+    process.stdout.write(`\x1B[${rowsBelowCursor}B`);
+  }
+  process.stdout.write('\r\n');
+  process.stdout.write('\x1B[J');
+  process.stdout.write(lines.join('\n'));
+
+  const moveUp = lines.length + rowsBelowCursor;
+  if (moveUp > 0) {
+    process.stdout.write(`\x1B[${moveUp}A`);
+  }
+};
+
+/**
+ * Clear the completion menu from the terminal.
+ *
+ * Moves cursor below input, erases everything, then restores position.
+ */
+export const clearCompletionMenu = (
+  rowsBelowCursor: number,
+): void => {
+  if (rowsBelowCursor > 0) {
+    process.stdout.write(`\x1B[${rowsBelowCursor}B`);
+  }
+  process.stdout.write('\r\n');
+  process.stdout.write('\x1B[J');
+
+  const moveUp = 1 + rowsBelowCursor;
+  if (moveUp > 0) {
+    process.stdout.write(`\x1B[${moveUp}A`);
+  }
+};

--- a/src/features/interactive/conversationLoop.ts
+++ b/src/features/interactive/conversationLoop.ts
@@ -15,7 +15,7 @@ import {
 import { createLogger } from '../../shared/utils/index.js';
 import { info, error, blankLine } from '../../shared/ui/index.js';
 import { getLabel, getLabelObject } from '../../shared/i18n/index.js';
-import { readMultilineInput } from './lineEditor.js';
+import { readInteractiveInput } from './interactiveInput.js';
 import { selectRecentSession } from './sessionSelector.js';
 import { matchSlashCommand } from './commandMatcher.js';
 import { SlashCommand } from '../../shared/constants.js';
@@ -127,7 +127,7 @@ export async function runConversationLoop(
   }
 
   while (true) {
-    const input = await readMultilineInput(chalk.green('> '));
+    const input = await readInteractiveInput(chalk.green('> '), ctx.lang);
 
     if (input === null) {
       blankLine();

--- a/src/features/interactive/conversationLoop.ts
+++ b/src/features/interactive/conversationLoop.ts
@@ -16,6 +16,7 @@ import { createLogger } from '../../shared/utils/index.js';
 import { info, error, blankLine } from '../../shared/ui/index.js';
 import { getLabel, getLabelObject } from '../../shared/i18n/index.js';
 import { readInteractiveInput } from './interactiveInput.js';
+import type { CommandAvailability } from './slashCommandRegistry.js';
 import { selectRecentSession } from './sessionSelector.js';
 import { matchSlashCommand } from './commandMatcher.js';
 import { SlashCommand } from '../../shared/constants.js';
@@ -126,8 +127,13 @@ export async function runConversationLoop(
     return { action: selectedAction, task };
   }
 
+  const commandAvailability: CommandAvailability = {
+    enableRetryCommand: strategy.enableRetryCommand,
+    hasPreviousOrder: !!strategy.previousOrderContent,
+  };
+
   while (true) {
-    const input = await readInteractiveInput(chalk.green('> '), ctx.lang);
+    const input = await readInteractiveInput(chalk.green('> '), ctx.lang, commandAvailability);
 
     if (input === null) {
       blankLine();

--- a/src/features/interactive/interactiveInput.ts
+++ b/src/features/interactive/interactiveInput.ts
@@ -1,0 +1,46 @@
+import type { Language } from '../../core/models/config-types.js';
+import { getLabel } from '../../shared/i18n/index.js';
+import { readMultilineInput } from './lineEditor.js';
+import { filterSlashCommands } from './slashCommandRegistry.js';
+
+/**
+ * Build localized slash-command completion candidates for the current input.
+ */
+export const getSlashCommandCompletions = (
+  prefix: string,
+  lang: Language,
+): readonly {
+  readonly value: string;
+  readonly description?: string;
+  readonly applyValue?: string;
+}[] =>
+  filterSlashCommands(prefix).map((entry) => ({
+    value: entry.command,
+    applyValue: `${entry.command} `,
+    description: getLabel(entry.labelKey, lang),
+  }));
+
+/**
+ * Create the slash-command completion provider used by interactive conversation modes.
+ */
+export const createSlashCommandCompletionProvider = (
+  lang: Language,
+): ((context: { buffer: string }) => readonly {
+  readonly value: string;
+  readonly description?: string;
+  readonly applyValue?: string;
+}[]) =>
+  ({ buffer }) => {
+    if (!buffer.startsWith('/') || buffer.includes('\n')) {
+      return [];
+    }
+    return getSlashCommandCompletions(buffer, lang);
+  };
+
+/**
+ * Read interactive input with slash-command completion enabled.
+ */
+export const readInteractiveInput = (prompt: string, lang: Language): Promise<string | null> =>
+  readMultilineInput(prompt, {
+    completionProvider: createSlashCommandCompletionProvider(lang),
+  });

--- a/src/features/interactive/interactiveInput.ts
+++ b/src/features/interactive/interactiveInput.ts
@@ -2,7 +2,7 @@ import type { Language } from '../../core/models/config-types.js';
 import { getLabel } from '../../shared/i18n/index.js';
 import { readMultilineInput } from './lineEditor.js';
 import { filterSlashCommands, type CommandAvailability } from './slashCommandRegistry.js';
-import type { CompletionCandidate } from './completionMenu.js';
+import type { CompletionCandidate, CompletionContext, CompletionProvider } from './completionMenu.js';
 
 /**
  * Build localized slash-command completion candidates for the current input.
@@ -21,21 +21,24 @@ export const getSlashCommandCompletions = (
 /**
  * Extract the slash command token from the buffer for completion.
  *
- * Supports both prefix form ("/go") and suffix form ("some text /go").
- * Returns the slash token and its start position, or null if none found.
+ * Supports both prefix form ("/go") and suffix form ("some text /go"), but only
+ * when the cursor is currently inside the slash-command token being edited.
  */
-const extractSlashToken = (buffer: string): { token: string; start: number } | null => {
+const extractSlashToken = (
+  buffer: string,
+  cursorPos: number,
+): { token: string; start: number; end: number } | null => {
   if (buffer.includes('\n')) return null;
+  if (cursorPos <= 0 || cursorPos > buffer.length) return null;
 
-  if (buffer.startsWith('/')) return { token: buffer, start: 0 };
+  const tokenStart = buffer.lastIndexOf(' ', cursorPos - 1) + 1;
+  if (cursorPos <= tokenStart) return null;
+  const nextSpace = buffer.indexOf(' ', tokenStart);
+  const tokenEnd = nextSpace >= 0 ? nextSpace : buffer.length;
+  const token = buffer.slice(tokenStart, tokenEnd);
+  if (!token.startsWith('/')) return null;
 
-  const lastSlashIndex = buffer.lastIndexOf(' /');
-  if (lastSlashIndex >= 0) {
-    const token = buffer.slice(lastSlashIndex + 1);
-    if (!token.includes(' ')) return { token, start: lastSlashIndex + 1 };
-  }
-
-  return null;
+  return { token, start: tokenStart, end: tokenEnd };
 };
 
 /**
@@ -44,18 +47,19 @@ const extractSlashToken = (buffer: string): { token: string; start: number } | n
 export const createSlashCommandCompletionProvider = (
   lang: Language,
   availability?: CommandAvailability,
-): ((context: { buffer: string }) => readonly CompletionCandidate[]) =>
-  ({ buffer }) => {
-    const match = extractSlashToken(buffer);
+): CompletionProvider =>
+  ({ buffer, cursorPos }: CompletionContext) => {
+    const match = extractSlashToken(buffer, cursorPos);
     if (!match) return [];
 
     const prefix = buffer.slice(0, match.start);
-    return getSlashCommandCompletions(match.token, lang, availability).map((entry) => ({
+    const suffix = buffer.slice(match.end);
+    const typedPrefix = buffer.slice(match.start, cursorPos);
+
+    return getSlashCommandCompletions(typedPrefix, lang, availability).map((entry) => ({
       ...entry,
-      applyValue: entry.applyValue
-        ? `${prefix}${entry.applyValue}`
-        : undefined,
-      value: `${prefix}${entry.value}`,
+      applyValue: `${prefix}${suffix.length === 0 ? (entry.applyValue ?? entry.value) : entry.value}${suffix}`,
+      value: `${prefix}${entry.value}${suffix}`,
     }));
   };
 

--- a/src/features/interactive/interactiveInput.ts
+++ b/src/features/interactive/interactiveInput.ts
@@ -1,7 +1,7 @@
 import type { Language } from '../../core/models/config-types.js';
 import { getLabel } from '../../shared/i18n/index.js';
 import { readMultilineInput } from './lineEditor.js';
-import { filterSlashCommands } from './slashCommandRegistry.js';
+import { filterSlashCommands, type CommandAvailability } from './slashCommandRegistry.js';
 
 /**
  * Build localized slash-command completion candidates for the current input.
@@ -9,38 +9,71 @@ import { filterSlashCommands } from './slashCommandRegistry.js';
 export const getSlashCommandCompletions = (
   prefix: string,
   lang: Language,
+  availability?: CommandAvailability,
 ): readonly {
   readonly value: string;
   readonly description?: string;
   readonly applyValue?: string;
 }[] =>
-  filterSlashCommands(prefix).map((entry) => ({
+  filterSlashCommands(prefix, availability).map((entry) => ({
     value: entry.command,
     applyValue: `${entry.command} `,
     description: getLabel(entry.labelKey, lang),
   }));
 
 /**
+ * Extract the slash command token from the buffer for completion.
+ *
+ * Supports both prefix form ("/go") and suffix form ("some text /go").
+ * Returns the slash token and its start position, or null if none found.
+ */
+const extractSlashToken = (buffer: string): { token: string; start: number } | null => {
+  if (buffer.includes('\n')) return null;
+
+  if (buffer.startsWith('/')) return { token: buffer, start: 0 };
+
+  const lastSlashIndex = buffer.lastIndexOf(' /');
+  if (lastSlashIndex >= 0) {
+    const token = buffer.slice(lastSlashIndex + 1);
+    if (!token.includes(' ')) return { token, start: lastSlashIndex + 1 };
+  }
+
+  return null;
+};
+
+/**
  * Create the slash-command completion provider used by interactive conversation modes.
  */
 export const createSlashCommandCompletionProvider = (
   lang: Language,
+  availability?: CommandAvailability,
 ): ((context: { buffer: string }) => readonly {
   readonly value: string;
   readonly description?: string;
   readonly applyValue?: string;
 }[]) =>
   ({ buffer }) => {
-    if (!buffer.startsWith('/') || buffer.includes('\n')) {
-      return [];
-    }
-    return getSlashCommandCompletions(buffer, lang);
+    const match = extractSlashToken(buffer);
+    if (!match) return [];
+
+    const prefix = buffer.slice(0, match.start);
+    return getSlashCommandCompletions(match.token, lang, availability).map((entry) => ({
+      ...entry,
+      applyValue: entry.applyValue
+        ? `${prefix}${entry.applyValue}`
+        : undefined,
+      value: `${prefix}${entry.value}`,
+    }));
   };
 
 /**
  * Read interactive input with slash-command completion enabled.
  */
-export const readInteractiveInput = (prompt: string, lang: Language): Promise<string | null> =>
+export const readInteractiveInput = (
+  prompt: string,
+  lang: Language,
+  availability?: CommandAvailability,
+): Promise<string | null> =>
   readMultilineInput(prompt, {
-    completionProvider: createSlashCommandCompletionProvider(lang),
+    completionProvider: createSlashCommandCompletionProvider(lang, availability),
   });

--- a/src/features/interactive/interactiveInput.ts
+++ b/src/features/interactive/interactiveInput.ts
@@ -2,6 +2,7 @@ import type { Language } from '../../core/models/config-types.js';
 import { getLabel } from '../../shared/i18n/index.js';
 import { readMultilineInput } from './lineEditor.js';
 import { filterSlashCommands, type CommandAvailability } from './slashCommandRegistry.js';
+import type { CompletionCandidate } from './completionMenu.js';
 
 /**
  * Build localized slash-command completion candidates for the current input.
@@ -10,11 +11,7 @@ export const getSlashCommandCompletions = (
   prefix: string,
   lang: Language,
   availability?: CommandAvailability,
-): readonly {
-  readonly value: string;
-  readonly description?: string;
-  readonly applyValue?: string;
-}[] =>
+): readonly CompletionCandidate[] =>
   filterSlashCommands(prefix, availability).map((entry) => ({
     value: entry.command,
     applyValue: `${entry.command} `,
@@ -47,11 +44,7 @@ const extractSlashToken = (buffer: string): { token: string; start: number } | n
 export const createSlashCommandCompletionProvider = (
   lang: Language,
   availability?: CommandAvailability,
-): ((context: { buffer: string }) => readonly {
-  readonly value: string;
-  readonly description?: string;
-  readonly applyValue?: string;
-}[]) =>
+): ((context: { buffer: string }) => readonly CompletionCandidate[]) =>
   ({ buffer }) => {
     const match = extractSlashToken(buffer);
     if (!match) return [];

--- a/src/features/interactive/lineEditor.ts
+++ b/src/features/interactive/lineEditor.ts
@@ -11,7 +11,7 @@ import * as readline from 'node:readline';
 import { StringDecoder } from 'node:string_decoder';
 import { stripAnsi, getDisplayWidth } from '../../shared/utils/text.js';
 import { createCompletionController } from './completionController.js';
-import type { CompletionCandidate } from './completionMenu.js';
+import type { CompletionProvider } from './completionMenu.js';
 
 /** Escape sequences for terminal protocol control */
 const PASTE_BRACKET_ENABLE = '\x1B[?2004h';
@@ -274,9 +274,7 @@ export const createEscapeParser = (
 export function readMultilineInput(
   prompt: string,
   options?: {
-    completionProvider?: (
-      context: { buffer: string },
-    ) => readonly CompletionCandidate[];
+    completionProvider?: CompletionProvider;
   },
 ): Promise<string | null> {
   if (!process.stdin.isTTY) {
@@ -671,6 +669,7 @@ export function readMultilineInput(
           onShiftEnter() { completion.hide(); insertNewline(); },
           onArrowLeft() {
             if (state !== 'normal') return;
+            const previousCursorPos = cursorPos;
             if (cursorPos > getLineStart()) {
               const len = charLengthBefore(cursorPos);
               const charWidth = getDisplayWidth(buffer.slice(cursorPos - len, cursorPos));
@@ -682,9 +681,11 @@ export function readMultilineInput(
               process.stdout.write('\x1B[A');
               process.stdout.write(`\x1B[${col}G`);
             }
+            if (cursorPos !== previousCursorPos) completion.update();
           },
           onArrowRight() {
             if (state !== 'normal') return;
+            const previousCursorPos = cursorPos;
             if (cursorPos < getLineEnd()) {
               const len = charLengthAt(cursorPos);
               const charWidth = getDisplayWidth(buffer.slice(cursorPos, cursorPos + len));
@@ -696,15 +697,17 @@ export function readMultilineInput(
               process.stdout.write('\x1B[B');
               process.stdout.write(`\x1B[${col}G`);
             }
+            if (cursorPos !== previousCursorPos) completion.update();
           },
           onArrowUp() {
             if (state !== 'normal') return;
-            
+
             if (completion.getState()) {
               completion.moveSelection(-1);
               return;
             }
 
+            const previousCursorPos = cursorPos;
             const logicalLineStart = getLineStart();
             const displayRowStart = getDisplayRowStart(cursorPos);
             const displayCol = getDisplayRowColumn(cursorPos);
@@ -721,6 +724,7 @@ export function readMultilineInput(
               const prevRowEnd = getDisplayRowEnd(prevLogicalLineEnd);
               moveCursorToDisplayRow(prevRowStart, prevRowEnd, displayCol, 'A');
             }
+            if (cursorPos !== previousCursorPos) completion.update();
           },
           onArrowDown() {
             if (state !== 'normal') return;
@@ -730,6 +734,7 @@ export function readMultilineInput(
               return;
             }
 
+            const previousCursorPos = cursorPos;
             const logicalLineEnd = getLineEnd();
             const displayRowEnd = getDisplayRowEnd(cursorPos);
             const displayCol = getDisplayRowColumn(cursorPos);
@@ -745,9 +750,11 @@ export function readMultilineInput(
               const nextRowEnd = getDisplayRowEnd(nextLineStart);
               moveCursorToDisplayRow(nextLineStart, nextRowEnd, displayCol, 'B');
             }
+            if (cursorPos !== previousCursorPos) completion.update();
           },
           onWordLeft() {
             if (state !== 'normal') return;
+            const previousCursorPos = cursorPos;
             const lineStart = getLineStart();
             if (cursorPos <= lineStart) return;
             let pos = cursorPos;
@@ -756,9 +763,11 @@ export function readMultilineInput(
             const moveWidth = getDisplayWidth(buffer.slice(pos, cursorPos));
             cursorPos = pos;
             process.stdout.write(`\x1B[${moveWidth}D`);
+            if (cursorPos !== previousCursorPos) completion.update();
           },
           onWordRight() {
             if (state !== 'normal') return;
+            const previousCursorPos = cursorPos;
             const lineEnd = getLineEnd();
             if (cursorPos >= lineEnd) return;
             let pos = cursorPos;
@@ -767,14 +776,19 @@ export function readMultilineInput(
             const moveWidth = getDisplayWidth(buffer.slice(cursorPos, pos));
             cursorPos = pos;
             process.stdout.write(`\x1B[${moveWidth}C`);
+            if (cursorPos !== previousCursorPos) completion.update();
           },
           onHome() {
             if (state !== 'normal') return;
+            const previousCursorPos = cursorPos;
             moveCursorToLogicalLineStart();
+            if (cursorPos !== previousCursorPos) completion.update();
           },
           onEnd() {
             if (state !== 'normal') return;
+            const previousCursorPos = cursorPos;
             moveCursorToLogicalLineEnd();
+            if (cursorPos !== previousCursorPos) completion.update();
           },
           onEsc() {
             completion.hide();
@@ -802,16 +816,7 @@ export function readMultilineInput(
 
             // Submit
             if (ch === '\r') {
-              const compState = completion.getState();
-              if (compState) {
-                const selected = compState.candidates[compState.selectedIndex];
-                if (selected) {
-                  buffer = selected.value;
-                  cursorPos = buffer.length;
-                }
-              }
-              
-              completion.hide();
+              completion.acceptSelection();
               process.stdout.write('\n');
               cleanup();
               resolve(buffer);
@@ -826,8 +831,18 @@ export function readMultilineInput(
             }
             // Editing
             if (ch === '\x7F' || ch === '\x08') { deleteCharBefore(); completion.update(); return; }
-            if (ch === '\x01') { moveCursorToDisplayRowStart(); return; }
-            if (ch === '\x05') { moveCursorToDisplayRowEnd(); return; }
+            if (ch === '\x01') {
+              const previousCursorPos = cursorPos;
+              moveCursorToDisplayRowStart();
+              if (cursorPos !== previousCursorPos) completion.update();
+              return;
+            }
+            if (ch === '\x05') {
+              const previousCursorPos = cursorPos;
+              moveCursorToDisplayRowEnd();
+              if (cursorPos !== previousCursorPos) completion.update();
+              return;
+            }
             if (ch === '\x0B') { deleteToLineEnd(); completion.update(); return; }
             if (ch === '\x15') { deleteToLineStart(); completion.update(); return; }
             if (ch === '\x17') { deleteWord(); completion.update(); return; }

--- a/src/features/interactive/lineEditor.ts
+++ b/src/features/interactive/lineEditor.ts
@@ -90,10 +90,10 @@ export interface InputCallbacks {
  * or -1 if the rest is a potential incomplete CSI/SS3 prefix that needs
  * more data, or 0 if the \x1B is a bare Esc.
  */
-function tryConsumeEscapeSequence(
+const tryConsumeEscapeSequence = (
   rest: string,
   callbacks: InputCallbacks,
-): number {
+): number => {
   if (rest.startsWith(ESC_PASTE_START)) {
     callbacks.onPasteStart();
     return ESC_PASTE_START.length;
@@ -155,7 +155,7 @@ function tryConsumeEscapeSequence(
 
   callbacks.onEsc();
   return 0;
-}
+};
 
 /**
  * Parse raw stdin data into semantic input events.

--- a/src/features/interactive/lineEditor.ts
+++ b/src/features/interactive/lineEditor.ts
@@ -199,7 +199,7 @@ const ESC_AMBIGUITY_TIMEOUT_MS = 50 as const;
 export const createEscapeParser = (
   callbacks: InputCallbacks,
 ): { feed: (data: string) => void; flush: () => void } => {
-  let pendingEsc = false;
+  let pendingFragment = '';
   let escTimer: ReturnType<typeof setTimeout> | null = null;
 
   const clearEscTimer = (): void => {
@@ -211,8 +211,8 @@ export const createEscapeParser = (
 
   const flush = (): void => {
     clearEscTimer();
-    if (pendingEsc) {
-      pendingEsc = false;
+    if (pendingFragment.length > 0) {
+      pendingFragment = '';
       callbacks.onEsc();
     }
   };
@@ -220,10 +220,10 @@ export const createEscapeParser = (
   const feed = (data: string): void => {
     let input = data;
 
-    if (pendingEsc) {
-      pendingEsc = false;
+    if (pendingFragment.length > 0) {
       clearEscTimer();
-      input = `\x1B${input}`;
+      input = `${pendingFragment}${input}`;
+      pendingFragment = '';
     }
 
     let i = 0;
@@ -234,14 +234,14 @@ export const createEscapeParser = (
         const rest = input.slice(i + 1);
 
         if (rest.length === 0) {
-          pendingEsc = true;
+          pendingFragment = '\x1B';
           escTimer = setTimeout(flush, ESC_AMBIGUITY_TIMEOUT_MS);
           return;
         }
 
         const consumed = tryConsumeEscapeSequence(rest, callbacks);
         if (consumed === -1) {
-          pendingEsc = true;
+          pendingFragment = input.slice(i);
           escTimer = setTimeout(flush, ESC_AMBIGUITY_TIMEOUT_MS);
           return;
         }

--- a/src/features/interactive/lineEditor.ts
+++ b/src/features/interactive/lineEditor.ts
@@ -11,6 +11,7 @@ import * as readline from 'node:readline';
 import { StringDecoder } from 'node:string_decoder';
 import { stripAnsi, getDisplayWidth } from '../../shared/utils/text.js';
 import { createCompletionController } from './completionController.js';
+import type { CompletionCandidate } from './completionMenu.js';
 
 /** Escape sequences for terminal protocol control */
 const PASTE_BRACKET_ENABLE = '\x1B[?2004h';
@@ -275,11 +276,7 @@ export function readMultilineInput(
   options?: {
     completionProvider?: (
       context: { buffer: string },
-    ) => readonly {
-      readonly value: string;
-      readonly description?: string;
-      readonly applyValue?: string;
-    }[];
+    ) => readonly CompletionCandidate[];
   },
 ): Promise<string | null> {
   if (!process.stdin.isTTY) {
@@ -377,7 +374,7 @@ export function readMultilineInput(
     /**
      * Count display rows between two arbitrary buffer positions.
      */
-    function countDisplayRowsBetweenPositions(from: number, to: number): number {
+    function countDisplayRowsAcrossLines(from: number, to: number): number {
       if (from >= to) return 0;
       let rows = 0;
       let pos = from;
@@ -400,8 +397,8 @@ export function readMultilineInput(
      * Count display rows from cursor position to end of buffer.
      */
     function countRowsBelowCursor(): number {
-      const cursorRow = countDisplayRowsBetweenPositions(0, cursorPos);
-      const totalRows = countDisplayRowsBetweenPositions(0, buffer.length);
+      const cursorRow = countDisplayRowsAcrossLines(0, cursorPos);
+      const totalRows = countDisplayRowsAcrossLines(0, buffer.length);
       return totalRows - cursorRow;
     }
 
@@ -412,6 +409,7 @@ export function readMultilineInput(
         getTermWidth,
         getTerminalColumn,
         countRowsBelowCursor,
+        getCursorRow: () => countDisplayRowsAcrossLines(0, cursorPos),
       },
       {
         setBuffer: (v) => { buffer = v; },
@@ -557,26 +555,10 @@ export function readMultilineInput(
       process.stdout.write(`\x1B[${termCol}G`);
     }
 
-    /** Count how many display rows lie between two buffer positions in the same logical line */
-    function countDisplayRowsBetween(from: number, to: number): number {
-      if (from === to) return 0;
-      const start = Math.min(from, to);
-      const end = Math.max(from, to);
-      let count = 0;
-      let pos = start;
-      while (pos < end) {
-        const nextRowStart = getDisplayRowEnd(pos);
-        if (nextRowStart >= end) break;
-        pos = nextRowStart;
-        count++;
-      }
-      return count;
-    }
-
     function moveCursorToLogicalLineStart(): void {
       const lineStart = getLineStart();
       if (cursorPos === lineStart) return;
-      const rowDiff = countDisplayRowsBetween(lineStart, cursorPos);
+      const rowDiff = countDisplayRowsAcrossLines(lineStart, cursorPos);
       cursorPos = lineStart;
       if (rowDiff > 0) {
         process.stdout.write(`\x1B[${rowDiff}A`);
@@ -588,7 +570,7 @@ export function readMultilineInput(
     function moveCursorToLogicalLineEnd(): void {
       const lineEnd = getLineEnd();
       if (cursorPos === lineEnd) return;
-      const rowDiff = countDisplayRowsBetween(cursorPos, lineEnd);
+      const rowDiff = countDisplayRowsAcrossLines(cursorPos, lineEnd);
       cursorPos = lineEnd;
       if (rowDiff > 0) {
         process.stdout.write(`\x1B[${rowDiff}B`);
@@ -811,7 +793,6 @@ export function readMultilineInput(
               return;
             }
 
-            // Tab: apply completion
             if (ch === '\t') {
               if (completion.getState()) {
                 completion.apply();
@@ -822,7 +803,7 @@ export function readMultilineInput(
             // Submit
             if (ch === '\r') {
               const compState = completion.getState();
-              if (compState && compState.candidates.length > 0) {
+              if (compState) {
                 const selected = compState.candidates[compState.selectedIndex];
                 if (selected) {
                   buffer = selected.value;

--- a/src/features/interactive/lineEditor.ts
+++ b/src/features/interactive/lineEditor.ts
@@ -84,6 +84,80 @@ export interface InputCallbacks {
 }
 
 /**
+ * Try to consume an escape sequence starting after the leading \x1B.
+ *
+ * Returns the number of characters consumed (excluding the \x1B itself),
+ * or -1 if the rest is a potential incomplete CSI/SS3 prefix that needs
+ * more data, or 0 if the \x1B is a bare Esc.
+ */
+function tryConsumeEscapeSequence(
+  rest: string,
+  callbacks: InputCallbacks,
+): number {
+  if (rest.startsWith(ESC_PASTE_START)) {
+    callbacks.onPasteStart();
+    return ESC_PASTE_START.length;
+  }
+  if (rest.startsWith(ESC_PASTE_END)) {
+    callbacks.onPasteEnd();
+    return ESC_PASTE_END.length;
+  }
+  if (rest.startsWith(ESC_SHIFT_ENTER)) {
+    callbacks.onShiftEnter();
+    return ESC_SHIFT_ENTER.length;
+  }
+  const ctrlKey = decodeCtrlKey(rest);
+  if (ctrlKey) {
+    callbacks.onChar(ctrlKey.ch);
+    return ctrlKey.consumed;
+  }
+
+  // Arrow keys
+  if (rest.startsWith('[D')) { callbacks.onArrowLeft(); return 2; }
+  if (rest.startsWith('[C')) { callbacks.onArrowRight(); return 2; }
+  if (rest.startsWith('[A')) { callbacks.onArrowUp(); return 2; }
+  if (rest.startsWith('[B')) { callbacks.onArrowDown(); return 2; }
+
+  // Option+Arrow (CSI modified): \x1B[1;3D (left), \x1B[1;3C (right)
+  if (rest.startsWith('[1;3D')) { callbacks.onWordLeft(); return 5; }
+  if (rest.startsWith('[1;3C')) { callbacks.onWordRight(); return 5; }
+
+  // Option+Arrow (SS3/alt): \x1Bb (left), \x1Bf (right)
+  if (rest.startsWith('b')) { callbacks.onWordLeft(); return 1; }
+  if (rest.startsWith('f')) { callbacks.onWordRight(); return 1; }
+
+  // Home: \x1B[H (CSI) or \x1BOH (SS3/application mode)
+  if (rest.startsWith('[H') || rest.startsWith('OH')) { callbacks.onHome(); return 2; }
+
+  // End: \x1B[F (CSI) or \x1BOF (SS3/application mode)
+  if (rest.startsWith('[F') || rest.startsWith('OF')) { callbacks.onEnd(); return 2; }
+
+  // Kitty keyboard protocol: ESC key → \x1B[27u or \x1B[27;1u
+  const kittyEscMatch = rest.match(/^\[27(?:;1)?u/);
+  if (kittyEscMatch) {
+    callbacks.onEsc();
+    return kittyEscMatch[0].length;
+  }
+
+  // Unknown CSI sequences: skip
+  if (rest.startsWith('[')) {
+    const csiMatch = rest.match(/^\[[0-9;]*[A-Za-z~]/);
+    if (csiMatch) return csiMatch[0].length;
+    // Incomplete CSI — need more data
+    return -1;
+  }
+
+  // SS3 prefix ('O') without a recognized follower — could be incomplete
+  if (rest.startsWith('O') && rest.length === 1) return -1;
+
+  // Bare Esc (followed by a non-sequence character or nothing)
+  if (rest.length === 0) return -1;
+
+  callbacks.onEsc();
+  return 0;
+}
+
+/**
  * Parse raw stdin data into semantic input events.
  *
  * Handles paste bracket mode, Kitty keyboard protocol, arrow keys,
@@ -96,108 +170,16 @@ export function parseInputData(data: string, callbacks: InputCallbacks): void {
 
     if (ch === '\x1B') {
       const rest = data.slice(i + 1);
+      const consumed = tryConsumeEscapeSequence(rest, callbacks);
 
-      if (rest.startsWith(ESC_PASTE_START)) {
-        callbacks.onPasteStart();
-        i += 1 + ESC_PASTE_START.length;
-        continue;
-      }
-      if (rest.startsWith(ESC_PASTE_END)) {
-        callbacks.onPasteEnd();
-        i += 1 + ESC_PASTE_END.length;
-        continue;
-      }
-      if (rest.startsWith(ESC_SHIFT_ENTER)) {
-        callbacks.onShiftEnter();
-        i += 1 + ESC_SHIFT_ENTER.length;
-        continue;
-      }
-      const ctrlKey = decodeCtrlKey(rest);
-      if (ctrlKey) {
-        callbacks.onChar(ctrlKey.ch);
-        i += 1 + ctrlKey.consumed;
-        continue;
-      }
-
-      // Arrow keys
-      if (rest.startsWith('[D')) {
-        callbacks.onArrowLeft();
-        i += 3;
-        continue;
-      }
-      if (rest.startsWith('[C')) {
-        callbacks.onArrowRight();
-        i += 3;
-        continue;
-      }
-      if (rest.startsWith('[A')) {
-        callbacks.onArrowUp();
-        i += 3;
-        continue;
-      }
-      if (rest.startsWith('[B')) {
-        callbacks.onArrowDown();
-        i += 3;
-        continue;
-      }
-
-      // Option+Arrow (CSI modified): \x1B[1;3D (left), \x1B[1;3C (right)
-      if (rest.startsWith('[1;3D')) {
-        callbacks.onWordLeft();
-        i += 6;
-        continue;
-      }
-      if (rest.startsWith('[1;3C')) {
-        callbacks.onWordRight();
-        i += 6;
-        continue;
-      }
-
-      // Option+Arrow (SS3/alt): \x1Bb (left), \x1Bf (right)
-      if (rest.startsWith('b')) {
-        callbacks.onWordLeft();
-        i += 2;
-        continue;
-      }
-      if (rest.startsWith('f')) {
-        callbacks.onWordRight();
-        i += 2;
-        continue;
-      }
-
-      // Home: \x1B[H (CSI) or \x1BOH (SS3/application mode)
-      if (rest.startsWith('[H') || rest.startsWith('OH')) {
-        callbacks.onHome();
-        i += 3;
-        continue;
-      }
-
-      // End: \x1B[F (CSI) or \x1BOF (SS3/application mode)
-      if (rest.startsWith('[F') || rest.startsWith('OF')) {
-        callbacks.onEnd();
-        i += 3;
-        continue;
-      }
-
-      // Kitty keyboard protocol: ESC key → \x1B[27u or \x1B[27;1u
-      const kittyEscMatch = rest.match(/^\[27(?:;1)?u/);
-      if (kittyEscMatch) {
+      if (consumed === -1) {
+        // Incomplete escape sequence at end of chunk — treat as bare Esc
         callbacks.onEsc();
-        i += 1 + kittyEscMatch[0].length;
+        i++;
         continue;
       }
 
-      // Unknown CSI sequences: skip
-      if (rest.startsWith('[')) {
-        const csiMatch = rest.match(/^\[[0-9;]*[A-Za-z~]/);
-        if (csiMatch) {
-          i += 1 + csiMatch[0].length;
-          continue;
-        }
-      }
-      // Bare Esc (not part of a recognized sequence)
-      callbacks.onEsc();
-      i++;
+      i += 1 + consumed;
       continue;
     }
 
@@ -205,6 +187,76 @@ export function parseInputData(data: string, callbacks: InputCallbacks): void {
     i++;
   }
 }
+
+const ESC_AMBIGUITY_TIMEOUT_MS = 50 as const;
+
+/**
+ * Stateful escape sequence parser for chunked stdin input.
+ *
+ * Holds an incomplete trailing \x1B across chunks and resolves it
+ * when the next chunk arrives or after a timeout.
+ */
+export const createEscapeParser = (
+  callbacks: InputCallbacks,
+): { feed: (data: string) => void; flush: () => void } => {
+  let pendingEsc = false;
+  let escTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearEscTimer = (): void => {
+    if (escTimer !== null) {
+      clearTimeout(escTimer);
+      escTimer = null;
+    }
+  };
+
+  const flush = (): void => {
+    clearEscTimer();
+    if (pendingEsc) {
+      pendingEsc = false;
+      callbacks.onEsc();
+    }
+  };
+
+  const feed = (data: string): void => {
+    let input = data;
+
+    if (pendingEsc) {
+      pendingEsc = false;
+      clearEscTimer();
+      input = `\x1B${input}`;
+    }
+
+    let i = 0;
+    while (i < input.length) {
+      const ch = input[i]!;
+
+      if (ch === '\x1B') {
+        const rest = input.slice(i + 1);
+
+        if (rest.length === 0) {
+          pendingEsc = true;
+          escTimer = setTimeout(flush, ESC_AMBIGUITY_TIMEOUT_MS);
+          return;
+        }
+
+        const consumed = tryConsumeEscapeSequence(rest, callbacks);
+        if (consumed === -1) {
+          pendingEsc = true;
+          escTimer = setTimeout(flush, ESC_AMBIGUITY_TIMEOUT_MS);
+          return;
+        }
+
+        i += 1 + consumed;
+        continue;
+      }
+
+      callbacks.onChar(ch);
+      i++;
+    }
+  };
+
+  return { feed, flush };
+};
 
 /**
  * Read multiline input from the user using raw mode with cursor management.
@@ -463,6 +515,7 @@ export function readMultilineInput(
     }
 
     function cleanup(): void {
+      escParser.flush();
       completion.hide();
       process.stdin.removeListener('data', onData);
       process.stdout.write(PASTE_BRACKET_DISABLE);
@@ -627,18 +680,13 @@ export function readMultilineInput(
 
     const utf8Decoder = new StringDecoder('utf8');
 
-    function onData(data: Buffer): void {
-      try {
-        const str = utf8Decoder.write(data);
-        if (!str) return;
-
-        parseInputData(str, {
-          onPasteStart() { state = 'paste'; },
+    const escParser = createEscapeParser({
+          onPasteStart() { state = 'paste'; completion.hide(); },
           onPasteEnd() {
             state = 'normal';
             rerenderFromCursor();
           },
-          onShiftEnter() { insertNewline(); },
+          onShiftEnter() { completion.hide(); insertNewline(); },
           onArrowLeft() {
             if (state !== 'normal') return;
             if (cursorPos > getLineStart()) {
@@ -810,6 +858,12 @@ export function readMultilineInput(
             completion.update();
           },
         });
+
+    function onData(data: Buffer): void {
+      try {
+        const str = utf8Decoder.write(data);
+        if (!str) return;
+        escParser.feed(str);
       } catch {
         cleanup();
         resolve(null);

--- a/src/features/interactive/lineEditor.ts
+++ b/src/features/interactive/lineEditor.ts
@@ -10,6 +10,7 @@
 import * as readline from 'node:readline';
 import { StringDecoder } from 'node:string_decoder';
 import { stripAnsi, getDisplayWidth } from '../../shared/utils/text.js';
+import { createCompletionController } from './completionController.js';
 
 /** Escape sequences for terminal protocol control */
 const PASTE_BRACKET_ENABLE = '\x1B[?2004h';
@@ -78,6 +79,7 @@ export interface InputCallbacks {
   onWordRight: () => void;
   onHome: () => void;
   onEnd: () => void;
+  onEsc: () => void;
   onChar: (ch: string) => void;
 }
 
@@ -177,6 +179,14 @@ export function parseInputData(data: string, callbacks: InputCallbacks): void {
         continue;
       }
 
+      // Kitty keyboard protocol: ESC key → \x1B[27u or \x1B[27;1u
+      const kittyEscMatch = rest.match(/^\[27(?:;1)?u/);
+      if (kittyEscMatch) {
+        callbacks.onEsc();
+        i += 1 + kittyEscMatch[0].length;
+        continue;
+      }
+
       // Unknown CSI sequences: skip
       if (rest.startsWith('[')) {
         const csiMatch = rest.match(/^\[[0-9;]*[A-Za-z~]/);
@@ -185,7 +195,8 @@ export function parseInputData(data: string, callbacks: InputCallbacks): void {
           continue;
         }
       }
-      // Unrecognized escape: skip the \x1B
+      // Bare Esc (not part of a recognized sequence)
+      callbacks.onEsc();
       i++;
       continue;
     }
@@ -207,7 +218,18 @@ export function parseInputData(data: string, callbacks: InputCallbacks): void {
  *
  * Falls back to readline.question() in non-TTY environments.
  */
-export function readMultilineInput(prompt: string): Promise<string | null> {
+export function readMultilineInput(
+  prompt: string,
+  options?: {
+    completionProvider?: (
+      context: { buffer: string },
+    ) => readonly {
+      readonly value: string;
+      readonly description?: string;
+      readonly applyValue?: string;
+    }[];
+  },
+): Promise<string | null> {
   if (!process.stdin.isTTY) {
     return new Promise((resolve) => {
       if (process.stdin.readable && !process.stdin.destroyed) {
@@ -297,6 +319,55 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
     function getTermWidth(): number {
       return process.stdout.columns || 80;
     }
+
+    // --- Completion menu helpers ---
+
+    /**
+     * Count display rows between two arbitrary buffer positions.
+     */
+    function countDisplayRowsBetweenPositions(from: number, to: number): number {
+      if (from >= to) return 0;
+      let rows = 0;
+      let pos = from;
+      while (pos < to) {
+        const rowEnd = getDisplayRowEnd(pos);
+        if (rowEnd >= to) break;
+        const nextChar = buffer[rowEnd];
+        if (nextChar === '\n') {
+          rows++;
+          pos = rowEnd + 1;
+        } else {
+          rows++;
+          pos = rowEnd;
+        }
+      }
+      return rows;
+    }
+
+    /**
+     * Count display rows from cursor position to end of buffer.
+     */
+    function countRowsBelowCursor(): number {
+      const cursorRow = countDisplayRowsBetweenPositions(0, cursorPos);
+      const totalRows = countDisplayRowsBetweenPositions(0, buffer.length);
+      return totalRows - cursorRow;
+    }
+
+    const completion = createCompletionController(
+      {
+        getBuffer: () => buffer,
+        getCursorPos: () => cursorPos,
+        getTermWidth,
+        getTerminalColumn,
+        countRowsBelowCursor,
+      },
+      {
+        setBuffer: (v) => { buffer = v; },
+        setCursorPos: (v) => { cursorPos = v; },
+      },
+      promptWidth,
+      options?.completionProvider,
+    );
 
     /** Buffer position of the display row start that contains `pos` */
     function getDisplayRowStart(pos: number): number {
@@ -392,6 +463,7 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
     }
 
     function cleanup(): void {
+      completion.hide();
       process.stdin.removeListener('data', onData);
       process.stdout.write(PASTE_BRACKET_DISABLE);
       process.stdout.write(KITTY_KB_DISABLE);
@@ -597,6 +669,12 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
           },
           onArrowUp() {
             if (state !== 'normal') return;
+            
+            if (completion.getState()) {
+              completion.moveSelection(-1);
+              return;
+            }
+
             const logicalLineStart = getLineStart();
             const displayRowStart = getDisplayRowStart(cursorPos);
             const displayCol = getDisplayRowColumn(cursorPos);
@@ -616,6 +694,12 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
           },
           onArrowDown() {
             if (state !== 'normal') return;
+
+            if (completion.getState()) {
+              completion.moveSelection(1);
+              return;
+            }
+
             const logicalLineEnd = getLineEnd();
             const displayRowEnd = getDisplayRowEnd(cursorPos);
             const displayCol = getDisplayRowColumn(cursorPos);
@@ -662,6 +746,9 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
             if (state !== 'normal') return;
             moveCursorToLogicalLineEnd();
           },
+          onEsc() {
+            completion.hide();
+          },
           onChar(ch: string) {
             if (state === 'paste') {
               if (ch === '\r' || ch === '\n') {
@@ -676,8 +763,26 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
               return;
             }
 
+            // Tab: apply completion
+            if (ch === '\t') {
+              if (completion.getState()) {
+                completion.apply();
+              }
+              return;
+            }
+
             // Submit
             if (ch === '\r') {
+              const compState = completion.getState();
+              if (compState && compState.candidates.length > 0) {
+                const selected = compState.candidates[compState.selectedIndex];
+                if (selected) {
+                  buffer = selected.value;
+                  cursorPos = buffer.length;
+                }
+              }
+              
+              completion.hide();
               process.stdout.write('\n');
               cleanup();
               resolve(buffer);
@@ -691,17 +796,18 @@ export function readMultilineInput(prompt: string): Promise<string | null> {
               return;
             }
             // Editing
-            if (ch === '\x7F' || ch === '\x08') { deleteCharBefore(); return; }
+            if (ch === '\x7F' || ch === '\x08') { deleteCharBefore(); completion.update(); return; }
             if (ch === '\x01') { moveCursorToDisplayRowStart(); return; }
             if (ch === '\x05') { moveCursorToDisplayRowEnd(); return; }
-            if (ch === '\x0B') { deleteToLineEnd(); return; }
-            if (ch === '\x15') { deleteToLineStart(); return; }
-            if (ch === '\x17') { deleteWord(); return; }
-            if (ch === '\x0A') { insertNewline(); return; }
+            if (ch === '\x0B') { deleteToLineEnd(); completion.update(); return; }
+            if (ch === '\x15') { deleteToLineStart(); completion.update(); return; }
+            if (ch === '\x17') { deleteWord(); completion.update(); return; }
+            if (ch === '\x0A') { completion.hide(); insertNewline(); return; }
             // Ignore unknown control characters
             if (ch.charCodeAt(0) < 0x20) return;
             // Regular character
             insertChar(ch);
+            completion.update();
           },
         });
       } catch {

--- a/src/features/interactive/slashCommandRegistry.ts
+++ b/src/features/interactive/slashCommandRegistry.ts
@@ -1,0 +1,41 @@
+/**
+ * Slash command registry with metadata for inline completion.
+ *
+ * Assembles slash command entries from the shared constants
+ * and provides filtering utilities for the completion menu.
+ */
+
+import { SlashCommand } from '../../shared/constants.js';
+
+/** i18n label key for each slash command description */
+const SLASH_COMMAND_LABEL_KEYS: Readonly<Record<SlashCommand, string>> = {
+  '/play': 'interactive.commands.play',
+  '/go': 'interactive.commands.go',
+  '/retry': 'interactive.commands.retry',
+  '/replay': 'interactive.commands.replay',
+  '/cancel': 'interactive.commands.cancel',
+  '/resume': 'interactive.commands.resume',
+} as const;
+
+/**
+ * Registry of all slash commands.
+ */
+const SLASH_COMMAND_REGISTRY: readonly {
+  readonly command: SlashCommand;
+  readonly labelKey: string;
+}[] = (Object.values(SlashCommand)).map(
+  (command) => ({ command, labelKey: SLASH_COMMAND_LABEL_KEYS[command] }),
+);
+
+/**
+ * Filter slash commands by prefix match.
+ */
+export const filterSlashCommands = (
+  prefix: string,
+): readonly {
+  readonly command: SlashCommand;
+  readonly labelKey: string;
+}[] => {
+  const lower = prefix.toLowerCase();
+  return SLASH_COMMAND_REGISTRY.filter((entry) => entry.command.startsWith(lower));
+};

--- a/src/features/interactive/slashCommandRegistry.ts
+++ b/src/features/interactive/slashCommandRegistry.ts
@@ -28,14 +28,29 @@ const SLASH_COMMAND_REGISTRY: readonly {
 );
 
 /**
- * Filter slash commands by prefix match.
+ * Conditions controlling which slash commands are available.
+ */
+export interface CommandAvailability {
+  readonly enableRetryCommand?: boolean;
+  readonly hasPreviousOrder?: boolean;
+}
+
+/**
+ * Filter slash commands by prefix match and availability conditions.
  */
 export const filterSlashCommands = (
   prefix: string,
+  availability?: CommandAvailability,
 ): readonly {
   readonly command: SlashCommand;
   readonly labelKey: string;
 }[] => {
   const lower = prefix.toLowerCase();
-  return SLASH_COMMAND_REGISTRY.filter((entry) => entry.command.startsWith(lower));
+  return SLASH_COMMAND_REGISTRY.filter((entry) => {
+    if (!entry.command.startsWith(lower)) return false;
+    if (!availability) return true;
+    if (entry.command === SlashCommand.Retry && !availability.enableRetryCommand) return false;
+    if (entry.command === SlashCommand.Replay && !availability.hasPreviousOrder) return false;
+    return true;
+  });
 };

--- a/src/shared/i18n/labels_en.yaml
+++ b/src/shared/i18n/labels_en.yaml
@@ -56,6 +56,13 @@ interactive:
     userStopped: "⚠️ Previous task was interrupted by user"
     piece: "Workflow: {pieceName}"
     timestamp: "Executed: {timestamp}"
+  commands:
+    play: "Run a task immediately"
+    go: "Create instruction & run"
+    retry: "Review & rerun with previous instructions"
+    replay: "Rerun immediately with previous instructions"
+    cancel: "Exit interactive mode"
+    resume: "Load a previous session"
 
 # ===== Piece Execution UI =====
 piece:

--- a/src/shared/i18n/labels_ja.yaml
+++ b/src/shared/i18n/labels_ja.yaml
@@ -56,6 +56,13 @@ interactive:
     userStopped: "⚠️ 前回のタスクはユーザーによって中断されました"
     piece: "使用ワークフロー: {pieceName}"
     timestamp: "実行時刻: {timestamp}"
+  commands:
+    play: "タスクを即実行する"
+    go: "指示書を作成して実行"
+    retry: "前回の指示書を確認して再実行"
+    replay: "前回の指示書で即再実行"
+    cancel: "対話モードを終了"
+    resume: "セッションを読み込む"
 
 # ===== Piece Execution UI =====
 piece:


### PR DESCRIPTION
- close #579 

## 概要

対話モードで  を入力するとスラッシュコマンドの候補が表示される補完メニューを実装する。

<img width="523" height="161" alt="Screenshot 2026-04-07 at 23 32 54" src="https://github.com/user-attachments/assets/f2839072-4959-40de-94ec-9d22e77f8a54" />

<img width="286" height="111" alt="image" src="https://github.com/user-attachments/assets/79bec0a0-6b35-4d44-bbc8-6cccaf0cdb40" />


## 実装内容

### 基本

以下の２つのパターンでサジェスト機能を実装

- /g→tab補完→/go
- /g→サジェストから選択→enter→実行

### それ以外

- escキーで候補を非表示に
- Retryやそれぞれの各モードで必要なコマンドしか表示されないように

## 補完の構造

```mermaid
flowchart TD
  A[conversationLoop.ts] -->|readInteractiveInput| B[interactiveInput.ts]
  Q[quietMode.ts] -->|readMultilineInput| E[lineEditor.ts]
  P[passthroughMode.ts] -->|readMultilineInput| E

  B -->|createSlashCommandCompletionProvider| C[slashCommandRegistry.ts]
  B -->|completionProvider有り| E

  E -->|候補更新/選択/適用| F[completionController.ts]
  F -->|描画/消去| G[completionMenu.ts]

  C -->|prefix一致のcommand一覧| B
```

- `conversationLoop` 経由だけ `interactiveInput` を通る
- `quietMode` / `passthroughMode` は `lineEditor` を直接呼ぶので、補完は有効にならない
