### PR TITLE
feat: Copilot プロバイダーに effort（推論の深さ）設定を追加

### DIFF
--- a/src/__tests__/provider-options-contract.test.ts
+++ b/src/__tests__/provider-options-contract.test.ts
@@ -18,9 +18,11 @@ describe('providerOptionsContract', () => {
       'provider_options.claude.effort',
       'provider_options.claude.sandbox.allow_unsandboxed_commands',
       'provider_options.claude.sandbox.excluded_commands',
+      'provider_options.copilot.effort',
     ]));
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.claude.allowed_tools');
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.codex.reasoning_effort');
+    expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.copilot.effort');
   });
 
   it('maps internal provider option paths to traced-config paths', () => {
@@ -36,11 +38,13 @@ describe('providerOptionsContract', () => {
     expect(getPresentProviderOptionPaths({
       codex: { networkAccess: true, reasoningEffort: 'high' },
       claude: { effort: 'medium', sandbox: { excludedCommands: ['rm -rf'] } },
+      copilot: { effort: 'high' },
     })).toEqual([
       'codex.networkAccess',
       'codex.reasoningEffort',
       'claude.effort',
       'claude.sandbox.excludedCommands',
+      'copilot.effort',
     ]);
   });
 });

--- a/src/core/models/schema-base.ts
+++ b/src/core/models/schema-base.ts
@@ -6,7 +6,7 @@
 
 import { z } from 'zod/v4';
 import { STATUS_VALUES } from './status.js';
-import { CLAUDE_EFFORT_VALUES, CODEX_REASONING_EFFORT_VALUES, RUNTIME_PREPARE_PRESETS } from './workflow-types.js';
+import { CLAUDE_EFFORT_VALUES, CODEX_REASONING_EFFORT_VALUES, COPILOT_EFFORT_VALUES, RUNTIME_PREPARE_PRESETS } from './workflow-types.js';
 
 export { McpServerConfigSchema, McpServersSchema } from './mcp-schemas.js';
 
@@ -67,6 +67,9 @@ export const StepProviderOptionsSchema = z.object({
     allowed_tools: z.array(z.string()).optional(),
     effort: z.enum(CLAUDE_EFFORT_VALUES).optional(),
     sandbox: ClaudeSandboxSchema,
+  }).optional(),
+  copilot: z.object({
+    effort: z.enum(COPILOT_EFFORT_VALUES).optional(),
   }).optional(),
 }).optional();
 

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -146,6 +146,8 @@ export const CODEX_REASONING_EFFORT_VALUES = ['minimal', 'low', 'medium', 'high'
 export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORT_VALUES)[number];
 export const CLAUDE_EFFORT_VALUES = ['low', 'medium', 'high', 'max'] as const;
 export type ClaudeEffort = (typeof CLAUDE_EFFORT_VALUES)[number];
+export const COPILOT_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh'] as const;
+export type CopilotEffort = (typeof COPILOT_EFFORT_VALUES)[number];
 const RUNTIME_PREPARE_PRESET_SET: ReadonlySet<string> = new Set(RUNTIME_PREPARE_PRESETS);
 export function isRuntimePreparePreset(entry: string): entry is RuntimePreparePreset {
   return RUNTIME_PREPARE_PRESET_SET.has(entry);
@@ -167,10 +169,15 @@ export interface ClaudeProviderOptions {
   sandbox?: ClaudeSandboxSettings;
 }
 
+export interface CopilotProviderOptions {
+  effort?: CopilotEffort;
+}
+
 export interface StepProviderOptions {
   codex?: CodexProviderOptions;
   opencode?: OpenCodeProviderOptions;
   claude?: ClaudeProviderOptions;
+  copilot?: CopilotProviderOptions;
 }
 
 export interface WorkflowStep {

--- a/src/infra/config/providerOptions.ts
+++ b/src/infra/config/providerOptions.ts
@@ -1,6 +1,7 @@
 import type {
   ClaudeEffort,
   CodexReasoningEffort,
+  CopilotEffort,
   StepProviderOptions,
 } from '../../core/models/workflow-types.js';
 import type {
@@ -26,6 +27,9 @@ type RawProviderOptions = {
       allow_unsandboxed_commands?: boolean;
       excluded_commands?: string[];
     };
+  };
+  copilot?: {
+    effort?: CopilotEffort;
   };
 };
 
@@ -81,6 +85,9 @@ export function normalizeProviderOptions(
       result.claude = claude;
     }
   }
+  if (options.copilot?.effort !== undefined) {
+    result.copilot = { effort: options.copilot.effort };
+  }
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
@@ -109,6 +116,14 @@ export function mergeProviderOptions(
           : {}),
         ...(layer.claude.sandbox
           ? { sandbox: { ...result.claude?.sandbox, ...layer.claude.sandbox } }
+          : {}),
+      };
+    }
+    if (layer.copilot) {
+      result.copilot = {
+        ...result.copilot,
+        ...(layer.copilot.effort !== undefined
+          ? { effort: layer.copilot.effort }
           : {}),
       };
     }
@@ -219,6 +234,11 @@ export function resolveEffectiveProviderOptions(
     stepOptions.opencode?.networkAccess,
     resolveProviderOptionOrigin(originResolver, 'opencode.networkAccess', source),
   );
+  const copilotEffort = selectProviderValue(
+    resolvedConfigOptions.copilot?.effort,
+    stepOptions.copilot?.effort,
+    resolveProviderOptionOrigin(originResolver, 'copilot.effort', source),
+  );
 
   const result: StepProviderOptions = {
     codex:
@@ -233,9 +253,10 @@ export function resolveEffectiveProviderOptions(
       claude.sandbox !== undefined || claude.allowedTools !== undefined || claude.effort !== undefined
         ? claude
         : undefined,
+    copilot: copilotEffort !== undefined ? { effort: copilotEffort } : undefined,
   };
 
-  return result.codex || result.opencode || result.claude ? result : undefined;
+  return result.codex || result.opencode || result.claude || result.copilot ? result : undefined;
 }
 
 function stripClaudeAllowedTools(
@@ -265,6 +286,9 @@ function stripClaudeAllowedTools(
       : {}),
     ...(sanitizedClaude !== undefined && Object.keys(sanitizedClaude).length > 0
       ? { claude: sanitizedClaude }
+      : {}),
+    ...(providerOptions.copilot !== undefined
+      ? { copilot: { ...providerOptions.copilot } }
       : {}),
   };
 

--- a/src/infra/config/providerOptionsContract.ts
+++ b/src/infra/config/providerOptionsContract.ts
@@ -9,6 +9,7 @@ const PROVIDER_OPTIONS_ENV_SPEC_ENTRIES = [
   { path: 'provider_options.claude.effort', type: 'string' },
   { path: 'provider_options.claude.sandbox.allow_unsandboxed_commands', type: 'boolean' },
   { path: 'provider_options.claude.sandbox.excluded_commands', type: 'json' },
+  { path: 'provider_options.copilot.effort', type: 'string' },
 ] as const satisfies readonly EnvSpec[];
 
 const PROVIDER_OPTIONS_TRACE_PATH_ENTRIES = [
@@ -24,6 +25,8 @@ const PROVIDER_OPTIONS_TRACE_PATH_ENTRIES = [
   'provider_options.claude.sandbox',
   'provider_options.claude.sandbox.allow_unsandboxed_commands',
   'provider_options.claude.sandbox.excluded_commands',
+  'provider_options.copilot',
+  'provider_options.copilot.effort',
 ] as const;
 
 const PROVIDER_OPTIONS_INTERNAL_PATH_ENTRIES = [
@@ -34,6 +37,7 @@ const PROVIDER_OPTIONS_INTERNAL_PATH_ENTRIES = [
   'claude.effort',
   'claude.sandbox.allowUnsandboxedCommands',
   'claude.sandbox.excludedCommands',
+  'copilot.effort',
 ] as const;
 
 export type ProviderOptionsTracePath = (typeof PROVIDER_OPTIONS_TRACE_PATH_ENTRIES)[number];
@@ -47,6 +51,7 @@ export const PROVIDER_OPTIONS_TRACKED_KEYS = [
   'provider_options.opencode',
   'provider_options.claude',
   'provider_options.claude.sandbox',
+  'provider_options.copilot',
   ...PROVIDER_OPTIONS_ENV_SPEC_ENTRIES.map((spec) => spec.path).filter((path) => path !== 'provider_options'),
   'provider_options.claude.allowed_tools',
 ] as const;

--- a/src/infra/copilot/client.ts
+++ b/src/infra/copilot/client.ts
@@ -68,6 +68,10 @@ function buildArgs(prompt: string, options: CopilotCallOptions & { shareFilePath
     args.push('--model', options.model);
   }
 
+  if (options.effort) {
+    args.push('--effort', options.effort);
+  }
+
   if (options.sessionId) {
     args.push('--resume', options.sessionId);
   }

--- a/src/infra/copilot/types.ts
+++ b/src/infra/copilot/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { StreamCallback } from '../claude/index.js';
+import type { CopilotEffort } from '../../core/models/workflow-types.js';
 import type { PermissionMode } from '../../core/models/index.js';
 
 /** Options for calling GitHub Copilot CLI */
@@ -11,6 +12,7 @@ export interface CopilotCallOptions {
   abortSignal?: AbortSignal;
   sessionId?: string;
   model?: string;
+  effort?: CopilotEffort;
   systemPrompt?: string;
   permissionMode?: PermissionMode;
   onStream?: StreamCallback;

--- a/src/infra/providers/copilot.ts
+++ b/src/infra/providers/copilot.ts
@@ -26,6 +26,7 @@ function toCopilotOptions(options: ProviderCallOptions): CopilotCallOptions {
     abortSignal: options.abortSignal,
     sessionId: options.sessionId,
     model: options.model,
+    effort: options.providerOptions?.copilot?.effort,
     permissionMode: options.permissionMode,
     onStream: options.onStream,
     copilotGithubToken: options.copilotGithubToken ?? resolveCopilotGithubToken(),


### PR DESCRIPTION
## Summary

- Copilot プロバイダーに `provider_options.copilot.effort` を追加し、Copilot CLI の `--effort` フラグを制御可能にしました
- Claude の既存 effort 実装パターンを踏襲しています
- 対応値: `low`, `medium`, `high`, `xhigh`

Ref #428（Copilot 部分）

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `src/core/models/workflow-types.ts` | `CopilotEffort` 型、`CopilotProviderOptions`、`StepProviderOptions.copilot` 追加 |
| `src/core/models/schema-base.ts` | `StepProviderOptionsSchema` に copilot ブロック追加 |
| `src/infra/copilot/types.ts` | `CopilotCallOptions.effort` 追加 |
| `src/infra/copilot/client.ts` | `buildArgs` に `--effort` フラグ追加 |
| `src/infra/providers/copilot.ts` | `toCopilotOptions` で `providerOptions?.copilot?.effort` を読み取り |
| `src/infra/config/providerOptions.ts` | normalize / merge / resolve に copilot 処理追加 |
| `src/infra/config/providerOptionsContract.ts` | 3つのレジストリに copilot.effort 追加 |
| `src/__tests__/provider-options-contract.test.ts` | テスト期待値に copilot.effort 追加 |

## YAML 設定例

```yaml
steps:
  - name: copilot_review
    provider: copilot
    model: gpt-5.4
    provider_options:
      copilot:
        effort: high
```

## 調査結果

Copilot CLI (`@github/copilot` v1.0.25) は `--effort` オプションをサポートしています:

```
--effort, --reasoning-effort <level>  Set the reasoning effort level
  (choices: "low", "medium", "high", "xhigh")
```

## テスト結果

- `npm run build`: 成功
- `npm run lint`: 成功
- `npm run test`: 全 4827 テストパス（371 ファイル）

## 動作確認

`npm link` でローカルビルドをグローバルに適用し、cross-review ワークフロー（Claude → Copilot 相互レビュー）で `provider_options.copilot.effort: high` の動作を確認済み。Copilot が正常にレビューを完了し APPROVE を返すことを実証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)