### PR TITLE
fix: scroll select menu in short terminals

### DIFF
--- a/src/__tests__/select-viewport.test.ts
+++ b/src/__tests__/select-viewport.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for viewport scrolling in select menu.
+ *
+ * Covers: countItemLines, createViewportState, adjustScrollOffset,
+ * renderMenuWithViewport.
+ */
+
+import { describe, it, expect } from 'vitest';
+import chalk from 'chalk';
+import type { SelectOptionItem } from '../shared/prompt/select-menu.js';
+import { countItemLines } from '../shared/prompt/select-menu.js';
+import {
+  createViewportState,
+  adjustScrollOffset,
+  renderMenuWithViewport,
+} from '../shared/prompt/select-viewport.js';
+
+chalk.level = 0;
+
+// ── Test fixtures ────────────────────────────────────────────────────
+
+function labelOnly(label: string, value: string): SelectOptionItem<string> {
+  return { label, value };
+}
+
+function withDescription(label: string, value: string, description: string): SelectOptionItem<string> {
+  return { label, value, description };
+}
+
+function withDetails(label: string, value: string, details: string[]): SelectOptionItem<string> {
+  return { label, value, details };
+}
+
+function withDescAndDetails(
+  label: string,
+  value: string,
+  description: string,
+  details: string[],
+): SelectOptionItem<string> {
+  return { label, value, description, details };
+}
+
+// ── countItemLines ───────────────────────────────────────────────────
+
+describe('countItemLines', () => {
+  it('should return 1 for label-only option', () => {
+    expect(countItemLines(labelOnly('A', 'a'))).toBe(1);
+  });
+
+  it('should return 2 when option has description', () => {
+    expect(countItemLines(withDescription('A', 'a', 'desc'))).toBe(2);
+  });
+
+  it('should count details lines', () => {
+    expect(countItemLines(withDetails('A', 'a', ['d1', 'd2']))).toBe(3);
+  });
+
+  it('should count description + details', () => {
+    expect(countItemLines(withDescAndDetails('A', 'a', 'desc', ['d1', 'd2', 'd3']))).toBe(5);
+  });
+});
+
+// ── createViewportState ──────────────────────────────────────────────
+
+describe('createViewportState', () => {
+  it('should be inactive when all items fit', () => {
+    // 3 label-only options = 3 lines, terminal 20 rows, available = 16
+    const options = [labelOnly('A', 'a'), labelOnly('B', 'b'), labelOnly('C', 'c')];
+    const state = createViewportState(20, options, false);
+
+    expect(state.active).toBe(false);
+    expect(state.scrollOffset).toBe(0);
+  });
+
+  it('should be inactive when items + cancel fit', () => {
+    const options = [labelOnly('A', 'a'), labelOnly('B', 'b')];
+    // 2 options + 1 cancel = 3 lines, available = 16
+    const state = createViewportState(20, options, true);
+
+    expect(state.active).toBe(false);
+  });
+
+  it('should be active when items exceed available lines', () => {
+    // 10 label-only options = 10 lines, terminal 10 rows, available = 6
+    const options = Array.from({ length: 10 }, (_, i) => labelOnly(`Opt${i}`, `v${i}`));
+    const state = createViewportState(10, options, false);
+
+    expect(state.active).toBe(true);
+    expect(state.maxOptionLines).toBe(6);
+    expect(state.scrollOffset).toBe(0);
+  });
+
+  it('should ensure maxOptionLines is at least 1', () => {
+    // terminal 5 rows: available = 1
+    const options = Array.from({ length: 10 }, (_, i) => labelOnly(`Opt${i}`, `v${i}`));
+    const state = createViewportState(5, options, false);
+
+    expect(state.active).toBe(true);
+    expect(state.maxOptionLines).toBe(1);
+  });
+
+  it('should account for multi-line options', () => {
+    // Each option = 2 lines (label + description) → total 6 lines
+    // Terminal 8 rows: available = 4, total 6 > 4 → active
+    const options = [
+      withDescription('A', 'a', 'desc a'),
+      withDescription('B', 'b', 'desc b'),
+      withDescription('C', 'c', 'desc c'),
+    ];
+    const state = createViewportState(8, options, false);
+
+    expect(state.active).toBe(true);
+    expect(state.maxOptionLines).toBe(4);
+  });
+});
+
+// ── adjustScrollOffset ───────────────────────────────────────────────
+
+describe('adjustScrollOffset', () => {
+  // 10 label-only options, maxOptionLines = 4 → 4 visible at a time
+  const options = Array.from({ length: 10 }, (_, i) => labelOnly(`Opt${i}`, `v${i}`));
+  const maxLines = 4;
+  const noCancel = false;
+
+  it('should not change when selected item is within visible range', () => {
+    // scrollOffset=0, visible=[0,1,2,3], selected=2
+    const result = adjustScrollOffset(2, 0, options, noCancel, maxLines);
+    expect(result).toBe(0);
+  });
+
+  it('should scroll down when selected item is below visible range', () => {
+    // scrollOffset=0, visible=[0,1,2,3], selected=5
+    const result = adjustScrollOffset(5, 0, options, noCancel, maxLines);
+    expect(result).toBeGreaterThan(0);
+    // Verify the selected item is now visible
+    const endCheck = adjustScrollOffset(5, result, options, noCancel, maxLines);
+    expect(endCheck).toBe(result);
+  });
+
+  it('should scroll up when selected item is above visible range', () => {
+    // scrollOffset=5, selected=2
+    const result = adjustScrollOffset(2, 5, options, noCancel, maxLines);
+    expect(result).toBe(2);
+  });
+
+  it('should handle wrap-around from last to first', () => {
+    // scrollOffset=6, selected=0 (wrapped from bottom to top)
+    const result = adjustScrollOffset(0, 6, options, noCancel, maxLines);
+    expect(result).toBe(0);
+  });
+
+  it('should handle wrap-around from first to last', () => {
+    // scrollOffset=0, selected=9 (wrapped from top to bottom)
+    const result = adjustScrollOffset(9, 0, options, noCancel, maxLines);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('should work with cancel option', () => {
+    // 3 options + cancel = 4 items, maxOptionLines = 2
+    const opts = [labelOnly('A', 'a'), labelOnly('B', 'b'), labelOnly('C', 'c')];
+    // Select cancel (index 3), scrollOffset=0
+    const result = adjustScrollOffset(3, 0, opts, true, 2);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('should work with multi-line options', () => {
+    const multiLineOpts = [
+      withDescription('A', 'a', 'desc a'),
+      withDescription('B', 'b', 'desc b'),
+      withDescription('C', 'c', 'desc c'),
+      withDescription('D', 'd', 'desc d'),
+    ];
+    // maxOptionLines = 4, each item = 2 lines → 2 items visible
+    // scrollOffset=0, selected=3 (below visible)
+    const result = adjustScrollOffset(3, 0, multiLineOpts, false, 4);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+// ── renderMenuWithViewport ───────────────────────────────────────────
+
+describe('renderMenuWithViewport', () => {
+  it('should show lower indicator at top of list', () => {
+    const options = Array.from({ length: 10 }, (_, i) => labelOnly(`Opt${i}`, `v${i}`));
+    // scrollOffset=0, maxOptionLines=3
+    const lines = renderMenuWithViewport(options, 0, false, 0, 3, 'Cancel');
+
+    // Last line: lower indicator
+    const lastLine = lines[lines.length - 1]!;
+    expect(lastLine).toContain('↓');
+    expect(lastLine).toContain('more');
+  });
+
+  it('should show upper indicator when scrolled down', () => {
+    const options = Array.from({ length: 10 }, (_, i) => labelOnly(`Opt${i}`, `v${i}`));
+    // scrollOffset=3, maxOptionLines=3
+    const lines = renderMenuWithViewport(options, 3, false, 3, 3, 'Cancel');
+
+    // First line: upper indicator
+    expect(lines[0]).toContain('↑');
+    expect(lines[0]).toContain('3 more');
+  });
+
+  it('should show both indicators in the middle', () => {
+    const options = Array.from({ length: 10 }, (_, i) => labelOnly(`Opt${i}`, `v${i}`));
+    // scrollOffset=3, maxOptionLines=3, one option fits between indicators
+    const lines = renderMenuWithViewport(options, 4, false, 3, 3, 'Cancel');
+
+    expect(lines[0]).toContain('↑');
+    expect(lines[0]).toContain('3 more');
+    const lastLine = lines[lines.length - 1]!;
+    expect(lastLine).toContain('↓');
+    expect(lastLine).toContain('6 more');
+  });
+
+  it('should show both indicators in constrained viewport', () => {
+    const options = Array.from({ length: 5 }, (_, i) => labelOnly(`Opt${i}`, `v${i}`));
+    // scrollOffset=2, maxOptionLines=3, one option fits between indicators
+    const lines = renderMenuWithViewport(options, 4, false, 2, 3, 'Cancel');
+
+    expect(lines[0]).toContain('↑');
+    expect(lines[0]).toContain('2 more');
+    const lastLine = lines[lines.length - 1]!;
+    expect(lastLine).toContain('↓');
+    expect(lastLine).toContain('2 more');
+  });
+
+  it('should show no lower indicator at end of list', () => {
+    const options = Array.from({ length: 5 }, (_, i) => labelOnly(`Opt${i}`, `v${i}`));
+    // scrollOffset=3, maxOptionLines=4 → items 3,4 visible, ↑ above, nothing below
+    const lines = renderMenuWithViewport(options, 4, false, 3, 4, 'Cancel');
+
+    expect(lines[0]).toContain('↑');
+    expect(lines[0]).toContain('3 more');
+    const lastLine = lines[lines.length - 1]!;
+    expect(lastLine).not.toContain('↓');
+  });
+
+  it('should render cancel option when visible', () => {
+    const options = [labelOnly('A', 'a'), labelOnly('B', 'b')];
+    // 2 options + cancel, maxOptionLines=3, all visible from offset 0
+    const lines = renderMenuWithViewport(options, 2, true, 0, 3, 'Cancel');
+
+    const joinedLines = lines.join('\n');
+    expect(joinedLines).toContain('Cancel');
+  });
+
+  it('should display correct hidden count with cancel option', () => {
+    const options = Array.from({ length: 5 }, (_, i) => labelOnly(`Opt${i}`, `v${i}`));
+    // 5 options + cancel = 6 items, scrollOffset=0, maxOptionLines=3, two items visible
+    const lines = renderMenuWithViewport(options, 0, true, 0, 3, 'Cancel');
+
+    const lastLine = lines[lines.length - 1]!;
+    expect(lastLine).toContain('↓');
+    expect(lastLine).toContain('4 more');
+  });
+
+  it('should render selected item cursor correctly', () => {
+    const options = [labelOnly('A', 'a'), labelOnly('B', 'b'), labelOnly('C', 'c')];
+    const lines = renderMenuWithViewport(options, 1, false, 0, 3, 'Cancel');
+
+    // Find the line with the cursor
+    const cursorLine = lines.find((l) => l.includes('❯'));
+    expect(cursorLine).toBeDefined();
+    expect(cursorLine).toContain('B');
+  });
+
+  it('should handle multi-line options within viewport', () => {
+    const options = [
+      withDescription('A', 'a', 'desc a'),
+      withDescription('B', 'b', 'desc b'),
+      withDescription('C', 'c', 'desc c'),
+    ];
+    // maxOptionLines=4, each item=2 lines → one item plus lower indicator
+    const lines = renderMenuWithViewport(options, 0, false, 0, 4, 'Cancel');
+
+    expect(lines.join('\n')).toContain('A');
+    expect(lines.join('\n')).toContain('desc a');
+    expect(lines.join('\n')).toContain('↓ 2 more');
+  });
+});

--- a/src/shared/prompt/select-menu.ts
+++ b/src/shared/prompt/select-menu.ts
@@ -1,0 +1,145 @@
+/**
+ * Pure functions for select menu rendering and input handling.
+ *
+ * All functions are side-effect-free and testable in isolation.
+ * IO concerns (stdin/stdout, raw mode) remain in select.ts.
+ * Viewport logic lives in select-viewport.ts.
+ */
+
+import chalk from 'chalk';
+import { truncateText } from '../utils/index.js';
+
+export interface SelectOptionItem<T extends string> {
+  label: string;
+  value: T;
+  description?: string;
+  details?: string[];
+}
+
+export type KeyInputResult =
+  | { action: 'move'; newIndex: number }
+  | { action: 'confirm'; selectedIndex: number }
+  | { action: 'cancel'; cancelIndex: number }
+  | { action: 'bookmark'; selectedIndex: number }
+  | { action: 'remove_bookmark'; selectedIndex: number }
+  | { action: 'exit' }
+  | { action: 'none' };
+
+export interface ViewportState {
+  readonly scrollOffset: number;
+  readonly maxOptionLines: number;
+  readonly active: boolean;
+}
+
+// ── Rendering helpers ────────────────────────────────────────────────
+
+const LABEL_PREFIX = 4;
+const DESC_PREFIX = 5;
+const DETAIL_PREFIX = 9;
+
+export function renderSingleOption<T extends string>(
+  opt: SelectOptionItem<T>,
+  isSelected: boolean,
+  maxWidth: number,
+): string[] {
+  const lines: string[] = [];
+  const cursor = isSelected ? chalk.cyan('❯') : ' ';
+  const truncatedLabel = truncateText(opt.label, maxWidth - LABEL_PREFIX);
+  const label = isSelected ? chalk.cyan.bold(truncatedLabel) : truncatedLabel;
+  lines.push(`  ${cursor} ${label}`);
+
+  if (opt.description) {
+    const truncatedDesc = truncateText(opt.description, maxWidth - DESC_PREFIX);
+    lines.push(chalk.gray(`     ${truncatedDesc}`));
+  }
+  if (opt.details && opt.details.length > 0) {
+    for (const detail of opt.details) {
+      const truncatedDetail = truncateText(detail, maxWidth - DETAIL_PREFIX);
+      lines.push(chalk.dim(`       • ${truncatedDetail}`));
+    }
+  }
+
+  return lines;
+}
+
+export function renderCancelOption(isSelected: boolean, cancelLabel: string): string {
+  const cursor = isSelected ? chalk.cyan('❯') : ' ';
+  const label = isSelected ? chalk.cyan.bold(cancelLabel) : chalk.gray(cancelLabel);
+  return `  ${cursor} ${label}`;
+}
+
+// ── Public pure functions ────────────────────────────────────────────
+
+export function countItemLines<T extends string>(opt: SelectOptionItem<T>): number {
+  let lines = 1;
+  if (opt.description) lines++;
+  if (opt.details) lines += opt.details.length;
+  return lines;
+}
+
+export function renderMenu<T extends string>(
+  options: SelectOptionItem<T>[],
+  selectedIndex: number,
+  hasCancelOption: boolean,
+  cancelLabel = 'Cancel',
+): string[] {
+  const maxWidth = process.stdout.columns || 80;
+  const lines: string[] = [];
+
+  for (let i = 0; i < options.length; i++) {
+    const opt = options[i];
+    if (!opt) continue;
+    const isSelected = i === selectedIndex;
+    lines.push(...renderSingleOption(opt, isSelected, maxWidth));
+  }
+
+  if (hasCancelOption) {
+    const isCancelSelected = selectedIndex === options.length;
+    lines.push(renderCancelOption(isCancelSelected, cancelLabel));
+  }
+
+  return lines;
+}
+
+export function countRenderedLines<T extends string>(
+  options: SelectOptionItem<T>[],
+  hasCancelOption: boolean,
+): number {
+  let count = 0;
+  for (const opt of options) {
+    count += countItemLines(opt);
+  }
+  if (hasCancelOption) count++;
+  return count;
+}
+
+export function handleKeyInput(
+  key: string,
+  currentIndex: number,
+  totalItems: number,
+  hasCancelOption: boolean,
+  optionCount: number,
+): KeyInputResult {
+  if (key === '\x1B[A' || key === 'k') {
+    return { action: 'move', newIndex: (currentIndex - 1 + totalItems) % totalItems };
+  }
+  if (key === '\x1B[B' || key === 'j') {
+    return { action: 'move', newIndex: (currentIndex + 1) % totalItems };
+  }
+  if (key === '\r' || key === '\n') {
+    return { action: 'confirm', selectedIndex: currentIndex };
+  }
+  if (key === '\x03') {
+    return { action: 'exit' };
+  }
+  if (key === '\x1B') {
+    return { action: 'cancel', cancelIndex: hasCancelOption ? optionCount : -1 };
+  }
+  if (key === 'b') {
+    return { action: 'bookmark', selectedIndex: currentIndex };
+  }
+  if (key === 'r') {
+    return { action: 'remove_bookmark', selectedIndex: currentIndex };
+  }
+  return { action: 'none' };
+}

--- a/src/shared/prompt/select-viewport.ts
+++ b/src/shared/prompt/select-viewport.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure functions for viewport-based select menu scrolling.
+ *
+ * Handles scroll offset calculation and viewport-limited rendering.
+ */
+
+import chalk from 'chalk';
+import type { SelectOptionItem, ViewportState } from './select-menu.js';
+import { countItemLines, countRenderedLines, renderSingleOption, renderCancelOption } from './select-menu.js';
+
+const HEADER_LINES = 4;
+
+/**
+ * Create viewport state from terminal dimensions and menu content.
+ *
+ * When all items fit within the available terminal space, viewport is
+ * inactive and the menu renders without scrolling (identical to the
+ * pre-viewport behaviour).
+ */
+export function createViewportState<T extends string>(
+  terminalRows: number,
+  options: SelectOptionItem<T>[],
+  hasCancelOption: boolean,
+): ViewportState {
+  const totalMenuLines = countRenderedLines(options, hasCancelOption);
+  const availableLines = Math.max(1, terminalRows - HEADER_LINES);
+
+  if (totalMenuLines <= availableLines) {
+    return { scrollOffset: 0, maxOptionLines: availableLines, active: false };
+  }
+
+  return {
+    scrollOffset: 0,
+    maxOptionLines: Math.max(1, availableLines),
+    active: true,
+  };
+}
+
+function getIndicatorLineCount(hasHiddenAbove: boolean, hasHiddenBelow: boolean): number {
+  let count = 0;
+  if (hasHiddenAbove) count++;
+  if (hasHiddenBelow) count++;
+  return count;
+}
+
+function calculateVisibleRange<T extends string>(
+  options: SelectOptionItem<T>[],
+  hasCancelOption: boolean,
+  scrollOffset: number,
+  availableLines: number,
+): { endIndex: number; hiddenBelow: number } {
+  const totalItems = hasCancelOption ? options.length + 1 : options.length;
+  const hasHiddenAbove = scrollOffset > 0;
+  let usedLines = 0;
+  let count = 0;
+
+  for (let i = scrollOffset; i < totalItems; i++) {
+    const itemLines = i < options.length ? countItemLines(options[i]!) : 1;
+    const remainingItems = totalItems - (i + 1);
+    const hasHiddenBelow = remainingItems > 0;
+    const nextUsedLines = usedLines + itemLines;
+    const indicatorLines = getIndicatorLineCount(hasHiddenAbove, hasHiddenBelow);
+
+    if (nextUsedLines + indicatorLines > availableLines) {
+      break;
+    }
+
+    usedLines = nextUsedLines;
+    count++;
+  }
+
+  if (count === 0 && scrollOffset < totalItems) {
+    return {
+      endIndex: scrollOffset + 1,
+      hiddenBelow: totalItems - (scrollOffset + 1),
+    };
+  }
+
+  const endIndex = scrollOffset + count;
+  return {
+    endIndex,
+    hiddenBelow: totalItems - endIndex,
+  };
+}
+
+/**
+ * Calculate the exclusive end index of items visible from scrollOffset,
+ * fitting within maxOptionLines.
+ *
+ * `totalItems` is options.length + (hasCancelOption ? 1 : 0).
+ */
+function calculateVisibleEndIndex<T extends string>(
+  options: SelectOptionItem<T>[],
+  hasCancelOption: boolean,
+  scrollOffset: number,
+  maxOptionLines: number,
+): number {
+  return calculateVisibleRange(options, hasCancelOption, scrollOffset, maxOptionLines).endIndex;
+}
+
+/**
+ * Adjust scrollOffset so that selectedIndex is visible within the viewport.
+ *
+ * Returns the new scrollOffset value.
+ */
+export function adjustScrollOffset<T extends string>(
+  selectedIndex: number,
+  scrollOffset: number,
+  options: SelectOptionItem<T>[],
+  hasCancelOption: boolean,
+  maxOptionLines: number,
+): number {
+  if (selectedIndex < scrollOffset) {
+    return selectedIndex;
+  }
+
+  const endIndex = calculateVisibleEndIndex(options, hasCancelOption, scrollOffset, maxOptionLines);
+  if (selectedIndex < endIndex) {
+    return scrollOffset;
+  }
+
+  let newOffset = selectedIndex;
+  while (newOffset > 0) {
+    const testEnd = calculateVisibleEndIndex(options, hasCancelOption, newOffset - 1, maxOptionLines);
+    if (testEnd <= selectedIndex) break;
+    newOffset--;
+  }
+
+  return newOffset;
+}
+
+/**
+ * Render the visible portion of the menu with viewport scrolling.
+ *
+ * Returns rendered lines including hidden-item indicators.
+ */
+export function renderMenuWithViewport<T extends string>(
+  options: SelectOptionItem<T>[],
+  selectedIndex: number,
+  hasCancelOption: boolean,
+  scrollOffset: number,
+  maxOptionLines: number,
+  cancelLabel: string,
+): string[] {
+  const maxWidth = process.stdout.columns || 80;
+  const { endIndex, hiddenBelow } = calculateVisibleRange(options, hasCancelOption, scrollOffset, maxOptionLines);
+  const lines: string[] = [];
+
+  if (scrollOffset > 0) {
+    lines.push(chalk.gray(`  ↑ ${scrollOffset} more`));
+  }
+
+  for (let i = scrollOffset; i < endIndex; i++) {
+    if (i < options.length) {
+      const opt = options[i]!;
+      const isSelected = i === selectedIndex;
+      lines.push(...renderSingleOption(opt, isSelected, maxWidth));
+    } else {
+      const isCancelSelected = selectedIndex === options.length;
+      lines.push(renderCancelOption(isCancelSelected, cancelLabel));
+    }
+  }
+
+  if (hiddenBelow > 0) {
+    lines.push(chalk.gray(`  ↓ ${hiddenBelow} more`));
+  }
+
+  return lines;
+}

--- a/src/shared/prompt/select.ts
+++ b/src/shared/prompt/select.ts
@@ -2,132 +2,33 @@
  * Interactive cursor-based selection menus.
  *
  * Provides arrow-key navigation for option selection in the terminal.
+ * Pure functions live in select-menu.ts (rendering, input) and
+ * select-viewport.ts (viewport scrolling).
  */
 
 import chalk from 'chalk';
-import { truncateText } from '../utils/index.js';
 import { resolveTtyPolicy, assertTtyIfForced } from './tty.js';
+import {
+  type SelectOptionItem,
+  type ViewportState,
+  renderMenu,
+  handleKeyInput,
+} from './select-menu.js';
+import {
+  createViewportState,
+  adjustScrollOffset,
+  renderMenuWithViewport,
+} from './select-viewport.js';
 
-/** Option type for selectOption */
-export interface SelectOptionItem<T extends string> {
-  label: string;
-  value: T;
-  description?: string;
-  details?: string[];
-}
+// Re-export public symbols so index.ts imports stay unchanged
+export {
+  type SelectOptionItem,
+  type KeyInputResult,
+  renderMenu,
+  countRenderedLines,
+  handleKeyInput,
+} from './select-menu.js';
 
-/**
- * Render the menu options to the terminal.
- * Exported for testing.
- */
-export function renderMenu<T extends string>(
-  options: SelectOptionItem<T>[],
-  selectedIndex: number,
-  hasCancelOption: boolean,
-  cancelLabel = 'Cancel',
-): string[] {
-  const maxWidth = process.stdout.columns || 80;
-  const labelPrefix = 4;
-  const descPrefix = 5;
-  const detailPrefix = 9;
-
-  const lines: string[] = [];
-
-  for (let i = 0; i < options.length; i++) {
-    const opt = options[i];
-    if (!opt) continue;
-    const isSelected = i === selectedIndex;
-    const cursor = isSelected ? chalk.cyan('❯') : ' ';
-    const truncatedLabel = truncateText(opt.label, maxWidth - labelPrefix);
-    const label = isSelected ? chalk.cyan.bold(truncatedLabel) : truncatedLabel;
-    lines.push(`  ${cursor} ${label}`);
-
-    if (opt.description) {
-      const truncatedDesc = truncateText(opt.description, maxWidth - descPrefix);
-      lines.push(chalk.gray(`     ${truncatedDesc}`));
-    }
-    if (opt.details && opt.details.length > 0) {
-      for (const detail of opt.details) {
-        const truncatedDetail = truncateText(detail, maxWidth - detailPrefix);
-        lines.push(chalk.dim(`       • ${truncatedDetail}`));
-      }
-    }
-  }
-
-  if (hasCancelOption) {
-    const isCancelSelected = selectedIndex === options.length;
-    const cursor = isCancelSelected ? chalk.cyan('❯') : ' ';
-    const label = isCancelSelected ? chalk.cyan.bold(cancelLabel) : chalk.gray(cancelLabel);
-    lines.push(`  ${cursor} ${label}`);
-  }
-
-  return lines;
-}
-
-/**
- * Count total rendered lines for a set of options.
- * Exported for testing.
- */
-export function countRenderedLines<T extends string>(
-  options: SelectOptionItem<T>[],
-  hasCancelOption: boolean,
-): number {
-  let count = 0;
-  for (const opt of options) {
-    count++;
-    if (opt.description) count++;
-    if (opt.details) count += opt.details.length;
-  }
-  if (hasCancelOption) count++;
-  return count;
-}
-
-/** Result of handling a key input */
-export type KeyInputResult =
-  | { action: 'move'; newIndex: number }
-  | { action: 'confirm'; selectedIndex: number }
-  | { action: 'cancel'; cancelIndex: number }
-  | { action: 'bookmark'; selectedIndex: number }
-  | { action: 'remove_bookmark'; selectedIndex: number }
-  | { action: 'exit' }
-  | { action: 'none' };
-
-/**
- * Pure function for key input state transitions.
- * Exported for testing.
- */
-export function handleKeyInput(
-  key: string,
-  currentIndex: number,
-  totalItems: number,
-  hasCancelOption: boolean,
-  optionCount: number,
-): KeyInputResult {
-  if (key === '\x1B[A' || key === 'k') {
-    return { action: 'move', newIndex: (currentIndex - 1 + totalItems) % totalItems };
-  }
-  if (key === '\x1B[B' || key === 'j') {
-    return { action: 'move', newIndex: (currentIndex + 1) % totalItems };
-  }
-  if (key === '\r' || key === '\n') {
-    return { action: 'confirm', selectedIndex: currentIndex };
-  }
-  if (key === '\x03') {
-    return { action: 'exit' };
-  }
-  if (key === '\x1B') {
-    return { action: 'cancel', cancelIndex: hasCancelOption ? optionCount : -1 };
-  }
-  if (key === 'b') {
-    return { action: 'bookmark', selectedIndex: currentIndex };
-  }
-  if (key === 'r') {
-    return { action: 'remove_bookmark', selectedIndex: currentIndex };
-  }
-  return { action: 'none' };
-}
-
-/** Print the menu header (message + hint). */
 function printHeader(message: string, hasCustomKeyHandler: boolean): void {
   console.log();
   console.log(chalk.cyan(message));
@@ -138,7 +39,6 @@ function printHeader(message: string, hasCustomKeyHandler: boolean): void {
   console.log();
 }
 
-/** Set up raw mode on stdin and return cleanup function. */
 function setupRawMode(): { cleanup: (listener: (data: Buffer) => void) => void; wasRaw: boolean } {
   const wasRaw = process.stdin.isRaw;
   process.stdin.setRawMode(true);
@@ -154,22 +54,28 @@ function setupRawMode(): { cleanup: (listener: (data: Buffer) => void) => void; 
   };
 }
 
-/** Redraw the menu using relative cursor movement. */
 function redrawMenu<T extends string>(
   options: SelectOptionItem<T>[],
   selectedIndex: number,
   hasCancelOption: boolean,
   prevTotalLines: number,
-  cancelLabel?: string,
+  cancelLabel: string,
+  viewport: ViewportState,
 ): number {
   process.stdout.write(`\x1B[${prevTotalLines}A`);
   process.stdout.write('\x1B[J');
-  const newLines = renderMenu(options, selectedIndex, hasCancelOption, cancelLabel);
+
+  const newLines = viewport.active
+    ? renderMenuWithViewport(
+        options, selectedIndex, hasCancelOption,
+        viewport.scrollOffset, viewport.maxOptionLines, cancelLabel,
+      )
+    : renderMenu(options, selectedIndex, hasCancelOption, cancelLabel);
+
   process.stdout.write(newLines.join('\n') + '\n');
   return newLines.length;
 }
 
-/** Callbacks for interactive select behavior */
 export interface InteractiveSelectCallbacks<T extends string> {
   /**
    * Custom key handler called before default key handling.
@@ -181,13 +87,11 @@ export interface InteractiveSelectCallbacks<T extends string> {
   cancelLabel?: string;
 }
 
-/** Result of interactive selection */
 interface InteractiveSelectResult<T extends string> {
   selectedIndex: number;
   finalOptions: SelectOptionItem<T>[];
 }
 
-/** Interactive cursor-based menu selection. */
 function interactiveSelect<T extends string>(
   message: string,
   options: SelectOptionItem<T>[],
@@ -201,13 +105,21 @@ function interactiveSelect<T extends string>(
     let selectedIndex = initialIndex;
     const cancelLabel = callbacks?.cancelLabel ?? 'Cancel';
 
+    const terminalRows = process.stdout.rows ?? 24;
+    let viewport = createViewportState(terminalRows, currentOptions, hasCancelOption);
+
     printHeader(message, !!callbacks?.onKeyPress);
 
     process.stdout.write('\x1B[?7l');
 
-    let totalLines = countRenderedLines(currentOptions, hasCancelOption);
-    const lines = renderMenu(currentOptions, selectedIndex, hasCancelOption, cancelLabel);
-    process.stdout.write(lines.join('\n') + '\n');
+    const initialLines = viewport.active
+      ? renderMenuWithViewport(
+          currentOptions, selectedIndex, hasCancelOption,
+          viewport.scrollOffset, viewport.maxOptionLines, cancelLabel,
+        )
+      : renderMenu(currentOptions, selectedIndex, hasCancelOption, cancelLabel);
+    let totalLines = initialLines.length;
+    process.stdout.write(initialLines.join('\n') + '\n');
 
     const { useTty, forceTouchTty } = resolveTtyPolicy();
     assertTtyIfForced(forceTouchTty);
@@ -228,37 +140,45 @@ function interactiveSelect<T extends string>(
       try {
         const key = data.toString();
 
-        // Try custom key handler first
         if (callbacks?.onKeyPress && selectedIndex < currentOptions.length) {
           const item = currentOptions[selectedIndex];
           if (item) {
             const customResult = callbacks.onKeyPress(key, item.value, selectedIndex);
             if (customResult !== null) {
-              // Custom handler processed the key
               const currentValue = item.value;
               currentOptions = customResult;
               totalItems = hasCancelOption ? currentOptions.length + 1 : currentOptions.length;
               const newIdx = currentOptions.findIndex((o) => o.value === currentValue);
               selectedIndex = newIdx >= 0 ? newIdx : Math.min(selectedIndex, currentOptions.length - 1);
-              totalLines = redrawMenu(currentOptions, selectedIndex, hasCancelOption, totalLines, cancelLabel);
+              const newViewport = createViewportState(terminalRows, currentOptions, hasCancelOption);
+              viewport = {
+                ...newViewport,
+                scrollOffset: adjustScrollOffset(
+                  selectedIndex, newViewport.scrollOffset, currentOptions, hasCancelOption, newViewport.maxOptionLines,
+                ),
+              };
+              totalLines = redrawMenu(currentOptions, selectedIndex, hasCancelOption, totalLines, cancelLabel, viewport);
               return;
             }
           }
         }
 
-        // Delegate to default handler
         const result = handleKeyInput(
-          key,
-          selectedIndex,
-          totalItems,
-          hasCancelOption,
-          currentOptions.length,
+          key, selectedIndex, totalItems, hasCancelOption, currentOptions.length,
         );
 
         switch (result.action) {
           case 'move':
             selectedIndex = result.newIndex;
-            totalLines = redrawMenu(currentOptions, selectedIndex, hasCancelOption, totalLines, cancelLabel);
+            if (viewport.active) {
+              viewport = {
+                ...viewport,
+                scrollOffset: adjustScrollOffset(
+                  selectedIndex, viewport.scrollOffset, currentOptions, hasCancelOption, viewport.maxOptionLines,
+                ),
+              };
+            }
+            totalLines = redrawMenu(currentOptions, selectedIndex, hasCancelOption, totalLines, cancelLabel, viewport);
             break;
           case 'confirm':
             cleanup(onKeypress);
@@ -269,10 +189,7 @@ function interactiveSelect<T extends string>(
             resolve({ selectedIndex: result.cancelIndex, finalOptions: currentOptions });
             break;
           case 'bookmark':
-            // Handled by custom onKeyPress
-            break;
           case 'remove_bookmark':
-            // Ignore - should be handled by custom onKeyPress
             break;
           case 'exit':
             cleanup(onKeypress);


### PR DESCRIPTION
## 概要

Closes #608

ターミナルの縦幅が狭い場合でも、選択メニューで現在選択中の項目が常に表示領域内に収まるようにしました。
<img width="643" height="210" alt="スクリーンショット 2026-04-09 20 25 21" src="https://github.com/user-attachments/assets/2a16c374-439b-4a36-932c-39b01a755cbc" />

## 変更内容

- `src/shared/prompt/select.ts`
  - 選択メニュー描画時に viewport を考慮するよう変更
- `src/shared/prompt/select-menu.ts`
  - メニュー描画・入力処理の純粋関数を整理
  - `countItemLines` を追加し、行数計算を共通化
- `src/shared/prompt/select-viewport.ts`
  - ターミナル高さに応じた viewport 計算とスクロール制御を追加
  - hidden indicator を含む表示範囲の計算を実装
- `src/__tests__/select-viewport.test.ts`
  - viewport スクロールと indicator 表示のテストを追加

## 確認内容

- `npm run build`
- `npm run lint`
- `npm test`
- Ghostty で文字サイズを変えながら、縦幅の狭いターミナル上で手動確認
- `takt`
- `takt list`
- TAKT の review を実施
