### PR TITLE
[#568] add-run-checkpoint-resume

### DIFF
--- a/src/__tests__/orderReader.test.ts
+++ b/src/__tests__/orderReader.test.ts
@@ -53,6 +53,16 @@ describe('findPreviousOrderContent', () => {
     expect(result).toBeNull();
   });
 
+  it('should return null for invalid slug with path traversal characters', () => {
+    const escapedOrderDir = join(TEST_DIR, '.takt', 'escaped-run', 'context', 'task');
+    mkdirSync(escapedOrderDir, { recursive: true });
+    writeFileSync(join(escapedOrderDir, 'order.md'), 'Escaped order', 'utf-8');
+
+    const result = findPreviousOrderContent(TEST_DIR, '../escaped-run');
+
+    expect(result).toBeNull();
+  });
+
   it('should return null for empty order.md content', () => {
     createRunWithOrder('20260218-run1', '');
 

--- a/src/__tests__/resolveTask.test.ts
+++ b/src/__tests__/resolveTask.test.ts
@@ -142,12 +142,12 @@ describe('resolveTaskExecution', () => {
     expect(result.workflowIdentifier).toBe('workflow-only');
   });
 
-  it('should resolve startStep from start_step alias', async () => {
+  it('should resolve startStep from start_movement', async () => {
     const root = createTempProjectDir();
     const task = createTask({
       data: ({
         task: 'Run task',
-        start_step: 'implement',
+        start_movement: 'implement',
       } as unknown) as NonNullable<TaskInfo['data']>,
     });
 
@@ -156,7 +156,7 @@ describe('resolveTaskExecution', () => {
     expect(result.startStep).toBe('implement');
   });
 
-  it('should prefer resume_point root step over stored start_step on workflow_call retry', async () => {
+  it('should prefer resume_point root step over stored start_movement on workflow_call retry', async () => {
     const root = createTempProjectDir();
     const workflowDir = path.join(root, '.takt', 'workflows');
     fs.mkdirSync(workflowDir, { recursive: true });
@@ -176,7 +176,7 @@ describe('resolveTaskExecution', () => {
     const task = createTask({
       data: ({
         task: 'Run task',
-        start_step: 'review',
+        start_movement: 'review',
         resume_point: {
           version: 1,
           stack: [

--- a/src/__tests__/run-order-content.test.ts
+++ b/src/__tests__/run-order-content.test.ts
@@ -33,6 +33,17 @@ describe('readRunContextOrderContent', () => {
     expect(result).toBe('# Task\n\nImplement exactly this.');
   });
 
+  it('不正な slug では .takt/runs 配下の外を読まない', () => {
+    const root = createTempProjectDir();
+    const escapedOrderPath = path.join(root, '.takt', 'escaped-run', 'context', 'task', 'order.md');
+    fs.mkdirSync(path.dirname(escapedOrderPath), { recursive: true });
+    fs.writeFileSync(escapedOrderPath, '# Escaped Task\n\nShould not be readable.', 'utf-8');
+
+    const result = readRunContextOrderContent(root, '../escaped-run');
+
+    expect(result).toBeUndefined();
+  });
+
   it('読み込み失敗時は onError を呼んで undefined を返す', () => {
     const root = createTempProjectDir();
     const slug = '20260216-run-order-error';
@@ -47,5 +58,35 @@ describe('readRunContextOrderContent', () => {
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError.mock.calls[0]?.[0]).toBe(orderPath);
     expect(onError.mock.calls[0]?.[1]).toBeInstanceOf(Error);
+  });
+
+  it('symlink 化した run directory 経由の order.md を読まない', () => {
+    const root = createTempProjectDir();
+    const slug = '20260216-linked-run';
+    const escapedRunDir = path.join(root, '.takt', 'escaped-run');
+    const linkedRunDir = path.join(root, '.takt', 'runs', slug);
+    const escapedOrderPath = path.join(escapedRunDir, 'context', 'task', 'order.md');
+    fs.mkdirSync(path.dirname(escapedOrderPath), { recursive: true });
+    fs.writeFileSync(escapedOrderPath, '# Escaped Task\n\nShould not be readable.', 'utf-8');
+    fs.mkdirSync(path.dirname(linkedRunDir), { recursive: true });
+    fs.symlinkSync(escapedRunDir, linkedRunDir, 'dir');
+
+    const result = readRunContextOrderContent(root, slug);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('symlink 化した order.md を読まない', () => {
+    const root = createTempProjectDir();
+    const slug = '20260216-linked-order';
+    const runTaskDir = path.join(root, '.takt', 'runs', slug, 'context', 'task');
+    const escapedOrderPath = path.join(root, '.takt', 'escaped-order.md');
+    fs.mkdirSync(runTaskDir, { recursive: true });
+    fs.writeFileSync(escapedOrderPath, '# Escaped Task\n\nShould not be readable.', 'utf-8');
+    fs.symlinkSync(escapedOrderPath, path.join(runTaskDir, 'order.md'), 'file');
+
+    const result = readRunContextOrderContent(root, slug);
+
+    expect(result).toBeUndefined();
   });
 });

--- a/src/__tests__/runMeta.test.ts
+++ b/src/__tests__/runMeta.test.ts
@@ -46,21 +46,50 @@ describe('RunMetaManager', () => {
 
     const initialMeta = JSON.parse(String(vi.mocked(writeFileAtomic).mock.calls[0]![1])) as {
       status: string;
+      updatedAt?: string;
       currentStep?: string;
       currentIteration?: number;
     };
     const updatedMeta = JSON.parse(String(vi.mocked(writeFileAtomic).mock.calls[1]![1])) as {
       status: string;
+      updatedAt?: string;
       currentStep?: string;
       currentIteration?: number;
     };
 
     expect(initialMeta.status).toBe('running');
+    expect(initialMeta.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(initialMeta.currentStep).toBeUndefined();
     expect(initialMeta.currentIteration).toBeUndefined();
     expect(updatedMeta.status).toBe('running');
+    expect(updatedMeta.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(updatedMeta.currentStep).toBe('implement');
     expect(updatedMeta.currentIteration).toBe(2);
+  });
+
+  it('should persist the latest phase alongside step progress', () => {
+    const manager = new RunMetaManager(createRunPaths(), 'Force fail task', 'default');
+    manager.updateStep('review', 3);
+
+    (
+      manager as unknown as {
+        updatePhase: (stepName: string, iteration: number, phase: 1 | 2 | 3) => void;
+      }
+    ).updatePhase('review', 3, 2);
+
+    const phasedMeta = JSON.parse(String(vi.mocked(writeFileAtomic).mock.calls[2]![1])) as {
+      status: string;
+      updatedAt?: string;
+      currentStep?: string;
+      currentIteration?: number;
+      phase?: number;
+    };
+
+    expect(phasedMeta.status).toBe('running');
+    expect(phasedMeta.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(phasedMeta.currentStep).toBe('review');
+    expect(phasedMeta.currentIteration).toBe(3);
+    expect(phasedMeta.phase).toBe(2);
   });
 
   it('should keep currentStep and currentIteration when finalize is called', () => {
@@ -73,6 +102,7 @@ describe('RunMetaManager', () => {
 
     const finalizedMeta = JSON.parse(String(vi.mocked(writeFileAtomic).mock.calls[2]![1])) as {
       status: string;
+      updatedAt?: string;
       currentStep?: string;
       currentIteration?: number;
       iterations?: number;
@@ -80,6 +110,7 @@ describe('RunMetaManager', () => {
     };
 
     expect(finalizedMeta.status).toBe('completed');
+    expect(finalizedMeta.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(finalizedMeta.currentStep).toBe('review');
     expect(finalizedMeta.currentIteration).toBe(3);
     expect(finalizedMeta.iterations).toBe(3);

--- a/src/__tests__/task-exceed-service.test.ts
+++ b/src/__tests__/task-exceed-service.test.ts
@@ -118,7 +118,7 @@ describe('TaskRunner - exceedTask', () => {
     expect(exceededTask.owner_pid).toBeNull();
   });
 
-  it('should record the current step as start_step', () => {
+  it('should record the current step as start_movement', () => {
     runner.addTask('Task A');
     runner.claimNextTasks(1);
     const taskName = (loadTasksFile(testDir).tasks[0] as Record<string, unknown>).name as string;
@@ -131,7 +131,8 @@ describe('TaskRunner - exceedTask', () => {
 
     const afterFile = loadTasksFile(testDir);
     const exceededTask = afterFile.tasks[0]!;
-    expect(exceededTask.start_step).toBe('reviewers');
+    expect(exceededTask.start_movement).toBe('reviewers');
+    expect(exceededTask.start_step).toBeUndefined();
   });
 
   it('should record exceeded_max_steps in tasks.yaml', () => {
@@ -360,7 +361,7 @@ describe('TaskRunner - requeueExceededTask', () => {
     expect(file.tasks[0]?.exceeded_current_iteration).toBe(30);
   });
 
-  it('should preserve start_step for re-entry point', () => {
+  it('should preserve start_movement for re-entry point', () => {
     writeExceededRecord(testDir, {
       name: 'task-a',
       start_step: 'reviewers',
@@ -369,7 +370,8 @@ describe('TaskRunner - requeueExceededTask', () => {
     runner.requeueExceededTask('task-a');
 
     const file = loadTasksFile(testDir);
-    expect(file.tasks[0]?.start_step).toBe('reviewers');
+    expect(file.tasks[0]?.start_movement).toBe('reviewers');
+    expect(file.tasks[0]?.start_step).toBeUndefined();
   });
 
   it('should preserve resume_point through requeue for workflow_call retry', () => {

--- a/src/__tests__/task-schema.test.ts
+++ b/src/__tests__/task-schema.test.ts
@@ -128,24 +128,57 @@ describe('TaskExecutionConfigSchema', () => {
     expect(config.start_step).toBe('plan');
   });
 
-  it('should reject unknown workflow keys', () => {
+  it('should reject unknown workflow keys and accept canonical start_movement', () => {
     expect(() => TaskExecutionConfigSchema.parse({
       [unexpectedWorkflowKey]: 'legacy-workflow',
     })).toThrow();
 
     expect(() => TaskExecutionConfigSchema.parse({
       [unexpectedStartStepKey]: 'plan',
+    })).not.toThrow();
+  });
+
+  it('should reject conflicting start_step and start_movement values', () => {
+    expect(() => TaskExecutionConfigSchema.parse({
+      start_step: 'plan',
+      start_movement: 'implement',
+    })).toThrow('start_step and start_movement must match when both are set');
+  });
+
+  it('should return safeParse failure instead of throwing for conflicting start_step and start_movement values', () => {
+    const input = {
+      start_step: 'plan',
+      start_movement: 'implement',
+    };
+
+    expect(() => TaskExecutionConfigSchema.safeParse(input)).not.toThrow();
+    const result = TaskExecutionConfigSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          message: 'start_step and start_movement must match when both are set',
+          path: ['start_movement'],
+        }),
+      ]));
+    }
+  });
+
+  it('should reject non-string start_movement values', () => {
+    expect(() => TaskExecutionConfigSchema.parse({
+      start_movement: 123,
     })).toThrow();
   });
 
   it('should resolve workflow and start step through shared helpers', () => {
     expect(resolveTaskWorkflowValue({ workflow: 'unit-test' })).toBe('unit-test');
     expect(resolveTaskStartStepValue({ start_step: 'plan' })).toBe('plan');
+    expect(resolveTaskStartStepValue({ [unexpectedStartStepKey]: 'plan' })).toBe('plan');
+    expect(resolveTaskStartStepValue({ start_step: 'plan', start_movement: 'plan' })).toBe('plan');
     expect(resolveTaskWorkflowValue({ [unexpectedWorkflowKey]: 'unit-test' })).toBeUndefined();
-    expect(resolveTaskStartStepValue({ [unexpectedStartStepKey]: 'plan' })).toBeUndefined();
   });
 
-  it('should serialize canonical task keys as workflow and start_step', () => {
+  it('should serialize canonical task keys as workflow and start_movement', () => {
     const serialized = serializeTaskRecord({
       ...makePendingRecord(),
       workflow: 'unit-test',
@@ -154,7 +187,7 @@ describe('TaskExecutionConfigSchema', () => {
 
     expect(serialized).toMatchObject({
       workflow: 'unit-test',
-      start_step: 'plan',
+      start_movement: 'plan',
     });
   });
 
@@ -175,6 +208,26 @@ describe('TaskFileSchema', () => {
     expect(() => TaskFileSchema.parse({ task: 'do something' })).not.toThrow();
   });
 
+  it('should return safeParse failure instead of throwing for conflicting start_step and start_movement values', () => {
+    const input = {
+      task: 'do something',
+      start_step: 'plan',
+      start_movement: 'implement',
+    };
+
+    expect(() => TaskFileSchema.safeParse(input)).not.toThrow();
+    const result = TaskFileSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          message: 'start_step and start_movement must match when both are set',
+          path: ['start_movement'],
+        }),
+      ]));
+    }
+  });
+
   it('should reject empty task string', () => {
     expect(() => TaskFileSchema.parse({ task: '' })).toThrow();
   });
@@ -188,6 +241,26 @@ describe('TaskRecordSchema', () => {
   describe('pending status', () => {
     it('should accept valid pending record', () => {
       expect(() => TaskRecordSchema.parse(makePendingRecord())).not.toThrow();
+    });
+
+    it('should return safeParse failure instead of throwing for conflicting start_step and start_movement values', () => {
+      const input = {
+        ...makePendingRecord(),
+        start_step: 'plan',
+        start_movement: 'implement',
+      };
+
+      expect(() => TaskRecordSchema.safeParse(input)).not.toThrow();
+      const result = TaskRecordSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            message: 'start_step and start_movement must match when both are set',
+            path: ['start_movement'],
+          }),
+        ]));
+      }
     });
 
     it('should reject pending record with started_at', () => {

--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -37,7 +37,8 @@ function expectRetryMetadataPreserved(
     resumePoint: Record<string, unknown>;
   },
 ): void {
-  expect(record?.start_step).toBe(expected.startStep);
+  expect(record?.start_movement).toBe(expected.startStep);
+  expect(record?.start_step).toBeUndefined();
   expect(record?.exceeded_current_iteration).toBe(expected.currentIteration);
   expect(record?.exceeded_max_steps).toBe(expected.maxSteps);
   expect(record?.resume_point).toEqual(expected.resumePoint);
@@ -145,6 +146,147 @@ describe('TaskRunner (tasks.yaml)', () => {
     const tasks = runner.listTasks();
     expect(tasks).toHaveLength(1);
     expect(tasks[0]?.status).toBe('pending');
+  });
+
+  it('should recover interrupted running tasks with start_movement from run meta', () => {
+    runner.addTask('Task A', {
+      workflow: 'default',
+      start_step: 'draft',
+      exceeded_max_steps: 30,
+      exceeded_current_iteration: 4,
+      resume_point: {
+        version: 1,
+        stack: [
+          { workflow: 'default', step: 'draft', kind: 'workflow_call' },
+        ],
+        iteration: 4,
+        elapsed_ms: 120000,
+      },
+    });
+    const task = runner.claimNextTasks(1)[0]!;
+    runner.updateRunningTaskExecution(task.name, {
+      runSlug: '20260413-task-a',
+    });
+    writeRunMeta(testDir, '20260413-task-a', {
+      task: 'Task A',
+      workflow: 'default',
+      runSlug: '20260413-task-a',
+      runRoot: '.takt/runs/20260413-task-a',
+      reportDirectory: '.takt/runs/20260413-task-a/reports',
+      contextDirectory: '.takt/runs/20260413-task-a/context',
+      logsDirectory: '.takt/runs/20260413-task-a/logs',
+      status: 'aborted',
+      startTime: '2026-04-13T00:00:00.000Z',
+      currentStep: 'delegate',
+      currentIteration: 7,
+      resume_point: {
+        version: 1,
+        stack: [
+          { workflow: 'default', step: 'delegate', kind: 'workflow_call' },
+          { workflow: 'takt/coding', step: 'review', kind: 'agent' },
+        ],
+        iteration: 7,
+        elapsed_ms: 183245,
+      },
+    });
+
+    const current = loadTasksFile(testDir);
+    const running = current.tasks[0] as Record<string, unknown>;
+    running.owner_pid = 999999999;
+    writeFileSync(join(testDir, '.takt', 'tasks.yaml'), stringifyYaml(current), 'utf-8');
+
+    const recovered = runner.recoverInterruptedRunningTasks();
+
+    expect(recovered).toBe(1);
+
+    const file = loadTasksFile(testDir);
+    expect(file.tasks[0]?.status).toBe('pending');
+    expect(file.tasks[0]?.run_slug).toBeUndefined();
+    expect(file.tasks[0]?.start_movement).toBe('delegate');
+    expect(file.tasks[0]?.start_step).toBeUndefined();
+    expect(file.tasks[0]?.resume_point).toBeUndefined();
+    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
+  });
+
+  it('should preserve existing retry metadata when recovering a stale running task without run_slug', () => {
+    const staleResumePoint = {
+      version: 1 as const,
+      stack: [
+        { workflow: 'default', step: 'delegate', kind: 'workflow_call' as const },
+      ],
+      iteration: 4,
+      elapsed_ms: 120000,
+    };
+
+    runner.addTask('Task A', {
+      workflow: 'default',
+      start_step: 'delegate',
+      exceeded_max_steps: 30,
+      exceeded_current_iteration: 4,
+      resume_point: staleResumePoint,
+    });
+    runner.claimNextTasks(1);
+
+    const current = loadTasksFile(testDir);
+    const running = current.tasks[0] as Record<string, unknown>;
+    running.owner_pid = 999999999;
+    writeFileSync(join(testDir, '.takt', 'tasks.yaml'), stringifyYaml(current), 'utf-8');
+
+    const recovered = runner.recoverInterruptedRunningTasks();
+
+    expect(recovered).toBe(1);
+
+    const file = loadTasksFile(testDir);
+    expect(file.tasks[0]?.status).toBe('pending');
+    expect(file.tasks[0]?.run_slug).toBeUndefined();
+    expectRetryMetadataPreserved(file.tasks[0], {
+      startStep: 'delegate',
+      currentIteration: 4,
+      maxSteps: 30,
+      resumePoint: staleResumePoint,
+    });
+  });
+
+  it('should preserve existing retry metadata when recovering a stale running task without run meta', () => {
+    const staleResumePoint = {
+      version: 1 as const,
+      stack: [
+        { workflow: 'default', step: 'delegate', kind: 'workflow_call' as const },
+      ],
+      iteration: 4,
+      elapsed_ms: 120000,
+    };
+
+    runner.addTask('Task A', {
+      workflow: 'default',
+      start_step: 'delegate',
+      exceeded_max_steps: 30,
+      exceeded_current_iteration: 4,
+      resume_point: staleResumePoint,
+    });
+    const task = runner.claimNextTasks(1)[0]!;
+    runner.updateRunningTaskExecution(task.name, {
+      runSlug: '20260413-task-a',
+    });
+
+    const current = loadTasksFile(testDir);
+    const running = current.tasks[0] as Record<string, unknown>;
+    running.owner_pid = 999999999;
+    writeFileSync(join(testDir, '.takt', 'tasks.yaml'), stringifyYaml(current), 'utf-8');
+
+    const recovered = runner.recoverInterruptedRunningTasks();
+
+    expect(recovered).toBe(1);
+
+    const file = loadTasksFile(testDir);
+    expect(file.tasks[0]?.status).toBe('pending');
+    expect(file.tasks[0]?.run_slug).toBeUndefined();
+    expectRetryMetadataPreserved(file.tasks[0], {
+      startStep: 'delegate',
+      currentIteration: 4,
+      maxSteps: 30,
+      resumePoint: staleResumePoint,
+    });
   });
 
   it('should keep running tasks owned by a live process', () => {
@@ -397,7 +539,7 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(pending[0]?.data?.retry_note).toBe('retry note');
   });
 
-  it('should persist canonical workflow and start_step keys when requeueing failed task', () => {
+  it('should persist canonical workflow and start_movement keys when requeueing failed task', () => {
     runner.addTask('Task A', { workflow: 'default' });
     const task = runner.claimNextTasks(1)[0]!;
     runner.failTask({
@@ -413,10 +555,11 @@ describe('TaskRunner (tasks.yaml)', () => {
 
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.workflow).toBe('default');
-    expect(file.tasks[0]?.start_step).toBe('implement');
+    expect(file.tasks[0]?.start_movement).toBe('implement');
+    expect(file.tasks[0]?.start_step).toBeUndefined();
   });
 
-  it('should persist canonical workflow and start_step keys when starting re-execution', () => {
+  it('should persist canonical workflow and start_movement keys when starting re-execution', () => {
     runner.addTask('Task A', { workflow: 'default' });
     const task = runner.claimNextTasks(1)[0]!;
     runner.failTask({
@@ -438,7 +581,8 @@ describe('TaskRunner (tasks.yaml)', () => {
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.status).toBe('running');
     expect(file.tasks[0]?.workflow).toBe('default');
-    expect(file.tasks[0]?.start_step).toBe('implement');
+    expect(file.tasks[0]?.start_movement).toBe('implement');
+    expect(file.tasks[0]?.start_step).toBeUndefined();
     expect(file.tasks[0]?.retry_note).toBe('retry note');
   });
 
@@ -475,7 +619,7 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(file.tasks[0]?.resume_point).toEqual(resumePoint);
   });
 
-  it('should refresh retry metadata from run meta when a re-executed task fails', () => {
+  it('should keep only start_movement when a re-executed task fails with run meta', () => {
     const latestResumePoint = {
       version: 1 as const,
       stack: [
@@ -529,13 +673,14 @@ describe('TaskRunner (tasks.yaml)', () => {
     });
 
     const file = loadTasksFile(testDir);
-    expect(file.tasks[0]?.start_step).toBe('final-review');
-    expect(file.tasks[0]?.exceeded_current_iteration).toBe(9);
-    expect(file.tasks[0]?.resume_point).toEqual(latestResumePoint);
+    expect(file.tasks[0]?.start_movement).toBe('final-review');
+    expect(file.tasks[0]?.start_step).toBeUndefined();
+    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
+    expect(file.tasks[0]?.resume_point).toBeUndefined();
     expect(file.tasks[0]?.exceeded_max_steps).toBeUndefined();
   });
 
-  it('should persist parent workflow_call resume_point when terminal failure happens after the child completes', () => {
+  it('should keep only start_movement when terminal failure happens after the child completes', () => {
     const workflowCallResumePoint = {
       version: 1 as const,
       stack: [
@@ -588,9 +733,10 @@ describe('TaskRunner (tasks.yaml)', () => {
     });
 
     const file = loadTasksFile(testDir);
-    expect(file.tasks[0]?.start_step).toBe('delegate');
-    expect(file.tasks[0]?.exceeded_current_iteration).toBe(7);
-    expect(file.tasks[0]?.resume_point).toEqual(workflowCallResumePoint);
+    expect(file.tasks[0]?.start_movement).toBe('delegate');
+    expect(file.tasks[0]?.start_step).toBeUndefined();
+    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
+    expect(file.tasks[0]?.resume_point).toBeUndefined();
   });
 
   it('should clear stale retry metadata when a re-executed task completes without run meta', () => {
@@ -625,6 +771,7 @@ describe('TaskRunner (tasks.yaml)', () => {
     });
 
     const file = loadTasksFile(testDir);
+    expect(file.tasks[0]?.start_movement).toBeUndefined();
     expect(file.tasks[0]?.start_step).toBeUndefined();
     expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
     expect(file.tasks[0]?.resume_point).toBeUndefined();
@@ -834,16 +981,17 @@ describe('TaskRunner (tasks.yaml)', () => {
     });
 
     const file = loadTasksFile(testDir);
+    expect(file.tasks[0]?.start_movement).toBeUndefined();
     expect(file.tasks[0]?.start_step).toBeUndefined();
     expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
     expect(file.tasks[0]?.resume_point).toBeUndefined();
     expect(file.tasks[0]?.exceeded_max_steps).toBeUndefined();
   });
 
-  it('should read workflow and start_step from tasks.yaml into task data', () => {
+  it('should read workflow and start_movement from tasks.yaml into task data', () => {
     writeTasksFile(testDir, [createPendingRecord({
       workflow: 'default',
-      start_step: 'implement',
+      start_movement: 'implement',
     })]);
 
     const tasks = runner.listTasks();

--- a/src/__tests__/taskResultHandler.test.ts
+++ b/src/__tests__/taskResultHandler.test.ts
@@ -55,7 +55,8 @@ describe('persistExceededTaskResult', () => {
     const { tasks } = loadTasksFile(testDir);
     const row = tasks[0]!;
     expect(row.status).toBe('exceeded');
-    expect(row.start_step).toBe('reviewers');
+    expect(row.start_movement).toBe('reviewers');
+    expect(row.start_step).toBeUndefined();
     expect(row.exceeded_max_steps).toBe(60);
     expect(row.exceeded_current_iteration).toBe(30);
     expect(mockInfo).toHaveBeenCalledWith(

--- a/src/__tests__/taskRetryActions.test.ts
+++ b/src/__tests__/taskRetryActions.test.ts
@@ -305,6 +305,52 @@ describe('retryFailedTask', () => {
     );
   });
 
+  it('should prefer task.runSlug over task content lookup when loading retry run context', async () => {
+    mockReadRunMetaBySlug.mockReturnValue({
+      task: 'Original task content',
+      workflow: 'default',
+      runSlug: 'run-1',
+      runRoot: '.takt/runs/run-1',
+      reportDirectory: '.takt/runs/run-1/reports',
+      contextDirectory: '.takt/runs/run-1/context',
+      logsDirectory: '.takt/runs/run-1/logs',
+      status: 'failed',
+      startTime: '2026-04-13T00:00:00.000Z',
+    });
+
+    await retryFailedTask(makeFailedTask({
+      content: 'Edited task content',
+      runSlug: 'run-1',
+    }), '/project');
+
+    expect(mockFindRunForTask).not.toHaveBeenCalled();
+    expect(mockReadRunMetaBySlug).toHaveBeenCalledWith(
+      '/project/.takt/worktrees/my-task',
+      'run-1',
+      expect.any(Function),
+    );
+    expect(mockFindPreviousOrderContent).toHaveBeenCalledWith(
+      '/project/.takt/worktrees/my-task',
+      'run-1',
+    );
+  });
+
+  it('should keep using task.runSlug for retry context when run meta is missing', async () => {
+    mockReadRunMetaBySlug.mockReturnValue(null);
+
+    await retryFailedTask(makeFailedTask({
+      content: 'Edited task content',
+      runSlug: 'run-1',
+    }), '/project');
+
+    expect(mockFindRunForTask).not.toHaveBeenCalled();
+    expect(mockLoadRunSessionContext).not.toHaveBeenCalled();
+    expect(mockFindPreviousOrderContent).toHaveBeenCalledWith(
+      '/project/.takt/worktrees/my-task',
+      'run-1',
+    );
+  });
+
   it('should keep root workflow_call step as retry default when child step was renamed', async () => {
     mockFindRunForTask.mockReturnValue('run-1');
     mockLoadWorkflowByIdentifier.mockReturnValue({

--- a/src/__tests__/workflowExecution-debug-prompts.test.ts
+++ b/src/__tests__/workflowExecution-debug-prompts.test.ts
@@ -409,16 +409,19 @@ describe('executeWorkflow debug prompts logging', () => {
     const metaCalls = vi.mocked(writeFileAtomic).mock.calls.filter(
       (call) => String(call[0]).endsWith('/meta.json')
     );
-    expect(metaCalls).toHaveLength(3);
+    expect(metaCalls.length).toBeGreaterThanOrEqual(3);
 
     const firstMeta = JSON.parse(String(metaCalls[0]![1])) as { status: string; endTime?: string };
-    const secondMeta = JSON.parse(String(metaCalls[1]![1])) as {
-      status: string;
-      currentStep?: string;
-      currentIteration?: number;
-      endTime?: string;
-    };
-    const thirdMeta = JSON.parse(String(metaCalls[2]![1])) as {
+    const stepMeta = metaCalls
+      .map((call) => JSON.parse(String(call[1])) as {
+        status: string;
+        currentStep?: string;
+        currentIteration?: number;
+        phase?: number;
+        endTime?: string;
+      })
+      .find((meta) => meta.currentStep === 'implement' && meta.currentIteration === 1 && meta.phase === undefined);
+    const finalMeta = JSON.parse(String(metaCalls[metaCalls.length - 1]![1])) as {
       status: string;
       currentStep?: string;
       currentIteration?: number;
@@ -426,14 +429,16 @@ describe('executeWorkflow debug prompts logging', () => {
     };
     expect(firstMeta.status).toBe('running');
     expect(firstMeta.endTime).toBeUndefined();
-    expect(secondMeta.status).toBe('running');
-    expect(secondMeta.currentStep).toBe('implement');
-    expect(secondMeta.currentIteration).toBe(1);
-    expect(secondMeta.endTime).toBeUndefined();
-    expect(thirdMeta.status).toBe('completed');
-    expect(thirdMeta.currentStep).toBe('implement');
-    expect(thirdMeta.currentIteration).toBe(1);
-    expect(thirdMeta.endTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(stepMeta).toMatchObject({
+      status: 'running',
+      currentStep: 'implement',
+      currentIteration: 1,
+    });
+    expect(stepMeta?.endTime).toBeUndefined();
+    expect(finalMeta.status).toBe('completed');
+    expect(finalMeta.currentStep).toBe('implement');
+    expect(finalMeta.currentIteration).toBe(1);
+    expect(finalMeta.endTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   it('should update meta status from running to aborted', async () => {
@@ -445,16 +450,19 @@ describe('executeWorkflow debug prompts logging', () => {
     const metaCalls = vi.mocked(writeFileAtomic).mock.calls.filter(
       (call) => String(call[0]).endsWith('/meta.json')
     );
-    expect(metaCalls).toHaveLength(3);
+    expect(metaCalls.length).toBeGreaterThanOrEqual(3);
 
     const firstMeta = JSON.parse(String(metaCalls[0]![1])) as { status: string; endTime?: string };
-    const secondMeta = JSON.parse(String(metaCalls[1]![1])) as {
-      status: string;
-      currentStep?: string;
-      currentIteration?: number;
-      endTime?: string;
-    };
-    const thirdMeta = JSON.parse(String(metaCalls[2]![1])) as {
+    const stepMeta = metaCalls
+      .map((call) => JSON.parse(String(call[1])) as {
+        status: string;
+        currentStep?: string;
+        currentIteration?: number;
+        phase?: number;
+        endTime?: string;
+      })
+      .find((meta) => meta.currentStep === 'implement' && meta.currentIteration === 1 && meta.phase === undefined);
+    const finalMeta = JSON.parse(String(metaCalls[metaCalls.length - 1]![1])) as {
       status: string;
       currentStep?: string;
       currentIteration?: number;
@@ -462,14 +470,16 @@ describe('executeWorkflow debug prompts logging', () => {
     };
     expect(firstMeta.status).toBe('running');
     expect(firstMeta.endTime).toBeUndefined();
-    expect(secondMeta.status).toBe('running');
-    expect(secondMeta.currentStep).toBe('implement');
-    expect(secondMeta.currentIteration).toBe(1);
-    expect(secondMeta.endTime).toBeUndefined();
-    expect(thirdMeta.status).toBe('aborted');
-    expect(thirdMeta.currentStep).toBe('implement');
-    expect(thirdMeta.currentIteration).toBe(1);
-    expect(thirdMeta.endTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(stepMeta).toMatchObject({
+      status: 'running',
+      currentStep: 'implement',
+      currentIteration: 1,
+    });
+    expect(stepMeta?.endTime).toBeUndefined();
+    expect(finalMeta.status).toBe('aborted');
+    expect(finalMeta.currentStep).toBe('implement');
+    expect(finalMeta.currentIteration).toBe(1);
+    expect(finalMeta.endTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   it('should finalize meta as aborted when WorkflowEngine constructor throws', async () => {

--- a/src/__tests__/workflowExecutionEvents.test.ts
+++ b/src/__tests__/workflowExecutionEvents.test.ts
@@ -36,6 +36,7 @@ describe('bindWorkflowExecutionEvents', () => {
     };
     const runMetaManager = {
       updateStep: vi.fn(),
+      updatePhase: vi.fn(),
       updateResumePoint: vi.fn(),
       finalize: vi.fn(),
     };
@@ -111,10 +112,15 @@ describe('bindWorkflowExecutionEvents', () => {
     };
 
     engine.emit('step:start', step, 2, 'instruction', { provider: 'mock', model: 'gpt-test' });
+    engine.emit('phase:start', step, 1, 'main', 'instruction', [], 'phase-1', 2);
+    engine.emit('phase:complete', step, 1, 'main', 'approved', 'done', undefined, 'phase-1', 2);
     engine.emit('step:complete', step, response, 'instruction');
     engine.emit('workflow:complete', { iteration: 2 });
 
     expect(runMetaManager.updateStep).toHaveBeenCalledWith('review', 2, resumePoint);
+    expect(runMetaManager.updatePhase).toHaveBeenCalledTimes(2);
+    expect(runMetaManager.updatePhase.mock.calls[0]?.slice(0, 3)).toEqual(['review', 2, 1]);
+    expect(runMetaManager.updatePhase.mock.calls[1]?.slice(0, 3)).toEqual(['review', 2, 1]);
     expect(runMetaManager.updateResumePoint).toHaveBeenCalledWith(resumePoint);
     expect(runMetaManager.finalize).toHaveBeenCalledWith('completed', 2);
     expect(bridge.state.lastStepName).toBe('review');

--- a/src/__tests__/worktree-exceeded-requeue.test.ts
+++ b/src/__tests__/worktree-exceeded-requeue.test.ts
@@ -208,7 +208,8 @@ describe('シナリオ1・2: exceeded status transition via executeAndCompleteTa
     const file = loadTasksFile(testDir);
     const exceededRecord = file.tasks[0];
     expect(exceededRecord?.status).toBe('exceeded');
-    expect(exceededRecord?.start_step).toBe('implement');
+    expect(exceededRecord?.start_movement).toBe('implement');
+    expect(exceededRecord?.start_step).toBeUndefined();
     expect(exceededRecord?.exceeded_max_steps).toBe(60);
     expect(exceededRecord?.exceeded_current_iteration).toBe(30);
     expect(exceededRecord?.resume_point).toEqual(resumePoint);

--- a/src/core/workflow/run/order-content.ts
+++ b/src/core/workflow/run/order-content.ts
@@ -1,4 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { isPathInside, isRealPathInside, isValidReportDirName } from '../../../shared/utils/index.js';
 import { buildRunPaths } from './run-paths.js';
 
 export interface ReadRunContextOrderContentOptions {
@@ -10,8 +12,20 @@ export function readRunContextOrderContent(
   slug: string,
   options?: ReadRunContextOrderContentOptions,
 ): string | undefined {
+  if (!isValidReportDirName(slug)) {
+    return undefined;
+  }
+
+  const runsDir = resolve(cwd, '.takt', 'runs');
   const runPaths = buildRunPaths(cwd, slug);
+  if (!isPathInside(runsDir, runPaths.contextTaskOrderAbs)) {
+    return undefined;
+  }
+
   if (!existsSync(runPaths.contextTaskOrderAbs)) {
+    return undefined;
+  }
+  if (!isRealPathInside(runsDir, runPaths.contextTaskOrderAbs)) {
     return undefined;
   }
 

--- a/src/core/workflow/run/run-meta.ts
+++ b/src/core/workflow/run/run-meta.ts
@@ -19,6 +19,8 @@ export interface RunMeta {
   iterations?: number;
   currentStep?: string;
   currentIteration?: number;
+  phase?: 1 | 2 | 3;
+  updatedAt?: string;
   resumePoint?: WorkflowResumePoint;
 }
 

--- a/src/features/tasks/execute/runMeta.ts
+++ b/src/features/tasks/execute/runMeta.ts
@@ -39,7 +39,15 @@ export class RunMetaManager {
   updateStep(stepName: string, iteration: number, resumePoint?: WorkflowResumePoint): void {
     this.runMeta.currentStep = stepName;
     this.runMeta.currentIteration = iteration;
+    delete this.runMeta.phase;
     this.runMeta.resumePoint = resumePoint;
+    this.writeRunMeta(this.runMeta);
+  }
+
+  updatePhase(stepName: string, iteration: number, phase: 1 | 2 | 3): void {
+    this.runMeta.currentStep = stepName;
+    this.runMeta.currentIteration = iteration;
+    this.runMeta.phase = phase;
     this.writeRunMeta(this.runMeta);
   }
 
@@ -63,11 +71,14 @@ export class RunMetaManager {
   }
 
   private writeRunMeta(meta: RunMeta): void {
+    const updatedAt = new Date().toISOString();
     const serialized: PersistedRunMeta = {
       ...meta,
+      updatedAt,
       ...(meta.resumePoint ? { resume_point: meta.resumePoint } : {}),
     };
     delete (serialized as Partial<RunMeta>).resumePoint;
+    this.runMeta.updatedAt = updatedAt;
     writeFileAtomic(this.metaAbs, JSON.stringify(serialized, null, 2));
   }
 }

--- a/src/features/tasks/execute/workflowExecutionEvents.ts
+++ b/src/features/tasks/execute/workflowExecutionEvents.ts
@@ -127,6 +127,7 @@ export function bindWorkflowExecutionEvents(
   };
 
   deps.engine.on('phase:start', (step, phase, phaseName, instruction, promptParts, phaseExecutionId, iteration) => {
+    deps.runMetaManager.updatePhase(step.name, iteration, phase);
     deps.sessionLogger.onPhaseStart(
       step,
       phase,
@@ -140,6 +141,7 @@ export function bindWorkflowExecutionEvents(
   });
 
   deps.engine.on('phase:complete', (step, phase, phaseName, content, phaseStatus, phaseError, phaseExecutionId, iteration) => {
+    deps.runMetaManager.updatePhase(step.name, iteration, phase);
     deps.sessionLogger.setIteration(state.currentIteration);
     deps.sessionLogger.onPhaseComplete(
       step,

--- a/src/features/tasks/list/taskRetryActions.ts
+++ b/src/features/tasks/list/taskRetryActions.ts
@@ -14,7 +14,7 @@ import { selectOptionWithDefault } from '../../../shared/prompt/index.js';
 import { info, header, blankLine, status, warn } from '../../../shared/ui/index.js';
 import { createLogger } from '../../../shared/utils/index.js';
 import type { WorkflowConfig, WorkflowResumePoint } from '../../../core/models/index.js';
-import { readRunMetaBySlug } from '../../../core/workflow/run/run-meta.js';
+import { readRunMetaBySlug, type RunMeta } from '../../../core/workflow/run/run-meta.js';
 import {
   findRunForTask,
   loadRunSessionContext,
@@ -107,19 +107,27 @@ function buildRetryRunInfo(
   };
 }
 
+function resolveRetryRunSlug(task: TaskListItem, worktreePath: string): string | null {
+  return task.runSlug ?? findRunForTask(worktreePath, task.content);
+}
+
+function readRetryRunMeta(worktreePath: string, runSlug: string | null): RunMeta | null {
+  if (!runSlug) {
+    return null;
+  }
+
+  return readRunMetaBySlug(worktreePath, runSlug, (warningMessage) => {
+    warn(warningMessage);
+  });
+}
+
 function resolveRetryResumePoint(
   task: TaskListItem,
-  worktreePath: string,
-  matchedSlug: string | null,
+  runMeta: RunMeta | null,
 ): WorkflowResumePoint | undefined {
-  if (matchedSlug) {
-    const runMeta = readRunMetaBySlug(worktreePath, matchedSlug, (warningMessage) => {
-      warn(warningMessage);
-    });
-    const metaResumePoint = runMeta?.resumePoint;
-    if (metaResumePoint) {
-      return metaResumePoint;
-    }
+  const metaResumePoint = runMeta?.resumePoint;
+  if (metaResumePoint) {
+    return metaResumePoint;
   }
 
   return task.data?.resume_point;
@@ -187,8 +195,9 @@ export async function retryFailedTask(
 
   displayFailureInfo(task);
 
-  const matchedSlug = findRunForTask(worktreePath, task.content);
-  const runInfo = matchedSlug ? buildRetryRunInfo(worktreePath, matchedSlug) : null;
+  const matchedSlug = resolveRetryRunSlug(task, worktreePath);
+  const runMeta = readRetryRunMeta(worktreePath, matchedSlug);
+  const runInfo = matchedSlug && runMeta ? buildRetryRunInfo(worktreePath, matchedSlug) : null;
 
   const selectedWorkflow = await selectWorkflowWithOptionalReuse(
     projectDir,
@@ -207,7 +216,7 @@ export async function retryFailedTask(
   }
   validateWorkflowExecutionTrustBoundary(workflowConfig, projectDir);
 
-  const resumePoint = resolveRetryResumePoint(task, worktreePath, matchedSlug);
+  const resumePoint = resolveRetryResumePoint(task, runMeta);
   const selectedStep = await selectStartStep(
     workflowConfig,
     resolveRetryDefaultStep(workflowConfig, task, resumePoint),

--- a/src/infra/task/taskConfigSerialization.ts
+++ b/src/infra/task/taskConfigSerialization.ts
@@ -33,8 +33,26 @@ export function resolveTaskWorkflowValue(record: Record<string, unknown>): strin
   return getStringField(record, 'workflow');
 }
 
+function validateTaskStartStepAlias(record: Record<string, unknown>, ctx: z.core.$RefinementCtx): void {
+  const startAlias = getStringField(record, 'start_movement');
+  const startStep = getStringField(record, 'start_step');
+
+  if (
+    startAlias !== undefined
+    && startStep !== undefined
+    && startAlias !== startStep
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'start_step and start_movement must match when both are set',
+      input: record,
+      path: ['start_movement'],
+    });
+  }
+}
+
 export function resolveTaskStartStepValue(record: Record<string, unknown>): string | undefined {
-  return getStringField(record, 'start_step');
+  return getStringField(record, 'start_movement') ?? getStringField(record, 'start_step');
 }
 
 export function normalizeTaskConfig(input: unknown): unknown {
@@ -58,6 +76,9 @@ export function normalizeTaskConfig(input: unknown): unknown {
   if (startStep !== undefined) {
     next.start_step = startStep;
   }
+  if (typeof record.start_movement === 'string') {
+    delete next.start_movement;
+  }
   if (resumePoint !== undefined) {
     next.resume_point = resumePoint;
   }
@@ -74,6 +95,7 @@ export function serializeTaskConfig(record: Record<string, unknown>): Record<str
 
   delete serialized.workflow;
   delete serialized.start_step;
+  delete serialized.start_movement;
   delete serialized.exceeded_max_steps;
   delete serialized.resume_point;
 
@@ -81,7 +103,7 @@ export function serializeTaskConfig(record: Record<string, unknown>): Record<str
     serialized.workflow = workflow;
   }
   if (startStep !== undefined) {
-    serialized.start_step = startStep;
+    serialized.start_movement = startStep;
   }
   if (exceededMax !== undefined) {
     serialized.exceeded_max_steps = exceededMax;
@@ -93,6 +115,15 @@ export function serializeTaskConfig(record: Record<string, unknown>): Record<str
   return serialized;
 }
 
-export function buildTaskSchema<T extends z.ZodType>(schema: T): z.ZodPipe<z.ZodTransform<unknown, unknown>, T> {
-  return z.preprocess(normalizeTaskConfig, schema);
+export function buildTaskSchema<T extends z.ZodType>(schema: T) {
+  return z.unknown()
+    .superRefine((input, ctx) => {
+      const record = toTaskConfigRecord(input);
+      if (!record) {
+        return;
+      }
+      validateTaskStartStepAlias(record, ctx);
+    })
+    .transform(normalizeTaskConfig)
+    .pipe(schema);
 }

--- a/src/infra/task/taskLifecycleService.ts
+++ b/src/infra/task/taskLifecycleService.ts
@@ -8,7 +8,7 @@ import { isStaleRunningTask } from './process.js';
 import { readRetryMetadataByRunSlug } from '../../core/workflow/run/retry-metadata.js';
 import {
   buildClaimedTaskRecord,
-  buildRecoveredTaskRecord,
+  buildRecoveredTaskRecordWithRetryMetadata,
   type ResolvedTaskRetryMetadata,
   buildTerminalTaskRecord,
   generateTaskName,
@@ -90,11 +90,31 @@ export class TaskLifecycleService {
           return task;
         }
         recovered++;
-        return buildRecoveredTaskRecord(task);
+        return buildRecoveredTaskRecordWithRetryMetadata(
+          task,
+          this.readRecoveryRetryMetadata(task),
+        );
       });
       return { tasks };
     });
     return recovered;
+  }
+
+  private readRecoveryRetryMetadata(task: TaskRecord): ResolvedTaskRetryMetadata {
+    if (!task.run_slug) {
+      return { preserveExisting: true };
+    }
+
+    const retryMetadata = this.readTerminalRetryMetadata(task);
+    if (retryMetadata.preserveExisting) {
+      return retryMetadata;
+    }
+
+    if (!retryMetadata.startStep) {
+      return { preserveExisting: true };
+    }
+
+    return { startStep: retryMetadata.startStep };
   }
 
   private readTerminalRetryMetadata(task: TaskRecord): ResolvedTaskRetryMetadata {
@@ -102,11 +122,18 @@ export class TaskLifecycleService {
       return {};
     }
 
-    return readRetryMetadataByRunSlug(
+    const retryMetadata = readRetryMetadataByRunSlug(
       task.worktree_path ?? this.projectDir,
       task.run_slug,
       this.onWarning,
     );
+    if (retryMetadata.preserveExisting) {
+      return retryMetadata;
+    }
+
+    return retryMetadata.startStep
+      ? { startStep: retryMetadata.startStep }
+      : {};
   }
 
   completeTask(result: TaskResult): string {

--- a/src/infra/task/taskRecordMutations.ts
+++ b/src/infra/task/taskRecordMutations.ts
@@ -30,13 +30,19 @@ export function buildClaimedTaskRecord(task: TaskRecord): TaskRecord {
   };
 }
 
-export function buildRecoveredTaskRecord(task: TaskRecord): TaskRecord {
+export function buildRecoveredTaskRecordWithRetryMetadata(
+  task: TaskRecord,
+  retryMetadata: ResolvedTaskRetryMetadata,
+): TaskRecord {
+  const nextTask = retryMetadata.preserveExisting ? { ...task } : clearRetryMetadata(task);
   return {
-    ...task,
+    ...nextTask,
     status: 'pending',
     started_at: null,
+    completed_at: null,
     owner_pid: null,
     run_slug: undefined,
+    ...(retryMetadata.startStep ? { start_step: retryMetadata.startStep } : {}),
   };
 }
 

--- a/test/helpers/deprecated-terminology.ts
+++ b/test/helpers/deprecated-terminology.ts
@@ -56,6 +56,8 @@ const deprecatedInlineCodeTerms = [
   ...terminologyMigrationLine.matchAll(/`([^`]+)`/g),
 ].map((match) => match[1]);
 
+const allowedDeprecatedTermContainers = ['start_movement'];
+
 export const deprecatedTerminologyTerms = Array.from(
   new Set([
     deprecatedWorkflowTerm,
@@ -71,5 +73,9 @@ export const deprecatedTerminologyTerms = Array.from(
 ).sort((left, right) => right.length - left.length);
 
 export function findDeprecatedTerms(content: string): string[] {
-  return deprecatedTerminologyTerms.filter((term) => lowerCaseIncludesDeprecatedTerm(content, term));
+  const sanitizedContent = allowedDeprecatedTermContainers.reduce(
+    (current, allowedValue) => current.split(allowedValue).join(''),
+    content,
+  );
+  return deprecatedTerminologyTerms.filter((term) => lowerCaseIncludesDeprecatedTerm(sanitizedContent, term));
 }


### PR DESCRIPTION
## Summary

## Summary
- run実行中の進捗（step/phase）をruns側に継続的に保存し、次回実行時の再開トリガーへ反映する
- 現状は中断時にtasks.yamlが中途状態を示すまま残るか、再開位置の保存が十分でないため、ここを解消する

## Why
- run再開時に前回の継続位置（step/phase）を正しく引き継げるようにするため
- piece/workflow や movement/step の名称差を吸収しつつ、workflow/step観点のUXを優先するため

## Proposed Changes
1. `.takt/runs/<slug>/checkpoint.json`（または同等のrunメタ）を新設
   - 保存項目: `workflow`, `step`, `phase(1|2|3)`, `iteration`, `status`, `updatedAt`
2. movement/step開始・phase開始/完了イベントで checkpoint を更新
3. 異常中断（abort等）時に、tasks.yaml の再開用値 `start_movement`（内部互換）を最新stepに反映
4. 次回再実行時は `resolveTaskExecution` の `start_movement` を使って再開
5. 既存フロー（claim/requeue/complete/fail）は壊さず、互換性維持

## Acceptance Criteria
- [ ] run中の step/phase1..3 遷移で checkpoint が更新される
- [ ] run中断/再開時に、前回の step から再開できる
- [ ] tasks.yaml には再開に必要な最小情報（`start_movement`）のみ反映される
- [ ] UI表示は workflow/step観点を優先しつつ、既存piece/movement内部実装は互換維持
- [ ] テストで中断後再開のシナリオがカバーされる

## Execution Report

Workflow `takt-default` completed successfully.

Closes #568