### PR TITLE
Release v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.38.0] - 2026-04-25
+
+### Added
+
+- `auto-improvement-loop` builtin workflow added (#653). An infinite-loop orchestration workflow that scans the repository on a schedule and routes work by priority (PR -> Issue -> fresh improvement -> wait -> route). Supporting infrastructure introduced together: `max_steps: infinite` (no step cap, no `exceeded` status), `pr_list` system input (open PRs filtered by `author` / `base_branch` / `head_branch` / `draft`), `task_queue_context.items` (queue contents observable from `when:`), `when:` array references with `exists(list, item.field == "X")` function (initial scope: `==` and `&&` only), and `followup-task` builtin structured-output schema with `enqueue_new_task` / `comment_on_pr` / `enqueue_from_pr` / `prepare_merge` / `noop` actions
+- `issue_list` / `issue_selection` system inputs added (#662). Orchestration workflows can now observe repo-wide open Issues, not just the current task's Issue. Resolves the dead Issue branch in `auto-improvement-loop` where PRs absent + open Issues present should route to the Issue planner
+- `persona_providers.<persona>.provider_options` added (#623). Persona-level `provider_options` (e.g. `claude.effort`, `codex.reasoning_effort`) can now be configured alongside `provider` / `model`, removing the need to repeat the same options across every step. Resolution priority: step > workflow > persona > project > global > default
+- Report handles `{current_report}` / `{previous_report}` / `{report_history}` / `{peer_reports}` added to instruction template variables (#627). Facets can now reference self/peer report files abstractly without hardcoding filenames; usable in `reviewer` / `fix` / `supervise` style steps
+- Standardized verification evidence section added to review output contracts (#628). `architecture-review`, `qa-review`, `testing-review`, `security-review`, `requirements-review` now emit a common build / test / behavior-check section with target, content, and result (or explicit "not verified") so supervisors can evaluate evidence consistently
+- `default-high` workflow added: full-spec general-purpose workflow combining team-leader implementation, 5-parallel review, AI antipattern review with arbitration, and supervision (`plan -> write_tests -> team-leader implement -> AI review -> 5-parallel review -> fix -> supervise -> complete`). Quick Start categories reorganized into `default` / `default-high` / `frontend` / `backend` / `dual`
+- `takt-default-refresh-all` / `takt-default-refresh-fast` workflows added: `session: refresh` variants of the TAKT development workflow. `refresh-all` refreshes every step for full conversation-carry-over comparison; `refresh-fast` refreshes only context-heavy steps (`write_tests`, `ai_review`, reviewers, `fix`)
+- `takt watch --ignore-exceed` option added (#651). Same semantics as `takt run --ignore-exceed`: ignores workflow `max_steps` and continues running tasks instead of marking them `exceeded`
+- `provider_options.*.effort` value and source surfaced in console / NDJSON (#647). Active provider's effort (`claude.effort`, `codex.reasoningEffort`, `copilot.effort`) is shown alongside `Provider:` / `Model:` in console output, with `(source: step|persona|global|...)` suffix in debug / verbose mode. NDJSON `step_start` records always include `providerOptions` and `providerOptionsSources` for the full tracked path set
+- Task-based PRs without an Issue now use `order.md` content for the `## Summary` section of the PR body (#600). Previously the section was empty; now reviewers can read the full task instructions directly from the PR
+
+### Changed
+
+- `<!-- takt:managed -->` hidden marker is now opt-in, not a default (#665). Normal `--auto-pr` / `autoPr` no longer attaches the marker; only orchestration-driven task creation (e.g. `enqueue_task` from `auto-improvement-loop`) adds it. PRs created by ordinary pipeline / task execution are now indistinguishable from human-authored PRs
+- Workflow `source` / `trust` resolution unified at the loader entry (#660). Parser / normalizer / doctor / `workflow_call` child loads now consume the `WorkflowTrustInfo` produced by the loader instead of re-classifying workflows by file path. Builtin privileged workflows (e.g. `auto-improvement-loop` with `kind: system` steps) are now treated consistently across discovery / runtime / doctor entrypoints
+- Interactive mode `--pr` source context separated from conversation history (#656). PR review comments fetched by `--pr` are no longer pushed into `history` as a hidden user message; they are kept as a separate "Source Context" block. `/go` summaries no longer treat the full PR comment thread as the user's request, preventing instruction bloat
+- `takt-default` `implement` step (team leader / part workers) now receives the parent `takt run` PID as a protected PID along with a short process-safety policy (#603). Prevents AI cleanup logic from killing the parent run via `pkill` / `killall` / name-based kill when stray child processes are present
+- Retry / re-execution now syncs the project-local `.takt/` directory from the root repository before re-running on an existing worktree (#607). Root-side facet / workflow / output-contract updates now take effect on retry by default, matching first-run behavior
+- PR sync system effects (`sync_with_root`, `resolve_conflicts_with_ai`) reorganized to operate on PR scope via a dedicated temporary worktree / checkout (#661). Effects no longer depend on the orchestration step's `cwd`, so `prepare_merge` from `auto-improvement-loop` succeeds deterministically regardless of where the orchestration runs
+
+### Fixed
+
+- `team_leader + output_contracts.report` no longer aborts when the root step has no session (#655). `runReportPhase()` now accepts the team leader's aggregated `lastResponse` as a fallback and only fails when both root session and `lastResponse` are absent
+- Builtin workflow `source` / `trust` is preserved during discovery loading inside the takt repo itself (#659). Stop-gap fix that prevented `auto-improvement-loop` and other builtin privileged workflows from being reclassified as project workflows when discovered from the takt repository root (root cause addressed in #660)
+- `provider_options.copilot.effort` round-trip persistence fixed (#626). `denormalizeProviderOptions()` now writes back `copilot.effort` instead of silently dropping it on config save
+- Removed the dependency on the `takt-managed` GitHub label for managed-PR identification. The hidden body marker `<!-- takt:managed -->` is now the single identifier
+
+### Internal
+
+- SDK dependencies bumped: `@anthropic-ai/claude-agent-sdk` ^0.2.71 -> ^0.2.119, `@openai/codex-sdk` ^0.114.0 -> ^0.125.0 (bundled `@openai/codex` binary 0.114.0 -> 0.125.0), `@opencode-ai/sdk` >=1.2.10 <1.3.0 -> ^1.14.24 (v2 export retained)
+- E2E test added for the `claude` provider verifying that `provider_options.allowed_tools` propagates to `claude --allowed-tools` so `Bash(python3 -m pytest:*)` runs without approval prompts in real claude provider runs
+- Test policy updated: line count thresholds are no longer treated as test failures in the review workflow
+
 ## [0.37.0] - 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- `auto-improvement-loop` builtin workflow added (#653). An infinite-loop orchestration workflow that scans the repository on a schedule and routes work by priority (PR -> Issue -> fresh improvement -> wait -> route). Supporting infrastructure introduced together: `max_steps: infinite` (no step cap, no `exceeded` status), `pr_list` system input (open PRs filtered by `author` / `base_branch` / `head_branch` / `draft`), `task_queue_context.items` (queue contents observable from `when:`), `when:` array references with `exists(list, item.field == "X")` function (initial scope: `==` and `&&` only), and `followup-task` builtin structured-output schema with `enqueue_new_task` / `comment_on_pr` / `enqueue_from_pr` / `prepare_merge` / `noop` actions
-- `issue_list` / `issue_selection` system inputs added (#662). Orchestration workflows can now observe repo-wide open Issues, not just the current task's Issue. Resolves the dead Issue branch in `auto-improvement-loop` where PRs absent + open Issues present should route to the Issue planner
 - `persona_providers.<persona>.provider_options` added (#623). Persona-level `provider_options` (e.g. `claude.effort`, `codex.reasoning_effort`) can now be configured alongside `provider` / `model`, removing the need to repeat the same options across every step. Resolution priority: step > workflow > persona > project > global > default
 - Report handles `{current_report}` / `{previous_report}` / `{report_history}` / `{peer_reports}` added to instruction template variables (#627). Facets can now reference self/peer report files abstractly without hardcoding filenames; usable in `reviewer` / `fix` / `supervise` style steps
 - Standardized verification evidence section added to review output contracts (#628). `architecture-review`, `qa-review`, `testing-review`, `security-review`, `requirements-review` now emit a common build / test / behavior-check section with target, content, and result (or explicit "not verified") so supervisors can evaluate evidence consistently
@@ -42,6 +40,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - SDK dependencies bumped: `@anthropic-ai/claude-agent-sdk` ^0.2.71 -> ^0.2.119, `@openai/codex-sdk` ^0.114.0 -> ^0.125.0 (bundled `@openai/codex` binary 0.114.0 -> 0.125.0), `@opencode-ai/sdk` >=1.2.10 <1.3.0 -> ^1.14.24 (v2 export retained)
 - E2E test added for the `claude` provider verifying that `provider_options.allowed_tools` propagates to `claude --allowed-tools` so `Bash(python3 -m pytest:*)` runs without approval prompts in real claude provider runs
 - Test policy updated: line count thresholds are no longer treated as test failures in the review workflow
+
+### Experimental
+
+The following features are still being tuned. Behavior, schema, and naming may change in subsequent releases. Use only if you are willing to follow breaking changes.
+
+- `auto-improvement-loop` builtin workflow (#653). An infinite-loop orchestration workflow that scans the repository on a schedule and routes work by priority (PR -> Issue -> fresh improvement -> wait -> route)
+- `max_steps: infinite` (no step cap, no `exceeded` status). Currently used by `auto-improvement-loop`
+- `pr_list` system input (open PRs filtered by `author` / `base_branch` / `head_branch` / `draft`)
+- `issue_list` / `issue_selection` system inputs (#662). Repo-wide open Issue observation from orchestration workflows
+- `task_queue_context.items` (queue contents observable from `when:`)
+- `when:` array references with `exists(list, item.field == "X")` function. Initial scope: `==` and `&&` only
+- `followup-task` builtin structured-output schema with `enqueue_new_task` / `comment_on_pr` / `enqueue_from_pr` / `prepare_merge` / `noop` actions
 
 ## [0.37.0] - 2026-04-20
 

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,43 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.38.0] - 2026-04-25
+
+### Added
+
+- `auto-improvement-loop` ビルトイン workflow を追加 (#653)。リポジトリを定期スキャンし、優先度（PR -> Issue -> fresh improvement -> wait -> route）でタスクを振り分ける無限ループのオーケストレーション workflow。同時に基盤機能を追加: `max_steps: infinite`（step 上限なし、`exceeded` にならない）、`pr_list` system input（`author` / `base_branch` / `head_branch` / `draft` で絞り込み可能な open PR 一覧）、`task_queue_context.items`（キュー内容を `when:` から参照可能）、`when:` の配列参照と `exists(list, item.field == "X")` 関数（初期スコープは `==` と `&&` のみ）、`followup-task` ビルトイン構造化出力 schema（`enqueue_new_task` / `comment_on_pr` / `enqueue_from_pr` / `prepare_merge` / `noop` の action）
+- `issue_list` / `issue_selection` system input を追加 (#662)。orchestration workflow から current task の Issue だけでなく、リポジトリ全体の open Issue を観測できるようになった。`auto-improvement-loop` で「PR なし + open Issue あり」の場合に Issue 分岐へ進めるよう dead branch を解消
+- `persona_providers.<persona>.provider_options` をサポート (#623)。persona ごとに `provider` / `model` と並んで `provider_options`（`claude.effort`、`codex.reasoning_effort` 等）を設定可能になり、各 step に同じ provider option を重複記述する必要がなくなった。優先順位: step > workflow > persona > project > global > default
+- インストラクションテンプレート変数に report handle (`{current_report}` / `{previous_report}` / `{report_history}` / `{peer_reports}`) を追加 (#627)。reviewer / fix / supervise 系 step で、自ステップ最新／直前レポートや peer ステップ最新レポート群を、ファセットに具体的なファイル名を直書きせず抽象的に参照できる
+- レビュー系 output contract に検証証跡セクションを標準化 (#628)。`architecture-review`、`qa-review`、`testing-review`、`security-review`、`requirements-review` でビルド / テスト / 動作確認の確認対象・確認内容・結果（または「未確認」の明示）を共通フォーマットで記録するようになり、Supervisor 側で証跡判定が安定する
+- `default-high` workflow を追加。team-leader 実装＋5並列レビュー＋仲裁付き AI アンチパターンレビュー＋監督を組み合わせたフルスペック汎用 workflow（`plan -> write_tests -> team-leader implement -> AI review -> 5並列 review -> fix -> supervise -> complete`）。Quick Start カテゴリも `default` / `default-high` / `frontend` / `backend` / `dual` に再構成
+- `takt-default-refresh-all` / `takt-default-refresh-fast` workflow を追加。TAKT 開発 workflow の `session: refresh` 比較版で、`refresh-all` は全 step を refresh、`refresh-fast` は文脈肥大しやすい step（`write_tests`、`ai_review`、各 reviewer、`fix`）にのみ refresh を入れる
+- `takt watch --ignore-exceed` オプションを追加 (#651)。`takt run --ignore-exceed` と同じ意味で、workflow の `max_steps` 超過を無視して継続実行し `exceeded` 扱いにしない
+- `provider_options.*.effort` の値と解決ソースを console / NDJSON に表示 (#647)。active な provider の effort（`claude.effort` / `codex.reasoningEffort` / `copilot.effort`）が console の `Provider:` / `Model:` と並んで表示され、debug / verbose 時には `(source: step|persona|global|...)` も表示される。NDJSON `step_start` には全追跡パスの `providerOptions` / `providerOptionsSources` が常時記録される
+- Issue を紐づけずに作成された task ベース PR の `## Summary` で `order.md` 全文を本文として使うように変更 (#600)。従来は空セクションだったが、PR 上で「何をやる task だったのか」を直接読めるようになった
+
+### Changed
+
+- `<!-- takt:managed -->` hidden marker をデフォルト付与から opt-in に変更 (#665)。通常の `--auto-pr` / `autoPr` で作成される PR には marker が付かなくなり、`auto-improvement-loop` などの orchestration 由来 task のみが marker を付与する。通常の pipeline / task 実行で作られる PR は人手作成 PR と区別がつかなくなる
+- workflow の `source` / `trust` 解決を loader 入口で一本化 (#660)。parser / normalizer / doctor / `workflow_call` の子ロード経路がいずれも loader が確定した `WorkflowTrustInfo` を使うようになり、後段の path-based fallback で再分類されなくなった。`auto-improvement-loop` のようなビルトインの privileged workflow が discovery / runtime / doctor で一貫して builtin として扱われる
+- インタラクティブモードで `--pr` のソースコンテキストを会話履歴から分離 (#656)。`--pr` で取得した PR レビューコメントは hidden な User 発話として `history` に積まず、独立した「Source Context」枠で保持する。`/go` 要約時に PR コメント全文をユーザー要求として誤解して指示書が肥大することを防ぐ
+- `takt-default` の `implement` step（team leader / part worker）に親 `takt run` の PID を protected PID として注入し、短い process-safety policy を適用 (#603)。AI が cleanup 判断時に `pkill` / `killall` / 名前ベース kill で親 run を巻き込む事故を防ぐ
+- Retry / re-execution の開始前に、既存 worktree の project-local `.takt/` を root の最新状態で同期するように変更 (#607)。root 側の facet / workflow / output-contract 修正が retry でも反映されるようになり、初回実行と retry の挙動が揃う
+- PR 同期系 system effect（`sync_with_root`、`resolve_conflicts_with_ai`）を PR スコープ実行に整理 (#661)。専用の一時 worktree / checkout で PR branch を直接対象化するため orchestration step の `cwd` に依存せず、`auto-improvement-loop` の `prepare_merge` が orchestration の実行場所に関わらず deterministic に成功する
+
+### Fixed
+
+- `team_leader + output_contracts.report` の step で、root session 不在を理由に report phase が abort する問題を修正 (#655)。`runReportPhase()` が team leader の集約 `lastResponse` を fallback として受け付けるようになり、root session も `lastResponse` も無い場合のみ失敗する
+- takt 自身のリポジトリで discovery 経由のロード時、ビルトイン workflow の `source` / `trust` 情報が path-based に project workflow へ再分類されてしまう問題を修正 (#659)。`auto-improvement-loop` を含む privileged ビルトイン workflow が discovery 経路でも builtin として正しく扱われる（恒久対応は #660）
+- `provider_options.copilot.effort` の設定保存ラウンドトリップが落ちていた問題を修正 (#626)。`denormalizeProviderOptions()` が `copilot.effort` を raw 形式へ書き戻すようになり、設定保存経路で値が消えなくなる
+- managed PR の判定で `takt-managed` GitHub label への依存を撤去。hidden marker `<!-- takt:managed -->` を managed PR の唯一の識別子に統一
+
+### Internal
+
+- SDK 依存を更新: `@anthropic-ai/claude-agent-sdk` ^0.2.71 -> ^0.2.119、`@openai/codex-sdk` ^0.114.0 -> ^0.125.0（バンドル `@openai/codex` バイナリも 0.114.0 -> 0.125.0）、`@opencode-ai/sdk` >=1.2.10 <1.3.0 -> ^1.14.24（v2 export は維持）
+- `claude` provider で `provider_options.allowed_tools` が `claude --allowed-tools` に伝搬し、`Bash(python3 -m pytest:*)` が approval なしで通ることを実 claude provider で検証する E2E テストを追加
+- レビュー系 workflow で行数閾値をテスト失敗扱いしないようガイダンスを更新
+
 ## [0.37.0] - 2026-04-20
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -10,8 +10,6 @@
 
 ### Added
 
-- `auto-improvement-loop` ビルトイン workflow を追加 (#653)。リポジトリを定期スキャンし、優先度（PR -> Issue -> fresh improvement -> wait -> route）でタスクを振り分ける無限ループのオーケストレーション workflow。同時に基盤機能を追加: `max_steps: infinite`（step 上限なし、`exceeded` にならない）、`pr_list` system input（`author` / `base_branch` / `head_branch` / `draft` で絞り込み可能な open PR 一覧）、`task_queue_context.items`（キュー内容を `when:` から参照可能）、`when:` の配列参照と `exists(list, item.field == "X")` 関数（初期スコープは `==` と `&&` のみ）、`followup-task` ビルトイン構造化出力 schema（`enqueue_new_task` / `comment_on_pr` / `enqueue_from_pr` / `prepare_merge` / `noop` の action）
-- `issue_list` / `issue_selection` system input を追加 (#662)。orchestration workflow から current task の Issue だけでなく、リポジトリ全体の open Issue を観測できるようになった。`auto-improvement-loop` で「PR なし + open Issue あり」の場合に Issue 分岐へ進めるよう dead branch を解消
 - `persona_providers.<persona>.provider_options` をサポート (#623)。persona ごとに `provider` / `model` と並んで `provider_options`（`claude.effort`、`codex.reasoning_effort` 等）を設定可能になり、各 step に同じ provider option を重複記述する必要がなくなった。優先順位: step > workflow > persona > project > global > default
 - インストラクションテンプレート変数に report handle (`{current_report}` / `{previous_report}` / `{report_history}` / `{peer_reports}`) を追加 (#627)。reviewer / fix / supervise 系 step で、自ステップ最新／直前レポートや peer ステップ最新レポート群を、ファセットに具体的なファイル名を直書きせず抽象的に参照できる
 - レビュー系 output contract に検証証跡セクションを標準化 (#628)。`architecture-review`、`qa-review`、`testing-review`、`security-review`、`requirements-review` でビルド / テスト / 動作確認の確認対象・確認内容・結果（または「未確認」の明示）を共通フォーマットで記録するようになり、Supervisor 側で証跡判定が安定する
@@ -42,6 +40,18 @@
 - SDK 依存を更新: `@anthropic-ai/claude-agent-sdk` ^0.2.71 -> ^0.2.119、`@openai/codex-sdk` ^0.114.0 -> ^0.125.0（バンドル `@openai/codex` バイナリも 0.114.0 -> 0.125.0）、`@opencode-ai/sdk` >=1.2.10 <1.3.0 -> ^1.14.24（v2 export は維持）
 - `claude` provider で `provider_options.allowed_tools` が `claude --allowed-tools` に伝搬し、`Bash(python3 -m pytest:*)` が approval なしで通ることを実 claude provider で検証する E2E テストを追加
 - レビュー系 workflow で行数閾値をテスト失敗扱いしないようガイダンスを更新
+
+### Experimental
+
+以下の機能は調整中です。挙動・スキーマ・命名は今後のリリースで変更される可能性があります。破壊的変更を許容できる場合のみ利用してください。
+
+- `auto-improvement-loop` ビルトイン workflow (#653)。リポジトリを定期スキャンし、優先度（PR -> Issue -> fresh improvement -> wait -> route）でタスクを振り分ける無限ループのオーケストレーション workflow
+- `max_steps: infinite`（step 上限なし、`exceeded` にならない）。現状は `auto-improvement-loop` で利用
+- `pr_list` system input（`author` / `base_branch` / `head_branch` / `draft` で絞り込み可能な open PR 一覧）
+- `issue_list` / `issue_selection` system input (#662)。orchestration workflow からリポジトリ全体の open Issue を観測できる
+- `task_queue_context.items`（キュー内容を `when:` から参照可能）
+- `when:` の配列参照と `exists(list, item.field == "X")` 関数。初期スコープは `==` と `&&` のみ
+- `followup-task` ビルトイン構造化出力 schema（`enqueue_new_task` / `comment_on_pr` / `enqueue_from_pr` / `prepare_merge` / `noop` の action）
 
 ## [0.37.0] - 2026-04-20
 

--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -159,7 +159,12 @@ takt run --ignore-exceed
 ```bash
 # .takt/tasks.yaml を監視してタスクを自動実行（常駐プロセス）
 takt watch
+
+# workflow の max_steps を無視して、exceeded 扱いにせず継続実行する
+takt watch --ignore-exceed
 ```
+
+`takt watch --ignore-exceed` の意味は `takt run --ignore-exceed` と同じです。workflow の `max_steps` を無視し、`.takt/tasks.yaml` に exceeded 用の再実行メタデータを書きません。
 
 ### takt list
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -159,7 +159,12 @@ Monitor `.takt/tasks.yaml` and auto-execute tasks as a resident process.
 ```bash
 # Monitor .takt/tasks.yaml and auto-execute tasks (resident process)
 takt watch
+
+# Ignore workflow max_steps and continue running tasks instead of marking them exceeded
+takt watch --ignore-exceed
 ```
+
+`takt watch --ignore-exceed` has the same semantics as `takt run --ignore-exceed`: it ignores the workflow `max_steps` iteration limit and does not write `exceeded` retry metadata to `.takt/tasks.yaml`.
 
 ### takt list
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Workflow Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- `persona_providers.<persona>.provider_options` added (#623). Persona-level `provider_options` (e.g. `claude.effort`, `codex.reasoning_effort`) can now be configured alongside `provider` / `model`
- Report handles `{current_report}` / `{previous_report}` / `{report_history}` / `{peer_reports}` added to instruction template variables (#627)
- Standardized verification evidence section added to review output contracts (#628)
- `default-high` workflow added: full-spec general-purpose workflow combining team-leader implementation, 5-parallel review, AI antipattern review with arbitration, and supervision. Quick Start categories reorganized into `default` / `default-high` / `frontend` / `backend` / `dual`
- `takt-default-refresh-all` / `takt-default-refresh-fast` workflows added: `session: refresh` variants of the TAKT development workflow
- `takt watch --ignore-exceed` option added (#651)
- `provider_options.*.effort` value and source surfaced in console / NDJSON (#647)
- Task-based PRs without an Issue now use `order.md` content for the `## Summary` section (#600)

### Changed

- `<!-- takt:managed -->` hidden marker is now opt-in, not a default (#665)
- Workflow `source` / `trust` resolution unified at the loader entry (#660)
- Interactive mode `--pr` source context separated from conversation history (#656)
- `takt-default` `implement` step now receives the parent `takt run` PID as a protected PID along with a process-safety policy (#603)
- Retry / re-execution now syncs the project-local `.takt/` directory from the root repository before re-running on an existing worktree (#607)
- PR sync system effects (`sync_with_root`, `resolve_conflicts_with_ai`) reorganized to operate on PR scope via a dedicated temporary worktree / checkout (#661)

### Fixed

- `team_leader + output_contracts.report` no longer aborts when the root step has no session (#655)
- Builtin workflow `source` / `trust` is preserved during discovery loading inside the takt repo itself (#659)
- `provider_options.copilot.effort` round-trip persistence fixed (#626)
- Removed the dependency on the `takt-managed` GitHub label

### Internal

- SDK dependencies bumped: `@anthropic-ai/claude-agent-sdk` ^0.2.71 -> ^0.2.119, `@openai/codex-sdk` ^0.114.0 -> ^0.125.0, `@opencode-ai/sdk` >=1.2.10 <1.3.0 -> ^1.14.24
- E2E test added for `claude` provider's `provider_options.allowed_tools` propagation
- Test policy updated: line count thresholds are no longer treated as test failures

### Experimental

The following features are still being tuned. Behavior, schema, and naming may change in subsequent releases.

- `auto-improvement-loop` builtin workflow (#653)
- `max_steps: infinite`
- `pr_list` system input
- `issue_list` / `issue_selection` system inputs (#662)
- `task_queue_context.items`
- `when:` array references with `exists()` function
- `followup-task` builtin structured-output schema