### PR TITLE
[#603] protect-parent-run-pid

### DIFF
--- a/src/__tests__/agent-usecases.test.ts
+++ b/src/__tests__/agent-usecases.test.ts
@@ -402,6 +402,35 @@ describe('agent-usecases', () => {
     );
   });
 
+  it('decomposeTask は workflowMeta を runAgent に伝搬する', async () => {
+    vi.mocked(runAgent).mockResolvedValue(doneResponse('x', {
+      parts: [
+        { id: 'p1', title: 'Part 1', instruction: 'Do 1' },
+      ],
+    }));
+    const workflowMeta = {
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      stepsList: [{ name: 'plan' }, { name: 'implement' }],
+      currentPosition: '2/2',
+      processSafety: {
+        protectedParentRunPid: 4242,
+      },
+    };
+
+    await decomposeTask('instruction', 2, {
+      cwd: '/repo',
+      persona: 'team-leader',
+      workflowMeta,
+    } as DecomposeTaskOptions & { workflowMeta: typeof workflowMeta });
+
+    expect(runAgent).toHaveBeenCalledWith(
+      'team-leader',
+      expect.any(String),
+      expect.objectContaining({ workflowMeta }),
+    );
+  });
+
   it('requestMoreParts は構造化出力をパースして返す', async () => {
     vi.mocked(runAgent).mockResolvedValue(doneResponse('x', {
       done: false,
@@ -448,6 +477,41 @@ describe('agent-usecases', () => {
       1,
       { cwd: '/repo', persona: 'team-leader' },
     )).rejects.toThrow('Team leader feedback failed: timeout');
+  });
+
+  it('requestMoreParts は workflowMeta を runAgent に伝搬する', async () => {
+    vi.mocked(runAgent).mockResolvedValue(doneResponse('x', {
+      done: true,
+      reasoning: 'enough',
+      parts: [],
+    }));
+    const workflowMeta = {
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      stepsList: [{ name: 'plan' }, { name: 'implement' }],
+      currentPosition: '2/2',
+      processSafety: {
+        protectedParentRunPid: 4242,
+      },
+    };
+
+    await requestMoreParts(
+      'instruction',
+      [{ id: 'p1', title: 'Part 1', status: 'done', content: 'ok' }],
+      ['p1'],
+      1,
+      {
+        cwd: '/repo',
+        persona: 'team-leader',
+        workflowMeta,
+      } as DecomposeTaskOptions & { workflowMeta: typeof workflowMeta },
+    );
+
+    expect(runAgent).toHaveBeenCalledWith(
+      'team-leader',
+      expect.any(String),
+      expect.objectContaining({ workflowMeta }),
+    );
   });
 
   // --- runTagJudgeStage (ARCH-NEW-DRY-Stage2-judgeStatus 再発防止) ---

--- a/src/__tests__/file-size-boundary.test.ts
+++ b/src/__tests__/file-size-boundary.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readModule(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf-8');
+}
+
+describe('file size boundary', () => {
+  it.each([
+    '../agents/runner.ts',
+    '../core/workflow/engine/OptionsBuilder.ts',
+    '../core/workflow/engine/TeamLeaderRunner.ts',
+  ])('keeps %s under the 300-line architecture limit', (path) => {
+    const source = readModule(path);
+    expect(source.trimEnd().split('\n').length).toBeLessThanOrEqual(299);
+  });
+});

--- a/src/__tests__/option-resolution-order.test.ts
+++ b/src/__tests__/option-resolution-order.test.ts
@@ -4,6 +4,7 @@ const {
   getProviderMock,
   loadCustomAgentsMock,
   loadAgentPromptMock,
+  loadPersonaPromptFromPathMock,
   loadProjectConfigMock,
   loadGlobalConfigMock,
   resolveConfigValueMock,
@@ -19,6 +20,7 @@ const {
     getProviderMock: vi.fn(() => ({ setup: providerSetup })),
     loadCustomAgentsMock: vi.fn(),
     loadAgentPromptMock: vi.fn(),
+    loadPersonaPromptFromPathMock: vi.fn(),
     loadProjectConfigMock: vi.fn(),
     loadGlobalConfigMock: vi.fn(),
     resolveConfigValueMock: vi.fn(),
@@ -38,6 +40,7 @@ vi.mock('../infra/config/index.js', () => ({
   loadGlobalConfig: loadGlobalConfigMock,
   loadCustomAgents: loadCustomAgentsMock,
   loadAgentPrompt: loadAgentPromptMock,
+  loadPersonaPromptFromPath: loadPersonaPromptFromPathMock,
 }));
 
 vi.mock('../infra/config/resolveConfigValue.js', () => ({
@@ -71,6 +74,7 @@ describe('option resolution order', () => {
     });
     loadCustomAgentsMock.mockReturnValue(new Map());
     loadAgentPromptMock.mockReturnValue('prompt');
+    loadPersonaPromptFromPathMock.mockReturnValue('persona prompt from path');
     loadTemplateMock.mockReturnValue('template');
   });
 
@@ -666,6 +670,155 @@ describe('option resolution order', () => {
       'task',
       expect.objectContaining({ allowedTools: ['Write'] }),
     );
+  });
+
+  it('should wrap inline persona prompt when workflowMeta has process safety', async () => {
+    loadProjectConfigMock.mockReturnValue({ provider: 'claude' });
+
+    await runAgent('inline persona', 'task', {
+      cwd: '/repo',
+      language: 'en',
+      workflowMeta: {
+        workflowName: 'takt-default',
+        currentStep: 'implement',
+        stepsList: [{ name: 'plan' }, { name: 'implement' }],
+        currentPosition: '2/2',
+        processSafety: { protectedParentRunPid: 4242 },
+      },
+    });
+
+    expect(loadTemplateMock).toHaveBeenCalledWith(
+      'perform_agent_system_prompt',
+      'en',
+      expect.objectContaining({
+        agentDefinition: 'inline persona',
+        workflowName: 'takt-default',
+        currentStep: 'implement',
+        hasProcessSafety: true,
+        protectedParentRunPid: '4242',
+      }),
+    );
+    expect(providerSetupMock).toHaveBeenCalledWith(expect.objectContaining({
+      systemPrompt: 'template',
+    }));
+  });
+
+  it('should wrap personaPath prompt when workflowMeta has process safety', async () => {
+    loadProjectConfigMock.mockReturnValue({ provider: 'claude' });
+
+    await runAgent(undefined, 'task', {
+      cwd: '/repo',
+      projectCwd: '/project',
+      personaPath: '/project/.takt/personas/coder.md',
+      language: 'en',
+      workflowMeta: {
+        workflowName: 'takt-default',
+        currentStep: 'implement',
+        stepsList: [{ name: 'plan' }, { name: 'implement' }],
+        currentPosition: '2/2',
+        processSafety: { protectedParentRunPid: 4242 },
+      },
+    });
+
+    expect(loadPersonaPromptFromPathMock).toHaveBeenCalledWith(
+      '/project/.takt/personas/coder.md',
+      '/project',
+    );
+    expect(loadTemplateMock).toHaveBeenCalledWith(
+      'perform_agent_system_prompt',
+      'en',
+      expect.objectContaining({
+        agentDefinition: 'persona prompt from path',
+        workflowName: 'takt-default',
+        currentStep: 'implement',
+        hasProcessSafety: true,
+        protectedParentRunPid: '4242',
+      }),
+    );
+    expect(providerSetupMock).toHaveBeenCalledWith(expect.objectContaining({
+      systemPrompt: 'template',
+    }));
+  });
+
+  it('should not wrap inline persona prompt when workflowMeta has no process safety', async () => {
+    loadProjectConfigMock.mockReturnValue({ provider: 'claude' });
+
+    await runAgent('inline persona', 'task', {
+      cwd: '/repo',
+      language: 'en',
+      workflowMeta: {
+        workflowName: 'custom-workflow',
+        currentStep: 'review',
+        stepsList: [{ name: 'plan' }, { name: 'review' }],
+        currentPosition: '2/2',
+      },
+    });
+
+    expect(loadTemplateMock).not.toHaveBeenCalled();
+    expect(providerSetupMock).toHaveBeenCalledWith(expect.objectContaining({
+      systemPrompt: 'inline persona',
+    }));
+  });
+
+  it('should wrap custom agent prompt when workflowMeta has process safety', async () => {
+    loadProjectConfigMock.mockReturnValue({ provider: 'claude' });
+    loadCustomAgentsMock.mockReturnValue(new Map([
+      ['custom', { name: 'custom', prompt: 'agent prompt' }],
+    ]));
+    loadAgentPromptMock.mockReturnValue('custom prompt');
+
+    await runAgent('custom', 'task', {
+      cwd: '/repo',
+      language: 'en',
+      workflowMeta: {
+        workflowName: 'takt-default',
+        currentStep: 'implement',
+        stepsList: [{ name: 'plan' }, { name: 'implement' }],
+        currentPosition: '2/2',
+        processSafety: { protectedParentRunPid: 4242 },
+      },
+    });
+
+    expect(loadTemplateMock).toHaveBeenCalledWith(
+      'perform_agent_system_prompt',
+      'en',
+      expect.objectContaining({
+        agentDefinition: 'custom prompt',
+        workflowName: 'takt-default',
+        currentStep: 'implement',
+        hasProcessSafety: true,
+        protectedParentRunPid: '4242',
+      }),
+    );
+    expect(providerSetupMock).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'custom',
+      systemPrompt: 'template',
+    }));
+  });
+
+  it('should not wrap custom agent prompt when workflowMeta has no process safety', async () => {
+    loadProjectConfigMock.mockReturnValue({ provider: 'claude' });
+    loadCustomAgentsMock.mockReturnValue(new Map([
+      ['custom', { name: 'custom', prompt: 'agent prompt' }],
+    ]));
+    loadAgentPromptMock.mockReturnValue('custom prompt');
+
+    await runAgent('custom', 'task', {
+      cwd: '/repo',
+      language: 'en',
+      workflowMeta: {
+        workflowName: 'custom-workflow',
+        currentStep: 'review',
+        stepsList: [{ name: 'plan' }, { name: 'review' }],
+        currentPosition: '2/2',
+      },
+    });
+
+    expect(loadTemplateMock).not.toHaveBeenCalled();
+    expect(providerSetupMock).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'custom',
+      systemPrompt: 'custom prompt',
+    }));
   });
 
   it('should resolve permission mode after provider resolution using provider profiles', async () => {

--- a/src/__tests__/options-builder.test.ts
+++ b/src/__tests__/options-builder.test.ts
@@ -13,7 +13,17 @@ function createStep(overrides: Partial<WorkflowStep> = {}): WorkflowStep {
   };
 }
 
-function createBuilder(step: WorkflowStep, engineOverrides: Partial<WorkflowEngineOptions> = {}): OptionsBuilder {
+type BuilderEngineOverrides = Partial<WorkflowEngineOptions> & {
+  workflowName?: string;
+};
+
+function createProcessSafetyByStep(parentRunPid: number): WorkflowEngineOptions['phase1ProcessSafetyByStep'] {
+  return {
+    implement: { protectedParentRunPid: parentRunPid },
+  };
+}
+
+function createBuilder(step: WorkflowStep, engineOverrides: BuilderEngineOverrides = {}): OptionsBuilder {
   const engineOptions: WorkflowEngineOptions = {
     projectCwd: '/project',
     provider: 'codex',
@@ -33,7 +43,7 @@ function createBuilder(step: WorkflowStep, engineOverrides: Partial<WorkflowEngi
     () => '.takt/runs/sample/reports',
     () => 'ja',
     () => [{ name: step.name }],
-    () => 'default',
+    () => engineOverrides.workflowName ?? 'default',
     () => 'test workflow',
   );
 }
@@ -244,6 +254,86 @@ describe('OptionsBuilder.buildBaseOptions', () => {
       codex: { reasoningEffort: 'low' },
     });
   });
+
+  it('buildBaseOptions は takt-default の implement でも process safety を workflowMeta に含めない', () => {
+    const step = createStep({ name: 'implement' });
+    const builder = createBuilder(step, {
+      workflowName: 'takt-default',
+      phase1ProcessSafetyByStep: createProcessSafetyByStep(4242),
+    });
+
+    const options = builder.buildBaseOptions(step);
+
+    expect(options.workflowMeta).toEqual(expect.objectContaining({
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+    }));
+    expect(options.workflowMeta?.processSafety).toBeUndefined();
+  });
+
+  it('takt-default の implement では Phase 1 agent options に process safety を workflowMeta に含める', () => {
+    const step = createStep({ name: 'implement' });
+    const builder = createBuilder(step, {
+      workflowName: 'takt-default',
+      phase1ProcessSafetyByStep: createProcessSafetyByStep(4242),
+    });
+
+    const options = builder.buildAgentOptions(step);
+
+    expect(options.workflowMeta).toEqual(expect.objectContaining({
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      processSafety: { protectedParentRunPid: 4242 },
+    }));
+  });
+
+  it('takt-default の implement.part-* でも process safety を workflowMeta に含める', () => {
+    const step = createStep({
+      name: 'implement.part-1',
+      persona: 'coder',
+      personaDisplayName: 'coder',
+    });
+    const builder = createBuilder(step, {
+      workflowName: 'takt-default',
+      phase1ProcessSafetyByStep: createProcessSafetyByStep(4242),
+    });
+
+    const options = builder.buildAgentOptions(step, {
+      teamLeaderPart: {
+        processSafety: { protectedParentRunPid: 4242 },
+      },
+    });
+
+    expect(options.workflowMeta).toEqual(expect.objectContaining({
+      workflowName: 'takt-default',
+      currentStep: 'implement.part-1',
+      processSafety: { protectedParentRunPid: 4242 },
+    }));
+  });
+
+  it('takt-default の非 implement step では process safety を workflowMeta に含めない', () => {
+    const step = createStep({ name: 'reviewers' });
+    const builder = createBuilder(step, {
+      workflowName: 'takt-default',
+      phase1ProcessSafetyByStep: createProcessSafetyByStep(4242),
+    });
+
+    const options = builder.buildAgentOptions(step);
+
+    expect(options.workflowMeta?.processSafety).toBeUndefined();
+  });
+
+  it('対象外の workflow/step では process safety を workflowMeta に含めない', () => {
+    const step = createStep({ name: 'reviewers' });
+    const builder = createBuilder(step, {
+      workflowName: 'custom-workflow',
+      phase1ProcessSafetyByStep: createProcessSafetyByStep(4242),
+    });
+
+    const options = builder.buildBaseOptions(step);
+
+    expect(options.workflowMeta?.processSafety).toBeUndefined();
+  });
 });
 
 describe('OptionsBuilder.resolveStepProviderModel', () => {
@@ -366,6 +456,39 @@ describe('OptionsBuilder.buildResumeOptions', () => {
     expect(options.allowedTools).toEqual([]);
     expect(options.maxTurns).toBe(3);
     expect(options.sessionId).toBe('session-123');
+  });
+
+  it('report/status phase では takt-default の implement でも process safety を付与しない', () => {
+    const step = createStep({ name: 'implement' });
+    const builder = createBuilder(step, {
+      workflowName: 'takt-default',
+      phase1ProcessSafetyByStep: createProcessSafetyByStep(4242),
+    });
+
+    const options = builder.buildResumeOptions(step, 'session-123', { maxTurns: 3 });
+
+    expect(options.workflowMeta?.processSafety).toBeUndefined();
+  });
+});
+
+describe('OptionsBuilder.buildNewSessionReportOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('new session の report phase でも process safety を付与しない', () => {
+    const step = createStep({ name: 'implement' });
+    const builder = createBuilder(step, {
+      workflowName: 'takt-default',
+      phase1ProcessSafetyByStep: createProcessSafetyByStep(4242),
+    });
+
+    const options = builder.buildNewSessionReportOptions(step, {
+      allowedTools: ['Write'],
+      maxTurns: 3,
+    });
+
+    expect(options.workflowMeta?.processSafety).toBeUndefined();
   });
 });
 

--- a/src/__tests__/prompts.test.ts
+++ b/src/__tests__/prompts.test.ts
@@ -284,6 +284,38 @@ describe('template content integrity', () => {
     expect(findDeprecatedTerms(ja)).toEqual([]);
   });
 
+  it('perform_agent_system_prompt renders full process safety guidance in both languages', () => {
+    const en = loadTemplate('perform_agent_system_prompt', 'en', {
+      agentDefinition: 'agent',
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      stepsList: '1. implement',
+      currentPosition: '1/1',
+      hasProcessSafety: true,
+      protectedParentRunPid: '4242',
+    });
+    expect(en).toContain('protected PID');
+    expect(en).toContain('pkill');
+    expect(en).toContain('killall');
+    expect(en).toContain('name-based kill');
+    expect(en).toContain('clearly own them');
+
+    const ja = loadTemplate('perform_agent_system_prompt', 'ja', {
+      agentDefinition: 'agent',
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      stepsList: '1. implement',
+      currentPosition: '1/1',
+      hasProcessSafety: true,
+      protectedParentRunPid: '4242',
+    });
+    expect(ja).toContain('protected PID');
+    expect(ja).toContain('pkill');
+    expect(ja).toContain('killall');
+    expect(ja).toContain('プロセス名ベースの kill');
+    expect(ja).toContain('自分が所有していると明確に分かるプロセス以外は停止してはいけません');
+  });
+
   it('perform_judge_message contains {{agentOutput}} and {{conditionList}} placeholders', () => {
     const result = loadTemplate('perform_judge_message', 'en');
     expect(result).toContain('{{agentOutput}}');

--- a/src/__tests__/structured-caller-prompt-based.test.ts
+++ b/src/__tests__/structured-caller-prompt-based.test.ts
@@ -157,6 +157,47 @@ describe('PromptBasedStructuredCaller', () => {
     );
   });
 
+  it('should pass workflowMeta through decomposeTask to runAgent', async () => {
+    mockRunAgent.mockResolvedValue({
+      persona: 'leader',
+      status: 'done',
+      content: [
+        '```json',
+        JSON.stringify([
+          { id: 'p1', title: 'First task', instruction: 'Do the first thing' },
+        ]),
+        '```',
+      ].join('\n'),
+      timestamp: new Date(),
+    });
+    const workflowMeta = {
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      stepsList: [{ name: 'plan' }, { name: 'implement' }],
+      currentPosition: '2/2',
+      processSafety: {
+        protectedParentRunPid: 4242,
+      },
+    };
+
+    const caller = new PromptBasedStructuredCaller();
+    await caller.decomposeTask('break down the work', 3, {
+      cwd: '/tmp/project',
+      provider: 'claude',
+      persona: 'team-leader',
+      workflowMeta,
+    } as Parameters<PromptBasedStructuredCaller['decomposeTask']>[2] & { workflowMeta: typeof workflowMeta });
+
+    expect(mockRunAgent).toHaveBeenCalledWith(
+      'team-leader',
+      expect.stringContaining('```json'),
+      expect.objectContaining({
+        cwd: '/tmp/project',
+        workflowMeta,
+      }),
+    );
+  });
+
   it('should parse additional parts from fenced JSON without outputSchema', async () => {
     mockRunAgent.mockResolvedValue({
       persona: 'leader',
@@ -237,6 +278,50 @@ describe('PromptBasedStructuredCaller', () => {
         resolvedProvider: 'cursor',
         model: 'sonnet',
         resolvedModel: 'cursor-fast',
+      }),
+    );
+  });
+
+  it('should pass workflowMeta through requestMoreParts to runAgent', async () => {
+    mockRunAgent.mockResolvedValue({
+      persona: 'leader',
+      status: 'done',
+      content: [
+        '```json',
+        JSON.stringify({ done: true, reasoning: 'enough', parts: [] }),
+        '```',
+      ].join('\n'),
+      timestamp: new Date(),
+    });
+    const workflowMeta = {
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      stepsList: [{ name: 'plan' }, { name: 'implement' }],
+      currentPosition: '2/2',
+      processSafety: {
+        protectedParentRunPid: 4242,
+      },
+    };
+
+    const caller = new PromptBasedStructuredCaller();
+    await caller.requestMoreParts(
+      'original task',
+      [{ id: 'p1', title: 'First', status: 'done', content: 'done' }],
+      ['p1'],
+      2,
+      {
+        cwd: '/tmp/project',
+        persona: 'team-leader',
+        workflowMeta,
+      } as Parameters<PromptBasedStructuredCaller['requestMoreParts']>[4] & { workflowMeta: typeof workflowMeta },
+    );
+
+    expect(mockRunAgent).toHaveBeenCalledWith(
+      'team-leader',
+      expect.stringContaining('```json ... ```'),
+      expect.objectContaining({
+        cwd: '/tmp/project',
+        workflowMeta,
       }),
     );
   });

--- a/src/__tests__/team-leader-runner-structured-caller.test.ts
+++ b/src/__tests__/team-leader-runner-structured-caller.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OptionsBuilder } from '../core/workflow/engine/OptionsBuilder.js';
 import { TeamLeaderRunner } from '../core/workflow/engine/TeamLeaderRunner.js';
 import type { WorkflowStep, WorkflowState } from '../core/models/types.js';
+import type { WorkflowEngineOptions } from '../core/workflow/types.js';
+
+function createProcessSafetyByStep(parentRunPid: number): WorkflowEngineOptions['phase1ProcessSafetyByStep'] {
+  return {
+    implement: { protectedParentRunPid: parentRunPid },
+  };
+}
 
 const {
   mockExecuteAgent,
@@ -49,6 +57,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
     const runner = new TeamLeaderRunner({
       optionsBuilder: {
         buildAgentOptions: vi.fn().mockReturnValue({ cwd: '/tmp/project' }),
+        buildBaseOptions: vi.fn().mockReturnValue({}),
+        buildPhase1WorkflowMeta: vi.fn().mockReturnValue(undefined),
         resolveStepProviderModel,
       },
       stepExecutor: {
@@ -164,6 +174,237 @@ describe('TeamLeaderRunner with structuredCaller', () => {
     );
   });
 
+  it('takt-default の implement では process safety を leader prompt に渡す', async () => {
+    mockExecuteAgent.mockResolvedValue({
+      persona: 'coder',
+      status: 'done',
+      content: 'API done',
+      timestamp: new Date('2026-04-01T00:00:00.000Z'),
+    });
+    const resolveStepProviderModel = vi.fn().mockReturnValue({
+      provider: 'opencode',
+      model: 'opencode/zai-coding-plan/glm-5.1',
+    });
+
+    const structuredCaller = {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        options.onPromptResolved?.({
+          systemPrompt: 'team-leader-system',
+          userInstruction: 'leader instruction',
+        });
+        return [
+          { id: 'part-1', title: 'API', instruction: 'Implement API' },
+        ];
+      }),
+      requestMoreParts: vi.fn().mockResolvedValue({
+        done: true,
+        reasoning: 'enough',
+        parts: [],
+      }),
+    };
+    const leaderWorkflowMeta = {
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      stepsList: [{ name: 'plan' }, { name: 'implement' }],
+      currentPosition: '2/2',
+      processSafety: { protectedParentRunPid: 4242 },
+    };
+
+    const runner = new TeamLeaderRunner({
+      optionsBuilder: {
+        buildAgentOptions: vi.fn().mockReturnValue({ cwd: '/tmp/project' }),
+        buildBaseOptions: vi.fn().mockReturnValue({
+          workflowMeta: {
+            workflowName: 'takt-default',
+            currentStep: 'implement',
+            stepsList: [{ name: 'plan' }, { name: 'implement' }],
+            currentPosition: '2/2',
+          },
+        }),
+        buildPhase1WorkflowMeta: vi.fn().mockReturnValue(leaderWorkflowMeta),
+        resolveStepProviderModel,
+      },
+      stepExecutor: {
+        buildInstruction: vi.fn().mockReturnValue('leader instruction'),
+        applyPostExecutionPhases: vi.fn(async (_step, _state, _iteration, response) => response),
+        persistPreviousResponseSnapshot: vi.fn(),
+        emitStepReports: vi.fn(),
+      },
+      engineOptions: {
+        projectCwd: '/tmp/project',
+        structuredCaller,
+      },
+      getCwd: () => '/tmp/project',
+      getInteractive: () => false,
+    } as ConstructorParameters<typeof TeamLeaderRunner>[0] & {
+      engineOptions: { projectCwd: string; structuredCaller: typeof structuredCaller };
+    });
+
+    const step: WorkflowStep = {
+      name: 'implement',
+      persona: 'coder',
+      personaDisplayName: 'coder',
+      instruction: 'Task: {task}',
+      passPreviousResponse: true,
+      teamLeader: {
+        persona: 'team-leader',
+        maxParts: 2,
+        refillThreshold: 0,
+        timeoutMs: 1000,
+        partPersona: 'coder',
+      },
+      rules: [{ condition: 'done', next: 'COMPLETE' }],
+    };
+
+    const state: WorkflowState = {
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      iteration: 1,
+      stepOutputs: new Map(),
+      structuredOutputs: new Map(),
+      systemContexts: new Map(),
+      effectResults: new Map(),
+      lastOutput: undefined,
+      previousResponseSourcePath: undefined,
+      userInputs: [],
+      personaSessions: new Map(),
+      stepIterations: new Map(),
+      status: 'running',
+    };
+
+    await runner.runTeamLeaderStep(
+      step,
+      state,
+      'implement feature',
+      5,
+      vi.fn(),
+    );
+
+    const [, , decomposeOptions] = structuredCaller.decomposeTask.mock.calls[0] ?? [];
+    const [, , , , requestOptions] = structuredCaller.requestMoreParts.mock.calls[0] ?? [];
+    expect(decomposeOptions.workflowMeta).toBe(leaderWorkflowMeta);
+    expect(requestOptions.workflowMeta).toBe(leaderWorkflowMeta);
+  });
+
+  it('takt-default の非 implement step では leader prompt に process safety を渡さない', async () => {
+    mockExecuteAgent.mockResolvedValue({
+      persona: 'coder',
+      status: 'done',
+      content: 'API done',
+      timestamp: new Date('2026-04-01T00:00:00.000Z'),
+    });
+    const resolveStepProviderModel = vi.fn().mockReturnValue({
+      provider: 'opencode',
+      model: 'opencode/zai-coding-plan/glm-5.1',
+    });
+
+    const structuredCaller = {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        options.onPromptResolved?.({
+          systemPrompt: 'team-leader-system',
+          userInstruction: 'leader instruction',
+        });
+        return [
+          { id: 'part-1', title: 'API', instruction: 'Implement API' },
+        ];
+      }),
+      requestMoreParts: vi.fn().mockResolvedValue({
+        done: true,
+        reasoning: 'enough',
+        parts: [],
+      }),
+    };
+
+    const engineOptions: WorkflowEngineOptions = {
+      projectCwd: '/tmp/project',
+      provider: 'opencode',
+      providerProfiles: {
+        opencode: {
+          defaultPermissionMode: 'full',
+        },
+      },
+      structuredCaller,
+      phase1ProcessSafetyByStep: createProcessSafetyByStep(4242),
+    };
+    const optionsBuilder = new OptionsBuilder(
+      engineOptions,
+      () => '/tmp/project',
+      () => '/tmp/project',
+      () => undefined,
+      () => '.takt/runs/sample/reports',
+      () => 'ja',
+      () => [{ name: 'reviewers' }],
+      () => 'takt-default',
+      () => 'test workflow',
+    );
+
+    const runner = new TeamLeaderRunner({
+      optionsBuilder,
+      stepExecutor: {
+        buildInstruction: vi.fn().mockReturnValue('leader instruction'),
+        applyPostExecutionPhases: vi.fn(async (_step, _state, _iteration, response) => response),
+        persistPreviousResponseSnapshot: vi.fn(),
+        emitStepReports: vi.fn(),
+      },
+      engineOptions: {
+        projectCwd: '/tmp/project',
+        structuredCaller,
+        phase1ProcessSafetyByStep: createProcessSafetyByStep(4242),
+      },
+      getCwd: () => '/tmp/project',
+      getInteractive: () => false,
+    } as ConstructorParameters<typeof TeamLeaderRunner>[0] & {
+      engineOptions: {
+        projectCwd: string;
+        structuredCaller: typeof structuredCaller;
+        phase1ProcessSafetyByStep: WorkflowEngineOptions['phase1ProcessSafetyByStep'];
+      };
+    });
+
+    const step: WorkflowStep = {
+      name: 'reviewers',
+      persona: 'coder',
+      personaDisplayName: 'coder',
+      instruction: 'Task: {task}',
+      passPreviousResponse: true,
+      teamLeader: {
+        persona: 'team-leader',
+        maxParts: 2,
+        refillThreshold: 0,
+        timeoutMs: 1000,
+        partPersona: 'coder',
+      },
+      rules: [{ condition: 'done', next: 'COMPLETE' }],
+    };
+
+    const state: WorkflowState = {
+      workflowName: 'takt-default',
+      currentStep: 'reviewers',
+      iteration: 1,
+      stepOutputs: new Map(),
+      structuredOutputs: new Map(),
+      systemContexts: new Map(),
+      effectResults: new Map(),
+      lastOutput: undefined,
+      previousResponseSourcePath: undefined,
+      userInputs: [],
+      personaSessions: new Map(),
+      stepIterations: new Map(),
+      status: 'running',
+    };
+
+    await runner.runTeamLeaderStep(
+      step,
+      state,
+      'implement feature',
+      5,
+      vi.fn(),
+    );
+
+    const [, , decomposeOptions] = structuredCaller.decomposeTask.mock.calls[0] ?? [];
+    expect(decomposeOptions.workflowMeta?.processSafety).toBeUndefined();
+  });
+
   it('Claude part execution では partAllowedTools を executeAgent options に反映する', async () => {
     mockExecuteAgent.mockResolvedValue({
       persona: 'coder',
@@ -198,10 +439,19 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       allowedTools: runtime?.teamLeaderPart?.partAllowedTools,
       providerOptions: undefined,
     }));
+    const leaderWorkflowMeta = {
+      workflowName: 'takt-default',
+      currentStep: 'implement',
+      stepsList: [{ name: 'plan' }, { name: 'implement' }],
+      currentPosition: '2/2',
+      processSafety: { protectedParentRunPid: 4242 },
+    };
 
     const runner = new TeamLeaderRunner({
       optionsBuilder: {
         buildAgentOptions,
+        buildBaseOptions: vi.fn().mockReturnValue({}),
+        buildPhase1WorkflowMeta: vi.fn().mockReturnValue(leaderWorkflowMeta),
         resolveStepProviderModel,
       },
       stepExecutor: {
@@ -290,10 +540,14 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         },
       },
     });
+    expect(runtimeArg?.teamLeaderPart?.processSafety).toEqual({
+      protectedParentRunPid: 4242,
+    });
     expect(runtimeArg).toEqual(expect.objectContaining({
       providerInfo: { provider: 'claude', model: 'sonnet' },
       teamLeaderPart: {
         partAllowedTools: ['Read', 'Edit'],
+        processSafety: { protectedParentRunPid: 4242 },
       },
     }));
     const [, , options] = mockExecuteAgent.mock.calls[0] ?? [];
@@ -337,6 +591,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
     const runner = new TeamLeaderRunner({
       optionsBuilder: {
         buildAgentOptions: vi.fn().mockReturnValue({ cwd: '/tmp/project' }),
+        buildBaseOptions: vi.fn().mockReturnValue({}),
+        buildPhase1WorkflowMeta: vi.fn().mockReturnValue(undefined),
         resolveStepProviderModel,
       },
       stepExecutor: {
@@ -436,6 +692,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
     const runner = new TeamLeaderRunner({
       optionsBuilder: {
         buildAgentOptions,
+        buildBaseOptions: vi.fn().mockReturnValue({}),
+        buildPhase1WorkflowMeta: vi.fn().mockReturnValue(undefined),
         resolveStepProviderModel,
       },
       stepExecutor: {

--- a/src/__tests__/workflowExecution-structured-caller.test.ts
+++ b/src/__tests__/workflowExecution-structured-caller.test.ts
@@ -497,6 +497,24 @@ beforeEach(() => {
     expect(MockWorkflowEngine.lastInstance.receivedOptions.model).toBe('cursor-fast');
   });
 
+  it('should pass resolved phase 1 process safety to WorkflowEngine', async () => {
+    await executeWorkflow({ ...makeConfig(), name: 'takt-default' }, 'task', '/tmp/project', {
+      projectCwd: '/tmp/project',
+    });
+
+    expect(MockWorkflowEngine.lastInstance.receivedOptions.phase1ProcessSafetyByStep).toEqual({
+      implement: { protectedParentRunPid: process.pid },
+    });
+  });
+
+  it('should not pass phase 1 process safety to WorkflowEngine for non target workflows', async () => {
+    await executeWorkflow(makeConfig(), 'task', '/tmp/project', {
+      projectCwd: '/tmp/project',
+    });
+
+    expect(MockWorkflowEngine.lastInstance.receivedOptions.phase1ProcessSafetyByStep).toBeUndefined();
+  });
+
   it('should resolve workflow_call named lookup in project -> user -> builtin order when executeWorkflow wires it', async () => {
     const projectDir = mkdtempSync(join(tmpdir(), 'takt-project-'));
     const configDir = mkdtempSync(join(tmpdir(), 'takt-config-'));

--- a/src/agents/decompose-task-usecase.ts
+++ b/src/agents/decompose-task-usecase.ts
@@ -1,6 +1,6 @@
 import type { Language, PartDefinition } from '../core/models/types.js';
 import type { ProviderType } from '../core/workflow/types.js';
-import { runAgent, type StreamCallback } from './runner.js';
+import { runAgent, type RunAgentOptions, type StreamCallback } from './runner.js';
 import { parseParts } from '../core/workflow/engine/task-decomposer.js';
 import { loadDecompositionSchema, loadMorePartsSchema } from '../infra/resources/schema-loader.js';
 import {
@@ -20,6 +20,7 @@ export interface DecomposeTaskOptions {
   resolvedModel?: string;
   resolvedProvider?: ProviderType;
   onStream?: StreamCallback;
+  workflowMeta?: RunAgentOptions['workflowMeta'];
   onPromptResolved?: (promptParts: {
     systemPrompt: string;
     userInstruction: string;
@@ -52,6 +53,7 @@ export async function decomposeTask(
     maxTurns: TEAM_LEADER_MAX_TURNS,
     outputSchema: loadDecompositionSchema(maxParts),
     onStream: options.onStream,
+    workflowMeta: options.workflowMeta,
     onPromptResolved: options.onPromptResolved,
   });
 
@@ -96,6 +98,7 @@ export async function requestMoreParts(
     maxTurns: TEAM_LEADER_MAX_TURNS,
     outputSchema: loadMorePartsSchema(maxAdditionalParts),
     onStream: options.onStream,
+    workflowMeta: options.workflowMeta,
   });
 
   if (response.status !== 'done') {

--- a/src/agents/persona-spec.ts
+++ b/src/agents/persona-spec.ts
@@ -1,0 +1,16 @@
+import { basename, dirname } from 'node:path';
+
+export function extractPersonaName(personaSpec: string): string {
+  if (!personaSpec.endsWith('.md')) {
+    return personaSpec;
+  }
+
+  const name = basename(personaSpec, '.md');
+  const dir = basename(dirname(personaSpec));
+
+  if (dir === 'personas' || dir === '.') {
+    return name;
+  }
+
+  return `${dir}/${name}`;
+}

--- a/src/agents/runner-prompt.ts
+++ b/src/agents/runner-prompt.ts
@@ -1,0 +1,34 @@
+import { loadTemplate } from '../shared/prompts/index.js';
+import type { RunAgentOptions } from './types.js';
+
+type WrappedPromptOptions = Pick<RunAgentOptions, 'language' | 'workflowMeta' | 'personaPath'>;
+
+function shouldWrapAgentDefinition(options: Pick<RunAgentOptions, 'personaPath' | 'workflowMeta'>): boolean {
+  return options.personaPath !== undefined || options.workflowMeta?.processSafety !== undefined;
+}
+
+export function buildWrappedSystemPrompt(
+  agentDefinition: string,
+  options: WrappedPromptOptions,
+): string {
+  if (!shouldWrapAgentDefinition(options)) {
+    return agentDefinition;
+  }
+
+  const templateVars: Record<string, string | boolean> = { agentDefinition };
+  if (options.workflowMeta) {
+    templateVars.workflowName = options.workflowMeta.workflowName;
+    templateVars.workflowDescription = options.workflowMeta.workflowDescription ?? '';
+    templateVars.currentStep = options.workflowMeta.currentStep;
+    templateVars.stepsList = options.workflowMeta.stepsList
+      .map((step, index) => `${index + 1}. ${step.name}${step.description ? ` - ${step.description}` : ''}`)
+      .join('\n');
+    templateVars.currentPosition = options.workflowMeta.currentPosition;
+    templateVars.hasProcessSafety = options.workflowMeta.processSafety !== undefined;
+    if (options.workflowMeta.processSafety) {
+      templateVars.protectedParentRunPid = String(options.workflowMeta.processSafety.protectedParentRunPid);
+    }
+  }
+
+  return loadTemplate('perform_agent_system_prompt', options.language ?? 'en', templateVars);
+}

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -1,8 +1,3 @@
-/**
- * Agent execution runners
- */
-
-import { basename, dirname } from 'node:path';
 import {
   loadCustomAgents,
   loadAgentPrompt,
@@ -23,8 +18,9 @@ import type { AgentResponse, CustomAgentConfig } from '../core/models/index.js';
 import { resolveAgentProviderModel } from '../core/workflow/provider-resolution.js';
 import { DEFAULT_PROVIDER_PERMISSION_PROFILES, resolveStepPermissionMode } from '../core/workflow/permission-profile-resolution.js';
 import { createLogger } from '../shared/utils/index.js';
-import { loadTemplate } from '../shared/prompts/index.js';
 import type { RunAgentOptions } from './types.js';
+import { buildWrappedSystemPrompt } from './runner-prompt.js';
+import { extractPersonaName } from './persona-spec.js';
 
 export type { RunAgentOptions, StreamCallback } from './types.js';
 
@@ -35,12 +31,6 @@ type ResolvedProviderOptionsHandoff = {
 
 type RunnerHandoffOptions = RunAgentOptions & ResolvedProviderOptionsHandoff;
 
-/**
- * Agent execution runner.
- *
- * Resolves agent configuration (provider, model, prompt) and
- * delegates execution to the appropriate provider.
- */
 export class AgentRunner {
   private static resolvePersonaProviders(cwd: string) {
     return resolveConfigValue(cwd, 'personaProviders');
@@ -92,25 +82,6 @@ export class AgentRunner {
     };
   }
 
-  /**
-   * Get persona name from path or spec.
-   * For personas in subdirectories, includes parent dir for pattern matching.
-   */
-  private static extractPersonaName(personaSpec: string): string {
-    if (!personaSpec.endsWith('.md')) {
-      return personaSpec;
-    }
-
-    const name = basename(personaSpec, '.md');
-    const dir = basename(dirname(personaSpec));
-
-    if (dir === 'personas' || dir === '.') {
-      return name;
-    }
-
-    return `${dir}/${name}`;
-  }
-
   private static resolveProviderOptions(
     cwd: string,
     personaDisplayName: string | undefined,
@@ -140,7 +111,6 @@ export class AgentRunner {
     );
   }
 
-  /** Build ProviderCallOptions from RunAgentOptions */
   private static buildCallOptions(
     resolvedModel: string | undefined,
     resolvedProvider: ProviderType,
@@ -194,7 +164,6 @@ export class AgentRunner {
     return options.permissionMode;
   }
 
-  /** Run a custom agent */
   async runCustom(
     agentConfig: CustomAgentConfig,
     task: string,
@@ -204,6 +173,7 @@ export class AgentRunner {
     const providerType = resolved.provider;
     const provider = getProvider(providerType);
     const resolvedSystemPrompt = loadAgentPrompt(agentConfig, options.cwd);
+    const systemPrompt = buildWrappedSystemPrompt(resolvedSystemPrompt, options);
     const customOptions: RunnerHandoffOptions = {
       ...options,
       allowedTools: options.allowedTools ?? agentConfig.allowedTools,
@@ -216,13 +186,13 @@ export class AgentRunner {
     );
 
     options.onPromptResolved?.({
-      systemPrompt: resolvedSystemPrompt,
+      systemPrompt,
       userInstruction: task,
     });
 
     const agent = provider.setup({
       name: agentConfig.name,
-      systemPrompt: resolvedSystemPrompt,
+      systemPrompt,
     });
 
     return agent.call(task, AgentRunner.buildCallOptions(
@@ -235,13 +205,12 @@ export class AgentRunner {
     ));
   }
 
-  /** Run an agent by name, path, inline prompt string, or no agent at all */
   async run(
     personaSpec: string | undefined,
     task: string,
     options: RunAgentOptions,
   ): Promise<AgentResponse> {
-    const personaName = personaSpec ? AgentRunner.extractPersonaName(personaSpec) : 'default';
+    const personaName = personaSpec ? extractPersonaName(personaSpec) : 'default';
     log.debug('Running agent', {
       personaSpec: personaSpec ?? '(none)',
       personaName,
@@ -272,27 +241,12 @@ export class AgentRunner {
       resolved.globalConfig,
     );
 
-    // 1. If personaPath is provided (resolved file exists), load prompt from file
-    //    and wrap it through the perform_agent_system_prompt template
     if (options.personaPath) {
       const agentDefinition = loadPersonaPromptFromPath(
         options.personaPath,
         options.projectCwd ?? options.cwd,
       );
-      const language = options.language ?? 'en';
-      const templateVars: Record<string, string> = { agentDefinition };
-
-      if (options.workflowMeta) {
-        templateVars.workflowName = options.workflowMeta.workflowName;
-        templateVars.workflowDescription = options.workflowMeta.workflowDescription ?? '';
-        templateVars.currentStep = options.workflowMeta.currentStep;
-        templateVars.stepsList = options.workflowMeta.stepsList
-          .map((m, i) => `${i + 1}. ${m.name}${m.description ? ` - ${m.description}` : ''}`)
-          .join('\n');
-        templateVars.currentPosition = options.workflowMeta.currentPosition;
-      }
-
-      const systemPrompt = loadTemplate('perform_agent_system_prompt', language, templateVars);
+      const systemPrompt = buildWrappedSystemPrompt(agentDefinition, options);
       options.onPromptResolved?.({
         systemPrompt,
         userInstruction: task,
@@ -301,8 +255,6 @@ export class AgentRunner {
       return agent.call(task, callOptions);
     }
 
-    // 2. If personaSpec is provided but no personaPath (file not found), try custom agent first,
-    //    then use the string as inline system prompt
     if (personaSpec) {
       const customAgents = loadCustomAgents();
       const agentConfig = customAgents.get(personaName);
@@ -310,15 +262,16 @@ export class AgentRunner {
         return this.runCustom(agentConfig, task, options);
       }
 
+      const systemPrompt = buildWrappedSystemPrompt(personaSpec, options);
+
       options.onPromptResolved?.({
-        systemPrompt: personaSpec,
+        systemPrompt,
         userInstruction: task,
       });
-      const agent = provider.setup({ name: personaName, systemPrompt: personaSpec });
+      const agent = provider.setup({ name: personaName, systemPrompt });
       return agent.call(task, callOptions);
     }
 
-    // 3. No persona specified — run with the resolved instruction only (no system prompt)
     options.onPromptResolved?.({
       systemPrompt: '',
       userInstruction: task,
@@ -327,8 +280,6 @@ export class AgentRunner {
     return agent.call(task, callOptions);
   }
 }
-
-// ---- Module-level function facade ----
 
 const defaultRunner = new AgentRunner();
 

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -173,6 +173,7 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
       permissionMode: 'readonly',
       maxTurns: TEAM_LEADER_MAX_TURNS,
       onStream: options.onStream,
+      workflowMeta: options.workflowMeta,
       onPromptResolved: options.onPromptResolved,
     });
 
@@ -210,6 +211,7 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
       permissionMode: 'readonly',
       maxTurns: TEAM_LEADER_MAX_TURNS,
       onStream: options.onStream,
+      workflowMeta: options.workflowMeta,
     });
 
     if (response.status !== 'done') {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -14,6 +14,19 @@ import type { ProviderType } from '../shared/types/provider.js';
 
 export type { StreamCallback };
 
+export interface WorkflowProcessSafetyMeta {
+  protectedParentRunPid: number;
+}
+
+export interface WorkflowMeta {
+  workflowName: string;
+  workflowDescription?: string;
+  currentStep: string;
+  stepsList: ReadonlyArray<{ name: string; description?: string }>;
+  currentPosition: string;
+  processSafety?: WorkflowProcessSafetyMeta;
+}
+
 /** Common options for running agents */
 export interface RunAgentOptions {
   cwd: string;
@@ -40,13 +53,7 @@ export interface RunAgentOptions {
   onAskUserQuestion?: AskUserQuestionHandler;
   bypassPermissions?: boolean;
   language?: Language;
-  workflowMeta?: {
-    workflowName: string;
-    workflowDescription?: string;
-    currentStep: string;
-    stepsList: ReadonlyArray<{ name: string; description?: string }>;
-    currentPosition: string;
-  };
+  workflowMeta?: WorkflowMeta;
   outputSchema?: Record<string, unknown>;
   onPromptResolved?: (promptParts: {
     systemPrompt: string;

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import type { WorkflowStep, WorkflowState, Language } from '../../models/types.js';
 import type { StepProviderOptions } from '../../models/workflow-types.js';
 import type { RunAgentOptions } from '../../../agents/runner.js';
+import type { WorkflowMeta } from '../../../agents/types.js';
 import type { StructuredCaller } from '../../../agents/structured-caller.js';
 import type { PhaseRunnerContext } from '../phase-runner.js';
 import {
@@ -26,6 +27,7 @@ import type {
 } from '../types.js';
 import { buildSessionKey } from '../session-key.js';
 import { resolveStepProviderModel } from '../provider-resolution.js';
+import { buildPhase1WorkflowMeta } from './workflow-meta.js';
 
 export class OptionsBuilder {
   constructor(
@@ -113,6 +115,13 @@ export class OptionsBuilder {
     const { provider: resolvedProvider, model: resolvedModel } = this.resolveStepProviderModel(step, runtime);
 
     const providerOptions = mergedProviderOptions ?? this.resolveMergedProviderOptions(step, runtime);
+    const workflowMeta: WorkflowMeta = {
+      workflowName: this.getWorkflowName(),
+      workflowDescription: this.getWorkflowDescription(),
+      currentStep: step.name,
+      stepsList: steps,
+      currentPosition,
+    };
     const baseOptions: RunAgentOptions & { resolvedProviderOptions?: StepProviderOptions } = {
       cwd: this.getCwd(),
       projectCwd: this.getProjectCwd(),
@@ -132,15 +141,22 @@ export class OptionsBuilder {
       onPermissionRequest: this.engineOptions.onPermissionRequest,
       onAskUserQuestion: this.engineOptions.onAskUserQuestion,
       bypassPermissions: this.engineOptions.bypassPermissions,
-      workflowMeta: {
-        workflowName: this.getWorkflowName(),
-        workflowDescription: this.getWorkflowDescription(),
-        currentStep: step.name,
-        stepsList: steps,
-        currentPosition,
-      },
+      workflowMeta,
     };
     return baseOptions;
+  }
+
+  buildPhase1WorkflowMeta(
+    workflowMeta: WorkflowMeta | undefined,
+    runtime?: RuntimeStepResolution,
+  ): WorkflowMeta | undefined {
+    if (!workflowMeta) {
+      return undefined;
+    }
+
+    const processSafety = runtime?.teamLeaderPart?.processSafety
+      ?? this.engineOptions.phase1ProcessSafetyByStep?.[workflowMeta.currentStep];
+    return buildPhase1WorkflowMeta(workflowMeta, processSafety);
   }
 
   /** Build RunAgentOptions for Phase 1 (main execution) */
@@ -170,9 +186,11 @@ export class OptionsBuilder {
     const shouldResumeSession = step.session !== 'refresh' && this.getCwd() === this.getProjectCwd();
 
     const supportsStructuredOutput = providerSupportsStructuredOutput(resolvedProvider);
+    const baseOptions = this.buildBaseOptions(step, mergedProviderOptions, runtime);
 
     return {
-      ...this.buildBaseOptions(step, mergedProviderOptions, runtime),
+      ...baseOptions,
+      workflowMeta: this.buildPhase1WorkflowMeta(baseOptions.workflowMeta, runtime),
       sessionId: shouldResumeSession ? this.getSessionId(buildSessionKey(step, runtime?.providerInfo?.provider)) : undefined,
       allowedTools,
       mcpServers: resolveMcpServersForProvider(step.mcpServers, resolvedProvider),

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -6,19 +6,18 @@ import type {
   PartResult,
   WorkflowMaxSteps,
 } from '../../models/types.js';
-import { executeAgent } from '../../../agents/agent-usecases.js';
-import { buildSessionKey } from '../session-key.js';
 import { ParallelLogger } from './parallel-logger.js';
 import { incrementStepIteration } from './state-manager.js';
-import { buildAbortSignal } from './abort-signal.js';
 import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
 import { runTeamLeaderExecution } from './team-leader-execution.js';
 import { buildTeamLeaderAggregatedContent } from './team-leader-aggregation.js';
-import { createPartStep, resolvePartErrorDetail, summarizeParts } from './team-leader-common.js';
+import { resolvePartErrorDetail, summarizeParts } from './team-leader-common.js';
 import { buildTeamLeaderParallelLoggerOptions, emitTeamLeaderProgressHint } from './team-leader-streaming.js';
+import type { RunAgentOptions } from '../../../agents/types.js';
 import type { OptionsBuilder } from './OptionsBuilder.js';
 import type { StepExecutor } from './StepExecutor.js';
 import type { WorkflowEngineOptions, PhaseName, PhasePromptParts } from '../types.js';
+import { buildTeamLeaderErrorPartResult, runTeamLeaderPart } from './team-leader-part-runner.js';
 
 const log = createLogger('team-leader-runner');
 const MAX_TOTAL_PARTS = 20;
@@ -82,6 +81,10 @@ export class TeamLeaderRunner {
       task,
       maxSteps,
     );
+    const leaderBaseOptions = this.deps.optionsBuilder.buildBaseOptions(leaderStep);
+    const leaderWorkflowMeta = this.deps.optionsBuilder.buildPhase1WorkflowMeta(
+      leaderBaseOptions.workflowMeta,
+    );
 
     emitTeamLeaderProgressHint(this.deps.engineOptions, 'decompose');
     let didEmitPhaseStart = false;
@@ -97,6 +100,7 @@ export class TeamLeaderRunner {
       provider: leaderProvider,
       resolvedModel: leaderModel,
       resolvedProvider: leaderProvider,
+      workflowMeta: leaderWorkflowMeta,
       onStream: this.deps.engineOptions.onStream,
       onPromptResolved: (promptParts) => {
         this.deps.onPhaseStart?.(leaderStep, 1, 'execute', promptParts.userInstruction, promptParts, undefined, parentIteration);
@@ -200,18 +204,20 @@ export class TeamLeaderRunner {
             provider: leaderProvider,
             resolvedModel: leaderModel,
             resolvedProvider: leaderProvider,
+            workflowMeta: leaderWorkflowMeta,
             onStream: this.deps.engineOptions.onStream,
           },
         );
       },
       runPart: async (part, partIndex) => this.runSinglePart(
         step,
+        leaderWorkflowMeta,
         part,
         partIndex,
         teamLeaderConfig.timeoutMs,
         updatePersonaSession,
         parallelLogger,
-      ).catch((error) => this.buildErrorPartResult(step, part, error)),
+      ).catch((error) => buildTeamLeaderErrorPartResult(step, part, error)),
     });
 
     const allFailed = partResults.every((result) => result.response.status === 'error');
@@ -259,62 +265,22 @@ export class TeamLeaderRunner {
 
   private async runSinglePart(
     step: WorkflowStep,
+    leaderWorkflowMeta: RunAgentOptions['workflowMeta'] | undefined,
     part: PartDefinition,
     partIndex: number,
     defaultTimeoutMs: number,
     updatePersonaSession: (persona: string, sessionId: string | undefined) => void,
     parallelLogger: ParallelLogger | undefined,
   ): Promise<PartResult> {
-    const partStep = createPartStep(step, part);
-    const partProviderInfo = this.deps.optionsBuilder.resolveStepProviderModel(partStep);
-    const partAllowedTools = step.teamLeader?.partAllowedTools;
-    const baseOptions = this.deps.optionsBuilder.buildAgentOptions(partStep, {
-      providerInfo: partProviderInfo,
-      teamLeaderPart: {
-        partAllowedTools,
-      },
-    });
-    const timeoutMs = defaultTimeoutMs;
-    const { signal, dispose } = buildAbortSignal(timeoutMs, baseOptions.abortSignal);
-    const options = parallelLogger
-      ? {
-        ...baseOptions,
-        abortSignal: signal,
-        onStream: parallelLogger.createStreamHandler(part.id, partIndex),
-      }
-      : {
-        ...baseOptions,
-        abortSignal: signal,
-      };
-
-    try {
-      const response = await executeAgent(partStep.persona, part.instruction, options);
-      updatePersonaSession(buildSessionKey(partStep, partProviderInfo.provider), response.sessionId);
-      return {
-        part,
-        response: {
-          ...response,
-          persona: partStep.name,
-        },
-      };
-    } finally {
-      dispose();
-    }
-  }
-
-  private buildErrorPartResult(
-    step: WorkflowStep,
-    part: PartDefinition,
-    error: unknown,
-  ): PartResult {
-    const errorMsg = getErrorMessage(error);
-    const errorResponse: AgentResponse = {
-      persona: `${step.name}.${part.id}`,
-      status: 'error',
-      content: '',
-      timestamp: new Date(),
-      error: errorMsg,
-    };
-    return { part, response: errorResponse };
+    return runTeamLeaderPart(
+      this.deps.optionsBuilder,
+      step,
+      leaderWorkflowMeta,
+      part,
+      partIndex,
+      defaultTimeoutMs,
+      updatePersonaSession,
+      parallelLogger,
+    );
   }
 }

--- a/src/core/workflow/engine/team-leader-part-runner.ts
+++ b/src/core/workflow/engine/team-leader-part-runner.ts
@@ -1,0 +1,71 @@
+import { executeAgent } from '../../../agents/agent-usecases.js';
+import type { RunAgentOptions } from '../../../agents/types.js';
+import type { PartDefinition, PartResult, WorkflowStep, AgentResponse } from '../../models/types.js';
+import { buildSessionKey } from '../session-key.js';
+import { buildAbortSignal } from './abort-signal.js';
+import type { OptionsBuilder } from './OptionsBuilder.js';
+import type { ParallelLogger } from './parallel-logger.js';
+import { createPartStep } from './team-leader-common.js';
+import { getErrorMessage } from '../../../shared/utils/index.js';
+
+export async function runTeamLeaderPart(
+  optionsBuilder: OptionsBuilder,
+  step: WorkflowStep,
+  leaderWorkflowMeta: RunAgentOptions['workflowMeta'] | undefined,
+  part: PartDefinition,
+  partIndex: number,
+  defaultTimeoutMs: number,
+  updatePersonaSession: (persona: string, sessionId: string | undefined) => void,
+  parallelLogger: ParallelLogger | undefined,
+): Promise<PartResult> {
+  const partStep = createPartStep(step, part);
+  const partProviderInfo = optionsBuilder.resolveStepProviderModel(partStep);
+  const baseOptions = optionsBuilder.buildAgentOptions(partStep, {
+    providerInfo: partProviderInfo,
+    teamLeaderPart: {
+      partAllowedTools: step.teamLeader?.partAllowedTools,
+      processSafety: leaderWorkflowMeta?.processSafety,
+    },
+  });
+  const { signal, dispose } = buildAbortSignal(defaultTimeoutMs, baseOptions.abortSignal);
+  const options = parallelLogger
+    ? {
+      ...baseOptions,
+      abortSignal: signal,
+      onStream: parallelLogger.createStreamHandler(part.id, partIndex),
+    }
+    : {
+      ...baseOptions,
+      abortSignal: signal,
+    };
+
+  try {
+    const response = await executeAgent(partStep.persona, part.instruction, options);
+    updatePersonaSession(buildSessionKey(partStep, partProviderInfo.provider), response.sessionId);
+    return {
+      part,
+      response: {
+        ...response,
+        persona: partStep.name,
+      },
+    };
+  } finally {
+    dispose();
+  }
+}
+
+export function buildTeamLeaderErrorPartResult(
+  step: WorkflowStep,
+  part: PartDefinition,
+  error: unknown,
+): PartResult {
+  const errorMsg = getErrorMessage(error);
+  const errorResponse: AgentResponse = {
+    persona: `${step.name}.${part.id}`,
+    status: 'error',
+    content: '',
+    timestamp: new Date(),
+    error: errorMsg,
+  };
+  return { part, response: errorResponse };
+}

--- a/src/core/workflow/engine/workflow-meta.ts
+++ b/src/core/workflow/engine/workflow-meta.ts
@@ -1,0 +1,22 @@
+import type { WorkflowMeta, WorkflowProcessSafetyMeta } from '../../../agents/types.js';
+
+function attachWorkflowProcessSafety(
+  workflowMeta: WorkflowMeta | undefined,
+  processSafety: WorkflowProcessSafetyMeta | undefined,
+): WorkflowMeta | undefined {
+  if (!workflowMeta || workflowMeta.processSafety || !processSafety) {
+    return workflowMeta;
+  }
+
+  return {
+    ...workflowMeta,
+    processSafety,
+  };
+}
+
+export function buildPhase1WorkflowMeta(
+  workflowMeta: WorkflowMeta | undefined,
+  processSafety: WorkflowProcessSafetyMeta | undefined,
+): WorkflowMeta | undefined {
+  return attachWorkflowProcessSafety(workflowMeta, processSafety);
+}

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -38,7 +38,6 @@ export type {
   StreamResultEventData,
   StreamErrorEventData,
 } from '../../shared/types/provider.js';
-
 export interface PermissionRequest {
   toolName: string;
   input: Record<string, unknown>;
@@ -93,6 +92,7 @@ export interface StepProviderInfo {
 
 export interface TeamLeaderPartRuntimeResolution {
   partAllowedTools?: string[];
+  processSafety?: { protectedParentRunPid: number };
 }
 
 export interface RuntimeStepResolution {
@@ -283,6 +283,7 @@ export interface WorkflowEngineOptions {
     issueNumber?: number;
     runSlug?: string;
   };
+  phase1ProcessSafetyByStep?: Record<string, { protectedParentRunPid: number }>;
   systemStepServicesFactory?: SystemStepServicesFactory;
   sharedRuntime?: WorkflowSharedRuntimeState;
   resumeStackPrefix?: WorkflowResumePointEntry[];

--- a/src/features/tasks/execute/workflowExecution.ts
+++ b/src/features/tasks/execute/workflowExecution.ts
@@ -29,6 +29,24 @@ function requireFiniteWorkflowMaxSteps(workflowConfig: WorkflowConfig): number {
   return workflowConfig.maxSteps;
 }
 
+function resolvePhase1ProcessSafetyByStep(
+  workflowConfig: WorkflowConfig,
+  parentRunPid: number,
+): Record<string, { protectedParentRunPid: number }> | undefined {
+  if (
+    workflowConfig.name !== 'takt-default'
+    || !workflowConfig.steps.some((step) => step.name === 'implement')
+  ) {
+    return undefined;
+  }
+
+  return {
+    implement: {
+      protectedParentRunPid: parentRunPid,
+    },
+  };
+}
+
 export async function executeWorkflow(
   workflowConfig: WorkflowConfig,
   task: string,
@@ -55,8 +73,10 @@ async function executeWorkflowInternal(
   options: WorkflowExecutionOptions,
   runContext?: WorkflowRunContext,
 ): Promise<WorkflowExecutionResult> {
+  const parentRunPid = process.pid;
   const bootstrap = createWorkflowExecutionBootstrap(workflowConfig, task, cwd, options);
   const workflowExecutionContext = createWorkflowExecutionContext(workflowConfig, options.projectCwd);
+  const phase1ProcessSafetyByStep = resolvePhase1ProcessSafetyByStep(workflowConfig, parentRunPid);
   let engine: WorkflowEngine | null = null;
   let eventBridge: WorkflowExecutionEventBridge | undefined;
   const getCurrentWorkflowStack = (): WorkflowResumePointEntry[] | undefined => {
@@ -139,6 +159,7 @@ async function executeWorkflowInternal(
       taskColorIndex: options.taskColorIndex,
       initialIteration: options.initialIterationOverride,
       currentTask: resolveCurrentTaskContext(options, bootstrap.runSlug),
+      phase1ProcessSafetyByStep,
       systemStepServicesFactory: createDefaultSystemStepServices,
       workflowCallResolver: createWorkflowCallResolver(workflowExecutionContext),
     });

--- a/src/shared/prompts/en/perform_agent_system_prompt.md
+++ b/src/shared/prompts/en/perform_agent_system_prompt.md
@@ -1,7 +1,7 @@
 <!--
   template: perform_agent_system_prompt
   role: system prompt for user-defined agents
-  vars: agentDefinition, workflowName, workflowDescription, currentStep, stepsList, currentPosition
+  vars: agentDefinition, workflowName, workflowDescription, currentStep, stepsList, currentPosition, hasProcessSafety, protectedParentRunPid
   caller: AgentRunner
 -->
 # TAKT
@@ -19,6 +19,15 @@ You are part of TAKT (AI Agent Orchestration Tool).
 - Processing Flow:
 {{stepsList}}
 - Current Position: {{currentPosition}}
+
+{{#if hasProcessSafety}}
+## Process Safety
+- Protected Parent Run PID (protected PID): {{protectedParentRunPid}}
+- Do not stop the protected PID listed above.
+- Do not use `pkill`, `killall`, or name-based kill.
+- Do not stop processes unless you clearly own them.
+
+{{/if}}
 
 Work with awareness of coordination with preceding and following steps.
 

--- a/src/shared/prompts/ja/perform_agent_system_prompt.md
+++ b/src/shared/prompts/ja/perform_agent_system_prompt.md
@@ -1,7 +1,7 @@
 <!--
   template: perform_agent_system_prompt
   role: system prompt for user-defined agents
-  vars: agentDefinition, workflowName, workflowDescription, currentStep, stepsList, currentPosition
+  vars: agentDefinition, workflowName, workflowDescription, currentStep, stepsList, currentPosition, hasProcessSafety, protectedParentRunPid
   caller: AgentRunner
 -->
 # TAKT
@@ -19,6 +19,15 @@
 - 処理フロー:
 {{stepsList}}
 - 現在の位置: {{currentPosition}}
+
+{{#if hasProcessSafety}}
+## Process Safety
+- Protected Parent Run PID（protected PID）: {{protectedParentRunPid}}
+- 上記の protected PID は停止してはいけません。
+- `pkill` / `killall` / プロセス名ベースの kill を使ってはいけません。
+- 自分が所有していると明確に分かるプロセス以外は停止してはいけません。
+
+{{/if}}
 
 前後のステップとの連携を意識して作業してください。
 


### PR DESCRIPTION
## Summary

## Summary

`takt-default` の `implement` (`team_leader` 配下の part worker) で、E2E 検証中にぶら下がったプロセスを AI が cleanup しようとすると、親の `takt run` まで誤って停止することがある。

現状は、part worker が別 worktree / 別 `takt run` を起動した後、それを安全に識別する手段がないため、`pkill` などの名前ベース停止に流れやすい。これにより、親ラン自身が巻き込まれる。

## Background

実際の run では、親 run の途中で `.takt/.runtime/tmp/takt-worktrees/...` 配下に複数の子 run が生成され、一部が `status: "running"` のまま残っていた。
その直後に part worker 側で「ぶら下がった `takt run` を止める」と判断し、親端末では `zsh: terminated  takt run` が出て親 run が終了した。

今回必要なのは「停止してよい PID の列挙」ではなく、まず「停止してはいけない親 PID」の明示である。子 run は AI がその場で起動し得るため、停止候補 PID を完全管理するのは難しいが、親 PID を protected として渡すだけでも誤爆を大きく減らせる。

## Proposal

`takt-default` の `implement` team leader / part worker 実行コンテキストに、親 `takt run` の PID を protected PID として注入する。

あわせて、短い process-safety policy を追加する。

- protected PID は停止してはいけない
- `pkill` / `killall` / 名前ベース kill を使ってはいけない
- 所有が明確でないプロセスを停止してはいけない

対象はまず `takt-default` の `implement` のみとする。全 workflow への一般化は後でよい。

## Acceptance Criteria

- `takt-default` の `implement` team leader / part worker prompt に親 `takt run` の PID が注入される
- process-safety policy が適用される
- policy は短く、実行コンテキストの PID 情報と重複しない
- 少なくとも親 `takt run` を名前ベース kill で巻き込む挙動を避ける方針が明示される

## Execution Report

Workflow `takt-default` completed successfully.

Closes #603