### PR TITLE
[#676] simplify-pr-actions

### DIFF
--- a/builtins/en/workflows/auto-improvement-loop.yaml
+++ b/builtins/en/workflows/auto-improvement-loop.yaml
@@ -6,6 +6,7 @@ max_steps: infinite
 initial_step: route_context
 schemas:
   followup-task: followup-task
+  pr-followup-task: pr-followup-task
 steps:
   - name: route_context
     mode: system
@@ -166,35 +167,30 @@ steps:
 
       Output the next action in action.
       If a follow-up implementation task is needed, output it in task_markdown.
-      If content should be left on the PR, output it in pr_comment_markdown.
 
       Allowed action values:
-      - comment_on_pr
       - enqueue_from_pr
       - prepare_merge
-      - noop
+      - reject_pr
     structured_output:
-      schema_ref: followup-task
+      schema_ref: pr-followup-task
     rules:
-      - when: structured.plan_from_existing_pr.action == "comment_on_pr"
-        next: comment_on_existing_pr
       - when: structured.plan_from_existing_pr.action == "enqueue_from_pr"
         next: enqueue_from_pr
       - when: structured.plan_from_existing_pr.action == "prepare_merge"
         next: prepare_merge
-      - when: structured.plan_from_existing_pr.action == "noop"
-        next: wait_before_next_scan
+      - when: structured.plan_from_existing_pr.action == "reject_pr"
+        next: reject_pr
       - when: "true"
         next: ABORT
 
-  - name: comment_on_existing_pr
+  - name: reject_pr
     mode: system
     effects:
-      - type: comment_pr
+      - type: close_pr
         pr: "{context:route_context.selected_pr.number}"
-        body: "{structured:plan_from_existing_pr.pr_comment_markdown}"
     rules:
-      - when: effect.comment_on_existing_pr.comment_pr.success == true
+      - when: effect.reject_pr.close_pr.success == true
         next: wait_before_next_scan
       - when: "true"
         next: ABORT

--- a/builtins/ja/workflows/auto-improvement-loop.yaml
+++ b/builtins/ja/workflows/auto-improvement-loop.yaml
@@ -6,6 +6,7 @@ max_steps: infinite
 initial_step: route_context
 schemas:
   followup-task: followup-task
+  pr-followup-task: pr-followup-task
 steps:
   - name: route_context
     mode: system
@@ -166,35 +167,30 @@ steps:
 
       action には次アクションを出力してください。
       修正 task が必要なら task_markdown に出力してください。
-      PR に残す内容があれば pr_comment_markdown に出力してください。
 
       action の候補:
-      - comment_on_pr
       - enqueue_from_pr
       - prepare_merge
-      - noop
+      - reject_pr
     structured_output:
-      schema_ref: followup-task
+      schema_ref: pr-followup-task
     rules:
-      - when: structured.plan_from_existing_pr.action == "comment_on_pr"
-        next: comment_on_existing_pr
       - when: structured.plan_from_existing_pr.action == "enqueue_from_pr"
         next: enqueue_from_pr
       - when: structured.plan_from_existing_pr.action == "prepare_merge"
         next: prepare_merge
-      - when: structured.plan_from_existing_pr.action == "noop"
-        next: wait_before_next_scan
+      - when: structured.plan_from_existing_pr.action == "reject_pr"
+        next: reject_pr
       - when: "true"
         next: ABORT
 
-  - name: comment_on_existing_pr
+  - name: reject_pr
     mode: system
     effects:
-      - type: comment_pr
+      - type: close_pr
         pr: "{context:route_context.selected_pr.number}"
-        body: "{structured:plan_from_existing_pr.pr_comment_markdown}"
     rules:
-      - when: effect.comment_on_existing_pr.comment_pr.success == true
+      - when: effect.reject_pr.close_pr.success == true
         next: wait_before_next_scan
       - when: "true"
         next: ABORT

--- a/builtins/schemas/followup-task.json
+++ b/builtins/schemas/followup-task.json
@@ -5,16 +5,10 @@
       "type": "string",
       "enum": [
         "enqueue_new_task",
-        "comment_on_pr",
-        "enqueue_from_pr",
-        "prepare_merge",
         "noop"
       ]
     },
     "task_markdown": {
-      "type": "string"
-    },
-    "pr_comment_markdown": {
       "type": "string"
     },
     "issue": {

--- a/builtins/schemas/pr-followup-task.json
+++ b/builtins/schemas/pr-followup-task.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": [
+        "enqueue_from_pr",
+        "prepare_merge",
+        "reject_pr"
+      ]
+    },
+    "task_markdown": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "action"
+  ],
+  "additionalProperties": false
+}

--- a/src/__tests__/github-pr.test.ts
+++ b/src/__tests__/github-pr.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as githubPrModule from '../infra/github/pr.js';
 
 const mockExecFileSync = vi.fn();
 vi.mock('node:child_process', () => ({
@@ -446,6 +447,66 @@ describe('mergePr', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('merge failed');
+  });
+});
+
+describe('closePr', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecFileSync.mockReset();
+    vi.mocked(checkGhCli).mockReset();
+    vi.mocked(checkGhCli).mockReturnValue({ available: true });
+  });
+
+  it('gh pr close を branch 削除なしで呼び出す', () => {
+    const closePr = (githubPrModule as Record<string, unknown>).closePr as
+      | ((prNumber: number, cwd: string) => { success: boolean; error?: string })
+      | undefined;
+
+    expect(closePr).toBeTypeOf('function');
+    mockExecFileSync.mockReturnValue('');
+
+    const result = closePr!(42, '/project');
+
+    expect(result).toEqual({ success: true });
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'gh',
+      ['pr', 'close', '42'],
+      expect.objectContaining({ cwd: '/project', encoding: 'utf-8' }),
+    );
+    const args = mockExecFileSync.mock.calls[0]?.[1] as string[];
+    expect(args).not.toContain('--delete-branch');
+    expect(args).not.toContain('--comment');
+    expect(args).not.toContain('--body');
+  });
+
+  it('gh CLI が利用不可なら失敗結果を返す', async () => {
+    const closePr = (githubPrModule as Record<string, unknown>).closePr as
+      | ((prNumber: number, cwd: string) => { success: boolean; error?: string })
+      | undefined;
+
+    expect(closePr).toBeTypeOf('function');
+    const { checkGhCli } = await import('../infra/github/issue.js');
+    vi.mocked(checkGhCli).mockReturnValueOnce({ available: false, error: 'gh unavailable' });
+
+    const result = closePr!(42, '/project');
+
+    expect(result).toEqual({ success: false, error: 'gh unavailable' });
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('gh pr close が失敗した場合は success: false を返す', () => {
+    const closePr = (githubPrModule as Record<string, unknown>).closePr as
+      | ((prNumber: number, cwd: string) => { success: boolean; error?: string })
+      | undefined;
+
+    expect(closePr).toBeTypeOf('function');
+    mockExecFileSync.mockImplementation(() => { throw new Error('close failed'); });
+
+    const result = closePr!(42, '/project');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('close failed');
   });
 });
 

--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -15,6 +15,7 @@ const {
   mockCreateIssue,
   mockFindExistingPr,
   mockCommentOnPr,
+  mockClosePr,
   mockCreatePullRequest,
   mockFetchPrReviewComments,
   mockMergePr,
@@ -25,6 +26,7 @@ const {
   mockCreateIssue: vi.fn(),
   mockFindExistingPr: vi.fn(),
   mockCommentOnPr: vi.fn(),
+  mockClosePr: vi.fn(),
   mockCreatePullRequest: vi.fn(),
   mockFetchPrReviewComments: vi.fn(),
   mockMergePr: vi.fn(),
@@ -40,6 +42,7 @@ vi.mock('../infra/github/issue.js', () => ({
 vi.mock('../infra/github/pr.js', () => ({
   findExistingPr: (...args: unknown[]) => mockFindExistingPr(...args),
   commentOnPr: (...args: unknown[]) => mockCommentOnPr(...args),
+  closePr: (...args: unknown[]) => mockClosePr(...args),
   createPullRequest: (...args: unknown[]) => mockCreatePullRequest(...args),
   fetchPrReviewComments: (...args: unknown[]) => mockFetchPrReviewComments(...args),
   mergePr: (...args: unknown[]) => mockMergePr(...args),
@@ -501,6 +504,42 @@ describe('GitHubProvider', () => {
       expect(mockMergePr).toHaveBeenCalledWith(42, process.cwd());
     });
   });
+
+  describe('closePr', () => {
+    it('closePr(prNumber, cwd) に委譲し MergeResult 互換の結果を返す', () => {
+      mockClosePr.mockReturnValue({ success: true });
+      const provider = new GitHubProvider() as unknown as {
+        closePr(prNumber: number, cwd?: string): { success: boolean; error?: string };
+      };
+
+      const result = provider.closePr(42, '/project');
+
+      expect(mockClosePr).toHaveBeenCalledWith(42, '/project');
+      expect(result).toEqual({ success: true });
+    });
+
+    it('失敗時はエラー結果を委譲して返す', () => {
+      mockClosePr.mockReturnValue({ success: false, error: 'close blocked' });
+      const provider = new GitHubProvider() as unknown as {
+        closePr(prNumber: number, cwd?: string): { success: boolean; error?: string };
+      };
+
+      const result = provider.closePr(42, '/project');
+
+      expect(result).toEqual({ success: false, error: 'close blocked' });
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      mockClosePr.mockReturnValue({ success: true });
+      const provider = new GitHubProvider() as unknown as {
+        closePr(prNumber: number, cwd?: string): { success: boolean; error?: string };
+      };
+
+      provider.closePr(42);
+
+      expect(mockClosePr).toHaveBeenCalledWith(42, process.cwd());
+    });
+  });
 });
 
 describe('getGitProvider', () => {
@@ -517,6 +556,7 @@ describe('getGitProvider', () => {
     expect(typeof provider.findExistingPr).toBe('function');
     expect(typeof provider.createPullRequest).toBe('function');
     expect(typeof provider.commentOnPr).toBe('function');
+    expect(typeof (provider as Record<string, unknown>).closePr).toBe('function');
     expect(typeof provider.mergePr).toBe('function');
   });
 

--- a/src/__tests__/gitlab-pr.test.ts
+++ b/src/__tests__/gitlab-pr.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as gitlabPrModule from '../infra/gitlab/pr.js';
 
 const mockExecFileSync = vi.fn();
 const { mockCheckGlabCli } = vi.hoisted(() => ({
@@ -627,6 +628,58 @@ describe('mergeMr', () => {
     mergeMr(42, '/my/project');
 
     expect(mockCheckGlabCli).toHaveBeenCalledWith('/my/project');
+  });
+});
+
+describe('closeMr', () => {
+  it('glab mr close を branch 削除なしで呼び出す', () => {
+    const closeMr = (gitlabPrModule as Record<string, unknown>).closeMr as
+      | ((mrNumber: number, cwd: string) => { success: boolean; error?: string })
+      | undefined;
+
+    expect(closeMr).toBeTypeOf('function');
+    mockExecFileSync.mockReturnValue('');
+
+    const result = closeMr!(42, '/project');
+
+    expect(result).toEqual({ success: true });
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'glab',
+      ['mr', 'close', '42'],
+      expect.objectContaining({ cwd: '/project', encoding: 'utf-8' }),
+    );
+    const args = mockExecFileSync.mock.calls[0]?.[1] as string[];
+    expect(args).not.toContain('--remove-source-branch');
+    expect(args).not.toContain('--comment');
+    expect(args).not.toContain('--body');
+  });
+
+  it('glab CLI が利用できない場合は execFileSync を呼ばず失敗を返す', () => {
+    const closeMr = (gitlabPrModule as Record<string, unknown>).closeMr as
+      | ((mrNumber: number, cwd: string) => { success: boolean; error?: string })
+      | undefined;
+
+    expect(closeMr).toBeTypeOf('function');
+    mockCheckGlabCli.mockReturnValueOnce({ available: false, error: 'glab unavailable' });
+
+    const result = closeMr!(42, '/project');
+
+    expect(result).toEqual({ success: false, error: 'glab unavailable' });
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('glab mr close が失敗した場合は success: false を返す', () => {
+    const closeMr = (gitlabPrModule as Record<string, unknown>).closeMr as
+      | ((mrNumber: number, cwd: string) => { success: boolean; error?: string })
+      | undefined;
+
+    expect(closeMr).toBeTypeOf('function');
+    mockExecFileSync.mockImplementation(() => { throw new Error('close denied'); });
+
+    const result = closeMr!(42, '/project');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('close denied');
   });
 });
 

--- a/src/__tests__/gitlab-provider.test.ts
+++ b/src/__tests__/gitlab-provider.test.ts
@@ -14,6 +14,7 @@ const {
   mockCreateIssue,
   mockFindExistingMr,
   mockCommentOnMr,
+  mockCloseMr,
   mockCreateMergeRequest,
   mockFetchMrReviewComments,
   mockMergeMr,
@@ -24,6 +25,7 @@ const {
   mockCreateIssue: vi.fn(),
   mockFindExistingMr: vi.fn(),
   mockCommentOnMr: vi.fn(),
+  mockCloseMr: vi.fn(),
   mockCreateMergeRequest: vi.fn(),
   mockFetchMrReviewComments: vi.fn(),
   mockMergeMr: vi.fn(),
@@ -46,6 +48,7 @@ vi.mock('../infra/gitlab/issue.js', () => ({
 vi.mock('../infra/gitlab/pr.js', () => ({
   findExistingMr: (...args: unknown[]) => mockFindExistingMr(...args),
   commentOnMr: (...args: unknown[]) => mockCommentOnMr(...args),
+  closeMr: (...args: unknown[]) => mockCloseMr(...args),
   createMergeRequest: (...args: unknown[]) => mockCreateMergeRequest(...args),
   fetchMrReviewComments: (...args: unknown[]) => mockFetchMrReviewComments(...args),
   mergeMr: (...args: unknown[]) => mockMergeMr(...args),
@@ -522,6 +525,42 @@ describe('GitLabProvider', () => {
       provider.mergePr(42);
 
       expect(mockMergeMr).toHaveBeenCalledWith(42, process.cwd());
+    });
+  });
+
+  describe('closePr', () => {
+    it('closeMr(prNumber, cwd) に委譲し結果を返す', () => {
+      mockCloseMr.mockReturnValue({ success: true });
+      const provider = new GitLabProvider() as unknown as {
+        closePr(prNumber: number, cwd?: string): { success: boolean; error?: string };
+      };
+
+      const result = provider.closePr(42, '/project');
+
+      expect(mockCloseMr).toHaveBeenCalledWith(42, '/project');
+      expect(result).toEqual({ success: true });
+    });
+
+    it('失敗時はエラー結果を委譲して返す', () => {
+      mockCloseMr.mockReturnValue({ success: false, error: 'close blocked' });
+      const provider = new GitLabProvider() as unknown as {
+        closePr(prNumber: number, cwd?: string): { success: boolean; error?: string };
+      };
+
+      const result = provider.closePr(42, '/project');
+
+      expect(result).toEqual({ success: false, error: 'close blocked' });
+    });
+
+    it('cwd 省略時は process.cwd() をフォールバックとして渡す', () => {
+      mockCloseMr.mockReturnValue({ success: true });
+      const provider = new GitLabProvider() as unknown as {
+        closePr(prNumber: number, cwd?: string): { success: boolean; error?: string };
+      };
+
+      provider.closePr(42);
+
+      expect(mockCloseMr).toHaveBeenCalledWith(42, process.cwd());
     });
   });
 });

--- a/src/__tests__/it-system-workflow-execution.test.ts
+++ b/src/__tests__/it-system-workflow-execution.test.ts
@@ -10,6 +10,7 @@ import { createDefaultSystemStepServices } from '../infra/workflow/system/Defaul
 
 const {
   mockCommentOnPr,
+  mockClosePr,
   mockMergePr,
   mockSaveTaskFile,
   mockCreateIssueFromTask,
@@ -21,6 +22,7 @@ const {
   mockTaskRunnerListAllTaskItems,
 } = vi.hoisted(() => ({
   mockCommentOnPr: vi.fn(),
+  mockClosePr: vi.fn(),
   mockMergePr: vi.fn(),
   mockSaveTaskFile: vi.fn(),
   mockCreateIssueFromTask: vi.fn(),
@@ -45,6 +47,7 @@ vi.mock('../infra/config/project/projectConfig.js', () => ({
 vi.mock('../infra/git/index.js', () => ({
   getGitProvider: vi.fn(() => ({
     commentOnPr: (...args: unknown[]) => mockCommentOnPr(...args),
+    closePr: (...args: unknown[]) => mockClosePr(...args),
     mergePr: (...args: unknown[]) => mockMergePr(...args),
     findExistingPr: (...args: unknown[]) => mockFindExistingPr(...args),
     fetchPrReviewComments: (...args: unknown[]) => mockFetchPrReviewComments(...args),
@@ -124,6 +127,32 @@ function loadBuiltinAutoImprovementLoopForIssueExecution(projectDir: string) {
   };
 }
 
+function loadBuiltinAutoImprovementLoopForPrExecution(projectDir: string) {
+  const config = normalizeWorkflowConfig(
+    parse(readFileSync(
+      join(process.cwd(), 'builtins', 'en', 'workflows', 'auto-improvement-loop.yaml'),
+      'utf-8',
+    )),
+    projectDir,
+  );
+  return {
+    ...config,
+    maxSteps: 6,
+    steps: config.steps.map((step) => {
+      if (step.name === 'wait_before_next_scan') {
+        return {
+          ...step,
+          delayBeforeMs: 0,
+          rules: [
+            { condition: 'true', next: 'COMPLETE' },
+          ],
+        };
+      }
+      return step;
+    }),
+  };
+}
+
 describe('system workflow execution integration', () => {
   let projectDir: string;
 
@@ -134,6 +163,7 @@ describe('system workflow execution integration', () => {
     mockSaveTaskFile.mockResolvedValue({ taskName: 'task-1', tasksFile: join(projectDir, '.takt', 'tasks.yaml') });
     mockCreateIssueFromTask.mockReturnValue(586);
     mockResolveBaseBranch.mockImplementation((_cwd: string, branch?: string) => ({ branch: branch ?? 'main' }));
+    mockClosePr.mockReturnValue({ success: true });
     mockMergePr.mockReturnValue({ success: true });
     mockListOpenIssues.mockReset();
     mockListOpenIssues.mockReturnValue([]);
@@ -1030,6 +1060,46 @@ describe('system workflow execution integration', () => {
     });
   });
 
+  it('close_pr effect の成功結果で遷移できる', async () => {
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'reject-pr-routing',
+        initial_step: 'reject_pr',
+        max_steps: 2,
+        steps: [
+          {
+            name: 'reject_pr',
+            mode: 'system',
+            effects: [
+              {
+                type: 'close_pr',
+                pr: 42,
+              },
+            ],
+            rules: [
+              { when: 'effect.reject_pr.close_pr.success == true', next: 'COMPLETE' },
+              { when: 'true', next: 'ABORT' },
+            ],
+          },
+        ],
+      },
+      projectDir,
+    );
+
+    const engine = new WorkflowEngine(config, projectDir, 'Current task body', createSystemEngineOptions(projectDir));
+    const state = await engine.run();
+    const stateRecord = state as Record<string, unknown>;
+
+    expect(state.status).toBe('completed');
+    expect(mockClosePr).toHaveBeenCalledWith(42, projectDir);
+    expect((stateRecord.effectResults as Map<string, unknown>).get('reject_pr')).toEqual({
+      close_pr: {
+        success: true,
+        failed: false,
+      },
+    });
+  });
+
   it('pr_list と queue.items を when の配列参照と exists で評価して遷移できる', async () => {
     const createServices = vi.fn(() => ({
       resolveSystemInput(input: { type: string }) {
@@ -1555,6 +1625,48 @@ describe('system workflow execution integration', () => {
     expect(mockSaveTaskFile).not.toHaveBeenCalled();
   });
 
+  it('builtin auto-improvement-loop の plan_from_issue は PR 専用 action を拒否する', async () => {
+    let abortReason = '';
+    setMockScenario([
+      {
+        persona: 'supervisor',
+        status: 'done',
+        content: 'Reject this issue as if it were a PR.',
+        structuredOutput: {
+          action: 'reject_pr',
+        },
+      },
+    ]);
+    mockListOpenIssues.mockReturnValue([
+      {
+        number: 586,
+        title: 'Repo issue',
+        labels: [],
+        updated_at: '2026-04-20T14:00:00Z',
+      },
+    ]);
+
+    const config = loadBuiltinAutoImprovementLoopForIssueExecution(projectDir);
+    const engine = new WorkflowEngine(
+      config,
+      projectDir,
+      'Current task body',
+      createSystemEngineOptions(projectDir),
+    );
+    engine.on('workflow:abort', (_state, reason) => {
+      abortReason = reason;
+    });
+
+    const state = await engine.run();
+    const stepNames = Array.from(state.stepOutputs.keys());
+
+    expect(state.status).toBe('aborted');
+    expect(stepNames).toEqual(['route_context', 'plan_from_issue']);
+    expect(abortReason).toContain('Workflow aborted by step transition');
+    expect(mockClosePr).not.toHaveBeenCalled();
+    expect(mockSaveTaskFile).not.toHaveBeenCalled();
+  });
+
   it('repo-wide issue からの enqueue は対話モードでも追加承認を要求しない', async () => {
     setMockScenario([
       {
@@ -1910,6 +2022,101 @@ describe('system workflow execution integration', () => {
 
     expect(state.status).toBe('completed');
     expect(executeEffect).not.toHaveBeenCalled();
+  });
+
+  it('builtin auto-improvement-loop の reject_pr は PR を close するだけで次の task を積まない', async () => {
+    setMockScenario([
+      {
+        persona: 'supervisor',
+        status: 'done',
+        content: 'Reject the current PR.',
+        structuredOutput: {
+          action: 'reject_pr',
+        },
+      },
+    ]);
+    mockListOpenPrs.mockReturnValue([
+      {
+        number: 42,
+        author: 'nrslib',
+        base_branch: 'improve',
+        head_branch: 'takt/20260425-reject-me',
+        managed_by_takt: true,
+        labels: ['takt-managed'],
+        same_repository: true,
+        draft: false,
+        updated_at: '2026-04-25T13:39:00Z',
+      },
+    ]);
+
+    const config = loadBuiltinAutoImprovementLoopForPrExecution(projectDir);
+    const state = await new WorkflowEngine(
+      config,
+      projectDir,
+      'Current task body',
+      createSystemEngineOptions(projectDir),
+    ).run();
+    const stepNames = Array.from(state.stepOutputs.keys());
+
+    expect(state.status).toBe('completed');
+    expect(stepNames).toEqual([
+      'route_context',
+      'plan_from_existing_pr',
+      'reject_pr',
+      'wait_before_next_scan',
+    ]);
+    expect(mockClosePr).toHaveBeenCalledWith(42, projectDir);
+    expect(mockCommentOnPr).not.toHaveBeenCalled();
+    expect(mockMergePr).not.toHaveBeenCalled();
+    expect(mockSaveTaskFile).not.toHaveBeenCalled();
+  });
+
+  it('builtin auto-improvement-loop の plan_from_existing_pr は noop を拒否する', async () => {
+    let abortReason = '';
+    setMockScenario([
+      {
+        persona: 'supervisor',
+        status: 'done',
+        content: 'Do nothing.',
+        structuredOutput: {
+          action: 'noop',
+        },
+      },
+    ]);
+    mockListOpenPrs.mockReturnValue([
+      {
+        number: 42,
+        author: 'nrslib',
+        base_branch: 'improve',
+        head_branch: 'takt/20260425-reject-noop',
+        managed_by_takt: true,
+        labels: ['takt-managed'],
+        same_repository: true,
+        draft: false,
+        updated_at: '2026-04-25T13:39:00Z',
+      },
+    ]);
+
+    const config = loadBuiltinAutoImprovementLoopForPrExecution(projectDir);
+    const engine = new WorkflowEngine(
+      config,
+      projectDir,
+      'Current task body',
+      createSystemEngineOptions(projectDir),
+    );
+    engine.on('workflow:abort', (_state, reason) => {
+      abortReason = reason;
+    });
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('aborted');
+    expect(abortReason).toContain('plan_from_existing_pr');
+    expect(abortReason).toContain('$.action must be equal to one of the allowed values');
+    expect(mockClosePr).not.toHaveBeenCalled();
+    expect(mockCommentOnPr).not.toHaveBeenCalled();
+    expect(mockMergePr).not.toHaveBeenCalled();
+    expect(mockSaveTaskFile).not.toHaveBeenCalled();
   });
 
   it('executor 実経路でも pr_list と pr_selection は同一スナップショットを共有する', async () => {

--- a/src/__tests__/it-workflow-loader.test.ts
+++ b/src/__tests__/it-workflow-loader.test.ts
@@ -98,12 +98,42 @@ function expectAutoImprovementLoopDownstreamContract(config: NonNullable<ReturnT
   const resolveConflicts = config.steps.find((step) => step.name === 'resolve_conflicts') as Record<string, unknown> | undefined;
   const enqueueConflictResolutionTask = config.steps.find((step) => step.name === 'enqueue_conflict_resolution_task') as Record<string, unknown> | undefined;
   const mergePr = config.steps.find((step) => step.name === 'merge_pr') as Record<string, unknown> | undefined;
-  const commentOnExistingPr = config.steps.find((step) => step.name === 'comment_on_existing_pr') as Record<string, unknown> | undefined;
+  const rejectPr = config.steps.find((step) => step.name === 'reject_pr') as Record<string, unknown> | undefined;
+  const planFromExistingPrStructuredOutput = planFromExistingPr?.structuredOutput as
+    | { schemaRef: string; schema: { properties?: Record<string, unknown> } }
+    | undefined;
 
   expect(String(planFromExistingPr?.instruction)).toContain('{context:route_context.selected_pr.number}');
-  expect(commentOnExistingPr?.effects).toEqual([
+  expect(String(planFromExistingPr?.instruction)).toContain('reject_pr');
+  expect(String(planFromExistingPr?.instruction)).toContain('enqueue_from_pr');
+  expect(String(planFromExistingPr?.instruction)).toContain('prepare_merge');
+  expect(String(planFromExistingPr?.instruction)).not.toContain('comment_on_pr');
+  expect(String(planFromExistingPr?.instruction)).not.toContain('pr_comment_markdown');
+  expect(String(planFromExistingPr?.instruction)).not.toContain('- noop');
+  expect(planFromExistingPr?.rules).toEqual([
+    expect.objectContaining({ condition: 'structured.plan_from_existing_pr.action == "enqueue_from_pr"', next: 'enqueue_from_pr' }),
+    expect.objectContaining({ condition: 'structured.plan_from_existing_pr.action == "prepare_merge"', next: 'prepare_merge' }),
+    expect.objectContaining({ condition: 'structured.plan_from_existing_pr.action == "reject_pr"', next: 'reject_pr' }),
+    expect.objectContaining({ condition: 'true', next: 'ABORT' }),
+  ]);
+  expect(planFromExistingPrStructuredOutput?.schemaRef).toBe('pr-followup-task');
+  expect(planFromExistingPrStructuredOutput?.schema).toEqual(expect.objectContaining({
+    type: 'object',
+    required: ['action'],
+    additionalProperties: false,
+    properties: expect.objectContaining({
+      action: {
+        type: 'string',
+        enum: ['enqueue_from_pr', 'prepare_merge', 'reject_pr'],
+      },
+      task_markdown: {
+        type: 'string',
+      },
+    }),
+  }));
+  expect(rejectPr?.effects).toEqual([
     expect.objectContaining({
-      type: 'comment_pr',
+      type: 'close_pr',
       pr: '{context:route_context.selected_pr.number}',
     }),
   ]);
@@ -147,6 +177,7 @@ function expectAutoImprovementLoopDownstreamContract(config: NonNullable<ReturnT
     expect.objectContaining({ condition: 'structured.plan_from_issue.action == "enqueue_new_task"', next: 'enqueue_from_issue' }),
     expect.objectContaining({ condition: 'structured.plan_from_issue.action == "noop"', next: 'wait_before_next_scan' }),
   ]));
+  expect(config.steps.find((step) => step.name === 'comment_on_existing_pr')).toBeUndefined();
   expect(config.steps.find((step) => step.name === 'confirm_issue_enqueue')).toBeUndefined();
 }
 
@@ -205,6 +236,7 @@ describe('Workflow Loader IT: builtin workflow loading', () => {
     expect((config as Record<string, unknown>).maxSteps).toBe('infinite');
     expect(config!.schemas).toEqual(expect.objectContaining({
       'followup-task': 'followup-task',
+      'pr-followup-task': 'pr-followup-task',
     }));
     expectAutoImprovementLoopRouteContext(config!);
     expectAutoImprovementLoopDownstreamContract(config!);
@@ -288,7 +320,7 @@ describe('Workflow Loader IT: builtin workflow loading', () => {
     const resolveConflicts = config!.steps.find((step) => step.name === 'resolve_conflicts') as Record<string, unknown> | undefined;
     const enqueueConflictResolutionTask = config!.steps.find((step) => step.name === 'enqueue_conflict_resolution_task') as Record<string, unknown> | undefined;
     const mergePr = config!.steps.find((step) => step.name === 'merge_pr') as Record<string, unknown> | undefined;
-    const commentOnExistingPr = config!.steps.find((step) => step.name === 'comment_on_existing_pr') as Record<string, unknown> | undefined;
+    const rejectPr = config!.steps.find((step) => step.name === 'reject_pr') as Record<string, unknown> | undefined;
     const waitBeforeNextScan = config!.steps.find((step) => step.name === 'wait_before_next_scan') as Record<string, unknown> | undefined;
 
     expect(planFromIssue?.delayBeforeMs).toBe(60000);
@@ -309,9 +341,21 @@ describe('Workflow Loader IT: builtin workflow loading', () => {
       }),
     ]);
     expect(planFromExistingPr?.rules).toEqual(expect.arrayContaining([
-      expect.objectContaining({ condition: 'structured.plan_from_existing_pr.action == "noop"', next: 'wait_before_next_scan' }),
+      expect.objectContaining({ condition: 'structured.plan_from_existing_pr.action == "enqueue_from_pr"', next: 'enqueue_from_pr' }),
+      expect.objectContaining({ condition: 'structured.plan_from_existing_pr.action == "prepare_merge"', next: 'prepare_merge' }),
+      expect.objectContaining({ condition: 'structured.plan_from_existing_pr.action == "reject_pr"', next: 'reject_pr' }),
       expect.objectContaining({ condition: 'true', next: 'ABORT' }),
     ]));
+    expect(planFromExistingPr?.rules).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ condition: 'structured.plan_from_existing_pr.action == "comment_on_pr"', next: 'comment_on_existing_pr' }),
+      expect.objectContaining({ condition: 'structured.plan_from_existing_pr.action == "noop"', next: 'wait_before_next_scan' }),
+    ]));
+    expect(rejectPr?.effects).toEqual([
+      expect.objectContaining({
+        type: 'close_pr',
+        pr: '{context:route_context.selected_pr.number}',
+      }),
+    ]);
     expectAutoImprovementLoopDownstreamContract(config!);
     expect(prepareMerge?.rules).toEqual(expect.arrayContaining([
       expect.objectContaining({ condition: 'effect.prepare_merge.sync_with_root.success == true', next: 'merge_pr' }),

--- a/src/__tests__/system-workflow-schema.test.ts
+++ b/src/__tests__/system-workflow-schema.test.ts
@@ -721,6 +721,27 @@ describe('system workflow schema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('close_pr effect を受け付ける', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'reject_pr',
+      mode: 'system',
+      effects: [
+        {
+          type: 'close_pr',
+          pr: '{context:route_context.selected_pr.number}',
+        },
+      ],
+      rules: [
+        {
+          when: 'true',
+          next: 'COMPLETE',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it('enqueue_task issue の bare string payload を reject する', () => {
     const result = WorkflowStepRawSchema.safeParse({
       name: 'enqueue_from_issue',
@@ -997,9 +1018,6 @@ describe('system workflow schema', () => {
             type: 'string',
             enum: [
               'enqueue_new_task',
-              'comment_on_pr',
-              'enqueue_from_pr',
-              'prepare_merge',
               'noop',
             ],
           },
@@ -1016,6 +1034,110 @@ describe('system workflow schema', () => {
           },
         }),
       }));
+      expect((structuredOutput.schema.properties as Record<string, unknown>).pr_comment_markdown).toBeUndefined();
+    } finally {
+      rmSync(workflowDir, { recursive: true, force: true });
+    }
+  });
+
+  it('builtin followup-task schema fallback は PR 専用 action を許可しない', () => {
+    const workflowDir = mkdtempSync(join(tmpdir(), 'takt-system-schema-followup-no-pr-actions-'));
+
+    try {
+      const raw = WorkflowConfigRawSchema.parse({
+        name: 'auto-improvement-loop',
+        max_steps: 3,
+        initial_step: 'plan_followup',
+        steps: [
+          {
+            name: 'plan_followup',
+            persona: 'supervisor',
+            instruction: 'Plan follow-up task',
+            structured_output: {
+              schema_ref: 'followup-task',
+            },
+            rules: [
+              {
+                when: 'true',
+                next: 'COMPLETE',
+              },
+            ],
+          },
+        ],
+      });
+
+      const normalized = normalizeWorkflowConfig(raw, workflowDir);
+      const step = normalized.steps[0] as Record<string, unknown>;
+      const structuredOutput = step.structuredOutput as {
+        schema: {
+          properties: {
+            action: {
+              enum: string[];
+            };
+          };
+        };
+      };
+      const allowedActions = structuredOutput.schema.properties.action.enum;
+
+      expect(allowedActions).toEqual(['enqueue_new_task', 'noop']);
+      expect(allowedActions).not.toContain('enqueue_from_pr');
+      expect(allowedActions).not.toContain('prepare_merge');
+      expect(allowedActions).not.toContain('reject_pr');
+    } finally {
+      rmSync(workflowDir, { recursive: true, force: true });
+    }
+  });
+
+  it('builtin pr-followup-task schema fallback を解決できる', () => {
+    const workflowDir = mkdtempSync(join(tmpdir(), 'takt-system-schema-pr-followup-builtins-'));
+
+    try {
+      const raw = WorkflowConfigRawSchema.parse({
+        name: 'auto-improvement-loop',
+        max_steps: 3,
+        initial_step: 'plan_from_existing_pr',
+        steps: [
+          {
+            name: 'plan_from_existing_pr',
+            persona: 'supervisor',
+            instruction: 'Plan next PR action',
+            structured_output: {
+              schema_ref: 'pr-followup-task',
+            },
+            rules: [
+              {
+                when: 'true',
+                next: 'COMPLETE',
+              },
+            ],
+          },
+        ],
+      });
+
+      const normalized = normalizeWorkflowConfig(raw, workflowDir);
+      const step = normalized.steps[0] as Record<string, unknown>;
+      const structuredOutput = step.structuredOutput as { schemaRef: string; schema: Record<string, unknown> };
+
+      expect(structuredOutput.schemaRef).toBe('pr-followup-task');
+      expect(structuredOutput.schema).toEqual(expect.objectContaining({
+        type: 'object',
+        required: ['action'],
+        additionalProperties: false,
+        properties: expect.objectContaining({
+          action: {
+            type: 'string',
+            enum: [
+              'enqueue_from_pr',
+              'prepare_merge',
+              'reject_pr',
+            ],
+          },
+          task_markdown: {
+            type: 'string',
+          },
+        }),
+      }));
+      expect((structuredOutput.schema.properties as Record<string, unknown>).issue).toBeUndefined();
     } finally {
       rmSync(workflowDir, { recursive: true, force: true });
     }
@@ -1516,7 +1638,7 @@ steps:
   - name: route_context
     mode: system
     effects:
-      - type: merge_pr
+      - type: close_pr
         pr: 42
     rules:
       - when: "true"
@@ -1528,7 +1650,7 @@ steps:
     try {
       const workflow = loadWorkflowFromFile(workflowPath, projectDir);
       expect(workflow.steps[0]?.effects).toEqual([
-        { type: 'merge_pr', pr: 42 },
+        { type: 'close_pr', pr: 42 },
       ]);
     } finally {
       rmSync(projectDir, { recursive: true, force: true });

--- a/src/core/models/workflow-system-input-types.ts
+++ b/src/core/models/workflow-system-input-types.ts
@@ -158,4 +158,8 @@ export type WorkflowEffect =
   | {
     type: 'merge_pr';
     pr: WorkflowEffectScalarReference;
+  }
+  | {
+    type: 'close_pr';
+    pr: WorkflowEffectScalarReference;
   };

--- a/src/core/models/workflow-system-schemas.ts
+++ b/src/core/models/workflow-system-schemas.ts
@@ -166,6 +166,10 @@ export const WorkflowEffectRawSchema = z.discriminatedUnion('type', [
     type: z.literal('merge_pr'),
     pr: EffectReferenceScalarSchema,
   }).strict(),
+  z.object({
+    type: z.literal('close_pr'),
+    pr: EffectReferenceScalarSchema,
+  }).strict(),
 ]);
 
 export function validateSystemStepFields(

--- a/src/core/workflow/system/system-step-effect-runner.ts
+++ b/src/core/workflow/system/system-step-effect-runner.ts
@@ -99,7 +99,12 @@ export function validateSystemEffectPayload(
     requireNumber(payload.pr, 'pr');
     requireString(payload.body, 'body');
   }
-  if (effect.type === 'sync_with_root' || effect.type === 'resolve_conflicts_with_ai' || effect.type === 'merge_pr') {
+  if (
+    effect.type === 'sync_with_root'
+    || effect.type === 'resolve_conflicts_with_ai'
+    || effect.type === 'merge_pr'
+    || effect.type === 'close_pr'
+  ) {
     requireNumber(payload.pr, 'pr');
   }
 }

--- a/src/infra/config/loaders/workflowSystemStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowSystemStepNormalizer.ts
@@ -81,6 +81,11 @@ function normalizeWorkflowEffect(effect: RawWorkflowEffect): WorkflowEffect {
       type: 'merge_pr',
       pr: requireEffectScalarReference(effect.pr, 'effects.pr'),
     };
+  case 'close_pr':
+    return {
+      type: 'close_pr',
+      pr: requireEffectScalarReference(effect.pr, 'effects.pr'),
+    };
   }
 }
 

--- a/src/infra/git/types.ts
+++ b/src/infra/git/types.ts
@@ -110,5 +110,7 @@ export interface GitProvider {
 
   commentOnPr(prNumber: number, body: string, cwd?: string): CommentResult;
 
+  closePr(prNumber: number, cwd?: string): MergeResult;
+
   mergePr(prNumber: number, cwd?: string): MergeResult;
 }

--- a/src/infra/github/GitHubProvider.ts
+++ b/src/infra/github/GitHubProvider.ts
@@ -7,7 +7,7 @@
  */
 
 import { checkGhCli, fetchIssue, listOpenIssues, createIssue } from './issue.js';
-import { findExistingPr, commentOnPr, createPullRequest, fetchPrReviewComments, listOpenPrs, mergePr } from './pr.js';
+import { findExistingPr, commentOnPr, closePr, createPullRequest, fetchPrReviewComments, listOpenPrs, mergePr } from './pr.js';
 import type { GitProvider, CliStatus, Issue, ExistingPr, IssueListItem, PrListItem, CreateIssueOptions, CreateIssueResult, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, PrReviewData } from '../git/types.js';
 
 export class GitHubProvider implements GitProvider {
@@ -45,6 +45,10 @@ export class GitHubProvider implements GitProvider {
 
   commentOnPr(prNumber: number, body: string, cwd?: string): CommentResult {
     return commentOnPr(prNumber, body, cwd ?? process.cwd());
+  }
+
+  closePr(prNumber: number, cwd?: string): MergeResult {
+    return closePr(prNumber, cwd ?? process.cwd());
   }
 
   mergePr(prNumber: number, cwd?: string): MergeResult {

--- a/src/infra/github/pr.ts
+++ b/src/infra/github/pr.ts
@@ -287,3 +287,23 @@ export function mergePr(prNumber: number, cwd: string): MergeResult {
     return { success: false, error: errorMessage };
   }
 }
+
+export function closePr(prNumber: number, cwd: string): MergeResult {
+  const ghStatus = checkGhCli(cwd);
+  if (!ghStatus.available) {
+    return { success: false, error: ghStatus.error };
+  }
+
+  try {
+    execFileSync('gh', ['pr', 'close', String(prNumber)], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { success: true };
+  } catch (err) {
+    const errorMessage = getErrorMessage(err);
+    log.error('PR close failed', { error: errorMessage });
+    return { success: false, error: errorMessage };
+  }
+}

--- a/src/infra/gitlab/GitLabProvider.ts
+++ b/src/infra/gitlab/GitLabProvider.ts
@@ -8,7 +8,7 @@
 
 import { checkGlabCli } from './utils.js';
 import { fetchIssue, listOpenIssues, createIssue } from './issue.js';
-import { findExistingMr, commentOnMr, createMergeRequest, fetchMrReviewComments, listOpenMrs, mergeMr } from './pr.js';
+import { findExistingMr, commentOnMr, closeMr, createMergeRequest, fetchMrReviewComments, listOpenMrs, mergeMr } from './pr.js';
 import type { GitProvider, CliStatus, Issue, ExistingPr, IssueListItem, PrListItem, CreateIssueOptions, CreateIssueResult, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, PrReviewData } from '../git/types.js';
 
 export class GitLabProvider implements GitProvider {
@@ -46,6 +46,10 @@ export class GitLabProvider implements GitProvider {
 
   commentOnPr(prNumber: number, body: string, cwd?: string): CommentResult {
     return commentOnMr(prNumber, body, cwd ?? process.cwd());
+  }
+
+  closePr(prNumber: number, cwd?: string): MergeResult {
+    return closeMr(prNumber, cwd ?? process.cwd());
   }
 
   mergePr(prNumber: number, cwd?: string): MergeResult {

--- a/src/infra/gitlab/pr.ts
+++ b/src/infra/gitlab/pr.ts
@@ -267,3 +267,23 @@ export function mergeMr(mrNumber: number, cwd: string): MergeResult {
     return { success: false, error: errorMessage };
   }
 }
+
+export function closeMr(mrNumber: number, cwd: string): MergeResult {
+  const glabStatus = checkGlabCli(cwd);
+  if (!glabStatus.available) {
+    return { success: false, error: glabStatus.error };
+  }
+
+  try {
+    execFileSync('glab', ['mr', 'close', String(mrNumber)], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { success: true };
+  } catch (err) {
+    const errorMessage = getErrorMessage(err);
+    log.error('MR close failed', { error: errorMessage });
+    return { success: false, error: errorMessage };
+  }
+}

--- a/src/infra/workflow/system/DefaultSystemStepServices.ts
+++ b/src/infra/workflow/system/DefaultSystemStepServices.ts
@@ -18,6 +18,7 @@ import {
 } from './system-git-context.js';
 import {
   commentPrEffect,
+  closePrEffect,
   mergePrEffect,
 } from './system-pr-effects.js';
 import { enqueueTaskEffect } from './system-enqueue-effect.js';
@@ -163,6 +164,8 @@ async function runEffect(
       return resolveConflictsWithAiEffect(options, payload as Parameters<typeof resolveConflictsWithAiEffect>[1]);
     case 'merge_pr':
       return mergePrEffect(options, payload as Parameters<typeof mergePrEffect>[1]);
+    case 'close_pr':
+      return closePrEffect(options, payload as Parameters<typeof closePrEffect>[1]);
   }
 }
 

--- a/src/infra/workflow/system/system-pr-effects.ts
+++ b/src/infra/workflow/system/system-pr-effects.ts
@@ -24,3 +24,15 @@ export function mergePrEffect(
     ...(result.error ? { error: result.error } : {}),
   };
 }
+
+export function closePrEffect(
+  options: SystemStepServicesOptions,
+  payload: { pr: number },
+): Record<string, unknown> {
+  const result = getGitProvider().closePr(payload.pr, options.projectCwd);
+  return {
+    success: result.success,
+    failed: result.success !== true,
+    ...(result.error ? { error: result.error } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

## 背景

`auto-improvement-loop` の PR 分岐は現在、`plan_from_existing_pr` で次の action を選ぶ設計になっている。

- `comment_on_pr`
- `enqueue_from_pr`
- `prepare_merge`
- `noop`

ただし北極星は、人の介在を前提にせず、PR があればその PR を前に進める loop にある。
その観点では、`comment_on_pr` と `noop` は本筋から外れている。

- `comment_on_pr` は人間向け通知であり、loop の前進に寄与しない
- `noop` は停滞の逃げ道になり、PR 分岐の意味を曖昧にする

一方で、PR を採用しない判断自体は必要であり、その場合は曖昧な `noop` ではなく明示的な action にすべき。

## 方針

PR 分岐の action を次の 3 つに整理する。

- `prepare_merge`
- `enqueue_from_pr`
- `reject_pr`

意味は以下に固定する。

- `prepare_merge`
  - この PR は採用し、merge 方向で進める
- `enqueue_from_pr`
  - この PR は採用するが、追加修正 task が必要
- `reject_pr`
  - この PR は採用せず close する

## 具体的な変更

- `plan_from_existing_pr` から `comment_on_pr` を削除する
- `plan_from_existing_pr` から `noop` を削除する
- `plan_from_existing_pr` に `reject_pr` を追加する
- `comment_on_existing_pr` step を削除する
- `reject_pr` 用の step を追加し、effect として `close_pr` を使う
- `followup-task` schema の action enum を更新する
- builtin workflow の ja/en を同期する
- 関連する loader / schema / execution テストを更新する

## 受け入れ条件

- builtin `auto-improvement-loop` の PR 分岐で `comment_on_pr` を選べない
- builtin `auto-improvement-loop` の PR 分岐で `noop` を選べない
- builtin `auto-improvement-loop` の PR 分岐で `reject_pr` を選べる
- `reject_pr` は PR を close する
- `reject_pr` はコメントしない
- `reject_pr` は branch を削除しない
- `reject_pr` は task を積み直さない
- ja/en builtin workflow が同じ契約になる
- schema / loader / execution テストが更新される

## 明示的にやらないこと

- Issue 分岐や fresh improvement 分岐の `noop` 整理はこの issue では扱わない
- PR action の優先順位や判断文面の全面再設計はこの issue では扱わない
- 重複防止や dedupe はこの issue では扱わない
- orchestration task を worktree 実行に変えない

## Execution Report

Workflow `takt-default` completed successfully.

Closes #676