### PR TITLE
Release v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.35.0] - 2026-04-07
+
+### Added
+
+- Claude Headless プロバイダを追加: Claude CLI のヘッドレスモード（`claude --print`）をサブプロセスとして実行する新プロバイダ。`claude` プロバイダ名で利用可能 (#584)
+- trace ログレベルを追加: `poll_tick`/`no_new_tasks` などの高頻度ログを抑制し、デバッグログの可読性を向上。`logging.trace: true` で有効化
+- レガシー設定キーの非推奨警告: `piece_*`/`movement*` 系の旧キー使用時に deprecation warning を表示し、新しい `workflow_*`/`step*` キーへの移行を促進 (#581, #594)
+- Mock プロバイダで `delayMs` と AbortSignal をサポート: SIGINT テスト等で利用可能に (#595)
+
+### Changed
+
+- **BREAKING:** `claude` プロバイダがヘッドレス CLI モードをデフォルトに変更。従来の SDK ベースプロバイダは `claude-sdk` として引き続き利用可能 (#584)
+- クローン環境からのプッシュに relay push パターンを導入: 一時 ref 経由でプッシュすることで、チェックアウト中のブランチへの直接プッシュによるデータ損失を防止 (#592)
+- PR 由来タスクのメタデータ伝搬を改善: `shouldPublishBranchToOrigin` フラグにより、ローカルプッシュ失敗時にクローンから直接 origin へプッシュするフォールバックを追加 (#592)
+- dual/backend ワークフローの `max_steps` を 60 に増加
+
+### Fixed
+
+- `pr_body_template` が `--task` オプション実行時に無視される問題を修正 (#538)
+- 既存 PR ブランチ更新時にリモートを正として worktree を作成するよう修正 (#557)
+- SIGINT（Ctrl+C）が AI レスポンス待機中に正しくアボートされない問題を修正 (#595)
+- mise 等のバージョン管理ツール環境下で Claude SDK サブプロセスの PATH が安定しない問題を修正 (#591)
+- ジャッジムーブメントのプロバイダフォールバック解決が正しく機能しない問題を修正 (#577)
+- exceeded 時のワークツリーパスが正しく解決されない問題を修正 (#575)
+- PR 作成時のエラー詳細が失われる問題を修正
+- non-fast-forward プッシュ拒否時にヒントメッセージを表示するよう改善
+
+### Internal
+
+- `.takt/config.yaml` の非推奨キーをリネーム
+- レガシーワークフローキー非推奨警告の重複排除 (#594)
+- `AgentSetup` から `claudeAgent`/`claudeSkill` フィールドを削除（Headless プロバイダ移行に伴い不要に）
+- 型定義ファイルから冗長な JSDoc コメントを整理
+- review-fix-takt-default ワークフローの max_steps を増加
+
 ## [0.34.0] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ TAKT is built with TAKT itself (dogfooding).
 
 Choose one:
 
-- **Provider CLIs**: [Codex](https://github.com/openai/codex), [OpenCode](https://opencode.ai), [Cursor Agent](https://docs.cursor.com/), or [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) installed
-- **Direct API**: Anthropic / OpenAI / OpenCode API Key (no CLI required)
+- **Provider CLIs**: [Claude Code](https://claude.ai/code) (default `claude` provider), [Codex](https://github.com/openai/codex), [OpenCode](https://opencode.ai), [Cursor Agent](https://docs.cursor.com/), or [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) installed
+- **Direct API**: OpenAI / OpenCode API Key (no CLI required)
 
 Optional:
 
@@ -162,7 +162,7 @@ See the [CLI Reference](./docs/cli-reference.md) for all commands and options.
 Minimal `~/.takt/config.yaml`:
 
 ```yaml
-provider: claude    # claude, codex, opencode, cursor, or copilot
+provider: claude    # claude, claude-sdk, codex, opencode, cursor, or copilot
 model: sonnet       # passed directly to provider
 language: en        # en or ja
 ```

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,41 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.35.0] - 2026-04-07
+
+### Added
+
+- Claude Headless プロバイダを追加: Claude CLI のヘッドレスモード（`claude --print`）をサブプロセスとして実行する新プロバイダ。`claude` プロバイダ名で利用可能 (#584)
+- trace ログレベルを追加: `poll_tick`/`no_new_tasks` などの高頻度ログを抑制し、デバッグログの可読性を向上。`logging.trace: true` で有効化
+- レガシー設定キーの非推奨警告: `piece_*`/`movement*` 系の旧キー使用時に deprecation warning を表示し、新しい `workflow_*`/`step*` キーへの移行を促進 (#581, #594)
+- Mock プロバイダで `delayMs` と AbortSignal をサポート: SIGINT テスト等で利用可能に (#595)
+
+### Changed
+
+- **BREAKING:** `claude` プロバイダがヘッドレス CLI モードをデフォルトに変更。従来の SDK ベースプロバイダは `claude-sdk` として引き続き利用可能 (#584)
+- クローン環境からのプッシュに relay push パターンを導入: 一時 ref 経由でプッシュすることで、チェックアウト中のブランチへの直接プッシュによるデータ損失を防止 (#592)
+- PR 由来タスクのメタデータ伝搬を改善: `shouldPublishBranchToOrigin` フラグにより、ローカルプッシュ失敗時にクローンから直接 origin へプッシュするフォールバックを追加 (#592)
+- dual/backend ワークフローの `max_steps` を 60 に増加
+
+### Fixed
+
+- `pr_body_template` が `--task` オプション実行時に無視される問題を修正 (#538)
+- 既存 PR ブランチ更新時にリモートを正として worktree を作成するよう修正 (#557)
+- SIGINT（Ctrl+C）が AI レスポンス待機中に正しくアボートされない問題を修正 (#595)
+- mise 等のバージョン管理ツール環境下で Claude SDK サブプロセスの PATH が安定しない問題を修正 (#591)
+- ジャッジムーブメントのプロバイダフォールバック解決が正しく機能しない問題を修正 (#577)
+- exceeded 時のワークツリーパスが正しく解決されない問題を修正 (#575)
+- PR 作成時のエラー詳細が失われる問題を修正
+- non-fast-forward プッシュ拒否時にヒントメッセージを表示するよう改善
+
+### Internal
+
+- `.takt/config.yaml` の非推奨キーをリネーム
+- レガシーワークフローキー非推奨警告の重複排除 (#594)
+- `AgentSetup` から `claudeAgent`/`claudeSkill` フィールドを削除（Headless プロバイダ移行に伴い不要に）
+- 型定義ファイルから冗長な JSDoc コメントを整理
+- review-fix-takt-default ワークフローの max_steps を増加
+
 ## [0.34.0] - 2026-04-03
 
 ### Added

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -22,8 +22,8 @@ TAKT は TAKT 自身で開発しています（ドッグフーディング）。
 
 次のいずれかが必要です。
 
-- **プロバイダー CLI**: [Codex](https://github.com/openai/codex)、[OpenCode](https://opencode.ai)、[Cursor Agent](https://docs.cursor.com/)、[GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) のいずれか
-- **API Key 直接利用**: Anthropic / OpenAI / OpenCode の API Key があれば CLI は不要です
+- **プロバイダー CLI**: [Claude Code](https://claude.ai/code)（デフォルトの `claude` プロバイダ）、[Codex](https://github.com/openai/codex)、[OpenCode](https://opencode.ai)、[Cursor Agent](https://docs.cursor.com/)、[GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) のいずれか
+- **API Key 直接利用**: OpenAI / OpenCode の API Key があれば CLI は不要です
 
 任意:
 
@@ -165,7 +165,7 @@ workflow ファイルの正式ディレクトリ名は `workflows/` です。旧
 最小限の `~/.takt/config.yaml` は次の通りです。
 
 ```yaml
-provider: claude    # claude, codex, opencode, cursor, or copilot
+provider: claude    # claude, claude-sdk, codex, opencode, cursor, or copilot
 model: sonnet       # プロバイダーにそのまま渡されます
 language: ja        # en or ja
 ```

--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -20,7 +20,7 @@
 | `--skip-git` | ブランチ作成、コミット、プッシュをスキップ（pipeline モード、workflow のみ実行） |
 | `--repo <owner/repo>` | リポジトリを指定（PR 作成用） |
 | `-q, --quiet` | 最小出力モード: AI 出力を抑制（CI 向け） |
-| `--provider <name>` | エージェント provider を上書き（claude\|codex\|opencode\|cursor\|copilot\|mock） |
+| `--provider <name>` | エージェント provider を上書き（claude-sdk\|claude\|codex\|opencode\|cursor\|copilot\|mock） |
 | `--model <name>` | エージェントモデルを上書き |
 | `--config <path>` | グローバル設定ファイルのパス（デフォルト: `~/.takt/config.yaml`） |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -20,7 +20,7 @@ This document provides a complete reference for all TAKT CLI commands and option
 | `--skip-git` | Skip branch creation, commit, and push (pipeline mode, workflow-only) |
 | `--repo <owner/repo>` | Specify repository (for PR creation) |
 | `-q, --quiet` | Minimal output mode: suppress AI output (for CI) |
-| `--provider <name>` | Override agent provider (claude\|codex\|opencode\|cursor\|copilot\|mock) |
+| `--provider <name>` | Override agent provider (claude-sdk\|claude\|codex\|opencode\|cursor\|copilot\|mock) |
 | `--model <name>` | Override agent model |
 | `--config <path>` | Path to global config file (default: `~/.takt/config.yaml`) |
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -119,7 +119,8 @@ interactive_preview_steps: 3      # インタラクティブモードでの step
 |-----------|------|---------|------|
 | `language` | `"en"` \| `"ja"` | `"en"` | UI 言語 |
 | `logging.level` | `"debug"` \| `"info"` \| `"warn"` \| `"error"` | `"info"` | ログレベル |
-| `provider` | `"claude"` \| `"codex"` \| `"opencode"` \| `"cursor"` \| `"copilot"` | `"claude"` | デフォルト AI provider |
+| `provider` | `"claude"` \| `"claude-sdk"` \| `"codex"` \| `"opencode"` \| `"cursor"` \| `"copilot"` | `"claude"` | デフォルト AI provider（`claude` = ヘッドレス CLI モード、`claude-sdk` = SDK/API モード） |
+| `logging.trace` | boolean | `false` | trace レベルのログを有効化（高頻度のデバッグノイズを抑制） |
 | `model` | string | - | デフォルトモデル名（provider にそのまま渡される） |
 | `branch_name_strategy` | `"romaji"` \| `"ai"` | `"romaji"` | ブランチ名生成方式 |
 | `prevent_sleep` | boolean | `false` | macOS アイドルスリープ防止（caffeinate） |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,7 +119,8 @@ interactive_preview_steps: 3      # Step previews in interactive mode (0-10, def
 |-------|------|---------|-------------|
 | `language` | `"en"` \| `"ja"` | `"en"` | UI language |
 | `logging.level` | `"debug"` \| `"info"` \| `"warn"` \| `"error"` | `"info"` | Log level |
-| `provider` | `"claude"` \| `"codex"` \| `"opencode"` \| `"cursor"` \| `"copilot"` | `"claude"` | Default AI provider |
+| `provider` | `"claude"` \| `"claude-sdk"` \| `"codex"` \| `"opencode"` \| `"cursor"` \| `"copilot"` | `"claude"` | Default AI provider (`claude` = headless CLI mode, `claude-sdk` = SDK/API mode) |
+| `logging.trace` | boolean | `false` | Enable trace-level logging (suppresses high-frequency debug noise) |
 | `model` | string | - | Default model name (passed to provider as-is) |
 | `branch_name_strategy` | `"romaji"` \| `"ai"` | `"romaji"` | Branch name generation strategy |
 | `prevent_sleep` | boolean | `false` | Prevent macOS idle sleep (caffeinate) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.71",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- Claude Headless プロバイダを追加: Claude CLI のヘッドレスモード（`claude --print`）をサブプロセスとして実行する新プロバイダ。`claude` プロバイダ名で利用可能 (#584)
- trace ログレベルを追加: `poll_tick`/`no_new_tasks` などの高頻度ログを抑制し、デバッグログの可読性を向上。`logging.trace: true` で有効化
- レガシー設定キーの非推奨警告: `piece_*`/`movement*` 系の旧キー使用時に deprecation warning を表示し、新しい `workflow_*`/`step*` キーへの移行を促進 (#581, #594)
- Mock プロバイダで `delayMs` と AbortSignal をサポート: SIGINT テスト等で利用可能に (#595)

### Changed

- **BREAKING:** `claude` プロバイダがヘッドレス CLI モードをデフォルトに変更。従来の SDK ベースプロバイダは `claude-sdk` として引き続き利用可能 (#584)
- クローン環境からのプッシュに relay push パターンを導入: 一時 ref 経由でプッシュすることで、チェックアウト中のブランチへの直接プッシュによるデータ損失を防止 (#592)
- PR 由来タスクのメタデータ伝搬を改善: `shouldPublishBranchToOrigin` フラグにより、ローカルプッシュ失敗時にクローンから直接 origin へプッシュするフォールバックを追加 (#592)
- dual/backend ワークフローの `max_steps` を 60 に増加

### Fixed

- `pr_body_template` が `--task` オプション実行時に無視される問題を修正 (#538)
- 既存 PR ブランチ更新時にリモートを正として worktree を作成するよう修正 (#557)
- SIGINT（Ctrl+C）が AI レスポンス待機中に正しくアボートされない問題を修正 (#595)
- mise 等のバージョン管理ツール環境下で Claude SDK サブプロセスの PATH が安定しない問題を修正 (#591)
- ジャッジムーブメントのプロバイダフォールバック解決が正しく機能しない問題を修正 (#577)
- exceeded 時のワークツリーパスが正しく解決されない問題を修正 (#575)
- PR 作成時のエラー詳細が失われる問題を修正
- non-fast-forward プッシュ拒否時にヒントメッセージを表示するよう改善

### Internal

- `.takt/config.yaml` の非推奨キーをリネーム
- レガシーワークフローキー非推奨警告の重複排除 (#594)
- `AgentSetup` から `claudeAgent`/`claudeSkill` フィールドを削除（Headless プロバイダ移行に伴い不要に）
- 型定義ファイルから冗長な JSDoc コメントを整理
- review-fix-takt-default ワークフローの max_steps を増加

## Commits

- 3b33b1d5 Release v0.35.0
- 415d6628 fix: pr_body_template が --task 実行時に無視される (#538)
- cea89a55 [#557] fix-remote-pr-worktree (#583)
- b5ad9266 [#592] fix-pr-task-meta-relay (#598)
- d46b2bfa fix: preserve PR creation error details
- 6543bfd6 chore: rename deprecated keys in .takt/config.yaml
- 4e0d1b0c [#595] fix-sigint-ai-abort (#596)
- 71b077ca chore: increase max_steps to 60 for dual/backend workflows
- d9285287 fix: add trace method to createLogger mocks broken by trace level addition
- 336686df feat: add trace log level to suppress poll_tick/no_new_tasks noise
- f31b7129 test: add E2E for SIGINT during AI output wait (currently failing)
- c7b9b292 takt: dedupe-deprecation-warnings (#594)
- 569ecda2 [#584] split-claude-providers (#585)
- 393f9a22 fix: stabilize Claude SDK subprocess PATH under version-managed runtimes (mise case) (#591)
- 90306b55 chore: increase review-fix-takt-default max steps
- 54182210 [#581] warn-legacy-piece-movement (#582)
- 16bb6168 takt: fix-judge-provider-fallback (#577)
- d7592210 Merge pull request #575 from nrslib/takt/562/fix-exceeded-worktree-path
- 4a2fe8f9 takt: fix-exceeded-worktree-path

## Closes

Closes #592