### PR TITLE
chore(coderabbit): TAKT facets を code_guidelines として参照

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -72,6 +72,19 @@ chat:
   auto_reply: true
 
 knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "builtins/ja/facets/policies/ai-antipattern.md"
+      - "builtins/ja/facets/policies/coding.md"
+      - "builtins/ja/facets/policies/review.md"
+      - "builtins/ja/facets/policies/task-decomposition.md"
+      - "builtins/ja/facets/policies/testing.md"
+      - "builtins/ja/facets/knowledge/architecture.md"
+      - "builtins/ja/facets/knowledge/e2e-testing.md"
+      - "builtins/ja/facets/knowledge/security.md"
+      - "builtins/ja/facets/knowledge/takt.md"
+      - "builtins/ja/facets/knowledge/unit-testing.md"
   learnings:
     scope: auto
   issues:


### PR DESCRIPTION
## Summary

`.coderabbit.yaml` の `knowledge_base.code_guidelines.filePatterns` に、TAKT 自身の `/review` ワークフロー (`takt-default` / `draft` / `peer-review`) が参照する facets を明示指定する。CodeRabbit にも同じレビュー基準を適用させる狙い。

公式 reference の解釈として `filePatterns` 明示指定なら配置ディレクトリに依らず全 PR 変更にグローバル適用される。実際の挙動は本 PR をマージ後の PR で観察して検証する。

## 参照する 10 ファイル

| カテゴリ | ファイル |
|------|--------|
| Policies | `policies/ai-antipattern.md` / `coding.md` / `review.md` / `task-decomposition.md` / `testing.md` |
| Knowledge | `knowledge/architecture.md` / `e2e-testing.md` / `security.md` / `takt.md` / `unit-testing.md` |

合計 約 120KB。`takt-default` ワークフローで使われている facet のみに絞っている（frontend / cqrs-es / terraform 等は TAKT 開発に直結しないので除外）。

## メリット

- 新規ファイル不要、TAKT の facet をそのまま参照
- スクリプトも CI も不要、facet 更新 → 自動的に CodeRabbit に反映
- 効果が薄ければ後で外せる（剥がすのも簡単）

## Test plan

- [ ] マージ後、続く別 PR で CodeRabbit のレビュー指摘が TAKT facet の REJECT 基準（AI antipattern、 architecture 等）に沿っているか観察
- [ ] CodeRabbit のレビュー速度が許容範囲か（120KB 増の影響）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ナレッジベースの参照対象範囲を拡張しました。システムが学習・参照できるドキュメント範囲を追加することで、より多くの情報源を活用できるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->