### PR TITLE
docs: add CodeRabbit as sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,18 @@ See [External Integrations](./docs/external-integrations.md) for other community
 | [External Integrations](./docs/external-integrations.md) | Community examples that extend TAKT without modifying core (audit trails, etc.) |
 | [Changelog](./CHANGELOG.md) ([日本語](./docs/CHANGELOG.ja.md)) | Version history |
 
+## Sponsors
+
+TAKT is supported by [CodeRabbit](https://coderabbit.link/nrslib) through its Open Source Support Program.
+
+<a href="https://coderabbit.link/nrslib">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_79b9189d19.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg">
+    <img alt="CodeRabbit" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg" height="40">
+  </picture>
+</a>
+
 ## Community
 
 Join the [TAKT Discord](https://discord.gg/R2Xz3uYWxD) for questions, discussions, and updates.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -293,6 +293,18 @@ npx create-takt-sdd
 | [External Integrations](./external-integrations.ja.md) | TAKT コアを変更せずに機能を拡張するコミュニティサンプル（監査ログ等） |
 | [Changelog](../CHANGELOG.md) ([日本語](./CHANGELOG.ja.md)) | バージョン履歴 |
 
+## スポンサー
+
+TAKT は [CodeRabbit](https://coderabbit.link/nrslib) の Open Source Support Program によってサポートされています。
+
+<a href="https://coderabbit.link/nrslib">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_79b9189d19.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg">
+    <img alt="CodeRabbit" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg" height="40">
+  </picture>
+</a>
+
 ## コミュニティ
 
 質問・議論・最新情報は [TAKT Discord](https://discord.gg/R2Xz3uYWxD) へどうぞ。


### PR DESCRIPTION
## Summary

- CodeRabbit から OSS Support Program のスポンサーシップを受けることになったので、README に `## Sponsors` セクションを追加
- ロゴは CodeRabbit 公式ブランドページ（coderabbit.ai/brand）で公開されている SVG を `<picture>` で light/dark 出し分け
- リンク先は Santosh 経由で共有された referral URL: https://coderabbit.link/nrslib

## Preview

GitHub のテーマ切り替え（右上アバター → Appearance → Light / Dark）でロゴが切り替わることを確認してください。

## Test plan

- [ ] GitHub 上で README をレンダリングして light / dark 両方ロゴが意図通りに表示されるか確認
- [ ] CodeRabbit がこの PR をレビューしてくることを確認（導入検証も兼ねる）
- [ ] Santosh に PR URL を共有して文言・見た目に問題ないか確認 → OK なら ready for review に上げて merge

## Notes

- 現状はロゴ SVG を外部 URL（CodeRabbit の Strapi CDN）から直接参照しています。長期的には `docs/assets/sponsors/` 配下に取り込む選択肢もありますが、まずは公式 CDN を使う最小構成で出しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * ドキュメントにスポンサー情報セクションを新たに追加しました。CodeRabbit の Open Source Support Program によるサポート内容を記載し、ライト/ダークモード対応のロゴ画像とリンクが表示されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->