### PR TITLE
[#590] dedupe-deprecation-warnings

### DIFF
--- a/src/__tests__/legacy-piece-movement-deprecation-warnings.test.ts
+++ b/src/__tests__/legacy-piece-movement-deprecation-warnings.test.ts
@@ -4,17 +4,16 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 
-import { GlobalConfigManager } from '../infra/config/global/globalConfigCore.js';
-import { loadProjectConfig } from '../infra/config/project/projectConfig.js';
-import { normalizePieceConfig } from '../infra/config/loaders/pieceParser.js';
-import { TaskFileSchema } from '../infra/task/schema.js';
-import { resolveWorkflowCliOption } from '../app/cli/helpers.js';
-import {
-  warnLegacyCategoryYamlKeys,
-  warnLegacyGlobalConfigYamlKeys,
-  warnLegacyProjectConfigYamlKeys,
-  warnLegacyWorkflowYamlKeys,
-} from '../infra/config/legacy-workflow-key-deprecation.js';
+let GlobalConfigManager: typeof import('../infra/config/global/globalConfigCore.js').GlobalConfigManager;
+let loadProjectConfig: typeof import('../infra/config/project/projectConfig.js').loadProjectConfig;
+let normalizePieceConfig: typeof import('../infra/config/loaders/pieceParser.js').normalizePieceConfig;
+let loadDefaultCategories: typeof import('../infra/config/loaders/pieceCategories.js').loadDefaultCategories;
+let TaskFileSchema: typeof import('../infra/task/schema.js').TaskFileSchema;
+let resolveWorkflowCliOption: typeof import('../app/cli/helpers.js').resolveWorkflowCliOption;
+let warnLegacyCategoryYamlKeys: typeof import('../infra/config/legacy-workflow-key-deprecation.js').warnLegacyCategoryYamlKeys;
+let warnLegacyGlobalConfigYamlKeys: typeof import('../infra/config/legacy-workflow-key-deprecation.js').warnLegacyGlobalConfigYamlKeys;
+let warnLegacyProjectConfigYamlKeys: typeof import('../infra/config/legacy-workflow-key-deprecation.js').warnLegacyProjectConfigYamlKeys;
+let warnLegacyWorkflowYamlKeys: typeof import('../infra/config/legacy-workflow-key-deprecation.js').warnLegacyWorkflowYamlKeys;
 
 function messagesFromWarnSpy(warnSpy: ReturnType<typeof vi.spyOn>): string[] {
   return warnSpy.mock.calls.map((call) => String(call[0]));
@@ -49,6 +48,30 @@ vi.mock('../infra/config/paths.js', () => ({
   getProjectTaktDir: vi.fn(),
   getProjectCwd: vi.fn(),
 }));
+
+async function loadSubjects(): Promise<void> {
+  ({ GlobalConfigManager } = await import('../infra/config/global/globalConfigCore.js'));
+  ({ loadProjectConfig } = await import('../infra/config/project/projectConfig.js'));
+  ({ normalizePieceConfig } = await import('../infra/config/loaders/pieceParser.js'));
+  ({ loadDefaultCategories } = await import('../infra/config/loaders/pieceCategories.js'));
+  ({ TaskFileSchema } = await import('../infra/task/schema.js'));
+  ({ resolveWorkflowCliOption } = await import('../app/cli/helpers.js'));
+  ({
+    warnLegacyCategoryYamlKeys,
+    warnLegacyGlobalConfigYamlKeys,
+    warnLegacyProjectConfigYamlKeys,
+    warnLegacyWorkflowYamlKeys,
+  } = await import('../infra/config/legacy-workflow-key-deprecation.js'));
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  await loadSubjects();
+});
+
+afterEach(() => {
+  GlobalConfigManager.resetInstance();
+});
 
 describe('legacy piece/movement deprecation warnings (#581)', () => {
   describe('GlobalConfigManager.load', () => {
@@ -756,6 +779,93 @@ describe('legacy piece/movement deprecation warnings (#581)', () => {
     });
   });
 
+  describe('loadDefaultCategories (#590 dedupe)', () => {
+    let testDir: string;
+    let resourcesDir: string;
+
+    beforeEach(async () => {
+      testDir = mkdtempSync(join(tmpdir(), 'takt-590-category-dedupe-'));
+      resourcesDir = join(testDir, 'resources', 'en');
+      mkdirSync(resourcesDir, { recursive: true });
+
+      vi.doMock('../infra/config/global/globalConfig.js', async (importOriginal) => {
+        const original = await importOriginal() as Record<string, unknown>;
+        return {
+          ...original,
+          loadGlobalConfig: () => ({}),
+        };
+      });
+
+      vi.doMock('../infra/config/resolveConfigValue.js', () => ({
+        resolveConfigValue: (_cwd: string, key: string) => {
+          if (key === 'language') return 'en';
+          if (key === 'enableBuiltinPieces') return true;
+          if (key === 'disabledBuiltins') return [];
+          return undefined;
+        },
+        resolveConfigValues: (_cwd: string, keys: readonly string[]) => {
+          const result: Record<string, unknown> = {};
+          for (const key of keys) {
+            if (key === 'language') result[key] = 'en';
+            if (key === 'enableBuiltinPieces') result[key] = true;
+            if (key === 'disabledBuiltins') result[key] = [];
+          }
+          return result;
+        },
+      }));
+
+      vi.doMock('../infra/resources/index.js', async (importOriginal) => {
+        const original = await importOriginal() as Record<string, unknown>;
+        return {
+          ...original,
+          getLanguageResourcesDir: (_lang: string) => resourcesDir,
+        };
+      });
+
+      vi.doMock('../infra/config/global/pieceCategories.js', async (importOriginal) => {
+        const original = await importOriginal() as Record<string, unknown>;
+        return {
+          ...original,
+          getPieceCategoriesPath: () => join(testDir, 'user-piece-categories.yaml'),
+        };
+      });
+
+      vi.resetModules();
+      await loadSubjects();
+    });
+
+    afterEach(() => {
+      vi.doUnmock('../infra/config/global/globalConfig.js');
+      vi.doUnmock('../infra/config/resolveConfigValue.js');
+      vi.doUnmock('../infra/resources/index.js');
+      vi.doUnmock('../infra/config/global/pieceCategories.js');
+      rmSync(testDir, { recursive: true, force: true });
+    });
+
+    it('should warn only once when loadDefaultCategories reads the same legacy category keys twice in one process', () => {
+      writeFileSync(
+        join(resourcesDir, 'workflow-categories.yaml'),
+        [
+          'piece_categories:',
+          '  Quick Start:',
+          '    pieces:',
+          '      - default',
+        ].join('\n'),
+        'utf-8',
+      );
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      loadDefaultCategories(testDir);
+      loadDefaultCategories(testDir);
+
+      const categoryMsgs = messagesFromWarnSpy(warnSpy).filter((m) => (
+        m.includes('piece_categories') && m.includes('workflow_categories')
+      ));
+      expect(categoryMsgs).toHaveLength(1);
+      warnSpy.mockRestore();
+    });
+  });
+
   describe('warnLegacyWorkflowYamlKeys (raw workflow object)', () => {
     it('should warn for parallel sub-object step without name', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
@@ -972,6 +1082,153 @@ describe('legacy piece/movement deprecation warnings (#581)', () => {
         (m) => m.includes('piece') && m.includes('workflow'),
       );
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('process-wide deprecation dedupe (#590)', () => {
+    it('should warn only once when TaskFileSchema parses the same legacy task key twice in one process', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      TaskFileSchema.parse({ task: 'do work', piece: 'default' });
+      TaskFileSchema.parse({ task: 'do work', piece: 'default' });
+
+      const matches = messagesFromWarnSpy(warnSpy).filter(
+        (m) => m.includes('piece') && m.includes('workflow') && !m.includes('(CLI)'),
+      );
+      expect(matches).toHaveLength(1);
+      warnSpy.mockRestore();
+    });
+
+    it('should warn only once when normalizePieceConfig parses the same legacy workflow key twice in one process', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const raw = {
+        name: 'wf-legacy-piece-config-process-shared',
+        piece_config: {},
+        movements: [minimalStep],
+        initial_movement: 'plan',
+      };
+
+      normalizePieceConfig(raw, process.cwd());
+      normalizePieceConfig(raw, process.cwd());
+
+      const matches = messagesFromWarnSpy(warnSpy).filter(
+        (m) => m.includes('piece_config') && m.includes('workflow_config'),
+      );
+      expect(matches).toHaveLength(1);
+      warnSpy.mockRestore();
+    });
+
+    it('should warn only once when loadProjectConfig loads the same legacy project key twice in one process', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const testDir = mkdtempSync(join(tmpdir(), 'takt-590-project-process-warn-'));
+      mkdirSync(join(testDir, '.takt'), { recursive: true });
+      writeFileSync(
+        join(testDir, '.takt', 'config.yaml'),
+        [
+          'piece_overrides:',
+          '  quality_gates:',
+          '    - Gate',
+        ].join('\n'),
+        'utf-8',
+      );
+
+      try {
+        loadProjectConfig(testDir);
+        loadProjectConfig(testDir);
+
+        const matches = messagesFromWarnSpy(warnSpy).filter(
+          (m) => m.includes('piece_overrides') && m.includes('workflow_overrides'),
+        );
+        expect(matches).toHaveLength(1);
+      } finally {
+        warnSpy.mockRestore();
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should warn only once when GlobalConfigManager reloads the same legacy global key twice in one process', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const testDir = mkdtempSync(join(tmpdir(), 'takt-590-global-process-warn-'));
+      mkdirSync(testDir, { recursive: true });
+      testGlobalConfigPath = join(testDir, 'config.yaml');
+      writeFileSync(
+        testGlobalConfigPath,
+        ['enable_builtin_pieces: true'].join('\n'),
+        'utf-8',
+      );
+
+      try {
+        GlobalConfigManager.resetInstance();
+        GlobalConfigManager.getInstance().load();
+        GlobalConfigManager.resetInstance();
+        GlobalConfigManager.getInstance().load();
+
+        const matches = messagesFromWarnSpy(warnSpy).filter(
+          (m) =>
+            m.includes('enable_builtin_pieces')
+            && m.includes('enable_builtin_workflows'),
+        );
+        expect(matches).toHaveLength(1);
+      } finally {
+        warnSpy.mockRestore();
+        GlobalConfigManager.resetInstance();
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should warn only once when resolveWorkflowCliOption sees the same legacy CLI key twice in one process', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      expect(resolveWorkflowCliOption({ piece: 'default' })).toBe('default');
+      expect(resolveWorkflowCliOption({ piece: 'default' })).toBe('default');
+
+      const matches = messagesFromWarnSpy(warnSpy).filter(
+        (m) => m.includes('piece') && m.includes('workflow') && m.includes('(CLI)'),
+      );
+      expect(matches).toHaveLength(1);
+      warnSpy.mockRestore();
+    });
+
+    it('should warn only once across global and project loaders when they emit the same deprecation message in one process', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const globalDir = mkdtempSync(join(tmpdir(), 'takt-590-global-project-global-'));
+      const projectDir = mkdtempSync(join(tmpdir(), 'takt-590-global-project-project-'));
+      mkdirSync(join(projectDir, '.takt'), { recursive: true });
+      testGlobalConfigPath = join(globalDir, 'config.yaml');
+      writeFileSync(
+        testGlobalConfigPath,
+        [
+          'piece_overrides:',
+          '  quality_gates:',
+          '    - Global Gate',
+        ].join('\n'),
+        'utf-8',
+      );
+      writeFileSync(
+        join(projectDir, '.takt', 'config.yaml'),
+        [
+          'piece_overrides:',
+          '  quality_gates:',
+          '    - Project Gate',
+        ].join('\n'),
+        'utf-8',
+      );
+
+      try {
+        GlobalConfigManager.resetInstance();
+        GlobalConfigManager.getInstance().load();
+        loadProjectConfig(projectDir);
+
+        const matches = messagesFromWarnSpy(warnSpy).filter(
+          (m) => m.includes('piece_overrides') && m.includes('workflow_overrides'),
+        );
+        expect(matches).toHaveLength(1);
+      } finally {
+        warnSpy.mockRestore();
+        GlobalConfigManager.resetInstance();
+        rmSync(globalDir, { recursive: true, force: true });
+        rmSync(projectDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/src/app/cli/helpers.ts
+++ b/src/app/cli/helpers.ts
@@ -8,7 +8,7 @@ import type { Command } from 'commander';
 import type { TaskExecutionOptions } from '../../features/tasks/index.js';
 import type { ProviderType } from '../../infra/providers/index.js';
 import { isIssueReference } from '../../infra/git/index.js';
-import { warnLegacyConfigKey } from '../../infra/config/legacy-workflow-key-deprecation.js';
+import { warnLegacyConfigKeyOncePerProcess } from '../../infra/config/legacy-workflow-key-deprecation.js';
 
 const REMOVED_ROOT_COMMANDS = new Set(['switch']);
 
@@ -77,7 +77,7 @@ export function resolveWorkflowCliOption(opts: Record<string, unknown>): string 
   }
 
   if (typeof piece === 'string') {
-    warnLegacyConfigKey(new Set(), 'piece', 'workflow', 'CLI');
+    warnLegacyConfigKeyOncePerProcess('piece', 'workflow', 'CLI');
   }
 
   return workflow ?? piece;

--- a/src/infra/config/global/globalConfigCore.ts
+++ b/src/infra/config/global/globalConfigCore.ts
@@ -28,7 +28,7 @@ import { expandOptionalHomePath } from '../pathExpansion.js';
 import { sanitizeConfigValue } from './globalConfigLegacyMigration.js';
 import { serializeGlobalConfig } from './globalConfigSerializer.js';
 import { loadGlobalConfigTrace, type ConfigTrace } from '../traced/tracedConfigLoader.js';
-import { warnLegacyGlobalConfigYamlKeys } from '../legacy-workflow-key-deprecation.js';
+import { warnLegacyGlobalConfigYamlKeysOncePerProcess } from '../legacy-workflow-key-deprecation.js';
 export { validateCliPath } from './cliPathValidator.js';
 
 function getRecord(value: unknown): Record<string, unknown> | undefined {
@@ -93,8 +93,7 @@ export class GlobalConfigManager {
         return sanitized;
       },
     );
-    const deprecationSeen = new Set<string>();
-    warnLegacyGlobalConfigYamlKeys(parsedConfig, deprecationSeen);
+    warnLegacyGlobalConfigYamlKeysOncePerProcess(parsedConfig);
     assertNoUnknownGlobalConfigKeys(parsedConfig);
     const parsed = GlobalConfigSchema.parse(rawConfig);
     const normalizedProvider = normalizeConfigProviderReference(

--- a/src/infra/config/legacy-workflow-key-deprecation.ts
+++ b/src/infra/config/legacy-workflow-key-deprecation.ts
@@ -10,6 +10,8 @@ function formatLegacyConfigKeyDeprecationMessage(
   return msg;
 }
 
+const legacyConfigKeyDeprecationSeen = new Set<string>();
+
 export function warnLegacyConfigKey(
   seen: Set<string>,
   legacyKey: string,
@@ -22,6 +24,14 @@ export function warnLegacyConfigKey(
   }
   seen.add(msg);
   console.warn(msg);
+}
+
+export function warnLegacyConfigKeyOncePerProcess(
+  legacyKey: string,
+  canonicalKey: string,
+  contextLabel?: string,
+): void {
+  warnLegacyConfigKey(legacyConfigKeyDeprecationSeen, legacyKey, canonicalKey, contextLabel);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -78,6 +88,10 @@ export function warnLegacyGlobalConfigYamlKeys(parsed: Record<string, unknown>, 
   warnLegacyOverridesNestedMovements(wo, 'workflow_overrides', seen);
 }
 
+export function warnLegacyGlobalConfigYamlKeysOncePerProcess(parsed: Record<string, unknown>): void {
+  warnLegacyGlobalConfigYamlKeys(parsed, legacyConfigKeyDeprecationSeen);
+}
+
 export function warnLegacyProjectConfigYamlKeys(parsed: Record<string, unknown>, seen: Set<string>): void {
   warnLegacyPieceStarYamlKeys(parsed, seen);
   const po = parsed.piece_overrides;
@@ -95,6 +109,10 @@ export function warnLegacyProjectConfigYamlKeys(parsed: Record<string, unknown>,
       }
     }
   }
+}
+
+export function warnLegacyProjectConfigYamlKeysOncePerProcess(parsed: Record<string, unknown>): void {
+  warnLegacyProjectConfigYamlKeys(parsed, legacyConfigKeyDeprecationSeen);
 }
 
 function walkParallelSubStepsForStepAlias(
@@ -149,6 +167,10 @@ export function warnLegacyWorkflowYamlKeys(raw: unknown, seen: Set<string>): voi
   }
 }
 
+export function warnLegacyWorkflowYamlKeysOncePerProcess(raw: unknown): void {
+  warnLegacyWorkflowYamlKeys(raw, legacyConfigKeyDeprecationSeen);
+}
+
 function walkCategoryNodesForLegacyPiecesKey(node: unknown, seen: Set<string>, path: string[]): void {
   if (!isPlainRecord(node)) {
     return;
@@ -194,4 +216,8 @@ export function warnLegacyCategoryYamlKeys(raw: unknown, seen: Set<string>): voi
   if (isPlainRecord(wc)) {
     walkCategoryRoot(wc, seen);
   }
+}
+
+export function warnLegacyCategoryYamlKeysOncePerProcess(raw: unknown): void {
+  warnLegacyCategoryYamlKeys(raw, legacyConfigKeyDeprecationSeen);
 }

--- a/src/infra/config/loaders/pieceCategories.ts
+++ b/src/infra/config/loaders/pieceCategories.ts
@@ -16,7 +16,7 @@ import { getLanguageResourcesDir } from '../../resources/index.js';
 import { listBuiltinPieceNames } from './pieceResolver.js';
 import { resolvePieceConfigValues } from '../resolvePieceConfigValue.js';
 import type { PieceWithSource } from './pieceResolver.js';
-import { warnLegacyCategoryYamlKeys } from '../legacy-workflow-key-deprecation.js';
+import { warnLegacyCategoryYamlKeysOncePerProcess } from '../legacy-workflow-key-deprecation.js';
 
 const CategoryConfigSchema = z.object({
   piece_categories: z.record(z.string(), z.unknown()).optional(),
@@ -214,7 +214,7 @@ function loadCategoryConfigFromPath(path: string, sourceLabel: string): ParsedCa
 
   const content = readFileSync(path, 'utf-8');
   const raw = parseYaml(content);
-  warnLegacyCategoryYamlKeys(raw, new Set());
+  warnLegacyCategoryYamlKeysOncePerProcess(raw);
   return parseCategoryConfig(raw, sourceLabel);
 }
 

--- a/src/infra/config/loaders/pieceParser.ts
+++ b/src/infra/config/loaders/pieceParser.ts
@@ -34,7 +34,9 @@ import { loadProjectConfig } from '../project/projectConfig.js';
 import { loadGlobalConfig } from '../global/globalConfig.js';
 import { normalizeConfigProviderReferenceDetailed, type ConfigProviderReference } from '../providerReference.js';
 import { mergeProviderOptions } from '../providerOptions.js';
-import { warnLegacyWorkflowYamlKeys } from '../legacy-workflow-key-deprecation.js';
+import {
+  warnLegacyWorkflowYamlKeysOncePerProcess,
+} from '../legacy-workflow-key-deprecation.js';
 
 type RawProviderReference = RawStep['provider'];
 
@@ -390,8 +392,7 @@ export function normalizePieceConfig(
   pieceArpeggioPolicy?: PieceArpeggioConfig,
   pieceMcpServersPolicy?: PieceMcpServersConfig,
 ): PieceConfig {
-  const deprecationSeen = new Set<string>();
-  warnLegacyWorkflowYamlKeys(raw, deprecationSeen);
+  warnLegacyWorkflowYamlKeysOncePerProcess(raw);
   const parsed = PieceConfigRawSchema.parse(raw);
 
   const resolvedPolicies = resolveSectionMap(parsed.policies, pieceDir);

--- a/src/infra/config/project/projectConfig.ts
+++ b/src/infra/config/project/projectConfig.ts
@@ -44,7 +44,7 @@ import {
 import { loadProjectConfigTrace, type ConfigTrace } from '../traced/tracedConfigLoader.js';
 import { getCachedProjectConfigTrace, setCachedProjectConfigTrace } from '../resolutionCache.js';
 import { assertValidProjectConfig } from './projectConfigValidation.js';
-import { warnLegacyProjectConfigYamlKeys } from '../legacy-workflow-key-deprecation.js';
+import { warnLegacyProjectConfigYamlKeysOncePerProcess } from '../legacy-workflow-key-deprecation.js';
 
 export type { ProjectConfig as ProjectLocalConfig } from '../types.js';
 
@@ -54,7 +54,7 @@ type RawProviderReference = ConfigProviderReference<ProviderType>;
 export function loadProjectConfig(projectDir: string): ProjectConfig {
   const configPath = getProjectConfigPath(projectDir);
   const { parsedConfig, rawConfig, trace } = loadProjectConfigTrace(configPath);
-  warnLegacyProjectConfigYamlKeys(parsedConfig, new Set());
+  warnLegacyProjectConfigYamlKeysOncePerProcess(parsedConfig);
   setCachedProjectConfigTrace(projectDir, trace);
   assertValidProjectConfig(parsedConfig, configPath, true);
   assertValidProjectConfig(rawConfig, configPath);

--- a/src/infra/task/schema.ts
+++ b/src/infra/task/schema.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod/v4';
 import { isValidTaskDir } from '../../shared/utils/taskPaths.js';
-import { warnLegacyConfigKey } from '../config/legacy-workflow-key-deprecation.js';
+import { warnLegacyConfigKeyOncePerProcess } from '../config/legacy-workflow-key-deprecation.js';
 
 function getStringField(record: Record<string, unknown>, key: string): string | undefined {
   const value = record[key];
@@ -71,15 +71,14 @@ function normalizeAliasedTaskConfig(input: unknown): unknown {
     return input;
   }
 
-  const deprecationSeen = new Set<string>();
   if ('piece' in record) {
-    warnLegacyConfigKey(deprecationSeen, 'piece', 'workflow');
+    warnLegacyConfigKeyOncePerProcess('piece', 'workflow');
   }
   if ('start_movement' in record) {
-    warnLegacyConfigKey(deprecationSeen, 'start_movement', 'start_step');
+    warnLegacyConfigKeyOncePerProcess('start_movement', 'start_step');
   }
   if ('exceeded_max_movements' in record) {
-    warnLegacyConfigKey(deprecationSeen, 'exceeded_max_movements', 'exceeded_max_steps');
+    warnLegacyConfigKeyOncePerProcess('exceeded_max_movements', 'exceeded_max_steps');
   }
 
   const workflow = resolveTaskWorkflowValue(record);


### PR DESCRIPTION
## Summary

## 概要
同じ deprecated warning が同一プロセス内で何度も出力される。

例:
- `Deprecated: "piece" is deprecated. Use "workflow" instead.`
- `Deprecated: "start_movement" is deprecated. Use "start_step" instead.`

タスク実行中に task/workflow/config の parse/load が複数回走ると、同じ警告が繰り返し表示され、ログの可読性が落ちる。

## 現在の挙動
同一メッセージでも、parse/load のたびに再度 warning が出る。

## 期待する挙動
同一プロセス内では、同じ deprecated warning は初回だけ表示する。
少なくとも通常の task 実行では、同じ warning が何度も並ばないようにしたい。

## 原因
`warnLegacyConfigKey(seen, ...)` 自体には重複抑止があるが、呼び出し元で毎回 `new Set()` を作っているため、抑止のスコープが「その 1 回の parse/load」だけになっている。

該当箇所:
- `src/infra/task/schema.ts`
- `src/infra/config/loaders/pieceParser.ts`
- `src/infra/config/project/projectConfig.ts`
- `src/infra/config/global/globalConfigCore.ts`
- `src/app/cli/helpers.ts`

## 方向性
- deprecation warning の dedupe をプロセス共有にする
- もしくは、少なくとも task 実行単位で共有される `seen` を導入する

## メモ
既存テストは「shared seen を渡した場合に重複しない」ことは確認しているが、実運用では毎回 `new Set()` しているため、期待どおりの抑止になっていない。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #590