### PR TITLE
[#550] fix-opencode-server-cleanup

### DIFF
--- a/src/__tests__/it-cli-opencode-exit-cleanup.test.ts
+++ b/src/__tests__/it-cli-opencode-exit-cleanup.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockResetSharedServer } = vi.hoisted(() => ({
+  mockResetSharedServer: vi.fn(),
+}));
+
+vi.mock('../infra/opencode/client.js', () => ({
+  resetSharedServer: () => mockResetSharedServer(),
+}));
+
+vi.mock('../shared/utils/index.js', () => ({
+  checkForUpdates: vi.fn(),
+}));
+
+vi.mock('../shared/utils/error.js', () => ({
+  getErrorMessage: vi.fn((error: unknown) => String(error)),
+}));
+
+vi.mock('../shared/ui/index.js', () => ({
+  error: vi.fn(),
+}));
+
+const {
+  mockParseOptions,
+  mockParseAsync,
+  mockRunPreActionHook,
+  mockExecuteDefaultAction,
+  mockResolveRemovedRootCommand,
+  mockResolveSlashFallbackTask,
+  mockInstallImmediateSigintExit,
+} = vi.hoisted(() => ({
+  mockParseOptions: vi.fn(() => ({ operands: [] })),
+  mockParseAsync: vi.fn().mockResolvedValue(undefined),
+  mockRunPreActionHook: vi.fn().mockResolvedValue(undefined),
+  mockExecuteDefaultAction: vi.fn(),
+  mockResolveRemovedRootCommand: vi.fn(() => null),
+  mockResolveSlashFallbackTask: vi.fn(() => null),
+  mockInstallImmediateSigintExit: vi.fn(),
+}));
+
+vi.mock('../app/cli/program.js', () => ({
+  program: {
+    parseOptions: (...args: unknown[]) => mockParseOptions(...args),
+    parseAsync: (...args: unknown[]) => mockParseAsync(...args),
+    commands: [],
+  },
+  runPreActionHook: (...args: unknown[]) => mockRunPreActionHook(...args),
+}));
+
+vi.mock('../app/cli/commands.js', () => ({}));
+
+vi.mock('../app/cli/routing.js', () => ({
+  executeDefaultAction: (...args: unknown[]) => mockExecuteDefaultAction(...args),
+}));
+
+vi.mock('../app/cli/helpers.js', () => ({
+  resolveRemovedRootCommand: (...args: unknown[]) => mockResolveRemovedRootCommand(...args),
+  resolveSlashFallbackTask: (...args: unknown[]) => mockResolveSlashFallbackTask(...args),
+}));
+
+vi.mock('../app/cli/immediateSigintExit.js', () => ({
+  installImmediateSigintExit: (...args: unknown[]) => mockInstallImmediateSigintExit(...args),
+}));
+
+describe('CLI entrypoint OpenCode exit cleanup integration', () => {
+  const originalArgv = [...process.argv];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.argv = ['node', 'takt'];
+  });
+
+  afterEach(() => {
+    process.argv = [...originalArgv];
+    vi.restoreAllMocks();
+  });
+
+  it('should register an exit hook that resets the shared OpenCode server', async () => {
+    const registeredExitListeners: Array<(code: number) => void> = [];
+    const originalOnce = process.once.bind(process);
+
+    vi.spyOn(process, 'once').mockImplementation(((event: string | symbol, listener: (...args: unknown[]) => void) => {
+      if (event === 'exit') {
+        registeredExitListeners.push(listener as (code: number) => void);
+        return process;
+      }
+      return originalOnce(event, listener);
+    }) as typeof process.once);
+
+    vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    await import('../app/cli/index.js');
+    await Promise.resolve();
+
+    expect(registeredExitListeners).toHaveLength(1);
+
+    registeredExitListeners[0]?.(0);
+
+    expect(mockResetSharedServer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/opencode-exit-cleanup.test.ts
+++ b/src/__tests__/opencode-exit-cleanup.test.ts
@@ -1,0 +1,42 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockResetSharedServer } = vi.hoisted(() => ({
+  mockResetSharedServer: vi.fn(),
+}));
+
+vi.mock('../infra/opencode/client.js', () => ({
+  resetSharedServer: () => mockResetSharedServer(),
+}));
+
+class FakeProcess extends EventEmitter {
+  pid = 1234;
+}
+
+describe('installOpencodeExitCleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('should reset the shared OpenCode server when the process exits', async () => {
+    const { installOpencodeExitCleanup } = await import('../app/cli/opencodeExitCleanup.js');
+    const runtime = new FakeProcess();
+
+    installOpencodeExitCleanup(runtime as never);
+    runtime.emit('exit', 0);
+
+    expect(mockResetSharedServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('should register the cleanup with once so repeated exit events do not reset twice', async () => {
+    const { installOpencodeExitCleanup } = await import('../app/cli/opencodeExitCleanup.js');
+    const runtime = new FakeProcess();
+
+    installOpencodeExitCleanup(runtime as never);
+    runtime.emit('exit', 0);
+    runtime.emit('exit', 1);
+
+    expect(mockResetSharedServer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/cli/index.ts
+++ b/src/app/cli/index.ts
@@ -11,6 +11,7 @@ import { getErrorMessage } from '../../shared/utils/error.js';
 import { error as errorLog } from '../../shared/ui/index.js';
 import { resolveRemovedRootCommand, resolveSlashFallbackTask } from './helpers.js';
 import { installImmediateSigintExit } from './immediateSigintExit.js';
+import { installOpencodeExitCleanup } from './opencodeExitCleanup.js';
 
 checkForUpdates();
 
@@ -21,6 +22,7 @@ import { executeDefaultAction } from './routing.js';
 
 (async () => {
   const args = process.argv.slice(2);
+  installOpencodeExitCleanup();
   installImmediateSigintExit(args[0]);
   const { operands } = program.parseOptions(args);
   const removedRootCommand = resolveRemovedRootCommand(operands);

--- a/src/app/cli/opencodeExitCleanup.ts
+++ b/src/app/cli/opencodeExitCleanup.ts
@@ -1,0 +1,13 @@
+import { resetSharedServer } from '../../infra/opencode/client.js';
+
+type ProcessLike = {
+  once: (event: 'exit', listener: (code: number) => void) => unknown;
+};
+
+export function installOpencodeExitCleanup(
+  runtime: ProcessLike = process,
+): void {
+  runtime.once('exit', () => {
+    resetSharedServer();
+  });
+}


### PR DESCRIPTION
## Summary

## 概要

OpenCodeプロバイダーでtaktを使用すると、taktが終了してもopencodeのサーバープロセスが残り続けます。

## 対象バージョン

```
$ takt --version
0.33.1
$ npm view takt@0.33.1 gitHead version dist.tarball
gitHead = 'b6df8430700a6b860cbdc3f825015024f6827126'
version = '0.33.1'
dist.tarball = 'https://registry.npmjs.org/takt/-/takt-0.33.1.tgz'
```

## 再現手順

1. `~/.takt/config.yaml`で`provider: opencode`を設定
2. opencodeプロセス数を確認
   ```
   $ ps aux | grep [o]pencode | wc -l
   0
   ```
3. takt経由でOpenCodeプロバイダーを起動
   ```
   $ takt
     # default pieceを選択
     # 対話モードで「OpenCodeプロバイダーでtaktを使用すると、taktが終了してもopencodeのサーバープロセスが残り続けます。」と入力
     # OpenCodeプロバイダー起動後、/cancelする。
   ✓ Complete

   > /cancel
   ```
4. takt完了後、ターミナルでプロセスを確認すると、opencodeプロセスが残っている
   ```
   $ ps aux | grep [o]pencode | wc -l
   2
   ```

- OpenCodeプロバイダーでtaktを複数回実行すると、その分だけプロセスが残り続けます。
- リソースを消費し続けるため、最終的にはメモリ・スワップを消費してしまいシステムに影響を及ぼします。

## 期待する動作

takt終了時にopencodeサーバープロセスも自動的に終了してほしいです。

## 確認したこと

- Codexプロバイダーでは発生しませんでした。Claude Codeは契約していないので不明です。

 AIエージェントの助けを借りてソースコードを調査しました。
- `src/infra/opencode/client.ts`に`resetSharedServer()`関数はありますが、呼び出し箇所がないようです。
- `src/features/tasks/execute/abortHandler.ts`ではClaude Codeのクリーンアップ（`interruptAllQueries()`）のみ実装されており、OpenCode向けの処理がないようです。
- `src/__tests__/opencode-client-cleanup.test.ts`のテストでは、`resetSharedServer()`がテストの`beforeEach`で呼ばれており、本来は本番コードでも呼ばれるべき関数のように思えます。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #550