### PR TITLE
fix-go-without-history

### DIFF
--- a/src/__tests__/conversationLoop-resume.test.ts
+++ b/src/__tests__/conversationLoop-resume.test.ts
@@ -245,6 +245,34 @@ describe('/resume command', () => {
     expect(result.action).toBe('cancel');
   });
 
+  it('should keep inline /go text as user note after resuming a session', async () => {
+    setupRawStdin(toRawInputs(['/resume', '/go add rollback plan']));
+    mockSelectRecentSession.mockResolvedValue('resumed-session-xyz');
+
+    const { provider, capture } = createScenarioProvider([
+      { content: 'Summarized resumed task.' },
+    ]);
+
+    const ctx: SessionContext = {
+      provider: provider as SessionContext['provider'],
+      providerType: 'mock' as SessionContext['providerType'],
+      model: undefined,
+      lang: 'en',
+      personaName: 'interactive',
+      sessionId: undefined,
+    };
+
+    const result = await runConversationLoop('/test', ctx, defaultStrategy, undefined, undefined);
+
+    expect(capture.callCount).toBe(1);
+    expect(capture.prompts[0]).toContain('User Note:\nadd rollback plan');
+    expect(capture.prompts[0]).not.toContain('User: add rollback plan');
+    expect(result).toEqual({
+      action: 'execute',
+      task: 'Summarized resumed task.',
+    });
+  });
+
   it('should reject /retry in non-retry mode', async () => {
     setupRawStdin(toRawInputs(['/retry', '/cancel']));
     setupProvider([]);

--- a/src/__tests__/instructMode.test.ts
+++ b/src/__tests__/instructMode.test.ts
@@ -119,6 +119,26 @@ describe('runInstructMode', () => {
     expect(result.task).toBe('Add unit tests for the feature.');
   });
 
+  it('should return action=execute with task on initial /go with inline task text', async () => {
+    setupRawStdin(toRawInputs(['/go add more tests', '/cancel']));
+    setupMockProvider(['Add unit tests from inline /go task.']);
+
+    const result = await runInstructMode('/project', 'branch context', 'feature-branch', 'my-task', 'Do something', '');
+
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('Add unit tests from inline /go task.');
+  });
+
+  it('should return action=execute with task on initial suffix /go command text', async () => {
+    setupRawStdin(toRawInputs(['add more tests /go', '/cancel']));
+    setupMockProvider(['Add unit tests from suffix /go task.']);
+
+    const result = await runInstructMode('/project', 'branch context', 'feature-branch', 'my-task', 'Do something', '');
+
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('Add unit tests from suffix /go task.');
+  });
+
   it('should return action=save_task when user selects save task', async () => {
     setupRawStdin(toRawInputs(['describe task', '/go']));
     setupMockProvider(['response', 'Summarized task.']);

--- a/src/__tests__/interactive-mode.test.ts
+++ b/src/__tests__/interactive-mode.test.ts
@@ -494,6 +494,24 @@ describe('personaMode', () => {
     );
   });
 
+  it('should summarize initial /go task text without prior conversation', async () => {
+    setupRawStdin(toRawInputs(['/go add regression coverage', '/cancel']));
+    setupMockProvider(['Add regression coverage for the shared /go path.']);
+    mockSelectOption.mockResolvedValue('execute');
+
+    const result = await personaMode('/project', mockFirstStep);
+
+    expect(result).toEqual({
+      action: 'execute',
+      task: 'Add regression coverage for the shared /go path.',
+    });
+    const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
+    expect(mockProvider._call).toHaveBeenCalledTimes(1);
+    const summaryPrompt = mockProvider._call.mock.calls[0]?.[0] as string;
+    expect(summaryPrompt).toContain('User: add regression coverage');
+    expect(summaryPrompt).not.toContain('User Note:\nadd regression coverage');
+  });
+
   it('should keep initialInput as source context until the user acts', async () => {
     // Given
     setupRawStdin(toRawInputs(['/go']));
@@ -513,6 +531,26 @@ describe('personaMode', () => {
     expect(firstPrompt).toContain('untrusted external reference data');
     expect(firstPrompt).toContain('```text');
     expect(firstPrompt).not.toContain('User: fix the login');
+  });
+
+  it('should keep initial /go text as user note when only source context exists', async () => {
+    setupRawStdin(toRawInputs(['/go inspect latest feedback', '/cancel']));
+    setupMockProvider(['Task summary with source context and note.']);
+    mockSelectOption.mockResolvedValue('execute');
+
+    const result = await personaMode('/project', mockFirstStep, { sourceContext: 'PR context' });
+
+    expect(result).toEqual({
+      action: 'execute',
+      task: 'Task summary with source context and note.',
+    });
+    const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
+    expect(mockProvider._call).toHaveBeenCalledTimes(1);
+    const summaryPrompt = mockProvider._call.mock.calls[0]?.[0] as string;
+    expect(summaryPrompt).toContain('Source Context');
+    expect(summaryPrompt).toContain('PR context');
+    expect(summaryPrompt).toContain('User Note:\ninspect latest feedback');
+    expect(summaryPrompt).not.toContain('User: inspect latest feedback');
   });
 
   it('should include source context in the first persona prompt without turning it into a user turn', async () => {

--- a/src/__tests__/interactive.test.ts
+++ b/src/__tests__/interactive.test.ts
@@ -129,6 +129,46 @@ describe('interactiveMode', () => {
     expect(result.task).toBe('Implement auth feature with chosen method.');
   });
 
+  it('should return action=execute with task on initial /go with inline task text', async () => {
+    // Given
+    setupRawStdin(toRawInputs(['/go add auth feature', '/cancel']));
+    setupMockProvider(['Implement auth feature from inline /go task.']);
+
+    // When
+    const result = await interactiveMode('/project');
+
+    // Then
+    expect(result).toEqual({
+      action: 'execute',
+      task: 'Implement auth feature from inline /go task.',
+    });
+    const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
+    expect(mockProvider._call).toHaveBeenCalledTimes(1);
+    const summaryPrompt = mockProvider._call.mock.calls[0]?.[0] as string;
+    expect(summaryPrompt).toContain('User: add auth feature');
+    expect(summaryPrompt).not.toContain('User Note:\nadd auth feature');
+  });
+
+  it('should return action=execute with task on initial suffix /go command text', async () => {
+    // Given
+    setupRawStdin(toRawInputs(['add auth feature /go', '/cancel']));
+    setupMockProvider(['Implement auth feature from suffix /go task.']);
+
+    // When
+    const result = await interactiveMode('/project');
+
+    // Then
+    expect(result).toEqual({
+      action: 'execute',
+      task: 'Implement auth feature from suffix /go task.',
+    });
+    const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
+    expect(mockProvider._call).toHaveBeenCalledTimes(1);
+    const summaryPrompt = mockProvider._call.mock.calls[0]?.[0] as string;
+    expect(summaryPrompt).toContain('User: add auth feature');
+    expect(summaryPrompt).not.toContain('User Note:\nadd auth feature');
+  });
+
   it('should reject /go with no prior conversation', async () => {
     // Given: /go immediately, then /cancel to exit
     setupRawStdin(toRawInputs(['/go', '/cancel']));
@@ -226,6 +266,25 @@ describe('interactiveMode', () => {
 
     expect(result.action).toBe('execute');
     expect(result.task).toBe('Clarify task for "a".');
+  });
+
+  it('should keep inline /go text as user note when source context exists before conversation', async () => {
+    setupRawStdin(toRawInputs(['/go add auth feature', '/cancel']));
+    setupMockProvider(['Clarify task for source context plus note.']);
+
+    const result = await interactiveMode('/project', { sourceContext: 'a' });
+
+    const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
+    expect(mockProvider._call).toHaveBeenCalledTimes(1);
+    const summaryPrompt = mockProvider._call.mock.calls[0]?.[0] as string;
+    expect(summaryPrompt).toContain('Source Context');
+    expect(summaryPrompt).toContain('a');
+    expect(summaryPrompt).toContain('User Note:\nadd auth feature');
+    expect(summaryPrompt).not.toContain('User: add auth feature');
+    expect(result).toEqual({
+      action: 'execute',
+      task: 'Clarify task for source context plus note.',
+    });
   });
 
   it('should send only explicit user turns and include initialInput in summary context', async () => {

--- a/src/__tests__/it-interactive-routes.test.ts
+++ b/src/__tests__/it-interactive-routes.test.ts
@@ -196,6 +196,19 @@ describe('/go summary flow', () => {
     expect(capture.callCount).toBe(2);
   });
 
+  it('should summarize inline /go task without prior conversation', async () => {
+    setupRawStdin(toRawInputs(['/go add error handling', '/cancel']));
+    const capture = setupProvider(['Add error handling to all API calls.']);
+
+    const result = await runInstruct();
+
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('Add error handling to all API calls.');
+    expect(capture.callCount).toBe(1);
+    expect(capture.prompts[0]).toContain('User: add error handling');
+    expect(capture.prompts[0]).not.toContain('User Note:\nadd error handling');
+  });
+
   it('should reject /go without prior conversation', async () => {
     setupRawStdin(toRawInputs(['/go', '/cancel']));
     setupProvider([]);
@@ -392,13 +405,17 @@ describe('end-of-line /go command', () => {
     expect(capture.prompts[1]).toContain('also check security');
   });
 
-  it('should reject end-of-line /go without prior conversation', async () => {
+  it('should use preceding text as first task input without prior conversation', async () => {
     setupRawStdin(toRawInputs(['実行して /go', '/cancel']));
-    setupProvider([]);
+    const capture = setupProvider(['実行タスクを整理する。']);
 
     const result = await runInstruct();
 
-    expect(result.action).toBe('cancel');
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('実行タスクを整理する。');
+    expect(capture.callCount).toBe(1);
+    expect(capture.prompts[0]).toContain('User: 実行して');
+    expect(capture.prompts[0]).not.toContain('User Note:\n実行して');
   });
 });
 

--- a/src/__tests__/it-retry-mode.test.ts
+++ b/src/__tests__/it-retry-mode.test.ts
@@ -227,6 +227,78 @@ describe('E2E: Retry mode with failure context injection', () => {
     expect(capture.callCount).toBe(2);
   });
 
+  it('should summarize inline /go task without prior conversation', async () => {
+    setupRawStdin(toRawInputs(['/go inspect the failing logs', '/cancel']));
+    const capture = setupProvider([
+      'Inspect the failing logs and summarize the timeout root cause.',
+    ]);
+
+    const retryContext: RetryContext = {
+      failure: {
+        taskName: 'implement-auth',
+        taskContent: 'Implement authentication feature',
+        createdAt: '2026-02-15T10:00:00Z',
+        failedStep: 'review',
+        error: 'Timeout after 300s',
+        lastMessage: 'Agent stopped responding',
+        retryNote: '',
+      },
+      branchName: 'takt/implement-auth',
+      workflowContext: {
+        name: 'default',
+        description: '',
+        workflowStructure: '',
+        stepPreviews: [],
+      },
+      run: null,
+      previousOrderContent: null,
+    };
+
+    const result = await runRetryMode(tmpDir, retryContext, null);
+
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('Inspect the failing logs and summarize the timeout root cause.');
+    expect(capture.callCount).toBe(1);
+    expect(capture.prompts[0]).toContain('User: inspect the failing logs');
+    expect(capture.prompts[0]).not.toContain('User Note:\ninspect the failing logs');
+  });
+
+  it('should summarize suffix /go task without prior conversation', async () => {
+    setupRawStdin(toRawInputs(['inspect the failing logs /go', '/cancel']));
+    const capture = setupProvider([
+      'Inspect the failing logs from the retry context and summarize the timeout root cause.',
+    ]);
+
+    const retryContext: RetryContext = {
+      failure: {
+        taskName: 'implement-auth',
+        taskContent: 'Implement authentication feature',
+        createdAt: '2026-02-15T10:00:00Z',
+        failedStep: 'review',
+        error: 'Timeout after 300s',
+        lastMessage: 'Agent stopped responding',
+        retryNote: '',
+      },
+      branchName: 'takt/implement-auth',
+      workflowContext: {
+        name: 'default',
+        description: '',
+        workflowStructure: '',
+        stepPreviews: [],
+      },
+      run: null,
+      previousOrderContent: null,
+    };
+
+    const result = await runRetryMode(tmpDir, retryContext, null);
+
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('Inspect the failing logs from the retry context and summarize the timeout root cause.');
+    expect(capture.callCount).toBe(1);
+    expect(capture.prompts[0]).toContain('User: inspect the failing logs');
+    expect(capture.prompts[0]).not.toContain('User Note:\ninspect the failing logs');
+  });
+
   it('should inject failure info AND run session data into system prompt', async () => {
     // Create run fixture with logs and reports
     createRunFixture(tmpDir, 'run-failed', {

--- a/src/features/interactive/conversationLoop.ts
+++ b/src/features/interactive/conversationLoop.ts
@@ -42,6 +42,25 @@ export { type CallAIResult, type SessionContext, callAIWithRetry } from './aiCal
 
 const log = createLogger('conversation-loop');
 
+function resolveGoSummaryInput(
+  history: ConversationMessage[],
+  hasSessionContext: boolean,
+  hasSourceContext: boolean,
+  inlineTaskText: string,
+): { summaryHistory: ConversationMessage[]; userNote: string } {
+  if (history.length > 0 || hasSessionContext || hasSourceContext || !inlineTaskText) {
+    return {
+      summaryHistory: history,
+      userNote: inlineTaskText,
+    };
+  }
+
+  return {
+    summaryHistory: [{ role: 'user', content: inlineTaskText }],
+    userNote: '',
+  };
+}
+
 /**
  * Display and clear previous session state if present.
  */
@@ -206,9 +225,14 @@ export async function runConversationLoop(
       }
 
       case SlashCommand.Go: {
-        const userNote = match.text;
+        const { summaryHistory, userNote } = resolveGoSummaryInput(
+          history,
+          !!sessionId,
+          !!sourceContext,
+          match.text,
+        );
         let summaryPrompt = buildSummaryPrompt(
-          history, !!sessionId, ctx.lang, noTranscript, conversationLabel, workflowContext, sourceContext,
+          summaryHistory, !!sessionId, ctx.lang, noTranscript, conversationLabel, workflowContext, sourceContext,
         );
         if (!summaryPrompt) {
           info(ui.noConversation);


### PR DESCRIPTION
## Summary

# タスク指示書

## 目的
`/go` コマンドが、事前の対話履歴が存在しない状態でも実行開始できるようにする。現状の「対話がないと `/go` を実行できない」制限を解消し、初回利用時の実行フローを実装・検証する。

## 優先度
- 高: `/go` 実行開始条件の見直しと実装
- 高: 無対話状態をカバーするテスト追加
- 中: 対話あり/なし両方で既存挙動を壊していないことの確認
- 低: エラーメッセージや案内文の調整が必要なら最小限で対応

## 参照資料
- なし

## 対象ファイル / モジュール
### 1. 高: `/go` コマンドのエントリポイント実装
- 対象モジュール:
  - CLI の `/go` コマンド受付
  - 対話モードからワークフロー実行へ橋渡しするハンドラ
- 作業内容:
  - 事前の対話履歴が必須になっている判定を特定し、無対話でも実行可能に変更する。
  - 無対話時でもワークフロー実行に必要な入力が組み立てられるようにする。
  - 既存の対話ありフローは維持し、今回の変更でのみ不要になった分岐やガードがあれば削除する。

### 2. 高: 指示書生成・入力解釈ロジック
- 対象モジュール:
  - 対話内容をワークフロー実行用タスクに変換するロジック
  - 実行開始時の入力ソース選択ロジック
- 作業内容:
  - 無対話状態で `/go` が失敗している原因が、履歴前提の要約・変換処理にある場合はそこも修正する。
  - 初回入力のみのケースで、ワークフローに渡すタスクが空にならないようにする。
  - 既存の対話履歴がある場合は、従来どおり履歴を使った指示書化が継続することを確認する。

### 3. 高: テスト
- 対象モジュール:
  - `/go` コマンドの単体テスト
  - 対話モードとワークフロー起動をまたぐ統合テストまたは E2E
- 作業内容:
  - 対話履歴が空の状態で `/go` を実行すると開始できるテストを追加する。
  - 対話履歴がある既存ケースでも `/go` が従来どおり動くテストを維持・更新する。
  - 入力が空、または実行用タスクを組み立てられない場合の異常系があるなら、その契約に沿ったテストを追加する。

### 4. 中: 実行メッセージ・エラーハンドリング
- 対象モジュール:
  - `/go` 実行前後のユーザー向けメッセージ
  - 対話不足を理由にしたエラー文言
- 作業内容:
  - 無対話時の実行が正常化された結果、不要になるエラー案内があれば整理する。
  - 文言変更は今回の仕様変更に直接必要な範囲に限定する。

## 実装要件
- `/go` は、事前の対話がない状態でも実行開始できること。
- 既存の対話ありフローは維持すること。
- 無対話対応のための後方互換コードや暫定フォールバックを増やさず、根本原因の判定を修正すること。
- 今回の変更で新たに未使用になった条件分岐や補助コードは削除すること。

## 再現手順
1. 対話モードを新規状態で開始する。
2. 事前の追加会話なしで `/go` を実行する。
3. 現状は対話不足扱いで開始できない挙動があれば、それを解消する。
4. 対話を1回以上行った後の `/go` 実行も確認し、既存挙動が維持されていることを確認する。

## 確認方法
- 単体テスト:
  - `/go` 実行開始条件の判定
  - 無対話時の入力組み立て
- 統合または E2E:
  - 新規対話セッションで `/go` が成功すること
  - 既存どおり対話ありでも成功すること
- 必要に応じて `npm test` と、対話モードや CLI 実行に関わる対象テストを実行すること

## Open Questions
- 無対話時に `/go` がワークフローへ渡す元データを、どの入力ソースから確定する実装になっているか。直前入力・セッション初期入力・内部バッファのどれを正とするかは、既存コードの責務に沿って planner が特定すること。

## Execution Report

Workflow `takt-default` completed successfully.