### PR TITLE
chore(ci): takt-review を /takt-review コメントトリガーに変更

### DIFF
--- a/.github/workflows/takt-review.yml
+++ b/.github/workflows/takt-review.yml
@@ -1,23 +1,52 @@
 name: TAKT PR Review
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: takt-review-${{ github.event.pull_request.number }}
+  group: takt-review-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   review:
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/takt-review') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     environment: takt-review
     permissions:
       contents: read
       pull-requests: write
     steps:
+      - name: 受付リアクション
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: PR の head SHA を取得
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            return pr.head.sha;
+
       - uses: actions/checkout@v4
         with:
+          ref: ${{ steps.pr.outputs.result }}
           fetch-depth: 0
 
       - name: API キー確認
@@ -39,7 +68,7 @@ jobs:
           npm install -g takt
 
       - name: TAKT Review 実行
-        run: takt --pipeline --skip-git --pr ${{ github.event.pull_request.number }} -w review-takt-default
+        run: takt --pipeline --skip-git --pr ${{ github.event.issue.number }} -w review-takt-default
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +81,7 @@ jobs:
           if [ -n "$REPORT_DIR" ]; then
             SUMMARY=$(find "$REPORT_DIR" -name "*review-summary*" -type f | head -1)
             if [ -n "$SUMMARY" ]; then
-              gh pr comment ${{ github.event.pull_request.number }} --body-file "$SUMMARY"
+              gh pr comment ${{ github.event.issue.number }} --body-file "$SUMMARY"
             else
               echo "レビューサマリーが見つかりません"
             fi


### PR DESCRIPTION
## Summary

- `takt-review` ワークフローのトリガーを `pull_request_target` から `issue_comment.created` に変更
- PR 内で `/takt-review` とコメントすると発火する形式に
- 発火可能なのは `OWNER` / `MEMBER` / `COLLABORATOR` のみ（API キー消費を伴うため第三者からの発火を防ぐ）

## 背景

これまで `pull_request_target` で全 PR に対し自動実行していたため、`environment: takt-review` の Required reviewers approval gate に引っかかり、PR チェック欄に常時「TAKT PR Review / review — Waiting」が Pending 状態で表示されていた。

明示的に必要な PR で発火させる運用に変えたい。

## 変更点

| 項目 | Before | After |
|---|---|---|
| トリガー | `pull_request_target` | `issue_comment.created` |
| 発火条件 | PR opened / synchronize 等 | `/takt-review` コメント + COLLABORATOR 以上 |
| PR 番号参照 | `pull_request.number` | `issue.number` |
| checkout の ref | デフォルト (PR head) | API 経由で取得した head SHA |
| 受付フィードバック | なし | コメントに 👀 リアクション |

## 使い方

PR 内に `/takt-review` とコメントすると発火する:

```
/takt-review
```

第三者がコメントしても発火しない（権限不足で `if` 条件に弾かれる）。

## Test plan

- [ ] 自分でこの PR に `/takt-review` とコメントして発火することを確認
- [ ] 発火時に 👀 リアクションが付くことを確認
- [ ] レビューサマリーが PR コメントに投稿されることを確認
- [ ] PR の checks 欄に「Pending」の TAKT PR Review が出ないことを確認