### PR TITLE
[#614] add-codex-capacity-retry

### DIFF
--- a/src/__tests__/codex-client-retry.test.ts
+++ b/src/__tests__/codex-client-retry.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockEvent = Record<string, unknown>;
+type RunPlan =
+  | { type: 'events'; events: MockEvent[] }
+  | { type: 'throw'; error: Error };
+
+let runPlans: RunPlan[] = [];
+let runPlanIndex = 0;
+let startThreadCalls: Array<Record<string, unknown> | undefined> = [];
+let resumeThreadCalls: Array<{ threadId: string; options?: Record<string, unknown> }> = [];
+
+function createEvents(events: MockEvent[]) {
+  return (async function* () {
+    for (const event of events) {
+      yield event;
+    }
+  })();
+}
+
+function createThread(id: string) {
+  return {
+    id,
+    runStreamed: async () => {
+      const plan = runPlans[runPlanIndex];
+      runPlanIndex += 1;
+      if (!plan) {
+        throw new Error(`Missing run plan for attempt ${runPlanIndex}`);
+      }
+      if (plan.type === 'throw') {
+        throw plan.error;
+      }
+      return { events: createEvents(plan.events) };
+    },
+  };
+}
+
+vi.mock('@openai/codex-sdk', () => {
+  return {
+    Codex: class MockCodex {
+      async startThread(options?: Record<string, unknown>) {
+        startThreadCalls.push(options);
+        return createThread('thread-1');
+      }
+
+      async resumeThread(threadId: string, options?: Record<string, unknown>) {
+        resumeThreadCalls.push({ threadId, options });
+        return createThread(threadId);
+      }
+    },
+  };
+});
+
+const { CodexClient } = await import('../infra/codex/client.js');
+
+describe('CodexClient retry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    runPlans = [];
+    runPlanIndex = 0;
+    startThreadCalls = [];
+    resumeThreadCalls = [];
+  });
+
+  it('turn.failed の at capacity を 1 秒後に retry して成功を返す', async () => {
+    vi.useFakeTimers();
+
+    runPlans = [
+      {
+        type: 'events',
+        events: [
+          { type: 'turn.failed', error: { message: 'Selected model is at capacity. Please try a different model.' } },
+        ],
+      },
+      {
+        type: 'events',
+        events: [
+          { type: 'thread.started', thread_id: 'thread-1' },
+          { type: 'item.completed', item: { id: 'msg-1', type: 'agent_message', text: 'retry succeeded' } },
+          { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 2 } },
+        ],
+      },
+    ];
+
+    const client = new CodexClient();
+
+    const resultPromise = client.call('coder', 'prompt', { cwd: '/tmp' });
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(resumeThreadCalls).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await resultPromise;
+
+    expect(startThreadCalls).toHaveLength(1);
+    expect(resumeThreadCalls).toEqual([
+      {
+        threadId: 'thread-1',
+        options: expect.objectContaining({ workingDirectory: '/tmp' }),
+      },
+    ]);
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('retry succeeded');
+  });
+
+  it('例外経路の at capacity を 1 秒、2 秒の指数バックオフで retry する', async () => {
+    vi.useFakeTimers();
+
+    runPlans = [
+      { type: 'throw', error: new Error('Selected model is at capacity. Please try a different model.') },
+      { type: 'throw', error: new Error('Selected model is at capacity. Please try a different model.') },
+      {
+        type: 'events',
+        events: [
+          { type: 'thread.started', thread_id: 'thread-1' },
+          { type: 'item.completed', item: { id: 'msg-1', type: 'agent_message', text: 'third attempt succeeded' } },
+          { type: 'turn.completed', usage: { input_tokens: 2, output_tokens: 3 } },
+        ],
+      },
+    ];
+
+    const client = new CodexClient();
+
+    const resultPromise = client.call('coder', 'prompt', { cwd: '/tmp' });
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(resumeThreadCalls).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resumeThreadCalls).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(resumeThreadCalls).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await resultPromise;
+
+    expect(resumeThreadCalls).toHaveLength(2);
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('third attempt succeeded');
+  });
+
+  it('at capacity が続く場合は 初回実行後に 8 回 retry して最後の失敗を返す', async () => {
+    vi.useFakeTimers();
+
+    runPlans = Array.from({ length: 9 }, () => ({
+      type: 'events' as const,
+      events: [
+        { type: 'turn.failed', error: { message: 'Selected model is at capacity. Please try a different model.' } },
+      ],
+    }));
+
+    const client = new CodexClient();
+    const resultPromise = client.call('coder', 'prompt', { cwd: '/tmp' });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(startThreadCalls).toHaveLength(1);
+    expect(resumeThreadCalls).toHaveLength(8);
+    expect(result.status).toBe('error');
+    expect(result.content).toBe('Selected model is at capacity. Please try a different model.');
+  });
+
+  it('at capacity が続く場合は 128 秒バックオフまで待ってから最後の retry を行う', async () => {
+    vi.useFakeTimers();
+
+    runPlans = Array.from({ length: 9 }, () => ({
+      type: 'events' as const,
+      events: [
+        { type: 'turn.failed', error: { message: 'Selected model is at capacity. Please try a different model.' } },
+      ],
+    }));
+
+    const client = new CodexClient();
+    const resultPromise = client.call('coder', 'prompt', { cwd: '/tmp' });
+
+    const retryDelaysMs = [1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000];
+    let elapsedMs = 0;
+
+    for (let index = 0; index < retryDelaysMs.length; index += 1) {
+      const delayMs = retryDelaysMs[index];
+      await vi.advanceTimersByTimeAsync(delayMs - 1);
+      expect(resumeThreadCalls).toHaveLength(index);
+
+      await vi.advanceTimersByTimeAsync(1);
+      elapsedMs += delayMs;
+      expect(resumeThreadCalls).toHaveLength(index + 1);
+      expect(elapsedMs).toBe(retryDelaysMs.slice(0, index + 1).reduce((sum, value) => sum + value, 0));
+    }
+
+    const result = await resultPromise;
+
+    expect(startThreadCalls).toHaveLength(1);
+    expect(resumeThreadCalls).toHaveLength(8);
+    expect(elapsedMs).toBe(255000);
+    expect(result.status).toBe('error');
+    expect(result.content).toBe('Selected model is at capacity. Please try a different model.');
+  });
+});

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -26,8 +26,9 @@ export type { CodexCallOptions } from './types.js';
 const log = createLogger('codex-sdk');
 const CODEX_STREAM_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 const CODEX_STREAM_ABORTED_MESSAGE = 'Codex execution aborted';
-const CODEX_RETRY_MAX_ATTEMPTS = 3;
-const CODEX_RETRY_BASE_DELAY_MS = 250;
+const CODEX_RETRY_MAX_RETRIES = 8;
+const CODEX_RETRY_TOTAL_ATTEMPTS = CODEX_RETRY_MAX_RETRIES + 1;
+const CODEX_RETRY_BASE_DELAY_MS = 1000;
 const CODEX_RETRYABLE_ERROR_PATTERNS = [
   'stream disconnected before completion',
   'transport error',
@@ -37,6 +38,7 @@ const CODEX_RETRYABLE_ERROR_PATTERNS = [
   'etimedout',
   'eai_again',
   'fetch failed',
+  'at capacity',
 ];
 
 function toNumber(value: unknown): number | undefined {
@@ -148,7 +150,7 @@ export class CodexClient {
       ? `${options.systemPrompt}\n\n${prompt}`
       : prompt;
 
-    for (let attempt = 1; attempt <= CODEX_RETRY_MAX_ATTEMPTS; attempt++) {
+    for (let attempt = 1; attempt <= CODEX_RETRY_TOTAL_ATTEMPTS; attempt++) {
       const codexClientOptions = {
         ...(options.openaiApiKey ? { apiKey: options.openaiApiKey } : {}),
         ...(options.codexPathOverride ? { codexPathOverride: options.codexPathOverride } : {}),
@@ -310,7 +312,7 @@ export class CodexClient {
         if (!success) {
           const message = failureMessage || 'Codex execution failed';
           const retriable = this.isRetriableError(message, streamAbortController.signal.aborted, abortCause);
-          if (retriable && attempt < CODEX_RETRY_MAX_ATTEMPTS) {
+          if (retriable && attempt <= CODEX_RETRY_MAX_RETRIES) {
             log.info('Retrying Codex call after transient failure', { agentType, attempt, message });
             threadId = currentThreadId;
             await this.waitForRetryDelay(attempt, options.abortSignal);
@@ -358,7 +360,7 @@ export class CodexClient {
         );
 
         const retriable = this.isRetriableError(errorMessage, streamAbortController.signal.aborted, abortCause);
-        if (retriable && attempt < CODEX_RETRY_MAX_ATTEMPTS) {
+        if (retriable && attempt <= CODEX_RETRY_MAX_RETRIES) {
           log.info('Retrying Codex call after transient exception', { agentType, attempt, errorMessage });
           threadId = currentThreadId;
           await this.waitForRetryDelay(attempt, options.abortSignal);


### PR DESCRIPTION
## Summary

## 背景

Codex プロバイダ経由で実行中、以下のエラーで movement が ABORT することがある。

```
Selected model is at capacity. Please try a different model.
```

実例: `.takt/worktrees/20260407T0325-602-rename-piece-to-workflow/.takt/runs/20260407-015913-piece-movement-workflow/logs/*-provider-events.jsonl` に `{"success":false,"error":"Selected model is at capacity..."}` として複数回記録されている。

検出自体は既に `turn.failed` イベントから `failureMessage` に入ってきており (`src/infra/codex/client.ts:234-241`)、上位には届いている。

## 現状

`src/infra/codex/client.ts:29-40` に retry 機構はあるが、

1. retry 対象パターンがトランスポート層のみ (`'at capacity'` が含まれていない)
2. backoff のレンジが狭い (`base=250ms`, `max=3回`, 合計 ~1.75s)

capacity エラーは分単位で継続するため、現状のままだと仮に retry が始まっても即失敗して ABORT する。

```ts
const CODEX_RETRY_MAX_ATTEMPTS = 3;
const CODEX_RETRY_BASE_DELAY_MS = 250;
const CODEX_RETRYABLE_ERROR_PATTERNS = [
  'stream disconnected before completion',
  'transport error',
  'network error',
  'error decoding response body',
  'econnreset',
  'etimedout',
  'eai_again',
  'fetch failed',
];
```

## 対応方針

\`CODEX_RETRYABLE_ERROR_PATTERNS\` に \`'at capacity'\` を追加し、既存の指数バックオフのレンジを広げて、transport / capacity の両方を単一機構で吸収する。カテゴリ分割はしない (分けても合計待機時間は変わらず、実装だけ複雑になるため)。

### 変更内容

```diff
- const CODEX_RETRY_MAX_ATTEMPTS = 3;
- const CODEX_RETRY_BASE_DELAY_MS = 250;
+ const CODEX_RETRY_MAX_ATTEMPTS = 8;
+ const CODEX_RETRY_BASE_DELAY_MS = 1000;
  const CODEX_RETRYABLE_ERROR_PATTERNS = [
    'stream disconnected before completion',
    'transport error',
    ...
+   'at capacity',
  ];
```

### retry スケジュール (指数バックオフ)

| attempt | delay |
|---|---|
| 1 | 1s |
| 2 | 2s |
| 3 | 4s |
| 4 | 8s |
| 5 | 16s |
| 6 | 32s |
| 7 | 64s |
| 8 | 128s |
| **合計** | **約 4 分 15 秒** |

- 初回が 1s なので transport エラー (瞬間的な切断) も数秒で復帰
- 後半の 60-128s で capacity 詰まり (分単位) も吸収
- transport 初回 retry が 250ms → 1s に伸びるが、transport エラー自体稀なので影響は軽微

## スコープ外

- **config 化**: 現時点で調整要望が無いため hardcoded のまま。将来必要になれば別 Issue で対応
- **provider 間の retry 共通化**: Codex 内で完結。Claude / OpenCode 側への展開は別議論
- **モデルフォールバック**: 10 分以上続く長時間 capacity 逼迫は Phase 2 単体では救えない。必要ならば別 Issue で対応

## 関連ファイル

- \`src/infra/codex/client.ts\`

## Execution Report

Workflow `takt-default` completed successfully.

Closes #614