### PR TITLE
chore: CodeRabbit 設定ファイル (.coderabbit.yaml) を追加

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,80 @@
+# CodeRabbit configuration for TAKT
+# Reference: https://docs.coderabbit.ai/reference/configuration
+
+language: ja-JP
+
+reviews:
+  # chill: 重要な問題（バグ・セキュリティ・即時可読性問題）に絞る。
+  # TAKT 自身の /review が詳細なレビューを行うため、CodeRabbit は早期発見・
+  # 補完的な役割に留める。
+  profile: chill
+
+  high_level_summary: true
+  poem: false
+  review_status: true
+  request_changes_workflow: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    # リリース PR / WIP PR は自動レビューしない
+    ignore_title_keywords:
+      - "Release v"
+      - "release/v"
+      - "WIP"
+      - "DO NOT MERGE"
+    # 自動 PR / Bot は対象外
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+      - "renovate[bot]"
+
+  # 自動生成物・依存物・ローカル成果物はレビュー対象から外す
+  path_filters:
+    - "!dist/**"
+    - "!node_modules/**"
+    - "!package-lock.json"
+    - "!.takt/**"
+    - "!coverage/**"
+
+  tools:
+    # JavaScript / TypeScript
+    eslint:
+      enabled: true
+    # Markdown ドキュメント
+    markdownlint:
+      enabled: true
+    # シェルスクリプト (e2e helpers 等)
+    shellcheck:
+      enabled: true
+    # GitHub Actions / builtins/**/*.yaml
+    yamllint:
+      enabled: true
+    # セキュリティ
+    gitleaks:
+      enabled: true
+    semgrep:
+      enabled: true
+    # 不要言語系は明示的に無効化（走査を軽くする）
+    ruff:
+      enabled: false
+    rubocop:
+      enabled: false
+    phpstan:
+      enabled: false
+    phpmd:
+      enabled: false
+    phpcs:
+      enabled: false
+
+chat:
+  art: false
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  pull_requests:
+    scope: auto


### PR DESCRIPTION
## Summary

導入した CodeRabbit に TAKT 向けの設定を与える `.coderabbit.yaml` を追加する。

CodeRabbit と TAKT 自身の `/review` を共存させる前提で、CodeRabbit は **早期発見・補完的役割** に絞り、詳細レビューは TAKT 側に任せる構成。

## 主な設定

| 項目 | 値 | 理由 |
|------|-----|------|
| `language` | `ja-JP` | レビューを日本語で出す |
| `reviews.profile` | `chill` | 重要な問題（バグ・セキュリティ・即時可読性）に絞る。TAKT の詳細レビューと重複指摘を避ける |
| `reviews.poem` | `false` | 演出 OFF、PR を真面目に保つ |
| `reviews.auto_review.enabled` | `true` | 全 main 向け PR で自動発火（運用してみてノイズが過剰なら `labels:` 追加してラベル運用に切替可能） |
| `reviews.auto_review.ignore_title_keywords` | `Release v` / `release/v` / `WIP` / `DO NOT MERGE` | リリース PR / WIP は対象外 |
| `reviews.auto_review.ignore_usernames` | `dependabot[bot]` / `github-actions[bot]` / `renovate[bot]` | 自動 PR は対象外 |
| `reviews.path_filters` | `dist/**` / `node_modules/**` / `package-lock.json` / `.takt/**` / `coverage/**` を除外 | 自動生成物・成果物・依存物 |
| `chat.art` | `false` | ASCII アート OFF |

## 有効化したツール

- `eslint` — TAKT が ESLint を採用
- `markdownlint` — docs/ 配下のレビュー用
- `shellcheck` — `e2e/helpers` 等のシェルスクリプト
- `yamllint` — `.github/workflows` と `builtins/**/*.yaml` のチェック
- `gitleaks` / `semgrep` — 秘密情報 / セキュリティパターン検出

## 明示的に無効化したツール

- `ruff` / `rubocop` / `phpstan` / `phpmd` / `phpcs` — 該当言語を使っていないので走査を軽くする

## Test plan

- [ ] この PR 自体に CodeRabbit が自動レビューを実行し、ノイズが許容範囲か確認
- [ ] CodeRabbit のコメントが日本語で投稿されることを確認
- [ ] `path_filters` で除外したパスが言及されないことを確認
- [ ] TAKT の `/review` (PR Comment Commands) と棲み分けて使えるか確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- 開発チームの品質管理およびコードレビュープロセスを強化するための設定を追加しました。自動レビュー、コード分析、セキュリティチェックなどの機能を活用し、より堅牢で高品質なサービスの提供を目指します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->