### PR TITLE
chore(ci): takt-review のトリガーを /review に短縮

### DIFF
--- a/.github/workflows/takt-review.yml
+++ b/.github/workflows/takt-review.yml
@@ -12,7 +12,12 @@ jobs:
   review:
     if: |
       github.event.issue.pull_request != null &&
-      contains(github.event.comment.body, '/takt-review') &&
+      (
+        github.event.comment.body == '/review' ||
+        startsWith(github.event.comment.body, '/review ') ||
+        startsWith(github.event.comment.body, '/review
+')
+      ) &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     environment: takt-review


### PR DESCRIPTION
## Summary

- #726 で導入した `/takt-review` コマンドを `/review` に短縮
- 判定を `contains()` から `startsWith()` ベースに変更し、`/review-arch` のような部分一致による誤発火を防止

## 背景

#726 で `/takt-review` を導入したが長くて打ちづらく、実際に PR #727 で `/review` と打って動かないインシデントが発生した。直感的な短いコマンドに変更する。

## 発火条件

次のいずれかにマッチした場合のみ発火:

- コメント本文が `/review` のみ
- `/review ` （空白付き引数）で始まる
- `/review\n` （改行付き）で始まる

`/review-arch` `/reviewer` などの部分一致では発火しない。

## Test plan

- [ ] マージ後、別 PR で `/review` とコメントしてワークフローが発火することを確認
- [ ] `/reviewer` のような誤コマンドで発火しないことを確認
- [ ] OWNER 以外のコメント (例: bot からの自動コメント) で発火しないことを確認