### PR TITLE
Release v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.39.0] - 2026-05-02
+
+### Added
+
+- Facet inheritance with `{extends:<parent>}` syntax added (#690). File-based facets can extend a parent facet of the same kind; the parent is resolved through the facet kind and layer order, with self-reference exclusion and circular detection both done by source path. Applies to instructions, policies, knowledge, output contracts, and loop monitor judge instructions. The parent name must be a bare facet name (no path or `@scope` references); persona facets do not support inheritance
+- Step-level `allow_git_commit` field added (#587). Opt-in flag (default `false`) that removes the standard "do not run git add / commit / push" prohibition injected into Phase 1 / Phase 2 instructions. Useful for workflows that consume many issues per task and need to commit per work unit
+- `default-mini` builtin workflow added: a lightweight variant of `default` with `write_tests` removed (`plan -> implement -> AI antipattern review -> parallel review -> complete`). Registered to both Quick Start and Mini categories and the builtin catalog
+- Run checkpoint resume added (#568). `.takt/runs/<slug>/meta.json` now records `currentStep` / `phase` / `iterations` / `resumePoint` continuously during run execution, and `tasks.yaml` accepts `start_step` (with `start_movement` retained as a backward-compatible alias) so interrupted runs resume from the last known step on retry
+- Agent failure categorization added (#678). Team leader part failures now distinguish `external_abort` / `part_timeout` / `provider_error` / `stream_idle_timeout` and surface the category in the trace report, session log, and aggregated error message instead of a generic "execution aborted". Codex client preserves abort cause (`timeout` / `external`) and propagates it through the failure detail
+
+### Changed
+
+- System-mode workflow execution is no longer restricted to the project workflows root (#691). `mode: system`, workflow-level `runtime.prepare`, and step `allow_git_commit: true` were previously rejected unless the workflow lived under `.takt/workflows/`. Builtin workflows (e.g. `auto-improvement-loop`) and user workflows under `~/.takt/workflows/` are now accepted, so reusable orchestration workflows can be installed globally and invoked by name. The previous workflow trust boundary that re-classified workflows by file path is removed in favour of the loader-confirmed `WorkflowTrustInfo`
+- `auto-improvement-loop` PR-branch action set simplified (#676). Removed `comment_on_pr` and `noop`; added `reject_pr`. The PR branch now chooses among `enqueue_from_pr` / `prepare_merge` / `reject_pr`. `reject_pr` closes the PR via `close_pr` effect without leaving a comment, deleting the branch, or re-enqueueing the task. The `pr-followup-task` schema enum was updated accordingly
+- `auto-improvement-loop` issue and fresh-planning paths tightened (#685). Removed `noop` from `plan_from_issue` and `plan_fresh_improvement`; planning instructions now explicitly reject low-value, cosmetic-only, ambiguous, or duplicate tasks and require concrete deliverables and completion conditions. The `followup-task` schema action enum is reduced to `enqueue_new_task` / `wait_before_next_scan`
+- Rate-limit cause is preserved through workflow abort (#569). When a Claude rate limit is observed in provider events, downstream phase / parallel / workflow errors now surface as `Rate limit exceeded. Please try again later.` instead of the generic `Claude Code process exited with code 1`. `AgentResponse.errorKind` is normalized at the provider boundary so session resume / report-phase retry paths no longer flatten the cause
+
+### Fixed
+
+- OpenCode shared server processes no longer leak after takt exit (#550). The server kept running in the background after `takt` terminated, accumulating across runs. Cleanup now runs on takt exit so OpenCode provider sessions release their server processes deterministically
+- Interactive `/go` works without prior conversation history (#680). `/go` could fail when there was no preceding dialog; the first input now flows directly into workflow execution while existing dialog-driven flows are preserved
+- `takt watch` stdin handlers cleaned up after stop. The immediate-SIGINT-exit installer now returns a cleanup hook that runs after `parseAsync` and slash-fallback paths, so stdin handlers installed for watch are released and process termination is no longer blocked
+- Interactive mode now shows progress feedback while the AI is responding. `Assistant is thinking...` is displayed after each user input is sent, and `Creating instruction...` is displayed while `/go` summarizes the conversation, so the user is no longer left wondering whether takt is hung. Stdin is paused for the duration of these calls. LF (`\n`) now submits the line in the multiline input editor in addition to CR (`\r`), so pasted text and `\n`-terminated inputs commit cleanly; `Shift+Enter` (CSI `13;2u`) remains the way to insert a literal newline
+
 ## [0.38.0] - 2026-04-25
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,30 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.39.0] - 2026-05-02
+
+### Added
+
+- ファセット継承構文 `{extends:<parent>}` を追加 (#690)。ファイル由来のファセットが同じ種類の親ファセットを継承できるようになった。親はファセット種別とレイヤ順で解決し、自己参照除外と循環検知はソースパスベースで行う。instructions / policies / knowledge / output contracts / loop monitor の judge instructions に適用される。親名は bare なファセット名のみ（path 参照や `@scope` 参照は不可）、persona ファセットは継承非対応
+- step レベルの `allow_git_commit` フィールドを追加 (#587)。Phase 1 / Phase 2 のインストラクションに注入される「git add / commit / push を実行しない」制約を、step 単位でオプトイン解除できる（デフォルト `false`）。1 つのタスクで多数の issue を消化するワークフローなど、作業単位ごとに git commit したいユースケースに使う
+- ビルトイン workflow `default-mini` を追加。`default` から `write_tests` を抜いたミニ版（`plan -> implement -> AI antipattern review -> parallel review -> complete`）。Quick Start カテゴリと Mini カテゴリ、builtin カタログに登録
+- run チェックポイント再開を追加 (#568)。run 実行中の `currentStep` / `phase` / `iterations` / `resumePoint` を `.takt/runs/<slug>/meta.json` に継続的に保存するようになり、`tasks.yaml` が `start_step`（`start_movement` は後方互換のエイリアスとして保持）を受け付けることで中断 run の再開時に最後に動いていた step から続行できる
+- エージェント失敗のカテゴリ分類を追加 (#678)。team leader part の失敗を `external_abort` / `part_timeout` / `provider_error` / `stream_idle_timeout` に分類し、trace report / session log / 集約エラーメッセージに分類を残すようになった。これまで「execution aborted」に潰れていた原因が判別可能になる。Codex クライアントは abort cause（`timeout` / `external`）を保持し、failure detail に伝搬する
+
+### Changed
+
+- `mode: system` ワークフローを project workflows root の外でも実行できるように緩和 (#691)。`mode: system` / workflow-level `runtime.prepare` / step `allow_git_commit: true` は従来 `.takt/workflows/` 配下でないと拒否されていたが、ビルトイン workflow（`auto-improvement-loop` 等）と `~/.takt/workflows/` 配下の global workflow を許可するようになった。再利用可能な orchestration workflow を global に置いて名前指定で実行できる。path-based に workflow を再分類していた旧 trust boundary は撤去され、loader 確定済みの `WorkflowTrustInfo` を後段でも使うようにした
+- `auto-improvement-loop` の PR 分岐 action セットを整理 (#676)。`comment_on_pr` と `noop` を削除し、`reject_pr` を追加。PR 分岐の選択肢は `enqueue_from_pr` / `prepare_merge` / `reject_pr` の 3 種に固定。`reject_pr` は `close_pr` effect で PR を close するのみで、コメント追加・ブランチ削除・タスク再エンキューは行わない。`pr-followup-task` schema の enum も同期して更新
+- `auto-improvement-loop` の Issue 分岐 / fresh planning を強化 (#685)。`plan_from_issue` / `plan_fresh_improvement` から `noop` を削除し、planning instruction で低価値・cosmetic-only・曖昧・既存 PR / Issue と重複するタスクを明示的に拒否、具体的な成果物・完了条件を必須化。`followup-task` schema の action enum は `enqueue_new_task` / `wait_before_next_scan` の 2 種に縮小
+- レートリミット原因を workflow abort 経由でも保持 (#569)。Claude のレートリミットが provider events で観測された場合、後段の phase / parallel / workflow エラー表示が generic な `Claude Code process exited with code 1` ではなく `Rate limit exceeded. Please try again later.` として残るようになった。`AgentResponse.errorKind` を provider 境界で正規化することで、session resume / report phase retry 経路でも原因が潰れない
+
+### Fixed
+
+- OpenCode 共有サーバーが takt 終了後に残り続ける問題を修正 (#550)。OpenCode provider を使った takt の終了後、opencode サーバープロセスがバックグラウンドで残ってリソースを消費し続ける状態だった。takt 終了時に共有サーバーを deterministic にクリーンアップするようになった
+- 対話モードの `/go` が事前会話履歴なしでも動作するように修正 (#680)。会話履歴が空の状態で `/go` を実行すると失敗していたが、初回入力をそのままワークフロー実行に渡せるようになった。既存の対話ありフローは維持
+- `takt watch` 停止後の stdin ハンドラ未解放を修正。即時 SIGINT exit インストーラーが cleanup フックを返すように変更し、`parseAsync` / slash fallback いずれの経路でも cleanup を呼ぶようにしたため、watch が組み込んだ stdin ハンドラが解放されてプロセス終了がブロックされなくなった
+- 対話モードに AI 応答中の進捗表示を追加。ユーザー入力送信後は `Assistant is thinking...`、`/go` での会話要約中は `Creating instruction...` を表示するようになり、takt が固まっているように見える状態を解消した。AI 呼び出し中は stdin を pause する。多段入力エディタの送信キーが CR (`\r`) に加えて LF (`\n`) でも反応するようになり、貼り付けや `\n` 終端の入力もそのまま送信される。改行を入力したい場合は `Shift+Enter`（CSI `13;2u`）を使う
+
 ## [0.38.0] - 2026-04-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Workflow Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- Facet inheritance with `{extends:<parent>}` syntax added (#690). File-based facets can extend a parent facet of the same kind; the parent is resolved through the facet kind and layer order, with self-reference exclusion and circular detection both done by source path. Applies to instructions, policies, knowledge, output contracts, and loop monitor judge instructions. The parent name must be a bare facet name (no path or `@scope` references); persona facets do not support inheritance
- Step-level `allow_git_commit` field added (#587). Opt-in flag (default `false`) that removes the standard "do not run git add / commit / push" prohibition injected into Phase 1 / Phase 2 instructions. Useful for workflows that consume many issues per task and need to commit per work unit
- `default-mini` builtin workflow added: a lightweight variant of `default` with `write_tests` removed (`plan -> implement -> AI antipattern review -> parallel review -> complete`). Registered to both Quick Start and Mini categories and the builtin catalog
- Run checkpoint resume added (#568). `.takt/runs/<slug>/meta.json` now records `currentStep` / `phase` / `iterations` / `resumePoint` continuously during run execution, and `tasks.yaml` accepts `start_step` (with `start_movement` retained as a backward-compatible alias) so interrupted runs resume from the last known step on retry
- Agent failure categorization added (#678). Team leader part failures now distinguish `external_abort` / `part_timeout` / `provider_error` / `stream_idle_timeout` and surface the category in the trace report, session log, and aggregated error message instead of a generic "execution aborted". Codex client preserves abort cause (`timeout` / `external`) and propagates it through the failure detail

### Changed

- System-mode workflow execution is no longer restricted to the project workflows root (#691). `mode: system`, workflow-level `runtime.prepare`, and step `allow_git_commit: true` were previously rejected unless the workflow lived under `.takt/workflows/`. Builtin workflows (e.g. `auto-improvement-loop`) and user workflows under `~/.takt/workflows/` are now accepted, so reusable orchestration workflows can be installed globally and invoked by name. The previous workflow trust boundary that re-classified workflows by file path is removed in favour of the loader-confirmed `WorkflowTrustInfo`
- `auto-improvement-loop` PR-branch action set simplified (#676). Removed `comment_on_pr` and `noop`; added `reject_pr`. The PR branch now chooses among `enqueue_from_pr` / `prepare_merge` / `reject_pr`. `reject_pr` closes the PR via `close_pr` effect without leaving a comment, deleting the branch, or re-enqueueing the task. The `pr-followup-task` schema enum was updated accordingly
- `auto-improvement-loop` issue and fresh-planning paths tightened (#685). Removed `noop` from `plan_from_issue` and `plan_fresh_improvement`; planning instructions now explicitly reject low-value, cosmetic-only, ambiguous, or duplicate tasks and require concrete deliverables and completion conditions. The `followup-task` schema action enum is reduced to `enqueue_new_task` / `wait_before_next_scan`
- Rate-limit cause is preserved through workflow abort (#569). When a Claude rate limit is observed in provider events, downstream phase / parallel / workflow errors now surface as `Rate limit exceeded. Please try again later.` instead of the generic `Claude Code process exited with code 1`. `AgentResponse.errorKind` is normalized at the provider boundary so session resume / report-phase retry paths no longer flatten the cause

### Fixed

- OpenCode shared server processes no longer leak after takt exit (#550). The server kept running in the background after `takt` terminated, accumulating across runs. Cleanup now runs on takt exit so OpenCode provider sessions release their server processes deterministically
- Interactive `/go` works without prior conversation history (#680). `/go` could fail when there was no preceding dialog; the first input now flows directly into workflow execution while existing dialog-driven flows are preserved
- `takt watch` stdin handlers cleaned up after stop. The immediate-SIGINT-exit installer now returns a cleanup hook that runs after `parseAsync` and slash-fallback paths, so stdin handlers installed for watch are released and process termination is no longer blocked
- Interactive mode now shows progress feedback while the AI is responding. `Assistant is thinking...` is displayed after each user input is sent, and `Creating instruction...` is displayed while `/go` summarizes the conversation, so the user is no longer left wondering whether takt is hung. Stdin is paused for the duration of these calls. LF (`\n`) now submits the line in the multiline input editor in addition to CR (`\r`), so pasted text and `\n`-terminated inputs commit cleanly; `Shift+Enter` (CSI `13;2u`) remains the way to insert a literal newline

## Commits

- 9c278d48 fix: clarify interactive input progress
- b7597ad9 takt: fix-opencode-server-cleanup (#689)
- 1c13b295 takt: allow-system-workflows (#692)
- d56d496c feat: add facet inheritance (#690)
- 681f3c06 fix: clean up watch stdin after stop
- 53bb4b1d takt: tighten-planning-noop-removal (#687)
- 66283f1f takt: add-allow-git-commit (#686)
- dc913f27 takt: simplify-pr-actions (#683)
- 357ee0c5 [#678] improve-abort-observability (#684)
- 7bbb7dbc takt: add-default-mini-workflow
- 831002a5 takt: preserve-rate-limit-cause (#674)
- c4bd7ca2 takt: add-run-checkpoint-resume (#675)
- c32c099f takt: fix-go-without-history (#680)