### PR TITLE
[#623] add-persona-provider-options

### DIFF
--- a/builtins/en/config.yaml
+++ b/builtins/en/config.yaml
@@ -54,16 +54,22 @@ language: en        # UI language: en | ja
 # Interactive mode
 # interactive_preview_steps: 3 # Number of step previews in interactive mode (0-10)
 
-# Per-persona provider/model overrides
+# Per-persona provider/model/provider_options overrides
 # persona_providers:
 #   coder:
 #     provider: claude
 #     model: opus
+#     provider_options:
+#       claude:
+#         effort: high
 #   reviewer:
 #     provider: codex
 #     model: gpt-5.2-codex
+#     provider_options:
+#       codex:
+#         reasoning_effort: high
 
-# Provider-specific options (lowest priority, overridden by workflow/step)
+# Provider-specific options (config defaults; env-resolved leaf overrides win, otherwise step > workflow > persona > project > global)
 # provider_options:
 #   codex:
 #     network_access: true

--- a/builtins/ja/config.yaml
+++ b/builtins/ja/config.yaml
@@ -54,16 +54,22 @@ language: ja         # 表示言語: ja | en
 # インタラクティブモード
 # interactive_preview_steps: 3 # インタラクティブモードでの step プレビュー数 (0-10)
 
-# ペルソナ別プロバイダー・モデル指定
+# ペルソナ別プロバイダー・モデル・provider_options 指定
 # persona_providers:
 #   coder:
 #     provider: claude
 #     model: opus
+#     provider_options:
+#       claude:
+#         effort: high
 #   reviewer:
 #     provider: codex
 #     model: gpt-5.2-codex
+#     provider_options:
+#       codex:
+#         reasoning_effort: high
 
-# プロバイダー固有オプション（最低優先度、workflow/step で上書き可能）
+# プロバイダー固有オプション（設定既定値。env 起源の leaf が最優先で、それ以外は step > workflow > persona > project > global の順）
 # provider_options:
 #   codex:
 #     network_access: true

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -36,14 +36,20 @@ interactive_preview_steps: 3      # インタラクティブモードでの step
 #     - gradle    # .runtime/ に Gradle キャッシュ/設定を準備
 #     - node      # .runtime/ に npm キャッシュを準備
 
-# persona ごとの provider / model 上書き（省略可）
+# persona ごとの provider / model / provider_options 上書き（省略可）
 # workflow を複製せずに特定の persona を別の provider / model にルーティング
 # persona_providers:
 #   coder:
 #     provider: codex        # coder を Codex で実行
 #     model: o3-mini         # 使用モデル（省略可）
+#     provider_options:
+#       codex:
+#         reasoning_effort: high
 #   ai-antipattern-reviewer:
 #     provider: claude       # レビュアーは Claude のまま
+#     provider_options:
+#       claude:
+#         effort: high
 
 # provider 固有のパーミッションプロファイル（省略可）
 # 優先順位: プロジェクト上書き > グローバル上書き > プロジェクトデフォルト > グローバルデフォルト > required_permission_mode（下限）
@@ -135,7 +141,7 @@ interactive_preview_steps: 3      # インタラクティブモードでの step
 | `auto_pr` | boolean | - | worktree 実行後に PR を自動作成 |
 | `minimal_output` | boolean | `false` | AI 出力を抑制（CI 向け） |
 | `runtime` | object | - | ランタイム環境デフォルト（例: `prepare: [gradle, node]`） |
-| `persona_providers` | object | - | persona ごとの provider / model 上書き（例: `coder: { provider: codex, model: o3-mini }`） |
+| `persona_providers` | object | - | persona ごとの provider / model / provider_options 上書き（例: `coder: { provider: codex, model: o3-mini, provider_options: { codex: { reasoning_effort: high } } }`） |
 | `provider_options` | object | - | グローバルな provider 固有オプション |
 | `provider_profiles` | object | - | provider 固有のパーミッションプロファイル |
 | `anthropic_api_key` | string | - | Claude 用 Anthropic API キー |
@@ -174,7 +180,7 @@ logging:
 concurrency: 2                # このプロジェクトでの takt run 並列タスク数（1-10）
 # base_branch: main           # クローン作成のベースブランチ（グローバルを上書き、デフォルト: リモートのデフォルトブランチ）
 
-# provider 固有オプション（グローバルを上書き、workflow/step で上書き可能）
+# provider 固有オプション（プロジェクト既定値。env 起源の leaf が最優先で、それ以外は step > workflow > persona > project > global の順）
 # provider_options:
 #   codex:
 #     network_access: true
@@ -294,11 +300,10 @@ copilot_cli_path: /usr/local/bin/github-copilot-cli
 
 ## モデル解決
 
-各 step で使用されるモデルは、次の優先順位（高い順）で解決されます。
+TAKT のモデル選択は 2 段階で解決されます。
 
-1. **Workflow step の `model`** - workflow YAML の step 定義で指定
-2. **グローバル設定の `model`** - `~/.takt/config.yaml` のデフォルトモデル
-3. **Provider デフォルト** - provider のビルトインデフォルトにフォールバック（Claude: `sonnet`、Codex: `codex`、OpenCode: provider デフォルト、Cursor: CLI デフォルト、Copilot: CLI デフォルト）
+1. **入力 `model` の解決** - workflow 実行前に、入力 `model` が CLI `--model`、次に config `model`、最後に provider デフォルトの順で解決されます。
+2. **Workflow step の `model` 解決** - 各 step では、実効モデルが `persona_providers[persona].model`、次に step YAML の `model`、最後に解決済みの入力 `model` の順で決まります。
 
 ### Provider 固有のモデルに関する注意
 
@@ -376,7 +381,7 @@ step の `required_permission_mode` は最低限の下限を設定します。pr
 
 ### Persona Provider
 
-workflow を複製せずに、特定の persona を別の provider や model にルーティングできます。
+workflow を複製せずに、特定の persona を別の provider、model、provider 固有オプションにルーティングできます。`~/.takt/config.yaml` と `.takt/config.yaml` のどちらでも定義できます。
 
 ```yaml
 # ~/.takt/config.yaml
@@ -384,11 +389,19 @@ persona_providers:
   coder:
     provider: codex        # coder persona を Codex で実行
     model: o3-mini         # 使用モデル（省略可）
+    provider_options:
+      codex:
+        reasoning_effort: high
   ai-antipattern-reviewer:
     provider: claude       # レビュアーは Claude のまま
+    provider_options:
+      claude:
+        effort: high
 ```
 
-`provider` と `model` はいずれも省略可能です。`model` の解決優先度: step YAML の `model` > `persona_providers[persona].model` > グローバル `model`。
+`provider`、`model`、`provider_options` は個別に省略できますが、各 persona entry には少なくとも 1 つ必要です。空の `provider_options` オブジェクトは受理されません。workflow step での `model` 優先順位は `persona_providers[persona].model` > step YAML の `model` > 解決済みの入力 `model` です。この入力 `model` は workflow 実行前に CLI `--model`、次に config の `model`、最後に provider デフォルトの順で解決されます。
+
+`provider_options` の優先順位は leaf ごとに解決されます。env 起源の config leaf が他のすべてのソースより優先され、それ以外は step `provider_options` > workflow `workflow_config.provider_options` > `persona_providers[persona].provider_options` > project `.takt/config.yaml` > global `~/.takt/config.yaml` の順です。
 
 これにより、単一の workflow 内で provider や model を混在させることができます。persona 名は step 定義の `persona` キーに対してマッチされます。
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,14 +36,20 @@ interactive_preview_steps: 3      # Step previews in interactive mode (0-10, def
 #     - gradle    # Prepare Gradle cache/config in .runtime/
 #     - node      # Prepare npm cache in .runtime/
 
-# Per-persona provider/model overrides (optional)
+# Per-persona provider/model/provider_options overrides (optional)
 # Route specific personas to different providers and models without duplicating workflows
 # persona_providers:
 #   coder:
 #     provider: codex        # Run coder on Codex
 #     model: o3-mini         # Use o3-mini model (optional)
+#     provider_options:
+#       codex:
+#         reasoning_effort: high
 #   ai-antipattern-reviewer:
 #     provider: claude       # Keep reviewers on Claude
+#     provider_options:
+#       claude:
+#         effort: high
 
 # Provider-specific permission profiles (optional)
 # Priority: project override > global override > project default > global default > required_permission_mode (floor)
@@ -135,7 +141,7 @@ interactive_preview_steps: 3      # Step previews in interactive mode (0-10, def
 | `auto_pr` | boolean | - | Auto-create PR after worktree execution |
 | `minimal_output` | boolean | `false` | Suppress AI output (for CI) |
 | `runtime` | object | - | Runtime environment defaults (e.g., `prepare: [gradle, node]`) |
-| `persona_providers` | object | - | Per-persona provider/model overrides (e.g., `coder: { provider: codex, model: o3-mini }`) |
+| `persona_providers` | object | - | Per-persona provider/model/provider_options overrides (e.g., `coder: { provider: codex, model: o3-mini, provider_options: { codex: { reasoning_effort: high } } }`) |
 | `provider_options` | object | - | Global provider-specific options |
 | `provider_profiles` | object | - | Provider-specific permission profiles |
 | `anthropic_api_key` | string | - | Anthropic API key for Claude |
@@ -174,7 +180,7 @@ logging:
 concurrency: 2                # Parallel task count for takt run in this project (1-10)
 # base_branch: main           # Base branch for clone creation (overrides global, default: remote default branch)
 
-# Provider-specific options (overrides global, overridden by workflow/step)
+# Provider-specific options (project defaults; env-resolved leaf overrides win, otherwise step > workflow > persona > project > global)
 # provider_options:
 #   codex:
 #     network_access: true
@@ -294,11 +300,10 @@ Paths must be absolute paths to executable files. Environment variables take pre
 
 ## Model Resolution
 
-The model used for each step is resolved with the following priority order (highest first):
+TAKT resolves model selection in two stages:
 
-1. **Workflow step `model`** - Specified in the step definition in workflow YAML
-2. **Global config `model`** - Default model in `~/.takt/config.yaml`
-3. **Provider default** - Falls back to the provider's built-in default (Claude: `sonnet`, Codex: `codex`, OpenCode: provider default, Cursor: CLI default, Copilot: CLI default)
+1. **Base input model** - Before workflow execution starts, the input `model` is resolved from CLI `--model`, then config `model`, then the provider default.
+2. **Workflow step model** - For each workflow step, the effective model is resolved from `persona_providers[persona].model`, then step YAML `model`, then the already-resolved input `model`.
 
 ### Provider-specific Model Notes
 
@@ -376,7 +381,7 @@ The `required_permission_mode` on a step sets the minimum floor. If the resolved
 
 ### Persona Providers
 
-Route specific personas to different providers and models without duplicating workflows:
+Route specific personas to different providers, models, and provider-specific options without duplicating workflows. You can define this in either `~/.takt/config.yaml` or `.takt/config.yaml`:
 
 ```yaml
 # ~/.takt/config.yaml
@@ -384,11 +389,19 @@ persona_providers:
   coder:
     provider: codex        # Run coder persona on Codex
     model: o3-mini         # Use o3-mini model (optional)
+    provider_options:
+      codex:
+        reasoning_effort: high
   ai-antipattern-reviewer:
     provider: claude       # Keep reviewers on Claude
+    provider_options:
+      claude:
+        effort: high
 ```
 
-Both `provider` and `model` are optional. `model` resolution priority: step YAML `model` > `persona_providers[persona].model` > global `model`.
+`provider`, `model`, and `provider_options` are individually optional, but each persona entry must include at least one of them. Empty `provider_options` objects are rejected. In workflow step resolution, `model` priority is `persona_providers[persona].model` > step YAML `model` > resolved input `model`. That input `model` is resolved before workflow execution from CLI `--model`, then config `model`, then the provider default.
+
+`provider_options` priority is resolved per leaf. An env-resolved config leaf overrides all other sources. Otherwise the order is: step `provider_options` > workflow `workflow_config.provider_options` > `persona_providers[persona].provider_options` > project `.takt/config.yaml` > global `~/.takt/config.yaml`.
 
 This allows mixing providers and models within a single workflow. The persona name is matched against the `persona` key in the step definition.
 

--- a/docs/provider-sandbox.md
+++ b/docs/provider-sandbox.md
@@ -119,7 +119,7 @@ steps:
 Settings are merged with the following priority (highest wins):
 
 ```
-Step > Workflow > Project (.takt/config.yaml) > Global (~/.takt/config.yaml)
+Env-resolved config leaf > Step > Workflow > Persona > Project (.takt/config.yaml) > Global (~/.takt/config.yaml)
 ```
 
 ### Codex sandbox mode reference
@@ -209,7 +209,7 @@ provider_options:
 
 ### Configuration levels
 
-Same 4-level merge as Codex (Step > Workflow > Project > Global). See the Codex section above for examples at each level.
+Same merge order as Codex: Env-resolved config leaf > Step > Workflow > Persona > Project > Global. See the Codex section above for examples at each level.
 
 ### Security comparison
 
@@ -325,22 +325,31 @@ provider_profiles:
 persona_providers:
   coder:
     provider: codex
+    provider_options:
+      codex:
+        network_access: true
   reviewer:
     provider: claude
+    provider_options:
+      claude:
+        sandbox:
+          allow_unsandboxed_commands: true
 ```
 
 ## Configuration Priority Summary
 
 Provider options (`provider_options`) and permission profiles (`provider_profiles`) are resolved from multiple sources. Higher priority wins:
 
-**Provider options** (merged, higher overrides lower):
+**Provider options** (merged per leaf, higher overrides lower):
 
 | Priority | Source | Example |
 |----------|--------|---------|
-| 1 (highest) | Step `provider_options` | `steps[].provider_options.codex.network_access` |
-| 2 | Workflow `workflow_config.provider_options` | `workflow_config.provider_options.codex.network_access` |
-| 3 | Project `.takt/config.yaml` | `provider_options.codex.network_access` |
-| 4 (lowest) | Global `~/.takt/config.yaml` | `provider_options.codex.network_access` |
+| 1 (highest) | Env-resolved config leaf | `TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS` -> `provider_options.codex.network_access` |
+| 2 | Step `provider_options` | `steps[].provider_options.codex.network_access` |
+| 3 | Workflow `workflow_config.provider_options` | `workflow_config.provider_options.codex.network_access` |
+| 4 | Persona `persona_providers.<persona>.provider_options` | `persona_providers.coder.provider_options.codex.network_access` |
+| 5 | Project `.takt/config.yaml` | `provider_options.codex.network_access` |
+| 6 (lowest) | Global `~/.takt/config.yaml` | `provider_options.codex.network_access` |
 
 **Permission mode** (first match wins):
 

--- a/src/__tests__/claude-provider-split-schema.test.ts
+++ b/src/__tests__/claude-provider-split-schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { GlobalConfigSchema } from '../core/models/index.js';
 import {
+  PersonaProviderEntrySchema,
   ProviderBlockSchema,
   ProviderPermissionProfilesSchema,
   ProviderReferenceSchema,
@@ -52,6 +53,36 @@ describe('Claude provider split (Zod)', () => {
           network_access: true,
         }),
       ).toThrow(/network_access/i);
+    });
+  });
+
+  describe('PersonaProviderEntrySchema', () => {
+    it('Given empty nested provider_options object, When parse, Then fails', () => {
+      expect(() =>
+        PersonaProviderEntrySchema.parse({
+          provider_options: {
+            claude: {
+              sandbox: {},
+            },
+          },
+        }),
+      ).toThrow(/provider_options/i);
+    });
+
+    it('Given nested provider_options leaf, When parse, Then succeeds', () => {
+      const parsed = PersonaProviderEntrySchema.parse({
+        provider_options: {
+          claude: {
+            sandbox: {
+              excluded_commands: ['rm'],
+            },
+          },
+        },
+      });
+
+      expect(parsed.provider_options?.claude?.sandbox).toEqual({
+        excluded_commands: ['rm'],
+      });
     });
   });
 

--- a/src/__tests__/config-normalizers-provider-options.test.ts
+++ b/src/__tests__/config-normalizers-provider-options.test.ts
@@ -16,6 +16,7 @@ describe('denormalizeProviderOptions', () => {
           excludedCommands: ['npm test'],
         },
       },
+      copilot: { effort: 'high' },
     });
 
     expect(result).toEqual({
@@ -28,6 +29,7 @@ describe('denormalizeProviderOptions', () => {
           excluded_commands: ['npm test'],
         },
       },
+      copilot: { effort: 'high' },
     });
   });
 
@@ -59,6 +61,9 @@ describe('denormalizeProviderOptions', () => {
         allowedTools: ['Read'],
         effort: 'medium',
       },
+      copilot: {
+        effort: 'medium',
+      },
     });
 
     expect(result).toEqual({
@@ -68,6 +73,9 @@ describe('denormalizeProviderOptions', () => {
       },
       claude: {
         allowed_tools: ['Read'],
+        effort: 'medium',
+      },
+      copilot: {
         effort: 'medium',
       },
     });

--- a/src/__tests__/engine-team-leader.test.ts
+++ b/src/__tests__/engine-team-leader.test.ts
@@ -401,6 +401,78 @@ describe('WorkflowEngine Integration: TeamLeaderRunner', () => {
     expect(partCall?.[2]?.providerOptions?.claude?.allowedTools).toBeUndefined();
   });
 
+  it('persona_providers の provider_options は team leader part に反映されつつ claude.allowed_tools は strip される', async () => {
+    const config = buildTeamLeaderConfig();
+    const step = config.steps[0];
+    if (!step?.teamLeader) {
+      throw new Error('teamLeader configuration is required');
+    }
+    step.teamLeader.partPersona = 'coder';
+
+    const engine = new WorkflowEngine(config, tmpDir, 'implement feature', {
+      projectCwd: tmpDir,
+      provider: 'claude',
+      personaProviders: {
+        coder: {
+          provider: 'opencode',
+          model: 'opencode/zai-coding-plan/glm-5.1',
+          providerOptions: {
+            opencode: {
+              networkAccess: true,
+            },
+            claude: {
+              allowedTools: ['Read', 'Edit', 'Bash', 'WebSearch'],
+              sandbox: {
+                allowUnsandboxedCommands: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    mockRunAgentWithPrompt(
+      makeResponse({
+        persona: 'team-leader',
+        structuredOutput: {
+          parts: [
+            { id: 'part-1', title: 'API', instruction: 'Implement API' },
+          ],
+        },
+      }),
+      makeResponse({ persona: 'coder', content: 'API done' }),
+      makeResponse({
+        persona: 'team-leader',
+        structuredOutput: { done: true, reasoning: 'enough', parts: [] },
+      }),
+    );
+
+    vi.mocked(detectMatchedRule).mockResolvedValueOnce({ index: 0, method: 'phase1_tag' });
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+
+    const partCall = vi.mocked(runAgent).mock.calls.find(([, , options]) => options?.resolvedProvider === 'opencode');
+    expect(partCall).toBeDefined();
+    expect(partCall?.[2]).toEqual(expect.objectContaining({
+      allowedTools: ['Read', 'Edit', 'Write'],
+      resolvedProvider: 'opencode',
+      resolvedModel: 'opencode/zai-coding-plan/glm-5.1',
+      providerOptions: {
+        opencode: {
+          networkAccess: true,
+        },
+        claude: {
+          sandbox: {
+            allowUnsandboxedCommands: true,
+          },
+        },
+      },
+    }));
+    expect(partCall?.[2]?.providerOptions?.claude?.allowedTools).toBeUndefined();
+  });
+
   it('Claude part で part_allowed_tools 未指定なら provider_options.claude.allowed_tools を継承する', async () => {
     const config = buildTeamLeaderConfig();
     const step = config.steps[0];

--- a/src/__tests__/engine-workflow-call.test.ts
+++ b/src/__tests__/engine-workflow-call.test.ts
@@ -450,6 +450,80 @@ steps:
     expect(options?.resolvedModel).toBeUndefined();
   });
 
+  it('workflow_call が provider を override しても child personaProviders の provider_options を保持する', async () => {
+    writeWorkflow(tmpDir, 'takt/coding.yaml', `name: takt/coding
+subworkflow:
+  callable: true
+initial_step: review
+max_steps: 5
+steps:
+  - name: review
+    persona: reviewer
+    instruction: "Review child workflow"
+    rules:
+      - condition: done
+        next: COMPLETE
+`);
+
+    const config = createParentWorkflow(tmpDir, {
+      name: 'parent',
+      initial_step: 'delegate',
+      max_steps: 10,
+      steps: [
+        {
+          name: 'delegate',
+          kind: 'workflow_call',
+          call: 'takt/coding',
+          overrides: {
+            provider: 'codex',
+          },
+          rules: [
+            {
+              condition: 'COMPLETE',
+              next: 'COMPLETE',
+            },
+          ],
+        },
+      ],
+    });
+
+    vi.mocked(runAgent).mockResolvedValueOnce(makeResponse({
+      persona: 'reviewer',
+      content: 'done',
+    }));
+    mockDetectMatchedRuleSequence([{ index: 0, method: 'phase1_tag' }]);
+
+    engine = new WorkflowEngine(config, tmpDir, 'Keep child persona provider options on workflow_call override', createWorkflowCallOptions(tmpDir, {
+      provider: 'claude',
+      model: 'parent-model',
+      providerOptions: {
+        codex: { networkAccess: false },
+      },
+      personaProviders: {
+        reviewer: {
+          provider: 'opencode',
+          model: 'reviewer-model',
+          providerOptions: {
+            codex: { reasoningEffort: 'high' },
+          },
+        },
+      },
+    }));
+
+    await engine.run();
+
+    const options = vi.mocked(runAgent).mock.calls[0]?.[2];
+
+    expect(options?.resolvedProvider).toBe('codex');
+    expect(options?.resolvedModel).toBeUndefined();
+    expect(options?.providerOptions).toEqual({
+      codex: {
+        networkAccess: false,
+        reasoningEffort: 'high',
+      },
+    });
+  });
+
   it('workflow_call が model だけ override しても child personaProviders の provider 解決を維持する', async () => {
     writeWorkflow(tmpDir, 'takt/coding.yaml', `name: takt/coding
 subworkflow:

--- a/src/__tests__/globalConfig-defaults.test.ts
+++ b/src/__tests__/globalConfig-defaults.test.ts
@@ -149,6 +149,109 @@ describe('loadGlobalConfig', () => {
     expect(raw).toContain('allow_git_filters: true');
   });
 
+  it('should load persona_providers provider_options from global config', () => {
+    const taktDir = join(testHomeDir, '.takt');
+    mkdirSync(taktDir, { recursive: true });
+    writeFileSync(
+      getGlobalConfigPath(),
+      [
+        'language: en',
+        'persona_providers:',
+        '  reviewer:',
+        '    provider_options:',
+        '      claude:',
+        '        allowed_tools:',
+        '          - Read',
+        '          - Edit',
+        '      codex:',
+        '        reasoning_effort: high',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const config = loadGlobalConfig();
+
+    expect(config.personaProviders).toEqual({
+      reviewer: {
+        providerOptions: {
+          claude: { allowedTools: ['Read', 'Edit'] },
+          codex: { reasoningEffort: 'high' },
+        },
+      },
+    });
+  });
+
+  it('should save personaProviders providerOptions as snake_case keys in global config', () => {
+    const taktDir = join(testHomeDir, '.takt');
+    mkdirSync(taktDir, { recursive: true });
+    writeFileSync(getGlobalConfigPath(), 'language: en\n', 'utf-8');
+
+    const config = loadGlobalConfig();
+    config.personaProviders = {
+      reviewer: {
+        providerOptions: {
+          claude: {
+            allowedTools: ['Read', 'Edit'],
+            sandbox: {
+              allowUnsandboxedCommands: true,
+              excludedCommands: ['./gradlew'],
+            },
+          },
+          codex: { reasoningEffort: 'high' },
+          copilot: { effort: 'high' },
+        },
+      },
+    };
+    saveGlobalConfig(config);
+
+    const raw = readFileSync(getGlobalConfigPath(), 'utf-8');
+    expect(raw).toContain('persona_providers:');
+    expect(raw).toContain('provider_options:');
+    expect(raw).toContain('allowed_tools:');
+    expect(raw).toContain('allow_unsandboxed_commands: true');
+    expect(raw).toContain('excluded_commands:');
+    expect(raw).toContain('reasoning_effort: high');
+    expect(raw).toContain('copilot:');
+    expect(raw).toContain('effort: high');
+    expect(raw).not.toContain('providerOptions:');
+    expect(raw).not.toContain('allowedTools:');
+  });
+
+  it('should reject empty nested persona_providers provider_options during load', () => {
+    const taktDir = join(testHomeDir, '.takt');
+    mkdirSync(taktDir, { recursive: true });
+    writeFileSync(
+      getGlobalConfigPath(),
+      [
+        'language: en',
+        'persona_providers:',
+        '  reviewer:',
+        '    provider_options:',
+        '      claude: {}',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    expect(() => loadGlobalConfig()).toThrow(/provider_options.*at least one provider-specific option/i);
+  });
+
+  it('should fail fast when saving empty personaProviders providerOptions in global config', () => {
+    const taktDir = join(testHomeDir, '.takt');
+    mkdirSync(taktDir, { recursive: true });
+    writeFileSync(getGlobalConfigPath(), 'language: en\n', 'utf-8');
+
+    const config = loadGlobalConfig();
+    config.personaProviders = {
+      reviewer: {
+        providerOptions: {},
+      },
+    };
+
+    expect(() => saveGlobalConfig(config)).toThrow(
+      /persona_providers\.reviewer\.provider_options must include at least one provider-specific option/i,
+    );
+  });
+
   it('should persist takt_providers.assistant when saving global config', () => {
     const taktDir = join(testHomeDir, '.takt');
     mkdirSync(taktDir, { recursive: true });
@@ -306,6 +409,8 @@ describe('loadGlobalConfig', () => {
         '      allow_unsandboxed_commands: true',
         '      excluded_commands:',
         '        - git push',
+        '  copilot:',
+        '    effort: high',
       ].join('\n'),
       'utf-8',
     );
@@ -324,9 +429,12 @@ describe('loadGlobalConfig', () => {
           excludedCommands: ['git push'],
         },
       },
+      copilot: { effort: 'high' },
     });
     const raw = readFileSync(getGlobalConfigPath(), 'utf-8');
     expect(raw).toContain('provider_options:');
+    expect(raw).toContain('copilot:');
+    expect(raw).toContain('effort: high');
   });
 
   it('should round-trip copilot global fields', () => {

--- a/src/__tests__/it-run-config-provider-options.test.ts
+++ b/src/__tests__/it-run-config-provider-options.test.ts
@@ -139,6 +139,31 @@ describe('IT: runAllTasks provider_options reflection', () => {
     });
   });
 
+  it('project persona_providers provider_options should override project provider_options in runAllTasks flow', async () => {
+    setProjectConfig(env.projectDir, [
+      'provider: claude',
+      'provider_options:',
+      '  claude:',
+      '    allowed_tools:',
+      '      - Read',
+      'persona_providers:',
+      '  planner:',
+      '    provider_options:',
+      '      claude:',
+      '        allowed_tools:',
+      '          - Read',
+      '          - Edit',
+    ].join('\n'));
+
+    await runAllTasksNoWorkflow(env.projectDir);
+
+    const options = vi.mocked(runAgent).mock.calls[0]?.[2];
+    expect(options?.providerOptions).toEqual({
+      claude: { allowedTools: ['Read', 'Edit'] },
+    });
+    expect(options?.allowedTools).toEqual(['Read', 'Edit']);
+  });
+
   it('env provider_options should override yaml in runAllTasks flow', async () => {
     setGlobalConfig(env.globalDir, [
       'provider_options:',

--- a/src/__tests__/it-workflow-patterns.test.ts
+++ b/src/__tests__/it-workflow-patterns.test.ts
@@ -57,6 +57,11 @@ vi.mock('../infra/config/resolveConfigValue.js', () => ({
     }
     return result;
   }),
+  resolveProviderOptionsWithTrace: vi.fn(() => ({
+    value: undefined,
+    source: 'default',
+    originResolver: () => 'default',
+  })),
 }));
 
 // --- Imports (after mocks) ---

--- a/src/__tests__/option-resolution-order.test.ts
+++ b/src/__tests__/option-resolution-order.test.ts
@@ -7,6 +7,7 @@ const {
   loadProjectConfigMock,
   loadGlobalConfigMock,
   resolveConfigValueMock,
+  resolveProviderOptionsWithTraceMock,
   loadTemplateMock,
   providerSetupMock,
   providerCallMock,
@@ -21,6 +22,7 @@ const {
     loadProjectConfigMock: vi.fn(),
     loadGlobalConfigMock: vi.fn(),
     resolveConfigValueMock: vi.fn(),
+    resolveProviderOptionsWithTraceMock: vi.fn(),
     loadTemplateMock: vi.fn(),
     providerSetupMock: providerSetup,
     providerCallMock: providerCall,
@@ -34,9 +36,13 @@ vi.mock('../infra/providers/index.js', () => ({
 vi.mock('../infra/config/index.js', () => ({
   loadProjectConfig: loadProjectConfigMock,
   loadGlobalConfig: loadGlobalConfigMock,
-  resolveConfigValue: resolveConfigValueMock,
   loadCustomAgents: loadCustomAgentsMock,
   loadAgentPrompt: loadAgentPromptMock,
+}));
+
+vi.mock('../infra/config/resolveConfigValue.js', () => ({
+  resolveConfigValue: resolveConfigValueMock,
+  resolveProviderOptionsWithTrace: resolveProviderOptionsWithTraceMock,
 }));
 
 vi.mock('../shared/prompts/index.js', () => ({
@@ -44,6 +50,7 @@ vi.mock('../shared/prompts/index.js', () => ({
 }));
 
 import { runAgent } from '../agents/runner.js';
+import type { RunAgentOptions } from '../agents/runner.js';
 
 describe('option resolution order', () => {
   beforeEach(() => {
@@ -56,11 +63,11 @@ describe('option resolution order', () => {
       concurrency: 1,
       taskPollIntervalMs: 500,
     });
-    resolveConfigValueMock.mockImplementation((_cwd: string, key: string) => {
-      if (key === 'personaProviders') {
-        return loadProjectConfigMock.mock.results.at(-1)?.value?.personaProviders;
-      }
-      return undefined;
+    resolveConfigValueMock.mockReturnValue(undefined);
+    resolveProviderOptionsWithTraceMock.mockReturnValue({
+      value: undefined,
+      source: 'default',
+      originResolver: () => 'default',
     });
     loadCustomAgentsMock.mockReturnValue(new Map());
     loadAgentPromptMock.mockReturnValue('prompt');
@@ -98,6 +105,9 @@ describe('option resolution order', () => {
   });
 
   it('should apply persona provider override before local/global config', async () => {
+    resolveConfigValueMock.mockReturnValue({
+      coder: { provider: 'claude' },
+    });
     loadProjectConfigMock.mockReturnValue({
       provider: 'opencode',
       personaProviders: {
@@ -118,7 +128,61 @@ describe('option resolution order', () => {
     expect(getProviderMock).toHaveBeenLastCalledWith('claude');
   });
 
+  it('should ignore global personaProviders when project personaProviders key exists', async () => {
+    resolveConfigValueMock.mockReturnValue({
+      coder: { provider: 'codex' },
+    });
+    loadProjectConfigMock.mockReturnValue({
+      provider: 'mock',
+      personaProviders: {
+        coder: { provider: 'codex' },
+      },
+    });
+    loadGlobalConfigMock.mockReturnValue({
+      provider: 'claude',
+      personaProviders: {
+        reviewer: { provider: 'opencode' },
+      },
+      language: 'en',
+      concurrency: 1,
+      taskPollIntervalMs: 500,
+    });
+
+    await runAgent('reviewer', 'task', {
+      cwd: '/repo',
+    });
+
+    expect(getProviderMock).toHaveBeenLastCalledWith('mock');
+  });
+
+  it('should honor env-resolved personaProviders in standalone runAgent calls', async () => {
+    resolveConfigValueMock.mockReturnValue({
+      reviewer: { provider: 'codex' },
+    });
+    loadProjectConfigMock.mockReturnValue({
+      provider: 'mock',
+      personaProviders: {
+        reviewer: { provider: 'claude' },
+      },
+    });
+    loadGlobalConfigMock.mockReturnValue({
+      provider: 'claude',
+      language: 'en',
+      concurrency: 1,
+      taskPollIntervalMs: 500,
+    });
+
+    await runAgent('reviewer', 'task', {
+      cwd: '/repo',
+    });
+
+    expect(getProviderMock).toHaveBeenLastCalledWith('codex');
+  });
+
   it('should resolve model in order: CLI > persona > local > global', async () => {
+    resolveConfigValueMock.mockReturnValue({
+      coder: { model: 'persona-model' },
+    });
     loadGlobalConfigMock.mockReturnValue({
       provider: 'claude',
       model: 'global-model',
@@ -218,6 +282,208 @@ describe('option resolution order', () => {
     );
   });
 
+  it('should merge persona providerOptions into standalone runAgent calls', async () => {
+    resolveConfigValueMock.mockReturnValue({
+      conductor: {
+        providerOptions: {
+          claude: {
+            effort: 'high',
+          },
+        },
+      },
+    });
+    loadProjectConfigMock.mockReturnValue({
+      provider: 'claude',
+      providerOptions: {
+        claude: {
+          sandbox: {
+            excludedCommands: ['rm'],
+          },
+        },
+      },
+      personaProviders: {
+        conductor: {
+          providerOptions: {
+            claude: {
+              effort: 'high',
+            },
+          },
+        },
+      },
+    });
+    resolveProviderOptionsWithTraceMock.mockReturnValue({
+      value: {
+        claude: {
+          sandbox: {
+            excludedCommands: ['rm'],
+          },
+        },
+      },
+      source: 'project',
+      originResolver: () => 'local',
+    });
+
+    await runAgent('conductor', 'task', {
+      cwd: '/repo',
+      providerOptions: {
+        claude: {
+          sandbox: {
+            allowUnsandboxedCommands: false,
+          },
+        },
+      },
+    });
+
+    expect(providerCallMock).toHaveBeenLastCalledWith(
+      'task',
+      expect.objectContaining({
+        providerOptions: {
+          claude: {
+            effort: 'high',
+            sandbox: {
+              allowUnsandboxedCommands: false,
+              excludedCommands: ['rm'],
+            },
+          },
+        },
+      }),
+    );
+  });
+
+  it('should keep env-origin config leaf ahead of persona and explicit providerOptions in standalone runAgent calls', async () => {
+    resolveConfigValueMock.mockReturnValue({
+      conductor: {
+        providerOptions: {
+          codex: {
+            reasoningEffort: 'high',
+            networkAccess: true,
+          },
+        },
+      },
+    });
+    loadProjectConfigMock.mockReturnValue({
+      provider: 'codex',
+      personaProviders: {
+        conductor: {
+          providerOptions: {
+            codex: {
+              reasoningEffort: 'high',
+              networkAccess: true,
+            },
+          },
+        },
+      },
+    });
+    resolveProviderOptionsWithTraceMock.mockReturnValue({
+      value: {
+        codex: {
+          reasoningEffort: 'low',
+          networkAccess: true,
+        },
+      },
+      source: 'project',
+      originResolver: (path: string) => (
+        path === 'codex.reasoningEffort' ? 'env' : 'local'
+      ),
+    });
+
+    await runAgent('conductor', 'task', {
+      cwd: '/repo',
+      providerOptions: {
+        codex: {
+          reasoningEffort: 'medium',
+          networkAccess: false,
+        },
+      },
+    });
+
+    expect(providerCallMock).toHaveBeenLastCalledWith(
+      'task',
+      expect.objectContaining({
+        providerOptions: {
+          codex: {
+            reasoningEffort: 'low',
+            networkAccess: false,
+          },
+        },
+      }),
+    );
+  });
+
+  it('should pass resolvedProviderOptions through without re-merging raw providerOptions', async () => {
+    resolveConfigValueMock.mockReturnValue({
+      coder: {
+        providerOptions: {
+          claude: {
+            allowedTools: ['Read', 'Edit', 'Bash', 'WebSearch'],
+          },
+        },
+      },
+    });
+    resolveProviderOptionsWithTraceMock.mockReturnValue({
+      value: {
+        claude: {
+          allowedTools: ['Read', 'Edit', 'Bash', 'WebSearch'],
+          sandbox: {
+            allowUnsandboxedCommands: true,
+          },
+        },
+      },
+      source: 'project',
+      originResolver: () => 'local',
+    });
+
+    const handoffOptions: RunAgentOptions & {
+      resolvedProviderOptions: {
+        opencode: {
+          networkAccess: boolean;
+        };
+        claude: {
+          sandbox: {
+            allowUnsandboxedCommands: boolean;
+          };
+        };
+      };
+    } = {
+      cwd: '/repo',
+      provider: 'opencode',
+      resolvedProvider: 'opencode',
+      providerOptions: {
+        claude: {
+          allowedTools: ['Read', 'Edit', 'Bash', 'WebSearch'],
+        },
+      },
+      resolvedProviderOptions: {
+        opencode: {
+          networkAccess: true,
+        },
+        claude: {
+          sandbox: {
+            allowUnsandboxedCommands: true,
+          },
+        },
+      },
+    };
+
+    await runAgent('coder', 'task', handoffOptions);
+
+    expect(providerCallMock).toHaveBeenLastCalledWith(
+      'task',
+      expect.objectContaining({
+        providerOptions: {
+          opencode: {
+            networkAccess: true,
+          },
+          claude: {
+            sandbox: {
+              allowUnsandboxedCommands: true,
+            },
+          },
+        },
+      }),
+    );
+  });
+
   it('should ignore custom agent provider/model overrides', async () => {
     loadProjectConfigMock.mockReturnValue({ provider: 'claude', model: 'project-model' });
     loadGlobalConfigMock.mockReturnValue({
@@ -237,6 +503,140 @@ describe('option resolution order', () => {
     expect(providerCallMock).toHaveBeenLastCalledWith(
       'task',
       expect.objectContaining({ model: 'project-model' }),
+    );
+  });
+
+  it('should merge persona providerOptions into custom agent runAgent calls', async () => {
+    resolveConfigValueMock.mockReturnValue({
+      custom: {
+        providerOptions: {
+          claude: {
+            effort: 'high',
+          },
+        },
+      },
+    });
+    loadProjectConfigMock.mockReturnValue({
+      provider: 'claude',
+      providerOptions: {
+        claude: {
+          sandbox: {
+            excludedCommands: ['rm'],
+          },
+        },
+      },
+      personaProviders: {
+        custom: {
+          providerOptions: {
+            claude: {
+              effort: 'high',
+            },
+          },
+        },
+      },
+    });
+    resolveProviderOptionsWithTraceMock.mockReturnValue({
+      value: {
+        claude: {
+          sandbox: {
+            excludedCommands: ['rm'],
+          },
+        },
+      },
+      source: 'project',
+      originResolver: () => 'local',
+    });
+    loadCustomAgentsMock.mockReturnValue(new Map([
+      ['custom', { name: 'custom', prompt: 'agent prompt' }],
+    ]));
+
+    await runAgent('custom', 'task', {
+      cwd: '/repo',
+      providerOptions: {
+        claude: {
+          sandbox: {
+            allowUnsandboxedCommands: false,
+          },
+        },
+      },
+    });
+
+    expect(providerCallMock).toHaveBeenLastCalledWith(
+      'task',
+      expect.objectContaining({
+        providerOptions: {
+          claude: {
+            effort: 'high',
+            sandbox: {
+              allowUnsandboxedCommands: false,
+              excludedCommands: ['rm'],
+            },
+          },
+        },
+      }),
+    );
+  });
+
+  it('should keep env-origin config leaf ahead of persona and explicit providerOptions in custom agent runAgent calls', async () => {
+    resolveConfigValueMock.mockReturnValue({
+      custom: {
+        providerOptions: {
+          codex: {
+            reasoningEffort: 'high',
+            networkAccess: true,
+          },
+        },
+      },
+    });
+    loadProjectConfigMock.mockReturnValue({
+      provider: 'codex',
+      personaProviders: {
+        custom: {
+          providerOptions: {
+            codex: {
+              reasoningEffort: 'high',
+              networkAccess: true,
+            },
+          },
+        },
+      },
+    });
+    resolveProviderOptionsWithTraceMock.mockReturnValue({
+      value: {
+        codex: {
+          reasoningEffort: 'low',
+          networkAccess: true,
+        },
+      },
+      source: 'project',
+      originResolver: (path: string) => (
+        path === 'codex.reasoningEffort' ? 'env' : 'local'
+      ),
+    });
+    loadCustomAgentsMock.mockReturnValue(new Map([
+      ['custom', { name: 'custom', prompt: 'agent prompt' }],
+    ]));
+
+    await runAgent('custom', 'task', {
+      cwd: '/repo',
+      providerOptions: {
+        codex: {
+          reasoningEffort: 'medium',
+          networkAccess: false,
+        },
+      },
+    });
+
+    expect(providerCallMock).toHaveBeenLastCalledWith(
+      'task',
+      expect.objectContaining({
+        providerOptions: {
+          codex: {
+            reasoningEffort: 'low',
+            networkAccess: false,
+          },
+        },
+      }),
     );
   });
 

--- a/src/__tests__/options-builder.test.ts
+++ b/src/__tests__/options-builder.test.ts
@@ -159,6 +159,38 @@ describe('OptionsBuilder.buildBaseOptions', () => {
     });
   });
 
+  it('lets persona provider_options override project provider options when step has none', () => {
+    const step = createStep({ personaDisplayName: 'reviewer' });
+    const builder = createBuilder(step, {
+      providerOptionsSource: 'project',
+      providerOptions: {
+        codex: { networkAccess: true, reasoningEffort: 'low' },
+        claude: {
+          allowedTools: ['Read', 'Glob'],
+          sandbox: { allowUnsandboxedCommands: false },
+        },
+      },
+      personaProviders: {
+        reviewer: {
+          providerOptions: {
+            codex: { reasoningEffort: 'high' },
+            claude: { allowedTools: ['Read', 'Edit'] },
+          },
+        },
+      },
+    });
+
+    const options = builder.buildBaseOptions(step);
+
+    expect(options.providerOptions).toEqual({
+      codex: { networkAccess: true, reasoningEffort: 'high' },
+      claude: {
+        allowedTools: ['Read', 'Edit'],
+        sandbox: { allowUnsandboxedCommands: false },
+      },
+    });
+  });
+
   it('uses nested env origin to keep config value only for the overridden leaf', () => {
     const step = createStep({
       providerOptions: {
@@ -184,6 +216,32 @@ describe('OptionsBuilder.buildBaseOptions', () => {
     expect(options.providerOptions).toEqual({
       codex: { networkAccess: true },
       claude: { allowedTools: ['Read', 'Edit'] },
+    });
+  });
+
+  it('keeps env-origin config leaf ahead of persona provider_options', () => {
+    const step = createStep({ personaDisplayName: 'reviewer' });
+    const builder = createBuilder(step, {
+      providerOptionsSource: 'project',
+      providerOptionsOriginResolver: (path: string) => (
+        path === 'codex.reasoningEffort' ? 'env' : 'default'
+      ),
+      providerOptions: {
+        codex: { reasoningEffort: 'low' },
+      },
+      personaProviders: {
+        reviewer: {
+          providerOptions: {
+            codex: { reasoningEffort: 'high' },
+          },
+        },
+      },
+    });
+
+    const options = builder.buildBaseOptions(step);
+
+    expect(options.providerOptions).toEqual({
+      codex: { reasoningEffort: 'low' },
     });
   });
 });

--- a/src/__tests__/projectConfig.test.ts
+++ b/src/__tests__/projectConfig.test.ts
@@ -238,6 +238,32 @@ unexpected_overrides:
       expect(() => loadProjectConfig(testDir)).toThrow(/reasoning_effort/);
     });
 
+    it('should reject empty persona_providers provider_options during load', () => {
+      const configPath = join(testDir, '.takt', 'config.yaml');
+      const configContent = [
+        'persona_providers:',
+        '  reviewer:',
+        '    provider_options: {}',
+      ].join('\n');
+      writeFileSync(configPath, configContent, 'utf-8');
+
+      expect(() => loadProjectConfig(testDir)).toThrow(/provider_options.*at least one provider-specific option/i);
+    });
+
+    it('should fail fast when saving empty personaProviders providerOptions', () => {
+      const config: ProjectLocalConfig = {
+        personaProviders: {
+          reviewer: {
+            providerOptions: {},
+          },
+        },
+      };
+
+      expect(() => saveProjectConfig(testDir, config)).toThrow(
+        /persona_providers\.reviewer\.provider_options must include at least one provider-specific option/i,
+      );
+    });
+
     it('should fail fast when claude effort is outside SDK enum', () => {
       const configPath = join(testDir, '.takt', 'config.yaml');
       const configContent = [
@@ -281,6 +307,33 @@ unexpected_overrides:
       expect(loaded.concurrency).toBe(3);
       expect(loaded.taskPollIntervalMs).toBe(1200);
       expect(loaded.interactivePreviewSteps).toBe(2);
+    });
+
+    it('should load persona_providers provider_options from project config yaml', () => {
+      const configPath = join(testDir, '.takt', 'config.yaml');
+      const configContent = [
+        'persona_providers:',
+        '  reviewer:',
+        '    provider_options:',
+        '      claude:',
+        '        allowed_tools:',
+        '          - Read',
+        '          - Edit',
+        '      codex:',
+        '        reasoning_effort: high',
+      ].join('\n');
+      writeFileSync(configPath, configContent, 'utf-8');
+
+      const loaded = loadProjectConfig(testDir);
+
+      expect(loaded.personaProviders).toEqual({
+        reviewer: {
+          providerOptions: {
+            claude: { allowedTools: ['Read', 'Edit'] },
+            codex: { reasoningEffort: 'high' },
+          },
+        },
+      });
     });
 
     it('should accept interactive_preview_steps in project config yaml', () => {
@@ -396,6 +449,40 @@ unexpected_overrides:
       expect(raw).toContain('concurrency: 4');
       expect(raw).toContain('task_poll_interval_ms: 1500');
       expect(raw).toContain('interactive_preview_steps: 1');
+    });
+
+    it('should save personaProviders providerOptions as snake_case keys', () => {
+      const config = {
+        personaProviders: {
+          reviewer: {
+            providerOptions: {
+              claude: {
+                allowedTools: ['Read', 'Edit'],
+                sandbox: {
+                  allowUnsandboxedCommands: true,
+                  excludedCommands: ['./gradlew'],
+                },
+              },
+              codex: { reasoningEffort: 'high' },
+              copilot: { effort: 'high' },
+            },
+          },
+        },
+      } as ProjectLocalConfig;
+
+      saveProjectConfig(testDir, config);
+
+      const raw = readFileSync(join(testDir, '.takt', 'config.yaml'), 'utf-8');
+      expect(raw).toContain('persona_providers:');
+      expect(raw).toContain('provider_options:');
+      expect(raw).toContain('allowed_tools:');
+      expect(raw).toContain('allow_unsandboxed_commands: true');
+      expect(raw).toContain('excluded_commands:');
+      expect(raw).toContain('reasoning_effort: high');
+      expect(raw).toContain('copilot:');
+      expect(raw).toContain('effort: high');
+      expect(raw).not.toContain('providerOptions:');
+      expect(raw).not.toContain('allowedTools:');
     });
 
     it('should save interactive preview count with canonical step key', () => {

--- a/src/__tests__/traced-config-boundary.test.ts
+++ b/src/__tests__/traced-config-boundary.test.ts
@@ -137,6 +137,56 @@ describe('traced config boundaries', () => {
     }
   });
 
+  it('project config loader は TAKT_PERSONA_PROVIDERS の nested provider_options を traced config 経路で保持する', () => {
+    const tempDir = join(tmpdir(), `takt-traced-persona-providers-${randomUUID()}`);
+    const configDir = join(tempDir, '.takt');
+    const configPath = join(configDir, 'config.yaml');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      [
+        'persona_providers:',
+        '  coder:',
+        '    provider: codex',
+        '    provider_options:',
+        '      codex:',
+        '        reasoning_effort: low',
+      ].join('\n'),
+      'utf-8',
+    );
+    process.env.TAKT_PERSONA_PROVIDERS = JSON.stringify({
+      coder: {
+        provider: 'codex',
+        provider_options: {
+          codex: {
+            reasoning_effort: 'high',
+          },
+        },
+      },
+    });
+
+    try {
+      const { rawConfig, trace } = loadProjectConfigTrace(configPath);
+
+      expect(rawConfig).toEqual({
+        persona_providers: {
+          coder: {
+            provider: 'codex',
+            provider_options: {
+              codex: {
+                reasoning_effort: 'high',
+              },
+            },
+          },
+        },
+      });
+      expect(trace.getOrigin('persona_providers.coder.provider_options')).toBe('env');
+      expect(trace.getOrigin('persona_providers.coder.provider_options.codex.reasoning_effort')).toBe('env');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('runtime bridge は cwd 配下の偽 traced-config を読まずに TAKT 同梱依存を使う', () => {
     const tempDir = join(tmpdir(), `takt-traced-runtime-${randomUUID()}`);
     const fakeModuleDir = join(tempDir, 'node_modules', 'traced-config');

--- a/src/__tests__/workflowResolver.test.ts
+++ b/src/__tests__/workflowResolver.test.ts
@@ -310,6 +310,41 @@ steps:
     expect(result.stepPreviews[0]?.allowedTools).toEqual(['Read', 'Bash']);
   });
 
+  it('should resolve preview tools from persona_providers provider_options', () => {
+    writeProjectConfig(tempDir, `provider: claude
+provider_options:
+  claude:
+    allowed_tools:
+      - Read
+persona_providers:
+  coder:
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Edit
+          - Bash
+`);
+
+    const workflowYaml = `name: preview-persona-tools
+initial_step: implement
+max_steps: 1
+
+steps:
+  - name: implement
+    persona: coder
+    instruction: "Implement the task"
+    edit: true
+`;
+
+    const workflowPath = join(tempDir, 'preview-persona-tools.yaml');
+    writeFileSync(workflowPath, workflowYaml);
+
+    const result = getWorkflowSummary(workflowPath, tempDir, 1);
+
+    expect(result.stepPreviews[0]?.allowedTools).toEqual(['Read', 'Edit', 'Bash']);
+  });
+
   it('should silently drop preview tools when configured for a non-Claude provider', () => {
     const workflowYaml = `name: preview-invalid-tools
 initial_step: plan

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -9,8 +9,15 @@ import {
   loadGlobalConfig,
   loadPersonaPromptFromPath,
   loadProjectConfig,
-  resolveConfigValue,
 } from '../infra/config/index.js';
+import {
+  resolveConfigValue,
+  resolveProviderOptionsWithTrace,
+} from '../infra/config/resolveConfigValue.js';
+import {
+  resolveEffectiveProviderOptions,
+  resolvePersonaProviderOptions,
+} from '../infra/config/providerOptions.js';
 import { getProvider, type ProviderType, type ProviderCallOptions } from '../infra/providers/index.js';
 import type { AgentResponse, CustomAgentConfig } from '../core/models/index.js';
 import { resolveAgentProviderModel } from '../core/workflow/provider-resolution.js';
@@ -22,6 +29,11 @@ import type { RunAgentOptions } from './types.js';
 export type { RunAgentOptions, StreamCallback } from './types.js';
 
 const log = createLogger('runner');
+type ResolvedProviderOptionsHandoff = {
+  resolvedProviderOptions?: ProviderCallOptions['providerOptions'];
+};
+
+type RunnerHandoffOptions = RunAgentOptions & ResolvedProviderOptionsHandoff;
 
 /**
  * Agent execution runner.
@@ -30,6 +42,10 @@ const log = createLogger('runner');
  * delegates execution to the appropriate provider.
  */
 export class AgentRunner {
+  private static resolvePersonaProviders(cwd: string) {
+    return resolveConfigValue(cwd, 'personaProviders');
+  }
+
   private static resolveProviderAndModel(
     cwd: string,
     personaDisplayName: string | undefined,
@@ -39,18 +55,20 @@ export class AgentRunner {
     model: string | undefined;
     localConfig: ReturnType<typeof loadProjectConfig>;
     globalConfig: ReturnType<typeof loadGlobalConfig>;
+    personaProviders: ReturnType<typeof AgentRunner.resolvePersonaProviders>;
   } {
     const localConfig = loadProjectConfig(cwd);
     const globalConfig = loadGlobalConfig();
+    const personaProviders = AgentRunner.resolvePersonaProviders(cwd);
     if (options?.resolvedProvider) {
       return {
         provider: options.resolvedProvider,
         model: options.resolvedModel,
         localConfig,
         globalConfig,
+        personaProviders,
       };
     }
-    const personaProviders = resolveConfigValue(cwd, 'personaProviders');
     const resolved = resolveAgentProviderModel({
       cliProvider: options?.provider,
       cliModel: options?.model,
@@ -70,6 +88,7 @@ export class AgentRunner {
       model: resolved.model,
       localConfig,
       globalConfig,
+      personaProviders,
     };
   }
 
@@ -92,10 +111,40 @@ export class AgentRunner {
     return `${dir}/${name}`;
   }
 
+  private static resolveProviderOptions(
+    cwd: string,
+    personaDisplayName: string | undefined,
+    options: RunnerHandoffOptions,
+    personaProviders: ReturnType<typeof AgentRunner.resolvePersonaProviders>,
+  ): ProviderCallOptions['providerOptions'] {
+    if (options.resolvedProviderOptions !== undefined) {
+      return options.resolvedProviderOptions;
+    }
+
+    const personaProviderOptions = resolvePersonaProviderOptions(
+      personaProviders,
+      personaDisplayName,
+    );
+    const {
+      value: resolvedConfigProviderOptions,
+      source: providerOptionsSource,
+      originResolver: providerOptionsOriginResolver,
+    } = resolveProviderOptionsWithTrace(cwd);
+
+    return resolveEffectiveProviderOptions(
+      providerOptionsSource,
+      providerOptionsOriginResolver,
+      resolvedConfigProviderOptions,
+      options.providerOptions,
+      personaProviderOptions,
+    );
+  }
+
   /** Build ProviderCallOptions from RunAgentOptions */
   private static buildCallOptions(
     resolvedModel: string | undefined,
     resolvedProvider: ProviderType,
+    resolvedProviderOptions: ProviderCallOptions['providerOptions'],
     options: RunAgentOptions,
     localConfig: ReturnType<typeof loadProjectConfig>,
     globalConfig: ReturnType<typeof loadGlobalConfig>,
@@ -116,7 +165,7 @@ export class AgentRunner {
       maxTurns: options.maxTurns,
       model: resolvedModel,
       permissionMode,
-      providerOptions: options.providerOptions,
+      providerOptions: resolvedProviderOptions,
       onStream: options.onStream,
       onPermissionRequest: options.onPermissionRequest,
       onAskUserQuestion: options.onAskUserQuestion,
@@ -155,6 +204,16 @@ export class AgentRunner {
     const providerType = resolved.provider;
     const provider = getProvider(providerType);
     const resolvedSystemPrompt = loadAgentPrompt(agentConfig, options.cwd);
+    const customOptions: RunnerHandoffOptions = {
+      ...options,
+      allowedTools: options.allowedTools ?? agentConfig.allowedTools,
+    };
+    const resolvedProviderOptions = AgentRunner.resolveProviderOptions(
+      options.cwd,
+      agentConfig.name,
+      customOptions,
+      resolved.personaProviders,
+    );
 
     options.onPromptResolved?.({
       systemPrompt: resolvedSystemPrompt,
@@ -166,14 +225,10 @@ export class AgentRunner {
       systemPrompt: resolvedSystemPrompt,
     });
 
-    const customOptions: RunAgentOptions = {
-      ...options,
-      allowedTools: options.allowedTools ?? agentConfig.allowedTools,
-    };
-
     return agent.call(task, AgentRunner.buildCallOptions(
       resolved.model,
       providerType,
+      resolvedProviderOptions,
       customOptions,
       resolved.localConfig,
       resolved.globalConfig,
@@ -202,9 +257,16 @@ export class AgentRunner {
     const resolved = AgentRunner.resolveProviderAndModel(options.cwd, personaName, options);
     const providerType = resolved.provider;
     const provider = getProvider(providerType);
+    const resolvedProviderOptions = AgentRunner.resolveProviderOptions(
+      options.cwd,
+      personaName,
+      options as RunnerHandoffOptions,
+      resolved.personaProviders,
+    );
     const callOptions = AgentRunner.buildCallOptions(
       resolved.model,
       providerType,
+      resolvedProviderOptions,
       options,
       resolved.localConfig,
       resolved.globalConfig,

--- a/src/core/models/config-types.ts
+++ b/src/core/models/config-types.ts
@@ -15,6 +15,7 @@ import type { VcsProviderType } from './vcs-types.js';
 export interface PersonaProviderEntry {
   provider?: ProviderType;
   model?: string;
+  providerOptions?: StepProviderOptions;
 }
 
 export interface TaktProviderEntry {

--- a/src/core/models/schema-base.ts
+++ b/src/core/models/schema-base.ts
@@ -199,22 +199,67 @@ export const StepQualityGatesOverrideSchema = z.object({
   quality_gates: QualityGatesSchema,
 }).optional();
 
+function hasPersonaProviderOptionsLeaf(
+  providerOptions: NonNullable<z.infer<typeof StepProviderOptionsSchema>>,
+): boolean {
+  return Object.values(providerOptions).some(hasDefinedProviderOptionLeaf);
+}
+
+function hasDefinedProviderOptionLeaf(value: unknown): boolean {
+  if (value === undefined) {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return true;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return true;
+  }
+
+  return Object.values(value).some(hasDefinedProviderOptionLeaf);
+}
+
 export const PersonaProviderEntrySchema = z.object({
+  type: ProviderTypeSchema.optional(),
   provider: ProviderTypeSchema.optional(),
   model: z.string().optional(),
-}).strict().refine(
-  (entry) => entry.provider !== undefined || entry.model !== undefined,
-  { message: "persona_providers entry must include either 'provider' or 'model'" }
-);
+  provider_options: StepProviderOptionsSchema,
+}).strict().superRefine((entry, ctx) => {
+  if (entry.type !== undefined && entry.provider !== undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      message: "persona_providers entry cannot include both 'type' and 'provider'",
+    });
+  }
 
-export const PersonaProviderBlockSchema = z.object({
-  type: ProviderTypeSchema,
-  model: z.string().optional(),
-}).strict();
+  if (
+    entry.type === undefined
+    && entry.provider === undefined
+    && entry.model === undefined
+    && entry.provider_options === undefined
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      message: "persona_providers entry must include at least one of 'provider', 'type', 'model', or 'provider_options'",
+    });
+  }
+
+  if (
+    entry.provider_options !== undefined
+    && !hasPersonaProviderOptionsLeaf(entry.provider_options)
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['provider_options'],
+      message: "persona_providers entry 'provider_options' must include at least one provider-specific option",
+    });
+  }
+});
 
 export const PersonaProviderReferenceSchema = z.union([
   ProviderTypeSchema,
-  PersonaProviderBlockSchema,
   PersonaProviderEntrySchema,
 ]);
 

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -7,6 +7,7 @@ import type { PhaseRunnerContext } from '../phase-runner.js';
 import {
   resolveEffectiveProviderOptions,
   resolveEffectiveTeamLeaderPartProviderOptions,
+  resolvePersonaProviderOptions,
 } from '../../../infra/config/providerOptions.js';
 import {
   assertProviderResolvedForCapabilitySensitiveOptions,
@@ -68,6 +69,11 @@ export class OptionsBuilder {
     step: WorkflowStep,
     runtime?: RuntimeStepResolution,
   ): StepProviderOptions | undefined {
+    const personaProviderOptions = resolvePersonaProviderOptions(
+      this.engineOptions.personaProviders,
+      step.personaDisplayName,
+    );
+
     if (runtime?.teamLeaderPart) {
       return resolveEffectiveTeamLeaderPartProviderOptions(
         this.engineOptions.providerOptionsSource,
@@ -76,6 +82,7 @@ export class OptionsBuilder {
         step.providerOptions,
         this.resolveStepProviderModel(step, runtime).provider,
         runtime.teamLeaderPart.partAllowedTools,
+        personaProviderOptions,
       );
     }
 
@@ -84,6 +91,7 @@ export class OptionsBuilder {
       this.engineOptions.providerOptionsOriginResolver,
       this.engineOptions.providerOptions,
       step.providerOptions,
+      personaProviderOptions,
     );
   }
 
@@ -98,7 +106,8 @@ export class OptionsBuilder {
     const currentPosition = currentIndex >= 0 ? `${currentIndex + 1}/${steps.length}` : '?/?';
     const { provider: resolvedProvider, model: resolvedModel } = this.resolveStepProviderModel(step, runtime);
 
-    return {
+    const providerOptions = mergedProviderOptions ?? this.resolveMergedProviderOptions(step, runtime);
+    const baseOptions: RunAgentOptions & { resolvedProviderOptions?: StepProviderOptions } = {
       cwd: this.getCwd(),
       projectCwd: this.getProjectCwd(),
       abortSignal: this.engineOptions.abortSignal,
@@ -110,7 +119,8 @@ export class OptionsBuilder {
         requiredPermissionMode: step.requiredPermissionMode,
         providerProfiles: this.engineOptions.providerProfiles,
       },
-      providerOptions: mergedProviderOptions ?? this.resolveMergedProviderOptions(step, runtime),
+      providerOptions,
+      resolvedProviderOptions: providerOptions,
       language: this.getLanguage(),
       onStream: this.engineOptions.onStream,
       onPermissionRequest: this.engineOptions.onPermissionRequest,
@@ -124,6 +134,7 @@ export class OptionsBuilder {
         currentPosition,
       },
     };
+    return baseOptions;
   }
 
   /** Build RunAgentOptions for Phase 1 (main execution) */

--- a/src/core/workflow/engine/WorkflowCallExecutor.ts
+++ b/src/core/workflow/engine/WorkflowCallExecutor.ts
@@ -51,6 +51,9 @@ export function applyWorkflowCallOverridesToPersonaProviders(
       } else if (overrides.provider === undefined && entry.model !== undefined) {
         nextEntry.model = entry.model;
       }
+      if (entry.providerOptions !== undefined) {
+        nextEntry.providerOptions = entry.providerOptions;
+      }
 
       return [persona, nextEntry];
     }),

--- a/src/infra/config/configNormalizers.ts
+++ b/src/infra/config/configNormalizers.ts
@@ -8,6 +8,23 @@ import type {
   TaktProvidersConfig,
 } from '../../core/models/config-types.js';
 import { validateProviderModelCompatibility } from './providerModelCompatibility.js';
+import {
+  normalizeConfigProviderReferenceDetailed,
+  type ConfigProviderReference,
+} from './providerReference.js';
+
+function assertNormalizedPersonaProviderOptions(
+  persona: string,
+  providerOptions: unknown,
+): void {
+  if (providerOptions !== undefined) {
+    return;
+  }
+
+  throw new Error(
+    `Configuration error: persona_providers.${persona}.provider_options must include at least one provider-specific option`,
+  );
+}
 
 export function normalizeRuntime(
   runtime: { prepare?: string[] } | undefined,
@@ -130,21 +147,34 @@ export function denormalizeWorkflowOverrides(
 }
 
 export function normalizePersonaProviders(
-  raw: Record<string, string | { type?: string; provider?: string; model?: string }> | undefined,
+  raw: Record<string, string | {
+    type?: string;
+    provider?: string;
+    model?: string;
+    provider_options?: Record<string, unknown>;
+  }> | undefined,
 ): Record<string, PersonaProviderEntry> | undefined {
   if (!raw) return undefined;
   const entries = Object.entries(raw);
   if (entries.length === 0) return undefined;
 
   return Object.fromEntries(entries.map(([persona, entry]) => {
-    const normalizedEntry: PersonaProviderEntry = typeof entry === 'string'
-      ? { provider: entry as PersonaProviderEntry['provider'] }
-      : {
-        ...(entry.provider !== undefined || entry.type !== undefined
-          ? { provider: (entry.provider ?? entry.type) as PersonaProviderEntry['provider'] }
-          : {}),
-        ...(entry.model !== undefined ? { model: entry.model } : {}),
-      };
+    const rawProviderOptions = typeof entry === 'string' ? undefined : entry.provider_options;
+    const normalizedReference = normalizeConfigProviderReferenceDetailed(
+      (typeof entry === 'string' ? entry : (entry.provider ?? entry.type)) as ConfigProviderReference<NonNullable<PersonaProviderEntry['provider']>>,
+      typeof entry === 'string' ? undefined : entry.model,
+      rawProviderOptions,
+    );
+    if (rawProviderOptions !== undefined) {
+      assertNormalizedPersonaProviderOptions(persona, normalizedReference.providerOptions);
+    }
+    const normalizedEntry: PersonaProviderEntry = {
+      ...(normalizedReference.provider !== undefined ? { provider: normalizedReference.provider } : {}),
+      ...(normalizedReference.model !== undefined ? { model: normalizedReference.model } : {}),
+      ...(normalizedReference.providerOptions !== undefined
+        ? { providerOptions: normalizedReference.providerOptions }
+        : {}),
+    };
     validateProviderModelCompatibility(
       normalizedEntry.provider,
       normalizedEntry.model,
@@ -154,6 +184,45 @@ export function normalizePersonaProviders(
       },
     );
     return [persona, normalizedEntry];
+  }));
+}
+
+export function denormalizePersonaProviders(
+  personaProviders: Record<string, PersonaProviderEntry> | undefined,
+): Record<string, Record<string, unknown>> | undefined {
+  if (!personaProviders) {
+    return undefined;
+  }
+
+  const entries = Object.entries(personaProviders);
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries.map(([persona, entry]) => {
+    const rawEntry: Record<string, unknown> = {};
+    if (entry.provider !== undefined) {
+      rawEntry.provider = entry.provider;
+    }
+    if (entry.model !== undefined) {
+      rawEntry.model = entry.model;
+    }
+
+    const rawProviderOptions = denormalizeProviderOptions(entry.providerOptions);
+    if (entry.providerOptions !== undefined) {
+      assertNormalizedPersonaProviderOptions(persona, rawProviderOptions);
+    }
+    if (rawProviderOptions !== undefined) {
+      rawEntry.provider_options = rawProviderOptions;
+    }
+
+    if (Object.keys(rawEntry).length === 0) {
+      throw new Error(
+        `Configuration error: persona_providers.${persona} must include at least one of 'provider', 'model', or 'provider_options'`,
+      );
+    }
+
+    return [persona, rawEntry];
   }));
 }
 
@@ -285,6 +354,9 @@ export function denormalizeProviderOptions(
     if (Object.keys(claude).length > 0) {
       raw.claude = claude;
     }
+  }
+  if (providerOptions.copilot?.effort !== undefined) {
+    raw.copilot = { effort: providerOptions.copilot.effort };
   }
 
   return Object.keys(raw).length > 0 ? raw : undefined;

--- a/src/infra/config/global/globalConfigCore.ts
+++ b/src/infra/config/global/globalConfigCore.ts
@@ -209,7 +209,12 @@ export class GlobalConfigManager {
         } | undefined,
       ),
       personaProviders: normalizePersonaProviders(
-        parsed.persona_providers as Record<string, string | { type?: string; provider?: string; model?: string }> | undefined,
+        parsed.persona_providers as Record<string, string | {
+          type?: string;
+          provider?: string;
+          model?: string;
+          provider_options?: Record<string, unknown>;
+        }> | undefined,
       ),
       branchNameStrategy: parsed.branch_name_strategy as GlobalConfig['branchNameStrategy'],
       minimalOutput: parsed.minimal_output as boolean | undefined,

--- a/src/infra/config/global/globalConfigSerializer.ts
+++ b/src/infra/config/global/globalConfigSerializer.ts
@@ -1,6 +1,7 @@
 import type { GlobalConfig } from '../../../core/models/config-types.js';
 import {
   denormalizeProviderProfiles,
+  denormalizePersonaProviders,
   denormalizeWorkflowOverrides,
   denormalizeProviderOptions,
 } from '../configNormalizers.js';
@@ -190,8 +191,9 @@ export function serializeGlobalConfig(config: GlobalConfig): Record<string, unkn
     }
     if (Object.keys(pipelineRaw).length > 0) raw.pipeline = pipelineRaw;
   }
-  if (config.personaProviders && Object.keys(config.personaProviders).length > 0) {
-    raw.persona_providers = config.personaProviders;
+  const rawPersonaProviders = denormalizePersonaProviders(config.personaProviders);
+  if (rawPersonaProviders && Object.keys(rawPersonaProviders).length > 0) {
+    raw.persona_providers = rawPersonaProviders;
   }
   if (config.branchNameStrategy !== undefined) {
     raw.branch_name_strategy = config.branchNameStrategy;

--- a/src/infra/config/loaders/workflowPreview.ts
+++ b/src/infra/config/loaders/workflowPreview.ts
@@ -9,7 +9,10 @@ import {
 import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
 import { resolveWorkflowConfigValues } from '../resolveWorkflowConfigValue.js';
 import { resolveProviderOptionsWithTrace } from '../resolveConfigValue.js';
-import { resolveEffectiveProviderOptions } from '../providerOptions.js';
+import {
+  resolveEffectiveProviderOptions,
+  resolvePersonaProviderOptions,
+} from '../providerOptions.js';
 import { loadPersonaPromptFromPath } from './agentLoader.js';
 import { loadWorkflowByIdentifier } from './workflowResolver.js';
 
@@ -95,6 +98,10 @@ function resolvePreviewAllowedTools(
     resolution.providerOptionsOriginResolver,
     resolution.providerOptions,
     step.providerOptions,
+    resolvePersonaProviderOptions(
+      resolution.personaProviders,
+      step.personaDisplayName,
+    ),
   );
   const resolvedProvider = resolveStepProviderModel({
     step,

--- a/src/infra/config/project/projectConfig.ts
+++ b/src/infra/config/project/projectConfig.ts
@@ -12,6 +12,7 @@ import {
   normalizeProviderProfiles,
   denormalizeProviderProfiles,
   denormalizeProviderOptions,
+  denormalizePersonaProviders,
   normalizePersonaProviders,
   normalizeTaktProviders,
   buildRawTaktProvidersOrThrow,
@@ -92,7 +93,12 @@ export function loadProjectConfig(projectDir: string): ProjectConfig {
     pipeline as { default_branch_prefix?: string; commit_message_template?: string; pr_body_template?: string } | undefined,
   );
   const normalizedPersonaProviders = normalizePersonaProviders(
-    persona_providers as Record<string, string | { type?: string; provider?: string; model?: string }> | undefined,
+    persona_providers as Record<string, string | {
+      type?: string;
+      provider?: string;
+      model?: string;
+      provider_options?: Record<string, unknown>;
+    }> | undefined,
   );
   const analyticsConfig = normalizeAnalytics(analytics as Record<string, unknown> | undefined);
   const normalizedTaktProviders = normalizeTaktProviders(
@@ -203,8 +209,9 @@ export function saveProjectConfig(projectDir: string, config: ProjectConfig): vo
     if (config.pipeline.prBodyTemplate !== undefined) pr.pr_body_template = config.pipeline.prBodyTemplate;
     if (Object.keys(pr).length > 0) savePayload.pipeline = pr;
   }
-  if (config.personaProviders && Object.keys(config.personaProviders).length > 0) {
-    savePayload.persona_providers = config.personaProviders;
+  const rawPersonaProviders = denormalizePersonaProviders(config.personaProviders);
+  if (rawPersonaProviders && Object.keys(rawPersonaProviders).length > 0) {
+    savePayload.persona_providers = rawPersonaProviders;
   } else {
     delete savePayload.persona_providers;
   }

--- a/src/infra/config/providerOptions.ts
+++ b/src/infra/config/providerOptions.ts
@@ -4,6 +4,7 @@ import type {
   CopilotEffort,
   StepProviderOptions,
 } from '../../core/models/workflow-types.js';
+import type { PersonaProviderEntry } from '../../core/models/config-types.js';
 import type {
   ProviderOptionsOriginResolver,
   ProviderOptionsSource,
@@ -168,13 +169,24 @@ export function resolveProviderOptionOrigin(
 
 function selectProviderValue<T>(
   configValue: T | undefined,
+  personaValue: T | undefined,
   stepValue: T | undefined,
   origin: ProviderOptionsTraceOrigin,
 ): T | undefined {
-  if (origin === 'env' || origin === 'cli') {
-    return configValue ?? stepValue;
+  if ((origin === 'env' || origin === 'cli') && configValue !== undefined) {
+    return configValue;
   }
-  return stepValue ?? configValue;
+  return stepValue ?? personaValue ?? configValue;
+}
+
+export function resolvePersonaProviderOptions(
+  personaProviders: Record<string, PersonaProviderEntry> | undefined,
+  personaDisplayName: string | undefined,
+): StepProviderOptions | undefined {
+  if (!personaDisplayName) {
+    return undefined;
+  }
+  return personaProviders?.[personaDisplayName]?.providerOptions;
 }
 
 export function resolveEffectiveProviderOptions(
@@ -182,23 +194,26 @@ export function resolveEffectiveProviderOptions(
   originResolver: ProviderOptionsOriginResolver | undefined,
   resolvedConfigOptions: StepProviderOptions | undefined,
   stepOptions: StepProviderOptions | undefined,
+  personaOptions?: StepProviderOptions,
 ): StepProviderOptions | undefined {
   if (!resolvedConfigOptions) {
-    return stepOptions;
+    return mergeProviderOptions(personaOptions, stepOptions);
   }
-  if (!stepOptions) {
+  if (!personaOptions && !stepOptions) {
     return resolvedConfigOptions;
   }
 
   const claudeSandbox = {
     allowUnsandboxedCommands: selectProviderValue(
       resolvedConfigOptions.claude?.sandbox?.allowUnsandboxedCommands,
-      stepOptions.claude?.sandbox?.allowUnsandboxedCommands,
+      personaOptions?.claude?.sandbox?.allowUnsandboxedCommands,
+      stepOptions?.claude?.sandbox?.allowUnsandboxedCommands,
       resolveProviderOptionOrigin(originResolver, 'claude.sandbox.allowUnsandboxedCommands', source),
     ),
     excludedCommands: selectProviderValue(
       resolvedConfigOptions.claude?.sandbox?.excludedCommands,
-      stepOptions.claude?.sandbox?.excludedCommands,
+      personaOptions?.claude?.sandbox?.excludedCommands,
+      stepOptions?.claude?.sandbox?.excludedCommands,
       resolveProviderOptionOrigin(originResolver, 'claude.sandbox.excludedCommands', source),
     ),
   };
@@ -209,34 +224,40 @@ export function resolveEffectiveProviderOptions(
       : undefined,
     allowedTools: selectProviderValue(
       resolvedConfigOptions.claude?.allowedTools,
-      stepOptions.claude?.allowedTools,
+      personaOptions?.claude?.allowedTools,
+      stepOptions?.claude?.allowedTools,
       resolveProviderOptionOrigin(originResolver, 'claude.allowedTools', source),
     ),
     effort: selectProviderValue(
       resolvedConfigOptions.claude?.effort,
-      stepOptions.claude?.effort,
+      personaOptions?.claude?.effort,
+      stepOptions?.claude?.effort,
       resolveProviderOptionOrigin(originResolver, 'claude.effort', source),
     ),
   };
 
   const codexNetworkAccess = selectProviderValue(
     resolvedConfigOptions.codex?.networkAccess,
-    stepOptions.codex?.networkAccess,
+    personaOptions?.codex?.networkAccess,
+    stepOptions?.codex?.networkAccess,
     resolveProviderOptionOrigin(originResolver, 'codex.networkAccess', source),
   );
   const codexReasoningEffort = selectProviderValue(
     resolvedConfigOptions.codex?.reasoningEffort,
-    stepOptions.codex?.reasoningEffort,
+    personaOptions?.codex?.reasoningEffort,
+    stepOptions?.codex?.reasoningEffort,
     resolveProviderOptionOrigin(originResolver, 'codex.reasoningEffort', source),
   );
   const opencodeNetworkAccess = selectProviderValue(
     resolvedConfigOptions.opencode?.networkAccess,
-    stepOptions.opencode?.networkAccess,
+    personaOptions?.opencode?.networkAccess,
+    stepOptions?.opencode?.networkAccess,
     resolveProviderOptionOrigin(originResolver, 'opencode.networkAccess', source),
   );
   const copilotEffort = selectProviderValue(
     resolvedConfigOptions.copilot?.effort,
-    stepOptions.copilot?.effort,
+    personaOptions?.copilot?.effort,
+    stepOptions?.copilot?.effort,
     resolveProviderOptionOrigin(originResolver, 'copilot.effort', source),
   );
 
@@ -304,12 +325,14 @@ export function resolveEffectiveTeamLeaderPartProviderOptions(
   stepOptions: StepProviderOptions | undefined,
   resolvedProvider: ProviderType | undefined,
   partAllowedTools: string[] | undefined,
+  personaOptions?: StepProviderOptions,
 ): StepProviderOptions | undefined {
   const mergedProviderOptions = resolveEffectiveProviderOptions(
     source,
     originResolver,
     resolvedConfigOptions,
     stepOptions,
+    personaOptions,
   );
 
   const shouldStripClaudeTools = partAllowedTools !== undefined


### PR DESCRIPTION
## Summary

## 背景

現状の `persona_providers` は `provider` / `model` のみを持てます。
一方で `provider_options` は global / project / workflow / step でのみ設定可能です。

このため、persona ごとに Claude の `effort` や Codex の `reasoning_effort` などを変えたい場合でも、実際には各 step の `provider_options` に重複して書く必要があります。

## ほしい挙動

`persona_providers.<persona>.provider_options` をサポートしたいです。

例:

```yaml
persona_providers:
  coder:
    provider: codex
    model: gpt-5
    provider_options:
      codex:
        reasoning_effort: high

  reviewer:
    provider: claude
    provider_options:
      claude:
        effort: high
```

## 期待する効果

- persona ごとの provider/model 設定と provider 固有オプションを同じ場所で管理できる
- workflow 側の step 設定の重複を減らせる
- `persona_providers` を provider 解決だけでなく provider 設定のレイヤーとして扱えるようになる

## 優先順位の案

`provider_options` の優先順位は次が自然だと思います。

1. `steps[].provider_options`
2. `workflow_config.provider_options`
3. `persona_providers.<persona>.provider_options`
4. project `.takt/config.yaml` の `provider_options`
5. global `~/.takt/config.yaml` の `provider_options`

`persona_providers` は「persona 単位のデフォルト」として扱い、workflow / step の明示指定よりは弱く、project / global よりは強い位置づけにする想定です。

## 実装メモ

- `persona_providers` のスキーマ/型に `provider_options` を追加する
- persona 解決時に provider/model だけでなく provider_options も併せて解決する
- provider option merge の優先順位に persona レイヤーを追加する
- config load/save, traced config, docs, tests を更新する


## Execution Report

Workflow `takt-default` completed successfully.

Closes #623