### PR TITLE
fix: stabilize Claude SDK subprocess PATH under version-managed runtimes (mise case)

### DIFF
--- a/src/__tests__/claude-executor-structured-output.test.ts
+++ b/src/__tests__/claude-executor-structured-output.test.ts
@@ -35,19 +35,18 @@ describe('SdkOptionsBuilder — outputFormat 変換', () => {
     expect(sdkOptions).not.toHaveProperty('outputFormat');
   });
 
-  it('Claude CLI のディレクトリを PATH の先頭に追加する', () => {
+  it('現在の Node.js 実行ディレクトリを PATH の先頭に追加する', () => {
     const originalPath = process.env.PATH;
-    const cliPath = '/tmp/test-bin/claude';
     try {
       process.env.PATH = ['/usr/bin', '/bin'].join(delimiter);
 
       const sdkOptions = buildSdkOptions({
         cwd: '/tmp',
-        pathToClaudeCodeExecutable: cliPath,
+        pathToClaudeCodeExecutable: '/tmp/test-bin/claude',
       });
 
       const pathEntries = sdkOptions.env?.PATH?.split(delimiter) ?? [];
-      expect(pathEntries[0]).toBe(dirname(cliPath));
+      expect(pathEntries[0]).toBe(dirname(process.execPath));
       expect(pathEntries).toContain('/usr/bin');
       expect(pathEntries).toContain(dirname(process.execPath));
     } finally {

--- a/src/infra/claude/options-builder.ts
+++ b/src/infra/claude/options-builder.ts
@@ -42,7 +42,6 @@ function buildSdkEnv(options: ClaudeSpawnOptions): Record<string, string> {
     .split(delimiter)
     .filter((entry): entry is string => entry.length > 0);
   const prependedEntries = [
-    options.pathToClaudeCodeExecutable ? dirname(options.pathToClaudeCodeExecutable) : undefined,
     process.execPath ? dirname(process.execPath) : undefined,
   ].filter((entry): entry is string => Boolean(entry));
 


### PR DESCRIPTION
## 概要

`mise` 配下でインストールした `takt` から Claude Code を実行した際に、Claude Agent SDK の query から `Grep` や `Glob` といった組み込みツール（`rg`を使うやつ？）で `EACCES` エラーとなり、Bash 経由の検索にフォールバックするケースを観測しました。

```
Glob Error: spawn /Users/nikkie/.local/share/mise/installs/nod...
Grep Error: spawn /Users/nikkie/.local/share/mise/installs/nod...
```

SDK に渡す `PATH` を補強し、~~Claude CLI のディレクトリと~~現在の Node.js 実行ディレクトリを先頭に追加するようにして、サブプロセスの起動安定性を改善します。

## 変更内容

- Claude SDK に渡す `env.PATH` の組み立てを調整
- `ANTHROPIC_API_KEY` の注入は従来どおり維持
- `PATH` 補強の挙動を確認するテストを追加

## 環境情報

macOS を以下のように環境構築しています

```bash
which node
# /Users/nikkie/.local/share/mise/installs/node/25.9.0/bin/node

which claude
# /Users/nikkie/.local/bin/claude
# curlでインストールしています
```

## 動作確認

`takt -w .takt/pieces/claude-grep-smoke.yaml`
以下のyamlを渡し、「クワイエット」で即`/play`して動作確認します

- 配布版 (0.33.2): Claude の組み込み `Grep` が `EACCES` で失敗（`Bash`にフォールバック）
- 修正版（このブランチ）: 同じ条件で `Grep` が成功

```yaml
name: claude-grep-smoke
description: >
  Minimal smoke workflow for verifying that Claude Code can invoke Grep/Bash
  tools successfully during a TAKT run.

max_movements: 1
initial_movement: grep_check

movements:
  - name: grep_check
    edit: false
    provider: claude
    model: opus
    session: refresh
    provider_options:
      claude:
        allowed_tools:
          - Read
          - Glob
          - Grep
          - Bash
    instruction: |
      Verify that Grep works in this repository.

      Search under `src/` for the text `provider`.
      Prefer the Grep tool. If needed, you may use Bash for supporting checks.

      Return:
      1. The total number of matches you found
      2. Up to 3 representative file paths containing matches
      3. A one-line conclusion stating whether Grep worked successfully
    rules:
      - condition: Grep verification complete
        next: COMPLETE
```