### PR TITLE
[#691] allow-system-workflows

### DIFF
--- a/src/__tests__/system-workflow-schema.test.ts
+++ b/src/__tests__/system-workflow-schema.test.ts
@@ -1385,7 +1385,7 @@ steps:
     }
   });
 
-  it('privileged な project 任意 path workflow では normalize 時点で reject する', () => {
+  it('privileged な project 任意 path workflow でも normalize して project schema_ref を解決できる', () => {
     const projectDir = mkdtempSync(join(tmpdir(), 'takt-system-schema-trust-project-'));
     const workflowDir = join(projectDir, 'adhoc-workflows');
     const globalConfigDir = mkdtempSync(join(tmpdir(), 'takt-global-config-trust-'));
@@ -1460,11 +1460,24 @@ steps:
         ],
       });
 
-      expect(() => normalizeWorkflowConfig(raw, workflowDir, {
+      const normalized = normalizeWorkflowConfig(raw, workflowDir, {
         lang: 'en',
         projectDir,
         workflowDir,
-      })).toThrow(/cannot use privileged system execution/);
+      });
+      const step = normalized.steps[0] as Record<string, unknown>;
+
+      expect(step.structuredOutput).toEqual({
+        schemaRef: 'followup-task',
+        schema: {
+          type: 'object',
+          properties: {
+            action: { type: 'string' },
+            source: { type: 'string', const: 'project' },
+          },
+          required: ['action', 'source'],
+        },
+      });
     } finally {
       if (previousConfigDir === undefined) {
         delete process.env.TAKT_CONFIG_DIR;

--- a/src/__tests__/taskExecution.test.ts
+++ b/src/__tests__/taskExecution.test.ts
@@ -343,7 +343,7 @@ describe('executeAndCompleteTask', () => {
     });
   });
 
-  it('should reject privileged worktree workflows before execution', async () => {
+  it('should execute privileged worktree workflows when explicitly selected', async () => {
     const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
       name: 'worktree-privileged',
       runtime: {
@@ -374,11 +374,12 @@ describe('executeAndCompleteTask', () => {
       cwd: '/project/.takt/worktrees/task-a',
       projectCwd: '/project',
       workflowIdentifier: './.takt/workflows/worktree-privileged.yaml',
-    })).rejects.toThrow('cannot use workflow-level runtime.prepare outside the project workflows root');
-    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    })).resolves.toBe(true);
+    expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockExecuteWorkflow.mock.calls[0]?.[0]).toBe(workflow);
   });
 
-  it('should reject allow_git_commit worktree workflows before execution', async () => {
+  it('should execute allow_git_commit worktree workflows when explicitly selected', async () => {
     const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
       name: 'worktree-commit',
       steps: [
@@ -407,8 +408,9 @@ describe('executeAndCompleteTask', () => {
       cwd: '/project/.takt/worktrees/task-a',
       projectCwd: '/project',
       workflowIdentifier: './.takt/workflows/worktree-commit.yaml',
-    })).rejects.toThrow('cannot use allow_git_commit in step "review" outside the project workflows root');
-    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    })).resolves.toBe(true);
+    expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockExecuteWorkflow.mock.calls[0]?.[0]).toBe(workflow);
   });
 
   it('should use workflow terminology when named workflow is missing', async () => {

--- a/src/__tests__/taskRetryActions.test.ts
+++ b/src/__tests__/taskRetryActions.test.ts
@@ -566,7 +566,7 @@ describe('retryFailedTask', () => {
     );
   });
 
-  it('should reject privileged worktree workflows during retry before selecting a step', async () => {
+  it('should allow privileged worktree workflows during retry and continue to step selection', async () => {
     const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
       ...defaultWorkflowConfig,
       name: 'selected-workflow',
@@ -583,13 +583,19 @@ describe('retryFailedTask', () => {
     mockSelectWorkflow.mockResolvedValue('./.takt/workflows/selected-workflow.yaml');
     mockLoadWorkflowByIdentifier.mockReturnValue(workflow);
 
-    await expect(retryFailedTask(makeFailedTask(), '/project')).rejects.toThrow(
-      'cannot use workflow-level runtime.prepare outside the project workflows root',
+    await expect(retryFailedTask(makeFailedTask(), '/project')).resolves.toBe(true);
+    expect(mockSelectOptionWithDefault).toHaveBeenCalledWith(
+      'Start from step:',
+      expect.arrayContaining([
+        expect.objectContaining({ value: 'plan' }),
+        expect.objectContaining({ value: 'implement' }),
+        expect.objectContaining({ value: 'review' }),
+      ]),
+      'review',
     );
-    expect(mockSelectOptionWithDefault).not.toHaveBeenCalled();
   });
 
-  it('should reject allow_git_commit worktree workflows during retry before selecting a step', async () => {
+  it('should allow allow_git_commit worktree workflows during retry and continue to step selection', async () => {
     const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
       ...defaultWorkflowConfig,
       name: 'selected-workflow',
@@ -613,10 +619,16 @@ describe('retryFailedTask', () => {
     mockSelectWorkflow.mockResolvedValue('./.takt/workflows/selected-workflow.yaml');
     mockLoadWorkflowByIdentifier.mockReturnValue(workflow);
 
-    await expect(retryFailedTask(makeFailedTask(), '/project')).rejects.toThrow(
-      'cannot use allow_git_commit in step "plan" outside the project workflows root',
+    await expect(retryFailedTask(makeFailedTask(), '/project')).resolves.toBe(true);
+    expect(mockSelectOptionWithDefault).toHaveBeenCalledWith(
+      'Start from step:',
+      expect.arrayContaining([
+        expect.objectContaining({ value: 'plan' }),
+        expect.objectContaining({ value: 'implement' }),
+        expect.objectContaining({ value: 'review' }),
+      ]),
+      'review',
     );
-    expect(mockSelectOptionWithDefault).not.toHaveBeenCalled();
   });
 
   it('should show deprecated config warning when selected run order uses legacy provider fields', async () => {

--- a/src/__tests__/workflow-doctor.test.ts
+++ b/src/__tests__/workflow-doctor.test.ts
@@ -756,7 +756,7 @@ steps:
   });
 
   it.each(worktreeRootCases)(
-    'validates runtime.prepare trust for worktree workflow path targets in $name',
+    'allows runtime.prepare for explicitly targeted worktree workflow paths in $name',
     async (rootCase) => {
       writeConfigForCase(rootCase);
       const { rootDirRelativePath } = rootCase;
@@ -780,16 +780,15 @@ steps:
 
       await expect(
         doctorWorkflowCommand([relative(projectDir, worktreeWorkflowPath)], projectDir),
-      ).rejects.toThrow('Workflow validation failed');
+      ).resolves.toBeUndefined();
 
-      expect(mockError).toHaveBeenCalledWith(
-        expect.stringContaining('cannot use workflow-level runtime.prepare outside the project workflows root'),
-      );
+      expect(mockSuccess).toHaveBeenCalledWith(expect.stringContaining('prepare.yaml'));
+      expect(mockError).not.toHaveBeenCalled();
     },
   );
 
   it.each(worktreeRootCases)(
-    'validates allow_git_commit trust for worktree workflow path targets in $name',
+    'allows allow_git_commit for explicitly targeted worktree workflow paths in $name',
     async (rootCase) => {
       writeConfigForCase(rootCase);
       const { rootDirRelativePath } = rootCase;
@@ -810,11 +809,10 @@ steps:
 
       await expect(
         doctorWorkflowCommand([relative(projectDir, worktreeWorkflowPath)], projectDir),
-      ).rejects.toThrow('Workflow validation failed');
+      ).resolves.toBeUndefined();
 
-      expect(mockError).toHaveBeenCalledWith(
-        expect.stringContaining('cannot use allow_git_commit in step "review" outside the project workflows root'),
-      );
+      expect(mockSuccess).toHaveBeenCalledWith(expect.stringContaining('commit.yaml'));
+      expect(mockError).not.toHaveBeenCalled();
     },
   );
 

--- a/src/__tests__/workflow-selection.test.ts
+++ b/src/__tests__/workflow-selection.test.ts
@@ -78,6 +78,23 @@ describe('selectWorkflowFromEntries', () => {
     expect(selected).toBe('builtin-flow');
     expect(selectOptionMock).toHaveBeenCalledTimes(1);
   });
+
+  it('should return builtin workflow identity instead of its file path', async () => {
+    const entries: WorkflowDirEntry[] = [
+      {
+        name: 'auto-improvement-loop',
+        path: '/repo/builtins/en/workflows/auto-improvement-loop.yaml',
+        source: 'builtin',
+      },
+    ];
+
+    selectOptionMock.mockResolvedValueOnce('auto-improvement-loop');
+
+    const selected = await selectWorkflowFromEntries(entries);
+
+    expect(selected).toBe('auto-improvement-loop');
+    expect(selected).not.toBe(entries[0]!.path);
+  });
 });
 
 function createWorkflowMap(entries: { name: string; source: 'user' | 'builtin' }[]): Map<string, WorkflowWithSource> {

--- a/src/__tests__/workflowLoader.test.ts
+++ b/src/__tests__/workflowLoader.test.ts
@@ -87,12 +87,20 @@ describe('isWorkflowPath', () => {
 
 describe('loadWorkflowByIdentifier', () => {
   let tempDir: string;
+  let previousConfigDir: string | undefined;
 
   beforeEach(() => {
+    previousConfigDir = process.env.TAKT_CONFIG_DIR;
     tempDir = mkdtempSync(join(tmpdir(), 'takt-test-'));
+    process.env.TAKT_CONFIG_DIR = join(tempDir, 'global-takt');
   });
 
   afterEach(() => {
+    if (previousConfigDir === undefined) {
+      delete process.env.TAKT_CONFIG_DIR;
+    } else {
+      process.env.TAKT_CONFIG_DIR = previousConfigDir;
+    }
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -111,7 +119,7 @@ describe('loadWorkflowByIdentifier', () => {
     expect(workflow!.name).toBe('test-workflow');
   });
 
-  it('should reject privileged system workflows loaded from arbitrary project paths', () => {
+  it('should load privileged system workflows from arbitrary project paths', () => {
     const filePath = join(tempDir, 'unsafe-system.yaml');
     writeFileSync(filePath, `name: unsafe-system
 initial_step: route_context
@@ -128,12 +136,14 @@ steps:
         next: COMPLETE
 `);
 
-    expect(() => loadWorkflowByIdentifier(filePath, tempDir)).toThrow(
-      /Project workflow ".*unsafe-system\.yaml" cannot use privileged system execution/,
-    );
+    const workflow = loadWorkflowByIdentifier(filePath, tempDir);
+
+    expect(workflow).not.toBeNull();
+    expect(workflow!.name).toBe('unsafe-system');
+    expect(workflow!.steps[0]?.kind).toBe('system');
   });
 
-  it('should reject privileged system workflows loaded from arbitrary relative project paths', () => {
+  it('should load privileged system workflows from arbitrary relative project paths', () => {
     writeFileSync(join(tempDir, 'unsafe-system.yaml'), `name: unsafe-system
 initial_step: route_context
 max_steps: 2
@@ -149,12 +159,14 @@ steps:
         next: COMPLETE
 `);
 
-    expect(() => loadWorkflowByIdentifier('./unsafe-system.yaml', tempDir)).toThrow(
-      /Project workflow ".*unsafe-system\.yaml" cannot use privileged system execution/,
-    );
+    const workflow = loadWorkflowByIdentifier('./unsafe-system.yaml', tempDir);
+
+    expect(workflow).not.toBeNull();
+    expect(workflow!.name).toBe('unsafe-system');
+    expect(workflow!.steps[0]?.kind).toBe('system');
   });
 
-  it('should reject allow_git_commit workflows loaded from arbitrary project absolute paths', () => {
+  it('should load allow_git_commit workflows from arbitrary project absolute paths', () => {
     const filePath = join(tempDir, 'unsafe-commit.yaml');
     writeFileSync(filePath, `name: unsafe-commit
 initial_step: implement
@@ -167,12 +179,14 @@ steps:
     instruction: "{task}"
 `);
 
-    expect(() => loadWorkflowByIdentifier(filePath, tempDir)).toThrow(
-      /Project workflow ".*unsafe-commit\.yaml" cannot use allow_git_commit in step "implement"/,
-    );
+    const workflow = loadWorkflowByIdentifier(filePath, tempDir);
+
+    expect(workflow).not.toBeNull();
+    expect(workflow!.name).toBe('unsafe-commit');
+    expect(workflow!.steps[0]?.allowGitCommit).toBe(true);
   });
 
-  it('should reject allow_git_commit workflows loaded from arbitrary project relative paths', () => {
+  it('should load allow_git_commit workflows from arbitrary project relative paths', () => {
     writeFileSync(join(tempDir, 'unsafe-commit.yaml'), `name: unsafe-commit
 initial_step: implement
 max_steps: 2
@@ -184,12 +198,14 @@ steps:
     instruction: "{task}"
 `);
 
-    expect(() => loadWorkflowByIdentifier('./unsafe-commit.yaml', tempDir)).toThrow(
-      /Project workflow ".*unsafe-commit\.yaml" cannot use allow_git_commit in step "implement"/,
-    );
+    const workflow = loadWorkflowByIdentifier('./unsafe-commit.yaml', tempDir);
+
+    expect(workflow).not.toBeNull();
+    expect(workflow!.name).toBe('unsafe-commit');
+    expect(workflow!.steps[0]?.allowGitCommit).toBe(true);
   });
 
-  it('should reject system-input workflows loaded from arbitrary project paths', () => {
+  it('should load system-input workflows from arbitrary project paths', () => {
     const filePath = join(tempDir, 'unsafe-system-inputs.yaml');
     writeFileSync(filePath, `name: unsafe-system-inputs
 initial_step: route_context
@@ -207,9 +223,11 @@ steps:
         next: COMPLETE
 `);
 
-    expect(() => loadWorkflowByIdentifier(filePath, tempDir)).toThrow(
-      /Project workflow ".*unsafe-system-inputs\.yaml" cannot use privileged system execution/,
-    );
+    const workflow = loadWorkflowByIdentifier(filePath, tempDir);
+
+    expect(workflow).not.toBeNull();
+    expect(workflow!.name).toBe('unsafe-system-inputs');
+    expect(workflow!.steps[0]?.kind).toBe('system');
   });
 
   it('should load workflow by relative path', () => {
@@ -579,6 +597,49 @@ steps:
     expect(workflow).not.toBeNull();
     expect(workflow!.name).toBe('auto-improvement-loop');
     expect(workflow!.steps[0]?.effects).toEqual([{ type: 'merge_pr', pr: 42 }]);
+  });
+
+  it('should load privileged global workflows by name and preserve user source identity', () => {
+    const globalWorkflowsDir = join(process.env.TAKT_CONFIG_DIR!, 'workflows');
+    mkdirSync(globalWorkflowsDir, { recursive: true });
+    writeFileSync(join(globalWorkflowsDir, 'global-system.yaml'), `name: global-system
+description: global system workflow
+initial_step: route_context
+max_steps: 2
+
+steps:
+  - name: route_context
+    mode: system
+    effects:
+      - type: merge_pr
+        pr: 42
+    rules:
+      - when: "true"
+        next: COMPLETE
+`);
+
+    const workflow = loadWorkflowByIdentifier('global-system', tempDir);
+
+    expect(workflow).not.toBeNull();
+    expect(workflow!.name).toBe('global-system');
+    expect(workflow!.steps[0]?.kind).toBe('system');
+    expect(getWorkflowTrustInfo(workflow!, tempDir)).toMatchObject({
+      source: 'user',
+      isProjectTrustRoot: false,
+      isProjectWorkflowRoot: false,
+    });
+  });
+
+  it('should load builtin auto-improvement-loop by name and preserve builtin source identity', () => {
+    const workflow = loadWorkflowByIdentifier('auto-improvement-loop', tempDir);
+
+    expect(workflow).not.toBeNull();
+    expect(workflow!.name).toBe('auto-improvement-loop');
+    expect(getWorkflowTrustInfo(workflow!, tempDir)).toMatchObject({
+      source: 'builtin',
+      isProjectTrustRoot: false,
+      isProjectWorkflowRoot: false,
+    });
   });
 
   it('should load privileged project-local workflows loaded by path', () => {

--- a/src/__tests__/workflowTrustBoundary.test.ts
+++ b/src/__tests__/workflowTrustBoundary.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 
 import * as workflowTrustBoundary from '../infra/config/loaders/workflowTrustBoundary.js';
 import { loadWorkflowByIdentifier } from '../infra/config/index.js';
-import { attachWorkflowSourcePath, attachWorkflowTrustInfo } from '../infra/config/loaders/workflowSourceMetadata.js';
+import { attachWorkflowTrustInfo } from '../infra/config/loaders/workflowSourceMetadata.js';
 
 describe('workflowTrustBoundary', () => {
   let projectDir: string;
@@ -29,80 +29,9 @@ describe('workflowTrustBoundary', () => {
     expect(workflowTrustBoundary).not.toHaveProperty('getWorkflowCallNamedLookupSources');
   });
 
-  it('should treat kind system steps as privileged when enforcing project trust boundary', () => {
-    expect(() => workflowTrustBoundary.validateProjectWorkflowTrustBoundaryForSteps(
-      [{ name: 'route', kind: 'system' }],
-      join(projectDir, 'outside.yaml'),
-      { isProjectWorkflowRoot: false },
-    )).toThrow('Project workflow');
-  });
-
-  it('should treat allow_git_commit steps as privileged when enforcing project trust boundary', () => {
-    expect(() => workflowTrustBoundary.validateProjectWorkflowTrustBoundaryForSteps(
-      [{ name: 'implement', allowGitCommit: true }],
-      join(projectDir, 'outside.yaml'),
-      { isProjectWorkflowRoot: false },
-    )).toThrow('cannot use allow_git_commit');
-  });
-
-  it('rejects allow_git_commit workflow execution outside the project workflows root', () => {
-    const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
-      name: 'external-committer',
-      steps: [
-        {
-          name: 'implement',
-          kind: 'agent',
-          persona: 'coder',
-          personaDisplayName: 'coder',
-          instruction: 'Implement the task',
-          allowGitCommit: true,
-          passPreviousResponse: true,
-        },
-      ],
-      initialStep: 'implement',
-      maxSteps: 3,
-    }, join(externalDir, 'external-committer.yaml')), {
-      source: 'external',
-      sourcePath: join(externalDir, 'external-committer.yaml'),
-      isProjectTrustRoot: false,
-      isProjectWorkflowRoot: false,
-    });
-
-    expect(() => workflowTrustBoundary.validateWorkflowExecutionTrustBoundary(
-      workflow,
-      projectDir,
-    )).toThrow(
-      `Workflow "${join(externalDir, 'external-committer.yaml')}" cannot use allow_git_commit in step "implement" outside the project workflows root`,
-    );
-  });
-
-  it('allows allow_git_commit workflow execution inside the project workflows root', () => {
-    const workflow = attachWorkflowTrustInfo(attachWorkflowSourcePath({
-      name: 'project-commit',
-      steps: [
-        {
-          name: 'implement',
-          kind: 'agent',
-          persona: 'coder',
-          personaDisplayName: 'coder',
-          instruction: 'Implement the task',
-          allowGitCommit: true,
-          passPreviousResponse: true,
-        },
-      ],
-      initialStep: 'implement',
-      maxSteps: 3,
-    }, join(projectDir, '.takt', 'workflows', 'project-commit.yaml')), {
-      source: 'project',
-      sourcePath: join(projectDir, '.takt', 'workflows', 'project-commit.yaml'),
-      isProjectTrustRoot: true,
-      isProjectWorkflowRoot: true,
-    });
-
-    expect(() => workflowTrustBoundary.validateWorkflowExecutionTrustBoundary(
-      workflow,
-      projectDir,
-    )).not.toThrow();
+  it('should keep load-time project workflow trust boundary private', () => {
+    expect(workflowTrustBoundary).not.toHaveProperty('validateProjectWorkflowTrustBoundary');
+    expect(workflowTrustBoundary).not.toHaveProperty('validateProjectWorkflowTrustBoundaryForSteps');
   });
 
   it('rejects privileged child when project parent is outside workflows root', () => {

--- a/src/features/tasks/execute/taskWorkflowExecution.ts
+++ b/src/features/tasks/execute/taskWorkflowExecution.ts
@@ -1,6 +1,5 @@
 import type { WorkflowConfig } from '../../../core/models/index.js';
 import { loadWorkflowByIdentifier, isWorkflowPath, resolveWorkflowConfigValues } from '../../../infra/config/index.js';
-import { validateWorkflowExecutionTrustBoundary } from '../../../infra/config/loaders/workflowTrustBoundary.js';
 import { resolveProviderOptionsWithTrace } from '../../../infra/config/resolveConfigValue.js';
 import { info, error } from '../../../shared/ui/index.js';
 import { createLogger } from '../../../shared/utils/index.js';
@@ -55,8 +54,6 @@ export async function executeTaskWorkflow(
     info('Specify a valid workflow when creating tasks (e.g., via "takt add").');
     return { success: false, reason: `Workflow "${safeWorkflowIdentifier}" not found.` };
   }
-  validateWorkflowExecutionTrustBoundary(workflowConfig, projectCwd);
-
   log.debug('Running workflow', {
     name: workflowConfig.name,
     steps: workflowConfig.steps.map((s: { name: string }) => s.name),

--- a/src/features/tasks/list/taskRetryActions.ts
+++ b/src/features/tasks/list/taskRetryActions.ts
@@ -9,7 +9,6 @@ import * as fs from 'node:fs';
 import type { TaskListItem } from '../../../infra/task/index.js';
 import { TaskRunner, resolveTaskWorkflowValue } from '../../../infra/task/index.js';
 import { loadWorkflowByIdentifier, resolveWorkflowConfigValue, getWorkflowDescription } from '../../../infra/config/index.js';
-import { validateWorkflowExecutionTrustBoundary } from '../../../infra/config/loaders/workflowTrustBoundary.js';
 import { selectOptionWithDefault } from '../../../shared/prompt/index.js';
 import { info, header, blankLine, status, warn } from '../../../shared/ui/index.js';
 import { createLogger } from '../../../shared/utils/index.js';
@@ -214,8 +213,6 @@ export async function retryFailedTask(
   if (!workflowConfig) {
     throw new Error(`Workflow "${sanitizeTerminalText(selectedWorkflow)}" not found after selection.`);
   }
-  validateWorkflowExecutionTrustBoundary(workflowConfig, projectDir);
-
   const resumePoint = resolveRetryResumePoint(task, runMeta);
   const selectedStep = await selectStartStep(
     workflowConfig,

--- a/src/infra/config/loaders/workflowDoctor.ts
+++ b/src/infra/config/loaders/workflowDoctor.ts
@@ -16,8 +16,7 @@ import {
 } from './workflowLookupDirectories.js';
 import { isWorkflowPath, validateWorkflowCallContracts } from './workflowResolver.js';
 import { loadWorkflowFileWithResolutionOptions } from './workflowResolvedLoader.js';
-import { getWorkflowTrustInfo, type WorkflowTrustSource } from './workflowTrustSource.js';
-import { validateWorkflowExecutionTrustBoundary } from './workflowTrustBoundary.js';
+import type { WorkflowTrustSource } from './workflowTrustSource.js';
 import {
   type FacetResolutionContext,
   type WorkflowSections,
@@ -203,9 +202,6 @@ export function inspectWorkflowFile(
     const lookupCwd = options?.lookupCwd ?? projectDir;
     try {
       const workflow = loadWorkflowForDoctorValidation(filePath, projectDir, raw, options);
-      if (getWorkflowTrustInfo(workflow, projectDir).source !== 'builtin') {
-        validateWorkflowExecutionTrustBoundary(workflow, projectDir);
-      }
       validateWorkflowCallContracts(workflow, projectDir, lookupCwd, { allowPathBasedCalls: false });
     } catch (error) {
       return {

--- a/src/infra/config/loaders/workflowFileLoader.ts
+++ b/src/infra/config/loaders/workflowFileLoader.ts
@@ -65,8 +65,6 @@ function loadWorkflowFromFileInternal(
     resolveWorkflowRuntimePreparePolicy(globalConfig.workflowRuntimePrepare, projectConfig.workflowRuntimePrepare),
     resolveWorkflowArpeggioPolicy(globalConfig.workflowArpeggio, projectConfig.workflowArpeggio),
     resolveWorkflowMcpServersPolicy(globalConfig.workflowMcpServers, projectConfig.workflowMcpServers),
-    filePath,
-    trustInfo,
     options?.callableArgs,
     options?.callableArgPolicy,
     loadMode,

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -7,7 +7,6 @@ import { WorkflowConfigRawSchema } from '../../../core/models/index.js';
 import type { WorkflowConfig, WorkflowStep, WorkflowSubworkflowConfig } from '../../../core/models/index.js';
 import { resolveLoopMonitorJudgeProviderModel, resolveStepProviderModel } from '../../../core/workflow/provider-resolution.js';
 import { validateProviderModelCompatibility } from '../../../core/workflow/provider-model-compatibility.js';
-import { isPathSafe } from '../paths.js';
 import { normalizeRuntime } from '../configNormalizers.js';
 import type { FacetResolutionContext, WorkflowSections } from './resource-resolver.js';
 import {
@@ -24,8 +23,6 @@ import {
   type WorkflowCallArgResolutionPolicy,
 } from './workflowCallableArgResolver.js';
 import { prepareCallableSubworkflowDiscoveryArgs } from './workflowCallableDiscoveryArgs.js';
-import { validateProjectWorkflowTrustBoundaryForSteps } from './workflowTrustBoundary.js';
-import { getWorkflowPathTrustInfo, type WorkflowTrustInfo } from './workflowTrustSource.js';
 
 function normalizeSubworkflowConfig(
   raw: ReturnType<typeof WorkflowConfigRawSchema.parse>['subworkflow'],
@@ -62,8 +59,6 @@ export function normalizeWorkflowConfig(
   workflowRuntimePreparePolicy?: WorkflowRuntimePrepareConfig,
   workflowArpeggioPolicy?: WorkflowArpeggioConfig,
   workflowMcpServersPolicy?: WorkflowMcpServersConfig,
-  workflowPath = workflowDir,
-  trustInfo?: WorkflowTrustInfo,
   callableArgs?: Record<string, string | string[]>,
   callableArgPolicy?: WorkflowCallArgResolutionPolicy,
   callableArgMode: 'runtime' | 'discovery' = 'runtime',
@@ -104,16 +99,6 @@ export function normalizeWorkflowConfig(
     parsed.workflow_config?.model,
     parsed.workflow_config?.provider_options,
   );
-  if (trustInfo?.isProjectTrustRoot) {
-    validateProjectWorkflowTrustBoundaryForSteps(parsed.steps, workflowPath, trustInfo);
-  } else if (!trustInfo && context?.projectDir && isPathSafe(context.projectDir, workflowDir)) {
-    validateProjectWorkflowTrustBoundaryForSteps(
-      parsed.steps,
-      workflowPath,
-      getWorkflowPathTrustInfo(workflowPath, context.projectDir),
-    );
-  }
-
   const steps: WorkflowStep[] = parsed.steps.map((step) =>
     normalizeStepFromRaw(
       step,

--- a/src/infra/config/loaders/workflowResolvedLoader.ts
+++ b/src/infra/config/loaders/workflowResolvedLoader.ts
@@ -1,7 +1,6 @@
 import type { WorkflowConfig } from '../../../core/models/index.js';
 import type { WorkflowCallArgResolutionPolicy } from './workflowCallableArgResolver.js';
 import { loadWorkflowFromFile, loadWorkflowFromFileForDiscovery } from './workflowFileLoader.js';
-import { validateProjectWorkflowTrustBoundary } from './workflowTrustBoundary.js';
 import {
   resolveWorkflowTrustInfo,
   type WorkflowTrustInfo,
@@ -50,10 +49,6 @@ export function loadWorkflowFileWithResolutionOptions(
     callableArgs: options.callableArgs,
     callableArgPolicy: buildWorkflowCallArgPolicy(options.parentTrustInfo, trustInfo),
   });
-
-  if (trustInfo.source === 'project') {
-    validateProjectWorkflowTrustBoundary(workflow, filePath, options.projectCwd);
-  }
 
   return workflow;
 }

--- a/src/infra/config/loaders/workflowTrustBoundary.ts
+++ b/src/infra/config/loaders/workflowTrustBoundary.ts
@@ -1,6 +1,5 @@
 import type { WorkflowConfig } from '../../../core/models/index.js';
 import { getWorkflowStepKind } from '../../../core/models/workflow-step-kind.js';
-import { getWorkflowSourcePath } from './workflowSourceMetadata.js';
 import { getWorkflowTrustInfo, type WorkflowTrustInfo } from './workflowTrustSource.js';
 
 type SystemStepLike = Parameters<typeof getWorkflowStepKind>[0] & {
@@ -46,86 +45,8 @@ function findPrivilegedCapability(steps: SystemStepLike[]): PrivilegedCapability
   return undefined;
 }
 
-function buildPrivilegedExecutionError(filePath: string, capability: PrivilegedCapability, scope: 'workflow' | 'project'): Error {
-  if (capability.reason === 'system') {
-    const subject = scope === 'project' ? 'Project workflow' : 'Workflow';
-    return new Error(
-      `${subject} "${filePath}" cannot use privileged system execution in step "${capability.step.name}" outside the project workflows root`,
-    );
-  }
-
-  const subject = scope === 'project' ? 'Project workflow' : 'Workflow';
-  return new Error(
-    `${subject} "${filePath}" cannot use allow_git_commit in step "${capability.step.name}" outside the project workflows root`,
-  );
-}
-
-function validateWorkflowExecutionTrustBoundaryInternal(
-  workflow: WorkflowConfig,
-  filePath: string,
-  trustInfo: Pick<WorkflowTrustInfo, 'isProjectWorkflowRoot'>,
-): void {
-  const privilegedCapability = findPrivilegedCapability(workflow.steps);
-  if (privilegedCapability && !trustInfo.isProjectWorkflowRoot) {
-    throw buildPrivilegedExecutionError(filePath, privilegedCapability, 'workflow');
-  }
-
-  if (hasPrivilegedRuntimePrepare(workflow) && !trustInfo.isProjectWorkflowRoot) {
-    throw new Error(
-      `Workflow "${filePath}" cannot use workflow-level runtime.prepare outside the project workflows root`,
-    );
-  }
-}
-
-export function findPrivilegedSystemStep<T extends SystemStepLike>(steps: T[]): T | undefined {
+function findPrivilegedSystemStep<T extends SystemStepLike>(steps: T[]): T | undefined {
   return steps.find((step) => getWorkflowStepKind(step) === 'system');
-}
-
-export function validateProjectWorkflowTrustBoundaryForSteps(
-  steps: SystemStepLike[],
-  filePath: string,
-  trustInfo: Pick<WorkflowTrustInfo, 'isProjectWorkflowRoot'>,
-): void {
-  const privilegedCapability = findPrivilegedCapability(steps);
-  if (!privilegedCapability) {
-    return;
-  }
-
-  if (trustInfo.isProjectWorkflowRoot) {
-    return;
-  }
-
-  if (privilegedCapability.reason === 'system') {
-    throw new Error(
-      `Project workflow "${filePath}" cannot use privileged system execution in step "${privilegedCapability.step.name}"`,
-    );
-  }
-
-  throw new Error(
-    `Project workflow "${filePath}" cannot use allow_git_commit in step "${privilegedCapability.step.name}"`,
-  );
-}
-
-export function validateProjectWorkflowTrustBoundary(
-  workflow: WorkflowConfig,
-  filePath: string,
-  projectCwd: string,
-): void {
-  const trustInfo = getWorkflowTrustInfo(workflow, projectCwd);
-  if (!trustInfo.isProjectTrustRoot) {
-    return;
-  }
-
-  validateProjectWorkflowTrustBoundaryForSteps(workflow.steps, filePath, trustInfo);
-}
-
-export function validateWorkflowExecutionTrustBoundary(
-  workflow: WorkflowConfig,
-  projectCwd: string,
-): void {
-  const filePath = getWorkflowSourcePath(workflow) ?? workflow.name;
-  const trustInfo = getWorkflowTrustInfo(workflow, projectCwd);
-  validateWorkflowExecutionTrustBoundaryInternal(workflow, filePath, trustInfo);
 }
 
 export function validateWorkflowCallTrustBoundary(


### PR DESCRIPTION
## Summary

## 背景

`auto-improvement-loop` のような orchestration workflow は `mode: system` を使い、PR / Issue / task queue を観測し、必要に応じて `enqueue_task` / `merge_pr` / `close_pr` などの effect を実行する。

現在の実装では、`mode: system` / `allow_git_commit` / workflow-level `runtime.prepare` を含む workflow が **project の `.takt/workflows/` 配下**にない場合、実行時 trust boundary で拒否される。

そのため、次のような自然な使い方ができない。

- builtin の `auto-improvement-loop` をそのまま実行する
- `~/.takt/workflows/` に置いた global workflow を複数 repo で使い回す
- ユーザーが自作した orchestration workflow を global に定義して再利用する

これは「ユーザーが workflow を定義できる」「global workflow を再利用できる」という TAKT の体験と衝突している。

## 現状の問題

現在の guard は、特権 workflow を project workflow root に強く結びつけすぎている。

- `mode: system` を含む builtin workflow が、builtin として選ばれても拒否され得る
- `~/.takt/workflows/` の user workflow では `mode: system` を使えない
- 対話式 workflow 選択で builtin の path が渡ると、さらに外部 YAML 扱いになって拒否される
- 結果として、`auto-improvement-loop` のような reusable orchestration workflow を配布・共有・再利用しづらい

`mode: system` は確かに副作用を持つが、TAKT の workflow として明示的に選択されたものまで project root 限定にする必要はない。ユーザーが workflow を選んで実行している以上、global workflow も通常の workflow 定義として扱えるべき。

## 方針

`mode: system` を project `.takt/workflows/` 限定にする現在の実行時拒否を廃止または緩和する。

少なくとも次を許可する。

- builtin workflow の `mode: system`
- project `.takt/workflows/` の `mode: system`
- global `~/.takt/workflows/` の `mode: system`

一方で、任意の外部パスをどう扱うかは明確にする。

推奨方針:

- 名前解決された builtin / project / global workflow は許可する
- 明示的な任意 path workflow も、ユーザーが指定しているなら許可してよい
- もし path だけは保護を残す場合でも、少なくとも builtin / global を拒否しない
- 対話式選択では workflow identity を壊さず、builtin/global/project の source を保持する

## 修正対象の観点

- `workflowTrustBoundary` の `mode: system` 実行拒否条件を見直す
- `getWorkflowTrustInfo` / workflow source metadata が builtin / user / project を正しく保持することを確認する
- workflow 選択 UI が builtin workflow を絶対パスの外部 workflow として渡さないようにする
- `auto-improvement-loop` を builtin として選択・実行できるようにする
- global user workflow に `mode: system` を書いても拒否されないようにする

## 受け入れ条件

- builtin `auto-improvement-loop` を対話式選択から実行しても、`cannot use privileged system execution ... outside the project workflows root` で落ちない
- `--workflow auto-improvement-loop` でも同様に落ちない
- `~/.takt/workflows/` に置いた `mode: system` workflow を名前指定で実行できる
- project `.takt/workflows/` の `mode: system` workflow は引き続き実行できる
- workflow selection / loader / execution の各経路で source identity が保持される
- 不要になった project-root-only 前提のテストは更新または削除される

## テスト観点

- builtin `auto-improvement-loop` を loader 経由で読み、実行 trust boundary で拒否されない
- 対話式 workflow selection で builtin `auto-improvement-loop` を選んだ場合、実行側に外部 path ではなく正しい workflow identity / source が渡る
- global `~/.takt/workflows/global-system.yaml` に `mode: system` を含め、名前指定で実行できる
- project `.takt/workflows/project-system.yaml` の既存許可挙動が壊れない
- 旧仕様の「project workflow root 外の `mode: system` は拒否する」前提のテストを、今回の新仕様に合わせて更新する

## やらないこと

- `auto-improvement-loop` のルーティング仕様自体はこの Issue では変えない
- PR / Issue / queue の dedupe 仕様はこの Issue では扱わない
- workflow DSL の effect 種類追加はこの Issue では扱わない
- global workflow の UX 改善や一覧表示の再設計は、必要なら別 Issue で扱う

## Execution Report

Workflow `takt-default` completed successfully.

Closes #691