### PR TITLE
feat(observability): log provider_options effort value + source

### DIFF
--- a/src/__tests__/provider-options-source.test.ts
+++ b/src/__tests__/provider-options-source.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PROVIDER_OPTION_PATHS,
+  resolveProviderOptionSource,
+  resolveProviderOptionsSources,
+} from '../infra/config/providerOptions.js';
+
+describe('resolveProviderOptionSource', () => {
+  it('Given step has value, When resolve, Then source is step', () => {
+    const source = resolveProviderOptionSource(
+      'claude.effort',
+      { claude: { effort: 'xhigh' } },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(source).toBe('step');
+  });
+
+  it('Given persona has value and step absent, When resolve, Then source is persona_providers', () => {
+    const source = resolveProviderOptionSource(
+      'claude.effort',
+      undefined,
+      { claude: { effort: 'high' } },
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(source).toBe('persona_providers');
+  });
+
+  it('Given only config has value (no resolver), When resolve, Then source derives from configSource', () => {
+    expect(
+      resolveProviderOptionSource(
+        'claude.effort',
+        undefined,
+        undefined,
+        { claude: { effort: 'medium' } },
+        undefined,
+        'project',
+      ),
+    ).toBe('project');
+    expect(
+      resolveProviderOptionSource(
+        'claude.effort',
+        undefined,
+        undefined,
+        { claude: { effort: 'medium' } },
+        undefined,
+        'global',
+      ),
+    ).toBe('global');
+    expect(
+      resolveProviderOptionSource(
+        'claude.effort',
+        undefined,
+        undefined,
+        { claude: { effort: 'medium' } },
+        undefined,
+        'default',
+      ),
+    ).toBe('default');
+  });
+
+  it('Given env/cli origin with config value, Then config wins over step/persona (mirrors selectProviderValue)', () => {
+    const source = resolveProviderOptionSource(
+      'claude.effort',
+      { claude: { effort: 'xhigh' } },
+      undefined,
+      { claude: { effort: 'low' } },
+      () => 'cli',
+      'project',
+    );
+    expect(source).toBe('cli');
+  });
+
+  it('Given nothing set, When resolve, Then undefined', () => {
+    expect(
+      resolveProviderOptionSource(
+        'claude.effort',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('Given resolver returns local for a path, When resolve, Then source maps to project', () => {
+    const source = resolveProviderOptionSource(
+      'codex.reasoningEffort',
+      undefined,
+      undefined,
+      { codex: { reasoningEffort: 'high' } },
+      (path) => (path === 'codex.reasoningEffort' ? 'local' : 'default'),
+      undefined,
+    );
+    expect(source).toBe('project');
+  });
+});
+
+describe('resolveProviderOptionsSources (all paths)', () => {
+  it('returns only paths with a defined source', () => {
+    const result = resolveProviderOptionsSources(
+      { claude: { effort: 'xhigh' } },
+      { codex: { reasoningEffort: 'high' } },
+      { copilot: { effort: 'medium' } },
+      undefined,
+      'global',
+    );
+    expect(result).toEqual({
+      'claude.effort': 'step',
+      'codex.reasoningEffort': 'persona_providers',
+      'copilot.effort': 'global',
+    });
+  });
+
+  it('exposes the full list of tracked paths', () => {
+    expect(PROVIDER_OPTION_PATHS).toContain('claude.effort');
+    expect(PROVIDER_OPTION_PATHS).toContain('codex.reasoningEffort');
+    expect(PROVIDER_OPTION_PATHS).toContain('copilot.effort');
+  });
+});

--- a/src/__tests__/sessionLogger.test.ts
+++ b/src/__tests__/sessionLogger.test.ts
@@ -197,6 +197,37 @@ describe('SessionLogger', () => {
     expect(buildWorkflowStepScopeKey('review', firstStack)).not.toBe(buildWorkflowStepScopeKey('review', secondStack));
   });
 
+  it('step_start record includes providerOptions and providerOptionsSources when providerInfo carries them', () => {
+    const logsDir = createTempLogsDir();
+    const ndjsonPath = initNdjsonLog('session-opts', 'task', 'wf', { logsDir });
+    const logger = new SessionLogger(ndjsonPath, true);
+    const step = {
+      name: 'plan',
+      kind: 'agent' as const,
+      persona: 'planner',
+      personaDisplayName: 'planner',
+      instruction: 'Plan it',
+      passPreviousResponse: true,
+    };
+
+    logger.onStepStart(step, 1, 'Plan it', undefined, {
+      provider: 'claude',
+      providerSource: 'global',
+      model: 'claude-opus-4-7',
+      modelSource: 'global',
+      providerOptions: { claude: { effort: 'xhigh' } },
+      providerOptionsSources: { 'claude.effort': 'step' },
+    });
+
+    const records = readFileSync(ndjsonPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const stepStart = records.find((record) => record.type === 'step_start');
+    expect(stepStart?.providerOptions).toEqual({ claude: { effort: 'xhigh' } });
+    expect(stepStart?.providerOptionsSources).toEqual({ 'claude.effort': 'step' });
+  });
+
   it('step_start record includes provider/model/source when providerInfo is given (#370)', () => {
     const logsDir = createTempLogsDir();
     const ndjsonPath = initNdjsonLog('session-source', 'task', 'wf', { logsDir });

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -8,6 +8,7 @@ import {
   resolveEffectiveProviderOptions,
   resolveEffectiveTeamLeaderPartProviderOptions,
   resolvePersonaProviderOptions,
+  resolveProviderOptionsSources,
 } from '../../../infra/config/providerOptions.js';
 import {
   assertProviderResolvedForCapabilitySensitiveOptions,
@@ -63,11 +64,23 @@ export class OptionsBuilder {
       modelSource: engineProviderInfo.modelSource,
       personaProviders: this.engineOptions.personaProviders,
     });
+    const providerOptions = this.resolveMergedProviderOptions(step, runtime);
+    const providerOptionsSources = resolveProviderOptionsSources(
+      step.providerOptions,
+      resolvePersonaProviderOptions(this.engineOptions.personaProviders, step.personaDisplayName),
+      this.engineOptions.providerOptions,
+      this.engineOptions.providerOptionsOriginResolver,
+      this.engineOptions.providerOptionsSource,
+    );
     return {
       provider: resolved.provider ?? engineProviderInfo.provider,
       providerSource: resolved.providerSource ?? engineProviderInfo.providerSource,
       model: resolved.model ?? engineProviderInfo.model,
       modelSource: resolved.modelSource ?? engineProviderInfo.modelSource,
+      providerOptions,
+      providerOptionsSources: Object.keys(providerOptionsSources).length > 0
+        ? providerOptionsSources
+        : undefined,
     };
   }
 

--- a/src/core/workflow/provider-options-trace.ts
+++ b/src/core/workflow/provider-options-trace.ts
@@ -16,6 +16,7 @@ export type ProviderOptionsOriginResolver = (path: string) => ProviderOptionsTra
  * - `default`: provider's built-in default (no explicit configuration)
  */
 export type ProviderResolutionSource =
+  | 'env'
   | 'cli'
   | 'persona_providers'
   | 'step'

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -88,6 +88,8 @@ export interface StepProviderInfo {
   model: string | undefined;
   providerSource?: ProviderResolutionSource;
   modelSource?: ProviderResolutionSource;
+  providerOptions?: StepProviderOptions;
+  providerOptionsSources?: Readonly<Record<string, ProviderResolutionSource>>;
 }
 
 export interface TeamLeaderPartRuntimeResolution {

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -16,14 +16,7 @@ import type { StructuredCaller } from '../../agents/structured-caller.js';
 import type { SystemStepServicesFactory } from './system/system-step-services.js';
 import type { ProviderOptionsOriginResolver, ProviderOptionsSource, ProviderResolutionSource } from './provider-options-trace.js';
 
-// Re-export shared provider protocol types to maintain backward compatibility.
-// The canonical definitions live in shared/types/provider.ts so that shared-layer
-// modules (StreamDisplay, providerEventLogger) can import them without creating
-// an upward shared → core dependency.
-import type {
-  ProviderType,
-  StreamCallback,
-} from '../../shared/types/provider.js';
+import type { ProviderType, StreamCallback } from '../../shared/types/provider.js';
 export type {
   ProviderType,
   StreamEvent,

--- a/src/features/tasks/execute/sessionLoggerRecordFactory.ts
+++ b/src/features/tasks/execute/sessionLoggerRecordFactory.ts
@@ -202,6 +202,8 @@ export function buildStepStartRecord(
     ...(providerInfo?.providerSource !== undefined ? { providerSource: providerInfo.providerSource } : {}),
     ...(providerInfo?.model !== undefined ? { model: providerInfo.model } : {}),
     ...(providerInfo?.modelSource !== undefined ? { modelSource: providerInfo.modelSource } : {}),
+    ...(providerInfo?.providerOptions !== undefined ? { providerOptions: providerInfo.providerOptions } : {}),
+    ...(providerInfo?.providerOptionsSources !== undefined ? { providerOptionsSources: providerInfo.providerOptionsSources } : {}),
   };
 }
 

--- a/src/features/tasks/execute/workflowExecutionEvents.ts
+++ b/src/features/tasks/execute/workflowExecutionEvents.ts
@@ -2,6 +2,8 @@ import { interruptAllQueries } from '../../../infra/claude/query-manager.js';
 import type { WorkflowResumePointEntry } from '../../../core/models/index.js';
 import type { WorkflowEngine } from '../../../core/workflow/index.js';
 import type { SessionLog } from '../../../infra/fs/index.js';
+import type { StepProviderInfo } from '../../../core/workflow/types.js';
+import type { ProviderType } from '../../../shared/types/provider.js';
 import { StreamDisplay } from '../../../shared/ui/index.js';
 import { sanitizeTerminalText } from '../../../shared/utils/text.js';
 import { isDebugEnabled, isVerboseConsole } from '../../../shared/utils/debug.js';
@@ -58,6 +60,46 @@ interface WorkflowExecutionEventBridgeDeps {
 export interface WorkflowExecutionEventBridge {
   state: WorkflowExecutionEventState;
   syncLatestResumePoint: () => void;
+}
+
+type OutInfo = { info: (line: string) => void };
+
+function sourceSuffix(
+  path: string,
+  sources: StepProviderInfo['providerOptionsSources'],
+  showSource: boolean,
+): string {
+  if (!showSource) return '';
+  const source = sources?.[path];
+  return source ? ` (source: ${source})` : '';
+}
+
+function emitEffortLines(
+  out: OutInfo,
+  stepProvider: ProviderType,
+  providerInfo: StepProviderInfo,
+  showSource: boolean,
+): void {
+  const options = providerInfo.providerOptions;
+  if (!options) return;
+  const sources = providerInfo.providerOptionsSources;
+
+  if (stepProvider === 'claude' || stepProvider === 'claude-sdk') {
+    const effort = options.claude?.effort;
+    if (effort !== undefined) {
+      out.info(`Effort: ${effort}${sourceSuffix('claude.effort', sources, showSource)}`);
+    }
+  } else if (stepProvider === 'codex') {
+    const effort = options.codex?.reasoningEffort;
+    if (effort !== undefined) {
+      out.info(`Reasoning effort: ${effort}${sourceSuffix('codex.reasoningEffort', sources, showSource)}`);
+    }
+  } else if (stepProvider === 'copilot') {
+    const effort = options.copilot?.effort;
+    if (effort !== undefined) {
+      out.info(`Effort: ${effort}${sourceSuffix('copilot.effort', sources, showSource)}`);
+    }
+  }
 }
 
 export function bindWorkflowExecutionEvents(
@@ -157,6 +199,7 @@ export function bindWorkflowExecutionEvents(
       : '';
     deps.out.info(`Provider: ${stepProvider}${providerSourceSuffix}`);
     deps.out.info(`Model: ${stepModel}${modelSourceSuffix}`);
+    emitEffortLines(deps.out, stepProvider, providerInfo, showSource);
     deps.analyticsEmitter.updateProviderInfo(iteration, stepProvider, stepModel);
 
     if (!deps.prefixWriter) {

--- a/src/infra/config/providerOptions.ts
+++ b/src/infra/config/providerOptions.ts
@@ -9,6 +9,7 @@ import type {
   ProviderOptionsOriginResolver,
   ProviderOptionsSource,
   ProviderOptionsTraceOrigin,
+  ProviderResolutionSource,
 } from '../../core/workflow/provider-options-trace.js';
 import type { ProviderType } from '../../shared/types/provider.js';
 import { providerSupportsClaudeAllowedTools } from '../providers/provider-capabilities.js';
@@ -344,4 +345,93 @@ export function resolveEffectiveTeamLeaderPartProviderOptions(
   return shouldStripClaudeTools
     ? stripClaudeAllowedTools(mergedProviderOptions)
     : mergedProviderOptions;
+}
+
+/** All paths we expose for per-option source attribution. */
+export const PROVIDER_OPTION_PATHS = [
+  'claude.effort',
+  'claude.allowedTools',
+  'claude.sandbox.allowUnsandboxedCommands',
+  'claude.sandbox.excludedCommands',
+  'codex.networkAccess',
+  'codex.reasoningEffort',
+  'opencode.networkAccess',
+  'copilot.effort',
+] as const;
+
+export type ProviderOptionPath = (typeof PROVIDER_OPTION_PATHS)[number];
+
+function getValueAtPath(
+  options: StepProviderOptions | undefined,
+  path: string,
+): unknown {
+  if (!options) return undefined;
+  return path.split('.').reduce<unknown>((acc, part) => {
+    if (acc === undefined || acc === null || typeof acc !== 'object') {
+      return undefined;
+    }
+    return (acc as Record<string, unknown>)[part];
+  }, options);
+}
+
+function originToResolutionSource(origin: ProviderOptionsTraceOrigin): ProviderResolutionSource {
+  switch (origin) {
+    case 'env': return 'env';
+    case 'cli': return 'cli';
+    case 'local': return 'project';
+    case 'global': return 'global';
+    case 'default': return 'default';
+  }
+}
+
+/**
+ * Resolve the source layer of a single provider_options path, mirroring
+ * `selectProviderValue` precedence (env/cli config beats step/persona,
+ * otherwise step > persona > config).
+ */
+export function resolveProviderOptionSource(
+  path: string,
+  stepOptions: StepProviderOptions | undefined,
+  personaOptions: StepProviderOptions | undefined,
+  configOptions: StepProviderOptions | undefined,
+  originResolver: ProviderOptionsOriginResolver | undefined,
+  configSource: ProviderOptionsSource | undefined,
+): ProviderResolutionSource | undefined {
+  const configValue = getValueAtPath(configOptions, path);
+  const personaValue = getValueAtPath(personaOptions, path);
+  const stepValue = getValueAtPath(stepOptions, path);
+  const origin = resolveProviderOptionOrigin(originResolver, path, configSource);
+
+  if ((origin === 'env' || origin === 'cli') && configValue !== undefined) {
+    return originToResolutionSource(origin);
+  }
+  if (stepValue !== undefined) return 'step';
+  if (personaValue !== undefined) return 'persona_providers';
+  if (configValue !== undefined) return originToResolutionSource(origin);
+  return undefined;
+}
+
+/** Compute source per known provider_options path. Returns only paths with values. */
+export function resolveProviderOptionsSources(
+  stepOptions: StepProviderOptions | undefined,
+  personaOptions: StepProviderOptions | undefined,
+  configOptions: StepProviderOptions | undefined,
+  originResolver: ProviderOptionsOriginResolver | undefined,
+  configSource: ProviderOptionsSource | undefined,
+): Record<string, ProviderResolutionSource> {
+  const result: Record<string, ProviderResolutionSource> = {};
+  for (const path of PROVIDER_OPTION_PATHS) {
+    const source = resolveProviderOptionSource(
+      path,
+      stepOptions,
+      personaOptions,
+      configOptions,
+      originResolver,
+      configSource,
+    );
+    if (source !== undefined) {
+      result[path] = source;
+    }
+  }
+  return result;
 }

--- a/src/shared/utils/types.ts
+++ b/src/shared/utils/types.ts
@@ -62,6 +62,8 @@ export interface NdjsonStepStart {
   providerSource?: string;
   model?: string;
   modelSource?: string;
+  providerOptions?: unknown;
+  providerOptionsSources?: Record<string, string>;
 }
 
 export interface NdjsonStepComplete {


### PR DESCRIPTION
**Draft** — #643 / #644 のマージ後のフォローアップ。provider_options.effort を表示・ログ出力する。

## 背景

#644 で provider/model の解決値と source を console/NDJSON に表示可能にした。本 PR はその value+source パターンを `provider_options.*.effort` に拡張する。

`--provider xxx` を指定すると Provider / Model が表示されるが、同じように `provider_options.claude.effort: xhigh` を設定したのに効いているかどうか log で確認できなかった。

## 出力

### Console

通常:

```
[INFO] Provider: claude
[INFO] Model: claude-opus-4-7
[INFO] Effort: xhigh
```

debug / verbose:

```
[INFO] Provider: claude (source: global)
[INFO] Model: claude-opus-4-7 (source: step)
[INFO] Effort: xhigh (source: step)
```

Provider 別の表示:
- `claude` / `claude-sdk` → `Effort:` (from `claude.effort`)
- `codex` → `Reasoning effort:` (from `codex.reasoningEffort`)
- `copilot` → `Effort:` (from `copilot.effort`)

### NDJSON (`step_start` レコード)

```json
{
  "type": "step_start",
  "step": "plan",
  "provider": "claude",
  "providerSource": "global",
  "model": "claude-opus-4-7",
  "modelSource": "step",
  "providerOptions": { "claude": { "effort": "xhigh" } },
  "providerOptionsSources": { "claude.effort": "step" }
}
```

## 設計

### Source 解決ロジック

既存の `selectProviderValue` の優先順位をそのまま反映:

```
env/cli config > step > persona > config (project/global/default)
```

`src/infra/config/providerOptions.ts` に追加:

- `PROVIDER_OPTION_PATHS` — 追跡対象の path 一覧（`claude.effort`, `codex.reasoningEffort`, `copilot.effort`, sandbox, allowed_tools, network_access）
- `resolveProviderOptionSource(path, step, persona, config, resolver, configSource)` — 単一 path の source 解決
- `resolveProviderOptionsSources(...)` — 全 path に対し source map (`Record<path, source>`) を返す

### StepProviderInfo 拡張

```ts
export interface StepProviderInfo {
  provider: ProviderType | undefined;
  model: string | undefined;
  providerSource?: ProviderResolutionSource;
  modelSource?: ProviderResolutionSource;
  providerOptions?: StepProviderOptions;                                    // ← NEW
  providerOptionsSources?: Readonly<Record<string, ProviderResolutionSource>>; // ← NEW
}
```

`OptionsBuilder.resolveStepProviderModel` で `resolveMergedProviderOptions` の結果と合わせて埋める。既存の `step:start` イベントパイプラインに自動的に流れる。

### ProviderResolutionSource に `'env'` を追加

既存の `ProviderOptionsTraceOrigin` (`'env' | 'cli' | 'local' | 'global' | 'default'`) と整合を取るため。provider/model には env 経路は無いが、provider_options の一部には env 由来がありうるため。

## モデル名非依存

#643 で入れた Claude effort + model 互換性検証 (`claude-opus-4-6` + `xhigh` を reject 等) は **設定時バリデーションのみ**であり、この PR の表示・ログ出力はモデル名を参照しません。Provider 種別 (claude / codex / copilot) だけで分岐します。

- `provider: claude, model: opus` + `claude.effort: xhigh` → 表示 ✓
- `provider: claude, model: claude-opus-4-6` + `claude.effort: high` → 表示 ✓（#643 でバリデーション済みの有効値）
- `provider: codex, model: gpt-5` + `codex.reasoningEffort: xhigh` → 表示 ✓

## クロスプロバイダー時の挙動

active でない provider の provider_options が設定されている状況（例: `provider: codex` なのに `claude.effort: xhigh` が残っている）:

| 状況 | Console | NDJSON |
|------|---------|--------|
| active provider の effort | 表示する | 記録する |
| 非 active provider の effort（クロス） | **隠す**（runtime で効かないため誤解防止） | 記録する（merged 全体） |

## Test plan

- [x] `npm run build` 成功
- [x] `npm run lint` 成功
- [x] `npm run test` 全 5207 件 PASS
- [x] 新規テスト
  - `provider-options-source.test.ts` (8 ケース): step / persona / config / env-cli config override / undefined / resolver prefix
  - `sessionLogger.test.ts` 追加 1 ケース: `providerOptions` + `providerOptionsSources` が step_start に載る

## 関連

- #643 (MERGED): `xhigh` effort + model 互換性検証
- #644 (MERGED): provider/model の value + source 可視化 — 本 PR はその provider_options 版