### PR TITLE
[#741] add-pr-thread-state-filter-1

### DIFF
--- a/src/__tests__/git-format.test.ts
+++ b/src/__tests__/git-format.test.ts
@@ -59,7 +59,7 @@ describe('formatIssueAsTask', () => {
 });
 
 describe('formatPrReviewAsTask', () => {
-  it('should format PR review data without provider-specific strings', () => {
+  it('should format legacy PR review data without provider-specific strings', () => {
     const prReview: PrReviewData = {
       number: 10,
       title: 'Feature PR',
@@ -71,9 +71,7 @@ describe('formatPrReviewAsTask', () => {
       reviews: [{ author: 'reviewer', body: 'Approved', path: 'src/app.ts', line: 5 }],
       files: ['src/app.ts'],
     };
-
     const result = formatPrReviewAsTask(prReview);
-
     expect(result).not.toContain('GitHub');
     expect(result).not.toContain('GitLab');
     expect(result).toContain('## PR #10 Review Comments: Feature PR');
@@ -82,6 +80,170 @@ describe('formatPrReviewAsTask', () => {
     expect(result).toContain('File: src/app.ts, Line: 5');
     expect(result).toContain('**dev**: LGTM');
     expect(result).toContain('- src/app.ts');
+  });
+
+  it('should put active review threads in the Active section', () => {
+    const prReview: PrReviewData = {
+      number: 11,
+      title: 'Threaded PR',
+      body: '',
+      url: 'https://example.com/pr/11',
+      headRefName: 'feature-branch',
+      comments: [],
+      reviews: [
+        {
+          author: 'reviewer',
+          body: 'Fix this current diff issue',
+          path: 'src/app.ts',
+          line: 12,
+          url: 'https://example.com/pr/11#discussion_r1',
+          threadState: 'active',
+          isOutdated: false,
+        },
+      ],
+      files: [],
+    };
+    const result = formatPrReviewAsTask(prReview);
+    expect(result).toContain('### Review Policy');
+    expect(result).toContain('### Active Review Threads');
+    expect(result).toContain('**reviewer**: Fix this current diff issue');
+    expect(result).toContain('File: src/app.ts, Line: 12');
+    expect(result).toContain('URL: https://example.com/pr/11#discussion_r1');
+    expect(result).not.toContain('### Review Comments');
+  });
+
+  it('should put unresolved outdated review threads in the outdated section', () => {
+    const prReview: PrReviewData = {
+      number: 12,
+      title: 'Outdated PR',
+      body: '',
+      url: 'https://example.com/pr/12',
+      headRefName: 'feature-branch',
+      comments: [],
+      reviews: [
+        {
+          author: 'reviewer',
+          body: 'Check whether this stale comment still applies',
+          path: 'src/old.ts',
+          line: 4,
+          threadState: 'outdated-unresolved',
+          isOutdated: true,
+        },
+      ],
+      files: [],
+    };
+    const result = formatPrReviewAsTask(prReview);
+    expect(result).toContain('### Outdated But Unresolved Review Threads');
+    expect(result).toContain('**reviewer**: Check whether this stale comment still applies');
+    expect(result).not.toContain('### Active Review Threads');
+    expect(result).not.toContain('### Review Comments');
+  });
+
+  it('should put resolved review threads in the reference section with resolution metadata', () => {
+    const prReview: PrReviewData = {
+      number: 13,
+      title: 'Resolved PR',
+      body: '',
+      url: 'https://example.com/pr/13',
+      headRefName: 'feature-branch',
+      comments: [],
+      reviews: [
+        {
+          author: 'coderabbitai[bot]',
+          body: 'Addressed in commit abc123',
+          path: 'src/app.ts',
+          line: 8,
+          threadState: 'resolved',
+          resolvedBy: 'coderabbitai[bot]',
+          isOutdated: true,
+        },
+      ],
+      files: [],
+    };
+    const result = formatPrReviewAsTask(prReview);
+    expect(result).toContain('### Resolved / Outdated Review Threads');
+    expect(result).toContain('**coderabbitai[bot]**: Addressed in commit abc123');
+    expect(result).toContain('Resolved by: coderabbitai[bot]');
+    expect(result).toContain('Outdated: yes');
+    expect(result).not.toContain('### Active Review Threads');
+    expect(result).not.toContain('### Review Comments');
+  });
+
+  it('should include policy instructions and preserve existing PR sections when thread states are present', () => {
+    const prReview: PrReviewData = {
+      number: 14,
+      title: 'Mixed PR',
+      body: 'PR description',
+      url: 'https://example.com/pr/14',
+      headRefName: 'feature-branch',
+      comments: [{ author: 'dev', body: 'Conversation comment' }],
+      reviews: [
+        { author: 'summary-reviewer', body: 'Overall review summary' },
+        {
+          author: 'active-reviewer',
+          body: 'Active issue',
+          path: 'src/active.ts',
+          line: 3,
+          threadState: 'active',
+          isOutdated: false,
+        },
+        {
+          author: 'outdated-reviewer',
+          body: 'Outdated issue',
+          path: 'src/outdated.ts',
+          line: 5,
+          threadState: 'outdated-unresolved',
+          isOutdated: true,
+        },
+        {
+          author: 'resolved-reviewer',
+          body: 'Resolved issue',
+          path: 'src/resolved.ts',
+          line: 7,
+          threadState: 'resolved',
+          resolvedBy: 'maintainer',
+          isOutdated: false,
+        },
+      ],
+      files: ['src/active.ts'],
+    };
+    const result = formatPrReviewAsTask(prReview);
+    expect(result).toContain('以下のレビューコメントは review thread state ごとに分類されています。');
+    expect(result).not.toContain('GitHub review thread');
+    expect(result).toContain('Active Review Threads を主な修正対象にしてください。');
+    expect(result).toContain('Resolved / Outdated のコメントは原則として修正対象にせず');
+    expect(result).toContain('各コメントについて、対応したか、スキップしたか、理由を最後に要約してください。');
+    expect(result).toContain('### PR Description');
+    expect(result).toContain('PR description');
+    expect(result).toContain('### Review Summaries');
+    expect(result).toContain('**summary-reviewer**: Overall review summary');
+    expect(result).toContain('### Conversation Comments');
+    expect(result).toContain('**dev**: Conversation comment');
+    expect(result).toContain('### Changed Files');
+    expect(result).toContain('- src/active.ts');
+
+    const activeIndex = result.indexOf('### Active Review Threads');
+    const outdatedIndex = result.indexOf('### Outdated But Unresolved Review Threads');
+    const resolvedIndex = result.indexOf('### Resolved / Outdated Review Threads');
+    expect(activeIndex).toBeLessThan(outdatedIndex);
+    expect(outdatedIndex).toBeLessThan(resolvedIndex);
+  });
+
+  it('should not include review policy when review comments have no thread state', () => {
+    const prReview: PrReviewData = {
+      number: 15,
+      title: 'Legacy PR',
+      body: '',
+      url: 'https://example.com/pr/15',
+      headRefName: 'feature-branch',
+      comments: [],
+      reviews: [{ author: 'reviewer', body: 'Legacy inline comment', path: 'src/app.ts' }],
+      files: [],
+    };
+    const result = formatPrReviewAsTask(prReview);
+    expect(result).not.toContain('### Review Policy');
+    expect(result).toContain('### Review Comments');
+    expect(result).toContain('**reviewer**: Legacy inline comment');
   });
 });
 

--- a/src/__tests__/git-format.test.ts
+++ b/src/__tests__/git-format.test.ts
@@ -211,6 +211,7 @@ describe('formatPrReviewAsTask', () => {
     expect(result).toContain('以下のレビューコメントは review thread state ごとに分類されています。');
     expect(result).not.toContain('GitHub review thread');
     expect(result).toContain('Active Review Threads を主な修正対象にしてください。');
+    expect(result).toContain('Outdated But Unresolved Review Threads は、現在のコードにまだ当てはまるか確認し、当てはまらなければスキップ理由を明記してください。');
     expect(result).toContain('Resolved / Outdated のコメントは原則として修正対象にせず');
     expect(result).toContain('各コメントについて、対応したか、スキップしたか、理由を最後に要約してください。');
     expect(result).toContain('### PR Description');

--- a/src/__tests__/github-pr.test.ts
+++ b/src/__tests__/github-pr.test.ts
@@ -15,6 +15,7 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   createLogger: () => ({
     info: vi.fn(),
     debug: vi.fn(),
+    warn: vi.fn(),
     error: vi.fn(),
   }),
   getErrorMessage: (e: unknown) => String(e),
@@ -38,6 +39,68 @@ function withGhApiResponse(body: unknown, nextPath?: string): string {
     ...(nextPath ? [`link: <https://api.github.com${nextPath}>; rel="next"`] : []),
   ];
   return `${headers.join('\n')}\n\n${JSON.stringify(body)}`;
+}
+
+function withReviewThreadsResponse(
+  nodes: unknown[],
+  pageInfo: { hasNextPage: boolean; endCursor: string | null } = { hasNextPage: false, endCursor: null },
+): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo,
+            nodes,
+          },
+        },
+      },
+    },
+  });
+}
+
+function withReviewThreadCommentsResponse(
+  nodes: unknown[],
+  pageInfo: { hasNextPage: boolean; endCursor: string | null } = { hasNextPage: false, endCursor: null },
+): string {
+  return JSON.stringify({
+    data: {
+      node: {
+        comments: {
+          pageInfo,
+          nodes,
+        },
+      },
+    },
+  });
+}
+
+function createReviewThread(overrides: {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  resolvedBy?: { login: string } | null;
+  comments: unknown[];
+  commentsPageInfo?: { hasNextPage: boolean; endCursor: string | null };
+}): unknown {
+  return {
+    id: overrides.id,
+    isResolved: overrides.isResolved,
+    isOutdated: overrides.isOutdated,
+    resolvedBy: overrides.resolvedBy ?? null,
+    comments: {
+      pageInfo: overrides.commentsPageInfo ?? { hasNextPage: false, endCursor: null },
+      nodes: overrides.comments,
+    },
+  };
+}
+
+function expectGraphqlField(args: unknown, flag: '-f' | '-F', value: string): void {
+  expect(args).toEqual(expect.any(Array));
+  const commandArgs = args as string[];
+  const valueIndex = commandArgs.indexOf(value);
+  expect(valueIndex).toBeGreaterThan(0);
+  expect(commandArgs[valueIndex - 1]).toBe(flag);
 }
 
 describe('findExistingPr', () => {
@@ -588,10 +651,10 @@ describe('buildPrBody', () => {
 describe('fetchPrReviewComments', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockExecFileSync.mockReset();
   });
 
   it('should return PrReviewData when gh pr view JSON is valid', () => {
-    // Given
     const ghResponse = {
       number: 456,
       title: 'Fix auth bug',
@@ -617,27 +680,56 @@ describe('fetchPrReviewComments', () => {
         { path: 'src/auth.test.ts' },
       ],
     };
-    const inlineCommentsResponse = [
-      { body: 'Fix null check here', path: 'src/auth.ts', line: 42, user: { login: 'reviewer1' } },
-    ];
+    const activeThread = createReviewThread({
+      id: 'thread-active-456',
+      isResolved: false,
+      isOutdated: false,
+      comments: [
+        {
+          body: 'Fix null check here',
+          path: 'src/auth.ts',
+          line: 42,
+          originalLine: 40,
+          url: 'https://github.com/org/repo/pull/456#discussion_r1',
+          author: { login: 'reviewer1' },
+        },
+      ],
+    });
+    const resolvedThread = createReviewThread({
+      id: 'thread-resolved-456',
+      isResolved: true,
+      isOutdated: true,
+      resolvedBy: { login: 'coderabbitai[bot]' },
+      comments: [
+        {
+          body: 'Already addressed in a later commit',
+          path: 'src/auth.ts',
+          line: null,
+          originalLine: 12,
+          url: 'https://github.com/org/repo/pull/456#discussion_r2',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+    });
     mockExecFileSync
       .mockReturnValueOnce(JSON.stringify(ghResponse))
-      .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
-
-    // When
+      .mockReturnValueOnce(withReviewThreadsResponse([activeThread, resolvedThread]));
     const result = fetchPrReviewComments(456, '/project');
-
-    // Then
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'gh',
       ['pr', 'view', '456', '--json', 'number,title,body,url,headRefName,baseRefName,comments,reviews,files'],
       expect.objectContaining({ encoding: 'utf-8' }),
     );
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'gh',
-      ['api', '--include', '/repos/org/repo/pulls/456/comments?per_page=100&page=1'],
-      expect.objectContaining({ encoding: 'utf-8' }),
-    );
+    expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(expect.arrayContaining([
+      'api',
+      'graphql',
+      'owner=org',
+      'repo=repo',
+      'number=456',
+    ]));
+    expectGraphqlField(mockExecFileSync.mock.calls[1]?.[1], '-f', 'owner=org');
+    expectGraphqlField(mockExecFileSync.mock.calls[1]?.[1], '-f', 'repo=repo');
+    expectGraphqlField(mockExecFileSync.mock.calls[1]?.[1], '-F', 'number=456');
     expect(result.number).toBe(456);
     expect(result.title).toBe('Fix auth bug');
     expect((result as { baseRefName?: string }).baseRefName).toBe('release/main');
@@ -645,13 +737,30 @@ describe('fetchPrReviewComments', () => {
     expect(result.comments).toEqual([{ author: 'commenter1', body: 'Please update tests' }]);
     expect(result.reviews).toEqual([
       { author: 'reviewer1', body: 'Looks mostly good' },
-      { author: 'reviewer1', body: 'Fix null check here', path: 'src/auth.ts', line: 42 },
+      {
+        author: 'reviewer1',
+        body: 'Fix null check here',
+        path: 'src/auth.ts',
+        line: 42,
+        url: 'https://github.com/org/repo/pull/456#discussion_r1',
+        threadState: 'active',
+        isOutdated: false,
+      },
+      {
+        author: 'coderabbitai[bot]',
+        body: 'Already addressed in a later commit',
+        path: 'src/auth.ts',
+        line: 12,
+        url: 'https://github.com/org/repo/pull/456#discussion_r2',
+        threadState: 'resolved',
+        resolvedBy: 'coderabbitai[bot]',
+        isOutdated: true,
+      },
     ]);
     expect(result.files).toEqual(['src/auth.ts', 'src/auth.test.ts']);
   });
 
   it('should skip reviews with empty body', () => {
-    // Given
     const ghResponse = {
       number: 10,
       title: 'Approved PR',
@@ -666,17 +775,12 @@ describe('fetchPrReviewComments', () => {
     };
     mockExecFileSync
       .mockReturnValueOnce(JSON.stringify(ghResponse))
-      .mockReturnValueOnce(JSON.stringify([]));
-
-    // When
+      .mockReturnValueOnce(withReviewThreadsResponse([]));
     const result = fetchPrReviewComments(10, '/project');
-
-    // Then
     expect(result.reviews).toEqual([]);
   });
 
-  it('should include inline comments from pulls comments API even when review bodies are empty', () => {
-    // Given
+  it('should include review thread comments even when review bodies are empty', () => {
     const ghResponse = {
       number: 11,
       title: 'Inline only',
@@ -689,122 +793,164 @@ describe('fetchPrReviewComments', () => {
       ],
       files: [],
     };
-    const inlineCommentsResponse = [
-      { body: 'Address this edge case', path: 'src/index.ts', line: 7, user: { login: 'reviewer3' } },
-    ];
+    const thread = createReviewThread({
+      id: 'thread-11',
+      isResolved: false,
+      isOutdated: false,
+      comments: [
+        {
+          body: 'Address this edge case',
+          path: 'src/index.ts',
+          line: 7,
+          originalLine: 7,
+          url: 'https://github.com/org/repo/pull/11#discussion_r1',
+          author: { login: 'reviewer3' },
+        },
+      ],
+    });
     mockExecFileSync
       .mockReturnValueOnce(JSON.stringify(ghResponse))
-      .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
-
-    // When
+      .mockReturnValueOnce(withReviewThreadsResponse([thread]));
     const result = fetchPrReviewComments(11, '/project');
-
-    // Then
     expect(result.reviews).toEqual([
-      { author: 'reviewer3', body: 'Address this edge case', path: 'src/index.ts', line: 7 },
+      {
+        author: 'reviewer3',
+        body: 'Address this edge case',
+        path: 'src/index.ts',
+        line: 7,
+        url: 'https://github.com/org/repo/pull/11#discussion_r1',
+        threadState: 'active',
+        isOutdated: false,
+      },
     ]);
   });
 
-  it('should fetch all inline review comments when total comments exceed one default page', () => {
-    // Given
+  it('should classify unresolved outdated review threads separately from active threads', () => {
     const ghResponse = {
       number: 12,
-      title: 'Many inline comments',
+      title: 'Outdated unresolved thread',
       body: '',
       url: 'https://github.com/org/repo/pull/12',
-      headRefName: 'fix/many-inline-comments',
+      headRefName: 'fix/outdated-thread',
       comments: [],
       reviews: [],
       files: [],
     };
-    const inlineCommentsResponse = Array.from({ length: 31 }, (_, i) => ({
-      body: `Inline comment ${i + 1}`,
-      path: 'src/index.ts',
-      line: i + 1,
-      user: { login: 'reviewer-pagination' },
-    }));
+    const thread = createReviewThread({
+      id: 'thread-12',
+      isResolved: false,
+      isOutdated: true,
+      comments: [
+        {
+          body: 'Confirm whether this stale diff still applies',
+          path: 'src/index.ts',
+          line: null,
+          originalLine: 31,
+          url: 'https://github.com/org/repo/pull/12#discussion_r1',
+          author: { login: 'reviewer-outdated' },
+        },
+      ],
+    });
     mockExecFileSync
       .mockReturnValueOnce(JSON.stringify(ghResponse))
-      .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
-
-    // When
+      .mockReturnValueOnce(withReviewThreadsResponse([thread]));
     const result = fetchPrReviewComments(12, '/project');
-
-    // Then
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'gh',
-      ['api', '--include', '/repos/org/repo/pulls/12/comments?per_page=100&page=1'],
-      expect.objectContaining({ encoding: 'utf-8' }),
-    );
-    expect(result.reviews).toHaveLength(31);
-    expect(result.reviews[0]).toEqual({
-      author: 'reviewer-pagination',
-      body: 'Inline comment 1',
-      path: 'src/index.ts',
-      line: 1,
-    });
-    expect(result.reviews[30]).toEqual({
-      author: 'reviewer-pagination',
-      body: 'Inline comment 31',
-      path: 'src/index.ts',
-      line: 31,
-    });
+    expect(result.reviews).toEqual([
+      {
+        author: 'reviewer-outdated',
+        body: 'Confirm whether this stale diff still applies',
+        path: 'src/index.ts',
+        line: 31,
+        url: 'https://github.com/org/repo/pull/12#discussion_r1',
+        threadState: 'outdated-unresolved',
+        isOutdated: true,
+      },
+    ]);
   });
 
-  it('should request additional pages when inline review comments exceed per_page', () => {
-    // Given
+  it('should request additional GraphQL pages when reviewThreads has a next page', () => {
     const ghResponse = {
       number: 13,
-      title: 'Paginated inline comments',
+      title: 'Paginated review threads',
       body: '',
       url: 'https://github.com/org/repo/pull/13',
-      headRefName: 'fix/paginated-inline-comments',
+      headRefName: 'fix/paginated-review-threads',
       comments: [],
       reviews: [],
       files: [],
     };
-    const firstPageInlineComments = Array.from({ length: 100 }, (_, i) => ({
-      body: `Inline comment ${i + 1}`,
-      path: 'src/index.ts',
-      line: i + 1,
-      user: { login: 'reviewer-pagination' },
-    }));
-    const secondPageInlineComments = [
-      { body: 'Inline comment 101', path: 'src/index.ts', line: 101, user: { login: 'reviewer-pagination' } },
-    ];
+    const firstThread = createReviewThread({
+      id: 'thread-13-first',
+      isResolved: false,
+      isOutdated: false,
+      comments: [
+        {
+          body: 'First page comment',
+          path: 'src/index.ts',
+          line: 1,
+          originalLine: 1,
+          url: 'https://github.com/org/repo/pull/13#discussion_r1',
+          author: { login: 'reviewer-pagination' },
+        },
+      ],
+    });
+    const secondThread = createReviewThread({
+      id: 'thread-13-second',
+      isResolved: false,
+      isOutdated: false,
+      comments: [
+        {
+          body: 'Second page comment',
+          path: 'src/index.ts',
+          line: 101,
+          originalLine: 101,
+          url: 'https://github.com/org/repo/pull/13#discussion_r2',
+          author: { login: 'reviewer-pagination' },
+        },
+      ],
+    });
     mockExecFileSync
       .mockReturnValueOnce(JSON.stringify(ghResponse))
-      .mockReturnValueOnce(withGhApiResponse(
-        firstPageInlineComments,
-        '/repos/org/repo/pulls/13/comments?per_page=100&page=2',
+      .mockReturnValueOnce(withReviewThreadsResponse(
+        [firstThread],
+        { hasNextPage: true, endCursor: 'cursor-1' },
       ))
-      .mockReturnValueOnce(withGhApiResponse(secondPageInlineComments));
-
-    // When
+      .mockReturnValueOnce(withReviewThreadsResponse([secondThread]));
     const result = fetchPrReviewComments(13, '/project');
-
-    // Then
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'gh',
-      ['api', '--include', '/repos/org/repo/pulls/13/comments?per_page=100&page=1'],
-      expect.objectContaining({ encoding: 'utf-8' }),
-    );
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'gh',
-      ['api', '--include', '/repos/org/repo/pulls/13/comments?per_page=100&page=2'],
-      expect.objectContaining({ encoding: 'utf-8' }),
-    );
-    expect(result.reviews).toHaveLength(101);
-    expect(result.reviews[100]).toEqual({
+    expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+    expect(mockExecFileSync.mock.calls[1]?.[1]).toEqual(expect.arrayContaining([
+      'api',
+      'graphql',
+      'number=13',
+    ]));
+    expect(mockExecFileSync.mock.calls[2]?.[1]).toEqual(expect.arrayContaining([
+      'api',
+      'graphql',
+      'endCursor=cursor-1',
+    ]));
+    expectGraphqlField(mockExecFileSync.mock.calls[2]?.[1], '-f', 'endCursor=cursor-1');
+    expect(result.reviews).toHaveLength(2);
+    expect(result.reviews[0]).toEqual({
       author: 'reviewer-pagination',
-      body: 'Inline comment 101',
+      body: 'First page comment',
+      path: 'src/index.ts',
+      line: 1,
+      url: 'https://github.com/org/repo/pull/13#discussion_r1',
+      threadState: 'active',
+      isOutdated: false,
+    });
+    expect(result.reviews[1]).toEqual({
+      author: 'reviewer-pagination',
+      body: 'Second page comment',
       path: 'src/index.ts',
       line: 101,
+      url: 'https://github.com/org/repo/pull/13#discussion_r2',
+      threadState: 'active',
+      isOutdated: false,
     });
   });
 
-  it('should fallback to original_line when line is null', () => {
-    // Given
+  it('should fallback to originalLine when line is null', () => {
     const ghResponse = {
       number: 14,
       title: 'Keep original line',
@@ -815,76 +961,214 @@ describe('fetchPrReviewComments', () => {
       reviews: [],
       files: [],
     };
-    const inlineCommentsResponse = [
-      {
-        body: 'Line moved after suggestion',
-        path: 'src/index.ts',
-        line: null,
-        original_line: 27,
-        user: { login: 'reviewer-original-line' },
-      },
-    ];
+    const thread = createReviewThread({
+      id: 'thread-14',
+      isResolved: false,
+      isOutdated: false,
+      comments: [
+        {
+          body: 'Line moved after suggestion',
+          path: 'src/index.ts',
+          line: null,
+          originalLine: 27,
+          url: 'https://github.com/org/repo/pull/14#discussion_r1',
+          author: { login: 'reviewer-original-line' },
+        },
+      ],
+    });
     mockExecFileSync
       .mockReturnValueOnce(JSON.stringify(ghResponse))
-      .mockReturnValueOnce(JSON.stringify(inlineCommentsResponse));
-
-    // When
+      .mockReturnValueOnce(withReviewThreadsResponse([thread]));
     const result = fetchPrReviewComments(14, '/project');
-
-    // Then
     expect(result.reviews).toEqual([
       {
         author: 'reviewer-original-line',
         body: 'Line moved after suggestion',
         path: 'src/index.ts',
         line: 27,
+        url: 'https://github.com/org/repo/pull/14#discussion_r1',
+        threadState: 'active',
+        isOutdated: false,
       },
     ]);
   });
 
-  it('should request one more page when inline comments fill the page exactly and stop on empty page', () => {
-    // Given
+  it('should preserve review thread comments from deleted GitHub users', () => {
     const ghResponse = {
-      number: 15,
-      title: 'Exact page boundary',
+      number: 16,
+      title: 'Deleted author',
       body: '',
-      url: 'https://github.com/org/repo/pull/15',
-      headRefName: 'fix/page-boundary',
+      url: 'https://github.com/org/repo/pull/16',
+      headRefName: 'fix/deleted-author',
       comments: [],
       reviews: [],
       files: [],
     };
-    const fullPage = Array.from({ length: 100 }, (_, i) => ({
-      body: `Comment ${i + 1}`,
+    const thread = createReviewThread({
+      id: 'thread-16',
+      isResolved: false,
+      isOutdated: false,
+      comments: [
+        {
+          body: 'Comment from an unavailable account',
+          path: 'src/index.ts',
+          line: 19,
+          originalLine: 19,
+          url: 'https://github.com/org/repo/pull/16#discussion_r1',
+          author: null,
+        },
+      ],
+    });
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(ghResponse))
+      .mockReturnValueOnce(withReviewThreadsResponse([thread]));
+    const result = fetchPrReviewComments(16, '/project');
+    expect(result.reviews).toEqual([
+      {
+        author: 'deleted GitHub user',
+        body: 'Comment from an unavailable account',
+        path: 'src/index.ts',
+        line: 19,
+        url: 'https://github.com/org/repo/pull/16#discussion_r1',
+        threadState: 'active',
+        isOutdated: false,
+      },
+    ]);
+  });
+
+  it('should fetch additional GraphQL pages when a review thread has more comments', () => {
+    const ghResponse = {
+      number: 15,
+      title: 'Large review thread',
+      body: '',
+      url: 'https://github.com/org/repo/pull/15',
+      headRefName: 'fix/large-thread',
+      comments: [],
+      reviews: [],
+      files: [],
+    };
+    const thread = {
+      id: 'thread-15-large',
+      isResolved: false,
+      isOutdated: false,
+      resolvedBy: null,
+      comments: {
+        pageInfo: { hasNextPage: true, endCursor: 'comment-cursor-1' },
+        nodes: [
+          {
+            body: 'First fetched thread comment',
+            path: 'src/index.ts',
+            line: 1,
+            originalLine: 1,
+            url: 'https://github.com/org/repo/pull/15#discussion_r1',
+            author: { login: 'reviewer-large-thread' },
+          },
+        ],
+      },
+    };
+    const secondPageComment = {
+      body: 'Second fetched thread comment',
       path: 'src/index.ts',
-      line: i + 1,
-      user: { login: 'reviewer-page-boundary' },
-    }));
+      line: 2,
+      originalLine: 2,
+      url: 'https://github.com/org/repo/pull/15#discussion_r2',
+      author: { login: 'reviewer-large-thread' },
+    };
 
     mockExecFileSync
       .mockReturnValueOnce(JSON.stringify(ghResponse))
-      .mockReturnValueOnce(withGhApiResponse(
-        fullPage,
-        '/repos/org/repo/pulls/15/comments?per_page=100&page=2',
-      ))
-      .mockReturnValueOnce(withGhApiResponse([]));
+      .mockReturnValueOnce(withReviewThreadsResponse([thread]))
+      .mockReturnValueOnce(withReviewThreadCommentsResponse([secondPageComment]));
 
-    // When
     const result = fetchPrReviewComments(15, '/project');
 
-    // Then
     expect(mockExecFileSync).toHaveBeenCalledTimes(3);
-    expect(mockExecFileSync).toHaveBeenNthCalledWith(
-      3,
-      'gh',
-      ['api', '--include', '/repos/org/repo/pulls/15/comments?per_page=100&page=2'],
-      expect.objectContaining({ encoding: 'utf-8' }),
-    );
-    expect(result.reviews).toHaveLength(100);
+    expect(mockExecFileSync.mock.calls[2]?.[1]).toEqual(expect.arrayContaining([
+      'api',
+      'graphql',
+      'threadId=thread-15-large',
+      'commentsEndCursor=comment-cursor-1',
+    ]));
+    expectGraphqlField(mockExecFileSync.mock.calls[2]?.[1], '-f', 'threadId=thread-15-large');
+    expectGraphqlField(mockExecFileSync.mock.calls[2]?.[1], '-f', 'commentsEndCursor=comment-cursor-1');
+    expect(result.reviews).toEqual([
+      {
+        author: 'reviewer-large-thread',
+        body: 'First fetched thread comment',
+        path: 'src/index.ts',
+        line: 1,
+        url: 'https://github.com/org/repo/pull/15#discussion_r1',
+        threadState: 'active',
+        isOutdated: false,
+      },
+      {
+        author: 'reviewer-large-thread',
+        body: 'Second fetched thread comment',
+        path: 'src/index.ts',
+        line: 2,
+        url: 'https://github.com/org/repo/pull/15#discussion_r2',
+        threadState: 'active',
+        isOutdated: false,
+      },
+    ]);
+  });
+
+  it('should pass GraphQL string variables as raw fields', () => {
+    const ghResponse = {
+      number: 17,
+      title: 'Raw GraphQL fields',
+      body: '',
+      url: 'https://github.com/@org/@repo/pull/17',
+      headRefName: 'fix/raw-graphql-fields',
+      comments: [],
+      reviews: [],
+      files: [],
+    };
+    const thread = createReviewThread({
+      id: '@/tmp/thread-id',
+      isResolved: false,
+      isOutdated: false,
+      commentsPageInfo: { hasNextPage: true, endCursor: '@/tmp/comment-cursor' },
+      comments: [
+        {
+          body: 'First page comment',
+          path: 'src/index.ts',
+          line: 1,
+          originalLine: 1,
+          url: 'https://github.com/org/repo/pull/17#discussion_r1',
+          author: { login: 'reviewer-raw-field' },
+        },
+      ],
+    });
+    const nextComment = {
+      body: 'Second page comment',
+      path: 'src/index.ts',
+      line: 2,
+      originalLine: 2,
+      url: 'https://github.com/org/repo/pull/17#discussion_r2',
+      author: { login: 'reviewer-raw-field' },
+    };
+
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(ghResponse))
+      .mockReturnValueOnce(withReviewThreadsResponse(
+        [thread],
+        { hasNextPage: true, endCursor: '@/tmp/thread-cursor' },
+      ))
+      .mockReturnValueOnce(withReviewThreadCommentsResponse([nextComment]))
+      .mockReturnValueOnce(withReviewThreadsResponse([]));
+
+    fetchPrReviewComments(17, '/project');
+
+    expectGraphqlField(mockExecFileSync.mock.calls[1]?.[1], '-f', 'owner=@org');
+    expectGraphqlField(mockExecFileSync.mock.calls[1]?.[1], '-f', 'repo=@repo');
+    expectGraphqlField(mockExecFileSync.mock.calls[1]?.[1], '-F', 'number=17');
+    expectGraphqlField(mockExecFileSync.mock.calls[2]?.[1], '-f', 'threadId=@/tmp/thread-id');
+    expectGraphqlField(mockExecFileSync.mock.calls[2]?.[1], '-f', 'commentsEndCursor=@/tmp/comment-cursor');
+    expectGraphqlField(mockExecFileSync.mock.calls[3]?.[1], '-f', 'endCursor=@/tmp/thread-cursor');
   });
 
   it('should pass cwd to all execFileSync calls', () => {
-    // Given
     const ghResponse = {
       number: 50,
       title: 'cwd test',
@@ -897,29 +1181,95 @@ describe('fetchPrReviewComments', () => {
     };
     mockExecFileSync
       .mockReturnValueOnce(JSON.stringify(ghResponse))
-      .mockReturnValueOnce(JSON.stringify([]));
-
-    // When
+      .mockReturnValueOnce(withReviewThreadsResponse([]));
     fetchPrReviewComments(50, '/worktree/clone');
-
-    // Then: all execFileSync calls should include cwd
     for (const call of mockExecFileSync.mock.calls) {
       expect(call[2]).toEqual(expect.objectContaining({ cwd: '/worktree/clone' }));
     }
   });
 
-  it('should throw when gh CLI fails', () => {
-    // Given
-    mockExecFileSync.mockImplementation(() => { throw new Error('gh: PR not found'); });
+  it('should preserve fetched thread state through task formatting', () => {
+    const ghResponse = {
+      number: 51,
+      title: 'Formatter handoff',
+      body: '',
+      url: 'https://github.com/org/repo/pull/51',
+      headRefName: 'fix/formatter-handoff',
+      comments: [],
+      reviews: [],
+      files: [],
+    };
+    const activeThread = createReviewThread({
+      id: 'thread-51-active',
+      isResolved: false,
+      isOutdated: false,
+      comments: [
+        {
+          body: 'Active comment',
+          path: 'src/active.ts',
+          line: 10,
+          originalLine: 10,
+          url: 'https://github.com/org/repo/pull/51#discussion_r1',
+          author: { login: 'active-reviewer' },
+        },
+      ],
+    });
+    const resolvedThread = createReviewThread({
+      id: 'thread-51-resolved',
+      isResolved: true,
+      isOutdated: true,
+      resolvedBy: { login: 'maintainer' },
+      comments: [
+        {
+          body: 'Resolved comment',
+          path: 'src/resolved.ts',
+          line: 20,
+          originalLine: 20,
+          url: 'https://github.com/org/repo/pull/51#discussion_r2',
+          author: { login: 'resolved-reviewer' },
+        },
+      ],
+    });
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(ghResponse))
+      .mockReturnValueOnce(withReviewThreadsResponse([activeThread, resolvedThread]));
+    const prReview = fetchPrReviewComments(51, '/project');
+    const task = formatPrReviewAsTask(prReview);
+    expect(task).toContain('### Active Review Threads');
+    expect(task).toContain('**active-reviewer**: Active comment');
+    expect(task).toContain('### Resolved / Outdated Review Threads');
+    expect(task).toContain('**resolved-reviewer**: Resolved comment');
+    expect(task).toContain('Resolved by: maintainer');
+    expect(task).not.toContain('### Review Comments');
+  });
 
-    // When/Then
+  it('should throw a clear error when GraphQL reviewThreads cannot be fetched', () => {
+    const ghResponse = {
+      number: 52,
+      title: 'GraphQL failure',
+      body: '',
+      url: 'https://github.com/org/repo/pull/52',
+      headRefName: 'fix/graphql-failure',
+      comments: [],
+      reviews: [],
+      files: [],
+    };
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(ghResponse))
+      .mockImplementationOnce(() => {
+        throw new Error('gh api graphql failed');
+      });
+    expect(() => fetchPrReviewComments(52, '/project')).toThrow('GraphQL reviewThreads failed');
+  });
+
+  it('should throw when gh CLI fails', () => {
+    mockExecFileSync.mockImplementation(() => { throw new Error('gh: PR not found'); });
     expect(() => fetchPrReviewComments(999, '/project')).toThrow('gh: PR not found');
   });
 });
 
 describe('formatPrReviewAsTask', () => {
   it('should format PR review data with all sections', () => {
-    // Given
     const prReview: PrReviewData = {
       number: 456,
       title: 'Fix auth bug',
@@ -930,20 +1280,25 @@ describe('formatPrReviewAsTask', () => {
         { author: 'commenter1', body: 'Can you also update the tests?' },
       ],
       reviews: [
-        { author: 'reviewer1', body: 'Fix the null check in auth.ts', path: 'src/auth.ts', line: 42 },
+        {
+          author: 'reviewer1',
+          body: 'Fix the null check in auth.ts',
+          path: 'src/auth.ts',
+          line: 42,
+          threadState: 'active',
+          isOutdated: false,
+        },
         { author: 'reviewer2', body: 'This function should handle edge cases' },
       ],
       files: ['src/auth.ts', 'src/auth.test.ts'],
     };
-
-    // When
     const result = formatPrReviewAsTask(prReview);
-
-    // Then
     expect(result).toContain('## PR #456 Review Comments: Fix auth bug');
     expect(result).toContain('### PR Description');
     expect(result).toContain('PR description text');
-    expect(result).toContain('### Review Comments');
+    expect(result).toContain('### Review Policy');
+    expect(result).toContain('### Review Summaries');
+    expect(result).toContain('### Active Review Threads');
     expect(result).toContain('**reviewer1**: Fix the null check in auth.ts');
     expect(result).toContain('File: src/auth.ts, Line: 42');
     expect(result).toContain('**reviewer2**: This function should handle edge cases');
@@ -955,7 +1310,6 @@ describe('formatPrReviewAsTask', () => {
   });
 
   it('should omit PR Description when body is empty', () => {
-    // Given
     const prReview: PrReviewData = {
       number: 10,
       title: 'Quick fix',
@@ -966,17 +1320,12 @@ describe('formatPrReviewAsTask', () => {
       reviews: [{ author: 'reviewer', body: 'Fix this' }],
       files: [],
     };
-
-    // When
     const result = formatPrReviewAsTask(prReview);
-
-    // Then
     expect(result).not.toContain('### PR Description');
-    expect(result).toContain('### Review Comments');
+    expect(result).toContain('### Review Summaries');
   });
 
   it('should omit empty sections', () => {
-    // Given
     const prReview: PrReviewData = {
       number: 20,
       title: 'Empty review',
@@ -987,18 +1336,13 @@ describe('formatPrReviewAsTask', () => {
       reviews: [{ author: 'reviewer', body: 'Add tests' }],
       files: [],
     };
-
-    // When
     const result = formatPrReviewAsTask(prReview);
-
-    // Then
     expect(result).not.toContain('### Conversation Comments');
     expect(result).not.toContain('### Changed Files');
-    expect(result).toContain('### Review Comments');
+    expect(result).toContain('### Review Summaries');
   });
 
   it('should format inline comment with path but no line', () => {
-    // Given
     const prReview: PrReviewData = {
       number: 30,
       title: 'Path only',
@@ -1009,11 +1353,7 @@ describe('formatPrReviewAsTask', () => {
       reviews: [{ author: 'reviewer', body: 'Fix this', path: 'src/index.ts' }],
       files: [],
     };
-
-    // When
     const result = formatPrReviewAsTask(prReview);
-
-    // Then
     expect(result).toContain('File: src/index.ts');
     expect(result).not.toContain('Line:');
   });

--- a/src/infra/git/format.ts
+++ b/src/infra/git/format.ts
@@ -5,7 +5,7 @@
  * from git/types.ts and contain no provider-specific logic.
  */
 
-import type { CreatePrOptions, Issue, PrReviewData } from './types.js';
+import type { CreatePrOptions, Issue, PrReviewComment, PrReviewData } from './types.js';
 
 export const TAKT_MANAGED_PR_MARKER = '<!-- takt:managed -->';
 
@@ -113,6 +113,59 @@ export function isIssueReference(task: string): boolean {
   return ISSUE_NUMBER_REGEX.test(task.trim());
 }
 
+const REVIEW_THREAD_POLICY = [
+  '以下のレビューコメントは review thread state ごとに分類されています。',
+  'Active Review Threads を主な修正対象にしてください。',
+  'Resolved / Outdated のコメントは原則として修正対象にせず、現在のコードに同じ問題が明確に残っている場合のみ報告してください。',
+  '各コメントについて、対応したか、スキップしたか、理由を最後に要約してください。',
+];
+
+function formatPrReviewComment(review: PrReviewComment): string {
+  const lines = [`**${review.author}**: ${review.body}`];
+
+  if (review.path) {
+    const location = review.line !== undefined
+      ? `  File: ${review.path}, Line: ${review.line}`
+      : `  File: ${review.path}`;
+    lines.push(location);
+  }
+  if (review.url) {
+    lines.push(`  URL: ${review.url}`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatResolvedPrReviewComment(review: PrReviewComment): string {
+  const lines = [formatPrReviewComment(review)];
+
+  if (review.resolvedBy) {
+    lines.push(`  Resolved by: ${review.resolvedBy}`);
+  }
+  if (review.isOutdated !== undefined) {
+    lines.push(`  Outdated: ${review.isOutdated ? 'yes' : 'no'}`);
+  }
+
+  return lines.join('\n');
+}
+
+function appendReviewSection(
+  parts: string[],
+  title: string,
+  reviews: PrReviewComment[],
+  formatReview: (review: PrReviewComment) => string,
+): void {
+  if (reviews.length === 0) {
+    return;
+  }
+
+  parts.push('');
+  parts.push(title);
+  for (const review of reviews) {
+    parts.push(formatReview(review));
+  }
+}
+
 /**
  * Format PR review data into task text for workflow execution.
  */
@@ -127,16 +180,45 @@ export function formatPrReviewAsTask(prReview: PrReviewData): string {
     parts.push(prReview.body);
   }
 
-  if (prReview.reviews.length > 0) {
-    parts.push('');
-    parts.push('### Review Comments');
-    for (const review of prReview.reviews) {
-      const location = review.path
-        ? `\n  File: ${review.path}${review.line ? `, Line: ${review.line}` : ''}`
-        : '';
-      parts.push(`**${review.author}**: ${review.body}${location}`);
+  const summaries: PrReviewComment[] = [];
+  const active: PrReviewComment[] = [];
+  const outdatedUnresolved: PrReviewComment[] = [];
+  const resolved: PrReviewComment[] = [];
+  const legacyInlineComments: PrReviewComment[] = [];
+
+  for (const review of prReview.reviews) {
+    switch (review.threadState) {
+      case 'active':
+        active.push(review);
+        break;
+      case 'outdated-unresolved':
+        outdatedUnresolved.push(review);
+        break;
+      case 'resolved':
+        resolved.push(review);
+        break;
+      case undefined:
+        if (review.path === undefined) {
+          summaries.push(review);
+        } else {
+          legacyInlineComments.push(review);
+        }
+        break;
     }
   }
+
+  const hasThreadState = active.length > 0 || outdatedUnresolved.length > 0 || resolved.length > 0;
+  if (hasThreadState) {
+    parts.push('');
+    parts.push('### Review Policy');
+    parts.push(...REVIEW_THREAD_POLICY);
+  }
+
+  appendReviewSection(parts, '### Review Summaries', summaries, formatPrReviewComment);
+  appendReviewSection(parts, '### Active Review Threads', active, formatPrReviewComment);
+  appendReviewSection(parts, '### Outdated But Unresolved Review Threads', outdatedUnresolved, formatPrReviewComment);
+  appendReviewSection(parts, '### Resolved / Outdated Review Threads', resolved, formatResolvedPrReviewComment);
+  appendReviewSection(parts, '### Review Comments', legacyInlineComments, formatPrReviewComment);
 
   if (prReview.comments.length > 0) {
     parts.push('');

--- a/src/infra/git/format.ts
+++ b/src/infra/git/format.ts
@@ -116,6 +116,7 @@ export function isIssueReference(task: string): boolean {
 const REVIEW_THREAD_POLICY = [
   '以下のレビューコメントは review thread state ごとに分類されています。',
   'Active Review Threads を主な修正対象にしてください。',
+  'Outdated But Unresolved Review Threads は、現在のコードにまだ当てはまるか確認し、当てはまらなければスキップ理由を明記してください。',
   'Resolved / Outdated のコメントは原則として修正対象にせず、現在のコードに同じ問題が明確に残っている場合のみ報告してください。',
   '各コメントについて、対応したか、スキップしたか、理由を最後に要約してください。',
 ];

--- a/src/infra/git/index.ts
+++ b/src/infra/git/index.ts
@@ -17,7 +17,7 @@ import { getErrorMessage } from '../../shared/utils/index.js';
 import type { GitProvider, CreatePrOptions, CreatePrResult } from './types.js';
 import type { VcsProviderType } from './detect.js';
 
-export type { GitProvider, Issue, CliStatus, ExistingPr, IssueListItem, PrListItem, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, CreateIssueOptions, CreateIssueResult, PrReviewComment, PrReviewData } from './types.js';
+export type { GitProvider, Issue, CliStatus, ExistingPr, IssueListItem, PrListItem, CreatePrOptions, CreatePrResult, CommentResult, MergeResult, CreateIssueOptions, CreateIssueResult, PrReviewComment, PrReviewData, PrReviewThreadState } from './types.js';
 export {
   formatIssueAsTask,
   parseIssueNumbers,

--- a/src/infra/git/types.ts
+++ b/src/infra/git/types.ts
@@ -72,11 +72,17 @@ export interface CreateIssueResult {
   error?: string;
 }
 
+export type PrReviewThreadState = 'active' | 'outdated-unresolved' | 'resolved';
+
 export interface PrReviewComment {
   author: string;
   body: string;
   path?: string;
   line?: number;
+  url?: string;
+  threadState?: PrReviewThreadState;
+  resolvedBy?: string;
+  isOutdated?: boolean;
 }
 
 export interface PrReviewData {

--- a/src/infra/github/pr.ts
+++ b/src/infra/github/pr.ts
@@ -10,7 +10,17 @@ import { fetchPaginatedApi } from '../git/paginated-api.js';
 import { isTaktManagedPrBody } from '../git/format.js';
 import { checkGhCli } from './issue.js';
 import { resolveRepositoryNameWithOwner } from './repository.js';
-import type { CreatePrOptions, CreatePrResult, ExistingPr, CommentResult, MergeResult, PrListItem, PrReviewData, PrReviewComment } from '../git/types.js';
+import type {
+  CreatePrOptions,
+  CreatePrResult,
+  ExistingPr,
+  CommentResult,
+  MergeResult,
+  PrListItem,
+  PrReviewData,
+  PrReviewComment,
+  PrReviewThreadState,
+} from '../git/types.js';
 
 const log = createLogger('github-pr');
 
@@ -47,7 +57,10 @@ interface GhPrListResponseItem {
 }
 
 const OPEN_PRS_PER_PAGE = 100;
-const INLINE_REVIEW_COMMENTS_PER_PAGE = 100;
+const REVIEW_THREADS_PER_PAGE = 100;
+const REVIEW_THREAD_COMMENTS_PER_PAGE = 100;
+const GRAPHQL_PAGINATION_HARD_CAP = 100;
+const DELETED_GITHUB_USER_AUTHOR = 'deleted GitHub user';
 
 export function listOpenPrs(cwd: string): PrListItem[] {
   const repo = resolveRepositoryNameWithOwner(cwd);
@@ -111,45 +124,278 @@ interface GhPrViewReviewResponse {
   files: Array<{ path: string }>;
 }
 
-/** Raw shape from GitHub Pull Request Review Comments API (null fields normalized on parse) */
-interface GhPrApiReviewComment {
-  body: string;
-  path: string;
-  line?: number;
-  original_line?: number;
-  user: { login: string };
+const REVIEW_THREADS_QUERY = `
+query($owner:String!, $repo:String!, $number:Int!, $endCursor:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:${REVIEW_THREADS_PER_PAGE}, after:$endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          resolvedBy { login }
+          comments(first:${REVIEW_THREAD_COMMENTS_PER_PAGE}) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              path
+              line
+              originalLine
+              body
+              url
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const REVIEW_THREAD_COMMENTS_QUERY = `
+query($threadId:ID!, $commentsEndCursor:String) {
+  node(id:$threadId) {
+    ... on PullRequestReviewThread {
+      comments(first:${REVIEW_THREAD_COMMENTS_PER_PAGE}, after:$commentsEndCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          path
+          line
+          originalLine
+          body
+          url
+          author { login }
+        }
+      }
+    }
+  }
+}
+`;
+
+interface GhGraphqlReviewThreadsResponse {
+  data?: {
+    repository: {
+      pullRequest: {
+        reviewThreads: GhGraphqlReviewThreadsConnection;
+      } | null;
+    } | null;
+  };
+  errors?: Array<{ message: string }>;
 }
 
-/** Raw JSON shape from GitHub API (line/original_line are nullable) */
-interface GhPrApiRawReviewComment {
-  body: string;
+interface GhGraphqlReviewThreadsConnection {
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+  nodes: GhGraphqlReviewThread[];
+}
+
+interface GhGraphqlReviewThreadCommentsResponse {
+  data?: {
+    node: GhGraphqlReviewThreadCommentsNode | null;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+interface GhGraphqlReviewThreadCommentsNode {
+  comments?: GhGraphqlReviewThreadCommentsConnection;
+}
+
+interface GhGraphqlReviewThreadCommentsConnection {
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+  nodes: GhGraphqlReviewThreadComment[];
+}
+
+interface GhGraphqlReviewThread {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  resolvedBy: { login: string } | null;
+  comments: GhGraphqlReviewThreadCommentsConnection;
+}
+
+interface GhGraphqlReviewThreadComment {
   path: string;
   line: number | null;
-  original_line?: number | null;
-  user: { login: string };
+  originalLine: number | null;
+  body: string;
+  url: string;
+  author: { login: string } | null;
 }
 
-function normalizeReviewComment(raw: GhPrApiRawReviewComment): GhPrApiReviewComment {
-  return {
-    body: raw.body,
-    path: raw.path,
-    line: raw.line ?? undefined,
-    original_line: raw.original_line ?? undefined,
-    user: raw.user,
-  };
+function buildReviewThreadsGraphqlArgs(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  endCursor: string | undefined,
+): string[] {
+  const args = [
+    'api',
+    'graphql',
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `repo=${repo}`,
+    '-F',
+    `number=${prNumber}`,
+  ];
+
+  if (endCursor !== undefined) {
+    args.push('-f', `endCursor=${endCursor}`);
+  }
+
+  args.push('-f', `query=${REVIEW_THREADS_QUERY}`);
+  return args;
 }
 
-function fetchInlineReviewComments(owner: string, repo: string, prNumber: number, cwd: string): GhPrApiReviewComment[] {
-  return fetchPaginatedApi<GhPrApiReviewComment>({
-    command: 'gh',
-    cwd,
-    context: `pull request #${prNumber} inline review comments`,
-    initialEndpoint: `/repos/${owner}/${repo}/pulls/${prNumber}/comments?per_page=${INLINE_REVIEW_COMMENTS_PER_PAGE}&page=1`,
-    parsePage: (body) => {
-      const parsed = JSON.parse(body) as GhPrApiRawReviewComment[];
-      return parsed.map(normalizeReviewComment);
-    },
+function buildReviewThreadCommentsGraphqlArgs(threadId: string, commentsEndCursor: string): string[] {
+  return [
+    'api',
+    'graphql',
+    '-f',
+    `threadId=${threadId}`,
+    '-f',
+    `commentsEndCursor=${commentsEndCursor}`,
+    '-f',
+    `query=${REVIEW_THREAD_COMMENTS_QUERY}`,
+  ];
+}
+
+function parseReviewThreadsResponse(raw: string): GhGraphqlReviewThreadsConnection {
+  const parsed = JSON.parse(raw) as GhGraphqlReviewThreadsResponse;
+  if (parsed.errors && parsed.errors.length > 0) {
+    throw new Error(parsed.errors.map((error) => error.message).join('; '));
+  }
+
+  const pullRequest = parsed.data?.repository?.pullRequest;
+  if (!pullRequest) {
+    throw new Error('Missing pull request reviewThreads in GraphQL response');
+  }
+
+  return pullRequest.reviewThreads;
+}
+
+function parseReviewThreadCommentsResponse(raw: string): GhGraphqlReviewThreadCommentsConnection {
+  const parsed = JSON.parse(raw) as GhGraphqlReviewThreadCommentsResponse;
+  if (parsed.errors && parsed.errors.length > 0) {
+    throw new Error(parsed.errors.map((error) => error.message).join('; '));
+  }
+
+  const thread = parsed.data?.node;
+  if (!thread?.comments) {
+    throw new Error('Missing pull request review thread comments in GraphQL response');
+  }
+
+  return thread.comments;
+}
+
+function resolveThreadState(thread: GhGraphqlReviewThread): PrReviewThreadState {
+  if (thread.isResolved) {
+    return 'resolved';
+  }
+  if (thread.isOutdated) {
+    return 'outdated-unresolved';
+  }
+  return 'active';
+}
+
+function resolveReviewThreadCommentAuthor(comment: GhGraphqlReviewThreadComment): string {
+  if (comment.author) {
+    return comment.author.login;
+  }
+  return DELETED_GITHUB_USER_AUTHOR;
+}
+
+function fetchReviewThreadComments(
+  thread: GhGraphqlReviewThread,
+  prNumber: number,
+  cwd: string,
+): GhGraphqlReviewThreadComment[] {
+  const comments = [...thread.comments.nodes];
+  let pageInfo = thread.comments.pageInfo;
+
+  for (let page = 1; page <= GRAPHQL_PAGINATION_HARD_CAP && pageInfo.hasNextPage; page += 1) {
+    if (!pageInfo.endCursor) {
+      throw new Error(`Missing review thread comments endCursor for next page in pull request #${prNumber}`);
+    }
+
+    const raw = execFileSync(
+      'gh',
+      buildReviewThreadCommentsGraphqlArgs(thread.id, pageInfo.endCursor),
+      { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    const nextComments = parseReviewThreadCommentsResponse(raw);
+    comments.push(...nextComments.nodes);
+    pageInfo = nextComments.pageInfo;
+  }
+
+  if (pageInfo.hasNextPage) {
+    throw new Error(
+      `Pagination limit exceeded while fetching pull request #${prNumber} review thread comments (>${GRAPHQL_PAGINATION_HARD_CAP} pages)`,
+    );
+  }
+
+  return comments;
+}
+
+function mapReviewThreadComments(
+  thread: GhGraphqlReviewThread,
+  comments: GhGraphqlReviewThreadComment[],
+): PrReviewComment[] {
+  const threadState = resolveThreadState(thread);
+  return comments.map((comment) => {
+    const line = comment.line ?? comment.originalLine ?? undefined;
+    return {
+      author: resolveReviewThreadCommentAuthor(comment),
+      body: comment.body,
+      path: comment.path,
+      ...(line !== undefined ? { line } : {}),
+      url: comment.url,
+      threadState,
+      ...(thread.resolvedBy ? { resolvedBy: thread.resolvedBy.login } : {}),
+      isOutdated: thread.isOutdated,
+    };
   });
+}
+
+function fetchPrReviewThreads(owner: string, repo: string, prNumber: number, cwd: string): PrReviewComment[] {
+  try {
+    const comments: PrReviewComment[] = [];
+    let endCursor: string | undefined;
+
+    for (let page = 1; page <= GRAPHQL_PAGINATION_HARD_CAP; page += 1) {
+      const raw = execFileSync(
+        'gh',
+        buildReviewThreadsGraphqlArgs(owner, repo, prNumber, endCursor),
+        { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+      );
+      const reviewThreads = parseReviewThreadsResponse(raw);
+
+      for (const thread of reviewThreads.nodes) {
+        const threadComments = fetchReviewThreadComments(thread, prNumber, cwd);
+        comments.push(...mapReviewThreadComments(thread, threadComments));
+      }
+
+      if (!reviewThreads.pageInfo.hasNextPage) {
+        return comments;
+      }
+      if (!reviewThreads.pageInfo.endCursor) {
+        throw new Error('Missing reviewThreads endCursor for next page');
+      }
+      endCursor = reviewThreads.pageInfo.endCursor;
+    }
+
+    throw new Error(
+      `Pagination limit exceeded while fetching pull request #${prNumber} review threads (>${GRAPHQL_PAGINATION_HARD_CAP} pages)`,
+    );
+  } catch (err) {
+    throw new Error(`GraphQL reviewThreads failed: ${getErrorMessage(err)}`);
+  }
 }
 
 function parseRepositoryFromPrUrl(prUrl: string): { owner: string; repo: string } {
@@ -183,8 +429,7 @@ export function fetchPrReviewComments(prNumber: number, cwd: string): PrReviewDa
 
   const data = JSON.parse(raw) as GhPrViewReviewResponse;
   const { owner, repo } = parseRepositoryFromPrUrl(data.url);
-
-  const inlineReviewComments = fetchInlineReviewComments(owner, repo, prNumber, cwd);
+  const threadReviewComments = fetchPrReviewThreads(owner, repo, prNumber, cwd);
 
   const comments: PrReviewComment[] = data.comments.map((c) => ({
     author: c.author.login,
@@ -197,14 +442,7 @@ export function fetchPrReviewComments(prNumber: number, cwd: string): PrReviewDa
       reviews.push({ author: review.author.login, body: review.body });
     }
   }
-  for (const comment of inlineReviewComments) {
-    reviews.push({
-      author: comment.user.login,
-      body: comment.body,
-      path: comment.path,
-      line: comment.line ?? comment.original_line,
-    });
-  }
+  reviews.push(...threadReviewComments);
 
   return {
     number: data.number,


### PR DESCRIPTION
## Summary

## 背景

`takt add --pr <number>` は現在、PR の review comments / reviews / changed files を取得してタスク本文に展開しているが、GitHub の review thread state である `resolved` / `outdated` を考慮していない。

そのため、CodeRabbit などが既に解決済みと判定したコメントや、後続 commit により outdated になったコメントも、未対応コメントと同じ粒度でタスクに混ざる。

PR #727 で確認した実例:

- review thread 合計: 5件
- 4件: `isResolved: true`, `isOutdated: true`, `resolvedBy: coderabbitai[bot]`
- 1件: `isResolved: false`, `isOutdated: false`, `resolvedBy: null`
- CodeRabbit は対応済みコメントに `Addressed in commit 9813f18` を付与していた

つまり、利用者が明示的に Resolve conversation を運用していなくても、CodeRabbit bot と GitHub により状態情報は実際に付与されている。

## 課題

現在の `--pr` タスク生成では、以下を区別できない。

- 未解決かつ current diff 上に残っているコメント
- bot または人間により resolved されたコメント
- 後続 commit により outdated になったコメント
- resolved かつ outdated な、基本的には対応済み扱いでよいコメント

この結果、TAKT が既に対応済みの指摘まで再対応しようとしたり、古い差分上のコメントを現在の修正対象として扱う可能性がある。

## 対応方針

`--pr` の GitHub コメント取得で GraphQL の `reviewThreads` を利用し、thread state を取得する。

取得したい主な情報:

- `reviewThreads.nodes[].isResolved`
- `reviewThreads.nodes[].isOutdated`
- `reviewThreads.nodes[].resolvedBy.login`
- `reviewThreads.nodes[].comments.nodes[].path`
- `reviewThreads.nodes[].comments.nodes[].line`
- `reviewThreads.nodes[].comments.nodes[].originalLine`
- `reviewThreads.nodes[].comments.nodes[].body`
- `reviewThreads.nodes[].comments.nodes[].url`
- `reviewThreads.nodes[].comments.nodes[].author.login`

## タスク本文の出し分け案

`formatPrReviewAsTask()` などの formatter で、レビューコメントを次のように分ける。

### Active Review Threads

`isResolved === false && isOutdated === false` のコメント。
原則として優先的に確認・対応する。

### Outdated But Unresolved Review Threads

`isResolved === false && isOutdated === true` のコメント。
現在のコードに同じ問題が残っているかだけ確認する。
残っていなければ修正しない。

### Resolved / Outdated Review Threads

`isResolved === true` または `isResolved === true && isOutdated === true` のコメント。
原則として修正対象にしない参考情報として扱う。

## タスク本文に入れるべき指示

生成タスクには次の方針を明示する。

```text
以下のレビューコメントは GitHub review thread の状態ごとに分類されています。
Active Review Threads を主な修正対象にしてください。
Resolved / Outdated のコメントは原則として修正対象にせず、現在のコードに同じ問題が明確に残っている場合のみ報告してください。
各コメントについて、対応したか、スキップしたか、理由を最後に要約してください。
```

## 実装候補

- `src/infra/github/pr.ts`
  - GraphQL 経由で `reviewThreads` を取得する処理を追加する
  - 既存の REST review comments と統合するか、PR review data に thread 情報を追加する
- `src/infra/git/format.ts`
  - review thread state に基づいてタスク本文を分類する
- 型定義
  - `PrReviewData` または関連型に review thread state を追加する
- テスト
  - resolved/outdated/current thread が分類されること
  - active thread が優先セクションに出ること
  - resolved/outdated thread が参考セクションに出ること

## 受け入れ条件

- `takt add --pr <number>` で GitHub review thread の `resolved` / `outdated` が取得される
- 未解決かつ outdated ではないコメントが Active として表示される
- resolved または outdated なコメントが未対応コメントと同列に表示されない
- 生成タスクに、既に対応済み・古いコメントを原則修正しない指示が含まれる
- 既存の PR description / conversation comments / changed files の出力は維持される
- GitHub API で thread state が取得できない場合の扱いが明確である

## 備考

`outdated` は GitHub が差分更新に応じて自動で付与する状態であり、修正済みの証明ではない。
`resolved` は人間または bot が解決済みとして付与する状態であり、PR #727 では CodeRabbit bot が自動で付与していた。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * PRレビュー取得を強化し、レビューを「Review Summaries」「Active」「Outdated But Unresolved」「Resolved / Outdated」等のセクションへ自動分類。セクション順や空セクション省略が改善され、解決者やアウトデート情報が明示されます。スレッド存在時にレビュー方針（Review Policy）を表示。

* **テスト**
  * 上記挙動を検証するテストを拡充し、レガシーコメントの扱いやセクション順も確認するケースを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->