### PR TITLE
[#707] fix-codex-structured-output

### DIFF
--- a/src/__tests__/codex-structured-output.test.ts
+++ b/src/__tests__/codex-structured-output.test.ts
@@ -72,6 +72,91 @@ describe('CodexClient — structuredOutput 抽出', () => {
     expect(result.structuredOutput).toEqual({ step: 2, reason: 'approved' });
   });
 
+  it('複数の agent_message JSON がある場合は最後の JSON を structuredOutput として返す', async () => {
+    const schema = { type: 'object', properties: { step: { type: 'integer' } } };
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      {
+        type: 'item.completed',
+        item: { id: 'msg-1', type: 'agent_message', text: '{"step": 1, "reason": "stale"}' },
+      },
+      {
+        type: 'item.completed',
+        item: { id: 'msg-2', type: 'agent_message', text: '{"step": 2, "reason": "final"}' },
+      },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    const result = await client.call('coder', 'prompt', { cwd: '/tmp', outputSchema: schema });
+
+    expect(result.status).toBe('done');
+    expect(result.structuredOutput).toEqual({ step: 2, reason: 'final' });
+  });
+
+  it('最後の agent_message が JSON でない場合は途中の JSON を structuredOutput として採用しない', async () => {
+    const schema = { type: 'object', properties: { step: { type: 'integer' } } };
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      {
+        type: 'item.completed',
+        item: { id: 'msg-1', type: 'agent_message', text: '{"step": 1, "reason": "stale"}' },
+      },
+      {
+        type: 'item.completed',
+        item: { id: 'msg-2', type: 'agent_message', text: 'plain text final response' },
+      },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    const result = await client.call('coder', 'prompt', { cwd: '/tmp', outputSchema: schema });
+
+    expect(result.status).toBe('done');
+    expect(result.structuredOutput).toBeUndefined();
+  });
+
+  it('item.updated の agent_message JSON は structuredOutput として採用しない', async () => {
+    const schema = { type: 'object', properties: { step: { type: 'integer' } } };
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      {
+        type: 'item.updated',
+        item: { id: 'msg-1', type: 'agent_message', text: '{"step": 1, "reason": "draft"}' },
+      },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    const result = await client.call('coder', 'prompt', { cwd: '/tmp', outputSchema: schema });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('{"step": 1, "reason": "draft"}');
+    expect(result.structuredOutput).toBeUndefined();
+  });
+
+  it('複数の agent_message がある場合も content は全テキストを改行連結して返す', async () => {
+    const schema = { type: 'object', properties: { step: { type: 'integer' } } };
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      {
+        type: 'item.completed',
+        item: { id: 'msg-1', type: 'agent_message', text: '{"step": 1, "reason": "stale"}' },
+      },
+      {
+        type: 'item.completed',
+        item: { id: 'msg-2', type: 'agent_message', text: '{"step": 2, "reason": "final"}' },
+      },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    const result = await client.call('coder', 'prompt', { cwd: '/tmp', outputSchema: schema });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('{"step": 1, "reason": "stale"}\n{"step": 2, "reason": "final"}');
+  });
+
   it('outputSchema なしの場合はテキストを JSON パースしない', async () => {
     mockEvents = [
       { type: 'thread.started', thread_id: 'thread-1' },

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -288,6 +288,7 @@ export class CodexClient {
         diag.onConnected();
 
         let content = '';
+        let lastAgentMessageText = '';
         const contentOffsets = new Map<string, number>();
         let success = true;
         let failureMessage = '';
@@ -362,6 +363,7 @@ export class CodexClient {
               if (item.type === 'agent_message' && typeof item.text === 'string') {
                 const itemId = item.id;
                 const text = item.text;
+                lastAgentMessageText = text;
                 if (itemId) {
                   const prev = contentOffsets.get(itemId) ?? 0;
                   if (text.length > prev) {
@@ -416,7 +418,7 @@ export class CodexClient {
         }
 
         const trimmed = content.trim();
-        const structuredOutput = parseStructuredOutput(trimmed, !!options.outputSchema);
+        const structuredOutput = parseStructuredOutput(lastAgentMessageText.trim(), !!options.outputSchema);
         emitResult(options.onStream, true, trimmed, currentThreadId);
 
         const response: AgentResponse = {


### PR DESCRIPTION
## Summary

## 背景

`auto-improvement-loop` を Codex provider で実行中、`plan_from_issue` が次のエラーで abort した。

```text
Step "plan_from_issue" requires structured_output for provider "codex": Structured output response is missing
```

対象 run:

```text
/Users/nrs/work/git/takt-auto-improvement-sandbox/.takt/runs/20260508-124839-auto-improvement-loop-pr-issue/logs/20260508-214839-215eq8-provider-events.jsonl
```

## 観測事実

`provider-events.jsonl` では `text` event が 4 回出ている。

```text
12:49:51 text  {"action":"wait_before_next_scan","task_markdown":"","issue":{"create":false,"labels":[]}}
12:49:54 text  {"action":"wait_before_next_scan","task_markdown":"","issue":{"create":false,"labels":[]}}
12:50:04 text  {"action":"wait_before_next_scan","task_markdown":"","issue":{"create":false,"labels":[]}}
12:50:49 text  {"action":"enqueue_new_task", ... ,"issue":{"create":false,"labels":[]}}
```

最後の `text` event は valid な structured output になっている。

しかし最終 `result` は、複数の `agent_message` text を改行連結した形になっている。

```text
{"action":"wait_before_next_scan",...}
{"action":"wait_before_next_scan",...}
{"action":"wait_before_next_scan",...}
{"action":"enqueue_new_task",...}
```

これは JSON object として parse できないため、TAKT 側で `structuredOutput` が `undefined` になり、workflow が abort している。

## 問題

`src/infra/codex/client.ts` は Codex stream の `agent_message` text を `content` に蓄積し、最後に `parseStructuredOutput(trimmed, true)` で連結済み全文を structured output として parse している。

Codex stream では、tool use 前後や暫定応答により、structured output 形式の `agent_message` が複数回出ることがある。この場合、連結済み全文は JSONL のような形になり、1 個の JSON object としては不正になる。

## 目標

Codex provider の structured output 抽出を、連結済み `content` ではなく `agent_message` 単位で扱えるようにする。

## 推奨方針

`outputSchema` がある場合、通常表示用の `content` 連結は維持しつつ、structured output 用には最後の `agent_message.text` を別に保持して parse する。

推奨は「最後に parse 成功した JSON」ではなく、「最後の agent_message を parse する」こと。

理由:

- 途中の古い `wait_before_next_scan` を誤採用しないため
- 最終応答が JSON でない場合は、正しく structured output missing として失敗させるため
- 通常の `content` 出力や provider event logging への影響を最小にできるため

概念例:

```ts
let lastAgentMessageText = '';

if (item.type === 'agent_message' && typeof item.text === 'string') {
  lastAgentMessageText = item.text;
  content += ...; // 従来通り
}

const structuredOutput = options.outputSchema
  ? parseStructuredOutput(lastAgentMessageText, true)
  : undefined;
```

## 受け入れ条件

- Codex provider で `outputSchema` がある場合、複数の `agent_message` text が出ても最後の valid structured output を採用できる
- 通常の `content` 連結・表示・ログ出力は従来通り維持される
- `outputSchema` がない場合は、JSON っぽい text を structured output として parse しない
- 最後の `agent_message.text` が JSON でない場合、途中の古い JSON を誤採用しない
- `auto-improvement-loop` の `plan_from_issue` が今回のような複数 `text` event で abort しない

## テスト観点

- `src/__tests__/codex-structured-output.test.ts`
  - 単一 `agent_message` JSON は従来通り `structuredOutput` として返る
  - 複数 `agent_message` JSON がある場合、最後の JSON を採用する
  - 最後の `agent_message` が JSON でない場合、途中の JSON を採用せず `structuredOutput` は `undefined` になる
  - `outputSchema` なしの場合は JSON text でも parse しない

## やらないこと

- Claude / Cursor / OpenCode の structured output 処理は変更しない
- workflow engine の validation 方針は変更しない
- `content` の連結仕様や provider event log の形式は変更しない
- auto-improvement-loop の workflow 分岐仕様はこの issue では変更しない

## Execution Report

Workflow `takt-default` completed successfully.

Closes #707