### PR TITLE
chore: CodeRabbit 設定読み込み確認用テストPR

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,7 @@ reviews:
   poem: false
 
   path_instructions:
-    - path: "**/*.{ts,tsx,js,jsx}"
+    - path: "**"
       instructions: |
         レビュー時は以下の手順で進めること。
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,21 @@ reviews:
   profile: assertive
   poem: false
 
+  path_instructions:
+    - path: "**/*.{ts,tsx,js,jsx}"
+      instructions: |
+        レビュー時は以下の手順で進めること。
+
+        Step 1: knowledge_base に登録された TAKT のコーディングガイドライン
+                （policies/ および knowledge/ 配下のファイル群）を網羅的に参照する。
+        Step 2: 各ガイドラインに含まれるルール・REJECT 例・判定基準を、
+                今回の差分に対して 1 つずつ照合する。
+        Step 3: 該当する違反が見つかった場合、どのガイドラインのどのルールに
+                基づく指摘かを明示して指摘を作成する。
+        Step 4: 一般的なベストプラクティスより、TAKT のガイドラインに
+                書かれた基準を優先せよ。広く使われているパターンであっても、
+                ガイドライン上 REJECT であれば指摘する。
+
   auto_review:
     ignore_title_keywords:
       - "Release v"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,34 +1,20 @@
-# CodeRabbit configuration for TAKT
-# Reference: https://docs.coderabbit.ai/reference/configuration
-
 language: ja-JP
 
 reviews:
-  # NOTE(probe): 通常 main では `chill` だが、ガイドライン参照度のテスト用に
-  # 一時的に assertive へ変更している。マージしないこと。
   profile: assertive
-
-  high_level_summary: true
   poem: false
-  review_status: true
-  request_changes_workflow: false
 
   auto_review:
-    enabled: true
-    drafts: false
-    # リリース PR / WIP PR は自動レビューしない
     ignore_title_keywords:
       - "Release v"
       - "release/v"
       - "WIP"
       - "DO NOT MERGE"
-    # 自動 PR / Bot は対象外
     ignore_usernames:
       - "dependabot[bot]"
       - "github-actions[bot]"
       - "renovate[bot]"
 
-  # 自動生成物・依存物・ローカル成果物はレビュー対象から外す
   path_filters:
     - "!dist/**"
     - "!node_modules/**"
@@ -37,24 +23,6 @@ reviews:
     - "!coverage/**"
 
   tools:
-    # JavaScript / TypeScript
-    eslint:
-      enabled: true
-    # Markdown ドキュメント
-    markdownlint:
-      enabled: true
-    # シェルスクリプト (e2e helpers 等)
-    shellcheck:
-      enabled: true
-    # GitHub Actions / builtins/**/*.yaml
-    yamllint:
-      enabled: true
-    # セキュリティ
-    gitleaks:
-      enabled: true
-    semgrep:
-      enabled: true
-    # 不要言語系は明示的に無効化（走査を軽くする）
     ruff:
       enabled: false
     rubocop:
@@ -68,11 +36,9 @@ reviews:
 
 chat:
   art: false
-  auto_reply: true
 
 knowledge_base:
   code_guidelines:
-    enabled: true
     filePatterns:
       - "builtins/ja/facets/policies/ai-antipattern.md"
       - "builtins/ja/facets/policies/coding.md"
@@ -84,9 +50,3 @@ knowledge_base:
       - "builtins/ja/facets/knowledge/security.md"
       - "builtins/ja/facets/knowledge/takt.md"
       - "builtins/ja/facets/knowledge/unit-testing.md"
-  learnings:
-    scope: auto
-  issues:
-    scope: auto
-  pull_requests:
-    scope: auto

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,10 +4,9 @@
 language: ja-JP
 
 reviews:
-  # chill: 重要な問題（バグ・セキュリティ・即時可読性問題）に絞る。
-  # TAKT 自身の /review が詳細なレビューを行うため、CodeRabbit は早期発見・
-  # 補完的な役割に留める。
-  profile: chill
+  # NOTE(probe): 通常 main では `chill` だが、ガイドライン参照度のテスト用に
+  # 一時的に assertive へ変更している。マージしないこと。
+  profile: assertive
 
   high_level_summary: true
   poem: false

--- a/tmp/coderabbit-probe.ts
+++ b/tmp/coderabbit-probe.ts
@@ -1,0 +1,42 @@
+interface ProcessOptions {
+  format?: string;
+}
+
+export async function processWithFormat(
+  input: string,
+  output: string,
+  options: ProcessOptions
+): Promise<void> {
+  if (options.format !== undefined) {
+    await processFile(input, output, { format: options.format });
+  } else {
+    await processFile(input, output);
+  }
+}
+
+export async function selectMode(): Promise<string | undefined> {
+  let selectedMode: string | undefined;
+  await promptUser(["dev", "prod"], (choice) => {
+    selectedMode = choice;
+  });
+  return selectedMode;
+}
+
+export function getUserId(user: { id?: string }): string {
+  return user.id ?? "unknown";
+}
+
+async function processFile(
+  _input: string,
+  _output: string,
+  _opts?: { format?: string }
+): Promise<void> {
+  return;
+}
+
+async function promptUser(
+  _choices: string[],
+  cb: (choice: string) => void
+): Promise<void> {
+  cb("dev");
+}


### PR DESCRIPTION
## 目的

`.coderabbit.yaml` および `knowledge_base.code_guidelines.filePatterns` で参照しているファセットファイル群が、CodeRabbit によって実際に読み込まれているかを確認するためのテスト PR です。

## 観察ポイント

### A. `.coderabbit.yaml` 自体が読まれているか

- `language: ja-JP` → レビューコメントが日本語で返るか
- `poem: false` → CodeRabbit の俳句が **出ない** か（PR #739 では出てしまっていた）
- `profile: chill` → 重要度の高い指摘に絞り込まれているか
- Run configuration が `defaults` 以外と表示されるか

### B. `knowledge_base.code_guidelines.filePatterns` が参照されているか

`tmp/coderabbit-probe.ts` に `builtins/ja/facets/policies/ai-antipattern.md` 由来の典型的な違反を 3 種仕込んでいます:

1. **冗長な条件分岐パターン** (`processWithFormat`)
   - `if (options.format !== undefined) { f(a, b, {format}) } else { f(a, b) }`
   - 出典: ai-antipattern.md L50-76
2. **コールバック + 外部変数キャプチャの濫用** (`selectMode`)
   - `let selectedMode; await promptUser(choices, c => { selectedMode = c })`
   - 出典: ai-antipattern.md L78-104
3. **フォールバック・デフォルト引数の濫用** (`getUserId`)
   - `user?.id ?? "unknown"` （必須データへのフォールバック）
   - 出典: ai-antipattern.md L248-267

これらは TAKT 独自の規約であり、一般的な lint やデフォルトのコードレビュー観点では指摘されない種類のパターンです。  
**CodeRabbit がこれらに対して `ai-antipattern.md` を参照した指摘を返してきたら、ガイドラインの参照は機能している** と判断できます。

## 動作確認手順

1. CodeRabbit のレビューが走るのを待つ
2. 上記 A / B の観点で出力を確認
3. 結果がどちらにせよ、確認後にこの PR は **クローズして破棄**（マージしない）

## 後始末

- `tmp/coderabbit-probe.ts` は本番コードではありません
- 観察が終わったら PR をクローズし、ブランチも削除します

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 簡易なファイル処理フロー、モード選択、ユーザーID取得を追加（ダミー実装で既定の開発モードを返し、不明なユーザーは "unknown" を返します）。

* **Chores**
  * レビュープロファイルを「assertive」に変更しレビュー設定を整理。
  * 静的解析／リンティング設定を簡素化・整理。
  * ナレッジベースの一部参照パターンを削除。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->