### PR TITLE
[#626] fix-copilot-effort-save

### DIFF
--- a/src/__tests__/config-normalizers-provider-options.test.ts
+++ b/src/__tests__/config-normalizers-provider-options.test.ts
@@ -3,6 +3,7 @@ import {
   buildRawTaktProvidersOrThrow,
   denormalizeProviderOptions,
 } from '../infra/config/configNormalizers.js';
+import { normalizeProviderOptions } from '../infra/config/providerOptions.js';
 
 describe('denormalizeProviderOptions', () => {
   it('should convert camelCase provider options into persisted snake_case format', () => {
@@ -79,6 +80,24 @@ describe('denormalizeProviderOptions', () => {
         effort: 'medium',
       },
     });
+  });
+
+  it('should round-trip copilot effort through normalize and denormalize', () => {
+    const rawProviderOptions = {
+      copilot: {
+        effort: 'high',
+      },
+    };
+
+    const normalizedProviderOptions = normalizeProviderOptions(rawProviderOptions);
+    const denormalizedProviderOptions = denormalizeProviderOptions(normalizedProviderOptions);
+
+    expect(normalizedProviderOptions).toEqual({
+      copilot: {
+        effort: 'high',
+      },
+    });
+    expect(denormalizedProviderOptions).toEqual(rawProviderOptions);
   });
 });
 


### PR DESCRIPTION
## Summary

## 背景

`provider_options.copilot.effort` を読み込み・実行時に使う実装は入っているが、設定保存時の `denormalizeProviderOptions()` が `copilot` を書き戻していない。

該当:

- 読み込み: `src/infra/config/providerOptions.ts`
- 実行: `src/infra/providers/copilot.ts`, `src/infra/copilot/client.ts`
- 保存: `src/infra/config/configNormalizers.ts`

## 現状

`denormalizeProviderOptions()` は `codex` / `opencode` / `claude` しか raw 形式へ戻しておらず、`copilot.effort` を永続化しない。

そのため、将来 `saveProjectConfig()` / `saveGlobalConfig()` 系の保存経路で `providerOptions` を round-trip させると、`provider_options.copilot.effort` だけ落ちる。

現時点ではこの保存経路をユーザーが高頻度で踏むわけではなさそうなので、優先度は高くない。

## やること

- `denormalizeProviderOptions()` に `copilot.effort` を追加する
- `config-normalizers-provider-options.test.ts` に round-trip 用の回帰テストを追加する

期待する出力:

```yaml
provider_options:
  copilot:
    effort: high
```

## 補足

PR #625 のマージブロッカーではないが、provider_options の round-trip 整合性としては埋めておいた方がよい。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #626