### PR TITLE
[#627] implement-report-handles

### DIFF
--- a/src/__tests__/engine-report-handles.test.ts
+++ b/src/__tests__/engine-report-handles.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+vi.mock('../agents/runner.js', () => ({
+  runAgent: vi.fn(),
+}));
+
+vi.mock('../core/workflow/evaluation/index.js', () => ({
+  detectMatchedRule: vi.fn(),
+}));
+
+vi.mock('../core/workflow/phase-runner.js', () => ({
+  needsStatusJudgmentPhase: vi.fn().mockReturnValue(false),
+  runReportPhase: vi.fn().mockResolvedValue(undefined),
+  runStatusJudgmentPhase: vi.fn().mockResolvedValue({ tag: '', ruleIndex: 0, method: 'auto_select' }),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
+}));
+
+import { WorkflowEngine } from '../core/workflow/index.js';
+import { runAgent } from '../agents/runner.js';
+import type { WorkflowConfig } from '../core/models/index.js';
+import {
+  applyDefaultMocks,
+  cleanupWorkflowEngine,
+  makeResponse,
+  makeRule,
+  makeStep,
+  mockDetectMatchedRuleSequence,
+  mockRunAgentSequence,
+} from './engine-test-helpers.js';
+
+function writeReport(reportDir: string, fileName: string, content: string): void {
+  mkdirSync(reportDir, { recursive: true });
+  writeFileSync(join(reportDir, fileName), content);
+}
+
+function createWorktreeDirs(): { baseDir: string; projectCwd: string; cloneCwd: string; reportDir: string } {
+  const baseDir = join(tmpdir(), `takt-report-handles-${randomUUID()}`);
+  const projectCwd = join(baseDir, 'project');
+  const cloneCwd = join(baseDir, 'clone');
+  const reportDir = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports');
+
+  mkdirSync(join(projectCwd, '.takt', 'runs', 'test-report-dir', 'reports'), { recursive: true });
+  mkdirSync(reportDir, { recursive: true });
+
+  return { baseDir, projectCwd, cloneCwd, reportDir };
+}
+
+function buildParallelReviewerConfig(): WorkflowConfig {
+  return {
+    name: 'reviewer-peer-reports',
+    description: 'Peer report handle test',
+    maxSteps: 5,
+    initialStep: 'reviewers',
+    steps: [
+      makeStep('reviewers', {
+        parallel: [
+          makeStep('arch-review', {
+            instruction: 'Peer reports:\n{peer_reports}',
+            passPreviousResponse: false,
+            outputContracts: [{ name: '05-arch-review.md', format: '# Arch Review' }],
+            rules: [makeRule('approved', 'COMPLETE')],
+          }),
+          makeStep('security-review', {
+            instruction: 'Peer reports:\n{peer_reports}',
+            passPreviousResponse: false,
+            outputContracts: [{ name: '06-security-review.md', format: '# Security Review' }],
+            rules: [makeRule('approved', 'COMPLETE')],
+          }),
+        ],
+        rules: [
+          makeRule('all("approved")', 'COMPLETE', {
+            isAggregateCondition: true,
+            aggregateType: 'all',
+            aggregateConditionText: 'approved',
+          }),
+        ],
+      }),
+    ],
+  };
+}
+
+function buildFixHandleConfig(): WorkflowConfig {
+  return {
+    name: 'fix-report-handles',
+    description: 'Current and peer report handle test',
+    maxSteps: 5,
+    initialStep: 'fix',
+    steps: [
+      makeStep('reviewers', {
+        parallel: [
+          makeStep('arch-review', {
+            instruction: 'arch review',
+            passPreviousResponse: false,
+            outputContracts: [{ name: '05-arch-review.md', format: '# Arch Review' }],
+            rules: [makeRule('approved', 'COMPLETE')],
+          }),
+          makeStep('security-review', {
+            instruction: 'security review',
+            passPreviousResponse: false,
+            outputContracts: [{ name: '06-security-review.md', format: '# Security Review' }],
+            rules: [makeRule('approved', 'COMPLETE')],
+          }),
+        ],
+        rules: [
+          makeRule('all("approved")', 'fix', {
+            isAggregateCondition: true,
+            aggregateType: 'all',
+            aggregateConditionText: 'approved',
+          }),
+        ],
+      }),
+      makeStep('fix', {
+        instruction: [
+          'Current: {current_report}',
+          'Previous: {previous_report}',
+          'History: {report_history}',
+          'Peers: {peer_reports}',
+        ].join('\n'),
+        passPreviousResponse: false,
+        outputContracts: [{ name: '07-fix.md', format: '# Fix Report' }],
+        rules: [makeRule('Fix complete', 'COMPLETE')],
+      }),
+    ],
+  };
+}
+
+function buildSuperviseHandleConfig(): WorkflowConfig {
+  return {
+    name: 'supervise-peer-reports',
+    description: 'Supervise peer report handle test',
+    maxSteps: 5,
+    initialStep: 'reviewers',
+    steps: [
+      makeStep('reviewers', {
+        parallel: [
+          makeStep('arch-review', {
+            instruction: 'arch review',
+            passPreviousResponse: false,
+            outputContracts: [{ name: '05-arch-review.md', format: '# Arch Review' }],
+            rules: [makeRule('approved', 'COMPLETE')],
+          }),
+          makeStep('security-review', {
+            instruction: 'security review',
+            passPreviousResponse: false,
+            outputContracts: [{ name: '06-security-review.md', format: '# Security Review' }],
+            rules: [makeRule('approved', 'COMPLETE')],
+          }),
+        ],
+        rules: [
+          makeRule('all("approved")', 'supervise', {
+            isAggregateCondition: true,
+            aggregateType: 'all',
+            aggregateConditionText: 'approved',
+          }),
+        ],
+      }),
+      makeStep('supervise', {
+        instruction: 'Peers:\n{peer_reports}',
+        passPreviousResponse: false,
+        rules: [makeRule('All checks passed', 'COMPLETE')],
+      }),
+    ],
+  };
+}
+
+describe('WorkflowEngine report handle integration', () => {
+  let baseDir: string;
+  let projectCwd: string;
+  let cloneCwd: string;
+  let reportDir: string;
+  const engines: WorkflowEngine[] = [];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    applyDefaultMocks();
+
+    const dirs = createWorktreeDirs();
+    baseDir = dirs.baseDir;
+    projectCwd = dirs.projectCwd;
+    cloneCwd = dirs.cloneCwd;
+    reportDir = dirs.reportDir;
+  });
+
+  afterEach(() => {
+    for (const engine of engines) {
+      cleanupWorkflowEngine(engine);
+    }
+    engines.length = 0;
+
+    if (existsSync(baseDir)) {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should inject sibling peer report paths for parallel reviewer sub-steps', async () => {
+    // Given
+    const config = buildParallelReviewerConfig();
+    const engine = new WorkflowEngine(config, cloneCwd, 'test task', { projectCwd });
+    engines.push(engine);
+
+    writeReport(reportDir, '05-arch-review.md', 'latest arch review');
+    writeReport(reportDir, '06-security-review.md', 'latest security review');
+
+    mockRunAgentSequence([
+      makeResponse({ persona: 'arch-review', content: 'approved' }),
+      makeResponse({ persona: 'security-review', content: 'approved' }),
+    ]);
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'aggregate' },
+    ]);
+
+    // When
+    const state = await engine.run();
+
+    // Then
+    expect(state.status).toBe('completed');
+
+    const runAgentMock = vi.mocked(runAgent);
+    const archCall = runAgentMock.mock.calls.find((call) => call[0] === '../personas/arch-review.md');
+    const securityCall = runAgentMock.mock.calls.find((call) => call[0] === '../personas/security-review.md');
+    const archInstruction = archCall?.[1] ?? '';
+    const securityInstruction = securityCall?.[1] ?? '';
+    const archPath = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports', '05-arch-review.md');
+    const securityPath = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports', '06-security-review.md');
+    const archPeerSection = archInstruction.split('Peer reports:\n')[1] ?? '';
+    const securityPeerSection = securityInstruction.split('Peer reports:\n')[1] ?? '';
+
+    expect(archInstruction).toContain(archPath);
+    expect(archInstruction).toContain(securityPath);
+    expect(archPeerSection).toContain(securityPath);
+    expect(archPeerSection).not.toContain(archPath);
+    expect(securityInstruction).toContain(archPath);
+    expect(securityInstruction).toContain(securityPath);
+    expect(securityPeerSection).toContain(archPath);
+    expect(securityPeerSection).not.toContain(securityPath);
+  });
+
+  it('should inject current previous history and peer report handles for fix step with clone-based paths', async () => {
+    // Given
+    const config = buildFixHandleConfig();
+    const engine = new WorkflowEngine(config, cloneCwd, 'test task', { projectCwd });
+    engines.push(engine);
+
+    writeReport(reportDir, '05-arch-review.md', 'latest arch review');
+    writeReport(reportDir, '06-security-review.md', 'latest security review');
+    writeReport(reportDir, '07-fix.md', 'latest fix report');
+    writeReport(reportDir, '07-fix.md.20260420T010000Z', 'previous fix report');
+    writeReport(reportDir, '07-fix.md.20260419T230000Z', 'older fix report');
+
+    mockRunAgentSequence([
+      makeResponse({ persona: 'fix', content: 'Fix complete' }),
+    ]);
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' },
+    ]);
+
+    // When
+    const state = await engine.run();
+
+    // Then
+    expect(state.status).toBe('completed');
+
+    const instruction = vi.mocked(runAgent).mock.calls[0]?.[1];
+    const latestFixPath = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports', '07-fix.md');
+    const previousFixPath = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports', '07-fix.md.20260420T010000Z');
+    const olderFixPath = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports', '07-fix.md.20260419T230000Z');
+    const archPath = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports', '05-arch-review.md');
+    const securityPath = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports', '06-security-review.md');
+
+    expect(instruction).toContain(latestFixPath);
+    expect(instruction).toContain(previousFixPath);
+    expect(instruction).toContain(olderFixPath);
+    expect(instruction).toContain(archPath);
+    expect(instruction).toContain(securityPath);
+    expect(instruction).not.toContain(join(projectCwd, '.takt', 'runs', 'test-report-dir', 'reports', '07-fix.md'));
+
+    expect(instruction!.indexOf(previousFixPath)).toBeLessThan(instruction!.indexOf(olderFixPath));
+  });
+
+  it('should inject clone-based reviewer peer report paths for supervise step', async () => {
+    // Given
+    const config = buildSuperviseHandleConfig();
+    const engine = new WorkflowEngine(config, cloneCwd, 'test task', { projectCwd });
+    engines.push(engine);
+
+    writeReport(reportDir, '05-arch-review.md', 'latest arch review');
+    writeReport(reportDir, '06-security-review.md', 'latest security review');
+
+    mockRunAgentSequence([
+      makeResponse({ persona: 'arch-review', content: 'approved' }),
+      makeResponse({ persona: 'security-review', content: 'approved' }),
+      makeResponse({ persona: 'supervise', content: 'All checks passed' }),
+    ]);
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'aggregate' },
+      { index: 0, method: 'phase1_tag' },
+    ]);
+
+    // When
+    const state = await engine.run();
+
+    // Then
+    expect(state.status).toBe('completed');
+
+    const superviseCall = vi.mocked(runAgent).mock.calls.find((call) => call[0] === '../personas/supervise.md');
+    const archPath = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports', '05-arch-review.md');
+    const securityPath = join(cloneCwd, '.takt', 'runs', 'test-report-dir', 'reports', '06-security-review.md');
+
+    expect(superviseCall?.[1]).toContain(archPath);
+    expect(superviseCall?.[1]).toContain(securityPath);
+    expect(superviseCall?.[1]).not.toContain(join(projectCwd, '.takt', 'runs', 'test-report-dir', 'reports', '05-arch-review.md'));
+  });
+});

--- a/src/__tests__/escape.test.ts
+++ b/src/__tests__/escape.test.ts
@@ -9,6 +9,7 @@ import {
   escapeTemplateChars,
   replaceTemplatePlaceholders,
 } from '../core/workflow/instruction/escape.js';
+import type { InstructionContext } from '../core/workflow/instruction/instruction-context.js';
 import { makeStep, makeInstructionContext } from './test-helpers.js';
 
 describe('escapeTemplateChars', () => {
@@ -155,6 +156,51 @@ describe('replaceTemplatePlaceholders', () => {
 
     const result = replaceTemplatePlaceholders(template, step, ctx);
     expect(result).toBe('Read /tmp/reports/review.md and /tmp/reports/plan.md');
+  });
+
+  it('should replace report handle placeholders with resolved paths', () => {
+    const step = makeStep();
+    const ctx = {
+      ...makeInstructionContext(),
+      currentReport: '/tmp/reports/07-fix.md',
+      previousReport: '/tmp/reports/07-fix.md.20260420T010000Z',
+      reportHistory: [
+        '/tmp/reports/07-fix.md.20260420T010000Z',
+        '/tmp/reports/07-fix.md.20260419T230000Z',
+      ].join('\n'),
+      peerReports: [
+        '/tmp/reports/05-arch-review.md',
+        '/tmp/reports/06-security-review.md',
+      ].join('\n'),
+    } as InstructionContext;
+    const template = [
+      'Current: {current_report}',
+      'Previous: {previous_report}',
+      'History: {report_history}',
+      'Peers: {peer_reports}',
+    ].join('\n');
+
+    const result = replaceTemplatePlaceholders(template, step, ctx);
+
+    expect(result).toContain('Current: /tmp/reports/07-fix.md');
+    expect(result).toContain('Previous: /tmp/reports/07-fix.md.20260420T010000Z');
+    expect(result).toContain('/tmp/reports/07-fix.md.20260419T230000Z');
+    expect(result).toContain('/tmp/reports/05-arch-review.md');
+    expect(result).toContain('/tmp/reports/06-security-review.md');
+    expect(result).not.toContain('{current_report}');
+    expect(result).not.toContain('{previous_report}');
+    expect(result).not.toContain('{report_history}');
+    expect(result).not.toContain('{peer_reports}');
+  });
+
+  it('should replace missing report handle placeholders with empty strings', () => {
+    const step = makeStep();
+    const ctx = makeInstructionContext() as InstructionContext;
+    const template = 'Current:{current_report}|Previous:{previous_report}|History:{report_history}|Peers:{peer_reports}';
+
+    const result = replaceTemplatePlaceholders(template, step, ctx);
+
+    expect(result).toBe('Current:|Previous:|History:|Peers:');
   });
 
   it('should handle template with multiple different placeholders', () => {

--- a/src/__tests__/instructionBuilder.test.ts
+++ b/src/__tests__/instructionBuilder.test.ts
@@ -526,6 +526,23 @@ describe('instruction-builder', () => {
       expect(result).toContain('Phase 1');
     });
 
+    it('should keep report file metadata for peer_reports instructions', () => {
+      const step = createMinimalStep('Peer reports:\n{peer_reports}');
+      step.outputContracts = [{ name: '05-arch-review.md', format: '05-arch-review', useJudge: true }];
+      const context = createMinimalContext({
+        reportDir: '/project/.takt/runs/20260129-test/reports',
+        peerReports: '/project/.takt/runs/20260129-test/reports/06-security-review.md',
+        language: 'en',
+      });
+
+      const result = buildInstruction(step, context);
+
+      expect(result).toContain('Report Directory');
+      expect(result).toContain('Report File');
+      expect(result).toContain('/project/.takt/runs/20260129-test/reports/05-arch-review.md');
+      expect(result).toContain('/project/.takt/runs/20260129-test/reports/06-security-review.md');
+    });
+
     it('should render Japanese step iteration suffix', () => {
       const step = createMinimalStep('Do work');
       const context = createMinimalContext({

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -33,6 +33,7 @@ import {
 } from './engine-provider-options.js';
 import { validateStructuredOutputAgainstSchema } from './structured-output-schema-validator.js';
 import { providerSupportsStructuredOutput } from '../../../infra/providers/provider-capabilities.js';
+import { resolveReportHandles } from '../instruction/report-handles.js';
 
 const log = createLogger('step-executor');
 
@@ -45,6 +46,7 @@ export interface StepExecutorDeps {
   readonly getLanguage: () => Language | undefined;
   readonly getInteractive: () => boolean;
   readonly getWorkflowSteps: () => ReadonlyArray<{ name: string; description?: string }>;
+  readonly getWorkflowDefinitionSteps: () => ReadonlyArray<WorkflowStep>;
   readonly getWorkflowName: () => string;
   readonly getWorkflowDescription: () => string | undefined;
   readonly getRetryNote: () => string | undefined;
@@ -259,6 +261,13 @@ export class StepExecutor {
       step.knowledgeContents,
     );
     const workflowSteps = this.deps.getWorkflowSteps();
+    const workflowDefinitionSteps = this.deps.getWorkflowDefinitionSteps();
+    const reportDir = join(this.deps.getCwd(), this.deps.getReportDir());
+    const reportHandles = resolveReportHandles({
+      step,
+      reportDir,
+      workflowSteps: workflowDefinitionSteps,
+    });
     return new InstructionBuilder(step, {
       task,
       iteration: state.iteration,
@@ -268,7 +277,11 @@ export class StepExecutor {
       projectCwd: this.deps.getProjectCwd(),
       userInputs: state.userInputs,
       previousOutput: getPreviousOutput(state),
-      reportDir: join(this.deps.getCwd(), this.deps.getReportDir()),
+      reportDir,
+      currentReport: reportHandles.currentReport,
+      previousReport: reportHandles.previousReport,
+      reportHistory: reportHandles.reportHistory,
+      peerReports: reportHandles.peerReports,
       language: this.deps.getLanguage(),
       interactive: this.deps.getInteractive(),
       workflowSteps,

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -145,6 +145,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     getLanguage: () => params.options.language,
     getInteractive: () => params.options.interactive === true,
     getWorkflowSteps: () => params.config.steps.map((step) => ({ name: step.name, description: step.description })),
+    getWorkflowDefinitionSteps: () => params.config.steps,
     getWorkflowName: () => params.config.name,
     getWorkflowDescription: () => params.config.description,
     getRetryNote: () => params.options.retryNote,

--- a/src/core/workflow/instruction/escape.ts
+++ b/src/core/workflow/instruction/escape.ts
@@ -72,6 +72,11 @@ export function replaceTemplatePlaceholders(
     result = result.replace(/\{report_dir\}/g, context.reportDir);
   }
 
+  result = result.replace(/\{current_report\}/g, context.currentReport ?? '');
+  result = result.replace(/\{previous_report\}/g, context.previousReport ?? '');
+  result = result.replace(/\{report_history\}/g, context.reportHistory ?? '');
+  result = result.replace(/\{peer_reports\}/g, context.peerReports ?? '');
+
   // Replace {report:filename} with reportDir/filename
   if (context.reportDir) {
     result = result.replace(/\{report:([^}]+)\}/g, (_match, filename: string) => {

--- a/src/core/workflow/instruction/instruction-context.ts
+++ b/src/core/workflow/instruction/instruction-context.ts
@@ -32,6 +32,14 @@ export interface InstructionContext {
   previousResponseText?: string;
   /** Report directory path */
   reportDir?: string;
+  /** Latest report paths for the current step */
+  currentReport?: string;
+  /** Most recent versioned report paths for the current step */
+  previousReport?: string;
+  /** Versioned report history paths for the current step */
+  reportHistory?: string;
+  /** Latest report paths for peer steps */
+  peerReports?: string;
   /** Language for metadata rendering. Defaults to 'en'. */
   language?: Language;
   /** Whether interactive-only rules are enabled */

--- a/src/core/workflow/instruction/report-handles.ts
+++ b/src/core/workflow/instruction/report-handles.ts
@@ -1,0 +1,121 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { WorkflowStep } from '../../models/types.js';
+import { getReportFiles } from '../evaluation/rule-utils.js';
+
+const REPORT_HISTORY_PATTERN = /^(?<base>.+)\.(?<timestamp>\d{8}T\d{6}Z)(?:\.(?<sequence>\d+))?$/;
+
+interface ReportHistoryEntry {
+  readonly path: string;
+  readonly timestamp: string;
+  readonly sequence: number;
+}
+
+interface ResolvedReportHandles {
+  readonly currentReport: string;
+  readonly previousReport: string;
+  readonly reportHistory: string;
+  readonly peerReports: string;
+}
+
+interface ReportHandleResolverContext {
+  readonly step: WorkflowStep;
+  readonly reportDir: string;
+  readonly workflowSteps: ReadonlyArray<WorkflowStep>;
+}
+
+export function resolveReportHandles(context: ReportHandleResolverContext): ResolvedReportHandles {
+  const currentReportPaths = resolveCurrentReportPaths(context.reportDir, context.step);
+  const stepReportFiles = getReportFiles(context.step.outputContracts);
+  const historyByFile = stepReportFiles.map((fileName) => resolveReportHistory(context.reportDir, fileName));
+  const peerReportPaths = resolvePeerSteps(context.step, context.workflowSteps)
+    .flatMap((peerStep) => resolveCurrentReportPaths(context.reportDir, peerStep));
+
+  return {
+    currentReport: currentReportPaths.join('\n'),
+    previousReport: historyByFile
+      .map((entries) => entries[0]?.path)
+      .filter((path): path is string => path !== undefined)
+      .join('\n'),
+    reportHistory: historyByFile
+      .flatMap((entries) => entries.map((entry) => entry.path))
+      .join('\n'),
+    peerReports: peerReportPaths.join('\n'),
+  };
+}
+
+function resolveCurrentReportPaths(reportDir: string, step: WorkflowStep): string[] {
+  return getReportFiles(step.outputContracts)
+    .map((fileName) => join(reportDir, fileName))
+    .filter((filePath) => existsSync(filePath));
+}
+
+function resolvePeerSteps(step: WorkflowStep, workflowSteps: ReadonlyArray<WorkflowStep>): WorkflowStep[] {
+  const parallelParent = findParallelParentStep(step.name, workflowSteps);
+  if (parallelParent?.parallel) {
+    return parallelParent.parallel.filter((peerStep) => peerStep.name !== step.name);
+  }
+
+  const currentIndex = workflowSteps.findIndex((candidate) => candidate.name === step.name);
+  if (currentIndex === -1) {
+    return [];
+  }
+
+  for (let index = currentIndex - 1; index >= 0; index -= 1) {
+    const candidate = workflowSteps[index]!;
+    const peerSteps = candidate.parallel?.filter(hasReportOutputs);
+    if (peerSteps && peerSteps.length > 0) {
+      return peerSteps;
+    }
+  }
+
+  return [];
+}
+
+function findParallelParentStep(
+  stepName: string,
+  workflowSteps: ReadonlyArray<WorkflowStep>,
+): WorkflowStep | undefined {
+  return workflowSteps.find((candidate) =>
+    candidate.parallel?.some((parallelStep) => parallelStep.name === stepName),
+  );
+}
+
+function hasReportOutputs(step: WorkflowStep): boolean {
+  return getReportFiles(step.outputContracts).length > 0;
+}
+
+function resolveReportHistory(reportDir: string, fileName: string): ReportHistoryEntry[] {
+  if (!existsSync(reportDir)) {
+    return [];
+  }
+
+  return readdirSync(reportDir)
+    .map((entryName) => parseHistoryEntry(reportDir, fileName, entryName))
+    .filter((entry): entry is ReportHistoryEntry => entry !== undefined)
+    .sort(compareHistoryEntries);
+}
+
+function parseHistoryEntry(
+  reportDir: string,
+  fileName: string,
+  entryName: string,
+): ReportHistoryEntry | undefined {
+  const match = REPORT_HISTORY_PATTERN.exec(entryName);
+  if (!match?.groups || match.groups.base !== fileName || !match.groups.timestamp) {
+    return undefined;
+  }
+
+  return {
+    path: join(reportDir, entryName),
+    timestamp: match.groups.timestamp,
+    sequence: Number.parseInt(match.groups.sequence ?? '0', 10),
+  };
+}
+
+function compareHistoryEntries(left: ReportHistoryEntry, right: ReportHistoryEntry): number {
+  if (left.timestamp !== right.timestamp) {
+    return right.timestamp.localeCompare(left.timestamp);
+  }
+  return right.sequence - left.sequence;
+}


### PR DESCRIPTION
## Summary

## 背景

現在のファセットでは、前回の自ステップ出力や peer のレビュー結果を参照したい場面がある一方、具体的なレポート名を instruction に直書きするとファセットの結合が強くなり、`takt-builder` の意図する抽象化を崩しやすい。

特に reviewer / fix / supervise では、次の情報を安定して参照したい。

- このステップの最新レポート
- このステップの直前レポート
- peer ステップの最新レポート群

現状は Report Directory を ad-hoc に探索するしかなく、instruction 側の記述が不安定になりやすい。

## やりたいこと

エンジン側で report handle を解決し、Phase 1 prompt context へ注入できるようにする。

候補:

- `{current_report}`
- `{previous_report}`
- `{report_history}`
- `{peer_reports}`
- `{review_reports}`

名前は要検討だが、少なくとも self の最新/直前と peer 群をファセットから抽象的に参照できるようにしたい。

## 受け入れ条件

- reviewer / fix / supervise で利用可能
- 無印レポートを latest、タイムスタンプ付きレポートを history として解決できる
- ファセットに固有のレポートファイル名を書かずに self 履歴参照と peer 参照ができる
- 既存の `{report:filename}` を壊さない

## メモ

- これは prompt context / engine 側の機能追加
- output contract 標準化とは別 Issue として扱う

## Execution Report

Workflow `takt-default` completed successfully.

Closes #627