### PR TITLE
docs: add External Integrations page (refs #589)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ await engine.run();
 | [Data Flow](./docs/data-flow.md) | Internal data flow and architecture diagrams |
 | [CI/CD Integration](./docs/ci-cd.md) | GitHub Actions and pipeline mode |
 | [Provider Sandbox & Permissions](./docs/provider-sandbox.md) | Sandbox, permission modes, and network access for Codex / OpenCode / Claude |
+| [External Integrations](./docs/external-integrations.md) | Community examples that extend TAKT without modifying core (audit trails, etc.) |
 | [Changelog](./CHANGELOG.md) ([日本語](./docs/CHANGELOG.ja.md)) | Version history |
 | [Security Policy](./SECURITY.md) | Vulnerability reporting |
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -273,6 +273,7 @@ await engine.run();
 | [データフロー](./data-flow.md) | 内部データフローとアーキテクチャ図 |
 | [CI/CD Integration](./ci-cd.ja.md) | GitHub Actions・パイプラインモード |
 | [Provider Sandbox & Permissions](./provider-sandbox.md) | Codex / OpenCode / Claude のサンドボックス、パーミッション、ネットワーク設定 |
+| [External Integrations](./external-integrations.ja.md) | TAKT コアを変更せずに機能を拡張するコミュニティサンプル（監査ログ等） |
 | [Changelog](../CHANGELOG.md) ([日本語](./CHANGELOG.ja.md)) | バージョン履歴 |
 | [Security Policy](../SECURITY.md) | 脆弱性の報告 |
 

--- a/docs/external-integrations.ja.md
+++ b/docs/external-integrations.ja.md
@@ -1,0 +1,11 @@
+# External Integrations
+
+TAKT のコアを変更せずに機能を拡張する、コミュニティメンテナンスのサンプル集です。TAKT として公式にサポート・推奨するものではありません。各プロジェクトのライセンス、依存関係、セキュリティ面を必ず確認した上で利用してください。
+
+ここに追加したい場合は、1 行の説明とパブリックリポジトリへのリンクを添えて PR を送ってください。
+
+## 監査ログ / レシート署名
+
+| 統合 | 説明 |
+|-----|------|
+| [ScopeBlind/examples/takt-workflow-receipts](https://github.com/ScopeBlind/examples/tree/main/takt-workflow-receipts) | `mcp_servers` で MCP サーバーを宣言する形で Ed25519 署名レシートと Cedar ポリシー検証を追加する。レシートは TAKT の NDJSON ログと並んで生成され、オフラインで検証可能。TAKT コアの変更不要。 |

--- a/docs/external-integrations.md
+++ b/docs/external-integrations.md
@@ -1,0 +1,11 @@
+# External Integrations
+
+Community-maintained examples that extend TAKT without modifying its core. They are not officially supported by TAKT, and inclusion in this list is not an endorsement — please review each project's license, dependencies, and security posture before adopting it.
+
+To add an integration here, open a PR with a one-line description and a link to a public repository.
+
+## Audit Trail / Receipt Signing
+
+| Integration | Description |
+|-------------|-------------|
+| [ScopeBlind/examples/takt-workflow-receipts](https://github.com/ScopeBlind/examples/tree/main/takt-workflow-receipts) | Adds Ed25519-signed receipts and Cedar policy enforcement via an MCP server declared in `mcp_servers`. Receipts sit alongside TAKT's NDJSON logs and can be verified offline. No TAKT core changes required. |


### PR DESCRIPTION
## Summary

Issue #589 で議論された Ed25519 receipt signing の Level 1 example が [ScopeBlind/examples/takt-workflow-receipts](https://github.com/ScopeBlind/examples/tree/main/takt-workflow-receipts) として完成しているので、TAKT コアには取り込まない方針のまま、docs に外部連携サンプルとして中立に参照を載せます。

## 背景

Issue #589 では Ed25519 署名レシートを TAKT に組み込む 3 段階の提案がありました：

- Level 1: \`mcp_servers\` で MCP サーバーとして宣言（コア改変ゼロ）
- Level 2: PieceEngine の event hook で署名（key management 等のスコープ拡大）
- Level 3: Repertoire パッケージとして配布

議論の結論は「Level 2/3 は TAKT のスコープを大きく超えるので external integration として扱う」でした。Level 1 example が完成したので、それを発見しやすくするための docs ページを追加します。

## 変更

### \`docs/external-integrations.md\` (en) / \`docs/external-integrations.ja.md\` (ja)

新規作成。冒頭で次を明示します：

- TAKT コアを変更せずに機能を拡張するコミュニティサンプル集
- 公式サポート・推奨ではない
- ライセンス・依存関係・セキュリティを利用者が確認すべき
- PR 歓迎

最初のエントリとして ScopeBlind/examples/takt-workflow-receipts を「監査ログ / レシート署名」カテゴリに掲載。

### \`README.md\` / \`docs/README.ja.md\`

Documentation テーブルに External Integrations 行を追加。

## 互換性

- ドキュメント追加のみ。コード変更なし
- TAKT コアの責任範囲は変わらない（外部サンプルへのリンクのみ）