### PR TITLE
[#287] implement-accept-command

### DIFF
--- a/src/__tests__/commandMatcher.test.ts
+++ b/src/__tests__/commandMatcher.test.ts
@@ -51,6 +51,11 @@ describe('start-of-line detection', () => {
     const result = matchSlashCommand('/resume');
     expect(result).toEqual({ command: '/resume', text: '' });
   });
+
+  it('should detect /accept', () => {
+    const result = matchSlashCommand('/accept');
+    expect(result).toEqual({ command: '/accept', text: '' });
+  });
 });
 
 // =================================================================
@@ -91,6 +96,11 @@ describe('end-of-line detection', () => {
     const result = matchSlashCommand('セッション復元 /resume');
     expect(result).toEqual({ command: '/resume', text: 'セッション復元' });
   });
+
+  it('should detect /accept at the end', () => {
+    const result = matchSlashCommand('この内容で採用 /accept');
+    expect(result).toEqual({ command: '/accept', text: 'この内容で採用' });
+  });
 });
 
 // =================================================================
@@ -123,6 +133,10 @@ describe('middle-of-text (not recognized)', () => {
 
   it('should not detect /resume in the middle of text', () => {
     expect(matchSlashCommand('I want to /resume the work now')).toBeNull();
+  });
+
+  it('should not detect /accept in the middle of text', () => {
+    expect(matchSlashCommand('I will /accept that once it is ready')).toBeNull();
   });
 });
 
@@ -181,6 +195,7 @@ describe('edge cases', () => {
     expect(matchSlashCommand('/Go')).toBeNull();
     expect(matchSlashCommand('/PLAY')).toBeNull();
     expect(matchSlashCommand('/Cancel')).toBeNull();
+    expect(matchSlashCommand('/Accept')).toBeNull();
   });
 
   it('should not match slash only', () => {

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -121,6 +121,7 @@ describe('label integrity', () => {
     expect(ui).toHaveProperty('actionPrompt');
     expect(ui).toHaveProperty('actions');
     expect(ui).toHaveProperty('cancelled');
+    expect(ui).toHaveProperty('acceptNoAssistant');
   });
 
   it('contains all expected workflow keys in en', () => {
@@ -146,6 +147,8 @@ describe('label integrity', () => {
       'interactive.ui.introQuiet',
       'interactive.ui.introPassthrough',
       'interactive.ui.cancelled',
+      'interactive.ui.acceptNoAssistant',
+      'interactive.commands.accept',
       'workflow.iterationLimit.maxReached',
       'workflow.notifyComplete',
       'workflow.sigintGraceful',
@@ -169,6 +172,7 @@ describe('label integrity', () => {
 
     expect(intro).toContain('/go');
     expect(intro).toContain('/play');
+    expect(intro).toContain('/accept');
     expect(intro).toContain('/resume');
     expect(intro).toContain('/cancel');
   });

--- a/src/__tests__/interactive.test.ts
+++ b/src/__tests__/interactive.test.ts
@@ -53,9 +53,12 @@ vi.mock('../shared/prompt/index.js', () => ({
 import { getProvider } from '../infra/providers/index.js';
 import { interactiveMode } from '../features/interactive/index.js';
 import { selectOption } from '../shared/prompt/index.js';
+import { info } from '../shared/ui/index.js';
+import { getLabel } from '../shared/i18n/index.js';
 
 const mockGetProvider = vi.mocked(getProvider);
 const mockSelectOption = vi.mocked(selectOption);
+const mockInfo = vi.mocked(info);
 
 function setupMockProvider(responses: string[]): void {
   const { provider } = createMockProvider(responses);
@@ -491,6 +494,42 @@ describe('interactiveMode', () => {
       expect(mockProvider._call).not.toHaveBeenCalled();
       expect(result.action).toBe('execute');
       expect(result.task).toBe('quick task');
+    });
+  });
+
+  describe('/accept command', () => {
+    it('should return action=execute with the latest assistant response unchanged', async () => {
+      // Given
+      const latestAssistantResponse = '  Implement the second request exactly.\nKeep this newline.\n';
+      setupRawStdin(toRawInputs(['first request', 'second request', '/accept', '/cancel']));
+      setupMockProvider(['Implement the first request.', latestAssistantResponse]);
+
+      // When
+      const result = await interactiveMode('/project');
+
+      // Then
+      expect(result).toEqual({
+        action: 'execute',
+        task: latestAssistantResponse,
+      });
+      const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
+      expect(mockProvider._call).toHaveBeenCalledTimes(2);
+      expect(mockSelectOption).not.toHaveBeenCalled();
+    });
+
+    it('should show an error and continue when there is no assistant response', async () => {
+      // Given
+      setupRawStdin(toRawInputs(['/accept', '/cancel']));
+      setupMockProvider([]);
+
+      // When
+      const result = await interactiveMode('/project');
+
+      // Then
+      expect(result).toEqual({ action: 'cancel', task: '' });
+      expect(mockInfo).toHaveBeenCalledWith(getLabel('interactive.ui.acceptNoAssistant', 'en'));
+      const mockProvider = mockGetProvider.mock.results[0]!.value as { _call: ReturnType<typeof vi.fn> };
+      expect(mockProvider._call).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/interactiveInput.test.ts
+++ b/src/__tests__/interactiveInput.test.ts
@@ -42,6 +42,18 @@ describe('interactiveInput', () => {
         },
       ]);
     });
+
+    it('should return localized /accept descriptions with apply values', () => {
+      const result = getSlashCommandCompletions('/accept', 'en');
+
+      expect(result).toEqual([
+        {
+          value: '/accept',
+          applyValue: '/accept ',
+          description: 'Accept latest assistant response',
+        },
+      ]);
+    });
   });
 
   describe('createSlashCommandCompletionProvider', () => {
@@ -120,6 +132,19 @@ describe('interactiveInput', () => {
           value: 'fix /go later',
           applyValue: 'fix /go later',
           description: 'Create instruction & run',
+        },
+      ]);
+    });
+
+    it('should complete /accept from suffix command prefix', () => {
+      const provider = createSlashCommandCompletionProvider('en');
+      const results = provider({ buffer: 'use that /a', cursorPos: 11 });
+
+      expect(results).toEqual([
+        {
+          value: 'use that /accept',
+          applyValue: 'use that /accept ',
+          description: 'Accept latest assistant response',
         },
       ]);
     });

--- a/src/__tests__/slashCommandRegistry.test.ts
+++ b/src/__tests__/slashCommandRegistry.test.ts
@@ -8,7 +8,17 @@ import { filterSlashCommands } from '../features/interactive/slashCommandRegistr
 describe('filterSlashCommands', () => {
   it('should return all commands when prefix is "/"', () => {
     const result = filterSlashCommands('/');
-    expect(result.length).toBe(6);
+    expect(result.length).toBe(7);
+  });
+
+  it('should filter by prefix "/a"', () => {
+    const result = filterSlashCommands('/a');
+    expect(result).toEqual([
+      {
+        command: '/accept',
+        labelKey: 'interactive.commands.accept',
+      },
+    ]);
   });
 
   it('should filter by prefix "/p"', () => {
@@ -32,7 +42,7 @@ describe('filterSlashCommands', () => {
 
   it('should return all commands for empty string prefix', () => {
     const result = filterSlashCommands('');
-    expect(result.length).toBe(6);
+    expect(result.length).toBe(7);
   });
 
   it('should not match prefix without leading slash', () => {
@@ -58,5 +68,10 @@ describe('filterSlashCommands', () => {
   it('should include labelKey for i18n lookup', () => {
     const result = filterSlashCommands('/play');
     expect(result[0]!.labelKey).toBe('interactive.commands.play');
+  });
+
+  it('should include /accept labelKey for i18n lookup', () => {
+    const result = filterSlashCommands('/accept');
+    expect(result[0]!.labelKey).toBe('interactive.commands.accept');
   });
 });

--- a/src/features/interactive/conversationLoop.ts
+++ b/src/features/interactive/conversationLoop.ts
@@ -61,6 +61,16 @@ function resolveGoSummaryInput(
   };
 }
 
+function findLatestAssistantMessage(history: ConversationMessage[]): ConversationMessage | undefined {
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const message = history[i];
+    if (message?.role === 'assistant') {
+      return message;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Display and clear previous session state if present.
  */
@@ -97,7 +107,7 @@ export interface ConversationStrategy {
 /**
  * Run the shared conversation loop.
  *
- * Handles: EOF, /play, /retry, /go (summary), /cancel, regular AI messaging.
+ * Handles: EOF, /play, /accept, /retry, /go (summary), /cancel, regular AI messaging.
  * The Strategy object controls system prompt, tool access, and prompt transformation.
  */
 export async function runConversationLoop(
@@ -199,6 +209,15 @@ export async function runConversationLoop(
     }
 
     switch (match.command) {
+      case SlashCommand.Accept: {
+        const assistantMessage = findLatestAssistantMessage(history);
+        if (!assistantMessage) {
+          info(ui.acceptNoAssistant);
+          continue;
+        }
+        return { action: 'execute', task: assistantMessage.content };
+      }
+
       case SlashCommand.Play: {
         if (!match.text) {
           info(ui.playNoTask);

--- a/src/features/interactive/interactive.ts
+++ b/src/features/interactive/interactive.ts
@@ -50,6 +50,7 @@ export interface InteractiveUIText {
     continue: string;
   };
   cancelled: string;
+  acceptNoAssistant: string;
   playNoTask: string;
   retryNoOrder: string;
   retryUnavailable: string;
@@ -115,9 +116,10 @@ export {
  *
  * Starts a conversation loop where the user can discuss task requirements
  * with AI. The conversation continues until:
- *   /go     → returns the conversation as a task
- *   /cancel → exits without executing
- *   Ctrl+D  → exits without executing
+ *   /go      → returns the conversation as a task
+ *   /accept  → returns the latest assistant response as a task
+ *   /cancel  → exits without executing
+ *   Ctrl+D   → exits without executing
  */
 export interface InteractiveModeOptions {
   /** Actions to exclude from the post-summary action selector. */

--- a/src/features/interactive/slashCommandRegistry.ts
+++ b/src/features/interactive/slashCommandRegistry.ts
@@ -9,6 +9,7 @@ import { SlashCommand } from '../../shared/constants.js';
 
 /** i18n label key for each slash command description */
 const SLASH_COMMAND_LABEL_KEYS: Readonly<Record<SlashCommand, string>> = {
+  '/accept': 'interactive.commands.accept',
   '/play': 'interactive.commands.play',
   '/go': 'interactive.commands.go',
   '/retry': 'interactive.commands.retry',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,6 +13,7 @@ export const DEFAULT_LANGUAGE: Language = 'en';
 
 /** Slash commands recognized in interactive mode */
 export const SlashCommand = {
+  Accept: '/accept',
   Play: '/play',
   Go: '/go',
   Retry: '/retry',

--- a/src/shared/i18n/labels_en.yaml
+++ b/src/shared/i18n/labels_en.yaml
@@ -11,7 +11,7 @@ interactive:
   conversationLabel: "Conversation:"
   noTranscript: "(No local transcript. Summarize the current session context.)"
   ui:
-    intro: "Interactive mode - describe your task. Commands: /go (create instruction & run), /play (run now), /resume (load session), /cancel (exit)"
+    intro: "Interactive mode - describe your task. Commands: /go (create instruction & run), /play (run now), /accept (use latest assistant response), /resume (load session), /cancel (exit)"
     introQuiet: "Quiet mode - describe your task. Instructions will be generated without further questions."
     introPassthrough: "Passthrough mode - describe your task. Your input will be passed directly as the task."
     resume: "Resuming previous session"
@@ -28,6 +28,7 @@ interactive:
       saveTask: "Save as Task"
       continue: "Continue editing"
     cancelled: "Cancelled"
+    acceptNoAssistant: "No assistant response found. Please describe your task first."
     playNoTask: "Please specify task content: /play <task>"
     retryNoOrder: "No previous order (order.md) found. /retry is only available during retry."
     retryUnavailable: "/retry is only available in Retry mode from `takt list`."
@@ -62,6 +63,7 @@ interactive:
     workflow: "Workflow: {workflowName}"
     timestamp: "Executed: {timestamp}"
   commands:
+    accept: "Accept latest assistant response"
     play: "Run a task immediately"
     go: "Create instruction & run"
     retry: "Review & rerun with previous instructions"

--- a/src/shared/i18n/labels_ja.yaml
+++ b/src/shared/i18n/labels_ja.yaml
@@ -11,7 +11,7 @@ interactive:
   conversationLabel: "会話:"
   noTranscript: "（ローカル履歴なし。現在のセッション文脈を要約してください。）"
   ui:
-    intro: "対話モード - タスク内容を入力してください。コマンド: /go（指示書作成・実行）, /play（即実行）, /resume（セッション読込）, /cancel（終了）"
+    intro: "対話モード - タスク内容を入力してください。コマンド: /go（指示書作成・実行）, /play（即実行）, /accept（最新のアシスタント発言を採用）, /resume（セッション読込）, /cancel（終了）"
     introQuiet: "クワイエットモード - タスク内容を入力してください。追加質問なしで指示書を生成します。"
     introPassthrough: "パススルーモード - タスク内容を入力してください。入力内容をそのまま実行します。"
     resume: "前回のセッションを再開します"
@@ -28,6 +28,7 @@ interactive:
       saveTask: "タスクにつむ"
       continue: "会話を続ける"
     cancelled: "キャンセルしました"
+    acceptNoAssistant: "アシスタント発言が見つかりません。まずタスク内容を入力してください。"
     playNoTask: "タスク内容を指定してください: /play <タスク内容>"
     retryNoOrder: "前回の指示書（order.md）が見つかりません。/retry はリトライ時のみ使用できます。"
     retryUnavailable: "/retry は `takt list` の Retry モードでのみ使用できます。"
@@ -62,6 +63,7 @@ interactive:
     workflow: "使用ワークフロー: {workflowName}"
     timestamp: "実行時刻: {timestamp}"
   commands:
+    accept: "最新のアシスタント発言を採用"
     play: "タスクを即実行する"
     go: "指示書を作成して実行"
     retry: "前回の指示書を確認して再実行"


### PR DESCRIPTION
## Summary

# タスク指示書: `/accept` コマンドの実装

## 概要

インタラクティブモードに `/accept` コマンドを新規追加する。直前のアシスタント発言をタスク指示書としてそのままピース実行に渡す機能。

## 背景

- 対話モードで会話中、アシスタントが指示書相当の内容を発言することがある
- 現状はそれをコピーして `/play` に貼るか、`/go` で再要約するしかない
- `/accept` により、直前のアシスタント発言をそのまま採用して即実行できるようにする

## 作業内容

### 【高】コマンドハンドラの実装

**対象:** `src/features/interactive/conversationLoop.ts`（既存の `/play`, `/go` と同じ場所）

- `/accept` コマンドを追加
- 動作: 会話履歴から直前のアシスタント発言を取得し、その内容をタスクとして `{ action: 'execute', task }` を返す
- エラーケース: アシスタントの発言が会話履歴に存在しない場合、エラーメッセージを表示して続行

### 【高】i18n ラベルの追加

**対象:** `src/shared/i18n/labels_en.yaml`, `src/shared/i18n/labels_ja.yaml`

- `/accept` のエラーメッセージ用ラベルを追加（アシスタント発言が見つからない場合）
- `intro` 行のコマンド一覧に `/accept` を追記

### 【高】テストの追加

**対象:** 既存のインタラクティブモードテストファイル（`src/__tests__/interactive.test.ts` 等）

- `/accept` で直前のアシスタント発言がタスクとして渡されることを検証
- アシスタント発言がない状態で `/accept` を実行した場合のエラーハンドリングを検証

## 参照資料

- `src/features/interactive/conversationLoop.ts` — 既存の `/play`, `/go` コマンド実装
- `src/shared/i18n/labels_en.yaml`, `src/shared/i18n/labels_ja.yaml` — ラベル定義
- `src/__tests__/interactive.test.ts` — 既存テスト

## 確認方法

1. インタラクティブモードで会話し、アシスタントが応答した後に `/accept` を入力
2. 直前のアシスタント発言がタスクとしてピース実行に渡されることを確認
3. 会話開始直後（アシスタント発言なし）で `/accept` を入力し、エラーメッセージが表示されることを確認

## Execution Report

Workflow `takt-default` completed successfully.

Closes #287