### PR TITLE
[#569] preserve-rate-limit-cause

### DIFF
--- a/src/__tests__/claude-client-status.test.ts
+++ b/src/__tests__/claude-client-status.test.ts
@@ -68,4 +68,45 @@ describe('ClaudeClient status normalization', () => {
     expect(response.error).toBe('SIGINT');
     expect(response.content).toBe('Interrupted by signal');
   });
+
+  it('should preserve provider-normalized errorKind on error responses', async () => {
+    mockExecuteClaudeCli.mockResolvedValue({
+      success: false,
+      content: '',
+      error: 'Rate limit exceeded. Please try again later.',
+      errorKind: 'rate_limit',
+      sessionId: 'session-3',
+    });
+
+    const client = new ClaudeClient();
+
+    const response = await client.call('coder', 'Implement feature', options);
+
+    expect(response.status).toBe('error');
+    expect(response.errorKind).toBe('rate_limit');
+    expect(response.error).toBe('Rate limit exceeded. Please try again later.');
+  });
+
+  it('should preserve provider-normalized errorKind on callCustom() error responses', async () => {
+    mockExecuteClaudeCli.mockResolvedValue({
+      success: false,
+      content: 'Claude Code process exited with code 1',
+      error: 'Claude Code process exited with code 1',
+      errorKind: 'rate_limit',
+      sessionId: 'session-4',
+    });
+
+    const client = new ClaudeClient();
+
+    const response = await client.callCustom(
+      'custom-coder',
+      'Implement feature',
+      'system prompt',
+      options,
+    );
+
+    expect(response.status).toBe('error');
+    expect(response.errorKind).toBe('rate_limit');
+    expect(response.error).toBe('Claude Code process exited with code 1');
+  });
 });

--- a/src/__tests__/claude-executor-rate-limit.test.ts
+++ b/src/__tests__/claude-executor-rate-limit.test.ts
@@ -1,0 +1,320 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  queryMock,
+  AbortErrorMock,
+} = vi.hoisted(() => {
+  class AbortErrorMock extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = 'AbortError';
+    }
+  }
+
+  return {
+    queryMock: vi.fn(),
+    AbortErrorMock,
+  };
+});
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: queryMock,
+  AbortError: AbortErrorMock,
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../shared/utils/index.js')>();
+  return {
+    ...original,
+    createLogger: vi.fn().mockReturnValue({
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { QueryExecutor } from '../infra/claude/executor.js';
+
+const RATE_LIMIT_MESSAGE = 'Rate limit exceeded. Please try again later.';
+const EXIT_CODE_MESSAGE = 'Claude Code process exited with code 1';
+type RateLimitStatus = 'allowed' | 'allowed_warning' | 'rejected';
+
+function createMockQuery(
+  messages: Array<Record<string, unknown>>,
+  error?: Error,
+) {
+  return {
+    interrupt: vi.fn(async () => {}),
+    async *[Symbol.asyncIterator](): AsyncGenerator<Record<string, unknown>, void, unknown> {
+      for (const message of messages) {
+        yield message;
+      }
+
+      if (error) {
+        throw error;
+      }
+    },
+  };
+}
+
+function createAssistantRateLimitMessage(): Record<string, unknown> {
+  return {
+    type: 'assistant',
+    message: { content: [] },
+    error: 'rate_limit',
+    uuid: 'assistant-rate-limit',
+    session_id: 'session-rate-limit',
+    parent_tool_use_id: null,
+  };
+}
+
+function createAssistantTextMessage(text: string): Record<string, unknown> {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{ type: 'text', text }],
+    },
+    session_id: 'session-rate-limit',
+  };
+}
+
+function createRateLimitEventMessage(
+  rateLimitInfo: {
+    status: RateLimitStatus;
+    overageStatus?: RateLimitStatus;
+  },
+): Record<string, unknown> {
+  return {
+    type: 'rate_limit_event',
+    rate_limit_info: {
+      status: rateLimitInfo.status,
+      rateLimitType: 'five_hour',
+      overageStatus: rateLimitInfo.overageStatus ?? rateLimitInfo.status,
+      overageDisabledReason: 'out_of_credits',
+      resetsAt: 1775059200,
+      overageResetsAt: 1775059200,
+      isUsingOverage: false,
+    },
+    uuid: 'rate-limit-event',
+    session_id: 'session-rate-limit',
+  };
+}
+
+function createResultMessage(
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    type: 'result',
+    subtype: 'success',
+    result: 'done',
+    ...overrides,
+  };
+}
+
+describe('QueryExecutor rate limit cause preservation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('assistant.error が rate_limit の場合は exit code 1 より優先して RateLimit 文言を返す', async () => {
+    // Given
+    queryMock.mockReturnValue(
+      createMockQuery([createAssistantRateLimitMessage()], new Error(EXIT_CODE_MESSAGE)),
+    );
+    const executor = new QueryExecutor();
+
+    // When
+    const result = await executor.execute('test prompt', { cwd: '/tmp/project' });
+
+    // Then
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(RATE_LIMIT_MESSAGE);
+    expect(result.errorKind).toBe('rate_limit');
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rate_limit_event が観測された場合も exit code 1 より優先して RateLimit 文言を返す', async () => {
+    // Given
+    queryMock.mockReturnValue(
+      createMockQuery([
+        createRateLimitEventMessage({ status: 'rejected' }),
+      ], new Error(EXIT_CODE_MESSAGE)),
+    );
+    const executor = new QueryExecutor();
+
+    // When
+    const result = await executor.execute('test prompt', { cwd: '/tmp/project' });
+
+    // Then
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(RATE_LIMIT_MESSAGE);
+    expect(result.errorKind).toBe('rate_limit');
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('overageStatus だけが rejected の rate_limit_event でも RateLimit 文言を返す', async () => {
+    // Given
+    queryMock.mockReturnValue(
+      createMockQuery([
+        createRateLimitEventMessage({
+          status: 'allowed',
+          overageStatus: 'rejected',
+        }),
+      ], new Error(EXIT_CODE_MESSAGE)),
+    );
+    const executor = new QueryExecutor();
+
+    // When
+    const result = await executor.execute('test prompt', { cwd: '/tmp/project' });
+
+    // Then
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(RATE_LIMIT_MESSAGE);
+    expect(result.errorKind).toBe('rate_limit');
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Claude response の result 文面が rate limit を示す場合も RateLimit 文言を返す', async () => {
+    // Given
+    queryMock.mockReturnValue(
+      createMockQuery([
+        createResultMessage({
+          subtype: 'error',
+          result: "You're out of extra usage. Please retry later.",
+        }),
+      ], new Error(EXIT_CODE_MESSAGE)),
+    );
+    const executor = new QueryExecutor();
+
+    // When
+    const result = await executor.execute('test prompt', { cwd: '/tmp/project' });
+
+    // Then
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(RATE_LIMIT_MESSAGE);
+    expect(result.errorKind).toBe('rate_limit');
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('assistant text のみで rate limit が示された場合も RateLimit 文言を返す', async () => {
+    // Given
+    queryMock.mockReturnValue(
+      createMockQuery([
+        createAssistantTextMessage("You're out of extra usage. Please retry later."),
+      ], new Error(EXIT_CODE_MESSAGE)),
+    );
+    const executor = new QueryExecutor();
+
+    // When
+    const result = await executor.execute('test prompt', { cwd: '/tmp/project' });
+
+    // Then
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(RATE_LIMIT_MESSAGE);
+    expect(result.errorKind).toBe('rate_limit');
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sessionId 付き実行で RateLimit を観測した場合は no-resume retry を行わない', async () => {
+    // Given
+    queryMock.mockImplementation(() => (
+      createMockQuery([createAssistantRateLimitMessage()], new Error(EXIT_CODE_MESSAGE))
+    ));
+    const executor = new QueryExecutor();
+
+    // When
+    const result = await executor.execute('test prompt', {
+      cwd: '/tmp/project',
+      sessionId: 'resume-session-1',
+    });
+
+    // Then
+    expect(result.error).toBe(RATE_LIMIT_MESSAGE);
+    expect(result.errorKind).toBe('rate_limit');
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(
+      (queryMock.mock.calls[0]?.[0] as { options?: { resume?: string } }).options?.resume,
+    ).toBe('resume-session-1');
+  });
+
+  it('sessionId 付き実行で rejected の rate_limit_event を観測した場合も no-resume retry を行わない', async () => {
+    // Given
+    queryMock.mockImplementation(() => (
+      createMockQuery([
+        createRateLimitEventMessage({ status: 'rejected' }),
+      ], new Error(EXIT_CODE_MESSAGE))
+    ));
+    const executor = new QueryExecutor();
+
+    // When
+    const result = await executor.execute('test prompt', {
+      cwd: '/tmp/project',
+      sessionId: 'resume-session-1',
+    });
+
+    // Then
+    expect(result.error).toBe(RATE_LIMIT_MESSAGE);
+    expect(result.errorKind).toBe('rate_limit');
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(
+      (queryMock.mock.calls[0]?.[0] as { options?: { resume?: string } }).options?.resume,
+    ).toBe('resume-session-1');
+  });
+
+  it('RateLimit シグナルがない generic exit code error は既存どおり no-resume retry する', async () => {
+    // Given
+    queryMock.mockImplementation(() => createMockQuery([], new Error(EXIT_CODE_MESSAGE)));
+    const executor = new QueryExecutor();
+
+    // When
+    const result = await executor.execute('test prompt', {
+      cwd: '/tmp/project',
+      sessionId: 'resume-session-1',
+    });
+
+    // Then
+    expect(result.error).toBe(EXIT_CODE_MESSAGE);
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(
+      (queryMock.mock.calls[0]?.[0] as { options?: { resume?: string } }).options?.resume,
+    ).toBe('resume-session-1');
+    expect(
+      (queryMock.mock.calls[1]?.[0] as { options?: { resume?: string } }).options?.resume,
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ['allowed', 'allowed'],
+    ['allowed_warning', 'allowed_warning'],
+    ['allowed', 'allowed_warning'],
+  ] as const)(
+    'rate_limit_event status=%s overageStatus=%s は失敗扱いせず generic error と no-resume retry を維持する',
+    async (status, overageStatus) => {
+      // Given
+      queryMock.mockImplementation(() => (
+        createMockQuery([
+          createRateLimitEventMessage({ status, overageStatus }),
+        ], new Error(EXIT_CODE_MESSAGE))
+      ));
+      const executor = new QueryExecutor();
+
+      // When
+      const result = await executor.execute('test prompt', {
+        cwd: '/tmp/project',
+        sessionId: 'resume-session-1',
+      });
+
+      // Then
+      expect(result.error).toBe(EXIT_CODE_MESSAGE);
+      expect(result.errorKind).toBeUndefined();
+      expect(queryMock).toHaveBeenCalledTimes(2);
+      expect(
+        (queryMock.mock.calls[0]?.[0] as { options?: { resume?: string } }).options?.resume,
+      ).toBe('resume-session-1');
+      expect(
+        (queryMock.mock.calls[1]?.[0] as { options?: { resume?: string } }).options?.resume,
+      ).toBeUndefined();
+    },
+  );
+});

--- a/src/__tests__/engine-parallel-failure.test.ts
+++ b/src/__tests__/engine-parallel-failure.test.ts
@@ -182,6 +182,26 @@ describe('WorkflowEngine Integration: Parallel Step Partial Failure', () => {
     expect(reason).toContain('All parallel sub-steps failed');
   });
 
+  it('should preserve the rate limit message in workflow abort reason when all sub-steps fail with it', async () => {
+    const config = buildParallelOnlyConfig();
+    const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+
+    const mock = vi.mocked(runAgent);
+    mock.mockRejectedValueOnce(new Error('Rate limit exceeded. Please try again later.'));
+    mock.mockRejectedValueOnce(new Error('Rate limit exceeded. Please try again later.'));
+
+    const abortFn = vi.fn();
+    engine.on('workflow:abort', abortFn);
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('aborted');
+    expect(abortFn).toHaveBeenCalledOnce();
+    const reason = abortFn.mock.calls[0]![1] as string;
+    expect(reason).toContain('All parallel sub-steps failed');
+    expect(reason).toContain('Rate limit exceeded. Please try again later.');
+  });
+
   it('should record failed sub-step error message in stepOutputs', async () => {
     const config = buildParallelOnlyConfig();
     const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });

--- a/src/__tests__/report-phase-retry.test.ts
+++ b/src/__tests__/report-phase-retry.test.ts
@@ -12,6 +12,8 @@ vi.mock('../agents/runner.js', () => ({
 import { runAgent } from '../agents/runner.js';
 import type { AgentResponse } from '../core/models/types.js';
 
+const RATE_LIMIT_MESSAGE = 'Rate limit exceeded. Please try again later.';
+
 function createStep(fileName: string): WorkflowStep {
   return {
     name: 'implement',
@@ -225,6 +227,53 @@ describe('runReportPhase retry with new session', () => {
     // When / Then
     await expect(runReportPhase(step, 1, ctx)).rejects.toThrow(
       'Report phase failed for 04-qa.md: Tool use is not allowed in this phase',
+    );
+    expect(runAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail immediately without retry when resumed session hits the rate limit', async () => {
+    // Given
+    const reportDir = join(tmpRoot, '.takt', 'runs', 'sample-run', 'reports');
+    const step = createStep('04-qa.md');
+    const ctx = createContext(reportDir, 'Aggregated reviewer output', 'session-resume-1');
+    queueRunAgentResponses([{
+      persona: 'coder',
+      status: 'error',
+      content: RATE_LIMIT_MESSAGE,
+      timestamp: new Date('2026-02-11T00:02:32Z'),
+      error: RATE_LIMIT_MESSAGE,
+      errorKind: 'rate_limit',
+    }]);
+    const runAgentMock = vi.mocked(runAgent);
+
+    // When / Then
+    await expect(runReportPhase(step, 1, ctx)).rejects.toThrow(
+      `Report phase failed for 04-qa.md: ${RATE_LIMIT_MESSAGE}`,
+    );
+    expect(runAgentMock).toHaveBeenCalledTimes(1);
+
+    const firstCallOptions = runAgentMock.mock.calls[0]?.[2] as { sessionId?: string };
+    expect(firstCallOptions.sessionId).toBe('session-resume-1');
+  });
+
+  it('should not depend on provider-specific error text when rate limit is classified', async () => {
+    // Given
+    const reportDir = join(tmpRoot, '.takt', 'runs', 'sample-run', 'reports');
+    const step = createStep('04-qa.md');
+    const ctx = createContext(reportDir, 'Aggregated reviewer output', 'session-resume-1');
+    queueRunAgentResponses([{
+      persona: 'coder',
+      status: 'error',
+      content: 'Claude Code process exited with code 1',
+      timestamp: new Date('2026-02-11T00:02:33Z'),
+      error: 'Claude Code process exited with code 1',
+      errorKind: 'rate_limit',
+    }]);
+    const runAgentMock = vi.mocked(runAgent);
+
+    // When / Then
+    await expect(runReportPhase(step, 1, ctx)).rejects.toThrow(
+      `Report phase failed for 04-qa.md: ${RATE_LIMIT_MESSAGE}`,
     );
     expect(runAgentMock).toHaveBeenCalledTimes(1);
   });

--- a/src/core/models/index.ts
+++ b/src/core/models/index.ts
@@ -30,6 +30,7 @@ export type {
   AgentWorkflowStep,
   SystemWorkflowStep,
   WorkflowCallStep,
+  AgentErrorKind,
   AgentResponse,
   ProviderUsageSnapshot,
   SessionState,

--- a/src/core/models/response.ts
+++ b/src/core/models/response.ts
@@ -4,6 +4,20 @@
 
 import type { Status, RuleMatchMethod } from './status.js';
 
+export type AgentErrorKind = 'rate_limit';
+export const RATE_LIMIT_ERROR_MESSAGE = 'Rate limit exceeded. Please try again later.';
+
+export function resolveAgentErrorMessage(
+  errorKind: AgentErrorKind | undefined,
+  fallbackMessage: string,
+): string {
+  if (errorKind === 'rate_limit') {
+    return RATE_LIMIT_ERROR_MESSAGE;
+  }
+
+  return fallbackMessage;
+}
+
 export interface ProviderUsageSnapshot {
   inputTokens?: number;
   outputTokens?: number;
@@ -24,6 +38,8 @@ export interface AgentResponse {
   sessionId?: string;
   /** Error message when the query failed (e.g., API error, rate limit) */
   error?: string;
+  /** Machine-readable error classification normalized at the provider boundary */
+  errorKind?: AgentErrorKind;
   /** Matched rule index (0-based) when rules-based detection was used */
   matchedRuleIndex?: number;
   /** How the rule match was detected */

--- a/src/core/models/types.ts
+++ b/src/core/models/types.ts
@@ -15,6 +15,7 @@ export type {
 
 // Agent response
 export type {
+  AgentErrorKind,
   AgentResponse,
   ProviderUsageSnapshot,
 } from './response.js';

--- a/src/core/workflow/report-phase-runner.ts
+++ b/src/core/workflow/report-phase-runner.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve, sep } from 'node:path';
 import type { AgentResponse, WorkflowStep } from '../models/types.js';
+import { resolveAgentErrorMessage } from '../models/response.js';
 import type { RunAgentOptions } from '../../agents/runner.js';
 import { executeAgent } from '../../agents/agent-usecases.js';
 import { createLogger } from '../../shared/utils/index.js';
@@ -129,7 +130,7 @@ export async function runReportPhase(
       continue;
     }
 
-    if (!currentSessionId || !hasLastResponse) {
+    if (!currentSessionId || !hasLastResponse || firstAttempt.errorKind === 'rate_limit') {
       throw new Error(`Report phase failed for ${fileName}: ${firstAttempt.errorMessage}`);
     }
 
@@ -178,7 +179,7 @@ function buildNewSessionRetryOptions(step: WorkflowStep, ctx: PhaseRunnerContext
 type ReportAttemptResult =
   | { kind: 'success'; content: string; response: AgentResponse }
   | { kind: 'blocked'; response: AgentResponse }
-  | { kind: 'retryable_failure'; errorMessage: string };
+  | { kind: 'retryable_failure'; errorMessage: string; errorKind?: AgentResponse['errorKind'] };
 
 async function runSingleReportAttempt(
   step: WorkflowStep,
@@ -215,9 +216,10 @@ async function runSingleReportAttempt(
   }
 
   if (response.status !== 'done') {
-    const errorMessage = response.error || response.content || 'Unknown error';
+    const fallbackMessage = response.error || response.content || 'Unknown error';
+    const errorMessage = resolveAgentErrorMessage(response.errorKind, fallbackMessage);
     ctx.onPhaseComplete?.(step, 2, 'report', response.content, response.status, errorMessage, undefined, ctx.iteration);
-    return { kind: 'retryable_failure', errorMessage };
+    return { kind: 'retryable_failure', errorMessage, errorKind: response.errorKind };
   }
 
   const trimmedContent = response.content.trim();

--- a/src/infra/claude/client.ts
+++ b/src/infra/claude/client.ts
@@ -75,6 +75,7 @@ export class ClaudeClient {
       timestamp: new Date(),
       sessionId: result.sessionId,
       error: result.error,
+      errorKind: result.errorKind,
       structuredOutput: result.structuredOutput,
       providerUsage: result.providerUsage,
     };
@@ -105,6 +106,7 @@ export class ClaudeClient {
       timestamp: new Date(),
       sessionId: result.sessionId,
       error: result.error,
+      errorKind: result.errorKind,
       structuredOutput: result.structuredOutput,
       providerUsage: result.providerUsage,
     };

--- a/src/infra/claude/executor.ts
+++ b/src/infra/claude/executor.ts
@@ -8,11 +8,16 @@
 import {
   query,
   AbortError,
+  type SDKMessage,
   type SDKResultMessage,
   type SDKAssistantMessage,
+  type SDKRateLimitEvent,
 } from '@anthropic-ai/claude-agent-sdk';
 import { USAGE_MISSING_REASONS } from '../../core/logging/contracts.js';
-import type { ProviderUsageSnapshot } from '../../core/models/response.js';
+import {
+  RATE_LIMIT_ERROR_MESSAGE,
+  type ProviderUsageSnapshot,
+} from '../../core/models/response.js';
 import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
 import {
   generateQueryId,
@@ -27,9 +32,38 @@ import type {
 } from './types.js';
 
 const log = createLogger('claude-sdk');
+const RATE_LIMIT_RESPONSE_PATTERNS = [
+  'rate_limit',
+  'rate limit',
+  'out of extra usage',
+] as const;
 
 function toNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function isRejectedRateLimitEvent(message: SDKRateLimitEvent): boolean {
+  return (
+    message.rate_limit_info.status === 'rejected'
+    || message.rate_limit_info.overageStatus === 'rejected'
+  );
+}
+
+function isRateLimitSignal(message: SDKMessage): boolean {
+  if (message.type === 'rate_limit_event') {
+    return isRejectedRateLimitEvent(message as SDKRateLimitEvent);
+  }
+
+  return message.type === 'assistant' && message.error === 'rate_limit';
+}
+
+function containsRateLimitText(text: string | undefined): boolean {
+  if (!text) {
+    return false;
+  }
+
+  const normalized = text.toLowerCase();
+  return RATE_LIMIT_RESPONSE_PATTERNS.some((pattern) => normalized.includes(pattern));
 }
 
 function extractProviderUsage(resultMsg: SDKResultMessage): ProviderUsageSnapshot {
@@ -148,6 +182,7 @@ export class QueryExecutor {
     let structuredOutput: Record<string, unknown> | undefined;
     let providerUsage: ProviderUsageSnapshot | undefined;
     let onExternalAbort: (() => void) | undefined;
+    let observedRateLimit = false;
     const applyAssistantMessage = (assistantMsg: SDKAssistantMessage): void => {
       for (const block of assistantMsg.message.content) {
         if (block.type === 'text') {
@@ -158,19 +193,22 @@ export class QueryExecutor {
     const applyResultMessage = (resultMsg: SDKResultMessage): void => {
       hasResultMessage = true;
       providerUsage = extractProviderUsage(resultMsg);
+      const resultPayload = resultMsg as SDKResultMessage & { result?: unknown };
       const resultErrors = Array.isArray((resultMsg as { errors?: unknown }).errors)
         ? ((resultMsg as { errors?: unknown }).errors as string[]).filter((error): error is string => typeof error === 'string')
         : [];
+      const resultText = typeof resultPayload.result === 'string' ? resultPayload.result : undefined;
+      if (resultErrors.length > 0) {
+        resultContent = resultErrors.join('\n');
+      } else if (resultText) {
+        resultContent = resultText;
+      }
 
       if (resultMsg.subtype !== 'success') {
         success = false;
-        if (resultErrors.length > 0) {
-          resultContent = resultErrors.join('\n');
-        }
         return;
       }
 
-      resultContent = resultMsg.result;
       const rawStructuredOutput = (resultMsg as unknown as {
         structured_output?: unknown;
         structuredOutput?: unknown;
@@ -217,6 +255,10 @@ export class QueryExecutor {
       for await (const message of q) {
         if ('session_id' in message) {
           sessionId = message.session_id;
+        }
+
+        if (isRateLimitSignal(message)) {
+          observedRateLimit = true;
         }
 
         if (options.onStream) {
@@ -269,7 +311,17 @@ export class QueryExecutor {
         options.abortSignal.removeEventListener('abort', onExternalAbort);
       }
       unregisterQuery(queryId);
-      return QueryExecutor.handleQueryError(error, queryId, sessionId, hasResultMessage, success, resultContent, stderrChunks);
+      return QueryExecutor.handleQueryError(
+        error,
+        queryId,
+        sessionId,
+        hasResultMessage,
+        success,
+        resultContent,
+        accumulatedAssistantText,
+        stderrChunks,
+        observedRateLimit,
+      );
     }
   }
 
@@ -284,7 +336,9 @@ export class QueryExecutor {
     hasResultMessage: boolean,
     success: boolean,
     resultContent: string | undefined,
+    assistantText: string,
     stderrChunks: string[],
+    observedRateLimit: boolean,
   ): ClaudeResult {
     if (error instanceof AbortError) {
       log.info('Claude query was interrupted', { queryId });
@@ -314,8 +368,18 @@ export class QueryExecutor {
 
     log.error('Claude query failed', { queryId, error: errorMessage });
 
-    if (errorMessage.includes('rate_limit') || errorMessage.includes('rate limit')) {
-      return { success: false, content: '', error: 'Rate limit exceeded. Please try again later.' };
+    if (
+      observedRateLimit
+      || containsRateLimitText(errorMessage)
+      || containsRateLimitText(resultContent)
+      || containsRateLimitText(assistantText)
+    ) {
+      return {
+        success: false,
+        content: '',
+        error: RATE_LIMIT_ERROR_MESSAGE,
+        errorKind: 'rate_limit',
+      };
     }
 
     if (errorMessage.includes('authentication') || errorMessage.includes('unauthorized')) {

--- a/src/infra/claude/types.ts
+++ b/src/infra/claude/types.ts
@@ -8,7 +8,7 @@
 import type { PermissionUpdate, AgentDefinition, SandboxSettings } from '@anthropic-ai/claude-agent-sdk';
 import type { PermissionMode, McpServerConfig } from '../../core/models/index.js';
 import type { ClaudeEffort } from '../../core/models/workflow-types.js';
-import type { ProviderUsageSnapshot } from '../../core/models/response.js';
+import type { AgentErrorKind, ProviderUsageSnapshot } from '../../core/models/response.js';
 
 export type { SandboxSettings };
 import type { PermissionResult } from '../../core/workflow/index.js';
@@ -128,6 +128,7 @@ export interface ClaudeResult {
   content: string;
   sessionId?: string;
   error?: string;
+  errorKind?: AgentErrorKind;
   interrupted?: boolean;
   /** All assistant text accumulated during execution (for status detection) */
   fullContent?: string;


### PR DESCRIPTION
## Summary

## Summary

Claude の RateLimit 自体は provider-events で観測できるようになったが、最終的な workflow / phase エラー表示が `Claude Code process exited with code 1` に潰れるケースがある。

そのため、実際には RateLimit で失敗しているのに、ユーザー向けには原因が不明瞭になる。

## Current Behavior

`reviewers` の report phase で Claude が RateLimit に達すると、provider-events には以下が記録される:

- `event_type: "rate_limit"`
- `event_type: "assistant_error"` with `error: "rate_limit"`
- `result: "You're out of extra usage ..."`

しかし、集約ログ / 最終エラーでは以下のように表示されることがある:

- `Report phase failed for architect-review.md: Claude Code process exited with code 1`
- `Workflow aborted ... All parallel sub-movements failed ... Claude Code process exited with code 1`

## Expected Behavior

RateLimit が provider-events / Claude response 上で確認できた場合、最終的な phase error / workflow abort reason でも RateLimit として明示されること。

例:

- `Report phase failed for architect-review.md: Rate limit exceeded. Please try again later.`
- あるいは `Claude rate limit exceeded` のような等価な明示的表現

## Notes

- これは「RateLimit を検知する」Issue ではなく、「検知済みの RateLimit 原因を最終表示に保持する」Issue。
- 特に session resume / report phase retry 経路で `exit code 1` に原因が潰れている可能性が高い。
- provider-events が追加されたことで、実際には RateLimit だったことは確認可能になっている。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #569