### PR TITLE
docs: レビューの例をコピペしてtaktを実行したときに、エラーが出ないように修正

### DIFF
--- a/docs/pieces.md
+++ b/docs/pieces.md
@@ -243,25 +243,29 @@ steps:
     persona: coder
     edit: true
     required_permission_mode: edit
-    allowed_tools: [Read, Glob, Grep, Edit, Write, Bash, WebSearch, WebFetch]
+    provider_options:
+      claude:
+        allowed_tools: [Read, Glob, Grep, Edit, Write, Bash, WebSearch, WebFetch]
     rules:
       - condition: Implementation complete
         next: review
       - condition: Cannot proceed
         next: ABORT
-    instruction_template: |
+    instruction: |
       Implement the requested changes.
 
   - name: review
     persona: reviewer
     edit: false
-    allowed_tools: [Read, Glob, Grep, WebSearch, WebFetch]
+    provider_options:
+      claude:
+        allowed_tools: [Read, Glob, Grep, WebSearch, WebFetch]
     rules:
       - condition: Approved
         next: COMPLETE
       - condition: Needs fix
         next: implement
-    instruction_template: |
+    instruction: |
       Review the implementation for code quality and best practices.
 ```
 


### PR DESCRIPTION
## 目的

`docs/pieces.md` の `with-review` サンプルが現行のスキーマと合っておらず、そのままでは validation error になる問題を修正します。

## 変更点

- `with-review` サンプル内の `allowed_tools` を step 直下ではなく `provider_options.claude.allowed_tools` 配下に移動
- `instruction_template` を `instruction` に変更

<details>
<summary>エラーメッセージ</summary>

```
[ERROR] [
  {
    "expected": "never",
    "code": "invalid_type",
    "path": [
      "movements",
      0,
      "allowed_tools"
    ],
    "message": "Invalid input: expected never, received array"
  },
  {
    "expected": "never",
    "code": "invalid_type",
    "path": [
      "movements",
      0,
      "instruction_template"
    ],
    "message": "Invalid input: expected never, received string"
  },
  {
    "expected": "never",
    "code": "invalid_type",
    "path": [
      "movements",
      1,
      "allowed_tools"
    ],
    "message": "Invalid input: expected never, received array"
  },
  {
    "expected": "never",
    "code": "invalid_type",
    "path": [
      "movements",
      1,
      "instruction_template"
    ],
    "message": "Invalid input: expected never, received string"
  }
]
```

</details>

## テスト結果

ローカルで `takt --piece example.yaml` を実行 (v0.34.0)

- 変更前の記述では validation error を確認
- 更新後の記述では該当エラーが解消されることを確認

## 影響範囲

- ドキュメントのみの変更です
- `with-review` サンプルを参照して workflow を作成する利用者の混乱軽減が期待できます