### PR TITLE
fix: stabilize claude-terminal tmux input

### DIFF
--- a/src/__tests__/claude-terminal-provider-wiring.test.ts
+++ b/src/__tests__/claude-terminal-provider-wiring.test.ts
@@ -126,7 +126,7 @@ describe('ClaudeTerminalProvider wiring', () => {
     expect(Object.prototype.hasOwnProperty.call(terminalOptions, 'maxTurns')).toBe(false);
   });
 
-  it('Given claude sandbox provider option, When call is invoked, Then provider error is returned before terminal client call', async () => {
+  it('Given claude sandbox provider option, When call is invoked, Then terminal provider ignores sandbox and continues', async () => {
     const provider = new ClaudeTerminalProvider();
     const agent = provider.setup({ name: 'coder' });
 
@@ -142,18 +142,13 @@ describe('ClaudeTerminalProvider wiring', () => {
       } as never,
     });
 
-    expect(mockCallClaudeTerminal).not.toHaveBeenCalled();
-    expect(result).toMatchObject({
-      persona: 'coder',
-      status: 'error',
+    expect(result.status).toBe('done');
+    expect(mockCallClaudeTerminal).toHaveBeenCalledWith('coder', 'implement this', expect.objectContaining({
+      cwd: '/tmp/worktree',
       sessionId: 'session-123',
-      failureCategory: 'provider_error',
-      providerUsage: {
-        usageMissing: true,
-        reason: USAGE_MISSING_REASONS.NOT_SUPPORTED_BY_PROVIDER,
-      },
-    });
-    expect(result.error).toMatch(/provider_options\.claude\.sandbox/i);
+    }));
+    const terminalOptions = mockCallClaudeTerminal.mock.calls[0]?.[2];
+    expect(Object.prototype.hasOwnProperty.call(terminalOptions, 'sandbox')).toBe(false);
   });
 
   it('Given incompatible claude effort, When call is invoked, Then provider error is returned before terminal client call', async () => {

--- a/src/__tests__/claude-terminal-tmux-backend.test.ts
+++ b/src/__tests__/claude-terminal-tmux-backend.test.ts
@@ -17,7 +17,14 @@ vi.mock('node:child_process', () => ({
 import { TmuxTerminalBackend } from '../infra/claude-terminal/tmux-backend.js';
 
 function mockExecFileSuccess(): void {
+  let captureCount = 0;
   mockExecFile.mockImplementation((_file, _args, _options, callback) => {
+    if (_args[0] === 'capture-pane') {
+      captureCount += 1;
+      const stdout = captureCount === 1 ? '❯' : `pane-${captureCount}`;
+      callback(null, { stdout, stderr: '' });
+      return;
+    }
     callback(null, { stdout: '', stderr: '' });
   });
 }
@@ -44,6 +51,12 @@ function createSpawnChild(stdinWrites: string[], exitCode: number, stderrText: s
     }),
   };
   return child;
+}
+
+function getNonCaptureTmuxArgs(): unknown[] {
+  return mockExecFile.mock.calls
+    .map((call) => call[1])
+    .filter((args) => args[0] !== 'capture-pane');
 }
 
 describe('TmuxTerminalBackend', () => {
@@ -88,7 +101,7 @@ describe('TmuxTerminalBackend', () => {
     );
   });
 
-  it('Given prompt text, When pasteText is called, Then tmux buffer operations run in order with trailing newline', async () => {
+  it('Given prompt text, When pasteText is called, Then tmux waits for prompt and submits pasted text', async () => {
     const backend = new TmuxTerminalBackend();
     const stdinWrites: string[] = [];
     mockSpawn.mockImplementation(() => createSpawnChild(stdinWrites, 0, ''));
@@ -98,19 +111,67 @@ describe('TmuxTerminalBackend', () => {
     expect(mockSpawn).toHaveBeenCalledWith('tmux', ['load-buffer', '-b', 'takt-session-prompt', '-'], {
       stdio: ['pipe', 'ignore', 'pipe'],
     });
-    expect(stdinWrites).toEqual(['implement task\n']);
-    expect(mockExecFile.mock.calls.map((call) => call[1])).toEqual([
-      ['paste-buffer', '-b', 'takt-session-prompt', '-t', 'takt-session'],
+    expect(stdinWrites).toEqual(['implement task']);
+    expect(mockExecFile.mock.calls.map((call) => call[1][0])).toEqual([
+      'capture-pane',
+      'capture-pane',
+      'paste-buffer',
+      'capture-pane',
+      'send-keys',
+      'delete-buffer',
+    ]);
+    expect(getNonCaptureTmuxArgs()).toEqual([
+      ['paste-buffer', '-p', '-b', 'takt-session-prompt', '-t', 'takt-session'],
       ['send-keys', '-t', 'takt-session', 'Enter'],
       ['delete-buffer', '-b', 'takt-session-prompt'],
+    ]);
+  });
+
+  it('Given Claude pane is still busy, When pasteText is called, Then prompt is not pasted until input is ready', async () => {
+    const backend = new TmuxTerminalBackend();
+    const stdinWrites: string[] = [];
+    const capturedPanes = [
+      'Running tool...',
+      'Thinking...',
+      'Ready\n❯\n? for shortcuts',
+      'Ready\n❯\n? for shortcuts',
+      'prompt entered',
+    ];
+    mockSpawn.mockImplementation(() => createSpawnChild(stdinWrites, 0, ''));
+    mockExecFile.mockImplementation((_file, args, _options, callback) => {
+      if (args[0] === 'capture-pane') {
+        callback(null, { stdout: capturedPanes.shift() ?? 'prompt entered', stderr: '' });
+        return;
+      }
+      callback(null, { stdout: '', stderr: '' });
+    });
+
+    await backend.pasteText({ id: 'tmux-session', name: 'takt-session' }, 'implement task');
+
+    expect(stdinWrites).toEqual(['implement task']);
+    expect(mockExecFile.mock.calls.map((call) => call[1][0])).toEqual([
+      'capture-pane',
+      'capture-pane',
+      'capture-pane',
+      'capture-pane',
+      'paste-buffer',
+      'capture-pane',
+      'send-keys',
+      'delete-buffer',
     ]);
   });
 
   it('Given tmux paste-buffer fails after loading prompt, When pasteText rejects, Then tmux buffer is deleted', async () => {
     const backend = new TmuxTerminalBackend();
     const stdinWrites: string[] = [];
+    let captureCount = 0;
     mockSpawn.mockImplementation(() => createSpawnChild(stdinWrites, 0, ''));
     mockExecFile.mockImplementation((_file, args, _options, callback) => {
+      if (args[0] === 'capture-pane') {
+        captureCount += 1;
+        callback(null, { stdout: captureCount === 1 ? '❯' : `pane-${captureCount}`, stderr: '' });
+        return;
+      }
       if (args[0] === 'paste-buffer') {
         callback(createExecFileError('Command failed with sensitive argv', 1, 'tmux paste-buffer failed'));
         return;
@@ -121,9 +182,9 @@ describe('TmuxTerminalBackend', () => {
     await expect(backend.pasteText({ id: 'tmux-session', name: 'takt-session' }, 'secret prompt'))
       .rejects.toThrow(/paste-buffer failed/i);
 
-    expect(stdinWrites).toEqual(['secret prompt\n']);
-    expect(mockExecFile.mock.calls.map((call) => call[1])).toEqual([
-      ['paste-buffer', '-b', 'takt-session-prompt', '-t', 'takt-session'],
+    expect(stdinWrites).toEqual(['secret prompt']);
+    expect(getNonCaptureTmuxArgs()).toEqual([
+      ['paste-buffer', '-p', '-b', 'takt-session-prompt', '-t', 'takt-session'],
       ['delete-buffer', '-b', 'takt-session-prompt'],
     ]);
   });
@@ -131,8 +192,14 @@ describe('TmuxTerminalBackend', () => {
   it('Given tmux send-keys fails after pasting prompt, When pasteText rejects, Then tmux buffer is deleted', async () => {
     const backend = new TmuxTerminalBackend();
     const stdinWrites: string[] = [];
+    let captureCount = 0;
     mockSpawn.mockImplementation(() => createSpawnChild(stdinWrites, 0, ''));
     mockExecFile.mockImplementation((_file, args, _options, callback) => {
+      if (args[0] === 'capture-pane') {
+        captureCount += 1;
+        callback(null, { stdout: captureCount === 1 ? '❯' : `pane-${captureCount}`, stderr: '' });
+        return;
+      }
       if (args[0] === 'send-keys') {
         callback(createExecFileError('Command failed with sensitive argv', 1, 'tmux send-keys failed'));
         return;
@@ -143,9 +210,9 @@ describe('TmuxTerminalBackend', () => {
     await expect(backend.pasteText({ id: 'tmux-session', name: 'takt-session' }, 'secret prompt'))
       .rejects.toThrow(/send-keys failed/i);
 
-    expect(stdinWrites).toEqual(['secret prompt\n']);
-    expect(mockExecFile.mock.calls.map((call) => call[1])).toEqual([
-      ['paste-buffer', '-b', 'takt-session-prompt', '-t', 'takt-session'],
+    expect(stdinWrites).toEqual(['secret prompt']);
+    expect(getNonCaptureTmuxArgs()).toEqual([
+      ['paste-buffer', '-p', '-b', 'takt-session-prompt', '-t', 'takt-session'],
       ['send-keys', '-t', 'takt-session', 'Enter'],
       ['delete-buffer', '-b', 'takt-session-prompt'],
     ]);

--- a/src/__tests__/claude-terminal-tmux-backend.test.ts
+++ b/src/__tests__/claude-terminal-tmux-backend.test.ts
@@ -161,6 +161,43 @@ describe('TmuxTerminalBackend', () => {
     ]);
   });
 
+  it('Given old busy output remains in pane history, When tail prompt is ready, Then prompt is pasted', async () => {
+    const backend = new TmuxTerminalBackend();
+    const stdinWrites: string[] = [];
+    const readyPaneWithHistory = [
+      'Running tool...',
+      'Tool completed',
+      'Ready',
+      '❯',
+      '? for shortcuts',
+    ].join('\n');
+    const capturedPanes = [
+      readyPaneWithHistory,
+      readyPaneWithHistory,
+      'implement task',
+    ];
+    mockSpawn.mockImplementation(() => createSpawnChild(stdinWrites, 0, ''));
+    mockExecFile.mockImplementation((_file, args, _options, callback) => {
+      if (args[0] === 'capture-pane') {
+        callback(null, { stdout: capturedPanes.shift() ?? 'implement task', stderr: '' });
+        return;
+      }
+      callback(null, { stdout: '', stderr: '' });
+    });
+
+    await backend.pasteText({ id: 'tmux-session', name: 'takt-session' }, 'implement task');
+
+    expect(stdinWrites).toEqual(['implement task']);
+    expect(mockExecFile.mock.calls.map((call) => call[1][0])).toEqual([
+      'capture-pane',
+      'capture-pane',
+      'paste-buffer',
+      'capture-pane',
+      'send-keys',
+      'delete-buffer',
+    ]);
+  });
+
   it('Given tmux paste-buffer fails after loading prompt, When pasteText rejects, Then tmux buffer is deleted', async () => {
     const backend = new TmuxTerminalBackend();
     const stdinWrites: string[] = [];

--- a/src/__tests__/claude-terminal-transcript-reader.test.ts
+++ b/src/__tests__/claude-terminal-transcript-reader.test.ts
@@ -426,6 +426,44 @@ describe('Claude terminal transcript reader', () => {
     }
   });
 
+  it('Given interactive transcript has assistant text followed by turn duration, When waiting, Then response is returned', async () => {
+    await withTemporaryClaudeHome(async (projectDir) => {
+      const sessionId = 'claude-session-1';
+      const sessionsDir = getClaudeProjectSessionsDir(projectDir);
+      const transcriptPath = join(sessionsDir, `${sessionId}.jsonl`);
+      const assistantLine = JSON.stringify({
+        type: 'assistant',
+        sessionId,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'add-review-thread-state' }],
+        },
+      });
+      const turnDurationLine = JSON.stringify({
+        type: 'system',
+        subtype: 'turn_duration',
+        sessionId,
+        durationMs: 2521,
+        messageCount: 8,
+      });
+      await mkdir(sessionsDir, { recursive: true });
+      await writeFile(transcriptPath, `${assistantLine}\n${turnDurationLine}`, 'utf-8');
+
+      const reader = new ProjectClaudeTranscriptReader();
+
+      await expect(reader.waitForAssistantResponse({
+        cwd: projectDir,
+        session: { sessionId },
+        baseline: { byteOffset: 0, lineNumberOffset: 0 },
+        timeoutMs: 30,
+        pollIntervalMs: 5,
+      })).resolves.toMatchObject({
+        sessionId,
+        assistantText: 'add-review-thread-state',
+      });
+    });
+  });
+
   it('Given transcript has assistant text without completion, When waiting, Then partial response is not returned', async () => {
     const originalHome = process.env.HOME;
     const homeDir = await mkdtemp(join(tmpdir(), 'takt-claude-terminal-home-'));

--- a/src/__tests__/workflowExecution-claude-terminal.test.ts
+++ b/src/__tests__/workflowExecution-claude-terminal.test.ts
@@ -143,6 +143,25 @@ describe('executeWorkflow claude-terminal integration', () => {
     }));
   });
 
+  it('Given global claude sandbox option, When claude-terminal runs, Then sandbox option does not abort the workflow', async () => {
+    const { executeWorkflow } = await import('../features/tasks/execute/workflowExecution.js');
+
+    const result = await executeWorkflow(makeConfig(), 'task', projectDir, {
+      projectCwd: projectDir,
+      provider: 'claude-terminal',
+      providerOptions: {
+        claude: {
+          sandbox: {
+            allowUnsandboxedCommands: true,
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(terminalMocks.start).toHaveBeenCalledOnce();
+  });
+
   it('Given claude-terminal step with outputContracts, When report phase runs, Then internal maxTurns does not fail the provider', async () => {
     const { executeWorkflow } = await import('../features/tasks/execute/workflowExecution.js');
     terminalMocks.waitForAssistantResponse

--- a/src/infra/claude-terminal/tmux-backend.ts
+++ b/src/infra/claude-terminal/tmux-backend.ts
@@ -1,11 +1,16 @@
 import * as childProcess from 'node:child_process';
 import type { ExecFileException } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { promisify } from 'node:util';
+import { stripAnsi } from '../../shared/utils/text.js';
 import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
 import { createClaudeTerminalSessionName } from './command.js';
 import type { TerminalBackend, TerminalSession, TerminalStartOptions } from './types.js';
 
 const log = createLogger('claude-terminal-tmux');
+const CLAUDE_READY_TIMEOUT_MS = 60000;
+const PANE_CHANGE_TIMEOUT_MS = 5000;
+const PANE_POLL_INTERVAL_MS = 100;
 
 function getProperty(error: object, property: string): unknown {
   return (error as Record<string, unknown>)[property];
@@ -96,6 +101,42 @@ async function loadBuffer(bufferName: string, text: string): Promise<void> {
   });
 }
 
+async function capturePane(session: TerminalSession, lines: number): Promise<string> {
+  return runTmux(['capture-pane', '-p', '-t', session.name, '-S', `-${lines}`]);
+}
+
+function isClaudeInputReady(capturedPane: string): boolean {
+  const plain = stripAnsi(capturedPane);
+  if (/(Running|thinking|Searching|Reading|Writing|Editing|Crunched)/i.test(plain)) {
+    return false;
+  }
+  return /^\s*[❯❱>]\s*$/m.test(plain);
+}
+
+async function waitForClaudeInputReady(session: TerminalSession): Promise<void> {
+  const deadline = Date.now() + CLAUDE_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const captured = await capturePane(session, 20);
+    if (isClaudeInputReady(captured)) {
+      return;
+    }
+    await sleep(PANE_POLL_INTERVAL_MS);
+  }
+  throw new Error('Timed out waiting for Claude terminal input prompt.');
+}
+
+async function waitForPaneChange(session: TerminalSession, before: string): Promise<void> {
+  const deadline = Date.now() + PANE_CHANGE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const captured = await capturePane(session, 40);
+    if (captured !== before) {
+      return;
+    }
+    await sleep(PANE_POLL_INTERVAL_MS);
+  }
+  throw new Error('Timed out waiting for Claude terminal paste to appear in pane.');
+}
+
 export class TmuxTerminalBackend implements TerminalBackend {
   async start(options: TerminalStartOptions): Promise<TerminalSession> {
     const name = createClaudeTerminalSessionName();
@@ -114,10 +155,13 @@ export class TmuxTerminalBackend implements TerminalBackend {
 
   async pasteText(session: TerminalSession, text: string): Promise<void> {
     const bufferName = `${session.name}-prompt`;
-    await loadBuffer(bufferName, `${text}\n`);
+    await waitForClaudeInputReady(session);
+    const beforePaste = await capturePane(session, 40);
+    await loadBuffer(bufferName, text);
     let pasteError: unknown;
     try {
-      await runTmux(['paste-buffer', '-b', bufferName, '-t', session.name]);
+      await runTmux(['paste-buffer', '-p', '-b', bufferName, '-t', session.name]);
+      await waitForPaneChange(session, beforePaste);
       await runTmux(['send-keys', '-t', session.name, 'Enter']);
     } catch (error) {
       pasteError = error;

--- a/src/infra/claude-terminal/tmux-backend.ts
+++ b/src/infra/claude-terminal/tmux-backend.ts
@@ -11,6 +11,9 @@ const log = createLogger('claude-terminal-tmux');
 const CLAUDE_READY_TIMEOUT_MS = 60000;
 const PANE_CHANGE_TIMEOUT_MS = 5000;
 const PANE_POLL_INTERVAL_MS = 100;
+const CLAUDE_READY_TAIL_LINES = 3;
+const CLAUDE_BUSY_PATTERN = /(Running|thinking|Searching|Reading|Writing|Editing|Crunched)/i;
+const CLAUDE_PROMPT_PATTERN = /^[❯❱>]$/;
 
 function getProperty(error: object, property: string): unknown {
   return (error as Record<string, unknown>)[property];
@@ -107,10 +110,14 @@ async function capturePane(session: TerminalSession, lines: number): Promise<str
 
 function isClaudeInputReady(capturedPane: string): boolean {
   const plain = stripAnsi(capturedPane);
-  if (/(Running|thinking|Searching|Reading|Writing|Editing|Crunched)/i.test(plain)) {
-    return false;
-  }
-  return /^\s*[❯❱>]\s*$/m.test(plain);
+  const tailLines = plain
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .slice(-CLAUDE_READY_TAIL_LINES);
+  const hasPrompt = tailLines.some((line) => CLAUDE_PROMPT_PATTERN.test(line));
+  const isBusy = CLAUDE_BUSY_PATTERN.test(tailLines.join('\n'));
+  return hasPrompt && !isBusy;
 }
 
 async function waitForClaudeInputReady(session: TerminalSession): Promise<void> {

--- a/src/infra/claude-terminal/transcript-reader.ts
+++ b/src/infra/claude-terminal/transcript-reader.ts
@@ -222,7 +222,8 @@ function hasCompletionEntry(
       index + 1 + lineNumberOffset,
       canIgnoreLineParseError(index, lines, transcriptBody, allowIncompleteFinalLine),
     );
-    return entry?.type === 'result';
+    return entry?.type === 'result'
+      || (entry?.type === 'system' && entry.subtype === 'turn_duration');
   });
 }
 

--- a/src/infra/providers/claude-terminal.ts
+++ b/src/infra/providers/claude-terminal.ts
@@ -40,13 +40,6 @@ function createCaughtProviderErrorResponse(
   );
 }
 
-function getUnsupportedProviderOptionMessage(options: ProviderCallOptions): string | undefined {
-  if (options.providerOptions?.claude?.sandbox !== undefined) {
-    return 'provider: claude-terminal does not support provider_options.claude.sandbox.';
-  }
-  return undefined;
-}
-
 function toTerminalOptions(options: ProviderCallOptions): ClaudeTerminalCallOptions {
   const claudeOptions = options.providerOptions?.claude;
   const terminalOptions = options.providerOptions?.claudeTerminal;
@@ -82,11 +75,6 @@ export class ClaudeTerminalProvider implements Provider {
 
     return {
       call: async (prompt: string, options: ProviderCallOptions): Promise<AgentResponse> => {
-        const unsupportedMessage = getUnsupportedProviderOptionMessage(options);
-        if (unsupportedMessage) {
-          return createProviderErrorResponse(name, options, unsupportedMessage);
-        }
-
         try {
           return await callClaudeTerminal(name, prompt, {
             ...toTerminalOptions(options),


### PR DESCRIPTION
## Summary

- wait for the Claude terminal input prompt before pasting into tmux
- paste prompt text without an embedded newline, then send Enter after the pane changes
- treat Claude terminal turn_duration transcript entries as completion markers
- ignore Claude SDK sandbox provider options for claude-terminal so global claude sandbox config does not abort terminal runs

## Verification

- npm test -- --run src/__tests__/claude-terminal-provider-wiring.test.ts src/__tests__/claude-terminal-tmux-backend.test.ts src/__tests__/claude-terminal-transcript-reader.test.ts src/__tests__/workflowExecution-claude-terminal.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **Bug Fixes**
  * サンドボックス指定時の扱いを改善し、ワークフローや端末呼び出しが意図せず中断されなくなりました。
  * 端末への貼り付け処理で末尾改行の扱いが調整され、入力送信の一貫性が向上しました。

* **New Features**
  * 端末の「入力準備」「ペイン内容変化」を検知する待機ロジックを導入し、より安定した対話操作を実現しました。
  * トランスクリプトの完了判定に新しい完了イベントを含め、応答検出の精度が向上しました。

* **Tests**
  * ターミナル周り、トランスクリプト、ワークフローのテストを拡充・改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->