### PR TITLE
[#695] feat(team-leader): PromptBasedStructuredCaller の JSON パース失敗時にリトライする

### DIFF
--- a/src/__tests__/delay.test.ts
+++ b/src/__tests__/delay.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { delay } from '../shared/utils/delay.js';
+
+describe('delay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not resolve before the timeout elapses', async () => {
+    const resolved = vi.fn();
+    void delay(1000).then(resolved);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(resolved).not.toHaveBeenCalled();
+  });
+
+  it('resolves once the timeout elapses', async () => {
+    const resolved = vi.fn();
+    void delay(1000).then(resolved);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves with undefined', async () => {
+    const promise = delay(50);
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('resolves immediately for ms = 0', async () => {
+    const resolved = vi.fn();
+    void delay(0).then(resolved);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/structured-caller-prompt-based.test.ts
+++ b/src/__tests__/structured-caller-prompt-based.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockRunAgent } = vi.hoisted(() => ({
   mockRunAgent: vi.fn(),
@@ -14,6 +14,12 @@ import { resolveStructuredStep } from '../agents/structured-caller/shared.js';
 describe('PromptBasedStructuredCaller', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    mockRunAgent.mockReset();
   });
 
   it('should evaluate conditions from [JUDGE:N] tags without outputSchema', async () => {
@@ -196,6 +202,103 @@ describe('PromptBasedStructuredCaller', () => {
         workflowMeta,
       }),
     );
+  });
+
+  it('should retry decomposeTask when first response has no JSON block and succeed on second attempt', async () => {
+    mockRunAgent
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: 'no json here',
+        timestamp: new Date(),
+      })
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify([
+            { id: 'p1', title: 'First task', instruction: 'Do the first thing' },
+          ]),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      });
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.decomposeTask('break down the work', 3, {
+      cwd: '/tmp/project',
+      provider: 'cursor',
+      persona: 'team-leader',
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([
+      { id: 'p1', title: 'First task', instruction: 'Do the first thing' },
+    ]);
+  });
+
+  it('should retry decomposeTask when first response is an empty array and succeed on second attempt', async () => {
+    mockRunAgent
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: '```json\n[]\n```',
+        timestamp: new Date(),
+      })
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify([
+            { id: 'p1', title: 'Recovered', instruction: 'Do it' },
+          ]),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      });
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.decomposeTask('break down the work', 3, {
+      cwd: '/tmp/project',
+      provider: 'cursor',
+      persona: 'team-leader',
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([
+      { id: 'p1', title: 'Recovered', instruction: 'Do it' },
+    ]);
+  });
+
+  it('should throw decomposeTask after three consecutive failures', async () => {
+    const failingResponse = {
+      persona: 'leader',
+      status: 'done',
+      content: 'never any json',
+      timestamp: new Date(),
+    };
+    mockRunAgent
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse);
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.decomposeTask('break down the work', 3, {
+      cwd: '/tmp/project',
+      provider: 'cursor',
+      persona: 'team-leader',
+    });
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(2000);
+    await assertion;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(3);
   });
 
   it('should parse additional parts from fenced JSON without outputSchema', async () => {

--- a/src/__tests__/structured-caller-prompt-based.test.ts
+++ b/src/__tests__/structured-caller-prompt-based.test.ts
@@ -429,6 +429,125 @@ describe('PromptBasedStructuredCaller', () => {
     );
   });
 
+  it('should retry requestMoreParts when first response has no JSON block and succeed on second attempt', async () => {
+    mockRunAgent
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: 'no json here',
+        timestamp: new Date(),
+      })
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify({
+            done: false,
+            reasoning: 'retry succeeded',
+            parts: [
+              { id: 'p2', title: 'Follow up', instruction: 'Handle remaining gap' },
+            ],
+          }),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      });
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.requestMoreParts(
+      'original task',
+      [{ id: 'p1', title: 'First', status: 'done', content: 'done' }],
+      ['p1'],
+      2,
+      { cwd: '/tmp/project', provider: 'cursor' },
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      done: false,
+      reasoning: 'retry succeeded',
+      parts: [
+        { id: 'p2', title: 'Follow up', instruction: 'Handle remaining gap' },
+      ],
+    });
+  });
+
+  it('should retry requestMoreParts when first response fails structural validation and succeed on second attempt', async () => {
+    mockRunAgent
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify({ done: 'not-bool', reasoning: 'x', parts: [] }),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      })
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify({
+            done: true,
+            reasoning: 'recovered',
+            parts: [],
+          }),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      });
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.requestMoreParts(
+      'original task',
+      [{ id: 'p1', title: 'First', status: 'done', content: 'done' }],
+      ['p1'],
+      2,
+      { cwd: '/tmp/project', provider: 'cursor' },
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      done: true,
+      reasoning: 'recovered',
+      parts: [],
+    });
+  });
+
+  it('should throw requestMoreParts after three consecutive failures', async () => {
+    const failingResponse = {
+      persona: 'leader',
+      status: 'done',
+      content: 'never any json',
+      timestamp: new Date(),
+    };
+    mockRunAgent
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse);
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.requestMoreParts(
+      'original task',
+      [{ id: 'p1', title: 'First', status: 'done', content: 'done' }],
+      ['p1'],
+      2,
+      { cwd: '/tmp/project', provider: 'cursor' },
+    );
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(2000);
+    await assertion;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(3);
+  });
+
   it('should return auto_select without calling agent when only one rule exists', async () => {
     const caller = new PromptBasedStructuredCaller();
     const result = await caller.judgeStatus(

--- a/src/__tests__/structured-caller-prompt-based.test.ts
+++ b/src/__tests__/structured-caller-prompt-based.test.ts
@@ -459,41 +459,6 @@ describe('PromptBasedStructuredCaller', () => {
     );
   });
 
-  it('should log two retry attempts when decomposeTask fails three times', async () => {
-    const failingResponse = {
-      persona: 'leader',
-      status: 'done',
-      content: 'never any json',
-      timestamp: new Date(),
-    };
-    mockRunAgent
-      .mockResolvedValueOnce(failingResponse)
-      .mockResolvedValueOnce(failingResponse)
-      .mockResolvedValueOnce(failingResponse);
-
-    const caller = new PromptBasedStructuredCaller();
-    const promise = caller.decomposeTask('break down the work', 3, {
-      cwd: '/tmp/project',
-      provider: 'cursor',
-      persona: 'team-leader',
-    });
-    const assertion = expect(promise).rejects.toThrow(/```json \.\.\. ``` block/);
-    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS * 2);
-    await assertion;
-
-    expect(infoMock).toHaveBeenCalledTimes(2);
-    expect(infoMock).toHaveBeenNthCalledWith(
-      1,
-      'Structured call failed, retrying',
-      expect.objectContaining({ attempt: 1, maxAttempts: 3 }),
-    );
-    expect(infoMock).toHaveBeenNthCalledWith(
-      2,
-      'Structured call failed, retrying',
-      expect.objectContaining({ attempt: 2, maxAttempts: 3 }),
-    );
-  });
-
   it('should parse additional parts from fenced JSON without outputSchema', async () => {
     mockRunAgent.mockResolvedValue({
       persona: 'leader',
@@ -838,6 +803,43 @@ describe('PromptBasedStructuredCaller', () => {
 
     expect(mockRunAgent).toHaveBeenCalledTimes(3);
     expect(result).toEqual({ done: true, reasoning: 'late ok', parts: [] });
+  });
+
+  it('should log two retry attempts when requestMoreParts fails three times', async () => {
+    const failingResponse = {
+      persona: 'leader',
+      status: 'done',
+      content: 'never any json',
+      timestamp: new Date(),
+    };
+    mockRunAgent
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse);
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.requestMoreParts(
+      'original task',
+      [{ id: 'p1', title: 'First', status: 'done', content: 'done' }],
+      ['p1'],
+      2,
+      { cwd: '/tmp/project', provider: 'cursor' },
+    );
+    const assertion = expect(promise).rejects.toThrow(/```json \.\.\. ``` block/);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS * 2);
+    await assertion;
+
+    expect(infoMock).toHaveBeenCalledTimes(2);
+    expect(infoMock).toHaveBeenNthCalledWith(
+      1,
+      'Structured call failed, retrying',
+      expect.objectContaining({ attempt: 1, maxAttempts: 3 }),
+    );
+    expect(infoMock).toHaveBeenNthCalledWith(
+      2,
+      'Structured call failed, retrying',
+      expect.objectContaining({ attempt: 2, maxAttempts: 3 }),
+    );
   });
 
   it('should return auto_select without calling agent when only one rule exists', async () => {

--- a/src/__tests__/structured-caller-prompt-based.test.ts
+++ b/src/__tests__/structured-caller-prompt-based.test.ts
@@ -294,11 +294,112 @@ describe('PromptBasedStructuredCaller', () => {
       provider: 'cursor',
       persona: 'team-leader',
     });
-    const assertion = expect(promise).rejects.toThrow();
+    const assertion = expect(promise).rejects.toThrow(/```json \.\.\. ``` block/);
     await vi.advanceTimersByTimeAsync(2000);
     await assertion;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(3);
+  });
+
+  it('should retry decomposeTask when first response status is error and succeed on second attempt', async () => {
+    mockRunAgent
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'error',
+        content: '',
+        error: 'provider failed',
+        timestamp: new Date(),
+      })
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify([
+            { id: 'p1', title: 'Recovered', instruction: 'Do it' },
+          ]),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      });
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.decomposeTask('break down the work', 3, {
+      cwd: '/tmp/project',
+      provider: 'cursor',
+      persona: 'team-leader',
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([
+      { id: 'p1', title: 'Recovered', instruction: 'Do it' },
+    ]);
+  });
+
+  it('should throw decomposeTask after three consecutive status:error responses with original detail', async () => {
+    const failingResponse = {
+      persona: 'leader',
+      status: 'error',
+      content: '',
+      error: 'provider blew up',
+      timestamp: new Date(),
+    };
+    mockRunAgent
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse);
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.decomposeTask('break down the work', 3, {
+      cwd: '/tmp/project',
+      provider: 'cursor',
+      persona: 'team-leader',
+    });
+    const assertion = expect(promise).rejects.toThrow(/Team leader failed: provider blew up/);
+    await vi.advanceTimersByTimeAsync(2000);
+    await assertion;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(3);
+  });
+
+  it('should succeed decomposeTask on the third attempt (boundary case)', async () => {
+    const failingResponse = {
+      persona: 'leader',
+      status: 'done',
+      content: 'no json here',
+      timestamp: new Date(),
+    };
+    mockRunAgent
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify([
+            { id: 'p1', title: 'Late success', instruction: 'Done' },
+          ]),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      });
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.decomposeTask('break down the work', 3, {
+      cwd: '/tmp/project',
+      provider: 'cursor',
+      persona: 'team-leader',
+    });
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(3);
+    expect(result).toEqual([
+      { id: 'p1', title: 'Late success', instruction: 'Done' },
+    ]);
   });
 
   it('should parse additional parts from fenced JSON without outputSchema', async () => {
@@ -541,11 +642,110 @@ describe('PromptBasedStructuredCaller', () => {
       2,
       { cwd: '/tmp/project', provider: 'cursor' },
     );
-    const assertion = expect(promise).rejects.toThrow();
+    const assertion = expect(promise).rejects.toThrow(/```json \.\.\. ``` block/);
     await vi.advanceTimersByTimeAsync(2000);
     await assertion;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(3);
+  });
+
+  it('should retry requestMoreParts when first response status is error and succeed on second attempt', async () => {
+    mockRunAgent
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'error',
+        content: '',
+        error: 'provider failed',
+        timestamp: new Date(),
+      })
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify({ done: true, reasoning: 'recovered', parts: [] }),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      });
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.requestMoreParts(
+      'original task',
+      [{ id: 'p1', title: 'First', status: 'done', content: 'done' }],
+      ['p1'],
+      2,
+      { cwd: '/tmp/project', provider: 'cursor' },
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ done: true, reasoning: 'recovered', parts: [] });
+  });
+
+  it('should throw requestMoreParts after three consecutive status:error responses with original detail', async () => {
+    const failingResponse = {
+      persona: 'leader',
+      status: 'error',
+      content: '',
+      error: 'provider blew up',
+      timestamp: new Date(),
+    };
+    mockRunAgent
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse);
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.requestMoreParts(
+      'original task',
+      [{ id: 'p1', title: 'First', status: 'done', content: 'done' }],
+      ['p1'],
+      2,
+      { cwd: '/tmp/project', provider: 'cursor' },
+    );
+    const assertion = expect(promise).rejects.toThrow(/Team leader feedback failed: provider blew up/);
+    await vi.advanceTimersByTimeAsync(2000);
+    await assertion;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(3);
+  });
+
+  it('should succeed requestMoreParts on the third attempt (boundary case)', async () => {
+    const failingResponse = {
+      persona: 'leader',
+      status: 'done',
+      content: 'no json here',
+      timestamp: new Date(),
+    };
+    mockRunAgent
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify({ done: true, reasoning: 'late ok', parts: [] }),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      });
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.requestMoreParts(
+      'original task',
+      [{ id: 'p1', title: 'First', status: 'done', content: 'done' }],
+      ['p1'],
+      2,
+      { cwd: '/tmp/project', provider: 'cursor' },
+    );
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+
+    expect(mockRunAgent).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({ done: true, reasoning: 'late ok', parts: [] });
   });
 
   it('should return auto_select without calling agent when only one rule exists', async () => {

--- a/src/__tests__/structured-caller-prompt-based.test.ts
+++ b/src/__tests__/structured-caller-prompt-based.test.ts
@@ -9,6 +9,7 @@ vi.mock('../agents/runner.js', () => ({
 }));
 
 import { PromptBasedStructuredCaller } from '../agents/structured-caller.js';
+import { RETRY_DELAY_MS } from '../agents/structured-caller/prompt-based-structured-caller.js';
 import { resolveStructuredStep } from '../agents/structured-caller/shared.js';
 
 describe('PromptBasedStructuredCaller', () => {
@@ -231,7 +232,7 @@ describe('PromptBasedStructuredCaller', () => {
       provider: 'cursor',
       persona: 'team-leader',
     });
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
     const result = await promise;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(2);
@@ -267,7 +268,7 @@ describe('PromptBasedStructuredCaller', () => {
       provider: 'cursor',
       persona: 'team-leader',
     });
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
     const result = await promise;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(2);
@@ -295,7 +296,7 @@ describe('PromptBasedStructuredCaller', () => {
       persona: 'team-leader',
     });
     const assertion = expect(promise).rejects.toThrow(/```json \.\.\. ``` block/);
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS * 2);
     await assertion;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(3);
@@ -329,7 +330,7 @@ describe('PromptBasedStructuredCaller', () => {
       provider: 'cursor',
       persona: 'team-leader',
     });
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
     const result = await promise;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(2);
@@ -358,7 +359,7 @@ describe('PromptBasedStructuredCaller', () => {
       persona: 'team-leader',
     });
     const assertion = expect(promise).rejects.toThrow(/Team leader failed: provider blew up/);
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS * 2);
     await assertion;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(3);
@@ -393,7 +394,7 @@ describe('PromptBasedStructuredCaller', () => {
       provider: 'cursor',
       persona: 'team-leader',
     });
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS * 2);
     const result = await promise;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(3);
@@ -563,7 +564,7 @@ describe('PromptBasedStructuredCaller', () => {
       2,
       { cwd: '/tmp/project', provider: 'cursor' },
     );
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
     const result = await promise;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(2);
@@ -611,7 +612,7 @@ describe('PromptBasedStructuredCaller', () => {
       2,
       { cwd: '/tmp/project', provider: 'cursor' },
     );
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
     const result = await promise;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(2);
@@ -643,7 +644,7 @@ describe('PromptBasedStructuredCaller', () => {
       { cwd: '/tmp/project', provider: 'cursor' },
     );
     const assertion = expect(promise).rejects.toThrow(/```json \.\.\. ``` block/);
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS * 2);
     await assertion;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(3);
@@ -677,7 +678,7 @@ describe('PromptBasedStructuredCaller', () => {
       2,
       { cwd: '/tmp/project', provider: 'cursor' },
     );
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
     const result = await promise;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(2);
@@ -706,7 +707,7 @@ describe('PromptBasedStructuredCaller', () => {
       { cwd: '/tmp/project', provider: 'cursor' },
     );
     const assertion = expect(promise).rejects.toThrow(/Team leader feedback failed: provider blew up/);
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS * 2);
     await assertion;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(3);
@@ -741,7 +742,7 @@ describe('PromptBasedStructuredCaller', () => {
       2,
       { cwd: '/tmp/project', provider: 'cursor' },
     );
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS * 2);
     const result = await promise;
 
     expect(mockRunAgent).toHaveBeenCalledTimes(3);

--- a/src/__tests__/structured-caller-prompt-based.test.ts
+++ b/src/__tests__/structured-caller-prompt-based.test.ts
@@ -1,7 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockRunAgent } = vi.hoisted(() => ({
-  mockRunAgent: vi.fn(),
+const { mockRunAgent, infoMock, createLoggerMock } = vi.hoisted(() => {
+  const infoMock = vi.fn();
+  const createLoggerMock = vi.fn(() => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: infoMock,
+    error: vi.fn(),
+    enter: vi.fn(),
+    exit: vi.fn(),
+  }));
+  return {
+    mockRunAgent: vi.fn(),
+    infoMock,
+    createLoggerMock,
+  };
+});
+
+vi.mock('../shared/utils/debug.js', () => ({
+  createLogger: createLoggerMock,
 }));
 
 vi.mock('../agents/runner.js', () => ({
@@ -401,6 +418,80 @@ describe('PromptBasedStructuredCaller', () => {
     expect(result).toEqual([
       { id: 'p1', title: 'Late success', instruction: 'Done' },
     ]);
+  });
+
+  it('should log one retry attempt when decomposeTask succeeds on second attempt', async () => {
+    mockRunAgent
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: 'no json here',
+        timestamp: new Date(),
+      })
+      .mockResolvedValueOnce({
+        persona: 'leader',
+        status: 'done',
+        content: [
+          '```json',
+          JSON.stringify([{ id: 'p1', title: 'Recovered', instruction: 'Do it' }]),
+          '```',
+        ].join('\n'),
+        timestamp: new Date(),
+      });
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.decomposeTask('break down the work', 3, {
+      cwd: '/tmp/project',
+      provider: 'cursor',
+      persona: 'team-leader',
+    });
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    await promise;
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+    expect(infoMock).toHaveBeenCalledWith(
+      'Structured call failed, retrying',
+      expect.objectContaining({
+        attempt: 1,
+        maxAttempts: 3,
+        error: expect.stringContaining('```json ... ``` block'),
+      }),
+    );
+  });
+
+  it('should log two retry attempts when decomposeTask fails three times', async () => {
+    const failingResponse = {
+      persona: 'leader',
+      status: 'done',
+      content: 'never any json',
+      timestamp: new Date(),
+    };
+    mockRunAgent
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse)
+      .mockResolvedValueOnce(failingResponse);
+
+    const caller = new PromptBasedStructuredCaller();
+    const promise = caller.decomposeTask('break down the work', 3, {
+      cwd: '/tmp/project',
+      provider: 'cursor',
+      persona: 'team-leader',
+    });
+    const assertion = expect(promise).rejects.toThrow(/```json \.\.\. ``` block/);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS * 2);
+    await assertion;
+
+    expect(infoMock).toHaveBeenCalledTimes(2);
+    expect(infoMock).toHaveBeenNthCalledWith(
+      1,
+      'Structured call failed, retrying',
+      expect.objectContaining({ attempt: 1, maxAttempts: 3 }),
+    );
+    expect(infoMock).toHaveBeenNthCalledWith(
+      2,
+      'Structured call failed, retrying',
+      expect.objectContaining({ attempt: 2, maxAttempts: 3 }),
+    );
   });
 
   it('should parse additional parts from fenced JSON without outputSchema', async () => {

--- a/src/__tests__/team-leader-runner-structured-caller.test.ts
+++ b/src/__tests__/team-leader-runner-structured-caller.test.ts
@@ -871,4 +871,139 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       expect(executedInstruction).not.toContain('Do NOT run git add');
     }
   });
+
+  describe('onPhaseStart deduplication on decomposeTask retry', () => {
+    function buildRunner(
+      structuredCaller: {
+        decomposeTask: ReturnType<typeof vi.fn>;
+        requestMoreParts: ReturnType<typeof vi.fn>;
+      },
+      onPhaseStart: ReturnType<typeof vi.fn>,
+    ) {
+      return new TeamLeaderRunner({
+        optionsBuilder: {
+          buildAgentOptions: vi.fn().mockReturnValue({ cwd: '/tmp/project' }),
+          buildBaseOptions: vi.fn().mockReturnValue({}),
+          buildPhase1WorkflowMeta: vi.fn().mockReturnValue(undefined),
+          resolveStepProviderModel: vi.fn().mockReturnValue({
+            provider: 'claude',
+            model: 'opus',
+          }),
+        },
+        stepExecutor: {
+          buildInstruction: vi.fn().mockReturnValue('leader instruction'),
+          applyPostExecutionPhases: vi.fn(async (_step, _state, _iteration, response) => response),
+          persistPreviousResponseSnapshot: vi.fn(),
+          emitStepReports: vi.fn(),
+        },
+        engineOptions: {
+          projectCwd: '/tmp/project',
+          structuredCaller,
+        },
+        onPhaseStart,
+        getCwd: () => '/tmp/project',
+        getInteractive: () => false,
+      } as ConstructorParameters<typeof TeamLeaderRunner>[0] & {
+        engineOptions: { projectCwd: string; structuredCaller: typeof structuredCaller };
+      });
+    }
+
+    function buildStep(): WorkflowStep {
+      return {
+        name: 'implement',
+        persona: 'coder',
+        personaDisplayName: 'coder',
+        instruction: 'Task: {task}',
+        passPreviousResponse: true,
+        teamLeader: {
+          persona: 'team-leader',
+          maxParts: 1,
+          refillThreshold: 0,
+          timeoutMs: 1000,
+          partPersona: 'coder',
+        },
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      };
+    }
+
+    function buildState(): WorkflowState {
+      return {
+        workflowName: 'workflow',
+        currentStep: 'implement',
+        iteration: 1,
+        stepOutputs: new Map(),
+        structuredOutputs: new Map(),
+        systemContexts: new Map(),
+        effectResults: new Map(),
+        lastOutput: undefined,
+        previousResponseSourcePath: undefined,
+        userInputs: [],
+        personaSessions: new Map(),
+        stepIterations: new Map(),
+        status: 'running',
+      };
+    }
+
+    it('emits onPhaseStart only once even when decomposeTask retries (onPromptResolved fires multiple times)', async () => {
+      mockExecuteAgent.mockResolvedValue({
+        persona: 'coder',
+        status: 'done',
+        content: 'API done',
+        timestamp: new Date('2026-04-01T00:00:00.000Z'),
+      });
+
+      const onPhaseStart = vi.fn();
+      const structuredCaller = {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+          options.onPromptResolved?.({
+            systemPrompt: 'team-leader-system',
+            userInstruction: 'leader instruction',
+          });
+          options.onPromptResolved?.({
+            systemPrompt: 'team-leader-system',
+            userInstruction: 'leader instruction',
+          });
+          options.onPromptResolved?.({
+            systemPrompt: 'team-leader-system',
+            userInstruction: 'leader instruction',
+          });
+          return [{ id: 'part-1', title: 'API', instruction: 'Implement API' }];
+        }),
+        requestMoreParts: vi.fn().mockResolvedValue({ done: true, reasoning: 'enough', parts: [] }),
+      };
+
+      const runner = buildRunner(structuredCaller, onPhaseStart);
+
+      await runner.runTeamLeaderStep(buildStep(), buildState(), 'implement feature', 5, vi.fn());
+
+      expect(onPhaseStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits onPhaseStart only once on the success path (single onPromptResolved call)', async () => {
+      mockExecuteAgent.mockResolvedValue({
+        persona: 'coder',
+        status: 'done',
+        content: 'API done',
+        timestamp: new Date('2026-04-01T00:00:00.000Z'),
+      });
+
+      const onPhaseStart = vi.fn();
+      const structuredCaller = {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+          options.onPromptResolved?.({
+            systemPrompt: 'team-leader-system',
+            userInstruction: 'leader instruction',
+          });
+          return [{ id: 'part-1', title: 'API', instruction: 'Implement API' }];
+        }),
+        requestMoreParts: vi.fn().mockResolvedValue({ done: true, reasoning: 'enough', parts: [] }),
+      };
+
+      const runner = buildRunner(structuredCaller, onPhaseStart);
+
+      await runner.runTeamLeaderStep(buildStep(), buildState(), 'implement feature', 5, vi.fn());
+
+      expect(onPhaseStart).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -161,28 +161,31 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
     options: DecomposeTaskOptions,
   ): Promise<PartDefinition[]> {
     const prompt = buildPromptBasedDecomposePrompt(instruction, maxParts, options.language);
-    const response = await runAgent(options.persona, prompt, {
-      cwd: options.cwd,
-      personaPath: options.personaPath,
-      language: options.language,
-      model: options.model,
-      provider: options.provider,
-      resolvedModel: options.resolvedModel,
-      resolvedProvider: options.resolvedProvider,
-      allowedTools: [],
-      permissionMode: 'readonly',
-      maxTurns: TEAM_LEADER_MAX_TURNS,
-      onStream: options.onStream,
-      workflowMeta: options.workflowMeta,
-      onPromptResolved: options.onPromptResolved,
+
+    return withRetry(async () => {
+      const response = await runAgent(options.persona, prompt, {
+        cwd: options.cwd,
+        personaPath: options.personaPath,
+        language: options.language,
+        model: options.model,
+        provider: options.provider,
+        resolvedModel: options.resolvedModel,
+        resolvedProvider: options.resolvedProvider,
+        allowedTools: [],
+        permissionMode: 'readonly',
+        maxTurns: TEAM_LEADER_MAX_TURNS,
+        onStream: options.onStream,
+        workflowMeta: options.workflowMeta,
+        onPromptResolved: options.onPromptResolved,
+      });
+
+      if (response.status !== 'done') {
+        const detail = response.error || response.content || response.status;
+        throw new Error(`Team leader failed: ${detail}`);
+      }
+
+      return parseParts(response.content, maxParts);
     });
-
-    if (response.status !== 'done') {
-      const detail = response.error || response.content || response.status;
-      throw new Error(`Team leader failed: ${detail}`);
-    }
-
-    return parseParts(response.content, maxParts);
   }
 
   async requestMoreParts(
@@ -199,26 +202,51 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
       maxAdditionalParts,
       options.language,
     );
-    const response = await runAgent(options.persona, prompt, {
-      cwd: options.cwd,
-      personaPath: options.personaPath,
-      language: options.language,
-      model: options.model,
-      provider: options.provider,
-      resolvedModel: options.resolvedModel,
-      resolvedProvider: options.resolvedProvider,
-      allowedTools: [],
-      permissionMode: 'readonly',
-      maxTurns: TEAM_LEADER_MAX_TURNS,
-      onStream: options.onStream,
-      workflowMeta: options.workflowMeta,
+
+    return withRetry(async () => {
+      const response = await runAgent(options.persona, prompt, {
+        cwd: options.cwd,
+        personaPath: options.personaPath,
+        language: options.language,
+        model: options.model,
+        provider: options.provider,
+        resolvedModel: options.resolvedModel,
+        resolvedProvider: options.resolvedProvider,
+        allowedTools: [],
+        permissionMode: 'readonly',
+        maxTurns: TEAM_LEADER_MAX_TURNS,
+        onStream: options.onStream,
+        workflowMeta: options.workflowMeta,
+      });
+
+      if (response.status !== 'done') {
+        const detail = response.error || response.content || response.status;
+        throw new Error(`Team leader feedback failed: ${detail}`);
+      }
+
+      return toMorePartsResponse(parseLastJsonBlock(response.content), maxAdditionalParts);
     });
-
-    if (response.status !== 'done') {
-      const detail = response.error || response.content || response.status;
-      throw new Error(`Team leader feedback failed: ${detail}`);
-    }
-
-    return toMorePartsResponse(parseLastJsonBlock(response.content), maxAdditionalParts);
   }
+}
+
+const RETRY_MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 1000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withRetry<T>(runOnce: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= RETRY_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await runOnce();
+    } catch (error) {
+      lastError = error;
+      if (attempt < RETRY_MAX_ATTEMPTS) {
+        await delay(RETRY_DELAY_MS);
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -26,7 +26,7 @@ import { createLogger, delay, getErrorMessage } from '../../shared/utils/index.j
 
 const log = createLogger('prompt-based-structured-caller');
 
-export const RETRY_MAX_ATTEMPTS = 3;
+const RETRY_MAX_ATTEMPTS = 3;
 export const RETRY_DELAY_MS = 1000;
 
 export class PromptBasedStructuredCaller implements StructuredCaller {

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -22,7 +22,7 @@ import {
   resolveStructuredStep,
 } from './shared.js';
 import { parseParts } from '../../core/workflow/engine/task-decomposer.js';
-import { createLogger, delay } from '../../shared/utils/index.js';
+import { createLogger, delay, getErrorMessage } from '../../shared/utils/index.js';
 
 const log = createLogger('prompt-based-structured-caller');
 
@@ -246,11 +246,11 @@ async function withRetry<T>(runOnce: () => Promise<T>): Promise<T> {
         log.info('Structured call failed, retrying', {
           attempt,
           maxAttempts: RETRY_MAX_ATTEMPTS,
-          error: error instanceof Error ? error.message : String(error),
+          error: getErrorMessage(error),
         });
         await delay(RETRY_DELAY_MS);
       }
     }
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  throw lastError instanceof Error ? lastError : new Error(getErrorMessage(lastError));
 }

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -26,8 +26,8 @@ import { createLogger, delay, getErrorMessage } from '../../shared/utils/index.j
 
 const log = createLogger('prompt-based-structured-caller');
 
-const RETRY_MAX_ATTEMPTS = 3;
-const RETRY_DELAY_MS = 1000;
+export const RETRY_MAX_ATTEMPTS = 3;
+export const RETRY_DELAY_MS = 1000;
 
 export class PromptBasedStructuredCaller implements StructuredCaller {
   async judgeStatus(

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -22,7 +22,9 @@ import {
   resolveStructuredStep,
 } from './shared.js';
 import { parseParts } from '../../core/workflow/engine/task-decomposer.js';
-import { delay } from '../../shared/utils/index.js';
+import { createLogger, delay } from '../../shared/utils/index.js';
+
+const log = createLogger('prompt-based-structured-caller');
 
 const RETRY_MAX_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 1000;
@@ -241,6 +243,11 @@ async function withRetry<T>(runOnce: () => Promise<T>): Promise<T> {
     } catch (error) {
       lastError = error;
       if (attempt < RETRY_MAX_ATTEMPTS) {
+        log.info('Structured call failed, retrying', {
+          attempt,
+          maxAttempts: RETRY_MAX_ATTEMPTS,
+          error: error instanceof Error ? error.message : String(error),
+        });
         await delay(RETRY_DELAY_MS);
       }
     }

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -24,6 +24,9 @@ import {
 import { parseParts } from '../../core/workflow/engine/task-decomposer.js';
 import { delay } from '../../shared/utils/index.js';
 
+const RETRY_MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 1000;
+
 export class PromptBasedStructuredCaller implements StructuredCaller {
   async judgeStatus(
     structuredInstruction: string,
@@ -229,9 +232,6 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
     });
   }
 }
-
-const RETRY_MAX_ATTEMPTS = 3;
-const RETRY_DELAY_MS = 1000;
 
 async function withRetry<T>(runOnce: () => Promise<T>): Promise<T> {
   let lastError: unknown;

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -22,6 +22,7 @@ import {
   resolveStructuredStep,
 } from './shared.js';
 import { parseParts } from '../../core/workflow/engine/task-decomposer.js';
+import { delay } from '../../shared/utils/index.js';
 
 export class PromptBasedStructuredCaller implements StructuredCaller {
   async judgeStatus(
@@ -231,10 +232,6 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
 
 const RETRY_MAX_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 1000;
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 async function withRetry<T>(runOnce: () => Promise<T>): Promise<T> {
   let lastError: unknown;

--- a/src/core/workflow/engine/ArpeggioRunner.ts
+++ b/src/core/workflow/engine/ArpeggioRunner.ts
@@ -19,7 +19,7 @@ import type { RunAgentOptions } from '../../../agents/runner.js';
 import { executeAgent } from '../../../agents/agent-usecases.js';
 import { detectMatchedRule } from '../evaluation/index.js';
 import { incrementStepIteration } from './state-manager.js';
-import { createLogger } from '../../../shared/utils/index.js';
+import { createLogger, delay } from '../../../shared/utils/index.js';
 import type { OptionsBuilder } from './OptionsBuilder.js';
 import type { StepExecutor } from './StepExecutor.js';
 import type { PhaseName, PhasePromptParts } from '../types.js';
@@ -152,10 +152,6 @@ async function executeBatchWithRetry(
     success: false,
     error: lastError,
   };
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function buildArpeggioPrompt(

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -103,6 +103,7 @@ export class TeamLeaderRunner {
       workflowMeta: leaderWorkflowMeta,
       onStream: this.deps.engineOptions.onStream,
       onPromptResolved: (promptParts) => {
+        if (didEmitPhaseStart) return;
         this.deps.onPhaseStart?.(leaderStep, 1, 'execute', promptParts.userInstruction, promptParts, undefined, parentIteration);
         didEmitPhaseStart = true;
       },

--- a/src/shared/utils/delay.ts
+++ b/src/shared/utils/delay.ts
@@ -1,0 +1,3 @@
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './debug.js';
+export * from './delay.js';
 export * from './error.js';
 export * from './notification.js';
 export * from './pathBoundary.js';


### PR DESCRIPTION
Close #695
## Summary

## 方針

- 最大3回試行（初回 + 2回リトライ）
- リトライ間隔は 1 秒
- 全試行失敗で最後のエラーをそのままスロー（`Team leader failed: ...` / `Team leader feedback failed: ...` のフォーマットを維持）

呼び出し元の workflow engine 側からは、これまでの「1 回失敗 → 即 abort」が「3 連続失敗 → これまで通りの abort」に変わるだけで、エラーメッセージや status 種別は維持する。

## 実装

`decomposeTask` / `requestMoreParts` の処理本体を共通ヘルパー `withRetry(runOnce)` でラップする。

```ts
return withRetry(async () => {
  const response = await runAgent(...);
  if (response.status !== 'done') {
    throw new Error(`Team leader failed: ${detail}`);
  }
  return parseParts(response.content, maxParts);
});
```

`delay()` 関数は `ArpeggioRunner` と完全に重複していたため、`src/shared/utils/delay.ts` に切り出して両者で共有する。

## 修正対象

- src/agents/structured-caller/prompt-based-structured-caller.ts
  - decomposeTask / requestMoreParts を withRetry でラップ
  - RETRY_MAX_ATTEMPTS = 3, RETRY_DELAY_MS = 1000, withRetry を追加
- src/shared/utils/delay.ts (新規)
  - delay(ms): Promise<void> を切り出し
- src/shared/utils/index.ts
  - delay を re-export
- src/core/workflow/engine/ArpeggioRunner.ts
  - 自前の delay 関数を削除し、shared/utils から import するよう変更
- src/__tests__/structured-caller-prompt-based.test.ts
  - リトライ挙動の検証ケースを追加
- src/__tests__/delay.test.ts (新規)
  - shared/utils/ 配下の他モジュール（debug.test.ts / slug.test.ts / sleep.test.ts
  等）の流儀に合わせ、delay() のユニットテストを追加

## テスト

検証ケース:

- decomposeTaskのリトライ × 3 ケース
  - JSON 抽出失敗 → 2 回目で成功
  - status: error → 2 回目で成功
  - 3 連続失敗 → 例外スロー（元のエラー詳細を保持）
- requestMorePartsのリトライ × 3 ケース（同上）
- 境界ケース: 3 回目で成功するシナリオも検証
- delay() 単体: 経過前は未解決 / 経過後に解決 / ms = 0 の即時解決

リトライ間隔はvi.useFakeTimers() + vi.advanceTimersByTimeAsync()で仮想時間を進めているため、テスト実行時間は増えない。