### PR TITLE
chore(coderabbit): assertive + Step by Step path_instructions に切り替え

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,35 +1,35 @@
-# CodeRabbit configuration for TAKT
-# Reference: https://docs.coderabbit.ai/reference/configuration
-
 language: ja-JP
 
 reviews:
-  # chill: 重要な問題（バグ・セキュリティ・即時可読性問題）に絞る。
-  # TAKT 自身の /review が詳細なレビューを行うため、CodeRabbit は早期発見・
-  # 補完的な役割に留める。
-  profile: chill
-
-  high_level_summary: true
+  profile: assertive
   poem: false
-  review_status: true
-  request_changes_workflow: false
+
+  path_instructions:
+    - path: "**"
+      instructions: |
+        レビュー時は以下の手順で進めること。
+
+        Step 1: knowledge_base に登録された TAKT のコーディングガイドライン
+                （policies/ および knowledge/ 配下のファイル群）を網羅的に参照する。
+        Step 2: 各ガイドラインに含まれるルール・REJECT 例・判定基準を、
+                今回の差分に対して 1 つずつ照合する。
+        Step 3: 該当する違反が見つかった場合、どのガイドラインのどのルールに
+                基づく指摘かを明示して指摘を作成する。
+        Step 4: 一般的なベストプラクティスより、TAKT のガイドラインに
+                書かれた基準を優先せよ。広く使われているパターンであっても、
+                ガイドライン上 REJECT であれば指摘する。
 
   auto_review:
-    enabled: true
-    drafts: false
-    # リリース PR / WIP PR は自動レビューしない
     ignore_title_keywords:
       - "Release v"
       - "release/v"
       - "WIP"
       - "DO NOT MERGE"
-    # 自動 PR / Bot は対象外
     ignore_usernames:
       - "dependabot[bot]"
       - "github-actions[bot]"
       - "renovate[bot]"
 
-  # 自動生成物・依存物・ローカル成果物はレビュー対象から外す
   path_filters:
     - "!dist/**"
     - "!node_modules/**"
@@ -38,24 +38,6 @@ reviews:
     - "!coverage/**"
 
   tools:
-    # JavaScript / TypeScript
-    eslint:
-      enabled: true
-    # Markdown ドキュメント
-    markdownlint:
-      enabled: true
-    # シェルスクリプト (e2e helpers 等)
-    shellcheck:
-      enabled: true
-    # GitHub Actions / builtins/**/*.yaml
-    yamllint:
-      enabled: true
-    # セキュリティ
-    gitleaks:
-      enabled: true
-    semgrep:
-      enabled: true
-    # 不要言語系は明示的に無効化（走査を軽くする）
     ruff:
       enabled: false
     rubocop:
@@ -69,11 +51,9 @@ reviews:
 
 chat:
   art: false
-  auto_reply: true
 
 knowledge_base:
   code_guidelines:
-    enabled: true
     filePatterns:
       - "builtins/ja/facets/policies/ai-antipattern.md"
       - "builtins/ja/facets/policies/coding.md"
@@ -85,9 +65,3 @@ knowledge_base:
       - "builtins/ja/facets/knowledge/security.md"
       - "builtins/ja/facets/knowledge/takt.md"
       - "builtins/ja/facets/knowledge/unit-testing.md"
-  learnings:
-    scope: auto
-  issues:
-    scope: auto
-  pull_requests:
-    scope: auto


### PR DESCRIPTION
## Summary

PR #743 のプローブ検証で得られた知見を main に反映する。

主な変更:

- `profile: chill` → **`assertive`**
- `reviews.path_instructions` を新設し、TAKT ガイドラインを網羅的に参照するための **Step by Step 手順** をインライン化（`path: "**"`）
- デフォルト値と一致する設定項目を全削除（`high_level_summary`, `review_status`, `request_changes_workflow`, `auto_review.enabled`/`drafts`, デフォルトで有効な tools 各種, `chat.auto_reply`, `code_guidelines.enabled`, `learnings/issues/pull_requests` 全体）
- コメントを全削除

## 検証結果（PR #743 プローブより）

`tmp/coderabbit-probe.ts` に仕込んだ AI antipattern 3 種に対する検出:

| 違反 | 元の chill | 試行 assertive | **本構成 (assertive + step-by-step + path:\*\*)** |
|---|---|---|---|
| 冗長な条件分岐 | ❌ | ✅ | ✅ |
| コールバック + 外部変数キャプチャ | 🟡 Nitpick | ✅ | ✅ |
| フォールバック濫用 (`user?.id ?? "unknown"`) | ❌ | ❌ | ✅ |

「フォールバック濫用」は assertive 単体では捕れず、**Step by Step 手順 + `path: "**"`** の組み合わせで初めて指摘されるようになった。指摘文言も「**REJECT パターンです**」「**As per coding guidelines, 「…は REJECT」**」とガイドライン由来であることを明示するようになった。

## なお

- `path: "**/*.{ts,tsx,...}"` のようなブレース展開は CodeRabbit の glob では効かない（プローブで判明）。本 PR では `path: "**"` を採用
- 既存の TAKT 自身の `/review` ワークフローとは指摘観点を住み分ける運用想定。assertive のノイズが大きすぎる場合は path_instructions の手順文言だけ残して `profile: chill` に戻す選択肢もある

## Test plan

- [ ] 本 PR に対する CodeRabbit のレビューが日本語・Step by Step を反映した形で来ることを確認
- [ ] 通常 PR 運用で指摘のノイズ／シグナル比が許容範囲か観察（マージ後しばらく）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CodeRabbitのレビュー設定を更新しました。レビュープロファイルがより厳密な「assertive」モードに変更され、ガイドラインに基づいた検証プロセスが強化されました。また、ナレッジベース構成を整理し、設定の効率化を図りました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->