### PR TITLE
Release v0.35.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.35.3] - 2026-04-10
+
+### Added
+
+- `loop_monitors` の judge に `provider`/`model` フィールドを追加。ジャッジムーブメントのプロバイダーとモデルを明示的に指定可能に (#599)
+- `takt list --action sync` を非インタラクティブモードでサポート
+
+### Changed
+
+- Codex プロバイダーのリトライ戦略を強化: 最大リトライ回数を 3→9 に増加、ベース遅延を 250ms→1000ms に変更、"at capacity" エラーを自動リトライ対象に追加 (#614)
+
+### Fixed
+
+- ループモニタージャッジが常にデフォルトプロバイダーで実行される問題を修正。トリガー元ムーブメントのプロバイダー/モデル設定を継承するよう変更 (#599)
+- 完了済みタスクのブランチ操作（merge/try-merge/diff）でルートブランチが欠落している場合にエラーとなる問題を修正。クローンから自動復元するよう改善 (#616)
+- Phase 2 エラーイベント（`phase:complete`）が `phase:start` より先に発火されることがある問題を修正
+
+### Internal
+
+- テストを多数追加（codex-client-retry, engine-loop-monitors, it-completed-task-root-branch, it-piece-loader, provider-resolution, taskBranchLifecycleActions 等）
+- `providerModelCompatibility` をコアモジュール（`src/core/piece/`）に移動
+- タスク実行後のプッシュ処理を簡素化（clone 内フォールバック push を廃止し、ルートリポジトリ経由に一本化）
+- git コマンドのエラーメッセージに stderr 詳細を含めるよう改善
+
 ## [0.35.2] - 2026-04-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.35.2",
+      "version": "0.35.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.71",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Piece Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- `loop_monitors` の judge に `provider`/`model` フィールドを追加。ジャッジムーブメントのプロバイダーとモデルを明示的に指定可能に (#599)
- `takt list --action sync` を非インタラクティブモードでサポート

### Changed

- Codex プロバイダーのリトライ戦略を強化: 最大リトライ回数を 3→9 に増加、ベース遅延を 250ms→1000ms に変更、"at capacity" エラーを自動リトライ対象に追加 (#614)

### Fixed

- ループモニタージャッジが常にデフォルトプロバイダーで実行される問題を修正。トリガー元ムーブメントのプロバイダー/モデル設定を継承するよう変更 (#599)
- 完了済みタスクのブランチ操作（merge/try-merge/diff）でルートブランチが欠落している場合にエラーとなる問題を修正。クローンから自動復元するよう改善 (#616)
- Phase 2 エラーイベント（`phase:complete`）が `phase:start` より先に発火されることがある問題を修正

### Internal

- テストを多数追加（codex-client-retry, engine-loop-monitors, it-completed-task-root-branch, it-piece-loader, provider-resolution, taskBranchLifecycleActions 等）
- `providerModelCompatibility` をコアモジュール（`src/core/piece/`）に移動
- タスク実行後のプッシュ処理を簡素化（clone 内フォールバック push を廃止し、ルートリポジトリ経由に一本化）
- git コマンドのエラーメッセージに stderr 詳細を含めるよう改善

## Commits

- 81c744c8 Release v0.35.3
- 1a4d9b2f fix: テストの失敗を修正
- b0c11c06 Merge pull request #617 from nrslib/takt/614/add-codex-capacity-retry
- 6adbe54f takt: add-codex-capacity-retry
- 50e0a52e Merge pull request #616 from nrslib/fix/completed-task-root-branch-preflight
- 9c27faad fix: restore completed task branch actions
- 9110153a fix: preserve original phase 2 errors before phase start
- 8702bec4 Merge pull request #613 from nrslib/takt/599/fix-judge-model-passing
- 22ee3954 takt: fix-judge-model-passing