### PR TITLE
fix: preserve builtin workflow trust during discovery

### DIFF
--- a/src/__tests__/workflowDiscovery.test.ts
+++ b/src/__tests__/workflowDiscovery.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+import {
+  loadAllWorkflowsWithSourcesFromDirs,
+} from '../infra/config/loaders/workflowDiscovery.js';
+
+describe('workflowDiscovery', () => {
+  it('repo 直下でも builtin の privileged workflow を discovery で skip しない', () => {
+    const onWarning = vi.fn();
+    const workflows = loadAllWorkflowsWithSourcesFromDirs(
+      process.cwd(),
+      [{
+        dir: join(process.cwd(), 'builtins', 'ja', 'workflows'),
+        source: 'builtin',
+      }],
+      { onWarning },
+    );
+
+    expect(onWarning.mock.calls).toEqual([]);
+    expect(workflows.has('auto-improvement-loop')).toBe(true);
+  });
+});

--- a/src/infra/config/loaders/workflowDiscovery.ts
+++ b/src/infra/config/loaders/workflowDiscovery.ts
@@ -5,9 +5,8 @@ import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
 import { getRepertoireDir } from '../paths.js';
 import { formatWorkflowLoadWarning } from './workflowLoadWarning.js';
 import { isMissingWorkflowCallArgError } from './workflowCallableArgResolver.js';
-import { loadWorkflowFromFile } from './workflowFileLoader.js';
+import { loadWorkflowFileWithResolutionOptions } from './workflowResolvedLoader.js';
 import type { WorkflowConfig } from '../../../core/models/index.js';
-import { validateProjectWorkflowTrustBoundary } from './workflowTrustBoundary.js';
 
 const log = createLogger('workflow-discovery');
 
@@ -87,11 +86,11 @@ function emitWorkflowLoadWarning(options: LoadWorkflowsOptions | undefined, work
 }
 
 function loadWorkflowEntry(entry: WorkflowDirEntry, cwd: string): WorkflowConfig {
-  const config = loadWorkflowFromFile(entry.path, cwd);
-  if (entry.source === 'project') {
-    validateProjectWorkflowTrustBoundary(config, entry.path, cwd);
-  }
-  return config;
+  return loadWorkflowFileWithResolutionOptions(entry.path, {
+    projectCwd: cwd,
+    lookupCwd: cwd,
+    source: entry.source,
+  });
 }
 
 export function* iterateWorkflowDir(

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -95,7 +95,7 @@ export function normalizeWorkflowConfig(
   );
   if (trustInfo?.isProjectTrustRoot) {
     validateProjectWorkflowTrustBoundaryForSteps(parsed.steps, workflowPath, trustInfo);
-  } else if (context?.projectDir && isPathSafe(context.projectDir, workflowDir)) {
+  } else if (!trustInfo && context?.projectDir && isPathSafe(context.projectDir, workflowDir)) {
     validateProjectWorkflowTrustBoundaryForSteps(
       parsed.steps,
       workflowPath,


### PR DESCRIPTION
## Summary
- preserve builtin workflow source/trust information during discovery loading
- stop workflow parser from reclassifying source-aware builtin workflows as project workflows
- add a regression test that keeps auto-improvement-loop discoverable from the takt repo root

## Problem
- builtin workflow discovery was loading builtins by path without preserving their source
- inside the takt repo, builtins/ja/workflows/auto-improvement-loop.yaml was reclassified as a project workflow
- that caused route_context to be rejected as privileged system execution during discovery

## Testing
- npm test -- --run src/__tests__/workflowDiscovery.test.ts src/__tests__/workflowTrustBoundary.test.ts src/__tests__/it-workflow-loader.test.ts
- npm test -- --run src/__tests__/builtin-workflow-categories.test.ts src/__tests__/system-workflow-schema.test.ts