### PR TITLE
[#662] add-repo-issue-inputs

### DIFF
--- a/builtins/en/workflows/auto-improvement-loop.yaml
+++ b/builtins/en/workflows/auto-improvement-loop.yaml
@@ -34,15 +34,17 @@ steps:
           labels: ['takt-managed']
           same_repository: true
           draft: false
-      - type: issue_context
-        source: current_task
-        as: issue
+      # Previously this loop watched issue_context on the current task,
+      # but orchestration should route from repo-wide open Issue observation.
+      - type: issue_selection
+        source: current_project
+        as: selected_issue
     rules:
       - when: context.route_context.selected_pr.exists == true
         next: plan_from_existing_pr
-      - when: context.route_context.selected_pr.exists == false && context.route_context.issue.exists == true
+      - when: context.route_context.selected_pr.exists == false && context.route_context.selected_issue.exists == true
         next: plan_from_issue
-      - when: context.route_context.selected_pr.exists == false && context.route_context.issue.exists == false
+      - when: context.route_context.selected_pr.exists == false && context.route_context.selected_issue.exists == false
         next: plan_fresh_improvement
 
   - name: plan_from_issue
@@ -56,9 +58,9 @@ steps:
       and plan exactly one next improvement task.
 
       Current issue:
-      - exists: {context:route_context.issue.exists}
-      - number: {context:route_context.issue.number}
-      - title: {context:route_context.issue.title}
+      - exists: {context:route_context.selected_issue.exists}
+      - number: {context:route_context.selected_issue.number}
+      - title: {context:route_context.selected_issue.title}
       - task_exists: {context:route_context.task.exists}
       - branch_exists: {context:route_context.branch.exists}
 

--- a/builtins/ja/workflows/auto-improvement-loop.yaml
+++ b/builtins/ja/workflows/auto-improvement-loop.yaml
@@ -34,15 +34,17 @@ steps:
           labels: ['takt-managed']
           same_repository: true
           draft: false
-      - type: issue_context
-        source: current_task
-        as: issue
+      # 旧仕様では current task に紐づく issue_context を見ていたが、
+      # orchestration loop では repo 全体の open Issue 観測を優先する。
+      - type: issue_selection
+        source: current_project
+        as: selected_issue
     rules:
       - when: context.route_context.selected_pr.exists == true
         next: plan_from_existing_pr
-      - when: context.route_context.selected_pr.exists == false && context.route_context.issue.exists == true
+      - when: context.route_context.selected_pr.exists == false && context.route_context.selected_issue.exists == true
         next: plan_from_issue
-      - when: context.route_context.selected_pr.exists == false && context.route_context.issue.exists == false
+      - when: context.route_context.selected_pr.exists == false && context.route_context.selected_issue.exists == false
         next: plan_fresh_improvement
 
   - name: plan_from_issue
@@ -56,9 +58,9 @@ steps:
       次に実行すべき改善 task を 1 件だけ計画してください。
 
       現在の Issue:
-      - exists: {context:route_context.issue.exists}
-      - number: {context:route_context.issue.number}
-      - title: {context:route_context.issue.title}
+      - exists: {context:route_context.selected_issue.exists}
+      - number: {context:route_context.selected_issue.number}
+      - title: {context:route_context.selected_issue.title}
       - task_exists: {context:route_context.task.exists}
       - branch_exists: {context:route_context.branch.exists}
 

--- a/src/__tests__/github-issue.test.ts
+++ b/src/__tests__/github-issue.test.ts
@@ -1,18 +1,122 @@
-/**
- * Tests for issue parsing and formatting functions.
- *
- * These functions live in git/format.ts (provider-neutral).
- * checkGhCli/fetchIssue are integration functions
- * that call `gh` CLI, so they are not unit-tested here.
- */
-
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { listOpenIssues } from '../infra/github/issue.js';
 import {
   parseIssueNumbers,
   isIssueReference,
   formatIssueAsTask,
 } from '../infra/git/format.js';
 import type { Issue } from '../infra/git/types.js';
+
+const mockExecFileSync = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+  getErrorMessage: (error: unknown) => String(error),
+}));
+
+function withGhApiResponse(body: unknown, nextPath?: string): string {
+  const headers = [
+    'HTTP/2 200 OK',
+    'content-type: application/json',
+    ...(nextPath ? [`link: <https://api.github.com${nextPath}>; rel="next"`] : []),
+  ];
+  return `${headers.join('\n')}\n\n${JSON.stringify(body)}`;
+}
+
+describe('listOpenIssues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecFileSync.mockReset();
+  });
+
+  it('repo 全体の open issue を後続ページまで取得して PR を除外する', () => {
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify({ nameWithOwner: 'org/repo' }))
+      .mockReturnValueOnce(withGhApiResponse(
+        [
+          {
+            number: 586,
+            title: 'First issue',
+            labels: [{ name: 'takt-managed' }],
+            updated_at: '2026-04-20T12:00:00Z',
+          },
+          {
+            number: 900,
+            title: 'Open pull request masquerading as issue',
+            labels: [{ name: 'takt-managed' }],
+            updated_at: '2026-04-20T12:30:00Z',
+            pull_request: { url: 'https://api.github.com/repos/org/repo/pulls/900' },
+          },
+        ],
+        '/repos/org/repo/issues?state=open&per_page=100&page=2',
+      ))
+      .mockReturnValueOnce(withGhApiResponse([
+        {
+          number: 587,
+          title: 'Second issue',
+          labels: [{ name: 'bug' }],
+          updated_at: '2026-04-21T08:00:00Z',
+        },
+      ]));
+
+    const result = listOpenIssues('/project');
+
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      1,
+      'gh',
+      ['repo', 'view', '--json', 'nameWithOwner'],
+      expect.objectContaining({ cwd: '/project', encoding: 'utf-8' }),
+    );
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      2,
+      'gh',
+      ['api', '--include', 'repos/org/repo/issues?state=open&per_page=100&page=1'],
+      expect.objectContaining({ cwd: '/project', encoding: 'utf-8' }),
+    );
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      3,
+      'gh',
+      ['api', '--include', '/repos/org/repo/issues?state=open&per_page=100&page=2'],
+      expect.objectContaining({ cwd: '/project', encoding: 'utf-8' }),
+    );
+    expect(result).toEqual([
+      { number: 586, title: 'First issue', labels: ['takt-managed'], updated_at: '2026-04-20T12:00:00Z' },
+      { number: 587, title: 'Second issue', labels: ['bug'], updated_at: '2026-04-21T08:00:00Z' },
+    ]);
+  });
+
+  it('pagination link が上限を超えて続く場合は明示エラーにする', () => {
+    let page = 1;
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify({ nameWithOwner: 'org/repo' }))
+      .mockImplementation(() => {
+        const response = withGhApiResponse(
+          [{
+            number: page,
+            title: `Issue ${page}`,
+            labels: [{ name: 'takt-managed' }],
+            updated_at: '2026-04-21T00:00:00Z',
+          }],
+          `/repos/org/repo/issues?state=open&per_page=100&page=${page + 1}`,
+        );
+        page += 1;
+        return response;
+      });
+
+    expect(() => listOpenIssues('/project')).toThrow(
+      'Pagination limit exceeded while fetching open issue list (>100 pages)',
+    );
+  });
+});
 
 describe('parseIssueNumbers', () => {
   it('should parse single issue reference', () => {

--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const {
   mockCheckGhCli,
   mockFetchIssue,
+  mockListOpenIssues,
   mockCreateIssue,
   mockFindExistingPr,
   mockCommentOnPr,
@@ -20,6 +21,7 @@ const {
 } = vi.hoisted(() => ({
   mockCheckGhCli: vi.fn(),
   mockFetchIssue: vi.fn(),
+  mockListOpenIssues: vi.fn(),
   mockCreateIssue: vi.fn(),
   mockFindExistingPr: vi.fn(),
   mockCommentOnPr: vi.fn(),
@@ -31,6 +33,7 @@ const {
 vi.mock('../infra/github/issue.js', () => ({
   checkGhCli: (...args: unknown[]) => mockCheckGhCli(...args),
   fetchIssue: (...args: unknown[]) => mockFetchIssue(...args),
+  listOpenIssues: (...args: unknown[]) => mockListOpenIssues(...args),
   createIssue: (...args: unknown[]) => mockCreateIssue(...args),
 }));
 
@@ -147,6 +150,34 @@ describe('GitHubProvider', () => {
 
       // Then
       expect(mockFetchIssue).toHaveBeenCalledWith(20, process.cwd());
+    });
+  });
+
+  describe('listOpenIssues', () => {
+    it('listOpenIssues() に委譲し結果を返す', () => {
+      const issues = [
+        { number: 586, title: 'Repo issue', labels: ['takt-managed'], updated_at: '2026-04-20T12:00:00Z' },
+      ];
+      mockListOpenIssues.mockReturnValue(issues);
+      const provider = new GitHubProvider();
+
+      const result = provider.listOpenIssues();
+
+      expect(mockListOpenIssues).toHaveBeenCalledWith(process.cwd());
+      expect(result).toBe(issues);
+    });
+
+    it('cwd を指定した場合は listOpenIssues にそのまま転送する', () => {
+      const issues = [
+        { number: 586, title: 'Repo issue', labels: ['takt-managed'], updated_at: '2026-04-20T12:00:00Z' },
+      ];
+      mockListOpenIssues.mockReturnValue(issues);
+      const provider = new GitHubProvider();
+
+      const result = provider.listOpenIssues('/worktree/clone');
+
+      expect(mockListOpenIssues).toHaveBeenCalledWith('/worktree/clone');
+      expect(result).toBe(issues);
     });
   });
 
@@ -480,6 +511,7 @@ describe('getGitProvider', () => {
     // Then
     expect(typeof provider.checkCliStatus).toBe('function');
     expect(typeof provider.fetchIssue).toBe('function');
+    expect(typeof provider.listOpenIssues).toBe('function');
     expect(typeof provider.createIssue).toBe('function');
     expect(typeof provider.fetchPrReviewComments).toBe('function');
     expect(typeof provider.findExistingPr).toBe('function');

--- a/src/__tests__/gitlab-issue.test.ts
+++ b/src/__tests__/gitlab-issue.test.ts
@@ -25,7 +25,7 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   getErrorMessage: (e: unknown) => String(e),
 }));
 
-import { fetchIssue, createIssue } from '../infra/gitlab/issue.js';
+import { fetchIssue, listOpenIssues, createIssue } from '../infra/gitlab/issue.js';
 
 function withGlabApiResponse(body: unknown, nextPath?: string): string {
   const headers = [
@@ -354,6 +354,55 @@ describe('fetchIssue', () => {
     // Then: glab api（notes）にも cwd が渡される
     const notesCall = mockExecFileSync.mock.calls[1];
     expect(notesCall[2]).toHaveProperty('cwd', '/worktree/clone');
+  });
+});
+
+describe('listOpenIssues', () => {
+  it('open issue list エンドポイントを複数ページ取得し iid と updated_at をマッピングする', () => {
+    mockExecFileSync
+      .mockReturnValueOnce(withGlabApiResponse(
+        [
+          { iid: 586, title: 'Repo issue', labels: ['takt-managed'], updated_at: '2026-04-20T12:00:00Z' },
+          { iid: 587, title: 'Second issue', labels: ['bug'], updated_at: '2026-04-21T08:00:00Z' },
+        ],
+        'projects/1/issues?state=opened&per_page=100&page=2',
+      ))
+      .mockReturnValueOnce(withGlabApiResponse([
+        { iid: 588, title: 'Last issue', labels: ['automation'], updated_at: '2026-04-22T09:30:00Z' },
+      ]));
+
+    const result = listOpenIssues('/project');
+
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      1,
+      'glab',
+      ['api', '--include', 'projects/:id/issues?state=opened&per_page=100&page=1'],
+      expect.objectContaining({ cwd: '/project', encoding: 'utf-8' }),
+    );
+    expect(mockExecFileSync).toHaveBeenNthCalledWith(
+      2,
+      'glab',
+      ['api', '--include', 'projects/1/issues?state=opened&per_page=100&page=2'],
+      expect.objectContaining({ cwd: '/project', encoding: 'utf-8' }),
+    );
+    expect(result).toEqual([
+      { number: 586, title: 'Repo issue', labels: ['takt-managed'], updated_at: '2026-04-20T12:00:00Z' },
+      { number: 587, title: 'Second issue', labels: ['bug'], updated_at: '2026-04-21T08:00:00Z' },
+      { number: 588, title: 'Last issue', labels: ['automation'], updated_at: '2026-04-22T09:30:00Z' },
+    ]);
+  });
+
+  it('open issue が1ページ未満なら追加ページを取得しない', () => {
+    mockExecFileSync.mockReturnValueOnce(withGlabApiResponse([
+      { iid: 586, title: 'Repo issue', labels: ['takt-managed'], updated_at: '2026-04-20T12:00:00Z' },
+    ]));
+
+    const result = listOpenIssues('/project');
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { number: 586, title: 'Repo issue', labels: ['takt-managed'], updated_at: '2026-04-20T12:00:00Z' },
+    ]);
   });
 });
 

--- a/src/__tests__/gitlab-provider.test.ts
+++ b/src/__tests__/gitlab-provider.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const {
   mockCheckGlabCli,
   mockFetchIssue,
+  mockListOpenIssues,
   mockCreateIssue,
   mockFindExistingMr,
   mockCommentOnMr,
@@ -19,6 +20,7 @@ const {
 } = vi.hoisted(() => ({
   mockCheckGlabCli: vi.fn(),
   mockFetchIssue: vi.fn(),
+  mockListOpenIssues: vi.fn(),
   mockCreateIssue: vi.fn(),
   mockFindExistingMr: vi.fn(),
   mockCommentOnMr: vi.fn(),
@@ -37,6 +39,7 @@ vi.mock('../infra/gitlab/utils.js', () => ({
 
 vi.mock('../infra/gitlab/issue.js', () => ({
   fetchIssue: (...args: unknown[]) => mockFetchIssue(...args),
+  listOpenIssues: (...args: unknown[]) => mockListOpenIssues(...args),
   createIssue: (...args: unknown[]) => mockCreateIssue(...args),
 }));
 
@@ -169,6 +172,34 @@ describe('GitLabProvider', () => {
 
       // Then
       expect(mockFetchIssue).toHaveBeenCalledWith(20, process.cwd());
+    });
+  });
+
+  describe('listOpenIssues', () => {
+    it('listOpenIssues() に委譲し結果を返す', () => {
+      const issues = [
+        { number: 586, title: 'Repo issue', labels: ['takt-managed'], updated_at: '2026-04-20T12:00:00Z' },
+      ];
+      mockListOpenIssues.mockReturnValue(issues);
+      const provider = new GitLabProvider();
+
+      const result = provider.listOpenIssues();
+
+      expect(mockListOpenIssues).toHaveBeenCalledWith(process.cwd());
+      expect(result).toBe(issues);
+    });
+
+    it('cwd を指定した場合は listOpenIssues にそのまま転送する', () => {
+      const issues = [
+        { number: 586, title: 'Repo issue', labels: ['takt-managed'], updated_at: '2026-04-20T12:00:00Z' },
+      ];
+      mockListOpenIssues.mockReturnValue(issues);
+      const provider = new GitLabProvider();
+
+      const result = provider.listOpenIssues('/my/project');
+
+      expect(mockListOpenIssues).toHaveBeenCalledWith('/my/project');
+      expect(result).toBe(issues);
     });
   });
 

--- a/src/__tests__/it-system-workflow-execution.test.ts
+++ b/src/__tests__/it-system-workflow-execution.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { parse } from 'yaml';
 import { setMockScenario, resetScenario } from '../infra/mock/index.js';
 import { detectRuleIndex } from '../shared/utils/ruleIndex.js';
 import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
@@ -15,6 +16,7 @@ const {
   mockResolveBaseBranch,
   mockFindExistingPr,
   mockFetchPrReviewComments,
+  mockListOpenIssues,
   mockListOpenPrs,
   mockTaskRunnerListAllTaskItems,
 } = vi.hoisted(() => ({
@@ -25,6 +27,7 @@ const {
   mockResolveBaseBranch: vi.fn(),
   mockFindExistingPr: vi.fn(),
   mockFetchPrReviewComments: vi.fn(),
+  mockListOpenIssues: vi.fn(),
   mockListOpenPrs: vi.fn(),
   mockTaskRunnerListAllTaskItems: vi.fn(),
 }));
@@ -45,6 +48,7 @@ vi.mock('../infra/git/index.js', () => ({
     mergePr: (...args: unknown[]) => mockMergePr(...args),
     findExistingPr: (...args: unknown[]) => mockFindExistingPr(...args),
     fetchPrReviewComments: (...args: unknown[]) => mockFetchPrReviewComments(...args),
+    listOpenIssues: (...args: unknown[]) => mockListOpenIssues(...args),
     listOpenPrs: (...args: unknown[]) => mockListOpenPrs(...args),
     checkCliStatus: vi.fn(() => ({ available: true })),
   })),
@@ -88,6 +92,38 @@ function createSystemEngineOptions(projectDir: string) {
   };
 }
 
+function loadBuiltinAutoImprovementLoopForIssueExecution(projectDir: string) {
+  const config = normalizeWorkflowConfig(
+    parse(readFileSync(
+      join(process.cwd(), 'builtins', 'en', 'workflows', 'auto-improvement-loop.yaml'),
+      'utf-8',
+    )),
+    projectDir,
+  );
+  return {
+    ...config,
+    maxSteps: 6,
+    steps: config.steps.map((step) => {
+      if (step.name === 'plan_from_issue' || step.name === 'plan_fresh_improvement') {
+        return {
+          ...step,
+          delayBeforeMs: 0,
+        };
+      }
+      if (step.name === 'wait_before_next_scan') {
+        return {
+          ...step,
+          delayBeforeMs: 0,
+          rules: [
+            { condition: 'true', next: 'COMPLETE' },
+          ],
+        };
+      }
+      return step;
+    }),
+  };
+}
+
 describe('system workflow execution integration', () => {
   let projectDir: string;
 
@@ -99,6 +135,8 @@ describe('system workflow execution integration', () => {
     mockCreateIssueFromTask.mockReturnValue(586);
     mockResolveBaseBranch.mockImplementation((_cwd: string, branch?: string) => ({ branch: branch ?? 'main' }));
     mockMergePr.mockReturnValue({ success: true });
+    mockListOpenIssues.mockReset();
+    mockListOpenIssues.mockReturnValue([]);
     mockListOpenPrs.mockReset();
     mockListOpenPrs.mockReturnValue([]);
     mockTaskRunnerListAllTaskItems.mockReturnValue([]);
@@ -121,6 +159,11 @@ describe('system workflow execution integration', () => {
         type: 'object',
         properties: {
           action: { type: 'string' },
+          task_markdown: { type: 'string' },
+          issue: {
+            type: 'object',
+            additionalProperties: true,
+          },
         },
         required: ['action'],
       }),
@@ -815,7 +858,9 @@ describe('system workflow execution integration', () => {
     );
 
     const instructions: string[] = [];
-    const engine = new WorkflowEngine(config, projectDir, 'Current task body', createSystemEngineOptions(projectDir));
+    const engine = new WorkflowEngine(config, projectDir, 'Current task body', {
+      ...createSystemEngineOptions(projectDir),
+    });
     engine.on('step:start', (step, _iteration, instruction) => {
       if (step.name === 'draft_review') {
         instructions.push(instruction);
@@ -1187,6 +1232,461 @@ describe('system workflow execution integration', () => {
     expect(executeEffect).not.toHaveBeenCalled();
     expect((stateRecord.systemContexts as Map<string, unknown>).get('route_context')).toEqual({
       selected_pr: { exists: false },
+    });
+  });
+
+  it('selected_pr が存在する場合は selected_issue があっても PR 分岐を優先する', async () => {
+    const visitedSteps: string[] = [];
+    const createServices = vi.fn(() => ({
+      resolveSystemInput(input: { type: string }) {
+        if (input.type === 'pr_selection') {
+          return { exists: true, number: 42 };
+        }
+        if (input.type === 'issue_selection') {
+          return { exists: true, number: 586, title: 'Repo issue' };
+        }
+        throw new Error(`Unexpected system input: ${input.type}`);
+      },
+      async executeEffect() {
+        throw new Error('No effects expected in this workflow');
+      },
+    }));
+
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'route-prefers-pr-over-issue',
+        initial_step: 'route_context',
+        max_steps: 2,
+        steps: [
+          {
+            name: 'route_context',
+            mode: 'system',
+            system_inputs: [
+              { type: 'pr_selection', source: 'current_project', as: 'selected_pr' },
+              { type: 'issue_selection', source: 'current_project', as: 'selected_issue' },
+            ],
+            rules: [
+              { when: 'context.route_context.selected_pr.exists == true', next: 'plan_from_existing_pr' },
+              { when: 'context.route_context.selected_pr.exists == false && context.route_context.selected_issue.exists == true', next: 'plan_from_issue' },
+              { when: 'true', next: 'plan_fresh_improvement' },
+            ],
+          },
+          {
+            name: 'plan_from_existing_pr',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'COMPLETE' }],
+          },
+          {
+            name: 'plan_from_issue',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'ABORT' }],
+          },
+          {
+            name: 'plan_fresh_improvement',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'ABORT' }],
+          },
+        ],
+      },
+      projectDir,
+    );
+
+    const engine = new WorkflowEngine(config, projectDir, 'Current task body', {
+      projectCwd: projectDir,
+      provider: 'mock',
+      detectRuleIndex,
+      structuredCaller: {
+        judgeStatus: vi.fn(),
+        evaluateCondition: vi.fn().mockResolvedValue(-1),
+        decomposeTask: vi.fn(),
+        requestMoreParts: vi.fn(),
+      },
+      reportDirName: 'test-report-dir',
+      systemStepServicesFactory: createServices as never,
+    });
+    engine.on('step:start', (step) => {
+      visitedSteps.push(step.name);
+    });
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+    expect(visitedSteps).toEqual(['route_context', 'plan_from_existing_pr']);
+  });
+
+  it('selected_pr がなく selected_issue が存在する場合は Issue 分岐に進む', async () => {
+    const visitedSteps: string[] = [];
+    const createServices = vi.fn(() => ({
+      resolveSystemInput(input: { type: string }) {
+        if (input.type === 'pr_selection') {
+          return { exists: false };
+        }
+        if (input.type === 'issue_selection') {
+          return { exists: true, number: 586, title: 'Repo issue' };
+        }
+        throw new Error(`Unexpected system input: ${input.type}`);
+      },
+      async executeEffect() {
+        throw new Error('No effects expected in this workflow');
+      },
+    }));
+
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'route-to-selected-issue',
+        initial_step: 'route_context',
+        max_steps: 2,
+        steps: [
+          {
+            name: 'route_context',
+            mode: 'system',
+            system_inputs: [
+              { type: 'pr_selection', source: 'current_project', as: 'selected_pr' },
+              { type: 'issue_selection', source: 'current_project', as: 'selected_issue' },
+            ],
+            rules: [
+              { when: 'context.route_context.selected_pr.exists == true', next: 'plan_from_existing_pr' },
+              { when: 'context.route_context.selected_pr.exists == false && context.route_context.selected_issue.exists == true', next: 'plan_from_issue' },
+              { when: 'true', next: 'plan_fresh_improvement' },
+            ],
+          },
+          {
+            name: 'plan_from_existing_pr',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'ABORT' }],
+          },
+          {
+            name: 'plan_from_issue',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'COMPLETE' }],
+          },
+          {
+            name: 'plan_fresh_improvement',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'ABORT' }],
+          },
+        ],
+      },
+      projectDir,
+    );
+
+    const engine = new WorkflowEngine(config, projectDir, 'Current task body', {
+      projectCwd: projectDir,
+      provider: 'mock',
+      detectRuleIndex,
+      structuredCaller: {
+        judgeStatus: vi.fn(),
+        evaluateCondition: vi.fn().mockResolvedValue(-1),
+        decomposeTask: vi.fn(),
+        requestMoreParts: vi.fn(),
+      },
+      reportDirName: 'test-report-dir',
+      systemStepServicesFactory: createServices as never,
+    });
+    engine.on('step:start', (step) => {
+      visitedSteps.push(step.name);
+    });
+
+    const state = await engine.run();
+    const routeContext = ((state as Record<string, unknown>).systemContexts as Map<string, unknown>).get('route_context');
+
+    expect(state.status).toBe('completed');
+    expect(visitedSteps).toEqual(['route_context', 'plan_from_issue']);
+    expect(routeContext).toEqual({
+      selected_pr: { exists: false },
+      selected_issue: { exists: true, number: 586, title: 'Repo issue' },
+    });
+  });
+
+  it('selected_pr も selected_issue も存在しない場合は fresh improvement 分岐に進む', async () => {
+    const visitedSteps: string[] = [];
+    const createServices = vi.fn(() => ({
+      resolveSystemInput(input: { type: string }) {
+        if (input.type === 'pr_selection') {
+          return { exists: false };
+        }
+        if (input.type === 'issue_selection') {
+          return { exists: false };
+        }
+        throw new Error(`Unexpected system input: ${input.type}`);
+      },
+      async executeEffect() {
+        throw new Error('No effects expected in this workflow');
+      },
+    }));
+
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'route-to-fresh-improvement',
+        initial_step: 'route_context',
+        max_steps: 2,
+        steps: [
+          {
+            name: 'route_context',
+            mode: 'system',
+            system_inputs: [
+              { type: 'pr_selection', source: 'current_project', as: 'selected_pr' },
+              { type: 'issue_selection', source: 'current_project', as: 'selected_issue' },
+            ],
+            rules: [
+              { when: 'context.route_context.selected_pr.exists == true', next: 'plan_from_existing_pr' },
+              { when: 'context.route_context.selected_pr.exists == false && context.route_context.selected_issue.exists == true', next: 'plan_from_issue' },
+              { when: 'true', next: 'plan_fresh_improvement' },
+            ],
+          },
+          {
+            name: 'plan_from_existing_pr',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'ABORT' }],
+          },
+          {
+            name: 'plan_from_issue',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'ABORT' }],
+          },
+          {
+            name: 'plan_fresh_improvement',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'COMPLETE' }],
+          },
+        ],
+      },
+      projectDir,
+    );
+
+    const engine = new WorkflowEngine(config, projectDir, 'Current task body', {
+      projectCwd: projectDir,
+      provider: 'mock',
+      detectRuleIndex,
+      structuredCaller: {
+        judgeStatus: vi.fn(),
+        evaluateCondition: vi.fn().mockResolvedValue(-1),
+        decomposeTask: vi.fn(),
+        requestMoreParts: vi.fn(),
+      },
+      reportDirName: 'test-report-dir',
+      systemStepServicesFactory: createServices as never,
+    });
+    engine.on('step:start', (step) => {
+      visitedSteps.push(step.name);
+    });
+
+    const state = await engine.run();
+    const routeContext = ((state as Record<string, unknown>).systemContexts as Map<string, unknown>).get('route_context');
+
+    expect(state.status).toBe('completed');
+    expect(visitedSteps).toEqual(['route_context', 'plan_fresh_improvement']);
+    expect(routeContext).toEqual({
+      selected_pr: { exists: false },
+      selected_issue: { exists: false },
+    });
+  });
+
+  it('repo-wide issue からの enqueue は非対話でも enqueue まで進む', async () => {
+    setMockScenario([
+      {
+        persona: 'supervisor',
+        status: 'done',
+        content: 'Plan issue task.',
+        structuredOutput: {
+          action: 'enqueue_new_task',
+          task_markdown: '## Task\nHandle issue safely',
+          issue: {
+            create: false,
+          },
+        },
+      },
+    ]);
+    mockListOpenIssues.mockReturnValue([
+      {
+        number: 586,
+        title: 'Repo issue',
+        labels: [],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+    ]);
+
+    const config = loadBuiltinAutoImprovementLoopForIssueExecution(projectDir);
+
+    const engine = new WorkflowEngine(config, projectDir, 'Current task body', createSystemEngineOptions(projectDir));
+    const state = await engine.run();
+    const stepNames = Array.from(state.stepOutputs.keys());
+
+    expect(state.status).toBe('completed');
+    expect(stepNames).toEqual(['route_context', 'plan_from_issue', 'enqueue_from_issue', 'wait_before_next_scan']);
+    expect(mockSaveTaskFile).toHaveBeenCalledWith(projectDir, '## Task\nHandle issue safely', {
+      workflow: 'takt-default',
+      worktree: true,
+      baseBranch: 'improve',
+      autoPr: true,
+      draftPr: true,
+    });
+  });
+
+  it('builtin auto-improvement-loop は issue が 0 件のとき fresh improvement にフォールバックする', async () => {
+    setMockScenario([
+      {
+        persona: 'supervisor',
+        status: 'done',
+        content: 'No repo issue available.',
+        structuredOutput: {
+          action: 'noop',
+        },
+      },
+    ]);
+    mockListOpenIssues.mockReturnValue([]);
+
+    const config = loadBuiltinAutoImprovementLoopForIssueExecution(projectDir);
+    const state = await new WorkflowEngine(
+      config,
+      projectDir,
+      'Current task body',
+      createSystemEngineOptions(projectDir),
+    ).run();
+    const routeContext = ((state as Record<string, unknown>).systemContexts as Map<string, unknown>).get('route_context');
+    const stepNames = Array.from(state.stepOutputs.keys());
+
+    expect(state.status).toBe('completed');
+    expect(stepNames).toEqual(['route_context', 'plan_fresh_improvement', 'wait_before_next_scan']);
+    expect(routeContext).toEqual(expect.objectContaining({
+      selected_issue: { exists: false },
+    }));
+    expect(mockSaveTaskFile).not.toHaveBeenCalled();
+  });
+
+  it('repo-wide issue からの enqueue は対話モードでも追加承認を要求しない', async () => {
+    setMockScenario([
+      {
+        persona: 'supervisor',
+        status: 'done',
+        content: 'Plan issue task.',
+        structuredOutput: {
+          action: 'enqueue_new_task',
+          task_markdown: '## Task\nHandle issue safely',
+          issue: {
+            create: false,
+          },
+        },
+      },
+    ]);
+    mockListOpenIssues.mockReturnValue([
+      {
+        number: 586,
+        title: 'Repo issue',
+        labels: [],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+    ]);
+
+    const config = loadBuiltinAutoImprovementLoopForIssueExecution(projectDir);
+    const onUserInput = vi.fn().mockResolvedValue('approve');
+    const engine = new WorkflowEngine(config, projectDir, 'Current task body', {
+      ...createSystemEngineOptions(projectDir),
+      interactive: true,
+      onUserInput,
+    });
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+    expect(onUserInput).not.toHaveBeenCalled();
+    expect(mockSaveTaskFile).toHaveBeenCalledWith(projectDir, '## Task\nHandle issue safely', {
+      workflow: 'takt-default',
+      worktree: true,
+      baseBranch: 'improve',
+      autoPr: true,
+      draftPr: true,
+    });
+  });
+
+  it('route_context の selected_issue は loop 間で次の issue に巡回できる', async () => {
+    const selectionHistory: number[] = [];
+    const repoIssues = [
+      { number: 587, title: 'Newest repo issue', labels: ['takt-managed'] },
+      { number: 586, title: 'Older repo issue', labels: ['takt-managed'] },
+    ];
+    const createServices = vi.fn(() => ({
+      resolveSystemInput(
+        input: { type: string },
+        state?: { systemContexts?: Map<string, unknown> },
+        stepName?: string,
+      ) {
+        if (input.type === 'issue_list') {
+          return repoIssues;
+        }
+        if (input.type === 'issue_selection') {
+          if (!state?.systemContexts) {
+            throw new Error('resolveSystemInput requires workflow state for issue_selection');
+          }
+          if (stepName !== 'route_context') {
+            throw new Error(`resolveSystemInput requires step name, got ${String(stepName)}`);
+          }
+          const previous = state.systemContexts.get('route_context') as { selected_issue?: { number?: number } } | undefined;
+          const selected = previous?.selected_issue?.number === 587 ? repoIssues[1] : repoIssues[0];
+          selectionHistory.push(selected.number);
+          return { exists: true, number: selected.number, title: selected.title };
+        }
+        throw new Error(`Unexpected system input: ${input.type}`);
+      },
+      async executeEffect() {
+        throw new Error('No effects expected in this workflow');
+      },
+    }));
+
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'route-rotates-issue-selection',
+        initial_step: 'route_context',
+        max_steps: 4,
+        steps: [
+          {
+            name: 'route_context',
+            mode: 'system',
+            system_inputs: [
+              { type: 'issue_list', source: 'current_project', as: 'issues' },
+              { type: 'issue_selection', source: 'current_project', as: 'selected_issue' },
+            ],
+            rules: [
+              { when: 'context.route_context.selected_issue.number == 587', next: 'wait_before_next_scan' },
+              { when: 'context.route_context.selected_issue.number == 586', next: 'COMPLETE' },
+              { when: 'true', next: 'ABORT' },
+            ],
+          },
+          {
+            name: 'wait_before_next_scan',
+            mode: 'system',
+            rules: [{ when: 'true', next: 'route_context' }],
+          },
+        ],
+      },
+      projectDir,
+    );
+
+    const engine = new WorkflowEngine(config, projectDir, 'Current task body', {
+      projectCwd: projectDir,
+      provider: 'mock',
+      detectRuleIndex,
+      structuredCaller: {
+        judgeStatus: vi.fn(),
+        evaluateCondition: vi.fn().mockResolvedValue(-1),
+        decomposeTask: vi.fn(),
+        requestMoreParts: vi.fn(),
+      },
+      reportDirName: 'test-report-dir',
+      systemStepServicesFactory: createServices as never,
+    });
+
+    const state = await engine.run();
+    const routeContext = ((state as Record<string, unknown>).systemContexts as Map<string, unknown>).get('route_context');
+
+    expect(state.status).toBe('completed');
+    expect(selectionHistory).toEqual([587, 586]);
+    expect(routeContext).toEqual({
+      issues: repoIssues,
+      selected_issue: {
+        exists: true,
+        number: 586,
+        title: 'Older repo issue',
+      },
     });
   });
 

--- a/src/__tests__/it-workflow-loader.test.ts
+++ b/src/__tests__/it-workflow-loader.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -81,16 +81,20 @@ function expectAutoImprovementLoopRouteContext(config: NonNullable<ReturnType<ty
       as: 'selected_pr',
       where: taktManagedPrRouteFilter,
     }),
-    expect.objectContaining({ type: 'issue_context', as: 'issue' }),
+    expect.objectContaining({
+      type: 'issue_selection',
+      as: 'selected_issue',
+    }),
   ]));
   expect(routeContext?.rules).toEqual(expect.arrayContaining([
     expect.objectContaining({ condition: 'context.route_context.selected_pr.exists == true', next: 'plan_from_existing_pr' }),
-    expect.objectContaining({ condition: 'context.route_context.selected_pr.exists == false && context.route_context.issue.exists == true', next: 'plan_from_issue' }),
+    expect.objectContaining({ condition: 'context.route_context.selected_pr.exists == false && context.route_context.selected_issue.exists == true', next: 'plan_from_issue' }),
   ]));
 }
 
 function expectAutoImprovementLoopDownstreamContract(config: NonNullable<ReturnType<typeof loadWorkflowConfig>>) {
   const planFromExistingPr = config.steps.find((step) => step.name === 'plan_from_existing_pr') as Record<string, unknown> | undefined;
+  const planFromIssue = config.steps.find((step) => step.name === 'plan_from_issue') as Record<string, unknown> | undefined;
   const enqueueFromPr = config.steps.find((step) => step.name === 'enqueue_from_pr') as Record<string, unknown> | undefined;
   const prepareMerge = config.steps.find((step) => step.name === 'prepare_merge') as Record<string, unknown> | undefined;
   const resolveConflicts = config.steps.find((step) => step.name === 'resolve_conflicts') as Record<string, unknown> | undefined;
@@ -141,6 +145,11 @@ function expectAutoImprovementLoopDownstreamContract(config: NonNullable<ReturnT
       pr: '{context:route_context.selected_pr.number}',
     }),
   ]);
+  expect(planFromIssue?.rules).toEqual(expect.arrayContaining([
+    expect.objectContaining({ condition: 'structured.plan_from_issue.action == "enqueue_new_task"', next: 'enqueue_from_issue' }),
+    expect.objectContaining({ condition: 'structured.plan_from_issue.action == "noop"', next: 'wait_before_next_scan' }),
+  ]));
+  expect(config.steps.find((step) => step.name === 'confirm_issue_enqueue')).toBeUndefined();
 }
 
 describe('Workflow Loader IT: builtin workflow loading', () => {
@@ -203,13 +212,29 @@ describe('Workflow Loader IT: builtin workflow loading', () => {
     expectAutoImprovementLoopDownstreamContract(config!);
   });
 
-  it('should keep takt-managed label contract aligned across builtin auto-improvement-loop workflows', () => {
+  it('should keep repo-wide issue routing aligned across builtin auto-improvement-loop workflows', () => {
     for (const language of ['en', 'ja'] as const) {
       const config = loadWorkflowFromFile(
         join(process.cwd(), 'builtins', language, 'workflows', 'auto-improvement-loop.yaml'),
         testDir,
       );
       expectAutoImprovementLoopRouteContext(config);
+      expectAutoImprovementLoopDownstreamContract(config);
+    }
+  });
+
+  it('should preserve the legacy issue_context comment in both builtin auto-improvement-loop YAML files', () => {
+    for (const language of ['en', 'ja'] as const) {
+      const workflowSource = readFileSync(
+        join(process.cwd(), 'builtins', language, 'workflows', 'auto-improvement-loop.yaml'),
+        'utf-8',
+      );
+      expect(workflowSource).toContain('issue_context');
+      expect(workflowSource).toContain(
+        language === 'en'
+          ? 'repo-wide open Issue observation'
+          : 'repo 全体の open Issue 観測',
+      );
     }
   });
 
@@ -229,7 +254,10 @@ describe('Workflow Loader IT: builtin workflow loading', () => {
     const waitBeforeNextScan = config!.steps.find((step) => step.name === 'wait_before_next_scan') as Record<string, unknown> | undefined;
 
     expect(planFromIssue?.delayBeforeMs).toBe(60000);
+    expect(String(planFromIssue?.instruction)).toContain('{context:route_context.selected_issue.number}');
+    expect(String(planFromIssue?.instruction)).toContain('{context:route_context.selected_issue.title}');
     expect(planFromIssue?.rules).toEqual(expect.arrayContaining([
+      expect.objectContaining({ condition: 'structured.plan_from_issue.action == "enqueue_new_task"', next: 'enqueue_from_issue' }),
       expect.objectContaining({ condition: 'structured.plan_from_issue.action == "noop"', next: 'wait_before_next_scan' }),
       expect.objectContaining({ condition: 'true', next: 'ABORT' }),
     ]));

--- a/src/__tests__/system-selection-helpers.test.ts
+++ b/src/__tests__/system-selection-helpers.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkflowState } from '../core/models/types.js';
+import {
+  getCachedCandidateSnapshot,
+  readPreviousSelectedNumber,
+  selectNextCandidate,
+} from '../infra/workflow/system/system-selection-helpers.js';
+
+function createWorkflowState(): WorkflowState {
+  return {
+    workflowName: 'auto-improvement-loop',
+    currentStep: 'route_context',
+    iteration: 1,
+    stepOutputs: new Map(),
+    structuredOutputs: new Map(),
+    systemContexts: new Map(),
+    effectResults: new Map(),
+    userInputs: [],
+    personaSessions: new Map(),
+    stepIterations: new Map(),
+    status: 'running',
+  };
+}
+
+describe('system-selection-helpers', () => {
+  it('candidate snapshot を resolution context 内で一度だけ評価する', () => {
+    const loadCandidates = vi.fn(() => [{ number: 587 }, { number: 586 }]);
+    const resolutionContext = { cache: new Map<string, unknown>() };
+
+    const first = getCachedCandidateSnapshot('issue_candidates:test', loadCandidates, resolutionContext);
+    const second = getCachedCandidateSnapshot('issue_candidates:test', loadCandidates, resolutionContext);
+
+    expect(loadCandidates).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
+
+  it('前回選択番号の次候補へ巡回する', () => {
+    expect(selectNextCandidate(
+      [{ number: 587 }, { number: 586 }],
+      587,
+    )).toEqual({ number: 586 });
+  });
+
+  it('workflow state から前回選択番号を読む', () => {
+    const state = createWorkflowState();
+    state.systemContexts.set('route_context', {
+      selected_issue: { exists: true, number: 586 },
+    });
+
+    expect(readPreviousSelectedNumber(state, 'route_context', 'selected_issue')).toBe(586);
+  });
+});

--- a/src/__tests__/system-step-services.test.ts
+++ b/src/__tests__/system-step-services.test.ts
@@ -6,6 +6,7 @@ const {
   mockExecFileSync,
   mockAgentCall,
   mockFetchIssue,
+  mockListOpenIssues,
   mockFetchPrReviewComments,
   mockListOpenPrs,
   mockFindExistingPr,
@@ -20,6 +21,7 @@ const {
   mockExecFileSync: vi.fn(),
   mockAgentCall: vi.fn(),
   mockFetchIssue: vi.fn(),
+  mockListOpenIssues: vi.fn(),
   mockFetchPrReviewComments: vi.fn(),
   mockListOpenPrs: vi.fn(),
   mockFindExistingPr: vi.fn(),
@@ -68,6 +70,7 @@ vi.mock('../infra/git/index.js', () => ({
   getGitProvider: vi.fn(() => ({
     checkCliStatus: vi.fn(() => ({ available: true })),
     fetchIssue: (...args: unknown[]) => mockFetchIssue(...args),
+    listOpenIssues: (...args: unknown[]) => mockListOpenIssues(...args),
     fetchPrReviewComments: (...args: unknown[]) => mockFetchPrReviewComments(...args),
     listOpenPrs: (...args: unknown[]) => mockListOpenPrs(...args),
     findExistingPr: (...args: unknown[]) => mockFindExistingPr(...args),
@@ -124,9 +127,23 @@ function createWorkflowState(currentStep = 'route_context'): WorkflowState {
 
 describe('DefaultSystemStepServices', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockGetCurrentBranch.mockReset();
+    mockExecFileSync.mockReset();
+    mockAgentCall.mockReset();
+    mockFetchIssue.mockReset();
+    mockListOpenIssues.mockReset();
+    mockFetchPrReviewComments.mockReset();
+    mockListOpenPrs.mockReset();
+    mockFindExistingPr.mockReset();
+    mockCommentOnPr.mockReset();
+    mockMergePr.mockReset();
+    mockSaveTaskFile.mockReset();
+    mockCreateIssueFromTask.mockReset();
+    mockTaskRunnerListAllTaskItems.mockReset();
+    mockResolveBaseBranch.mockReset();
     mockGetCurrentBranch.mockReturnValue('task/test-branch');
     mockFindExistingPr.mockReturnValue(undefined);
+    mockListOpenIssues.mockReturnValue([]);
     mockListOpenPrs.mockReturnValue([]);
     mockAgentCall.mockResolvedValue({
       status: 'done',
@@ -182,6 +199,304 @@ describe('DefaultSystemStepServices', () => {
 
     expect(mockFetchIssue).not.toHaveBeenCalled();
     expect(result).toEqual({ exists: false });
+  });
+
+  it('resolves issue_list with updated_at desc ordering', () => {
+    mockListOpenIssues.mockReturnValue([
+      {
+        number: 586,
+        title: 'Oldest issue',
+        labels: ['bug'],
+        updated_at: '2026-04-20T10:00:00Z',
+      },
+      {
+        number: 588,
+        title: 'Newest issue',
+        labels: ['takt-managed'],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+      {
+        number: 587,
+        title: 'Middle issue',
+        labels: ['automation'],
+        updated_at: '2026-04-20T12:00:00Z',
+      },
+    ]);
+
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Inspect issue list',
+    });
+
+    const result = services.resolveSystemInput({
+      type: 'issue_list',
+      source: 'current_project',
+      as: 'issues',
+    });
+
+    expect(mockListOpenIssues).toHaveBeenCalledWith('/repo');
+    expect(result).toEqual([
+      { number: 588, title: 'Newest issue' },
+      { number: 587, title: 'Middle issue' },
+      { number: 586, title: 'Oldest issue' },
+    ]);
+  });
+
+  it('does not mutate the provider issue list when ordering issues', () => {
+    const providerIssues = [
+      {
+        number: 586,
+        title: 'Oldest issue',
+        labels: ['bug'],
+        updated_at: '2026-04-20T10:00:00Z',
+      },
+      {
+        number: 588,
+        title: 'Newest issue',
+        labels: ['takt-managed'],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+      {
+        number: 587,
+        title: 'Middle issue',
+        labels: ['automation'],
+        updated_at: '2026-04-20T12:00:00Z',
+      },
+    ];
+    mockListOpenIssues.mockReturnValue(providerIssues);
+
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Inspect issue list without mutation',
+    });
+
+    services.resolveSystemInput({
+      type: 'issue_list',
+      source: 'current_project',
+      as: 'issues',
+    });
+
+    expect(providerIssues.map((issue) => issue.number)).toEqual([586, 588, 587]);
+  });
+
+  it('resolves issue_list deterministically when updated_at is tied', () => {
+    mockListOpenIssues.mockReturnValue([
+      {
+        number: 586,
+        title: 'Earlier number',
+        labels: ['bug'],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+      {
+        number: 587,
+        title: 'Later number',
+        labels: ['automation'],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+    ]);
+
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Inspect deterministic issue ordering',
+    });
+
+    const result = services.resolveSystemInput({
+      type: 'issue_list',
+      source: 'current_project',
+      as: 'issues',
+    });
+
+    expect(result).toEqual([
+      { number: 587, title: 'Later number' },
+      { number: 586, title: 'Earlier number' },
+    ]);
+  });
+
+  it('resolves issue_selection deterministically when updated_at is tied', () => {
+    mockListOpenIssues.mockReturnValue([
+      {
+        number: 586,
+        title: 'Earlier number',
+        labels: ['bug'],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+      {
+        number: 587,
+        title: 'Later number',
+        labels: ['automation'],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+    ]);
+
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Inspect deterministic issue selection',
+    });
+
+    const result = services.resolveSystemInput({
+      type: 'issue_selection',
+      source: 'current_project',
+      as: 'selected_issue',
+    }, createWorkflowState(), 'route_context');
+
+    expect(result).toEqual({
+      exists: true,
+      number: 587,
+      title: 'Later number',
+    });
+  });
+
+  it('resolves issue_selection by rotating after the previously selected issue', () => {
+    mockListOpenIssues.mockReturnValue([
+      {
+        number: 586,
+        title: 'Older issue',
+        labels: ['bug'],
+        updated_at: '2026-04-20T10:00:00Z',
+      },
+      {
+        number: 587,
+        title: 'Newest issue',
+        labels: ['takt-managed'],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+    ]);
+
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Inspect issue selection',
+    });
+    const state = createWorkflowState();
+    state.systemContexts.set('route_context', {
+      selected_issue: {
+        exists: true,
+        number: 587,
+      },
+    });
+
+    const resolveSystemInput = services.resolveSystemInput as unknown as (
+      input: {
+        type: 'issue_selection';
+        source: 'current_project';
+        as: 'selected_issue';
+      },
+      workflowState: WorkflowState,
+      stepName: string,
+    ) => unknown;
+
+    const result = resolveSystemInput({
+      type: 'issue_selection',
+      source: 'current_project',
+      as: 'selected_issue',
+    }, state, 'route_context');
+
+    expect(result).toEqual({
+      exists: true,
+      number: 586,
+      title: 'Older issue',
+    });
+  });
+
+  it('reuses the same issue candidate snapshot when issue_list and issue_selection share a resolution context', () => {
+    mockListOpenIssues
+      .mockReturnValueOnce([
+        {
+          number: 586,
+          title: 'Older issue',
+          labels: ['bug'],
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+        {
+          number: 587,
+          title: 'Newest issue',
+          labels: ['takt-managed'],
+          updated_at: '2026-04-20T14:00:00Z',
+        },
+      ])
+      .mockReturnValueOnce([
+        {
+          number: 999,
+          title: 'Unexpected second fetch',
+          labels: ['unexpected'],
+          updated_at: '2026-04-20T16:00:00Z',
+        },
+      ]);
+
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Inspect issue snapshot consistency',
+    });
+    const state = createWorkflowState();
+    state.systemContexts.set('route_context', {
+      selected_issue: {
+        exists: true,
+        number: 587,
+      },
+    });
+    const resolutionContext = { cache: new Map<string, unknown>() };
+
+    const issues = services.resolveSystemInput(
+      { type: 'issue_list', source: 'current_project', as: 'issues' },
+      state,
+      'route_context',
+      resolutionContext,
+    ) as Array<{ number: number }>;
+    const selectedIssue = services.resolveSystemInput(
+      { type: 'issue_selection', source: 'current_project', as: 'selected_issue' },
+      state,
+      'route_context',
+      resolutionContext,
+    ) as { exists: boolean; number: number };
+
+    expect(mockListOpenIssues).toHaveBeenCalledTimes(1);
+    expect(issues.map((issue) => issue.number)).toEqual([587, 586]);
+    expect(selectedIssue).toEqual({
+      exists: true,
+      number: 586,
+      title: 'Older issue',
+    });
+    expect(issues.some((issue) => issue.number === selectedIssue.number)).toBe(true);
+  });
+
+  it('keeps repo-wide issue_selection behavior for unlabeled issues without a filter', () => {
+    mockListOpenIssues.mockReturnValue([
+      {
+        number: 586,
+        title: 'Newest unlabeled issue',
+        labels: [],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+      {
+        number: 587,
+        title: 'Older labeled issue',
+        labels: ['takt-managed'],
+        updated_at: '2026-04-20T12:00:00Z',
+      },
+    ]);
+
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Inspect repo-wide issue selection',
+    });
+
+    const result = services.resolveSystemInput({
+      type: 'issue_selection',
+      source: 'current_project',
+      as: 'selected_issue',
+    }, createWorkflowState(), 'route_context');
+
+    expect(result).toEqual({
+      exists: true,
+      number: 586,
+      title: 'Newest unlabeled issue',
+    });
   });
 
   it('resolves pr_context when the current branch has an open PR', () => {
@@ -1117,6 +1432,7 @@ describe('DefaultSystemStepServices', () => {
     vi.mocked(getGitProvider).mockReturnValueOnce({
       checkCliStatus: vi.fn(() => ({ available: false, error: 'gh unavailable' })),
       fetchIssue: (...args: unknown[]) => mockFetchIssue(...args),
+      listOpenIssues: (...args: unknown[]) => mockListOpenIssues(...args),
       fetchPrReviewComments: (...args: unknown[]) => mockFetchPrReviewComments(...args),
       listOpenPrs: (...args: unknown[]) => mockListOpenPrs(...args),
       findExistingPr: (...args: unknown[]) => mockFindExistingPr(...args),
@@ -1136,6 +1452,32 @@ describe('DefaultSystemStepServices', () => {
       as: 'prs',
     })).toThrow('gh unavailable');
     expect(mockListOpenPrs).not.toHaveBeenCalled();
+  });
+
+  it('issue_list は CLI が利用不可なら listOpenIssues を呼ばずに失敗する', () => {
+    vi.mocked(getGitProvider).mockReturnValueOnce({
+      checkCliStatus: vi.fn(() => ({ available: false, error: 'gh unavailable' })),
+      fetchIssue: (...args: unknown[]) => mockFetchIssue(...args),
+      listOpenIssues: (...args: unknown[]) => mockListOpenIssues(...args),
+      fetchPrReviewComments: (...args: unknown[]) => mockFetchPrReviewComments(...args),
+      listOpenPrs: (...args: unknown[]) => mockListOpenPrs(...args),
+      findExistingPr: (...args: unknown[]) => mockFindExistingPr(...args),
+      commentOnPr: (...args: unknown[]) => mockCommentOnPr(...args),
+      mergePr: (...args: unknown[]) => mockMergePr(...args),
+    });
+
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Inspect issue list',
+    });
+
+    expect(() => services.resolveSystemInput({
+      type: 'issue_list',
+      source: 'current_project',
+      as: 'issues',
+    })).toThrow('gh unavailable');
+    expect(mockListOpenIssues).not.toHaveBeenCalled();
   });
 
   it('creates a new follow-up task and forwards worktree options', async () => {

--- a/src/__tests__/system-workflow-schema.test.ts
+++ b/src/__tests__/system-workflow-schema.test.ts
@@ -169,6 +169,122 @@ describe('system workflow schema', () => {
     }
   });
 
+  it('issue_list system input を受け付ける', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'route_context',
+      mode: 'system',
+      system_inputs: [
+        {
+          type: 'issue_list',
+          source: 'current_project',
+          as: 'issues',
+        },
+      ],
+      rules: [
+        {
+          when: 'context.route_context.issues.length > 0',
+          next: 'plan_from_issue',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const step = result.data as Record<string, unknown>;
+      expect(step.system_inputs).toEqual([
+        {
+          type: 'issue_list',
+          source: 'current_project',
+          as: 'issues',
+        },
+      ]);
+    }
+  });
+
+  it('issue_selection system input を受け付ける', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'route_context',
+      mode: 'system',
+      system_inputs: [
+        {
+          type: 'issue_selection',
+          source: 'current_project',
+          as: 'selected_issue',
+        },
+      ],
+      rules: [
+        {
+          when: 'context.route_context.selected_issue.exists == true',
+          next: 'plan_from_issue',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const step = result.data as Record<string, unknown>;
+      expect(step.system_inputs).toEqual([
+        {
+          type: 'issue_selection',
+          source: 'current_project',
+          as: 'selected_issue',
+        },
+      ]);
+    }
+  });
+
+  it('user_input_context system input を reject する', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'confirm_issue_enqueue',
+      mode: 'system',
+      instruction: 'Enter approve or reject.',
+      system_inputs: [
+        {
+          type: 'user_input_context',
+          source: 'current_workflow',
+          as: 'approval',
+        },
+      ],
+      rules: [
+        {
+          when: 'context.confirm_issue_enqueue.approval.exists == false',
+          requires_user_input: true,
+        },
+        {
+          when: 'context.confirm_issue_enqueue.approval.value == "approve"',
+          next: 'enqueue_from_issue',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('issue_list system input では where filter を reject する', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'route_context',
+      mode: 'system',
+      system_inputs: [
+        {
+          type: 'issue_list',
+          source: 'current_project',
+          as: 'issues',
+          where: {
+            labels: [TAKT_MANAGED_PR_LABEL],
+          },
+        },
+      ],
+      rules: [
+        {
+          when: 'context.route_context.issues.length > 0',
+          next: 'plan_from_issue',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('pr_selection の where がキー順だけ異なっても同じ step の pr_list と一致として扱う', () => {
     const result = WorkflowStepRawSchema.safeParse({
       name: 'route_context',
@@ -257,6 +373,31 @@ describe('system workflow schema', () => {
         }),
       ]),
     );
+  });
+
+  it('issue_selection system input では where filter を reject する', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'route_context',
+      mode: 'system',
+      system_inputs: [
+        {
+          type: 'issue_selection',
+          source: 'current_project',
+          as: 'selected_issue',
+          where: {
+            labels: [TAKT_MANAGED_PR_LABEL],
+          },
+        },
+      ],
+      rules: [
+        {
+          when: 'context.route_context.selected_issue.exists == true',
+          next: 'plan_from_issue',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it('task_queue_context system input で exclude_current_task を受け付ける', () => {
@@ -699,6 +840,10 @@ describe('system workflow schema', () => {
         expect.objectContaining({
           path: ['required_permission_mode'],
           message: 'System step does not allow "required_permission_mode"',
+        }),
+        expect.objectContaining({
+          path: ['instruction'],
+          message: 'System step does not allow "instruction"',
         }),
         expect.objectContaining({
           path: ['structured_output'],

--- a/src/core/models/workflow-issue-system-schemas.ts
+++ b/src/core/models/workflow-issue-system-schemas.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod/v4';
+
+const SystemInputBindingSchema = z.object({
+  as: z.string().min(1),
+});
+
+export const IssueListSystemInputRawSchema = SystemInputBindingSchema.extend({
+  type: z.literal('issue_list'),
+  source: z.literal('current_project'),
+}).strict();
+
+export const IssueSelectionSystemInputRawSchema = SystemInputBindingSchema.extend({
+  type: z.literal('issue_selection'),
+  source: z.literal('current_project'),
+}).strict();

--- a/src/core/models/workflow-provider-options.ts
+++ b/src/core/models/workflow-provider-options.ts
@@ -1,0 +1,81 @@
+import type { ProviderType } from '../../shared/types/provider.js';
+
+export interface McpStdioServerConfig {
+  type?: 'stdio';
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface McpSseServerConfig {
+  type: 'sse';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export interface McpHttpServerConfig {
+  type: 'http';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type McpServerConfig = McpStdioServerConfig | McpSseServerConfig | McpHttpServerConfig;
+
+export interface CodexProviderOptions {
+  networkAccess?: boolean;
+  reasoningEffort?: CodexReasoningEffort;
+}
+
+export interface OpenCodeProviderOptions {
+  networkAccess?: boolean;
+}
+
+export const RUNTIME_PREPARE_PRESETS = ['gradle', 'node'] as const;
+export type RuntimePreparePreset = (typeof RUNTIME_PREPARE_PRESETS)[number];
+export const CODEX_REASONING_EFFORT_VALUES = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORT_VALUES)[number];
+export const CLAUDE_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+export type ClaudeEffort = (typeof CLAUDE_EFFORT_VALUES)[number];
+export const COPILOT_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh'] as const;
+export type CopilotEffort = (typeof COPILOT_EFFORT_VALUES)[number];
+const RUNTIME_PREPARE_PRESET_SET: ReadonlySet<string> = new Set(RUNTIME_PREPARE_PRESETS);
+
+export function isRuntimePreparePreset(entry: string): entry is RuntimePreparePreset {
+  return RUNTIME_PREPARE_PRESET_SET.has(entry);
+}
+
+export type RuntimePrepareEntry = RuntimePreparePreset | string;
+
+export interface WorkflowRuntimeConfig {
+  prepare?: RuntimePrepareEntry[];
+}
+
+export interface ClaudeSandboxSettings {
+  allowUnsandboxedCommands?: boolean;
+  excludedCommands?: string[];
+}
+
+export interface ClaudeProviderOptions {
+  allowedTools?: string[];
+  effort?: ClaudeEffort;
+  sandbox?: ClaudeSandboxSettings;
+}
+
+export interface CopilotProviderOptions {
+  effort?: CopilotEffort;
+}
+
+export interface StepProviderOptions {
+  codex?: CodexProviderOptions;
+  opencode?: OpenCodeProviderOptions;
+  claude?: ClaudeProviderOptions;
+  copilot?: CopilotProviderOptions;
+}
+
+export type WorkflowStepKind = 'agent' | 'system' | 'workflow_call';
+
+export interface WorkflowCallOverrides {
+  provider?: ProviderType;
+  model?: string;
+  providerOptions?: StepProviderOptions;
+}

--- a/src/core/models/workflow-system-input-types.ts
+++ b/src/core/models/workflow-system-input-types.ts
@@ -1,0 +1,160 @@
+export interface WorkflowPrListWhere {
+  author?: string;
+  base_branch?: string;
+  head_branch?: string;
+  managed_by_takt?: boolean;
+  labels?: string[];
+  same_repository?: boolean;
+  draft?: boolean;
+}
+
+function normalizeWorkflowPrListWhereLabels(labels: string[] | undefined): string[] | undefined {
+  if (labels === undefined) {
+    return undefined;
+  }
+  return [...new Set(labels)].sort();
+}
+
+export function normalizeWorkflowPrListWhere(
+  where: WorkflowPrListWhere | undefined,
+): WorkflowPrListWhere | undefined {
+  if (where === undefined) {
+    return undefined;
+  }
+
+  const normalized: WorkflowPrListWhere = {};
+
+  if (where.author !== undefined) {
+    normalized.author = where.author;
+  }
+  if (where.base_branch !== undefined) {
+    normalized.base_branch = where.base_branch;
+  }
+  if (where.head_branch !== undefined) {
+    normalized.head_branch = where.head_branch;
+  }
+  if (where.managed_by_takt !== undefined) {
+    normalized.managed_by_takt = where.managed_by_takt;
+  }
+
+  const labels = normalizeWorkflowPrListWhereLabels(where.labels);
+  if (labels !== undefined) {
+    normalized.labels = labels;
+  }
+  if (where.same_repository !== undefined) {
+    normalized.same_repository = where.same_repository;
+  }
+  if (where.draft !== undefined) {
+    normalized.draft = where.draft;
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+export function workflowPrListWhereEquals(
+  left: WorkflowPrListWhere | undefined,
+  right: WorkflowPrListWhere | undefined,
+): boolean {
+  return JSON.stringify(normalizeWorkflowPrListWhere(left) ?? {})
+    === JSON.stringify(normalizeWorkflowPrListWhere(right) ?? {});
+}
+
+export function stringifyWorkflowPrListWhere(where: WorkflowPrListWhere | undefined): string {
+  return JSON.stringify(normalizeWorkflowPrListWhere(where) ?? {});
+}
+
+interface WorkflowSystemBinding {
+  as: string;
+}
+
+export type WorkflowSystemInput =
+  | (WorkflowSystemBinding & {
+    type: 'task_context';
+    source: 'current_task';
+  })
+  | (WorkflowSystemBinding & {
+    type: 'branch_context';
+    source: 'current_task';
+  })
+  | (WorkflowSystemBinding & {
+    type: 'pr_context';
+    source: 'current_branch';
+  })
+  | (WorkflowSystemBinding & {
+    type: 'issue_context';
+    source: 'current_task';
+  })
+  | (WorkflowSystemBinding & {
+    type: 'task_queue_context';
+    source: 'current_project';
+    exclude_current_task?: boolean;
+  })
+  | (WorkflowSystemBinding & {
+    type: 'pr_list';
+    source: 'current_project';
+    where?: WorkflowPrListWhere;
+  })
+  | (WorkflowSystemBinding & {
+    type: 'issue_list';
+    source: 'current_project';
+  })
+  | (WorkflowSystemBinding & {
+    type: 'pr_selection';
+    source: 'current_project';
+    where?: WorkflowPrListWhere;
+  })
+  | (WorkflowSystemBinding & {
+    type: 'issue_selection';
+    source: 'current_project';
+  });
+
+export interface WorkflowEnqueueIssueConfig {
+  create?: boolean;
+  labels?: string[];
+}
+
+export interface WorkflowEnqueueWorktreeConfig {
+  enabled?: boolean;
+  auto_pr?: boolean;
+  draft_pr?: boolean;
+}
+
+type WorkflowContextTemplateReference = `{context:${string}}`;
+type WorkflowStructuredTemplateReference = `{structured:${string}}`;
+type WorkflowEffectTemplateReference = `{effect:${string}}`;
+
+export type WorkflowTemplateReference =
+  | WorkflowContextTemplateReference
+  | WorkflowStructuredTemplateReference
+  | WorkflowEffectTemplateReference;
+
+export type WorkflowEffectScalarReference = WorkflowTemplateReference | number;
+
+export type WorkflowEffect =
+  | {
+    type: 'enqueue_task';
+    mode: 'new' | 'from_pr';
+    workflow: string;
+    task: string;
+    pr?: WorkflowEffectScalarReference;
+    issue?: WorkflowEnqueueIssueConfig | WorkflowTemplateReference;
+    base_branch?: string;
+    worktree?: WorkflowEnqueueWorktreeConfig;
+  }
+  | {
+    type: 'comment_pr';
+    pr: WorkflowEffectScalarReference;
+    body: string;
+  }
+  | {
+    type: 'sync_with_root';
+    pr: WorkflowEffectScalarReference;
+  }
+  | {
+    type: 'resolve_conflicts_with_ai';
+    pr: WorkflowEffectScalarReference;
+  }
+  | {
+    type: 'merge_pr';
+    pr: WorkflowEffectScalarReference;
+  };

--- a/src/core/models/workflow-system-schemas.ts
+++ b/src/core/models/workflow-system-schemas.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod/v4';
 import { getWorkflowStepKind } from './workflow-step-kind.js';
-import { workflowPrListWhereEquals } from './workflow-types.js';
+import {
+  workflowPrListWhereEquals,
+} from './workflow-types.js';
 import type { WorkflowPrListWhere } from './workflow-types.js';
+import {
+  IssueListSystemInputRawSchema,
+  IssueSelectionSystemInputRawSchema,
+} from './workflow-issue-system-schemas.js';
 
 export const StructuredOutputRawSchema = z.object({
   schema_ref: z.string().min(1),
@@ -63,11 +69,13 @@ export const SystemInputRawSchema = z.discriminatedUnion('type', [
     source: z.literal('current_project'),
     where: PrListWhereRawSchema.optional(),
   }),
+  IssueListSystemInputRawSchema,
   SystemInputBindingSchema.extend({
     type: z.literal('pr_selection'),
     source: z.literal('current_project'),
     where: PrListWhereRawSchema.optional(),
   }),
+  IssueSelectionSystemInputRawSchema,
 ]);
 
 const EffectReferenceScalarSchema = z.union([TemplateReferenceSchema, z.number().int().positive()]);
@@ -248,7 +256,6 @@ export function validateSystemStepFields(
       }
     }
   }
-
   const effectTypes = new Set<string>();
   for (const [index, effect] of (data.effects ?? []).entries()) {
     if (effectTypes.has(effect.type)) {

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -3,6 +3,56 @@ import type { PermissionMode } from './status.js';
 import type { AgentResponse } from './response.js';
 import type { InteractiveMode } from './interactive-mode.js';
 import type { TeamLeaderConfig } from './part.js';
+import type {
+  McpServerConfig,
+  StepProviderOptions,
+  WorkflowCallOverrides,
+  WorkflowRuntimeConfig,
+  WorkflowStepKind,
+} from './workflow-provider-options.js';
+import type {
+  WorkflowEffect,
+  WorkflowSystemInput,
+} from './workflow-system-input-types.js';
+
+export type {
+  WorkflowPrListWhere,
+  WorkflowSystemInput,
+  WorkflowEffect,
+  WorkflowEnqueueIssueConfig,
+  WorkflowEnqueueWorktreeConfig,
+  WorkflowTemplateReference,
+  WorkflowEffectScalarReference,
+} from './workflow-system-input-types.js';
+export {
+  normalizeWorkflowPrListWhere,
+  workflowPrListWhereEquals,
+  stringifyWorkflowPrListWhere,
+} from './workflow-system-input-types.js';
+export type {
+  McpServerConfig,
+  RuntimePreparePreset,
+  RuntimePrepareEntry,
+  WorkflowRuntimeConfig,
+  CodexReasoningEffort,
+  ClaudeEffort,
+  CopilotEffort,
+  ClaudeSandboxSettings,
+  CodexProviderOptions,
+  OpenCodeProviderOptions,
+  ClaudeProviderOptions,
+  CopilotProviderOptions,
+  StepProviderOptions,
+  WorkflowStepKind,
+  WorkflowCallOverrides,
+} from './workflow-provider-options.js';
+export {
+  RUNTIME_PREPARE_PRESETS,
+  CODEX_REASONING_EFFORT_VALUES,
+  CLAUDE_EFFORT_VALUES,
+  COPILOT_EFFORT_VALUES,
+  isRuntimePreparePreset,
+} from './workflow-provider-options.js';
 
 export interface WorkflowRule {
   condition: string;
@@ -25,161 +75,6 @@ export interface WorkflowStructuredOutput {
   schema: Record<string, unknown>;
 }
 
-interface WorkflowSystemBinding {
-  as: string;
-}
-
-export interface WorkflowPrListWhere {
-  author?: string;
-  base_branch?: string;
-  head_branch?: string;
-  managed_by_takt?: boolean;
-  labels?: string[];
-  same_repository?: boolean;
-  draft?: boolean;
-}
-
-function normalizeWorkflowPrListWhereLabels(labels: string[] | undefined): string[] | undefined {
-  if (labels === undefined) {
-    return undefined;
-  }
-  return [...new Set(labels)].sort();
-}
-
-export function normalizeWorkflowPrListWhere(
-  where: WorkflowPrListWhere | undefined,
-): WorkflowPrListWhere | undefined {
-  if (where === undefined) {
-    return undefined;
-  }
-
-  const normalized: WorkflowPrListWhere = {};
-
-  if (where.author !== undefined) {
-    normalized.author = where.author;
-  }
-  if (where.base_branch !== undefined) {
-    normalized.base_branch = where.base_branch;
-  }
-  if (where.head_branch !== undefined) {
-    normalized.head_branch = where.head_branch;
-  }
-  if (where.managed_by_takt !== undefined) {
-    normalized.managed_by_takt = where.managed_by_takt;
-  }
-
-  const labels = normalizeWorkflowPrListWhereLabels(where.labels);
-  if (labels !== undefined) {
-    normalized.labels = labels;
-  }
-  if (where.same_repository !== undefined) {
-    normalized.same_repository = where.same_repository;
-  }
-  if (where.draft !== undefined) {
-    normalized.draft = where.draft;
-  }
-
-  return Object.keys(normalized).length > 0 ? normalized : undefined;
-}
-
-export function workflowPrListWhereEquals(
-  left: WorkflowPrListWhere | undefined,
-  right: WorkflowPrListWhere | undefined,
-): boolean {
-  return JSON.stringify(normalizeWorkflowPrListWhere(left) ?? {})
-    === JSON.stringify(normalizeWorkflowPrListWhere(right) ?? {});
-}
-
-export function stringifyWorkflowPrListWhere(where: WorkflowPrListWhere | undefined): string {
-  return JSON.stringify(normalizeWorkflowPrListWhere(where) ?? {});
-}
-
-export type WorkflowSystemInput =
-  | (WorkflowSystemBinding & {
-    type: 'task_context';
-    source: 'current_task';
-  })
-  | (WorkflowSystemBinding & {
-    type: 'branch_context';
-    source: 'current_task';
-  })
-  | (WorkflowSystemBinding & {
-    type: 'pr_context';
-    source: 'current_branch';
-  })
-  | (WorkflowSystemBinding & {
-    type: 'issue_context';
-    source: 'current_task';
-  })
-  | (WorkflowSystemBinding & {
-    type: 'task_queue_context';
-    source: 'current_project';
-    exclude_current_task?: boolean;
-  })
-  | (WorkflowSystemBinding & {
-    type: 'pr_list';
-    source: 'current_project';
-    where?: WorkflowPrListWhere;
-  })
-  | (WorkflowSystemBinding & {
-    type: 'pr_selection';
-    source: 'current_project';
-    where?: WorkflowPrListWhere;
-  });
-
-export interface WorkflowEnqueueIssueConfig {
-  create?: boolean;
-  labels?: string[];
-}
-
-export interface WorkflowEnqueueWorktreeConfig {
-  enabled?: boolean;
-  auto_pr?: boolean;
-  draft_pr?: boolean;
-}
-
-type WorkflowContextTemplateReference = `{context:${string}}`;
-type WorkflowStructuredTemplateReference = `{structured:${string}}`;
-type WorkflowEffectTemplateReference = `{effect:${string}}`;
-
-// The parser/schema enforce the exact DSL shape. Keep the public type broad enough
-// that valid nested template paths are not rejected at compile time.
-export type WorkflowTemplateReference =
-  | WorkflowContextTemplateReference
-  | WorkflowStructuredTemplateReference
-  | WorkflowEffectTemplateReference;
-
-export type WorkflowEffectScalarReference = WorkflowTemplateReference | number;
-
-export type WorkflowEffect =
-  | {
-    type: 'enqueue_task';
-    mode: 'new' | 'from_pr';
-    workflow: string;
-    task: string;
-    pr?: WorkflowEffectScalarReference;
-    issue?: WorkflowEnqueueIssueConfig | WorkflowTemplateReference;
-    base_branch?: string;
-    worktree?: WorkflowEnqueueWorktreeConfig;
-  }
-  | {
-    type: 'comment_pr';
-    pr: WorkflowEffectScalarReference;
-    body: string;
-  }
-  | {
-    type: 'sync_with_root';
-    pr: WorkflowEffectScalarReference;
-  }
-  | {
-    type: 'resolve_conflicts_with_ai';
-    pr: WorkflowEffectScalarReference;
-  }
-  | {
-    type: 'merge_pr';
-    pr: WorkflowEffectScalarReference;
-  };
-
 export interface OutputContractItem {
   name: string;
   format: string;
@@ -188,84 +83,6 @@ export interface OutputContractItem {
 }
 
 export type OutputContractEntry = OutputContractItem;
-
-export interface McpStdioServerConfig {
-  type?: 'stdio';
-  command: string;
-  args?: string[];
-  env?: Record<string, string>;
-}
-
-export interface McpSseServerConfig {
-  type: 'sse';
-  url: string;
-  headers?: Record<string, string>;
-}
-
-export interface McpHttpServerConfig {
-  type: 'http';
-  url: string;
-  headers?: Record<string, string>;
-}
-
-export type McpServerConfig = McpStdioServerConfig | McpSseServerConfig | McpHttpServerConfig;
-
-export interface CodexProviderOptions {
-  networkAccess?: boolean;
-  reasoningEffort?: CodexReasoningEffort;
-}
-
-export interface OpenCodeProviderOptions {
-  networkAccess?: boolean;
-}
-
-export const RUNTIME_PREPARE_PRESETS = ['gradle', 'node'] as const;
-export type RuntimePreparePreset = (typeof RUNTIME_PREPARE_PRESETS)[number];
-export const CODEX_REASONING_EFFORT_VALUES = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
-export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORT_VALUES)[number];
-export const CLAUDE_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
-export type ClaudeEffort = (typeof CLAUDE_EFFORT_VALUES)[number];
-export const COPILOT_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh'] as const;
-export type CopilotEffort = (typeof COPILOT_EFFORT_VALUES)[number];
-const RUNTIME_PREPARE_PRESET_SET: ReadonlySet<string> = new Set(RUNTIME_PREPARE_PRESETS);
-export function isRuntimePreparePreset(entry: string): entry is RuntimePreparePreset {
-  return RUNTIME_PREPARE_PRESET_SET.has(entry);
-}
-export type RuntimePrepareEntry = RuntimePreparePreset | string;
-
-export interface WorkflowRuntimeConfig {
-  prepare?: RuntimePrepareEntry[];
-}
-
-export interface ClaudeSandboxSettings {
-  allowUnsandboxedCommands?: boolean;
-  excludedCommands?: string[];
-}
-
-export interface ClaudeProviderOptions {
-  allowedTools?: string[];
-  effort?: ClaudeEffort;
-  sandbox?: ClaudeSandboxSettings;
-}
-
-export interface CopilotProviderOptions {
-  effort?: CopilotEffort;
-}
-
-export interface StepProviderOptions {
-  codex?: CodexProviderOptions;
-  opencode?: OpenCodeProviderOptions;
-  claude?: ClaudeProviderOptions;
-  copilot?: CopilotProviderOptions;
-}
-
-export type WorkflowStepKind = 'agent' | 'system' | 'workflow_call';
-
-export interface WorkflowCallOverrides {
-  provider?: ProviderType;
-  model?: string;
-  providerOptions?: StepProviderOptions;
-}
 
 export type WorkflowParamType = 'facet_ref' | 'facet_ref[]';
 export type WorkflowParamFacetKind = 'knowledge' | 'policy' | 'instruction' | 'report_format';

--- a/src/infra/git/index.ts
+++ b/src/infra/git/index.ts
@@ -17,7 +17,7 @@ import { getErrorMessage } from '../../shared/utils/index.js';
 import type { GitProvider, CreatePrOptions, CreatePrResult } from './types.js';
 import type { VcsProviderType } from './detect.js';
 
-export type { GitProvider, Issue, CliStatus, ExistingPr, PrListItem, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, CreateIssueOptions, CreateIssueResult, PrReviewComment, PrReviewData } from './types.js';
+export type { GitProvider, Issue, CliStatus, ExistingPr, IssueListItem, PrListItem, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, CreateIssueOptions, CreateIssueResult, PrReviewComment, PrReviewData } from './types.js';
 export {
   formatIssueAsTask,
   parseIssueNumbers,

--- a/src/infra/git/types.ts
+++ b/src/infra/git/types.ts
@@ -15,6 +15,13 @@ export interface ExistingPr {
   url: string;
 }
 
+export interface IssueListItem {
+  number: number;
+  title: string;
+  labels: string[];
+  updated_at: string;
+}
+
 export interface PrListItem {
   number: number;
   author: string;
@@ -92,6 +99,8 @@ export interface GitProvider {
   createIssue(options: CreateIssueOptions, cwd?: string): CreateIssueResult;
 
   fetchPrReviewComments(prNumber: number, cwd?: string): PrReviewData;
+
+  listOpenIssues(cwd?: string): IssueListItem[];
 
   listOpenPrs(cwd?: string): PrListItem[];
 

--- a/src/infra/github/GitHubProvider.ts
+++ b/src/infra/github/GitHubProvider.ts
@@ -6,9 +6,9 @@
  * the GitProvider contract to the GitHub/gh-CLI implementation.
  */
 
-import { checkGhCli, fetchIssue, createIssue } from './issue.js';
+import { checkGhCli, fetchIssue, listOpenIssues, createIssue } from './issue.js';
 import { findExistingPr, commentOnPr, createPullRequest, fetchPrReviewComments, listOpenPrs, mergePr } from './pr.js';
-import type { GitProvider, CliStatus, Issue, ExistingPr, PrListItem, CreateIssueOptions, CreateIssueResult, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, PrReviewData } from '../git/types.js';
+import type { GitProvider, CliStatus, Issue, ExistingPr, IssueListItem, PrListItem, CreateIssueOptions, CreateIssueResult, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, PrReviewData } from '../git/types.js';
 
 export class GitHubProvider implements GitProvider {
   checkCliStatus(cwd?: string): CliStatus {
@@ -25,6 +25,10 @@ export class GitHubProvider implements GitProvider {
 
   fetchPrReviewComments(prNumber: number, cwd?: string): PrReviewData {
     return fetchPrReviewComments(prNumber, cwd ?? process.cwd());
+  }
+
+  listOpenIssues(cwd?: string): IssueListItem[] {
+    return listOpenIssues(cwd ?? process.cwd());
   }
 
   listOpenPrs(cwd?: string): PrListItem[] {

--- a/src/infra/github/issue.ts
+++ b/src/infra/github/issue.ts
@@ -4,9 +4,20 @@
 
 import { execFileSync } from 'node:child_process';
 import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
-import type { CliStatus, Issue, CreateIssueOptions, CreateIssueResult } from '../git/types.js';
+import { fetchPaginatedApi } from '../git/paginated-api.js';
+import { resolveRepositoryNameWithOwner } from './repository.js';
+import type { CliStatus, Issue, IssueListItem, CreateIssueOptions, CreateIssueResult } from '../git/types.js';
 
 const log = createLogger('github');
+const OPEN_ISSUES_PER_PAGE = 100;
+
+interface GhIssueListResponseItem {
+  number: number;
+  title: string;
+  labels: Array<{ name: string }>;
+  updated_at: string;
+  pull_request?: object;
+}
 
 /**
  * Check if `gh` CLI is available and authenticated.
@@ -62,6 +73,29 @@ export function fetchIssue(issueNumber: number, cwd: string): Issue {
       body: c.body,
     })),
   };
+}
+
+export function listOpenIssues(cwd: string): IssueListItem[] {
+  log.debug('Listing open issues');
+
+  const repo = resolveRepositoryNameWithOwner(cwd);
+  const data = fetchPaginatedApi<GhIssueListResponseItem>({
+    command: 'gh',
+    cwd,
+    context: 'open issue list',
+    initialEndpoint: `repos/${repo}/issues?state=open&per_page=${OPEN_ISSUES_PER_PAGE}&page=1`,
+    parsePage: (body) => {
+      const page = JSON.parse(body) as GhIssueListResponseItem[];
+      return page.filter((item) => item.pull_request === undefined);
+    },
+  });
+
+  return data.map((issue) => ({
+    number: issue.number,
+    title: issue.title,
+    labels: issue.labels.map((label) => label.name),
+    updated_at: issue.updated_at,
+  }));
 }
 
 /**

--- a/src/infra/github/pr.ts
+++ b/src/infra/github/pr.ts
@@ -9,6 +9,7 @@ import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
 import { fetchPaginatedApi } from '../git/paginated-api.js';
 import { isTaktManagedPrBody } from '../git/format.js';
 import { checkGhCli } from './issue.js';
+import { resolveRepositoryNameWithOwner } from './repository.js';
 import type { CreatePrOptions, CreatePrResult, ExistingPr, CommentResult, MergeResult, PrListItem, PrReviewData, PrReviewComment } from '../git/types.js';
 
 const log = createLogger('github-pr');
@@ -45,25 +46,8 @@ interface GhPrListResponseItem {
   updated_at: string;
 }
 
-interface GhRepoViewResponse {
-  nameWithOwner: string;
-}
-
 const OPEN_PRS_PER_PAGE = 100;
 const INLINE_REVIEW_COMMENTS_PER_PAGE = 100;
-
-function resolveRepositoryNameWithOwner(cwd: string): string {
-  const output = execFileSync(
-    'gh',
-    ['repo', 'view', '--json', 'nameWithOwner'],
-    { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-  );
-  const repo = JSON.parse(output) as GhRepoViewResponse;
-  if (!repo.nameWithOwner) {
-    throw new Error('gh repo view did not return nameWithOwner');
-  }
-  return repo.nameWithOwner;
-}
 
 export function listOpenPrs(cwd: string): PrListItem[] {
   const repo = resolveRepositoryNameWithOwner(cwd);

--- a/src/infra/github/repository.ts
+++ b/src/infra/github/repository.ts
@@ -1,0 +1,18 @@
+import { execFileSync } from 'node:child_process';
+
+interface GhRepoViewResponse {
+  nameWithOwner: string;
+}
+
+export function resolveRepositoryNameWithOwner(cwd: string): string {
+  const output = execFileSync(
+    'gh',
+    ['repo', 'view', '--json', 'nameWithOwner'],
+    { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+  );
+  const repo = JSON.parse(output) as GhRepoViewResponse;
+  if (!repo.nameWithOwner) {
+    throw new Error('gh repo view did not return nameWithOwner');
+  }
+  return repo.nameWithOwner;
+}

--- a/src/infra/gitlab/GitLabProvider.ts
+++ b/src/infra/gitlab/GitLabProvider.ts
@@ -7,9 +7,9 @@
  */
 
 import { checkGlabCli } from './utils.js';
-import { fetchIssue, createIssue } from './issue.js';
+import { fetchIssue, listOpenIssues, createIssue } from './issue.js';
 import { findExistingMr, commentOnMr, createMergeRequest, fetchMrReviewComments, listOpenMrs, mergeMr } from './pr.js';
-import type { GitProvider, CliStatus, Issue, ExistingPr, PrListItem, CreateIssueOptions, CreateIssueResult, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, PrReviewData } from '../git/types.js';
+import type { GitProvider, CliStatus, Issue, ExistingPr, IssueListItem, PrListItem, CreateIssueOptions, CreateIssueResult, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, PrReviewData } from '../git/types.js';
 
 export class GitLabProvider implements GitProvider {
   checkCliStatus(cwd?: string): CliStatus {
@@ -26,6 +26,10 @@ export class GitLabProvider implements GitProvider {
 
   fetchPrReviewComments(prNumber: number, cwd?: string): PrReviewData {
     return fetchMrReviewComments(prNumber, cwd ?? process.cwd());
+  }
+
+  listOpenIssues(cwd?: string): IssueListItem[] {
+    return listOpenIssues(cwd ?? process.cwd());
   }
 
   listOpenPrs(cwd?: string): PrListItem[] {

--- a/src/infra/gitlab/issue.ts
+++ b/src/infra/gitlab/issue.ts
@@ -6,7 +6,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
-import type { Issue, CreateIssueOptions, CreateIssueResult } from '../git/types.js';
+import type { Issue, IssueListItem, CreateIssueOptions, CreateIssueResult } from '../git/types.js';
 import { checkGlabCli, fetchAllPages, parseJson, ITEMS_PER_PAGE } from './utils.js';
 
 const log = createLogger('gitlab');
@@ -61,6 +61,29 @@ export function fetchIssue(issueNumber: number, cwd: string): Issue {
         body: n.body,
       })),
   };
+}
+
+interface GlabOpenIssueItem {
+  iid: number;
+  title: string;
+  labels: string[];
+  updated_at: string;
+}
+
+export function listOpenIssues(cwd: string): IssueListItem[] {
+  const issues = fetchAllPages<GlabOpenIssueItem>(
+    'projects/:id/issues?state=opened',
+    ITEMS_PER_PAGE,
+    'open issue list',
+    cwd,
+  );
+
+  return issues.map((issue) => ({
+    number: issue.iid,
+    title: issue.title,
+    labels: issue.labels,
+    updated_at: issue.updated_at,
+  }));
 }
 
 /**

--- a/src/infra/workflow/system/DefaultSystemStepServices.ts
+++ b/src/infra/workflow/system/DefaultSystemStepServices.ts
@@ -22,6 +22,7 @@ import {
 } from './system-pr-effects.js';
 import { enqueueTaskEffect } from './system-enqueue-effect.js';
 import { resolveConflictsWithAiEffect, syncWithRootEffect } from './system-sync-effects.js';
+import { resolveIssueListInput, resolveIssueSelectionInput } from './system-issue-input-resolver.js';
 import { resolvePrListInput, resolvePrSelectionInput } from './system-pr-input-resolver.js';
 
 function listQueueTasks(projectCwd: string) {
@@ -135,6 +136,10 @@ function resolveInput(
     case 'task_queue_context': {
       return resolveTaskQueueInput(input, options);
     }
+    case 'issue_list':
+      return resolveIssueListInput(input, options.projectCwd, resolutionContext);
+    case 'issue_selection':
+      return resolveIssueSelectionInput(input, options.projectCwd, state, stepName, resolutionContext);
     case 'pr_list':
       return resolvePrListInput(input, options.projectCwd, resolutionContext);
     case 'pr_selection':

--- a/src/infra/workflow/system/system-git-context.ts
+++ b/src/infra/workflow/system/system-git-context.ts
@@ -1,4 +1,4 @@
-import { getGitProvider, type ExistingPr, type Issue, type PrListItem, type PrReviewData } from '../../git/index.js';
+import { getGitProvider, type ExistingPr, type Issue, type IssueListItem, type PrListItem, type PrReviewData } from '../../git/index.js';
 import { getCurrentBranch } from '../../task/index.js';
 
 export interface CurrentBranchResolution {
@@ -61,6 +61,10 @@ export function fetchPrContext(cwd: string, prNumber: number): PrReviewData {
 
 export function fetchIssueContext(cwd: string, issueNumber: number): Issue {
   return requireAvailableProvider(cwd).fetchIssue(issueNumber, cwd);
+}
+
+export function fetchOpenIssueList(cwd: string): IssueListItem[] {
+  return requireAvailableProvider(cwd).listOpenIssues(cwd);
 }
 
 export function fetchOpenPrList(cwd: string): PrListItem[] {

--- a/src/infra/workflow/system/system-issue-input-resolver.ts
+++ b/src/infra/workflow/system/system-issue-input-resolver.ts
@@ -1,0 +1,79 @@
+import type {
+  WorkflowState,
+  WorkflowSystemInput,
+} from '../../../core/models/types.js';
+import type { SystemStepInputResolutionContext } from '../../../core/workflow/system/system-step-services.js';
+import type { IssueListItem } from '../../git/types.js';
+import { fetchOpenIssueList } from './system-git-context.js';
+import {
+  getCachedCandidateSnapshot,
+  readPreviousSelectedNumber,
+  selectNextCandidate,
+} from './system-selection-helpers.js';
+
+function listMatchingIssues(projectCwd: string): IssueListItem[] {
+  const issues = [...fetchOpenIssueList(projectCwd)];
+  issues.sort((left, right) => {
+    const updatedAtComparison = right.updated_at.localeCompare(left.updated_at);
+    if (updatedAtComparison !== 0) {
+      return updatedAtComparison;
+    }
+    return right.number - left.number;
+  });
+  return issues;
+}
+
+function getIssueCandidateSnapshot(
+  projectCwd: string,
+  resolutionContext?: SystemStepInputResolutionContext,
+): IssueListItem[] {
+  return getCachedCandidateSnapshot(
+    'issue_candidates',
+    () => listMatchingIssues(projectCwd),
+    resolutionContext,
+  );
+}
+
+function toIssueListSummary(issue: IssueListItem) {
+  return {
+    number: issue.number,
+    title: issue.title,
+  };
+}
+
+export function resolveIssueListInput(
+  _input: Extract<WorkflowSystemInput, { type: 'issue_list' }>,
+  projectCwd: string,
+  resolutionContext?: SystemStepInputResolutionContext,
+) {
+  return getIssueCandidateSnapshot(projectCwd, resolutionContext).map(toIssueListSummary);
+}
+
+export function resolveIssueSelectionInput(
+  input: Extract<WorkflowSystemInput, { type: 'issue_selection' }>,
+  projectCwd: string,
+  state: WorkflowState | undefined,
+  stepName: string | undefined,
+  resolutionContext?: SystemStepInputResolutionContext,
+) {
+  if (!state) {
+    throw new Error('issue_selection requires workflow state');
+  }
+  if (!stepName) {
+    throw new Error('issue_selection requires step name');
+  }
+
+  const candidates = getIssueCandidateSnapshot(projectCwd, resolutionContext);
+  const selectedIssue = selectNextCandidate(
+    candidates,
+    readPreviousSelectedNumber(state, stepName, input.as),
+  );
+  if (!selectedIssue) {
+    return { exists: false };
+  }
+
+  return {
+    exists: true,
+    ...toIssueListSummary(selectedIssue),
+  };
+}

--- a/src/infra/workflow/system/system-pr-input-resolver.ts
+++ b/src/infra/workflow/system/system-pr-input-resolver.ts
@@ -7,6 +7,11 @@ import { stringifyWorkflowPrListWhere } from '../../../core/models/workflow-type
 import type { SystemStepInputResolutionContext } from '../../../core/workflow/system/system-step-services.js';
 import type { PrListItem } from '../../git/types.js';
 import { fetchOpenPrList } from './system-git-context.js';
+import {
+  getCachedCandidateSnapshot,
+  readPreviousSelectedNumber,
+  selectNextCandidate,
+} from './system-selection-helpers.js';
 
 function matchesSimpleWildcard(value: string, pattern: string): boolean {
   const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
@@ -50,19 +55,12 @@ function getPrCandidateSnapshot(
   where: WorkflowPrListWhere | undefined,
   resolutionContext?: SystemStepInputResolutionContext,
 ): PrListItem[] {
-  if (!resolutionContext) {
-    return listMatchingPrs(projectCwd, where);
-  }
-
   const cacheKey = `pr_candidates:${stringifyWorkflowPrListWhere(where)}`;
-  const cached = resolutionContext.cache.get(cacheKey);
-  if (cached) {
-    return cached as PrListItem[];
-  }
-
-  const candidates = listMatchingPrs(projectCwd, where);
-  resolutionContext.cache.set(cacheKey, candidates);
-  return candidates;
+  return getCachedCandidateSnapshot(
+    cacheKey,
+    () => listMatchingPrs(projectCwd, where),
+    resolutionContext,
+  );
 }
 
 function toPrSummary({
@@ -85,41 +83,6 @@ function toPrSummary({
     same_repository,
     draft,
   };
-}
-
-function readPreviousSelectedPrNumber(
-  state: WorkflowState,
-  stepName: string,
-  bindingName: string,
-): number | undefined {
-  const context = state.systemContexts.get(stepName);
-  if (!context || typeof context !== 'object') {
-    return undefined;
-  }
-
-  const selectedPr = (context as Record<string, unknown>)[bindingName];
-  if (!selectedPr || typeof selectedPr !== 'object') {
-    return undefined;
-  }
-
-  const number = (selectedPr as Record<string, unknown>).number;
-  return typeof number === 'number' ? number : undefined;
-}
-
-function selectNextPr(candidates: PrListItem[], previousNumber: number | undefined): PrListItem | undefined {
-  if (candidates.length === 0) {
-    return undefined;
-  }
-  if (previousNumber === undefined) {
-    return candidates[0];
-  }
-
-  const previousIndex = candidates.findIndex((candidate) => candidate.number === previousNumber);
-  if (previousIndex === -1) {
-    return candidates[0];
-  }
-
-  return candidates[(previousIndex + 1) % candidates.length];
 }
 
 export function resolvePrListInput(
@@ -145,9 +108,9 @@ export function resolvePrSelectionInput(
   }
 
   const candidates = getPrCandidateSnapshot(projectCwd, input.where, resolutionContext);
-  const selectedPr = selectNextPr(
+  const selectedPr = selectNextCandidate(
     candidates,
-    readPreviousSelectedPrNumber(state, stepName, input.as),
+    readPreviousSelectedNumber(state, stepName, input.as),
   );
   if (!selectedPr) {
     return { exists: false };

--- a/src/infra/workflow/system/system-selection-helpers.ts
+++ b/src/infra/workflow/system/system-selection-helpers.ts
@@ -1,0 +1,63 @@
+import type { WorkflowState } from '../../../core/models/types.js';
+import type { SystemStepInputResolutionContext } from '../../../core/workflow/system/system-step-services.js';
+
+interface NumberedCandidate {
+  number: number;
+}
+
+export function getCachedCandidateSnapshot<T>(
+  cacheKey: string,
+  loadCandidates: () => T[],
+  resolutionContext?: SystemStepInputResolutionContext,
+): T[] {
+  if (!resolutionContext) {
+    return loadCandidates();
+  }
+
+  const cached = resolutionContext.cache.get(cacheKey);
+  if (cached) {
+    return cached as T[];
+  }
+
+  const candidates = loadCandidates();
+  resolutionContext.cache.set(cacheKey, candidates);
+  return candidates;
+}
+
+export function readPreviousSelectedNumber(
+  state: WorkflowState,
+  stepName: string,
+  bindingName: string,
+): number | undefined {
+  const context = state.systemContexts.get(stepName);
+  if (!context || typeof context !== 'object') {
+    return undefined;
+  }
+
+  const selectedItem = (context as Record<string, unknown>)[bindingName];
+  if (!selectedItem || typeof selectedItem !== 'object') {
+    return undefined;
+  }
+
+  const number = (selectedItem as Record<string, unknown>).number;
+  return typeof number === 'number' ? number : undefined;
+}
+
+export function selectNextCandidate<T extends NumberedCandidate>(
+  candidates: T[],
+  previousNumber: number | undefined,
+): T | undefined {
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  if (previousNumber === undefined) {
+    return candidates[0];
+  }
+
+  const previousIndex = candidates.findIndex((candidate) => candidate.number === previousNumber);
+  if (previousIndex === -1) {
+    return candidates[0];
+  }
+
+  return candidates[(previousIndex + 1) % candidates.length];
+}


### PR DESCRIPTION
## Summary

Issue #662: orchestration loop から repo 全体の Issue を観測できる system input を追加する。

`auto-improvement-loop` の Issue 分岐が `issue_context`（current task 起点の 1 件のみ）に依存して実質 dead branch になっていた問題を解消し、PR と対称な `issue_list` / `issue_selection` を追加する。

## 変更内容

- `src/core/models/workflow-issue-system-schemas.ts`（新規）— issue 観測用 system input schema
- `src/core/models/workflow-system-input-types.ts`（新規）— system input 型の切り出し
- `src/core/models/workflow-provider-options.ts`（新規）— provider options の切り出し
- `src/core/models/workflow-types.ts` — 既存型を新ファイルへ分割
- `src/infra/workflow/system/system-issue-input-resolver.ts`（新規）— `issue_list` / `issue_selection` の resolver
- `src/infra/workflow/system/system-selection-helpers.ts`（新規）— 選択ヘルパ
- `src/infra/github/issue.ts` / `src/infra/gitlab/issue.ts` / provider 類 — repo 全体の open Issue 取得 API を拡充
- `builtins/{en,ja}/workflows/auto-improvement-loop.yaml` — Issue 分岐を repo 観測ベースに更新
- テスト: `system-workflow-schema.test.ts`、`it-system-workflow-execution.test.ts`、`system-step-services.test.ts`、provider 系テスト拡張

## 受け入れ条件（Issue より）

- orchestration workflow から repo 全体の open Issue を観測できる
- list と selection の両方が使える
- `auto-improvement-loop` の Issue 分岐が current task issue に依存しない
- PR がないが open Issue がある場合、Issue 分岐に進める
- 旧仕様の意図はコメントで残す

Closes #662