### PR TITLE
[#724] add-base-branch-creation

### DIFF
--- a/builtins/en/workflows/auto-improvement-loop.yaml
+++ b/builtins/en/workflows/auto-improvement-loop.yaml
@@ -117,7 +117,11 @@ steps:
       - type: enqueue_task
         mode: new
         workflow: takt-default
-        base_branch: improve
+        base_branch:
+          name: improve
+          create_if_missing:
+            from: main
+            push: true
         task: "{structured:plan_from_issue.task_markdown}"
         issue: "{structured:plan_from_issue.issue}"
         worktree:
@@ -187,7 +191,11 @@ steps:
       - type: enqueue_task
         mode: new
         workflow: takt-default
-        base_branch: improve
+        base_branch:
+          name: improve
+          create_if_missing:
+            from: main
+            push: true
         task: "{structured:plan_fresh_improvement.task_markdown}"
         issue: "{structured:plan_fresh_improvement.issue}"
         worktree:
@@ -255,7 +263,11 @@ steps:
         mode: from_pr
         pr: "{context:route_context.selected_pr.number}"
         workflow: takt-default
-        base_branch: improve
+        base_branch:
+          name: improve
+          create_if_missing:
+            from: main
+            push: true
         task: "{structured:plan_from_existing_pr.task_markdown}"
     rules:
       - when: effect.enqueue_from_pr.enqueue_task.success == true
@@ -296,7 +308,11 @@ steps:
         mode: from_pr
         pr: "{context:route_context.selected_pr.number}"
         workflow: takt-default
-        base_branch: improve
+        base_branch:
+          name: improve
+          create_if_missing:
+            from: main
+            push: true
         task: |
           Resolve the conflicts raised while syncing the PR with its base branch.
           Target PR: {context:route_context.selected_pr.number}

--- a/builtins/ja/workflows/auto-improvement-loop.yaml
+++ b/builtins/ja/workflows/auto-improvement-loop.yaml
@@ -117,7 +117,11 @@ steps:
       - type: enqueue_task
         mode: new
         workflow: takt-default
-        base_branch: improve
+        base_branch:
+          name: improve
+          create_if_missing:
+            from: main
+            push: true
         task: "{structured:plan_from_issue.task_markdown}"
         issue: "{structured:plan_from_issue.issue}"
         worktree:
@@ -187,7 +191,11 @@ steps:
       - type: enqueue_task
         mode: new
         workflow: takt-default
-        base_branch: improve
+        base_branch:
+          name: improve
+          create_if_missing:
+            from: main
+            push: true
         task: "{structured:plan_fresh_improvement.task_markdown}"
         issue: "{structured:plan_fresh_improvement.issue}"
         worktree:
@@ -255,7 +263,11 @@ steps:
         mode: from_pr
         pr: "{context:route_context.selected_pr.number}"
         workflow: takt-default
-        base_branch: improve
+        base_branch:
+          name: improve
+          create_if_missing:
+            from: main
+            push: true
         task: "{structured:plan_from_existing_pr.task_markdown}"
     rules:
       - when: effect.enqueue_from_pr.enqueue_task.success == true
@@ -296,7 +308,11 @@ steps:
         mode: from_pr
         pr: "{context:route_context.selected_pr.number}"
         workflow: takt-default
-        base_branch: improve
+        base_branch:
+          name: improve
+          create_if_missing:
+            from: main
+            push: true
         task: |
           PR の base branch 取り込み時に発生したコンフリクトを解消すること。
           対象 PR: {context:route_context.selected_pr.number}

--- a/src/__tests__/addTask.test.ts
+++ b/src/__tests__/addTask.test.ts
@@ -45,6 +45,7 @@ vi.mock('../infra/task/index.js', async (importOriginal) => ({
 
 vi.mock('../infra/task/clone-base-branch.js', () => ({
   branchExists: vi.fn(),
+  createBaseBranchIfMissing: vi.fn().mockReturnValue({ branch: 'main', created: false }),
   localBranchExists: vi.fn(),
   remoteBranchExists: vi.fn(),
   localBranchExistsAbortable: vi.fn(),

--- a/src/__tests__/clone-base-branch.test.ts
+++ b/src/__tests__/clone-base-branch.test.ts
@@ -23,7 +23,7 @@ vi.mock('../infra/task/branchList.js', () => ({
 
 import { execFileSync } from 'node:child_process';
 import { resolveConfigValue } from '../infra/config/index.js';
-import { branchExists, resolveBaseBranch } from '../infra/task/clone-base-branch.js';
+import { branchExists, createBaseBranchIfMissing, resolveBaseBranch } from '../infra/task/clone-base-branch.js';
 
 const mockExecFileSync = vi.mocked(execFileSync);
 const mockResolveConfigValue = vi.mocked(resolveConfigValue);
@@ -178,5 +178,253 @@ describe('resolveBaseBranch — assertValidBranchRef argument correctness', () =
 
     // Then: check-ref-format should not be called (no assertValidBranchRef)
     expect(checkRefFormatCalls).toHaveLength(0);
+  });
+});
+
+describe('createBaseBranchIfMissing', () => {
+  it('should create missing base branch from a local source branch without checkout', () => {
+    const gitCalls: string[][] = [];
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      gitCalls.push([...argsArr]);
+      if (argsArr[0] === 'check-ref-format') {
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'show-ref') {
+        const ref = argsArr[3];
+        if (ref === 'refs/heads/main') {
+          return Buffer.from('');
+        }
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    const result = createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'main' },
+    });
+
+    expect(result).toEqual({ branch: 'improve', created: true });
+    expect(gitCalls).toContainEqual(['branch', 'improve', 'main']);
+    expect(gitCalls.some((call) => call[0] === 'checkout')).toBe(false);
+    expect(gitCalls.some((call) => call[0] === 'push')).toBe(false);
+  });
+
+  it('should create missing base branch from a remote-only source branch', () => {
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'show-ref') {
+        const ref = argsArr[3];
+        if (ref === 'refs/remotes/origin/main') {
+          return Buffer.from('');
+        }
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    const result = createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'main' },
+    });
+
+    expect(result).toEqual({ branch: 'improve', created: true });
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['branch', 'improve', 'origin/main'], {
+      cwd: '/project',
+      stdio: 'pipe',
+    });
+  });
+
+  it('should publish the base branch only when it was created and push is true', () => {
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'show-ref') {
+        const ref = argsArr[3];
+        if (ref === 'refs/heads/main') {
+          return Buffer.from('');
+        }
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    const result = createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'main', push: true },
+    });
+
+    expect(result).toEqual({ branch: 'improve', created: true });
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['push', 'origin', 'improve'], {
+      cwd: '/project',
+      stdio: 'pipe',
+    });
+  });
+
+  it('should not create or publish when the base branch already exists', () => {
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'show-ref') {
+        const ref = argsArr[3];
+        if (ref === 'refs/heads/main' || ref === 'refs/heads/improve') {
+          return Buffer.from('');
+        }
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    const result = createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'main', push: true },
+    });
+
+    expect(result).toEqual({ branch: 'improve', created: false });
+    expect(mockExecFileSync).not.toHaveBeenCalledWith('git', ['branch', 'improve', 'main'], expect.anything());
+    expect(mockExecFileSync).not.toHaveBeenCalledWith('git', ['push', 'origin', 'improve'], expect.anything());
+  });
+
+  it('should fail fast when create_if_missing.from does not exist', () => {
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'show-ref') {
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    expect(() => createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'main' },
+    })).toThrow('Base branch source does not exist: main');
+  });
+
+  it('should use the existing base branch without resolving create_if_missing.from', () => {
+    const showRefCalls: string[][] = [];
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format') {
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'show-ref') {
+        showRefCalls.push([...argsArr]);
+        const ref = argsArr[3];
+        if (ref === 'refs/heads/improve') {
+          return Buffer.from('');
+        }
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    const result = createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'main', push: true },
+    });
+
+    expect(result).toEqual({ branch: 'improve', created: false });
+    expect(showRefCalls).toEqual([
+      ['show-ref', '--verify', '--quiet', 'refs/heads/improve'],
+    ]);
+    expect(mockExecFileSync).not.toHaveBeenCalledWith('git', ['branch', 'improve', 'main'], expect.anything());
+    expect(mockExecFileSync).not.toHaveBeenCalledWith('git', ['push', 'origin', 'improve'], expect.anything());
+  });
+
+  it('should reject invalid create_if_missing.from even when the base branch already exists', () => {
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format' && argsArr[2] === 'invalid..ref') {
+        throw new Error('invalid ref');
+      }
+      if (argsArr[0] === 'show-ref') {
+        const ref = argsArr[3];
+        if (ref === 'refs/heads/improve') {
+          return Buffer.from('');
+        }
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    expect(() => createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'invalid..ref' },
+    })).toThrow('Invalid base branch: invalid..ref');
+  });
+
+  it('should reject remote-tracking create_if_missing.from even when the base branch already exists', () => {
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'show-ref') {
+        const ref = argsArr[3];
+        if (ref === 'refs/heads/improve') {
+          return Buffer.from('');
+        }
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    expect(() => createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'origin/main' },
+    })).toThrow('Base branch must be a branch name, not a remote-tracking ref: origin/main');
+  });
+
+  it('should reject invalid branch names for name and create_if_missing.from', () => {
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'check-ref-format' && argsArr[2] === 'invalid..ref') {
+        throw new Error('invalid ref');
+      }
+      if (argsArr[0] === 'show-ref') {
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    expect(() => createBaseBranchIfMissing('/project', {
+      name: 'invalid..ref',
+      create_if_missing: { from: 'main' },
+    })).toThrow('Invalid base branch: invalid..ref');
+
+    expect(() => createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'invalid..ref' },
+    })).toThrow('Invalid base branch: invalid..ref');
+  });
+
+  it('should reject remote-tracking refs for name and create_if_missing.from', () => {
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'show-ref') {
+        throw new Error('branch not found');
+      }
+      return Buffer.from('');
+    });
+
+    expect(() => createBaseBranchIfMissing('/project', {
+      name: 'origin/improve',
+      create_if_missing: { from: 'main' },
+    })).toThrow('Base branch must be a branch name, not a remote-tracking ref: origin/improve');
+
+    expect(() => createBaseBranchIfMissing('/project', {
+      name: 'improve',
+      create_if_missing: { from: 'refs/remotes/origin/main' },
+    })).toThrow('Base branch must be a branch name, not a remote-tracking ref: refs/remotes/origin/main');
   });
 });

--- a/src/__tests__/it-system-workflow-execution.test.ts
+++ b/src/__tests__/it-system-workflow-execution.test.ts
@@ -15,6 +15,7 @@ const {
   mockMergePr,
   mockSaveTaskFile,
   mockCreateIssueFromTask,
+  mockCreateBaseBranchIfMissing,
   mockResolveBaseBranch,
   mockFindExistingPr,
   mockFetchPrReviewComments,
@@ -28,6 +29,7 @@ const {
   mockMergePr: vi.fn(),
   mockSaveTaskFile: vi.fn(),
   mockCreateIssueFromTask: vi.fn(),
+  mockCreateBaseBranchIfMissing: vi.fn(),
   mockResolveBaseBranch: vi.fn(),
   mockFindExistingPr: vi.fn(),
   mockFetchPrReviewComments: vi.fn(),
@@ -67,6 +69,7 @@ vi.mock('../features/tasks/add/index.js', () => ({
 
 vi.mock('../infra/task/index.js', () => ({
   getCurrentBranch: vi.fn(() => 'task/test-branch'),
+  createBaseBranchIfMissing: (...args: unknown[]) => mockCreateBaseBranchIfMissing(...args),
   materializeCloneHeadToRootBranch: vi.fn(),
   relayPushCloneToOrigin: vi.fn(),
   resolveBaseBranch: (...args: unknown[]) => mockResolveBaseBranch(...args),
@@ -223,6 +226,10 @@ describe('system workflow execution integration', () => {
     projectDir = mkdtempSync(join(tmpdir(), 'takt-system-it-'));
     mockSaveTaskFile.mockResolvedValue({ taskName: 'task-1', tasksFile: join(projectDir, '.takt', 'tasks.yaml') });
     mockCreateIssueFromTask.mockReturnValue(586);
+    mockCreateBaseBranchIfMissing.mockImplementation((_cwd: string, config: { name: string }) => ({
+      branch: config.name,
+      created: true,
+    }));
     mockResolveBaseBranch.mockImplementation((_cwd: string, branch?: string) => ({ branch: branch ?? 'main' }));
     mockClosePr.mockReturnValue({ success: true });
     mockMergePr.mockReturnValue({ success: true });

--- a/src/__tests__/it-workflow-loader.test.ts
+++ b/src/__tests__/it-workflow-loader.test.ts
@@ -53,6 +53,13 @@ const taktManagedPrRouteFilter = {
   same_repository: true,
   draft: false,
 };
+const autoImprovementLoopBaseBranch = {
+  name: 'improve',
+  create_if_missing: {
+    from: 'main',
+    push: true,
+  },
+};
 
 // --- Test helpers ---
 
@@ -155,7 +162,7 @@ function expectAutoImprovementLoopDownstreamContract(config: NonNullable<ReturnT
       mode: 'from_pr',
       pr: '{context:route_context.selected_pr.number}',
       workflow: 'takt-default',
-      base_branch: 'improve',
+      base_branch: autoImprovementLoopBaseBranch,
     }),
   ]);
   expect(prepareMerge?.effects).toEqual([
@@ -176,7 +183,7 @@ function expectAutoImprovementLoopDownstreamContract(config: NonNullable<ReturnT
       mode: 'from_pr',
       pr: '{context:route_context.selected_pr.number}',
       workflow: 'takt-default',
-      base_branch: 'improve',
+      base_branch: autoImprovementLoopBaseBranch,
     }),
   ]);
   expect(mergePr?.effects).toEqual([
@@ -415,6 +422,31 @@ describe('Workflow Loader IT: builtin workflow loading', () => {
     }
   });
 
+  it('should opt in base branch creation for improve-based enqueue effects in builtin auto-improvement-loop workflows', () => {
+    for (const language of ['en', 'ja'] as const) {
+      const config = loadWorkflowFromFile(
+        join(process.cwd(), 'builtins', language, 'workflows', 'auto-improvement-loop.yaml'),
+        testDir,
+      );
+
+      for (const stepName of [
+        'enqueue_from_issue',
+        'enqueue_fresh',
+        'enqueue_from_pr',
+        'enqueue_conflict_resolution_task',
+      ]) {
+        const step = config.steps.find((workflowStep) => workflowStep.name === stepName) as Record<string, unknown> | undefined;
+
+        expect(step?.effects).toEqual([
+          expect.objectContaining({
+            type: 'enqueue_task',
+            base_branch: autoImprovementLoopBaseBranch,
+          }),
+        ]);
+      }
+    }
+  });
+
   it('should preserve the legacy issue_context comment in both builtin auto-improvement-loop YAML files', () => {
     for (const language of ['en', 'ja'] as const) {
       const workflowSource = readFileSync(
@@ -470,7 +502,7 @@ describe('Workflow Loader IT: builtin workflow loading', () => {
         type: 'enqueue_task',
         mode: 'new',
         workflow: 'takt-default',
-        base_branch: 'improve',
+        base_branch: autoImprovementLoopBaseBranch,
         issue: '{structured:plan_from_issue.issue}',
       }),
     ]);

--- a/src/__tests__/system-step-services.test.ts
+++ b/src/__tests__/system-step-services.test.ts
@@ -16,6 +16,7 @@ const {
   mockCreateIssueFromTask,
   mockTaskRunnerListAllTaskItems,
   mockResolveBaseBranch,
+  mockCreateBaseBranchIfMissing,
   mockResolveCloneBaseDir,
   mockCloneAndIsolate,
   mockRemoveClone,
@@ -36,6 +37,7 @@ const {
   mockCreateIssueFromTask: vi.fn(),
   mockTaskRunnerListAllTaskItems: vi.fn(),
   mockResolveBaseBranch: vi.fn(),
+  mockCreateBaseBranchIfMissing: vi.fn(),
   mockResolveCloneBaseDir: vi.fn(),
   mockCloneAndIsolate: vi.fn(),
   mockRemoveClone: vi.fn(),
@@ -55,6 +57,7 @@ vi.mock('../infra/task/index.js', () => ({
   },
   getCurrentBranch: (...args: unknown[]) => mockGetCurrentBranch(...args),
   materializeCloneHeadToRootBranch: (...args: unknown[]) => mockMaterializeCloneHeadToRootBranch(...args),
+  createBaseBranchIfMissing: (...args: unknown[]) => mockCreateBaseBranchIfMissing(...args),
   relayPushCloneToOrigin: (...args: unknown[]) => mockRelayPushCloneToOrigin(...args),
   resolveBaseBranch: (...args: unknown[]) => mockResolveBaseBranch(...args),
   resolveCloneBaseDir: (...args: unknown[]) => mockResolveCloneBaseDir(...args),
@@ -163,6 +166,7 @@ describe('DefaultSystemStepServices', () => {
     mockCreateIssueFromTask.mockReset();
     mockTaskRunnerListAllTaskItems.mockReset();
     mockResolveBaseBranch.mockReset();
+    mockCreateBaseBranchIfMissing.mockReset();
     mockResolveCloneBaseDir.mockReset();
     mockCloneAndIsolate.mockReset();
     mockRemoveClone.mockReset();
@@ -184,6 +188,10 @@ describe('DefaultSystemStepServices', () => {
     mockCreateIssueFromTask.mockReturnValue(undefined);
     mockTaskRunnerListAllTaskItems.mockReturnValue([]);
     mockResolveBaseBranch.mockImplementation((_cwd: string, branch?: string) => ({ branch: branch ?? 'main' }));
+    mockCreateBaseBranchIfMissing.mockImplementation((_cwd: string, config: { name: string }) => ({
+      branch: config.name,
+      created: true,
+    }));
     mockResolveCloneBaseDir.mockReturnValue('/repo/.takt');
   });
 
@@ -1688,6 +1696,47 @@ describe('DefaultSystemStepServices', () => {
     });
   });
 
+  it('creates a new follow-up task with opt-in base branch creation', async () => {
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Plan follow-up',
+    });
+    const baseBranch = {
+      name: 'improve',
+      create_if_missing: {
+        from: 'main',
+        push: true,
+      },
+    };
+
+    const result = await services.executeEffect({
+      type: 'enqueue_task',
+      mode: 'new',
+      workflow: 'takt-default',
+      task: '{structured:plan.dummy_field}',
+      base_branch: baseBranch,
+    } as never, {
+      mode: 'new',
+      workflow: 'takt-default',
+      task: 'Implement follow-up effect',
+      base_branch: baseBranch,
+    }, {} as never);
+
+    expect(mockCreateBaseBranchIfMissing).toHaveBeenCalledWith('/repo', baseBranch);
+    expect(mockResolveBaseBranch).not.toHaveBeenCalled();
+    expect(mockSaveTaskFile).toHaveBeenCalledWith('/repo', 'Implement follow-up effect', {
+      workflow: 'takt-default',
+      baseBranch: 'improve',
+    });
+    expect(result).toEqual({
+      success: true,
+      failed: false,
+      taskName: 'task-1',
+      tasksFile: '/repo/.takt/tasks.yaml',
+    });
+  });
+
   it('returns failed result when issue creation for enqueue_task fails', async () => {
     const services = new DefaultSystemStepServices({
       cwd: '/repo/worktree',
@@ -1758,6 +1807,66 @@ describe('DefaultSystemStepServices', () => {
       prNumber: 42,
     });
     expect(mockResolveBaseBranch).toHaveBeenCalledWith('/repo', 'main');
+    expect(result).toEqual({
+      success: true,
+      failed: false,
+      taskName: 'task-1',
+      tasksFile: '/repo/.takt/tasks.yaml',
+      prNumber: 42,
+    });
+  });
+
+  it('creates a PR follow-up task with opt-in base branch creation', async () => {
+    mockFetchPrReviewComments.mockReturnValue({
+      number: 42,
+      title: 'Follow-up PR',
+      body: 'Body',
+      url: 'https://example.test/pr/42',
+      headRefName: 'task/test-branch',
+      baseRefName: 'main',
+      comments: [],
+      reviews: [],
+      files: [],
+    });
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Plan follow-up',
+    });
+    const baseBranch = {
+      name: 'improve',
+      create_if_missing: {
+        from: 'main',
+        push: true,
+      },
+    };
+
+    const result = await services.executeEffect({
+      type: 'enqueue_task',
+      mode: 'from_pr',
+      workflow: 'takt-default',
+      task: '{structured:plan.dummy_field}',
+      pr: '{context:route.pr.number}',
+      base_branch: baseBranch,
+    } as never, {
+      mode: 'from_pr',
+      workflow: 'takt-default',
+      task: 'Address review comments',
+      pr: 42,
+      base_branch: baseBranch,
+    }, {} as never);
+
+    expect(mockCreateBaseBranchIfMissing).toHaveBeenCalledWith('/repo', baseBranch);
+    expect(mockResolveBaseBranch).not.toHaveBeenCalled();
+    expect(mockSaveTaskFile).toHaveBeenCalledWith('/repo', 'Address review comments', {
+      workflow: 'takt-default',
+      worktree: true,
+      branch: 'task/test-branch',
+      baseBranch: 'improve',
+      autoPr: false,
+      shouldPublishBranchToOrigin: true,
+      prNumber: 42,
+    });
     expect(result).toEqual({
       success: true,
       failed: false,
@@ -1910,6 +2019,67 @@ describe('DefaultSystemStepServices', () => {
     }, {} as never)).rejects.toThrow(
       'System effect requires "worktree.enabled" when auto_pr, draft_pr, or managed_pr is true',
     );
+  });
+
+  it('rejects malformed enqueue_task base_branch object at the effect boundary', async () => {
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Plan follow-up',
+    });
+
+    await expect(services.executeEffect({
+      type: 'enqueue_task',
+      mode: 'new',
+      workflow: 'takt-default',
+      task: '{structured:plan.dummy_field}',
+      base_branch: {
+        name: 'improve',
+        create_if_missing: {
+          from: 'main',
+        },
+      },
+    } as never, {
+      mode: 'new',
+      workflow: 'takt-default',
+      task: 'Implement follow-up effect',
+      base_branch: {
+        name: 'improve',
+      },
+    }, {} as never)).rejects.toThrow('System effect requires object field "base_branch.create_if_missing"');
+  });
+
+  it('rejects non-boolean enqueue_task base_branch create_if_missing.push at the effect boundary', async () => {
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Plan follow-up',
+    });
+
+    await expect(services.executeEffect({
+      type: 'enqueue_task',
+      mode: 'new',
+      workflow: 'takt-default',
+      task: '{structured:plan.dummy_field}',
+      base_branch: {
+        name: 'improve',
+        create_if_missing: {
+          from: 'main',
+          push: true,
+        },
+      },
+    } as never, {
+      mode: 'new',
+      workflow: 'takt-default',
+      task: 'Implement follow-up effect',
+      base_branch: {
+        name: 'improve',
+        create_if_missing: {
+          from: 'main',
+          push: 'true',
+        },
+      },
+    }, {} as never)).rejects.toThrow('System effect requires boolean field "base_branch.create_if_missing.push"');
   });
 
   it('fails enqueue_task when base_branch is rejected by resolveBaseBranch', async () => {

--- a/src/__tests__/system-workflow-schema.test.ts
+++ b/src/__tests__/system-workflow-schema.test.ts
@@ -904,6 +904,103 @@ describe('system workflow schema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('enqueue_task base_branch の opt-in 作成設定を受け付ける', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'enqueue_from_issue',
+      mode: 'system',
+      effects: [
+        {
+          type: 'enqueue_task',
+          mode: 'new',
+          workflow: 'takt-default',
+          task: '{structured:plan.dummy_field}',
+          base_branch: {
+            name: 'improve',
+            create_if_missing: {
+              from: 'main',
+              push: true,
+            },
+          },
+        },
+      ],
+      rules: [
+        {
+          when: 'true',
+          next: 'COMPLETE',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.effects?.[0]).toEqual(expect.objectContaining({
+        base_branch: {
+          name: 'improve',
+          create_if_missing: {
+            from: 'main',
+            push: true,
+          },
+        },
+      }));
+    }
+  });
+
+  it('enqueue_task base_branch object は create_if_missing を必須にする', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'enqueue_from_issue',
+      mode: 'system',
+      effects: [
+        {
+          type: 'enqueue_task',
+          mode: 'new',
+          workflow: 'takt-default',
+          task: '{structured:plan.dummy_field}',
+          base_branch: {
+            name: 'improve',
+          },
+        },
+      ],
+      rules: [
+        {
+          when: 'true',
+          next: 'COMPLETE',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('enqueue_task base_branch object の別名キーを reject する', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'enqueue_from_issue',
+      mode: 'system',
+      effects: [
+        {
+          type: 'enqueue_task',
+          mode: 'new',
+          workflow: 'takt-default',
+          task: '{structured:plan.dummy_field}',
+          base_branch: {
+            name: 'improve',
+            ensure_exists: {
+              from: 'main',
+              publish: true,
+            },
+          },
+        },
+      ],
+      rules: [
+        {
+          when: 'true',
+          next: 'COMPLETE',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('同じ type の effect 重複を reject する', () => {
     const result = WorkflowStepRawSchema.safeParse({
       name: 'prepare_merge',

--- a/src/core/models/index.ts
+++ b/src/core/models/index.ts
@@ -8,6 +8,7 @@ export type {
   WorkflowMaxSteps,
   WorkflowSystemInput,
   WorkflowEffect,
+  WorkflowEnqueueBaseBranchConfig,
   WorkflowEnqueueIssueConfig,
   WorkflowEnqueueWorktreeConfig,
   WorkflowTemplateReference,

--- a/src/core/models/types.ts
+++ b/src/core/models/types.ts
@@ -41,6 +41,7 @@ export type {
   WorkflowPrListWhere,
   WorkflowSystemInput,
   WorkflowEffect,
+  WorkflowEnqueueBaseBranchConfig,
   WorkflowEnqueueIssueConfig,
   WorkflowEnqueueWorktreeConfig,
   WorkflowTemplateReference,

--- a/src/core/models/workflow-system-input-types.ts
+++ b/src/core/models/workflow-system-input-types.ts
@@ -122,6 +122,14 @@ export interface WorkflowEnqueueWorktreeConfig {
   managed_pr?: boolean;
 }
 
+export interface WorkflowEnqueueBaseBranchConfig {
+  name: string;
+  create_if_missing: {
+    from: string;
+    push?: boolean;
+  };
+}
+
 type WorkflowContextTemplateReference = `{context:${string}}`;
 type WorkflowStructuredTemplateReference = `{structured:${string}}`;
 type WorkflowEffectTemplateReference = `{effect:${string}}`;
@@ -141,7 +149,7 @@ export type WorkflowEffect =
     task: string;
     pr?: WorkflowEffectScalarReference;
     issue?: WorkflowEnqueueIssueConfig | WorkflowTemplateReference;
-    base_branch?: string;
+    base_branch?: string | WorkflowEnqueueBaseBranchConfig;
     worktree?: WorkflowEnqueueWorktreeConfig;
   }
   | {

--- a/src/core/models/workflow-system-schemas.ts
+++ b/src/core/models/workflow-system-schemas.ts
@@ -108,6 +108,19 @@ const EnqueueWorktreeRawSchema = z.object({
   }
 });
 
+const EnqueueBaseBranchCreateIfMissingRawSchema = z.object({
+  from: z.string().min(1),
+  push: z.boolean().optional(),
+}).strict();
+
+const EnqueueBaseBranchRawSchema = z.union([
+  z.string().min(1),
+  z.object({
+    name: z.string().min(1),
+    create_if_missing: EnqueueBaseBranchCreateIfMissingRawSchema,
+  }).strict(),
+]);
+
 const EnqueueTaskEffectBaseSchema = z.object({
   type: z.literal('enqueue_task'),
   mode: z.enum(['new', 'from_pr']),
@@ -115,7 +128,7 @@ const EnqueueTaskEffectBaseSchema = z.object({
   task: z.string().min(1),
   pr: EffectReferenceScalarSchema.optional(),
   issue: z.union([EnqueueIssueRawSchema, TemplateReferenceSchema]).optional(),
-  base_branch: z.string().min(1).optional(),
+  base_branch: EnqueueBaseBranchRawSchema.optional(),
   worktree: EnqueueWorktreeRawSchema.optional(),
 }).strict();
 

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -19,6 +19,7 @@ export type {
   WorkflowPrListWhere,
   WorkflowSystemInput,
   WorkflowEffect,
+  WorkflowEnqueueBaseBranchConfig,
   WorkflowEnqueueIssueConfig,
   WorkflowEnqueueWorktreeConfig,
   WorkflowTemplateReference,

--- a/src/core/workflow/system/system-step-effect-runner.ts
+++ b/src/core/workflow/system/system-step-effect-runner.ts
@@ -71,6 +71,24 @@ function validateWorktreePayload(value: unknown): void {
   }
 }
 
+function validateBaseBranchPayload(value: unknown): void {
+  if (typeof value === 'string') {
+    requireString(value, 'base_branch');
+    return;
+  }
+
+  const baseBranch = requireObject(value, 'base_branch');
+  validateAllowedKeys(baseBranch, 'base_branch', ['name', 'create_if_missing']);
+  requireString(baseBranch.name, 'base_branch.name');
+
+  const createIfMissing = requireObject(baseBranch.create_if_missing, 'base_branch.create_if_missing');
+  validateAllowedKeys(createIfMissing, 'base_branch.create_if_missing', ['from', 'push']);
+  requireString(createIfMissing.from, 'base_branch.create_if_missing.from');
+  if (createIfMissing.push !== undefined && typeof createIfMissing.push !== 'boolean') {
+    throw new Error('System effect requires boolean field "base_branch.create_if_missing.push"');
+  }
+}
+
 export function validateSystemEffectPayload(
   effect: WorkflowEffect,
   payload: Record<string, unknown>,
@@ -80,7 +98,7 @@ export function validateSystemEffectPayload(
     if (payload.workflow !== undefined) requireString(payload.workflow, 'workflow');
     if (payload.task !== undefined) requireString(payload.task, 'task');
     if (payload.pr !== undefined) requireNumber(payload.pr, 'pr');
-    if (payload.base_branch !== undefined) requireString(payload.base_branch, 'base_branch');
+    if (payload.base_branch !== undefined) validateBaseBranchPayload(payload.base_branch);
     if (payload.issue !== undefined) validateIssuePayload(payload.issue);
     if (payload.worktree !== undefined) validateWorktreePayload(payload.worktree);
     if (payload.mode === 'new' && payload.pr !== undefined) {

--- a/src/infra/task/clone-base-branch.ts
+++ b/src/infra/task/clone-base-branch.ts
@@ -34,6 +34,14 @@ export function branchExists(projectDir: string, branch: string): boolean {
   return localBranchExists(projectDir, branch) || remoteBranchExists(projectDir, branch);
 }
 
+export interface CreateBaseBranchIfMissingConfig {
+  name: string;
+  create_if_missing: {
+    from: string;
+    push?: boolean;
+  };
+}
+
 export async function localBranchExistsAbortable(
   projectDir: string,
   branch: string,
@@ -102,6 +110,49 @@ function assertNotRemoteTrackingRef(ref: string): void {
   }
 }
 
+function assertExplicitBaseBranch(projectDir: string, branch: string): void {
+  assertNotRemoteTrackingRef(branch);
+  assertValidBranchRef(projectDir, branch);
+}
+
+function resolveBaseBranchStartPoint(projectDir: string, branch: string): string {
+  if (localBranchExists(projectDir, branch)) {
+    return branch;
+  }
+  if (remoteBranchExists(projectDir, branch)) {
+    return `origin/${branch}`;
+  }
+  throw new Error(`Base branch source does not exist: ${branch}`);
+}
+
+export function createBaseBranchIfMissing(
+  projectDir: string,
+  config: CreateBaseBranchIfMissingConfig,
+): { branch: string; created: boolean } {
+  assertExplicitBaseBranch(projectDir, config.name);
+  assertExplicitBaseBranch(projectDir, config.create_if_missing.from);
+
+  if (branchExists(projectDir, config.name)) {
+    return { branch: config.name, created: false };
+  }
+
+  const startPoint = resolveBaseBranchStartPoint(projectDir, config.create_if_missing.from);
+
+  execFileSync('git', ['branch', config.name, startPoint], {
+    cwd: projectDir,
+    stdio: 'pipe',
+  });
+
+  if (config.create_if_missing.push === true) {
+    execFileSync('git', ['push', 'origin', config.name], {
+      cwd: projectDir,
+      stdio: 'pipe',
+    });
+  }
+
+  return { branch: config.name, created: true };
+}
+
 export function resolveBaseBranch(
   projectDir: string,
   explicitBaseBranch?: string,
@@ -112,8 +163,7 @@ export function resolveBaseBranch(
   const baseBranch = configBaseBranch ?? detectDefaultBranch(projectDir);
 
   if (explicitBaseBranch !== undefined) {
-    assertNotRemoteTrackingRef(baseBranch);
-    assertValidBranchRef(projectDir, baseBranch);
+    assertExplicitBaseBranch(projectDir, baseBranch);
   }
 
   if (explicitBaseBranch !== undefined && !branchExists(projectDir, baseBranch)) {
@@ -154,8 +204,7 @@ export async function resolveBaseBranchAbortable(
   const baseBranch = configBaseBranch ?? detectDefaultBranch(projectDir);
 
   if (explicitBaseBranch !== undefined) {
-    assertNotRemoteTrackingRef(baseBranch);
-    assertValidBranchRef(projectDir, baseBranch);
+    assertExplicitBaseBranch(projectDir, baseBranch);
   }
 
   if (explicitBaseBranch !== undefined && !await branchExistsAbortable(projectDir, baseBranch, abortSignal)) {

--- a/src/infra/task/clone.ts
+++ b/src/infra/task/clone.ts
@@ -16,7 +16,13 @@ import { cloneAndIsolate, cloneAndIsolateAbortable, resolveCloneSubmoduleOptions
 import { loadCloneMeta, removeCloneMeta as removeCloneMetaFile, saveCloneMeta as saveCloneMetaFile } from './clone-meta.js';
 
 export type { WorktreeOptions, WorktreeResult };
-export { branchExists, localBranchExists, remoteBranchExists } from './clone-base-branch.js';
+export {
+  branchExists,
+  createBaseBranchIfMissing,
+  localBranchExists,
+  remoteBranchExists,
+  type CreateBaseBranchIfMissingConfig,
+} from './clone-base-branch.js';
 
 const log = createLogger('clone');
 

--- a/src/infra/task/index.ts
+++ b/src/infra/task/index.ts
@@ -53,11 +53,13 @@ export {
   saveCloneMeta,
   removeCloneMeta,
   cleanupOrphanedClone,
+  createBaseBranchIfMissing,
   resolveBaseBranch,
   resolveCloneBaseDir,
   branchExists,
   localBranchExists,
   remoteBranchExists,
+  type CreateBaseBranchIfMissingConfig,
 } from './clone.js';
 export {
   detectDefaultBranch,

--- a/src/infra/workflow/system/system-enqueue-effect.ts
+++ b/src/infra/workflow/system/system-enqueue-effect.ts
@@ -1,7 +1,11 @@
 import { saveTaskFile, createIssueFromTask } from '../../../features/tasks/add/index.js';
-import type { WorkflowEnqueueIssueConfig, WorkflowEnqueueWorktreeConfig } from '../../../core/models/types.js';
+import type {
+  WorkflowEnqueueBaseBranchConfig,
+  WorkflowEnqueueIssueConfig,
+  WorkflowEnqueueWorktreeConfig,
+} from '../../../core/models/types.js';
 import type { SystemStepServicesOptions } from '../../../core/workflow/system/system-step-services.js';
-import { resolveBaseBranch } from '../../task/index.js';
+import { createBaseBranchIfMissing, resolveBaseBranch } from '../../task/index.js';
 import { fetchPrContext } from './system-git-context.js';
 
 function filterIssueLabels(issue: WorkflowEnqueueIssueConfig): string[] | undefined {
@@ -9,9 +13,15 @@ function filterIssueLabels(issue: WorkflowEnqueueIssueConfig): string[] | undefi
   return labels && labels.length > 0 ? labels : undefined;
 }
 
-function resolveValidatedBaseBranch(projectCwd: string, baseBranch?: string): string | undefined {
+function resolveValidatedBaseBranch(
+  projectCwd: string,
+  baseBranch?: string | WorkflowEnqueueBaseBranchConfig,
+): string | undefined {
   if (baseBranch === undefined) {
     return undefined;
+  }
+  if (typeof baseBranch !== 'string') {
+    return createBaseBranchIfMissing(projectCwd, baseBranch).branch;
   }
   return resolveBaseBranch(projectCwd, baseBranch).branch;
 }
@@ -24,7 +34,7 @@ export async function enqueueTaskEffect(
     task: string;
     pr?: number;
     issue?: WorkflowEnqueueIssueConfig;
-    base_branch?: string;
+    base_branch?: string | WorkflowEnqueueBaseBranchConfig;
     worktree?: WorkflowEnqueueWorktreeConfig;
   },
 ): Promise<Record<string, unknown>> {
@@ -64,7 +74,7 @@ export async function enqueueTaskEffect(
   if (!requestedBaseBranch) {
     return { success: false, failed: true, error: 'PR base branch is not available' };
   }
-  const prBaseBranch = resolveBaseBranch(options.projectCwd, requestedBaseBranch).branch;
+  const prBaseBranch = baseBranch ?? resolveBaseBranch(options.projectCwd, requestedBaseBranch).branch;
   const created = await saveTaskFile(options.projectCwd, payload.task, {
     workflow: payload.workflow,
     worktree: true,


### PR DESCRIPTION
## Summary

## 背景

`auto-improvement-loop` などの workflow では、system effect の `enqueue_task` が `base_branch: improve` のような固定 base branch を要求する場合がある。

現状では、指定された base branch がローカルにも `origin/` にも存在しない場合、`Base branch does not exist: improve` で workflow が abort する。これは誤設定を検出する挙動としては妥当だが、workflow 側が明示的に「なければ作る」前提を持ちたいケースでは、事前セットアップ漏れで止まりやすい。

## 提案

`base_branch` の YAML 構文を後方互換を保ったまま拡張し、明示的に opt-in された場合のみ、存在しない base branch を作成できるようにする。

例:

```yaml
effects:
  - type: enqueue_task
    mode: new
    workflow: takt-default
    base_branch:
      name: improve
      create_if_missing:
        from: main
        push: true
```

または同等の意味で、命名は要検討:

```yaml
base_branch:
  name: improve
  ensure_exists:
    from: main
    publish: true
```

## 要件

- 既存の `base_branch: improve` のような string 指定は従来どおり維持する
- string 指定では、存在しない branch を自動作成しない
- object 指定かつ `create_if_missing` がある場合のみ branch 作成を許可する
- `name` は作成または解決する base branch 名として扱う
- `from` は作成元 branch として扱う
- `from` が存在しない場合は fail-fast する
- `name` が既に存在する場合は作成せず、その branch を使う
- `push: true` の場合は作成した branch を `origin` に publish する
- branch 名 validation と remote-tracking ref 禁止は既存の base branch 検証と同等に行う
- dirty worktree に依存しないよう、checkout ではなく `git branch <name> <from>` 相当で作成する

## 実装候補

- workflow system schema の `base_branch` を `string | object` に拡張する
- normalizer で後方互換を維持する
- `system-enqueue-effect.ts` の base branch 解決周辺で ensure 処理を行う
- 既存の `resolveBaseBranch` は原則「存在確認」の責務を維持し、自動作成は opt-in object 指定の処理に閉じ込める
- `auto-improvement-loop` は必要に応じて object 指定へ移行する

## 完了条件

- string 指定の既存 workflow とテストが壊れない
- object 指定で missing branch が `from` から作成される
- `push: true` 指定時に remote に publish される
- `from` missing、invalid branch name、`origin/foo` のような remote-tracking ref 指定は明確に失敗する
- `auto-improvement-loop` のような workflow で、必要な base branch の初期化漏れにより abort しない構成が書ける

## Execution Report

Workflow `takt-default` completed successfully.

Closes #724