### PR TITLE
feat: workflow/step span の shadow 計装を追加

### DIFF
--- a/src/__tests__/workflowExecution-session-loading.test.ts
+++ b/src/__tests__/workflowExecution-session-loading.test.ts
@@ -438,6 +438,7 @@ describe('executeWorkflow session loading', () => {
     });
 
     expect(mockInitializeOtelFoundation).toHaveBeenCalledWith(observability);
+    expect(MockWorkflowEngine.lastInstance.receivedOptions.observability).toBe(observability);
     expect(mockObservabilityShutdown).toHaveBeenCalledOnce();
   });
 

--- a/src/__tests__/workflowSpans.test.ts
+++ b/src/__tests__/workflowSpans.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowStep } from '../core/models/types.js';
+import type { StepRunResult } from '../core/workflow/types.js';
+
+type FakeSpanStatus = {
+  code: number;
+  message?: string;
+};
+
+class FakeSpan {
+  readonly attributes: Record<string, unknown>;
+  readonly exceptions: unknown[] = [];
+  status: FakeSpanStatus | undefined;
+  ended = false;
+  parentName: string | undefined;
+
+  constructor(
+    readonly name: string,
+    attributes: Record<string, unknown>,
+  ) {
+    this.attributes = { ...attributes };
+  }
+
+  setAttribute(key: string, value: unknown): this {
+    this.attributes[key] = value;
+    return this;
+  }
+
+  setAttributes(attributes: Record<string, unknown>): this {
+    Object.assign(this.attributes, attributes);
+    return this;
+  }
+
+  setStatus(status: FakeSpanStatus): this {
+    this.status = status;
+    return this;
+  }
+
+  recordException(error: unknown): void {
+    this.exceptions.push(error);
+  }
+
+  end(): void {
+    this.ended = true;
+  }
+}
+
+async function loadWorkflowSpansWithMockedApi() {
+  vi.resetModules();
+
+  const spans: FakeSpan[] = [];
+  let activeSpan: FakeSpan | undefined;
+
+  vi.doMock('@opentelemetry/api', () => ({
+    SpanStatusCode: {
+      ERROR: 2,
+    },
+    context: {
+      active: vi.fn(() => ({ span: activeSpan })),
+      with: vi.fn(async (ctx: { span?: FakeSpan }, fn: () => Promise<unknown>) => {
+        const previous = activeSpan;
+        activeSpan = ctx.span;
+        try {
+          return await fn();
+        } finally {
+          activeSpan = previous;
+        }
+      }),
+    },
+    trace: {
+      getTracer: vi.fn(() => ({
+        startSpan: vi.fn((name: string, options: { attributes?: Record<string, unknown> } = {}) => {
+          const span = new FakeSpan(name, options.attributes ?? {});
+          span.parentName = activeSpan?.name;
+          spans.push(span);
+          return span;
+        }),
+      })),
+      setSpan: vi.fn((_ctx: unknown, span: FakeSpan) => ({ span })),
+    },
+  }));
+
+  const module = await import('../core/workflow/observability/workflowSpans.js');
+  return { module, spans };
+}
+
+function makeStep(overrides: Partial<WorkflowStep> = {}): WorkflowStep {
+  return {
+    name: 'implement',
+    persona: '../agents/coder.md',
+    instruction: 'Implement',
+    rules: [{ condition: 'done', next: 'COMPLETE' }],
+    ...overrides,
+  };
+}
+
+function makeDoneResult(): StepRunResult {
+  return {
+    response: {
+      persona: 'coder',
+      status: 'done',
+      content: 'ok',
+      timestamp: new Date('2026-05-18T00:00:00.000Z'),
+    },
+    instruction: 'Implement',
+    providerInfo: {
+      provider: 'codex',
+      model: 'gpt-5',
+      providerSource: 'project',
+      modelSource: 'global',
+    },
+  };
+}
+
+describe('workflow OpenTelemetry spans', () => {
+  afterEach(() => {
+    vi.doUnmock('@opentelemetry/api');
+    vi.resetModules();
+  });
+
+  it('does not start spans when observability is disabled', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+
+    const result = await module.runWithWorkflowSpan({
+      enabled: false,
+      workflowName: 'test-workflow',
+      initialStep: 'implement',
+      stepCount: 1,
+      maxSteps: 3,
+      runMode: 'full',
+      resumeDepth: 0,
+    }, async () => 'ok', () => ({ status: 'completed' }));
+
+    expect(result).toBe('ok');
+    expect(spans).toEqual([]);
+  });
+
+  it('records workflow span attributes and terminal status', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+
+    await module.runWithWorkflowSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      initialStep: 'implement',
+      stepCount: 2,
+      maxSteps: 'infinite',
+      runMode: 'full',
+      resumeDepth: 1,
+    }, async () => ({ done: true }), () => ({ status: 'completed' }));
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.name).toBe('workflow.test-workflow');
+    expect(spans[0]?.attributes).toMatchObject({
+      'takt.workflow.name': 'test-workflow',
+      'takt.workflow.initial_step': 'implement',
+      'takt.workflow.step_count': 2,
+      'takt.workflow.max_steps': 'infinite',
+      'takt.workflow.run_mode': 'full',
+      'takt.workflow.resume_depth': 1,
+      'takt.workflow.status': 'completed',
+    });
+    expect(spans[0]?.ended).toBe(true);
+  });
+
+  it('creates step spans as workflow children with provider and step attributes', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step = makeStep();
+
+    await module.runWithWorkflowSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      initialStep: 'implement',
+      stepCount: 1,
+      maxSteps: 3,
+      runMode: 'full',
+      resumeDepth: 0,
+    }, async () => {
+      await module.runWithStepSpan({
+        enabled: true,
+        workflowName: 'test-workflow',
+        step,
+        iteration: 2,
+        stepIteration: 1,
+        getFinalStepIteration: () => 1,
+      }, async () => makeDoneResult());
+      return { done: true };
+    }, () => ({ status: 'completed' }));
+
+    expect(spans.map((span) => span.name)).toEqual([
+      'workflow.test-workflow',
+      'step.implement',
+    ]);
+    expect(spans[1]?.parentName).toBe('workflow.test-workflow');
+    expect(spans[1]?.attributes).toMatchObject({
+      'takt.workflow.name': 'test-workflow',
+      'takt.step.name': 'implement',
+      'takt.step.type': 'agent',
+      'takt.step.iteration': 2,
+      'takt.step.local_iteration': 1,
+      'takt.step.status': 'done',
+      'takt.provider.name': 'codex',
+      'takt.provider.source': 'project',
+      'takt.model.name': 'gpt-5',
+      'takt.model.source': 'global',
+    });
+    expect(spans[1]?.ended).toBe(true);
+  });
+
+  it('marks thrown step spans as errors without swallowing the original error', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const error = new Error('agent failed');
+
+    await expect(
+      module.runWithStepSpan({
+        enabled: true,
+        workflowName: 'test-workflow',
+        step: makeStep(),
+        iteration: 1,
+      }, async () => {
+        throw error;
+      }),
+    ).rejects.toThrow('agent failed');
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.status).toEqual({ code: 2, message: 'agent failed' });
+    expect(spans[0]?.exceptions).toEqual([error]);
+    expect(spans[0]?.ended).toBe(true);
+  });
+});

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -24,6 +24,7 @@ import { runSingleWorkflowIteration, runWorkflowToCompletion } from './WorkflowR
 import { validateWorkflowConfig } from './WorkflowValidator.js';
 import { getWorkflowStepKind } from '../step-kind.js';
 import { buildWorkflowResumePointEntry } from '../workflow-reference.js';
+import { runWithWorkflowSpan, type WorkflowSpanParams } from '../observability/workflowSpans.js';
 import { WorkflowEngineStepCoordinator } from './WorkflowEngineStepCoordinator.js';
 import {
   applyRuntimeEnvironment,
@@ -180,40 +181,48 @@ export class WorkflowEngine extends EventEmitter {
       emitReport: (step, filePath, fileName) => this.emit('step:report', step, filePath, fileName),
     });
     workflowRunExecutors.set(this, () => this.runWithSystemCleanup(
-      () => runWorkflowToCompletion({
-        state: this.state,
-        options: this.options,
-        getCwd: () => this.cwd,
-        getMaxSteps: () => this.maxSteps,
-        getReportDir: () => this.runPaths.reportsAbs,
-        abortRequested: () => this.abortRequested,
-        getStep: this.stepCoordinator.getStep.bind(this.stepCoordinator),
-        applyRuntimeEnvironment: (stage) => applyRuntimeEnvironment(this.cwd, this.config, stage),
-        loopDetectorCheck: (stepName) => {
-          const result = this.loopDetector.check(stepName);
-          return {
-            shouldWarn: result.shouldWarn ?? false,
-            shouldAbort: result.shouldAbort ?? false,
-            count: result.count,
-            isLoop: result.isLoop,
-          };
-        },
-        cycleDetectorRecordAndCheck: (stepName) => this.cycleDetector.recordAndCheck(stepName),
-        resolveDoneTransition: this.stepCoordinator.resolveTransitionFromDone.bind(this.stepCoordinator),
-        runLoopMonitorJudge: this.stepCoordinator.runLoopMonitorJudge.bind(this.stepCoordinator),
-        runStep: this.stepCoordinator.runStep.bind(this.stepCoordinator),
-        buildInstruction: this.stepCoordinator.buildInstruction.bind(this.stepCoordinator),
-        buildPhase1Instruction: this.stepCoordinator.buildPhase1Instruction.bind(this.stepCoordinator),
-        resolveStepProviderModel: (step, runtime) => this.optionsBuilder.resolveStepProviderModel(step, runtime),
-        resolveRuntimeForStep: this.stepCoordinator.resolveRuntimeForStep.bind(this.stepCoordinator),
-        setActiveStep: this.setActiveResumePoint.bind(this),
-        addUserInput: this.addUserInput.bind(this),
-        emit: (event, ...args) => this.emit(event as never, ...args as []),
-        updateMaxSteps: (maxSteps) => {
-          this.maxSteps = maxSteps;
-          this.sharedRuntime.maxSteps = maxSteps;
-        },
-      }),
+      () => runWithWorkflowSpan(
+        this.buildWorkflowSpanParams('full'),
+        () => runWorkflowToCompletion({
+          state: this.state,
+          options: this.options,
+          getWorkflowName: () => this.config.name,
+          getCwd: () => this.cwd,
+          getMaxSteps: () => this.maxSteps,
+          getReportDir: () => this.runPaths.reportsAbs,
+          abortRequested: () => this.abortRequested,
+          getStep: this.stepCoordinator.getStep.bind(this.stepCoordinator),
+          applyRuntimeEnvironment: (stage) => applyRuntimeEnvironment(this.cwd, this.config, stage),
+          loopDetectorCheck: (stepName) => {
+            const result = this.loopDetector.check(stepName);
+            return {
+              shouldWarn: result.shouldWarn ?? false,
+              shouldAbort: result.shouldAbort ?? false,
+              count: result.count,
+              isLoop: result.isLoop,
+            };
+          },
+          cycleDetectorRecordAndCheck: (stepName) => this.cycleDetector.recordAndCheck(stepName),
+          resolveDoneTransition: this.stepCoordinator.resolveTransitionFromDone.bind(this.stepCoordinator),
+          runLoopMonitorJudge: this.stepCoordinator.runLoopMonitorJudge.bind(this.stepCoordinator),
+          runStep: this.stepCoordinator.runStep.bind(this.stepCoordinator),
+          buildInstruction: this.stepCoordinator.buildInstruction.bind(this.stepCoordinator),
+          buildPhase1Instruction: this.stepCoordinator.buildPhase1Instruction.bind(this.stepCoordinator),
+          resolveStepProviderModel: (step, runtime) => this.optionsBuilder.resolveStepProviderModel(step, runtime),
+          resolveRuntimeForStep: this.stepCoordinator.resolveRuntimeForStep.bind(this.stepCoordinator),
+          setActiveStep: this.setActiveResumePoint.bind(this),
+          addUserInput: this.addUserInput.bind(this),
+          emit: (event, ...args) => this.emit(event as never, ...args as []),
+          updateMaxSteps: (maxSteps) => {
+            this.maxSteps = maxSteps;
+            this.sharedRuntime.maxSteps = maxSteps;
+          },
+        }),
+        (result) => ({
+          status: result.state.status,
+          abortKind: result.abort?.kind,
+        }),
+      ),
       () => true,
     ));
 
@@ -285,6 +294,18 @@ export class WorkflowEngine extends EventEmitter {
     this.systemStepExecutor.cleanup();
   }
 
+  private buildWorkflowSpanParams(runMode: WorkflowSpanParams['runMode']): WorkflowSpanParams {
+    return {
+      enabled: this.options.observability?.enabled === true,
+      workflowName: this.config.name,
+      initialStep: this.config.initialStep,
+      stepCount: this.config.steps.length,
+      maxSteps: this.maxSteps,
+      runMode,
+      resumeDepth: this.resumeStackPrefix.length,
+    };
+  }
+
   private async runWithSystemCleanup<T>(
     execute: () => Promise<T>,
     shouldCleanup: (result: T | undefined, error: unknown | undefined) => boolean,
@@ -317,37 +338,45 @@ export class WorkflowEngine extends EventEmitter {
     loopDetected?: boolean;
   }> {
     return this.runWithSystemCleanup(
-      () => runSingleWorkflowIteration({
-        state: this.state,
-        options: this.options,
-        getCwd: () => this.cwd,
-        getMaxSteps: () => this.maxSteps,
-        getReportDir: () => this.runPaths.reportsAbs,
-        abortRequested: () => this.abortRequested,
-        getStep: this.stepCoordinator.getStep.bind(this.stepCoordinator),
-        applyRuntimeEnvironment: (stage) => applyRuntimeEnvironment(this.cwd, this.config, stage),
-        loopDetectorCheck: (stepName) => {
-          const loopResult = this.loopDetector.check(stepName);
-          return {
-            shouldWarn: loopResult.shouldWarn ?? false,
-            shouldAbort: loopResult.shouldAbort ?? false,
-            count: loopResult.count,
-            isLoop: loopResult.isLoop,
-          };
-        },
-        cycleDetectorRecordAndCheck: (stepName) => this.cycleDetector.recordAndCheck(stepName),
-        resolveDoneTransition: this.stepCoordinator.resolveTransitionFromDone.bind(this.stepCoordinator),
-        runLoopMonitorJudge: this.stepCoordinator.runLoopMonitorJudge.bind(this.stepCoordinator),
-        runStep: this.stepCoordinator.runStep.bind(this.stepCoordinator),
-        buildInstruction: this.stepCoordinator.buildInstruction.bind(this.stepCoordinator),
-        buildPhase1Instruction: this.stepCoordinator.buildPhase1Instruction.bind(this.stepCoordinator),
-        resolveStepProviderModel: (step, runtime) => this.optionsBuilder.resolveStepProviderModel(step, runtime),
-        resolveRuntimeForStep: this.stepCoordinator.resolveRuntimeForStep.bind(this.stepCoordinator),
-        setActiveStep: this.setActiveResumePoint.bind(this),
-        addUserInput: this.addUserInput.bind(this),
-        emit: (event, ...args) => this.emit(event as never, ...args as []),
-        updateMaxSteps: () => {},
-      }),
+      () => runWithWorkflowSpan(
+        this.buildWorkflowSpanParams('single_iteration'),
+        () => runSingleWorkflowIteration({
+          state: this.state,
+          options: this.options,
+          getWorkflowName: () => this.config.name,
+          getCwd: () => this.cwd,
+          getMaxSteps: () => this.maxSteps,
+          getReportDir: () => this.runPaths.reportsAbs,
+          abortRequested: () => this.abortRequested,
+          getStep: this.stepCoordinator.getStep.bind(this.stepCoordinator),
+          applyRuntimeEnvironment: (stage) => applyRuntimeEnvironment(this.cwd, this.config, stage),
+          loopDetectorCheck: (stepName) => {
+            const loopResult = this.loopDetector.check(stepName);
+            return {
+              shouldWarn: loopResult.shouldWarn ?? false,
+              shouldAbort: loopResult.shouldAbort ?? false,
+              count: loopResult.count,
+              isLoop: loopResult.isLoop,
+            };
+          },
+          cycleDetectorRecordAndCheck: (stepName) => this.cycleDetector.recordAndCheck(stepName),
+          resolveDoneTransition: this.stepCoordinator.resolveTransitionFromDone.bind(this.stepCoordinator),
+          runLoopMonitorJudge: this.stepCoordinator.runLoopMonitorJudge.bind(this.stepCoordinator),
+          runStep: this.stepCoordinator.runStep.bind(this.stepCoordinator),
+          buildInstruction: this.stepCoordinator.buildInstruction.bind(this.stepCoordinator),
+          buildPhase1Instruction: this.stepCoordinator.buildPhase1Instruction.bind(this.stepCoordinator),
+          resolveStepProviderModel: (step, runtime) => this.optionsBuilder.resolveStepProviderModel(step, runtime),
+          resolveRuntimeForStep: this.stepCoordinator.resolveRuntimeForStep.bind(this.stepCoordinator),
+          setActiveStep: this.setActiveResumePoint.bind(this),
+          addUserInput: this.addUserInput.bind(this),
+          emit: (event, ...args) => this.emit(event as never, ...args as []),
+          updateMaxSteps: () => {},
+        }),
+        (result) => ({
+          status: result.isComplete ? this.state.status : 'running',
+          nextStep: result.nextStep,
+        }),
+      ),
       (result, error) => error !== undefined || result?.isComplete === true || this.state.status !== 'running',
     );
   }

--- a/src/core/workflow/engine/WorkflowRunLoop.ts
+++ b/src/core/workflow/engine/WorkflowRunLoop.ts
@@ -15,12 +15,14 @@ import { decrementStepIteration, incrementStepIteration } from './state-manager.
 import { handleBlocked } from './blocked-handler.js';
 import { isDelegatedWorkflowStep } from '../step-kind.js';
 import { resolvePromotionRuntime } from '../promotion/promotion-runtime.js';
+import { runWithStepSpan } from '../observability/workflowSpans.js';
 
 const log = createLogger('workflow-run-loop');
 
 interface WorkflowRunLoopDeps {
   state: WorkflowState;
   options: WorkflowEngineOptions;
+  getWorkflowName: () => string;
   getCwd: () => string;
   getMaxSteps: () => WorkflowMaxSteps;
   getReportDir: () => string;
@@ -280,18 +282,27 @@ export async function runWorkflowToCompletion(deps: WorkflowRunLoopDeps): Promis
       ? deps.buildPhase1Instruction(step, prebuiltInstruction, stepRuntime)
       : '';
     deps.setActiveStep(step, activeIteration);
-    deps.emit('step:start', step, activeIteration, stepInstruction, deps.resolveStepProviderModel(step, stepRuntime));
+    const providerInfo = deps.resolveStepProviderModel(step, stepRuntime);
+    deps.emit('step:start', step, activeIteration, stepInstruction, providerInfo);
 
     try {
-      const result = await deps.runStep(step, prebuiltInstruction, stepRuntime);
-      const { response, instruction, providerInfo } = result;
+      const result = await runWithStepSpan({
+        enabled: deps.options.observability?.enabled === true,
+        workflowName: deps.getWorkflowName(),
+        step,
+        iteration: activeIteration,
+        stepIteration,
+        providerInfo,
+        getFinalStepIteration: () => deps.state.stepIterations.get(step.name),
+      }, () => deps.runStep(step, prebuiltInstruction, stepRuntime));
+      const { response, instruction, providerInfo: resultProviderInfo } = result;
       if (stepRuntime?.fallback) {
         deps.state.pendingFallback = undefined;
       }
       deps.emit('step:complete', step, response, instruction);
 
       if (response.status === 'rate_limited') {
-        const currentProvider = providerInfo ?? deps.resolveStepProviderModel(step, stepRuntime);
+        const currentProvider = resultProviderInfo ?? providerInfo;
         const consumedStepIterations = result.consumedStepIterations ?? [step.name];
         const fallbackResult = prepareRateLimitFallback(
           deps,
@@ -448,8 +459,17 @@ export async function runSingleWorkflowIteration(deps: WorkflowRunLoopDeps): Pro
   if (!isDelegated && stepIteration !== undefined) {
     prebuiltInstruction = deps.buildInstruction(step, stepIteration);
   }
-  const result = await deps.runStep(step, prebuiltInstruction, stepRuntime);
-  const { response, providerInfo } = result;
+  const providerInfo = deps.resolveStepProviderModel(step, stepRuntime);
+  const result = await runWithStepSpan({
+    enabled: deps.options.observability?.enabled === true,
+    workflowName: deps.getWorkflowName(),
+    step,
+    iteration: activeIteration,
+    stepIteration,
+    providerInfo,
+    getFinalStepIteration: () => deps.state.stepIterations.get(step.name),
+  }, () => deps.runStep(step, prebuiltInstruction, stepRuntime));
+  const { response, providerInfo: resultProviderInfo } = result;
   if (stepRuntime?.fallback) {
     deps.state.pendingFallback = undefined;
   }
@@ -460,7 +480,7 @@ export async function runSingleWorkflowIteration(deps: WorkflowRunLoopDeps): Pro
     return { response, nextStep: ABORT_STEP, isComplete: true, loopDetected: loopCheck.isLoop };
   }
   if (response.status === 'rate_limited') {
-    const currentProvider = providerInfo ?? deps.resolveStepProviderModel(step, stepRuntime);
+    const currentProvider = resultProviderInfo ?? providerInfo;
     const consumedStepIterations = result.consumedStepIterations ?? [step.name];
     const fallbackResult = prepareRateLimitFallback(
       deps,

--- a/src/core/workflow/observability/workflowSpans.ts
+++ b/src/core/workflow/observability/workflowSpans.ts
@@ -1,0 +1,169 @@
+import { context, SpanStatusCode, trace, type Attributes, type Span } from '@opentelemetry/api';
+import { getErrorMessage } from '../../../shared/utils/index.js';
+import type { WorkflowMaxSteps, WorkflowStep } from '../../models/types.js';
+import type { StepProviderInfo, StepRunResult } from '../types.js';
+import { getWorkflowStepKind } from '../step-kind.js';
+
+const tracer = trace.getTracer('takt.workflow');
+
+type AttributeInput = Record<string, string | number | boolean | undefined>;
+
+export interface WorkflowSpanParams {
+  enabled: boolean;
+  workflowName: string;
+  initialStep: string;
+  stepCount: number;
+  maxSteps: WorkflowMaxSteps;
+  runMode: 'full' | 'single_iteration';
+  resumeDepth: number;
+}
+
+export interface WorkflowSpanOutcome {
+  status?: string;
+  abortKind?: string;
+  nextStep?: string;
+}
+
+export interface StepSpanParams {
+  enabled: boolean;
+  workflowName: string;
+  step: WorkflowStep;
+  iteration: number;
+  stepIteration?: number;
+  providerInfo?: StepProviderInfo;
+  getFinalStepIteration?: () => number | undefined;
+}
+
+export async function runWithWorkflowSpan<T>(
+  params: WorkflowSpanParams,
+  execute: () => Promise<T>,
+  getOutcome: (result: T) => WorkflowSpanOutcome,
+): Promise<T> {
+  if (!params.enabled) {
+    return execute();
+  }
+
+  return runInSpan(
+    buildSpanName('workflow', params.workflowName),
+    buildWorkflowAttributes(params),
+    async (span) => {
+      const result = await execute();
+      recordWorkflowOutcome(span, getOutcome(result));
+      return result;
+    },
+  );
+}
+
+export async function runWithStepSpan(
+  params: StepSpanParams,
+  execute: () => Promise<StepRunResult>,
+): Promise<StepRunResult> {
+  if (!params.enabled) {
+    return execute();
+  }
+
+  return runInSpan(
+    buildSpanName('step', params.step.name),
+    buildStepAttributes(params),
+    async (span) => {
+      const result = await execute();
+      recordStepResult(span, params, result);
+      return result;
+    },
+  );
+}
+
+function buildWorkflowAttributes(params: WorkflowSpanParams): Attributes {
+  return compactAttributes({
+    'takt.workflow.name': params.workflowName,
+    'takt.workflow.initial_step': params.initialStep,
+    'takt.workflow.step_count': params.stepCount,
+    'takt.workflow.max_steps': params.maxSteps,
+    'takt.workflow.run_mode': params.runMode,
+    'takt.workflow.resume_depth': params.resumeDepth,
+  });
+}
+
+function buildStepAttributes(params: StepSpanParams): Attributes {
+  return compactAttributes({
+    'takt.workflow.name': params.workflowName,
+    'takt.step.name': params.step.name,
+    'takt.step.type': getWorkflowStepKind(params.step),
+    'takt.step.iteration': params.iteration,
+    'takt.step.local_iteration': params.stepIteration,
+    ...providerAttributes(params.providerInfo),
+  });
+}
+
+async function runInSpan<T>(
+  name: string,
+  attributes: Attributes,
+  execute: (span: Span) => Promise<T>,
+): Promise<T> {
+  const span = tracer.startSpan(name, { attributes });
+  return context.with(trace.setSpan(context.active(), span), async () => {
+    try {
+      return await execute(span);
+    } catch (error) {
+      recordSpanError(span, error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+function recordWorkflowOutcome(span: Span, outcome: WorkflowSpanOutcome): void {
+  const attributes = compactAttributes({
+    'takt.workflow.status': outcome.status,
+    'takt.workflow.abort.kind': outcome.abortKind,
+    'takt.workflow.next_step': outcome.nextStep,
+  });
+  span.setAttributes(attributes);
+
+  if (outcome.status && outcome.status !== 'completed' && outcome.status !== 'running') {
+    span.setStatus({ code: SpanStatusCode.ERROR, message: `workflow ${outcome.status}` });
+  }
+}
+
+function recordStepResult(span: Span, params: StepSpanParams, result: StepRunResult): void {
+  const finalStepIteration = params.getFinalStepIteration?.();
+  span.setAttributes(compactAttributes({
+    'takt.step.local_iteration': finalStepIteration ?? params.stepIteration,
+    'takt.step.status': result.response.status,
+    ...providerAttributes(result.providerInfo ?? params.providerInfo),
+  }));
+
+  if (result.response.status === 'error' || result.response.status === 'rate_limited') {
+    span.setStatus({ code: SpanStatusCode.ERROR, message: `step ${result.response.status}` });
+  }
+}
+
+function providerAttributes(providerInfo: StepProviderInfo | undefined): AttributeInput {
+  return {
+    'takt.provider.name': providerInfo?.provider,
+    'takt.provider.source': providerInfo?.providerSource,
+    'takt.model.name': providerInfo?.model,
+    'takt.model.source': providerInfo?.modelSource,
+  };
+}
+
+function recordSpanError(span: Span, error: unknown): void {
+  const message = getErrorMessage(error);
+  span.recordException(error instanceof Error ? error : message);
+  span.setStatus({ code: SpanStatusCode.ERROR, message });
+}
+
+function buildSpanName(prefix: 'workflow' | 'step', name: string): string {
+  return `${prefix}.${name || 'unknown'}`;
+}
+
+function compactAttributes(attributes: AttributeInput): Attributes {
+  const compacted: Attributes = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value !== undefined) {
+      compacted[key] = value;
+    }
+  }
+  return compacted;
+}

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -12,7 +12,7 @@ import type {
   RateLimitFallbackConfig,
   FallbackContext,
 } from '../models/types.js';
-import type { PersonaProviderEntry } from '../models/config-types.js';
+import type { PersonaProviderEntry, ResolvedObservabilityConfig } from '../models/config-types.js';
 import type { ProviderPermissionProfiles } from '../models/provider-profiles.js';
 import type { StepProviderOptions } from '../models/workflow-types.js';
 import type { StructuredCaller } from '../../agents/structured-caller.js';
@@ -246,6 +246,8 @@ export interface WorkflowEngineOptions {
   bypassPermissions?: boolean;
   /** Project root directory (where .takt/ lives). */
   projectCwd: string;
+  /** Resolved observability opt-in config for workflow instrumentation. */
+  observability?: ResolvedObservabilityConfig;
   /** Language for instruction metadata. Defaults to 'en'. */
   language?: Language;
   provider?: ProviderType;

--- a/src/features/tasks/execute/workflowExecution.ts
+++ b/src/features/tasks/execute/workflowExecution.ts
@@ -142,6 +142,7 @@ async function executeWorkflowInternal(
       onAskUserQuestion: createDenyAskUserQuestionHandler(),
       ignoreIterationLimit: runContext?.ignoreIterationLimit === true,
       projectCwd: options.projectCwd,
+      observability: bootstrap.observability,
       language: options.language,
       provider: bootstrap.currentProvider,
       providerSource: bootstrap.currentProviderSource,

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import { CapabilityAwareStructuredCaller } from '../../../agents/structured-caller.js';
 import type { WorkflowConfig } from '../../../core/models/index.js';
+import type { ResolvedObservabilityConfig } from '../../../core/models/config-types.js';
 import { buildRunPaths } from '../../../core/workflow/run/run-paths.js';
 import { resolveRuntimeConfig } from '../../../core/runtime/runtime-environment.js';
 import {
@@ -64,6 +65,7 @@ export interface WorkflowExecutionBootstrap {
   effectiveWorkflowConfig: WorkflowConfig;
   providerEventLogger: ReturnType<typeof createProviderEventLogger>;
   usageEventLogger: ReturnType<typeof createUsageEventLogger>;
+  observability: ResolvedObservabilityConfig;
   observabilityHandle: OtelFoundationHandle;
   analyticsEmitter: AnalyticsEmitter;
   structuredCaller: CapabilityAwareStructuredCaller;
@@ -251,6 +253,7 @@ export async function createWorkflowExecutionBootstrap(
     effectiveWorkflowConfig,
     providerEventLogger,
     usageEventLogger,
+    observability: globalConfig.observability,
     observabilityHandle,
     analyticsEmitter,
     structuredCaller,


### PR DESCRIPTION
Closes #700.
Parent: #649.

## 概要

OpenTelemetry observability foundation (#706) の上に、opt-in の workflow / step span shadow 計装を追加します。この PR では exporter、metric、phase span、LLM call span、monitor.json 出力は追加しません。

## 変更内容

- `observability.enabled === true` のときだけ workflow / step span を開始する helper を追加
- `WorkflowEngine` の full run / single iteration を workflow span でラップ
- `WorkflowRunLoop` の step 実行を step span でラップし、workflow 名、step 名、step 種別、iteration、provider/model/source、step status を span attribute に記録
- `executeWorkflow` bootstrap で解決済み observability config を engine に渡す
- disabled 時に span を開始しないこと、workflow → step の親子関係、属性、例外記録を単体テストで固定

## 互換性

- `observability.enabled` が false または未指定の場合は span helper が元の処理をそのまま呼ぶだけです
- 既存 NDJSON session log、usage_events、provider_events の出力経路は変更していません
- `SessionLogExporter` / `UsageEventsExporter` / `MonitorJsonExporter` はこの PR のスコープ外です

## 検証

- `git diff --check`
- `npm run build`
- `npm run lint`
- `npm test` pass: 431 files / 6025 tests
- `npm run test:e2e:mock` pass: 36 files passed / 1 skipped, 107 tests passed / 14 skipped / 30 todo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワークフロー実行とステップ実行のトレース可視化機能を追加しました。OpenTelemetry を用いてワークフロー全体およびステップごとの実行情報を記録できるようになります。

* **テスト**
  * ワークフロー観測機能に関する包括的なテストを追加しました。ワークフロー・ステップのスパン生成と属性記録を検証します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->