### PR TITLE
facet の継承を追加

### DIFF
--- a/docs/faceted-prompting.ja.md
+++ b/docs/faceted-prompting.ja.md
@@ -364,6 +364,16 @@ steps:
 
 エンジンは各キーをファイルに解決し、内容を読み込み、実行時に最終的なプロンプトを組み立てる。ワークフローの作者がモノリシックなプロンプトを書くことはない。どのファセットを組み合わせるかを選択するだけである。
 
+instructions、policies、knowledge、output contracts の facet ファイルは、standalone directive で同じ kind の別 facet を継承できる。
+
+```md
+{extends:fix}
+
+プロジェクト固有の追加指示。
+```
+
+canonical form はコロン後にスペースを入れない `{extends:fix}` だが、`{extends: fix}` も受理される。親名は bare facet name のみで、path reference や `@scope` reference による継承はサポートしない。親 lookup では現在の source file を候補から除外するため、project-level の `fix.md` は自身を再帰的に読むことなく lower-layer の `fix.md` を継承できる。persona facet は継承対象外である。
+
 ## 既存手法との違い
 
 | 手法 | 内容 | 本手法との違い |

--- a/docs/faceted-prompting.md
+++ b/docs/faceted-prompting.md
@@ -364,6 +364,16 @@ steps:
 
 The engine resolves each key to its file, reads the content, and assembles the final prompt at runtime. The workflow author never writes a monolithic prompt — only selects which facets to combine.
 
+Facet files for instructions, policies, knowledge, and output contracts can inherit another facet of the same kind with a standalone directive:
+
+```md
+{extends:fix}
+
+Additional project-specific instructions.
+```
+
+The canonical form has no space after the colon (`{extends:fix}`), but `{extends: fix}` is also accepted. The parent name must be a bare facet name; path references and `@scope` references are not supported for inheritance. The current source file is excluded from parent lookup, so a project-level `fix.md` can extend the lower-layer `fix.md` without recursively reading itself. Persona facets do not support inheritance.
+
 ## How It Differs from Existing Approaches
 
 | Approach | What it does | How this differs |

--- a/src/__tests__/facet-resolution.test.ts
+++ b/src/__tests__/facet-resolution.test.ts
@@ -23,6 +23,7 @@ import {
   type FacetResolutionContext,
   type WorkflowSections,
 } from '../infra/config/loaders/resource-resolver.js';
+import { replaceTemplatePlaceholders } from '../core/workflow/instruction/escape.js';
 import {
   getProjectFacetDir,
   getGlobalFacetDir,
@@ -266,6 +267,186 @@ describe('resolveRefList with layer resolution', () => {
     );
 
     expect(result).toEqual(['Map content for coding']);
+  });
+});
+
+describe('facet inheritance', () => {
+  let tempDir: string;
+  let projectDir: string;
+  let workflowDir: string;
+  let globalConfigDir: string;
+  let previousTaktConfigDir: string | undefined;
+  let context: FacetResolutionContext;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'takt-facet-extends-test-'));
+    projectDir = join(tempDir, 'project');
+    workflowDir = join(tempDir, 'workflows');
+    globalConfigDir = join(tempDir, 'global');
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(workflowDir, { recursive: true });
+    previousTaktConfigDir = process.env.TAKT_CONFIG_DIR;
+    process.env.TAKT_CONFIG_DIR = globalConfigDir;
+    context = { projectDir, lang: 'ja', workflowDir };
+  });
+
+  afterEach(() => {
+    if (previousTaktConfigDir === undefined) {
+      delete process.env.TAKT_CONFIG_DIR;
+    } else {
+      process.env.TAKT_CONFIG_DIR = previousTaktConfigDir;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeProjectFacet(type: FacetType, name: string, content: string): void {
+    const dir = getProjectFacetDir(projectDir, type);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${name}.md`), content);
+  }
+
+  function writeGlobalFacet(type: FacetType, name: string, content: string): void {
+    const dir = getGlobalFacetDir(type);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${name}.md`), content);
+  }
+
+  it('should append local content after an inherited instruction parent', () => {
+    writeProjectFacet('instructions', 'base', 'Base instruction');
+    writeProjectFacet('instructions', 'custom', '{extends:base}\n\nCustom instruction');
+
+    const content = resolveRefToContent('custom', undefined, workflowDir, 'instructions', context);
+
+    expect(content).toBe('Base instruction\n\nCustom instruction');
+  });
+
+  it('should preserve local content around an inherited instruction parent', () => {
+    writeProjectFacet('instructions', 'base', 'Base instruction');
+    writeProjectFacet('instructions', 'custom', 'Before\n{extends: base}\nAfter');
+
+    const content = resolveRefToContent('custom', undefined, workflowDir, 'instructions', context);
+
+    expect(content).toBe('Before\nBase instruction\nAfter');
+  });
+
+  it('should let same-name project overrides inherit from lower layers', () => {
+    writeGlobalFacet('instructions', 'fix', 'Global fix instruction');
+    writeProjectFacet('instructions', 'fix', '{extends:fix}\nProject fix addition');
+
+    const content = resolveRefToContent('fix', undefined, workflowDir, 'instructions', context);
+
+    expect(content).toBe('Global fix instruction\nProject fix addition');
+  });
+
+  it('should let differently named project facets inherit project siblings', () => {
+    writeProjectFacet('instructions', 'fix', 'Project fix instruction');
+    writeProjectFacet('instructions', 'my-fix', '{extends:fix}\nMy fix addition');
+
+    const content = resolveRefToContent('my-fix', undefined, workflowDir, 'instructions', context);
+
+    expect(content).toBe('Project fix instruction\nMy fix addition');
+  });
+
+  it('should resolve parents only within the same facet kind', () => {
+    writeProjectFacet('instructions', 'fix', 'Instruction fix');
+    writeProjectFacet('policies', 'custom', '{extends:fix}\nPolicy addition');
+
+    expect(() => resolveRefToContent('custom', undefined, workflowDir, 'policies', context)).toThrow(
+      /parent "fix" not found/,
+    );
+  });
+
+  it('should expand inheritance for policies, knowledge, and output contracts during workflow normalization', () => {
+    writeProjectFacet('policies', 'base-policy', 'Base policy');
+    writeProjectFacet('policies', 'custom-policy', '{extends:base-policy}\nCustom policy');
+    writeProjectFacet('knowledge', 'base-knowledge', 'Base knowledge');
+    writeProjectFacet('knowledge', 'custom-knowledge', '{extends:base-knowledge}\nCustom knowledge');
+    writeProjectFacet('output-contracts', 'base-report', 'Base report');
+    writeProjectFacet('output-contracts', 'custom-report', '{extends:base-report}\nCustom report');
+
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'facet-extends-workflow',
+        steps: [
+          {
+            name: 'review',
+            persona: 'coder',
+            policy: 'custom-policy',
+            knowledge: 'custom-knowledge',
+            instruction: '{task}',
+            output_contracts: {
+              report: [{ name: 'review.md', format: 'custom-report' }],
+            },
+          },
+        ],
+      },
+      workflowDir,
+      context,
+    );
+
+    expect(config.steps[0]!.policyContents).toEqual(['Base policy\nCustom policy']);
+    expect(config.steps[0]!.knowledgeContents).toEqual(['Base knowledge\nCustom knowledge']);
+    expect(config.steps[0]!.outputContracts?.[0]?.format).toBe('Base report\nCustom report');
+  });
+
+  it('should keep runtime placeholders interpolated after inheritance expansion', () => {
+    writeProjectFacet('instructions', 'base', 'Parent task: {task}');
+    writeProjectFacet('instructions', 'custom', '{extends:base}\nChild instruction');
+
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'placeholder-workflow',
+        steps: [
+          {
+            name: 'step1',
+            persona: 'coder',
+            instruction: 'custom',
+          },
+        ],
+      },
+      workflowDir,
+      context,
+    );
+    const step = config.steps[0]!;
+    const rendered = replaceTemplatePlaceholders(step.instruction, step, {
+      task: 'Runtime task',
+      iteration: 1,
+      maxSteps: 3,
+      stepIteration: 1,
+      cwd: projectDir,
+      projectCwd: projectDir,
+      userInputs: [],
+    });
+
+    expect(step.instruction).toBe('Parent task: {task}\nChild instruction');
+    expect(rendered).toContain('Parent task: Runtime task');
+  });
+
+  it('should reject missing parents, malformed directives, unsupported references, inline extends, and cycles', () => {
+    writeProjectFacet('instructions', 'missing-parent', '{extends:missing}\nChild');
+    expect(() => resolveRefToContent('missing-parent', undefined, workflowDir, 'instructions', context)).toThrow(
+      /parent "missing" not found/,
+    );
+
+    writeProjectFacet('instructions', 'multiple', '{extends:base}\n{extends:other}');
+    expect(() => resolveRefToContent('multiple', undefined, workflowDir, 'instructions', context)).toThrow(
+      /multiple extends directives/,
+    );
+
+    writeProjectFacet('instructions', 'path-parent', '{extends:../fix.md}');
+    expect(() => resolveRefToContent('path-parent', undefined, workflowDir, 'instructions', context)).toThrow(
+      /only bare facet names/,
+    );
+
+    expect(() => resolveRefToContent('{extends:fix}', undefined, workflowDir, 'instructions', context)).toThrow(
+      /requires a source file path/,
+    );
+
+    writeProjectFacet('instructions', 'a', '{extends:b}');
+    writeProjectFacet('instructions', 'b', '{extends:a}');
+    expect(() => resolveRefToContent('a', undefined, workflowDir, 'instructions', context)).toThrow(
+      /inheritance cycle/,
+    );
   });
 });
 

--- a/src/infra/config/loaders/resource-resolver.ts
+++ b/src/infra/config/loaders/resource-resolver.ts
@@ -8,11 +8,13 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import type { FacetType } from '../paths.js';
 import {
   resolveFacetPath as resolveFacetPathGeneric,
-  resolveRefToContent as resolveRefToContentGeneric,
   resolvePersona as resolvePersonaGeneric,
+  isResourcePath,
+  resolveResourcePath,
   isScopeRef,
   parseScopeRef,
   resolveScopeRef,
@@ -28,20 +30,261 @@ import {
 export interface WorkflowSections {
   personas?: Record<string, string>;
   resolvedPolicies?: Record<string, string>;
+  resolvedPoliciesWithSource?: ResolvedSectionMap;
   resolvedKnowledge?: Record<string, string>;
+  resolvedKnowledgeWithSource?: ResolvedSectionMap;
   resolvedInstructions?: Record<string, string>;
+  resolvedInstructionsWithSource?: ResolvedSectionMap;
   resolvedReportFormats?: Record<string, string>;
+  resolvedReportFormatsWithSource?: ResolvedSectionMap;
 }
 
 export {
   isResourcePath,
   resolveResourcePath,
-  resolveResourceContent,
   resolveSectionMap,
   extractPersonaDisplayName,
 } from 'faceted-prompting';
 
 export type { FacetResolutionContext } from './workflowPackageScope.js';
+
+export interface ResolvedFacetContent {
+  content: string;
+  sourcePath?: string;
+  facetType?: FacetType;
+  refName?: string;
+}
+
+export type ResolvedSectionMap = Record<string, ResolvedFacetContent>;
+
+type ResolvedMapInput = Record<string, string> | ResolvedSectionMap;
+
+interface FacetInheritanceFrame {
+  sourcePath?: string;
+  refName?: string;
+}
+
+interface ExtendsDirective {
+  parentName: string;
+  start: number;
+  end: number;
+}
+
+function samePath(a: string, b: string): boolean {
+  return resolve(a) === resolve(b);
+}
+
+function isPathInside(basePath: string, targetPath: string): boolean {
+  const rel = relative(resolve(basePath), resolve(targetPath));
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+function contentSourceLabel(content: ResolvedFacetContent): string {
+  return content.sourcePath ?? content.refName ?? '<inline>';
+}
+
+function formatInheritanceChain(frames: FacetInheritanceFrame[], current: ResolvedFacetContent): string {
+  return [...frames.map((frame) => frame.sourcePath ?? frame.refName ?? '<inline>'), contentSourceLabel(current)].join(' -> ');
+}
+
+function isResolvedFacetContent(value: string | ResolvedFacetContent): value is ResolvedFacetContent {
+  return typeof value !== 'string';
+}
+
+function toResolvedContent(
+  value: string | ResolvedFacetContent,
+  facetType: FacetType | undefined,
+  refName: string | undefined,
+): ResolvedFacetContent {
+  if (isResolvedFacetContent(value)) {
+    return {
+      ...value,
+      facetType: value.facetType ?? facetType,
+      refName: value.refName ?? refName,
+    };
+  }
+  return { content: value, facetType, refName };
+}
+
+export function unwrapResolvedSectionMap(map: ResolvedSectionMap | undefined): Record<string, string> | undefined {
+  if (!map) {
+    return undefined;
+  }
+  const result: Record<string, string> = {};
+  for (const [name, value] of Object.entries(map)) {
+    result[name] = value.content;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export function resolveResourceContentWithSource(
+  spec: string | undefined,
+  workflowDir: string,
+  facetType?: FacetType,
+  refName?: string,
+): ResolvedFacetContent | undefined {
+  if (spec == null) {
+    return undefined;
+  }
+  if (spec.endsWith('.md')) {
+    const resolved = resolveResourcePath(spec, workflowDir);
+    if (existsSync(resolved)) {
+      return {
+        content: readFileSync(resolved, 'utf-8'),
+        sourcePath: resolved,
+        facetType,
+        refName,
+      };
+    }
+  }
+  return { content: spec, facetType, refName };
+}
+
+export function resolveSectionMapWithSource(
+  raw: Record<string, string> | undefined,
+  workflowDir: string,
+  facetType: FacetType,
+): ResolvedSectionMap | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const resolved: ResolvedSectionMap = {};
+  for (const [name, value] of Object.entries(raw)) {
+    const content = resolveResourceContentWithSource(value, workflowDir, facetType, name);
+    if (content?.content) {
+      resolved[name] = content;
+    }
+  }
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
+}
+
+const EXTENDS_LIKE_PATTERN = /\{\s*extends\s*:[^}]*\}/g;
+const EXTENDS_LINE_PATTERN = /^[ \t]*\{extends:\s*([^}]+?)\s*\}[ \t]*$/gm;
+const BARE_FACET_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function isBareFacetName(name: string): boolean {
+  return BARE_FACET_NAME_PATTERN.test(name)
+    && !isResourcePath(name)
+    && !isScopeRef(name);
+}
+
+function parseExtendsDirective(content: string, sourceLabel: string): ExtendsDirective | undefined {
+  const likeMatches = [...content.matchAll(EXTENDS_LIKE_PATTERN)];
+  if (content.includes('{extends:') && likeMatches.length === 0) {
+    throw new Error(`Malformed facet extends directive in ${sourceLabel}`);
+  }
+  if (likeMatches.length === 0) {
+    return undefined;
+  }
+
+  const lineMatches = [...content.matchAll(EXTENDS_LINE_PATTERN)];
+  if (lineMatches.length !== likeMatches.length) {
+    throw new Error(`Facet extends directive must be on its own line in ${sourceLabel}`);
+  }
+  if (lineMatches.length > 1) {
+    throw new Error(`Facet file ${sourceLabel} contains multiple extends directives`);
+  }
+
+  const match = lineMatches[0]!;
+  const parentName = (match[1] ?? '').trim();
+  if (!isBareFacetName(parentName)) {
+    throw new Error(`Unsupported facet extends parent "${parentName}" in ${sourceLabel}; only bare facet names are supported`);
+  }
+
+  const start = match.index;
+  if (start === undefined) {
+    throw new Error(`Malformed facet extends directive in ${sourceLabel}`);
+  }
+  return {
+    parentName,
+    start,
+    end: start + match[0].length,
+  };
+}
+
+function findSourceLayerIndex(sourcePath: string, candidateDirs: readonly string[]): number | undefined {
+  const index = candidateDirs.findIndex((dir) => isPathInside(dir, sourcePath));
+  return index >= 0 ? index : undefined;
+}
+
+function resolveFacetFromCandidateDirs(
+  name: string,
+  facetType: FacetType,
+  candidateDirs: readonly string[],
+  refName: string,
+  excludeSourcePath?: string,
+): ResolvedFacetContent | undefined {
+  for (const dir of candidateDirs) {
+    const filePath = join(dir, `${name}.md`);
+    if (excludeSourcePath && samePath(filePath, excludeSourcePath)) {
+      continue;
+    }
+    if (existsSync(filePath)) {
+      return {
+        content: readFileSync(filePath, 'utf-8'),
+        sourcePath: filePath,
+        facetType,
+        refName,
+      };
+    }
+  }
+  return undefined;
+}
+
+function resolveParentFacetWithSource(
+  parentName: string,
+  facetType: FacetType,
+  context: FacetResolutionContext | undefined,
+  currentSourcePath: string,
+): ResolvedFacetContent | undefined {
+  if (!context) {
+    return undefined;
+  }
+
+  const candidateDirs = buildCandidateDirsWithPackage(facetType, context);
+  const sourceLayerIndex = findSourceLayerIndex(currentSourcePath, candidateDirs);
+  const searchDirs = candidateDirs.slice(sourceLayerIndex ?? 0);
+  return resolveFacetFromCandidateDirs(parentName, facetType, searchDirs, parentName, currentSourcePath);
+}
+
+function expandFacetInheritance(
+  resolved: ResolvedFacetContent,
+  facetType: FacetType | undefined,
+  context: FacetResolutionContext | undefined,
+  frames: FacetInheritanceFrame[] = [],
+): ResolvedFacetContent {
+  if (!facetType) {
+    return resolved;
+  }
+
+  const sourceLabel = contentSourceLabel(resolved);
+  const directive = parseExtendsDirective(resolved.content, sourceLabel);
+  if (!directive) {
+    return resolved;
+  }
+
+  if (!resolved.sourcePath) {
+    throw new Error(`Facet extends directive in ${sourceLabel} requires a source file path`);
+  }
+
+  if (frames.some((frame) => frame.sourcePath && samePath(frame.sourcePath, resolved.sourcePath!))) {
+    throw new Error(`Facet inheritance cycle detected: ${formatInheritanceChain(frames, resolved)}`);
+  }
+
+  const parent = resolveParentFacetWithSource(directive.parentName, facetType, context, resolved.sourcePath);
+  if (!parent) {
+    throw new Error(`Facet extends parent "${directive.parentName}" not found for ${sourceLabel}`);
+  }
+
+  const expandedParent = expandFacetInheritance(parent, facetType, context, [
+    ...frames,
+    { sourcePath: resolved.sourcePath, refName: resolved.refName },
+  ]);
+  return {
+    ...resolved,
+    content: `${resolved.content.slice(0, directive.start)}${expandedParent.content}${resolved.content.slice(directive.end)}`,
+  };
+}
 
 /**
  * Resolve a facet name to its file path via 4-layer lookup (package-local → project → user → builtin).
@@ -75,9 +318,26 @@ export function resolveFacetByName(
   facetType: FacetType,
   context: FacetResolutionContext,
 ): string | undefined {
+  return resolveFacetByNameWithSource(name, facetType, context)?.content;
+}
+
+export function resolveFacetByNameWithSource(
+  name: string,
+  facetType: FacetType,
+  context: FacetResolutionContext,
+): ResolvedFacetContent | undefined {
   const filePath = resolveFacetPath(name, facetType, context);
   if (filePath) {
-    return readFileSync(filePath, 'utf-8');
+    return expandFacetInheritance(
+      {
+        content: readFileSync(filePath, 'utf-8'),
+        sourcePath: filePath,
+        facetType,
+        refName: name,
+      },
+      facetType,
+      context,
+    );
   }
   return undefined;
 }
@@ -90,26 +350,62 @@ export function resolveFacetByName(
  */
 export function resolveRefToContent(
   ref: string,
-  resolvedMap: Record<string, string> | undefined,
+  resolvedMap: ResolvedMapInput | undefined,
   workflowDir: string,
   facetType?: FacetType,
   context?: FacetResolutionContext,
 ): string | undefined {
+  return resolveRefToContentWithSource(ref, resolvedMap, workflowDir, facetType, context)?.content;
+}
+
+export function resolveRefToContentWithSource(
+  ref: string,
+  resolvedMap: ResolvedMapInput | undefined,
+  workflowDir: string,
+  facetType?: FacetType,
+  context?: FacetResolutionContext,
+): ResolvedFacetContent | undefined {
+  const mapped = resolvedMap?.[ref];
+  if (mapped !== undefined) {
+    return expandFacetInheritance(toResolvedContent(mapped, facetType, ref), facetType, context);
+  }
+
   if (facetType && context && isScopeRef(ref) && context.repertoireDir) {
     const scopeRef = parseScopeRef(ref);
     const filePath = resolveScopeRef(scopeRef, facetType, context.repertoireDir);
-    return existsSync(filePath) ? readFileSync(filePath, 'utf-8') : undefined;
+    return existsSync(filePath)
+      ? expandFacetInheritance({
+          content: readFileSync(filePath, 'utf-8'),
+          sourcePath: filePath,
+          facetType,
+          refName: ref,
+        }, facetType, context)
+      : undefined;
   }
+
+  if (isResourcePath(ref)) {
+    const resource = resolveResourceContentWithSource(ref, workflowDir, facetType, ref);
+    return resource ? expandFacetInheritance(resource, facetType, context) : undefined;
+  }
+
   const candidateDirs = facetType && context
     ? buildCandidateDirsWithPackage(facetType, context)
     : undefined;
-  return resolveRefToContentGeneric(ref, resolvedMap, workflowDir, candidateDirs);
+  if (candidateDirs) {
+    const facetContent = resolveFacetFromCandidateDirs(ref, facetType!, candidateDirs, ref);
+    if (facetContent !== undefined) {
+      return expandFacetInheritance(facetContent, facetType, context);
+    }
+  }
+
+  const resource = resolveResourceContentWithSource(ref, workflowDir, facetType, ref);
+  return resource ? expandFacetInheritance(resource, facetType, context) : undefined;
 }
 
 /** Resolve multiple references to content strings (for fields that accept string | string[]). */
 export function resolveRefList(
   refs: string | string[] | undefined,
-  resolvedMap: Record<string, string> | undefined,
+  resolvedMap: ResolvedMapInput | undefined,
   workflowDir: string,
   facetType?: FacetType,
   context?: FacetResolutionContext,

--- a/src/infra/config/loaders/workflowLoopMonitorNormalizer.ts
+++ b/src/infra/config/loaders/workflowLoopMonitorNormalizer.ts
@@ -28,7 +28,13 @@ function normalizeLoopMonitorJudge(
     model: normalizedProvider.model,
     providerOptions: normalizedProvider.providerOptions,
     instruction: raw.instruction
-      ? resolveRefToContent(raw.instruction, sections.resolvedInstructions, workflowDir, 'instructions', context)
+      ? resolveRefToContent(
+          raw.instruction,
+          sections.resolvedInstructionsWithSource ?? sections.resolvedInstructions,
+          workflowDir,
+          'instructions',
+          context,
+        )
       : undefined,
     rules: raw.rules.map((rule) => ({ condition: rule.condition, next: rule.next })),
   };

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -10,7 +10,10 @@ import { validateProviderModelCompatibility } from '../../../core/workflow/provi
 import { isPathSafe } from '../paths.js';
 import { normalizeRuntime } from '../configNormalizers.js';
 import type { FacetResolutionContext, WorkflowSections } from './resource-resolver.js';
-import { resolveSectionMap } from './resource-resolver.js';
+import {
+  resolveSectionMapWithSource,
+  unwrapResolvedSectionMap,
+} from './resource-resolver.js';
 import {
   validateWorkflowRuntimePrepare,
 } from './workflowNormalizationPolicies.js';
@@ -78,12 +81,20 @@ export function normalizeWorkflowConfig(
       context,
     },
   );
+  const resolvedPoliciesWithSource = resolveSectionMapWithSource(parsed.policies, workflowDir, 'policies');
+  const resolvedKnowledgeWithSource = resolveSectionMapWithSource(parsed.knowledge, workflowDir, 'knowledge');
+  const resolvedInstructionsWithSource = resolveSectionMapWithSource(parsed.instructions, workflowDir, 'instructions');
+  const resolvedReportFormatsWithSource = resolveSectionMapWithSource(parsed.report_formats, workflowDir, 'output-contracts');
   const sections: WorkflowSections = {
     personas: parsed.personas,
-    resolvedPolicies: resolveSectionMap(parsed.policies, workflowDir),
-    resolvedKnowledge: resolveSectionMap(parsed.knowledge, workflowDir),
-    resolvedInstructions: resolveSectionMap(parsed.instructions, workflowDir),
-    resolvedReportFormats: resolveSectionMap(parsed.report_formats, workflowDir),
+    resolvedPolicies: unwrapResolvedSectionMap(resolvedPoliciesWithSource),
+    resolvedPoliciesWithSource,
+    resolvedKnowledge: unwrapResolvedSectionMap(resolvedKnowledgeWithSource),
+    resolvedKnowledgeWithSource,
+    resolvedInstructions: unwrapResolvedSectionMap(resolvedInstructionsWithSource),
+    resolvedInstructionsWithSource,
+    resolvedReportFormats: unwrapResolvedSectionMap(resolvedReportFormatsWithSource),
+    resolvedReportFormatsWithSource,
   };
 
   const workflowRuntime = normalizeRuntime(parsed.workflow_config?.runtime);

--- a/src/infra/config/loaders/workflowStepFeaturesNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepFeaturesNormalizer.ts
@@ -8,7 +8,7 @@ import type {
   TeamLeaderConfig,
   WorkflowStepRawSchema,
 } from '../../../core/models/index.js';
-import type { FacetResolutionContext, WorkflowSections } from './resource-resolver.js';
+import type { FacetResolutionContext, ResolvedSectionMap, WorkflowSections } from './resource-resolver.js';
 import { resolvePersona, resolveRefToContent } from './resource-resolver.js';
 
 type RawStep = z.output<typeof WorkflowStepRawSchema>;
@@ -16,7 +16,7 @@ type RawStep = z.output<typeof WorkflowStepRawSchema>;
 export function normalizeOutputContracts(
   raw: { report?: Array<{ name: string; format: string | { $param: string }; use_judge?: boolean; order?: string }> } | undefined,
   workflowDir: string,
-  resolvedReportFormats: Record<string, string> | undefined,
+  resolvedReportFormats: Record<string, string> | ResolvedSectionMap | undefined,
   context?: FacetResolutionContext,
 ): OutputContractEntry[] | undefined {
   if (raw?.report == null || raw.report.length === 0) {

--- a/src/infra/config/loaders/workflowStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepNormalizer.ts
@@ -91,7 +91,7 @@ export function normalizeStepFromRaw(
     ? undefined
     : resolveRefList(
       (step as Record<string, unknown>).policy as string | string[] | undefined,
-      sections.resolvedPolicies,
+      sections.resolvedPoliciesWithSource ?? sections.resolvedPolicies,
       workflowDir,
       'policies',
       context,
@@ -100,7 +100,7 @@ export function normalizeStepFromRaw(
     ? undefined
     : resolveRefList(
       (step as Record<string, unknown>).knowledge as string | string[] | undefined,
-      sections.resolvedKnowledge,
+      sections.resolvedKnowledgeWithSource ?? sections.resolvedKnowledge,
       workflowDir,
       'knowledge',
       context,
@@ -112,7 +112,13 @@ export function normalizeStepFromRaw(
   const instruction = isSystemStep || isWorkflowCallStep
     ? undefined
     : step.instruction
-    ? resolveRefToContent(step.instruction as string, sections.resolvedInstructions, workflowDir, 'instructions', context)
+    ? resolveRefToContent(
+        step.instruction as string,
+        sections.resolvedInstructionsWithSource ?? sections.resolvedInstructions,
+        workflowDir,
+        'instructions',
+        context,
+      )
     : undefined;
 
   validateWorkflowArpeggio(step.name, step.arpeggio, workflowArpeggioPolicy);
@@ -176,7 +182,12 @@ export function normalizeStepFromRaw(
       projectDir: context?.projectDir ?? workflowDir,
     }),
     rules,
-    outputContracts: normalizeOutputContracts(step.output_contracts, workflowDir, sections.resolvedReportFormats, context),
+    outputContracts: normalizeOutputContracts(
+      step.output_contracts,
+      workflowDir,
+      sections.resolvedReportFormatsWithSource ?? sections.resolvedReportFormats,
+      context,
+    ),
     qualityGates: applyQualityGateOverrides(
       step.name,
       step.quality_gates,


### PR DESCRIPTION
## 概要
- `{extends:fix}` 形式で、ファイル由来の facet が親 facet を継承できるようにしました。
- 親 facet は facet 種別とレイヤ順に沿って解決し、同一ファイルの自己参照除外と循環検知は source path ベースで行います。
- instructions、policies、knowledge、output contracts、loop monitor の judge instructions で継承後の内容が使われるようにしました。
- faceted prompting の英語版・日本語版ドキュメントに継承構文を追記しました。

## 検証
- `npm run build`
- `npm run lint`
- `npm test`
- `openspec validate add-facet-extends`

補足: `openspec/` 配下はローカルで ignore されているため、この PR には含めていません。