### PR TITLE
[#587] add-allow-git-commit

### DIFF
--- a/src/__tests__/allow-git-commit.test.ts
+++ b/src/__tests__/allow-git-commit.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  ParallelSubStepRawSchema,
+  WorkflowStepRawSchema,
+} from '../core/models/index.js';
+import { InstructionBuilder } from '../core/workflow/instruction/InstructionBuilder.js';
+import {
+  ReportInstructionBuilder,
+  type ReportInstructionContext,
+} from '../core/workflow/instruction/ReportInstructionBuilder.js';
+import type { InstructionContext } from '../core/workflow/instruction/instruction-context.js';
+import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
+import { loadTemplate } from '../shared/prompts/index.js';
+
+type Language = 'en' | 'ja';
+
+function createTestDir(): string {
+  return mkdtempSync(join(tmpdir(), 'takt-allow-git-commit-'));
+}
+
+function withTestDir<T>(run: (testDir: string) => T): T {
+  const testDir = createTestDir();
+  try {
+    return run(testDir);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+}
+
+function createInstructionContext(language: Language): InstructionContext {
+  return {
+    task: 'Implement the requested change.',
+    iteration: 1,
+    maxSteps: 5,
+    stepIteration: 1,
+    cwd: '/tmp/project',
+    projectCwd: '/tmp/project',
+    userInputs: [],
+    language,
+  };
+}
+
+function createReportContext(language: Language): ReportInstructionContext {
+  return {
+    cwd: '/tmp/project',
+    reportDir: '/tmp/project/.takt/runs/test/reports',
+    stepIteration: 1,
+    language,
+  };
+}
+
+function gitRuleText(language: Language): { commit: string; push: string; add?: string } {
+  if (language === 'ja') {
+    return {
+      commit: 'git commit を実行しないでください',
+      push: 'git push を実行しないでください',
+      add: 'git add を実行しないでください',
+    };
+  }
+
+  return {
+    commit: 'Do NOT run git commit',
+    push: 'Do NOT run git push',
+    add: 'Do NOT run git add',
+  };
+}
+
+function normalizeFirstStep(
+  rawStep: Record<string, unknown>,
+  testDir: string,
+) {
+  const config = normalizeWorkflowConfig({
+    name: 'allow-git-commit-test',
+    steps: [rawStep],
+  }, testDir);
+
+  return config.steps[0]!;
+}
+
+describe('allow_git_commit', () => {
+  describe('raw schema', () => {
+    it('should default allow_git_commit to false for agent steps when omitted', () => {
+      const result = WorkflowStepRawSchema.safeParse({
+        name: 'implement',
+        persona: 'coder',
+        instruction: '{task}',
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) {
+        return;
+      }
+
+      expect(result.data.allow_git_commit).toBe(false);
+    });
+
+    it('should accept allow_git_commit on parallel sub-steps and preserve omission for parent inheritance', () => {
+      const omitted = ParallelSubStepRawSchema.safeParse({
+        name: 'review',
+        persona: 'reviewer',
+        instruction: 'Review the implementation',
+      });
+      const enabled = ParallelSubStepRawSchema.safeParse({
+        name: 'review',
+        persona: 'reviewer',
+        instruction: 'Review the implementation',
+        allow_git_commit: true,
+      });
+
+      expect(omitted.success).toBe(true);
+      if (omitted.success) {
+        expect(omitted.data.allow_git_commit).toBeUndefined();
+      }
+
+      expect(enabled.success).toBe(true);
+      if (enabled.success) {
+        expect(enabled.data.allow_git_commit).toBe(true);
+      }
+    });
+
+    it('should reject allow_git_commit on workflow_call steps', () => {
+      const result = WorkflowStepRawSchema.safeParse({
+        name: 'delegate',
+        kind: 'workflow_call',
+        call: 'shared/review-loop',
+        allow_git_commit: true,
+        rules: [
+          {
+            condition: 'COMPLETE',
+            next: 'COMPLETE',
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          path: ['allow_git_commit'],
+          message: 'workflow_call step does not allow "allow_git_commit"',
+        }),
+      ]));
+    });
+
+    it('should reject allow_git_commit on system steps', () => {
+      const result = WorkflowStepRawSchema.safeParse({
+        name: 'route_context',
+        mode: 'system',
+        allow_git_commit: true,
+        rules: [
+          {
+            when: 'true',
+            next: 'COMPLETE',
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          path: ['allow_git_commit'],
+          message: 'System step does not allow "allow_git_commit"',
+        }),
+      ]));
+    });
+
+    it('should accept allow_git_commit on team_leader steps and default it when omitted', () => {
+      const omitted = WorkflowStepRawSchema.safeParse({
+        name: 'delegate',
+        persona: 'coder',
+        instruction: '{task}',
+        team_leader: {
+          max_parts: 2,
+        },
+      });
+      const enabled = WorkflowStepRawSchema.safeParse({
+        name: 'delegate',
+        persona: 'coder',
+        instruction: '{task}',
+        allow_git_commit: true,
+        team_leader: {
+          max_parts: 2,
+        },
+      });
+
+      expect(omitted.success).toBe(true);
+      if (omitted.success) {
+        expect(omitted.data.allow_git_commit).toBe(false);
+      }
+
+      expect(enabled.success).toBe(true);
+      if (enabled.success) {
+        expect(enabled.data.allow_git_commit).toBe(true);
+      }
+    });
+
+    it('should accept allow_git_commit on arpeggio steps and default it when omitted', () => {
+      const omitted = WorkflowStepRawSchema.safeParse({
+        name: 'batch',
+        persona: 'coder',
+        instruction: '{task}',
+        arpeggio: {
+          source: 'csv',
+          source_path: './data.csv',
+          template: './prompt.md',
+        },
+      });
+      const enabled = WorkflowStepRawSchema.safeParse({
+        name: 'batch',
+        persona: 'coder',
+        instruction: '{task}',
+        allow_git_commit: true,
+        arpeggio: {
+          source: 'csv',
+          source_path: './data.csv',
+          template: './prompt.md',
+        },
+      });
+
+      expect(omitted.success).toBe(true);
+      if (omitted.success) {
+        expect(omitted.data.allow_git_commit).toBe(false);
+      }
+
+      expect(enabled.success).toBe(true);
+      if (enabled.success) {
+        expect(enabled.data.allow_git_commit).toBe(true);
+      }
+    });
+  });
+
+  describe('normalization', () => {
+    it('should preserve allowGitCommit for agent, arpeggio, parallel, and team_leader steps', () => {
+      withTestDir((testDir) => {
+        const config = normalizeWorkflowConfig({
+          name: 'allow-git-commit-test',
+          steps: [
+            {
+              name: 'implement',
+              persona: 'coder',
+              instruction: '{task}',
+              allow_git_commit: true,
+            },
+            {
+              name: 'delegate',
+              persona: 'coder',
+              instruction: '{task}',
+              allow_git_commit: true,
+              team_leader: {
+                max_parts: 2,
+              },
+            },
+            {
+              name: 'batch',
+              persona: 'coder',
+              instruction: '{task}',
+              allow_git_commit: true,
+              arpeggio: {
+                source: 'csv',
+                source_path: './data.csv',
+                template: './prompt.md',
+              },
+            },
+            {
+              name: 'review',
+              parallel: [
+                {
+                  name: 'security',
+                  persona: 'reviewer',
+                  instruction: 'Review the security impact',
+                  allow_git_commit: true,
+                },
+                {
+                  name: 'qa',
+                  persona: 'reviewer',
+                  instruction: 'Review the regression risk',
+                },
+              ],
+              rules: [
+                {
+                  condition: 'all("done")',
+                  next: 'COMPLETE',
+                },
+              ],
+            },
+          ],
+        }, testDir);
+
+        expect(config.steps[0]).toMatchObject({ allowGitCommit: true });
+        expect(config.steps[1]).toMatchObject({ allowGitCommit: true });
+        expect(config.steps[2]).toMatchObject({ allowGitCommit: true });
+        expect(config.steps[3]!.parallel?.[0]).toMatchObject({ allowGitCommit: true });
+        expect(config.steps[3]!.parallel?.[1]).toMatchObject({ allowGitCommit: false });
+      });
+    });
+
+    it('should inherit allowGitCommit from a parallel parent only when the sub-step omits it', () => {
+      withTestDir((testDir) => {
+        const config = normalizeWorkflowConfig({
+          name: 'allow-git-commit-parallel-inherit-test',
+          steps: [
+            {
+              name: 'review',
+              persona: 'reviewer',
+              instruction: '{task}',
+              allow_git_commit: true,
+              parallel: [
+                {
+                  name: 'security',
+                  persona: 'reviewer',
+                  instruction: 'Review the security impact',
+                },
+                {
+                  name: 'qa',
+                  persona: 'reviewer',
+                  instruction: 'Review the regression risk',
+                  allow_git_commit: false,
+                },
+                {
+                  name: 'docs',
+                  persona: 'reviewer',
+                  instruction: 'Review the documentation impact',
+                  allow_git_commit: true,
+                },
+              ],
+              rules: [
+                {
+                  condition: 'all("done")',
+                  next: 'COMPLETE',
+                },
+              ],
+            },
+          ],
+        }, testDir);
+
+        expect(config.steps[0]).toMatchObject({ allowGitCommit: true });
+        expect(config.steps[0]!.parallel?.[0]).toMatchObject({ allowGitCommit: true });
+        expect(config.steps[0]!.parallel?.[1]).toMatchObject({ allowGitCommit: false });
+        expect(config.steps[0]!.parallel?.[2]).toMatchObject({ allowGitCommit: true });
+      });
+    });
+  });
+
+  describe('phase 1 instruction', () => {
+    it.each([
+      { language: 'en' as const, allowGitCommit: undefined, expectsGitRules: true },
+      { language: 'en' as const, allowGitCommit: false, expectsGitRules: true },
+      { language: 'en' as const, allowGitCommit: true, expectsGitRules: false },
+      { language: 'ja' as const, allowGitCommit: undefined, expectsGitRules: true },
+      { language: 'ja' as const, allowGitCommit: false, expectsGitRules: true },
+      { language: 'ja' as const, allowGitCommit: true, expectsGitRules: false },
+    ])(
+      'should toggle git execution rules in Phase 1 when allow_git_commit is $allowGitCommit ($language)',
+      ({ language, allowGitCommit, expectsGitRules }) => {
+        withTestDir((testDir) => {
+          const step = normalizeFirstStep({
+            name: 'implement',
+            persona: 'coder',
+            instruction: '{task}',
+            ...(allowGitCommit === undefined ? {} : { allow_git_commit: allowGitCommit }),
+          }, testDir);
+
+          const result = new InstructionBuilder(step, createInstructionContext(language)).build();
+          const gitRule = gitRuleText(language);
+
+          if (expectsGitRules) {
+            expect(result).toContain(gitRule.commit);
+            expect(result).toContain(gitRule.push);
+            expect(result).toContain(gitRule.add!);
+          } else {
+            expect(result).not.toContain(gitRule.commit);
+            expect(result).not.toContain(gitRule.push);
+            expect(result).not.toContain(gitRule.add!);
+          }
+        });
+      },
+    );
+  });
+
+  describe('phase 2 instruction', () => {
+    it.each([
+      { language: 'en' as const, allowGitCommit: undefined, expectsGitRules: true },
+      { language: 'en' as const, allowGitCommit: false, expectsGitRules: true },
+      { language: 'en' as const, allowGitCommit: true, expectsGitRules: false },
+      { language: 'ja' as const, allowGitCommit: undefined, expectsGitRules: true },
+      { language: 'ja' as const, allowGitCommit: false, expectsGitRules: true },
+      { language: 'ja' as const, allowGitCommit: true, expectsGitRules: false },
+    ])(
+      'should toggle git execution rules in Phase 2 when allow_git_commit is $allowGitCommit ($language)',
+      ({ language, allowGitCommit, expectsGitRules }) => {
+        withTestDir((testDir) => {
+          const step = normalizeFirstStep({
+            name: 'plan',
+            persona: 'planner',
+            instruction: '{task}',
+            ...(allowGitCommit === undefined ? {} : { allow_git_commit: allowGitCommit }),
+            output_contracts: {
+              report: [
+                {
+                  name: '00-plan.md',
+                  format: '# Plan Report',
+                  use_judge: true,
+                },
+              ],
+            },
+          }, testDir);
+
+          const result = new ReportInstructionBuilder(step, createReportContext(language)).build();
+          const gitRule = gitRuleText(language);
+
+          if (expectsGitRules) {
+            expect(result).toContain(gitRule.commit);
+            expect(result).toContain(gitRule.push);
+          } else {
+            expect(result).not.toContain(gitRule.commit);
+            expect(result).not.toContain(gitRule.push);
+          }
+        });
+      },
+    );
+  });
+
+  describe('templates', () => {
+    it('should keep git prohibition text out of phase templates so builders can inject it conditionally', () => {
+      const phase1En = loadTemplate('perform_phase1_message', 'en');
+      const phase1Ja = loadTemplate('perform_phase1_message', 'ja');
+      const phase2En = loadTemplate('perform_phase2_message', 'en');
+      const phase2Ja = loadTemplate('perform_phase2_message', 'ja');
+
+      expect(phase1En).not.toContain('Do NOT run git commit');
+      expect(phase1En).not.toContain('Do NOT run git push');
+      expect(phase1En).not.toContain('Do NOT run git add');
+      expect(phase1Ja).not.toContain('git commit を実行しないでください');
+      expect(phase1Ja).not.toContain('git push を実行しないでください');
+      expect(phase1Ja).not.toContain('git add を実行しないでください');
+      expect(phase2En).not.toContain('Do NOT run git commit');
+      expect(phase2En).not.toContain('Do NOT run git push');
+      expect(phase2Ja).not.toContain('git commit を実行しないでください');
+      expect(phase2Ja).not.toContain('git push を実行しないでください');
+    });
+  });
+});

--- a/src/__tests__/engine-arpeggio.test.ts
+++ b/src/__tests__/engine-arpeggio.test.ts
@@ -323,6 +323,52 @@ describe('ArpeggioRunner integration', () => {
     expect(phaseStarts.some((instruction) => instruction.includes('Process '))).toBe(true);
   });
 
+  it.each([
+    {
+      allowGitCommit: false,
+      expectedPrompts: ['Do NOT run git commit', 'Do NOT run git push', 'Do NOT run git add'],
+      unexpectedPrompts: [],
+    },
+    {
+      allowGitCommit: true,
+      expectedPrompts: [],
+      unexpectedPrompts: ['Do NOT run git commit', 'Do NOT run git push', 'Do NOT run git add'],
+    },
+  ])(
+    'should toggle git execution rules in arpeggio prompts when allowGitCommit is $allowGitCommit',
+    async ({ allowGitCommit, expectedPrompts, unexpectedPrompts }) => {
+      const { tmpDir, csvPath, templatePath } = createArpeggioTestDir();
+      const arpeggioConfig = createArpeggioConfig(csvPath, templatePath, { concurrency: 1 });
+      const config = buildArpeggioWorkflowConfig(arpeggioConfig, tmpDir);
+      config.steps[0]!.allowGitCommit = allowGitCommit;
+      const prompts: string[] = [];
+
+      vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
+        prompts.push(instruction);
+        options?.onPromptResolved?.({
+          systemPrompt: typeof persona === 'string' ? persona : '',
+          userInstruction: instruction,
+        });
+        return makeResponse({ content: 'Processed' });
+      });
+      vi.mocked(detectMatchedRule).mockResolvedValueOnce({ index: 0, method: 'phase1_tag' });
+
+      engine = new WorkflowEngine(config, tmpDir, 'test task', createEngineOptions(tmpDir));
+      const state = await engine.run();
+
+      expect(state.status).toBe('completed');
+      expect(prompts.length).toBe(3);
+      for (const prompt of prompts) {
+        for (const expectedPrompt of expectedPrompts) {
+          expect(prompt).toContain(expectedPrompt);
+        }
+        for (const unexpectedPrompt of unexpectedPrompts) {
+          expect(prompt).not.toContain(unexpectedPrompt);
+        }
+      }
+    },
+  );
+
   it('should keep phaseExecutionId bindings correct when completion order is reversed', async () => {
     const { tmpDir, csvPath, templatePath } = createArpeggioTestDir();
     const arpeggioConfig = createArpeggioConfig(csvPath, templatePath, { concurrency: 2 });

--- a/src/__tests__/engine-parallel.test.ts
+++ b/src/__tests__/engine-parallel.test.ts
@@ -37,6 +37,7 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
 import { WorkflowEngine } from '../core/workflow/index.js';
 import { runAgent } from '../agents/runner.js';
 import { detectMatchedRule } from '../core/workflow/evaluation/index.js';
+import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
 import {
   makeResponse,
   buildDefaultWorkflowConfig,
@@ -129,6 +130,94 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
     expect(state.stepOutputs.get('arch-review')!.content).toBe('Arch content');
     expect(state.stepOutputs.get('security-review')!.content).toBe('Sec content');
   });
+
+  it.each([
+    { allowGitCommit: undefined, expectsGitRules: true },
+    { allowGitCommit: false, expectsGitRules: true },
+    { allowGitCommit: true, expectsGitRules: false },
+  ])(
+    'should reflect parallel parent allowGitCommit=$allowGitCommit in sub-step prompts',
+    async ({ allowGitCommit, expectsGitRules }) => {
+      const config = normalizeWorkflowConfig({
+        name: 'parallel-allow-git-commit',
+        max_steps: 5,
+        initial_step: 'reviewers',
+        steps: [
+          {
+            name: 'reviewers',
+            persona: '../personas/reviewers.md',
+            instruction: 'Run parallel reviews',
+            ...(allowGitCommit === undefined ? {} : { allow_git_commit: allowGitCommit }),
+            parallel: [
+              {
+                name: 'arch-review',
+                persona: '../personas/arch-review.md',
+                instruction: 'Review architecture',
+                rules: [
+                  {
+                    condition: 'approved',
+                    next: 'COMPLETE',
+                  },
+                ],
+              },
+              {
+                name: 'security-review',
+                persona: '../personas/security-review.md',
+                instruction: 'Review security',
+                rules: [
+                  {
+                    condition: 'approved',
+                    next: 'COMPLETE',
+                  },
+                ],
+              },
+            ],
+            rules: [
+              {
+                condition: 'all("approved")',
+                next: 'COMPLETE',
+              },
+            ],
+          },
+        ],
+      }, tmpDir);
+      const prompts: string[] = [];
+      const gitCommitRule = 'Do NOT run git commit';
+      const gitPushRule = 'Do NOT run git push';
+      const gitAddRule = 'Do NOT run git add';
+
+      vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
+        prompts.push(instruction);
+        options.onPromptResolved?.({
+          systemPrompt: typeof persona === 'string' ? persona : '',
+          userInstruction: instruction,
+        });
+        return makeResponse({ persona: String(persona), content: 'approved' });
+      });
+      mockDetectMatchedRuleSequence([
+        { index: 0, method: 'phase1_tag' },
+        { index: 0, method: 'phase1_tag' },
+        { index: 0, method: 'aggregate' },
+      ]);
+
+      const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+      const state = await engine.run();
+
+      expect(state.status).toBe('completed');
+      expect(prompts).toHaveLength(2);
+      for (const prompt of prompts) {
+        if (expectsGitRules) {
+          expect(prompt).toContain(gitCommitRule);
+          expect(prompt).toContain(gitPushRule);
+          expect(prompt).toContain(gitAddRule);
+        } else {
+          expect(prompt).not.toContain(gitCommitRule);
+          expect(prompt).not.toContain(gitPushRule);
+          expect(prompt).not.toContain(gitAddRule);
+        }
+      }
+    },
+  );
 
   it('should persist aggregated previous_response snapshot for parallel parent step', async () => {
     const config = buildDefaultWorkflowConfig();

--- a/src/__tests__/engine-workflow-call.test.ts
+++ b/src/__tests__/engine-workflow-call.test.ts
@@ -1440,6 +1440,50 @@ steps:
     });
   });
 
+  it('project parent の named child は user workflow fallback 先の allow_git_commit を trust boundary で拒否する', () => {
+    const configDir = createTestTmpDir();
+    cleanupDirs.push(configDir);
+    process.env.TAKT_CONFIG_DIR = configDir;
+    invalidateGlobalConfigCache();
+    invalidateAllResolvedConfigCache();
+
+    const userWorkflowDir = join(configDir, 'workflows', 'takt');
+    mkdirSync(userWorkflowDir, { recursive: true });
+    writeFileSync(join(userWorkflowDir, 'coding.yaml'), `name: takt/coding
+subworkflow:
+  callable: true
+initial_step: review
+max_steps: 5
+steps:
+  - name: review
+    persona: user-reviewer
+    allow_git_commit: true
+    instruction: "User child"
+    rules:
+      - condition: done
+        next: COMPLETE
+`, 'utf-8');
+    writeWorkflow(tmpDir, 'parent.yaml', `name: parent
+initial_step: delegate
+max_steps: 3
+steps:
+  - name: delegate
+    kind: workflow_call
+    call: takt/coding
+    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+      - condition: ABORT
+        next: ABORT
+`);
+
+    const parentWorkflow = loadWorkflowOrThrow('parent', tmpDir);
+
+    expect(() => resolveWorkflowCallTarget(parentWorkflow, 'takt/coding', 'delegate', tmpDir)).toThrow(
+      'Workflow step "delegate" cannot call privileged workflow "takt/coding" across trust boundary',
+    );
+  });
+
   it('source metadata を持たない project parent も user workflow fallback を解決できる', () => {
     const configDir = createTestTmpDir();
     cleanupDirs.push(configDir);
@@ -1906,6 +1950,45 @@ steps:
         pr: 42
     rules:
       - when: "true"
+        next: COMPLETE
+`, 'utf-8');
+    writeWorkflow(tmpDir, 'parent.yaml', `name: parent
+initial_step: delegate
+max_steps: 3
+steps:
+  - name: delegate
+    kind: workflow_call
+    call: ${externalWorkflowPath}
+    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+      - condition: ABORT
+        next: ABORT
+`);
+
+    const parentWorkflow = loadWorkflowOrThrow('parent', tmpDir);
+
+    expect(() => resolveWorkflowCallTarget(parentWorkflow, externalWorkflowPath, 'delegate', tmpDir)).toThrow(
+      'Workflow step "delegate" cannot call privileged workflow "external-child" across trust boundary',
+    );
+  });
+
+  it('project parent は allow_git_commit を持つ external child path を拒否する', () => {
+    const externalDir = createTestTmpDir();
+    cleanupDirs.push(externalDir);
+    const externalWorkflowPath = join(externalDir, 'child.yaml');
+    writeFileSync(externalWorkflowPath, `name: external-child
+subworkflow:
+  callable: true
+initial_step: review
+max_steps: 5
+steps:
+  - name: review
+    persona: external-reviewer
+    allow_git_commit: true
+    instruction: "External child"
+    rules:
+      - condition: done
         next: COMPLETE
 `, 'utf-8');
     writeWorkflow(tmpDir, 'parent.yaml', `name: parent

--- a/src/__tests__/instructionBuilder.test.ts
+++ b/src/__tests__/instructionBuilder.test.ts
@@ -768,7 +768,7 @@ describe('instruction-builder', () => {
       expect(result).toContain('Do NOT modify project source files');
     });
 
-    it('should include no-commit and no-cd rules', () => {
+    it('should include no-commit, no-push, and no-cd rules', () => {
       const step = createMinimalStep('Do work');
       step.outputContracts = [{ name: '00-plan.md', format: '00-plan', useJudge: true }];
       const ctx = createReportContext();
@@ -776,6 +776,7 @@ describe('instruction-builder', () => {
       const result = buildReportInstruction(step, ctx);
 
       expect(result).toContain('Do NOT run git commit');
+      expect(result).toContain('Do NOT run git push');
       expect(result).toContain('Do NOT use `cd`');
     });
 

--- a/src/__tests__/prompts.test.ts
+++ b/src/__tests__/prompts.test.ts
@@ -344,7 +344,7 @@ describe('template content integrity', () => {
     const en = loadTemplate('perform_phase1_message', 'en');
     expect(en).toContain('## Execution Context');
     expect(en).toContain('## Execution Rules');
-    expect(en).toContain('Do NOT run git commit');
+    expect(en).toContain('{{gitRules}}');
     expect(en).toContain('Do NOT use `cd`');
     expect(en).toContain('## Workflow Context');
     expect(findDeprecatedTerms(en)).toEqual([]);
@@ -353,7 +353,7 @@ describe('template content integrity', () => {
 
   it('perform_phase1_message uses workflow/step terminology in both languages', () => {
     const en = loadTemplate('perform_phase1_message', 'en');
-    expect(en).toContain('after workflow completion');
+    expect(en).toContain('{{#if hasGitRules}}{{gitRules}}');
     expect(en).toContain('- Workflow: {{workflowName}}');
     expect(en).toContain('- Step Iteration: {{stepIteration}}');
     expect(en).toContain('- Step: {{stepName}}');
@@ -361,7 +361,7 @@ describe('template content integrity', () => {
     expect(findDeprecatedTerms(en)).toEqual([]);
 
     const ja = loadTemplate('perform_phase1_message', 'ja');
-    expect(ja).toContain('ワークフロー完了後');
+    expect(ja).toContain('{{#if hasGitRules}}{{gitRules}}');
     expect(ja).toContain('- ワークフロー: {{workflowName}}');
     expect(ja).toContain('- Step Iteration: {{stepIteration}}');
     expect(ja).toContain('- Step: {{stepName}}');
@@ -378,14 +378,14 @@ describe('template content integrity', () => {
 
   it('perform_phase2_message contains report-specific rules', () => {
     const en = loadTemplate('perform_phase2_message', 'en');
-    expect(en).toContain('after workflow completion');
+    expect(en).toContain('{{#if hasGitRules}}{{gitRules}}');
     expect(en).toContain('Do NOT modify project source files');
     expect(en).toContain('## Workflow Context');
     expect(findDeprecatedTerms(en)).toEqual([]);
     expect(en).toContain('## Instructions');
 
     const ja = loadTemplate('perform_phase2_message', 'ja');
-    expect(ja).toContain('ワークフロー完了後');
+    expect(ja).toContain('{{#if hasGitRules}}{{gitRules}}');
     expect(ja).toContain('プロジェクトのソースファイルを変更しないでください');
     expect(ja).toContain('## Workflow Context');
     expect(findDeprecatedTerms(ja)).toEqual([]);

--- a/src/__tests__/taskExecution.test.ts
+++ b/src/__tests__/taskExecution.test.ts
@@ -378,6 +378,39 @@ describe('executeAndCompleteTask', () => {
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
   });
 
+  it('should reject allow_git_commit worktree workflows before execution', async () => {
+    const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
+      name: 'worktree-commit',
+      steps: [
+        {
+          name: 'review',
+          kind: 'agent',
+          persona: 'reviewer',
+          personaDisplayName: 'reviewer',
+          instruction: 'Review',
+          allowGitCommit: true,
+          passPreviousResponse: true,
+        },
+      ],
+      initialStep: 'review',
+      maxSteps: 3,
+    }, '/project/.takt/worktrees/task-a/.takt/workflows/worktree-commit.yaml'), {
+      source: 'worktree',
+      sourcePath: '/project/.takt/worktrees/task-a/.takt/workflows/worktree-commit.yaml',
+      isProjectTrustRoot: false,
+      isProjectWorkflowRoot: false,
+    });
+    mockLoadWorkflowByIdentifier.mockReturnValue(workflow);
+
+    await expect(executeTask({
+      task: 'Task: worktree trust boundary',
+      cwd: '/project/.takt/worktrees/task-a',
+      projectCwd: '/project',
+      workflowIdentifier: './.takt/workflows/worktree-commit.yaml',
+    })).rejects.toThrow('cannot use allow_git_commit in step "review" outside the project workflows root');
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
   it('should use workflow terminology when named workflow is missing', async () => {
     mockLoadWorkflowByIdentifier.mockReturnValueOnce(undefined);
 

--- a/src/__tests__/taskRetryActions.test.ts
+++ b/src/__tests__/taskRetryActions.test.ts
@@ -589,6 +589,36 @@ describe('retryFailedTask', () => {
     expect(mockSelectOptionWithDefault).not.toHaveBeenCalled();
   });
 
+  it('should reject allow_git_commit worktree workflows during retry before selecting a step', async () => {
+    const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
+      ...defaultWorkflowConfig,
+      name: 'selected-workflow',
+      steps: [
+        {
+          name: 'plan',
+          persona: 'planner',
+          instruction: '',
+          allowGitCommit: true,
+        },
+        { name: 'implement', persona: 'coder', instruction: '' },
+        { name: 'review', persona: 'reviewer', instruction: '' },
+      ],
+    }, '/project/.takt/worktrees/my-task/.takt/workflows/selected-workflow.yaml'), {
+      source: 'worktree',
+      sourcePath: '/project/.takt/worktrees/my-task/.takt/workflows/selected-workflow.yaml',
+      isProjectTrustRoot: false,
+      isProjectWorkflowRoot: false,
+    });
+    mockConfirm.mockResolvedValue(false);
+    mockSelectWorkflow.mockResolvedValue('./.takt/workflows/selected-workflow.yaml');
+    mockLoadWorkflowByIdentifier.mockReturnValue(workflow);
+
+    await expect(retryFailedTask(makeFailedTask(), '/project')).rejects.toThrow(
+      'cannot use allow_git_commit in step "plan" outside the project workflows root',
+    );
+    expect(mockSelectOptionWithDefault).not.toHaveBeenCalled();
+  });
+
   it('should show deprecated config warning when selected run order uses legacy provider fields', async () => {
     const task = makeFailedTask();
     mockFindPreviousOrderContent.mockReturnValue([

--- a/src/__tests__/team-leader-common.test.ts
+++ b/src/__tests__/team-leader-common.test.ts
@@ -53,6 +53,7 @@ describe('createPartStep', () => {
       persona: 'coder',
       personaDisplayName: 'coder',
       instruction: 'do work',
+      allowGitCommit: true,
       passPreviousResponse: false,
       teamLeader: {
         persona: 'leader',
@@ -73,5 +74,6 @@ describe('createPartStep', () => {
     expect(partStep.name).toBe('implement.part-1');
     expect(partStep.persona).toBe('coder');
     expect(partStep.personaDisplayName).toBe('coder');
+    expect(partStep.allowGitCommit).toBe(true);
   });
 });

--- a/src/__tests__/team-leader-runner-structured-caller.test.ts
+++ b/src/__tests__/team-leader-runner-structured-caller.test.ts
@@ -767,4 +767,108 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       allowedTools: ['Read', 'Edit'],
     }));
   });
+
+  it.each([
+    { allowGitCommit: false, expectsGitRules: true },
+    { allowGitCommit: true, expectsGitRules: false },
+  ])('team leader part prompt should respect allowGitCommit=$allowGitCommit', async ({ allowGitCommit, expectsGitRules }) => {
+    mockExecuteAgent.mockResolvedValue({
+      persona: 'coder',
+      status: 'done',
+      content: 'API done',
+      timestamp: new Date('2026-04-01T00:00:00.000Z'),
+    });
+    const structuredCaller = {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        options.onPromptResolved?.({
+          systemPrompt: 'team-leader-system',
+          userInstruction: 'leader instruction',
+        });
+        return [
+          { id: 'part-1', title: 'API', instruction: 'Implement API' },
+        ];
+      }),
+      requestMoreParts: vi.fn().mockResolvedValue({
+        done: true,
+        reasoning: 'enough',
+        parts: [],
+      }),
+    };
+
+    const runner = new TeamLeaderRunner({
+      optionsBuilder: {
+        buildAgentOptions: vi.fn().mockReturnValue({ cwd: '/tmp/project', language: 'en' }),
+        buildBaseOptions: vi.fn().mockReturnValue({}),
+        buildPhase1WorkflowMeta: vi.fn().mockReturnValue(undefined),
+        resolveStepProviderModel: vi.fn().mockReturnValue({ provider: 'opencode', model: 'model' }),
+      },
+      stepExecutor: {
+        buildInstruction: vi.fn().mockReturnValue('leader instruction'),
+        applyPostExecutionPhases: vi.fn(async (_step, _state, _iteration, response) => response),
+        persistPreviousResponseSnapshot: vi.fn(),
+        emitStepReports: vi.fn(),
+      },
+      engineOptions: {
+        projectCwd: '/tmp/project',
+        structuredCaller,
+      },
+      getCwd: () => '/tmp/project',
+      getInteractive: () => false,
+    } as ConstructorParameters<typeof TeamLeaderRunner>[0] & {
+      engineOptions: { projectCwd: string; structuredCaller: typeof structuredCaller };
+    });
+
+    const step: WorkflowStep = {
+      name: 'implement',
+      persona: 'coder',
+      personaDisplayName: 'coder',
+      instruction: 'Task: {task}',
+      allowGitCommit,
+      passPreviousResponse: true,
+      teamLeader: {
+        persona: 'team-leader',
+        maxParts: 2,
+        refillThreshold: 0,
+        timeoutMs: 1000,
+        partPersona: 'coder',
+      },
+      rules: [{ condition: 'done', next: 'COMPLETE' }],
+    };
+
+    const state: WorkflowState = {
+      workflowName: 'workflow',
+      currentStep: 'implement',
+      iteration: 1,
+      stepOutputs: new Map(),
+      structuredOutputs: new Map(),
+      systemContexts: new Map(),
+      effectResults: new Map(),
+      lastOutput: undefined,
+      previousResponseSourcePath: undefined,
+      userInputs: [],
+      personaSessions: new Map(),
+      stepIterations: new Map(),
+      status: 'running',
+    };
+
+    await runner.runTeamLeaderStep(
+      step,
+      state,
+      'implement feature',
+      5,
+      vi.fn(),
+    );
+
+    const [, executedInstruction] = mockExecuteAgent.mock.calls[0] ?? [];
+    expect(executedInstruction).toContain('Implement API');
+    if (expectsGitRules) {
+      expect(executedInstruction).toContain('Do NOT run git commit');
+      expect(executedInstruction).toContain('Do NOT run git push');
+      expect(executedInstruction).toContain('Do NOT run git add');
+    } else {
+      expect(executedInstruction).not.toContain('Do NOT run git commit');
+      expect(executedInstruction).not.toContain('Do NOT run git push');
+      expect(executedInstruction).not.toContain('Do NOT run git add');
+    }
+  });
 });

--- a/src/__tests__/team-leader-schema-loader.test.ts
+++ b/src/__tests__/team-leader-schema-loader.test.ts
@@ -77,6 +77,21 @@ describe('team_leader schema', () => {
     const result = WorkflowStepRawSchema.safeParse(raw);
     expect(result.success).toBe(false);
   });
+
+  it('team_leader では allow_git_commit を受け付ける', () => {
+    const raw = {
+      name: 'implement',
+      allow_git_commit: true,
+      team_leader: {
+        max_parts: 2,
+      },
+      instruction: 'decompose',
+    };
+
+    const result = WorkflowStepRawSchema.safeParse(raw);
+
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('normalizeWorkflowConfig team_leader', () => {
@@ -87,6 +102,7 @@ describe('normalizeWorkflowConfig team_leader', () => {
       steps: [
         {
           name: 'implement',
+          allow_git_commit: true,
           team_leader: {
             persona: 'team-leader',
             max_parts: 2,
@@ -104,6 +120,7 @@ describe('normalizeWorkflowConfig team_leader', () => {
     const config = normalizeWorkflowConfig(raw, workflowDir);
     const step = config.steps[0];
     expect(step).toBeDefined();
+    expect(step!.allowGitCommit).toBe(true);
     expect(step!.teamLeader).toEqual({
       persona: 'team-leader',
       personaPath: undefined,

--- a/src/__tests__/workflow-doctor.test.ts
+++ b/src/__tests__/workflow-doctor.test.ts
@@ -789,6 +789,36 @@ steps:
   );
 
   it.each(worktreeRootCases)(
+    'validates allow_git_commit trust for worktree workflow path targets in $name',
+    async (rootCase) => {
+      writeConfigForCase(rootCase);
+      const { rootDirRelativePath } = rootCase;
+      const rootDir = join(projectDir, rootDirRelativePath);
+      const worktreeDir = join(rootDir, 'feature-branch');
+      const worktreeWorkflowPath = join(worktreeDir, '.takt', 'workflows', 'commit.yaml');
+      mkdirSync(dirname(worktreeWorkflowPath), { recursive: true });
+      writeFileSync(worktreeWorkflowPath, `name: commit
+max_steps: 10
+initial_step: review
+steps:
+  - name: review
+    allow_git_commit: true
+    rules:
+      - condition: done
+        next: COMPLETE
+`, 'utf-8');
+
+      await expect(
+        doctorWorkflowCommand([relative(projectDir, worktreeWorkflowPath)], projectDir),
+      ).rejects.toThrow('Workflow validation failed');
+
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('cannot use allow_git_commit in step "review" outside the project workflows root'),
+      );
+    },
+  );
+
+  it.each(worktreeRootCases)(
     'passes derived worktree lookupCwd into workflow_call contract validation for path targets in $name',
     async (rootCase) => {
       writeConfigForCase(rootCase);

--- a/src/__tests__/workflowLoader.test.ts
+++ b/src/__tests__/workflowLoader.test.ts
@@ -154,6 +154,41 @@ steps:
     );
   });
 
+  it('should reject allow_git_commit workflows loaded from arbitrary project absolute paths', () => {
+    const filePath = join(tempDir, 'unsafe-commit.yaml');
+    writeFileSync(filePath, `name: unsafe-commit
+initial_step: implement
+max_steps: 2
+
+steps:
+  - name: implement
+    persona: coder
+    allow_git_commit: true
+    instruction: "{task}"
+`);
+
+    expect(() => loadWorkflowByIdentifier(filePath, tempDir)).toThrow(
+      /Project workflow ".*unsafe-commit\.yaml" cannot use allow_git_commit in step "implement"/,
+    );
+  });
+
+  it('should reject allow_git_commit workflows loaded from arbitrary project relative paths', () => {
+    writeFileSync(join(tempDir, 'unsafe-commit.yaml'), `name: unsafe-commit
+initial_step: implement
+max_steps: 2
+
+steps:
+  - name: implement
+    persona: coder
+    allow_git_commit: true
+    instruction: "{task}"
+`);
+
+    expect(() => loadWorkflowByIdentifier('./unsafe-commit.yaml', tempDir)).toThrow(
+      /Project workflow ".*unsafe-commit\.yaml" cannot use allow_git_commit in step "implement"/,
+    );
+  });
+
   it('should reject system-input workflows loaded from arbitrary project paths', () => {
     const filePath = join(tempDir, 'unsafe-system-inputs.yaml');
     writeFileSync(filePath, `name: unsafe-system-inputs

--- a/src/__tests__/workflowTrustBoundary.test.ts
+++ b/src/__tests__/workflowTrustBoundary.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 
 import * as workflowTrustBoundary from '../infra/config/loaders/workflowTrustBoundary.js';
 import { loadWorkflowByIdentifier } from '../infra/config/index.js';
-import { attachWorkflowTrustInfo } from '../infra/config/loaders/workflowSourceMetadata.js';
+import { attachWorkflowSourcePath, attachWorkflowTrustInfo } from '../infra/config/loaders/workflowSourceMetadata.js';
 
 describe('workflowTrustBoundary', () => {
   let projectDir: string;
@@ -35,6 +35,74 @@ describe('workflowTrustBoundary', () => {
       join(projectDir, 'outside.yaml'),
       { isProjectWorkflowRoot: false },
     )).toThrow('Project workflow');
+  });
+
+  it('should treat allow_git_commit steps as privileged when enforcing project trust boundary', () => {
+    expect(() => workflowTrustBoundary.validateProjectWorkflowTrustBoundaryForSteps(
+      [{ name: 'implement', allowGitCommit: true }],
+      join(projectDir, 'outside.yaml'),
+      { isProjectWorkflowRoot: false },
+    )).toThrow('cannot use allow_git_commit');
+  });
+
+  it('rejects allow_git_commit workflow execution outside the project workflows root', () => {
+    const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
+      name: 'external-committer',
+      steps: [
+        {
+          name: 'implement',
+          kind: 'agent',
+          persona: 'coder',
+          personaDisplayName: 'coder',
+          instruction: 'Implement the task',
+          allowGitCommit: true,
+          passPreviousResponse: true,
+        },
+      ],
+      initialStep: 'implement',
+      maxSteps: 3,
+    }, join(externalDir, 'external-committer.yaml')), {
+      source: 'external',
+      sourcePath: join(externalDir, 'external-committer.yaml'),
+      isProjectTrustRoot: false,
+      isProjectWorkflowRoot: false,
+    });
+
+    expect(() => workflowTrustBoundary.validateWorkflowExecutionTrustBoundary(
+      workflow,
+      projectDir,
+    )).toThrow(
+      `Workflow "${join(externalDir, 'external-committer.yaml')}" cannot use allow_git_commit in step "implement" outside the project workflows root`,
+    );
+  });
+
+  it('allows allow_git_commit workflow execution inside the project workflows root', () => {
+    const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
+      name: 'project-commit',
+      steps: [
+        {
+          name: 'implement',
+          kind: 'agent',
+          persona: 'coder',
+          personaDisplayName: 'coder',
+          instruction: 'Implement the task',
+          allowGitCommit: true,
+          passPreviousResponse: true,
+        },
+      ],
+      initialStep: 'implement',
+      maxSteps: 3,
+    }, join(projectDir, '.takt', 'workflows', 'project-commit.yaml')), {
+      source: 'project',
+      sourcePath: join(projectDir, '.takt', 'workflows', 'project-commit.yaml'),
+      isProjectTrustRoot: true,
+      isProjectWorkflowRoot: true,
+    });
+
+    expect(() => workflowTrustBoundary.validateWorkflowExecutionTrustBoundary(
+      workflow,
+      projectDir,
+    )).not.toThrow();
   });
 
   it('rejects privileged child when project parent is outside workflows root', () => {
@@ -170,6 +238,55 @@ steps:
           personaDisplayName: 'reviewer',
           instruction: 'Review the task',
           passPreviousResponse: true,
+        },
+      ],
+      initialStep: 'review',
+      maxSteps: 3,
+    }, {
+      source: 'external',
+      sourcePath: join(externalDir, 'external-child.yaml'),
+      isProjectTrustRoot: false,
+      isProjectWorkflowRoot: false,
+    });
+
+    expect(() => workflowTrustBoundary.validateWorkflowCallTrustBoundary(
+      {
+        source: 'project',
+        sourcePath: join(projectDir, '.takt', 'workflows', 'parent.yaml'),
+        isProjectTrustRoot: true,
+        isProjectWorkflowRoot: true,
+      },
+      childWorkflow,
+      'delegate',
+      projectDir,
+    )).toThrow(
+      'Workflow step "delegate" cannot call privileged workflow "external-child" across trust boundary',
+    );
+  });
+
+  it('rejects child workflow with allow_git_commit in parallel sub-step across trust boundary', () => {
+    const childWorkflow = attachWorkflowTrustInfo({
+      name: 'external-child',
+      subworkflow: { callable: true },
+      steps: [
+        {
+          name: 'review',
+          kind: 'agent',
+          persona: 'reviewer',
+          personaDisplayName: 'reviewer',
+          instruction: 'Review the task',
+          passPreviousResponse: true,
+          parallel: [
+            {
+              name: 'commit-worker',
+              kind: 'agent',
+              persona: 'reviewer',
+              personaDisplayName: 'reviewer',
+              instruction: 'Commit the result',
+              allowGitCommit: true,
+              passPreviousResponse: false,
+            },
+          ],
         },
       ],
       initialStep: 'review',

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -128,6 +128,7 @@ export const ParallelSubStepRawSchema = z.object({
   persona_name: z.string().optional(),
   policy: WorkflowFacetRefListOrParamSchema.optional(),
   knowledge: WorkflowFacetRefListOrParamSchema.optional(),
+  allow_git_commit: z.boolean().optional(),
   allowed_tools: z.never().optional(),
   mcp_servers: McpServersSchema,
   provider: ProviderReferenceSchema.optional(),
@@ -200,162 +201,173 @@ const WorkflowSubworkflowRawSchema = z.object({
 
 function createWorkflowStepRawSchema(options?: { relaxWorkflowCallConditions?: boolean }) {
   return z.object({
-  name: z.string().min(1),
-  description: z.string().optional(),
-  kind: WorkflowStepKindSchema.optional(),
-  mode: z.literal('system').optional(),
-  call: z.string().min(1).optional(),
-  overrides: WorkflowCallOverridesRawSchema.optional(),
-  args: WorkflowCallArgsRawSchema.optional(),
-  session: z.enum(['continue', 'refresh']).optional(),
-  persona: z.string().optional(),
-  persona_name: z.string().optional(),
-  policy: WorkflowFacetRefListOrParamSchema.optional(),
-  knowledge: WorkflowFacetRefListOrParamSchema.optional(),
-  allowed_tools: z.never().optional(),
-  mcp_servers: McpServersSchema,
-  provider: ProviderReferenceSchema.optional(),
-  model: z.string().optional(),
-  permission_mode: z.never().optional(),
-  required_permission_mode: PermissionModeSchema.optional(),
-  provider_options: StepProviderOptionsSchema,
-  edit: z.boolean().optional(),
-  instruction: WorkflowFacetRefOrParamSchema.optional(),
-  instruction_template: z.never().optional(),
-  delay_before_ms: z.number().int().min(0).optional(),
-  structured_output: StructuredOutputRawSchema.optional(),
-  system_inputs: z.array(SystemInputRawSchema).optional(),
-  effects: z.array(WorkflowEffectRawSchema).optional(),
-  rules: z.array(WorkflowRuleSchema).optional(),
-  output_contracts: OutputContractsFieldSchema,
-  quality_gates: QualityGatesSchema,
-  pass_previous_response: z.boolean().optional(),
-  parallel: z.array(ParallelSubStepRawSchema).optional(),
-  concurrency: z.number().int().min(1).optional(),
-  arpeggio: ArpeggioConfigRawSchema.optional(),
-  team_leader: TeamLeaderConfigRawSchema.optional(),
-}).refine(
-  (data) => [data.parallel, data.arpeggio, data.team_leader].filter((value) => value != null).length <= 1,
-  {
-    message: "'parallel', 'arpeggio', and 'team_leader' are mutually exclusive",
-    path: ['parallel'],
-  },
-).superRefine((data, ctx) => {
-  if (data.kind !== undefined && data.mode !== undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['kind'],
-      message: 'Step kind must be expressed with either "kind" or "mode", not both',
-    });
-  }
-
-  const stepKind = getWorkflowStepKind(data);
-
-  if (data.call !== undefined && stepKind !== 'workflow_call') {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['call'],
-      message: 'Only workflow_call steps can declare "call"',
-    });
-  }
-
-  if (data.overrides !== undefined && stepKind !== 'workflow_call') {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['overrides'],
-      message: 'Only workflow_call steps can declare "overrides"',
-    });
-  }
-
-  if (data.args !== undefined && stepKind !== 'workflow_call') {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['args'],
-      message: 'Only workflow_call steps can declare "args"',
-    });
-  }
-
-  if (stepKind === 'workflow_call') {
-    if (data.call === undefined) {
+    name: z.string().min(1),
+    description: z.string().optional(),
+    kind: WorkflowStepKindSchema.optional(),
+    mode: z.literal('system').optional(),
+    call: z.string().min(1).optional(),
+    overrides: WorkflowCallOverridesRawSchema.optional(),
+    args: WorkflowCallArgsRawSchema.optional(),
+    session: z.enum(['continue', 'refresh']).optional(),
+    persona: z.string().optional(),
+    persona_name: z.string().optional(),
+    policy: WorkflowFacetRefListOrParamSchema.optional(),
+    knowledge: WorkflowFacetRefListOrParamSchema.optional(),
+    allow_git_commit: z.boolean().optional(),
+    allowed_tools: z.never().optional(),
+    mcp_servers: McpServersSchema,
+    provider: ProviderReferenceSchema.optional(),
+    model: z.string().optional(),
+    permission_mode: z.never().optional(),
+    required_permission_mode: PermissionModeSchema.optional(),
+    provider_options: StepProviderOptionsSchema,
+    edit: z.boolean().optional(),
+    instruction: WorkflowFacetRefOrParamSchema.optional(),
+    instruction_template: z.never().optional(),
+    delay_before_ms: z.number().int().min(0).optional(),
+    structured_output: StructuredOutputRawSchema.optional(),
+    system_inputs: z.array(SystemInputRawSchema).optional(),
+    effects: z.array(WorkflowEffectRawSchema).optional(),
+    rules: z.array(WorkflowRuleSchema).optional(),
+    output_contracts: OutputContractsFieldSchema,
+    quality_gates: QualityGatesSchema,
+    pass_previous_response: z.boolean().optional(),
+    parallel: z.array(ParallelSubStepRawSchema).optional(),
+    concurrency: z.number().int().min(1).optional(),
+    arpeggio: ArpeggioConfigRawSchema.optional(),
+    team_leader: TeamLeaderConfigRawSchema.optional(),
+  }).refine(
+    (data) => [data.parallel, data.arpeggio, data.team_leader].filter((value) => value != null).length <= 1,
+    {
+      message: "'parallel', 'arpeggio', and 'team_leader' are mutually exclusive",
+      path: ['parallel'],
+    },
+  ).superRefine((data, ctx) => {
+    if (data.kind !== undefined && data.mode !== undefined) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['call'],
-        message: 'workflow_call step requires "call"',
+        path: ['kind'],
+        message: 'Step kind must be expressed with either "kind" or "mode", not both',
       });
     }
 
-    for (const field of [
-      'persona',
-      'persona_name',
-      'policy',
-      'knowledge',
-      'mcp_servers',
-      'provider',
-      'model',
-      'provider_options',
-      'required_permission_mode',
-      'edit',
-      'instruction',
-      'session',
-      'delay_before_ms',
-      'structured_output',
-      'system_inputs',
-      'effects',
-      'parallel',
-      'concurrency',
-      'arpeggio',
-      'team_leader',
-      'output_contracts',
-      'quality_gates',
-      'pass_previous_response',
-    ] as const) {
-      if (data[field] !== undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: [field],
-          message: `workflow_call step does not allow "${field}"`,
-        });
-      }
+    const stepKind = getWorkflowStepKind(data);
+
+    if (data.call !== undefined && stepKind !== 'workflow_call') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['call'],
+        message: 'Only workflow_call steps can declare "call"',
+      });
     }
 
-    data.rules?.forEach((rule, index) => {
-      if (rule.when !== undefined) {
+    if (data.overrides !== undefined && stepKind !== 'workflow_call') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['overrides'],
+        message: 'Only workflow_call steps can declare "overrides"',
+      });
+    }
+
+    if (data.args !== undefined && stepKind !== 'workflow_call') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['args'],
+        message: 'Only workflow_call steps can declare "args"',
+      });
+    }
+
+    if (stepKind === 'workflow_call') {
+      if (data.call === undefined) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ['rules', index, 'when'],
-          message: 'workflow_call rules do not allow "when"; use condition: COMPLETE or ABORT',
+          path: ['call'],
+          message: 'workflow_call step requires "call"',
         });
       }
 
-      if (rule.condition === undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['rules', index, 'condition'],
-          message: 'workflow_call rules require condition: COMPLETE or ABORT',
-        });
-        return;
+      for (const field of [
+        'persona',
+        'persona_name',
+        'policy',
+        'knowledge',
+        'allow_git_commit',
+        'mcp_servers',
+        'provider',
+        'model',
+        'provider_options',
+        'required_permission_mode',
+        'edit',
+        'instruction',
+        'session',
+        'delay_before_ms',
+        'structured_output',
+        'system_inputs',
+        'effects',
+        'parallel',
+        'concurrency',
+        'arpeggio',
+        'team_leader',
+        'output_contracts',
+        'quality_gates',
+        'pass_previous_response',
+      ] as const) {
+        if (data[field] !== undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [field],
+            message: `workflow_call step does not allow "${field}"`,
+          });
+        }
       }
 
-      const allowExtendedConditions = options?.relaxWorkflowCallConditions === true;
-      const isBuiltInCondition = rule.condition === 'COMPLETE' || rule.condition === 'ABORT';
-      const isExtendedCondition = allowExtendedConditions
-        && !AI_CONDITION_REGEX.test(rule.condition)
-        && !AGGREGATE_CONDITION_REGEX.test(rule.condition);
+      data.rules?.forEach((rule, index) => {
+        if (rule.when !== undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['rules', index, 'when'],
+            message: 'workflow_call rules do not allow "when"; use condition: COMPLETE or ABORT',
+          });
+        }
 
-      if (!isBuiltInCondition && !isExtendedCondition) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['rules', index, 'condition'],
-          message: allowExtendedConditions
-            ? 'workflow_call rules only allow COMPLETE, ABORT, or callable return conditions'
-            : 'workflow_call rules only allow COMPLETE or ABORT conditions',
-        });
-      }
-    });
-  }
+        if (rule.condition === undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['rules', index, 'condition'],
+            message: 'workflow_call rules require condition: COMPLETE or ABORT',
+          });
+          return;
+        }
 
-  validateSystemStepFields(data, ctx);
-});
+        const allowExtendedConditions = options?.relaxWorkflowCallConditions === true;
+        const isBuiltInCondition = rule.condition === 'COMPLETE' || rule.condition === 'ABORT';
+        const isExtendedCondition = allowExtendedConditions
+          && !AI_CONDITION_REGEX.test(rule.condition)
+          && !AGGREGATE_CONDITION_REGEX.test(rule.condition);
+
+        if (!isBuiltInCondition && !isExtendedCondition) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['rules', index, 'condition'],
+            message: allowExtendedConditions
+              ? 'workflow_call rules only allow COMPLETE, ABORT, or callable return conditions'
+              : 'workflow_call rules only allow COMPLETE or ABORT conditions',
+          });
+        }
+      });
+    }
+
+    validateSystemStepFields(data, ctx);
+  }).transform((data) => {
+    if (getWorkflowStepKind(data) !== 'agent') {
+      return data;
+    }
+
+    return {
+      ...data,
+      allow_git_commit: data.allow_git_commit ?? false,
+    };
+  });
 }
 
 export const WorkflowStepRawSchema = createWorkflowStepRawSchema();

--- a/src/core/models/workflow-system-schemas.ts
+++ b/src/core/models/workflow-system-schemas.ts
@@ -212,6 +212,7 @@ export function validateSystemStepFields(
       'persona_name',
       'policy',
       'knowledge',
+      'allow_git_commit',
       'mcp_servers',
       'provider',
       'model',

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -131,6 +131,7 @@ export interface AgentWorkflowStep extends WorkflowStepBase {
   call?: never;
   overrides?: never;
   persona?: string;
+  allowGitCommit?: boolean;
   session?: 'continue' | 'refresh';
   mcpServers?: Record<string, McpServerConfig>;
   personaPath?: string;
@@ -158,6 +159,7 @@ export interface SystemWorkflowStep extends WorkflowStepBase {
   call?: never;
   overrides?: never;
   persona?: never;
+  allowGitCommit?: never;
   session?: 'continue' | 'refresh';
   mcpServers?: never;
   personaPath?: never;
@@ -186,6 +188,7 @@ export interface WorkflowCallStep extends WorkflowStepBase {
   overrides?: WorkflowCallOverrides;
   args?: Record<string, WorkflowCallArgValue>;
   persona?: never;
+  allowGitCommit?: never;
   session?: never;
   mcpServers?: never;
   personaPath?: never;

--- a/src/core/workflow/engine/ArpeggioRunner.ts
+++ b/src/core/workflow/engine/ArpeggioRunner.ts
@@ -24,6 +24,7 @@ import type { OptionsBuilder } from './OptionsBuilder.js';
 import type { StepExecutor } from './StepExecutor.js';
 import type { PhaseName, PhasePromptParts } from '../types.js';
 import type { StructuredCaller } from '../../../agents/structured-caller.js';
+import { buildGitRules } from '../instruction/instruction-context.js';
 
 const log = createLogger('arpeggio-runner');
 
@@ -89,12 +90,18 @@ class Semaphore {
 async function executeBatchWithRetry(
   batch: DataBatch,
   template: string,
+  allowGitCommit: boolean | undefined,
   persona: string | undefined,
   agentOptions: RunAgentOptions,
   maxRetries: number,
   retryDelayMs: number,
 ): Promise<BatchResult> {
-  const prompt = expandTemplate(template, batch);
+  const prompt = buildArpeggioPrompt(
+    template,
+    batch,
+    allowGitCommit,
+    agentOptions.language ?? 'en',
+  );
   let lastError: string | undefined;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -149,6 +156,20 @@ async function executeBatchWithRetry(
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildArpeggioPrompt(
+  template: string,
+  batch: DataBatch,
+  allowGitCommit: boolean | undefined,
+  language: NonNullable<RunAgentOptions['language']>,
+): string {
+  const prompt = expandTemplate(template, batch);
+  const gitRules = buildGitRules(allowGitCommit, language, 'phase1');
+  if (!gitRules) {
+    return prompt;
+  }
+  return `${gitRules}\n\n${prompt}`;
 }
 
 export class ArpeggioRunner {
@@ -286,6 +307,7 @@ export class ArpeggioRunner {
         const result = await executeBatchWithRetry(
           batch,
           template,
+          step.allowGitCommit,
           step.persona,
           batchAgentOptions,
           config.maxRetries,

--- a/src/core/workflow/engine/team-leader-common.ts
+++ b/src/core/workflow/engine/team-leader-common.ts
@@ -45,6 +45,7 @@ export function createPartStep(step: WorkflowStep, part: PartDefinition): Workfl
     model: step.model,
     requiredPermissionMode: step.teamLeader.partPermissionMode ?? step.requiredPermissionMode,
     edit: step.teamLeader.partEdit ?? step.edit,
+    allowGitCommit: step.allowGitCommit,
     instruction: part.instruction,
     passPreviousResponse: false,
   };

--- a/src/core/workflow/engine/team-leader-part-runner.ts
+++ b/src/core/workflow/engine/team-leader-part-runner.ts
@@ -6,6 +6,7 @@ import { buildAbortSignal } from './abort-signal.js';
 import type { OptionsBuilder } from './OptionsBuilder.js';
 import type { ParallelLogger } from './parallel-logger.js';
 import { createPartStep } from './team-leader-common.js';
+import { buildGitRules } from '../instruction/instruction-context.js';
 import { getErrorMessage } from '../../../shared/utils/index.js';
 import { classifyAbortSignalReason } from '../../../shared/types/agent-failure.js';
 
@@ -41,7 +42,11 @@ export async function runTeamLeaderPart(
     };
 
   try {
-    const response = await executeAgent(partStep.persona, part.instruction, options);
+    const gitRules = buildGitRules(partStep.allowGitCommit, options.language ?? 'en', 'phase1');
+    const partInstruction = gitRules
+      ? `${gitRules}\n\n${part.instruction}`
+      : part.instruction;
+    const response = await executeAgent(partStep.persona, partInstruction, options);
     updatePersonaSession(buildSessionKey(partStep, partProviderInfo.provider), response.sessionId);
     return {
       part,

--- a/src/core/workflow/instruction/InstructionBuilder.ts
+++ b/src/core/workflow/instruction/InstructionBuilder.ts
@@ -10,7 +10,7 @@
 
 import type { WorkflowStep, Language, OutputContractItem, OutputContractEntry } from '../../models/types.js';
 import type { InstructionContext } from './instruction-context.js';
-import { buildEditRule } from './instruction-context.js';
+import { buildEditRule, buildGitRules } from './instruction-context.js';
 import { escapeTemplateChars, replaceTemplatePlaceholders } from './escape.js';
 import { loadTemplate } from '../../../shared/prompts/index.js';
 import {
@@ -73,6 +73,8 @@ export class InstructionBuilder {
 
     // Execution context variables
     const editRule = buildEditRule(this.step.edit, language);
+    const gitRules = buildGitRules(this.step.allowGitCommit, language, 'phase1');
+    const hasGitRules = gitRules.length > 0;
 
     // Workflow structure (loop expansion done in code)
     const workflowStructure = this.buildWorkflowStructure(language);
@@ -163,6 +165,8 @@ export class InstructionBuilder {
 
     return loadTemplate('perform_phase1_message', language, {
       workingDirectory: this.context.cwd,
+      hasGitRules,
+      gitRules,
       editRule,
       workflowName,
       workflowDescription,

--- a/src/core/workflow/instruction/ReportInstructionBuilder.ts
+++ b/src/core/workflow/instruction/ReportInstructionBuilder.ts
@@ -7,6 +7,7 @@
 
 import type { WorkflowStep, Language } from '../../models/types.js';
 import type { InstructionContext } from './instruction-context.js';
+import { buildGitRules } from './instruction-context.js';
 import { replaceTemplatePlaceholders } from './escape.js';
 import { isOutputContractItem, renderReportContext, renderReportOutputInstruction } from './InstructionBuilder.js';
 import { loadTemplate } from '../../../shared/prompts/index.js';
@@ -46,6 +47,8 @@ export class ReportInstructionBuilder {
     }
 
     const language = this.context.language ?? 'en';
+    const gitRules = buildGitRules(this.step.allowGitCommit, language, 'phase2');
+    const hasGitRules = gitRules.length > 0;
 
     let reportContext: string;
     if (this.context.targetFile) {
@@ -92,6 +95,8 @@ export class ReportInstructionBuilder {
 
     return loadTemplate('perform_phase2_message', language, {
       workingDirectory: this.context.cwd,
+      hasGitRules,
+      gitRules,
       reportContext,
       hasLastResponse: this.context.lastResponse != null && this.context.lastResponse.trim().length > 0,
       lastResponse: this.context.lastResponse ?? '',

--- a/src/core/workflow/instruction/instruction-context.ts
+++ b/src/core/workflow/instruction/instruction-context.ts
@@ -87,3 +87,35 @@ export function buildEditRule(edit: boolean | undefined, language: Language): st
   }
   return '';
 }
+
+type GitRulePhase = 'phase1' | 'phase2';
+
+export function buildGitRules(
+  allowGitCommit: boolean | undefined,
+  language: Language,
+  phase: GitRulePhase,
+): string {
+  if (allowGitCommit === true) {
+    return '';
+  }
+
+  if (language === 'ja') {
+    const rules = [
+      '- **git commit を実行しないでください。** コミットはワークフロー完了後にシステムが自動で行います。',
+      '- **git push を実行しないでください。** プッシュもシステムが自動で行います。',
+    ];
+    if (phase === 'phase1') {
+      rules.push('- **git add を実行しないでください。** ステージングもシステムが自動で行います。新規ファイルが未追跡（`??`）でも正常です。');
+    }
+    return rules.join('\n');
+  }
+
+  const rules = [
+    '- **Do NOT run git commit.** Commits are handled automatically by the system after workflow completion.',
+    '- **Do NOT run git push.** Pushes are also handled automatically by the system.',
+  ];
+  if (phase === 'phase1') {
+    rules.push('- **Do NOT run git add.** Staging is also handled automatically by the system. Untracked files (`??`) are normal.');
+  }
+  return rules.join('\n');
+}

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -112,6 +112,7 @@ export function normalizeWorkflowConfig(
       normalizedWorkflowProvider.provider,
       normalizedWorkflowProvider.model,
       normalizedWorkflowProvider.providerOptions,
+      undefined,
       context,
       projectOverrides,
       globalOverrides,

--- a/src/infra/config/loaders/workflowStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepNormalizer.ts
@@ -57,6 +57,7 @@ export function normalizeStepFromRaw(
   inheritedProvider?: WorkflowStep['provider'],
   inheritedModel?: WorkflowStep['model'],
   inheritedProviderOptions?: WorkflowStep['providerOptions'],
+  inheritedAllowGitCommit?: boolean,
   context?: FacetResolutionContext,
   projectOverrides?: WorkflowOverrides,
   globalOverrides?: WorkflowOverrides,
@@ -170,6 +171,7 @@ export function normalizeStepFromRaw(
     requiredPermissionMode: step.required_permission_mode,
     providerOptions: mergeProviderOptions(inheritedProviderOptions, normalizedProvider.providerOptions),
     edit: step.edit,
+    allowGitCommit: step.allow_git_commit ?? inheritedAllowGitCommit ?? false,
     instruction: instruction || '{task}',
     delayBeforeMs: step.delay_before_ms,
     structuredOutput: resolveStructuredOutput(step, workflowSchemas, {
@@ -200,6 +202,7 @@ export function normalizeStepFromRaw(
         normalizedStep.provider,
         normalizedStep.model,
         normalizedStep.providerOptions,
+        normalizedStep.allowGitCommit,
         context,
         projectOverrides,
         globalOverrides,

--- a/src/infra/config/loaders/workflowTrustBoundary.ts
+++ b/src/infra/config/loaders/workflowTrustBoundary.ts
@@ -5,10 +5,59 @@ import { getWorkflowTrustInfo, type WorkflowTrustInfo } from './workflowTrustSou
 
 type SystemStepLike = Parameters<typeof getWorkflowStepKind>[0] & {
   name: string;
+  allowGitCommit?: boolean;
+  parallel?: SystemStepLike[];
 };
+
+type PrivilegedCapability =
+  | { step: SystemStepLike; reason: 'system' }
+  | { step: SystemStepLike; reason: 'allow_git_commit' };
 
 function hasPrivilegedRuntimePrepare(workflow: WorkflowConfig): boolean {
   return (workflow.runtime?.prepare?.length ?? 0) > 0;
+}
+
+function findPrivilegedAllowGitCommitStep(steps: SystemStepLike[]): SystemStepLike | undefined {
+  for (const step of steps) {
+    if (step.allowGitCommit === true) {
+      return step;
+    }
+    const privilegedParallelStep = step.parallel
+      ? findPrivilegedAllowGitCommitStep(step.parallel)
+      : undefined;
+    if (privilegedParallelStep) {
+      return privilegedParallelStep;
+    }
+  }
+  return undefined;
+}
+
+function findPrivilegedCapability(steps: SystemStepLike[]): PrivilegedCapability | undefined {
+  const privilegedSystemStep = findPrivilegedSystemStep(steps);
+  if (privilegedSystemStep) {
+    return { step: privilegedSystemStep, reason: 'system' };
+  }
+
+  const privilegedAllowGitCommitStep = findPrivilegedAllowGitCommitStep(steps);
+  if (privilegedAllowGitCommitStep) {
+    return { step: privilegedAllowGitCommitStep, reason: 'allow_git_commit' };
+  }
+
+  return undefined;
+}
+
+function buildPrivilegedExecutionError(filePath: string, capability: PrivilegedCapability, scope: 'workflow' | 'project'): Error {
+  if (capability.reason === 'system') {
+    const subject = scope === 'project' ? 'Project workflow' : 'Workflow';
+    return new Error(
+      `${subject} "${filePath}" cannot use privileged system execution in step "${capability.step.name}" outside the project workflows root`,
+    );
+  }
+
+  const subject = scope === 'project' ? 'Project workflow' : 'Workflow';
+  return new Error(
+    `${subject} "${filePath}" cannot use allow_git_commit in step "${capability.step.name}" outside the project workflows root`,
+  );
 }
 
 function validateWorkflowExecutionTrustBoundaryInternal(
@@ -16,11 +65,9 @@ function validateWorkflowExecutionTrustBoundaryInternal(
   filePath: string,
   trustInfo: Pick<WorkflowTrustInfo, 'isProjectWorkflowRoot'>,
 ): void {
-  const privilegedStep = findPrivilegedSystemStep(workflow.steps);
-  if (privilegedStep && !trustInfo.isProjectWorkflowRoot) {
-    throw new Error(
-      `Workflow "${filePath}" cannot use privileged system execution in step "${privilegedStep.name}" outside the project workflows root`,
-    );
+  const privilegedCapability = findPrivilegedCapability(workflow.steps);
+  if (privilegedCapability && !trustInfo.isProjectWorkflowRoot) {
+    throw buildPrivilegedExecutionError(filePath, privilegedCapability, 'workflow');
   }
 
   if (hasPrivilegedRuntimePrepare(workflow) && !trustInfo.isProjectWorkflowRoot) {
@@ -39,8 +86,8 @@ export function validateProjectWorkflowTrustBoundaryForSteps(
   filePath: string,
   trustInfo: Pick<WorkflowTrustInfo, 'isProjectWorkflowRoot'>,
 ): void {
-  const privilegedStep = findPrivilegedSystemStep(steps);
-  if (!privilegedStep) {
+  const privilegedCapability = findPrivilegedCapability(steps);
+  if (!privilegedCapability) {
     return;
   }
 
@@ -48,8 +95,14 @@ export function validateProjectWorkflowTrustBoundaryForSteps(
     return;
   }
 
+  if (privilegedCapability.reason === 'system') {
+    throw new Error(
+      `Project workflow "${filePath}" cannot use privileged system execution in step "${privilegedCapability.step.name}"`,
+    );
+  }
+
   throw new Error(
-    `Project workflow "${filePath}" cannot use privileged system execution in step "${privilegedStep.name}"`,
+    `Project workflow "${filePath}" cannot use allow_git_commit in step "${privilegedCapability.step.name}"`,
   );
 }
 
@@ -82,9 +135,9 @@ export function validateWorkflowCallTrustBoundary(
   projectCwd: string,
 ): void {
   const childTrustInfo = getWorkflowTrustInfo(childWorkflow, projectCwd);
-  const privilegedStep = findPrivilegedSystemStep(childWorkflow.steps);
+  const privilegedCapability = findPrivilegedCapability(childWorkflow.steps);
   const hasPrivilegedRuntime = hasPrivilegedRuntimePrepare(childWorkflow);
-  if (!privilegedStep && !hasPrivilegedRuntime) {
+  if (!privilegedCapability && !hasPrivilegedRuntime) {
     return;
   }
 

--- a/src/shared/prompts/en/perform_phase1_message.md
+++ b/src/shared/prompts/en/perform_phase1_message.md
@@ -1,19 +1,20 @@
 <!--
   template: perform_phase1_message
   phase: 1 (main execution)
-  vars: workingDirectory, editRule, workflowName, workflowDescription, hasWorkflowDescription,
-        workflowStructure, iteration, stepIteration, stepName, hasReport, reportInfo,
-        phaseNote, hasTaskSection, userRequest, hasPreviousResponse, previousResponse,
-        hasUserInputs, userInputs, hasRetryNote, retryNote, hasPolicy, policyContent,
-        hasKnowledge, knowledgeContent, hasQualityGates, qualityGatesContent, instructions
+  vars: workingDirectory, hasGitRules, gitRules, editRule, workflowName, workflowDescription,
+        hasWorkflowDescription, workflowStructure, iteration, stepIteration, stepName,
+        hasReport, reportInfo, phaseNote, hasTaskSection, userRequest, hasPreviousResponse,
+        previousResponse, hasUserInputs, userInputs, hasRetryNote, retryNote, hasPolicy,
+        policyContent, hasKnowledge, knowledgeContent, hasQualityGates, qualityGatesContent,
+        instructions
   builder: InstructionBuilder
 -->
 ## Execution Context
 - Working Directory: {{workingDirectory}}
 
 ## Execution Rules
-- **Do NOT run git commit.** Commits are handled automatically by the system after workflow completion.
-- **Do NOT run git add.** Staging is also handled automatically by the system. Untracked files (`??`) are normal.
+{{#if hasGitRules}}{{gitRules}}
+{{/if}}
 - **Do NOT use `cd` in Bash commands.** Your working directory is already set correctly. Run commands directly without changing directories.
 {{#if editRule}}- {{editRule}}
 {{/if}}

--- a/src/shared/prompts/en/perform_phase2_message.md
+++ b/src/shared/prompts/en/perform_phase2_message.md
@@ -1,15 +1,16 @@
 <!--
   template: perform_phase2_message
   phase: 2 (report output)
-  vars: workingDirectory, reportContext, hasLastResponse, lastResponse, hasReportOutput, reportOutput,
-        hasOutputContract, outputContract
+  vars: workingDirectory, hasGitRules, gitRules, reportContext, hasLastResponse, lastResponse,
+        hasReportOutput, reportOutput, hasOutputContract, outputContract
   builder: ReportInstructionBuilder
 -->
 ## Execution Context
 - Working Directory: {{workingDirectory}}
 
 ## Execution Rules
-- **Do NOT run git commit.** Commits are handled automatically by the system after workflow completion.
+{{#if hasGitRules}}{{gitRules}}
+{{/if}}
 - **Do NOT use `cd` in Bash commands.** Your working directory is already set correctly. Run commands directly without changing directories.
 - **Do NOT modify project source files.** Only respond with the report content.
 - **Use only the Report Directory files listed below.** Do not search or open reports outside that directory.

--- a/src/shared/prompts/ja/perform_phase1_message.md
+++ b/src/shared/prompts/ja/perform_phase1_message.md
@@ -1,19 +1,20 @@
 <!--
   template: perform_phase1_message
   phase: 1 (main execution)
-  vars: workingDirectory, editRule, workflowName, workflowDescription, hasWorkflowDescription,
-        workflowStructure, iteration, stepIteration, stepName, hasReport, reportInfo,
-        phaseNote, hasTaskSection, userRequest, hasPreviousResponse, previousResponse,
-        hasUserInputs, userInputs, hasRetryNote, retryNote, hasPolicy, policyContent,
-        hasKnowledge, knowledgeContent, hasQualityGates, qualityGatesContent, instructions
+  vars: workingDirectory, hasGitRules, gitRules, editRule, workflowName, workflowDescription,
+        hasWorkflowDescription, workflowStructure, iteration, stepIteration, stepName,
+        hasReport, reportInfo, phaseNote, hasTaskSection, userRequest, hasPreviousResponse,
+        previousResponse, hasUserInputs, userInputs, hasRetryNote, retryNote, hasPolicy,
+        policyContent, hasKnowledge, knowledgeContent, hasQualityGates, qualityGatesContent,
+        instructions
   builder: InstructionBuilder
 -->
 ## 実行コンテキスト
 - 作業ディレクトリ: {{workingDirectory}}
 
 ## 実行ルール
-- **git commit を実行しないでください。** コミットはワークフロー完了後にシステムが自動で行います。
-- **git add を実行しないでください。** ステージングもシステムが自動で行います。新規ファイルが未追跡（`??`）でも正常です。
+{{#if hasGitRules}}{{gitRules}}
+{{/if}}
 - **Bashコマンドで `cd` を使用しないでください。** 作業ディレクトリは既に正しく設定されています。ディレクトリを変更せずにコマンドを実行してください。
 {{#if editRule}}- {{editRule}}
 {{/if}}

--- a/src/shared/prompts/ja/perform_phase2_message.md
+++ b/src/shared/prompts/ja/perform_phase2_message.md
@@ -1,15 +1,16 @@
 <!--
   template: perform_phase2_message
   phase: 2 (report output)
-  vars: workingDirectory, reportContext, hasLastResponse, lastResponse, hasReportOutput, reportOutput,
-        hasOutputContract, outputContract
+  vars: workingDirectory, hasGitRules, gitRules, reportContext, hasLastResponse, lastResponse,
+        hasReportOutput, reportOutput, hasOutputContract, outputContract
   builder: ReportInstructionBuilder
 -->
 ## 実行コンテキスト
 - 作業ディレクトリ: {{workingDirectory}}
 
 ## 実行ルール
-- **git commit を実行しないでください。** コミットはワークフロー完了後にシステムが自動で行います。
+{{#if hasGitRules}}{{gitRules}}
+{{/if}}
 - **Bashコマンドで `cd` を使用しないでください。** 作業ディレクトリは既に正しく設定されています。ディレクトリを変更せずにコマンドを実行してください。
 - **プロジェクトのソースファイルを変更しないでください。** レポート内容のみを回答してください。
 - **Report Directory内のファイルのみ使用してください。** 他のレポートディレクトリは検索/参照しないでください。


### PR DESCRIPTION
## Summary

## Summary

- ムーブメント実行中の git add / git commit / git push 禁止制約を、ムーブメント単位でオプトインで解除できるようにする
- `PieceMovement` に `allow_git_commit: boolean`（デフォルト `false`）を追加し、`true` の場合に git 禁止セクションを注入しない

## Why

- 現在、すべてのムーブメントに対して git 操作の禁止がテンプレート `.md` にハードコードされている
- 大量の issue を1つのタスクで消化するワークフローなど、作業単位ごとに git commit したいユースケースがある
- インストラクションでのオーバーライド指示は可能だが、エージェントの判断に依存するため不安定

## Proposed Changes

1. **スキーマ**: `src/core/models/workflow-schemas.ts` — `PieceMovementRawSchema` に `allow_git_commit` フィールド（`z.boolean().optional().default(false)`）を追加
2. **型**: `src/core/models/piece-types.ts` — `PieceMovement` インターフェースに `allowGitCommit: boolean` フィールド追加
3. **パーサー**: `src/infra/config/loaders/pieceParser.ts` — `allow_git_commit` の正規化（snake_case → camelCase）
4. **テンプレート（4ファイル）**: git 禁止テキストを除去
   - `src/shared/prompts/en/perform_phase1_message.md` (L15-16)
   - `src/shared/prompts/ja/perform_phase1_message.md` (L15-16)
   - `src/shared/prompts/en/perform_phase2_message.md` (L12)
   - `src/shared/prompts/ja/perform_phase2_message.md` (L12)
5. **InstructionBuilder**: `src/core/piece/instruction/InstructionBuilder.ts` — `allowGitCommit` が `false` または未指定の場合に git 禁止テキストを注入する処理を追加（`instruction-context.ts` の `buildEditRule()` と同様のパターン）
6. **ReportInstructionBuilder**: `src/core/piece/instruction/ReportInstructionBuilder.ts` — 同上（Phase 2 用）
7. **ユニットテスト追加**: `allow_git_commit: true` / `false` / 未指定 それぞれでの git 禁止テキストの有無を検証

## Acceptance Criteria

- [ ] `allow_git_commit` 未指定 → git 禁止テキストが注入される（既存動作維持）
- [ ] `allow_git_commit: false` → git 禁止テキストが注入される
- [ ] `allow_git_commit: true` → git 禁止テキストが注入されない
- [ ] Phase 1（InstructionBuilder）と Phase 2（ReportInstructionBuilder）の両方で上記が成立する
- [ ] en / ja 両言語で正しく動作する
- [ ] デフォルト `false` で既存ワークフローに影響なし（Opt-in 形式）

## 参照すべき既存パターン

- `instruction-context.ts` の `buildEditRule()` — 条件付きテキスト注入のパターン
- `pieceParser.ts` の既存フィールド正規化処理（snake_case → camelCase の変換パターン）

## ピースYAMLでの使用例

```yaml
movements:
  - name: implement-and-commit
    allow_git_commit: true
    persona: coder
    edit: true
    instruction: |
      各issueの修正後に git add && git commit してください。
```

## Execution Report

Workflow `takt-default` completed successfully.

Closes #587