### PR TITLE
fix(opencode): delta と全文スナップショット両出し時の content 二重化を修正

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -209,6 +209,102 @@ describe('OpenCodeClient stream cleanup', () => {
     );
   });
 
+  it('should not duplicate text when part.delta is followed by a full-snapshot part.updated', async () => {
+    // Reproduces the OpenAI (codex OAuth) streaming pattern observed via opencode:
+    // an empty text part is created, content arrives as a `message.part.delta`,
+    // then the same part is re-sent as a full-snapshot `message.part.updated`.
+    // Both paths must share the offset so content is "apple", not "appleapple".
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const stream = new MockEventStream([
+      {
+        type: 'message.part.updated',
+        properties: { part: { id: 'p-1', type: 'text', text: '' } },
+      },
+      {
+        type: 'message.part.delta',
+        properties: { sessionID: 'session-dup', partID: 'p-1', field: 'text', delta: 'apple' },
+      },
+      {
+        type: 'message.part.updated',
+        properties: { part: { id: 'p-1', type: 'text', text: 'apple' } },
+      },
+      {
+        type: 'session.idle',
+        properties: { sessionID: 'session-dup' },
+      },
+    ]);
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-dup' } });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const result = await Promise.race([
+      client.call('interactive', 'hello', { cwd: '/tmp', model: 'openai/gpt-5.5' }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timed out')), 500)),
+    ]);
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('apple');
+  });
+
+  it('should accumulate incremental part.delta chunks before a full snapshot without duplication', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const stream = new MockEventStream([
+      {
+        type: 'message.part.updated',
+        properties: { part: { id: 'p-2', type: 'text', text: '' } },
+      },
+      {
+        type: 'message.part.delta',
+        properties: { sessionID: 'session-dup2', partID: 'p-2', field: 'text', delta: 'ap' },
+      },
+      {
+        type: 'message.part.delta',
+        properties: { sessionID: 'session-dup2', partID: 'p-2', field: 'text', delta: 'ple' },
+      },
+      {
+        type: 'message.part.updated',
+        properties: { part: { id: 'p-2', type: 'text', text: 'apple' } },
+      },
+      {
+        type: 'session.idle',
+        properties: { sessionID: 'session-dup2' },
+      },
+    ]);
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-dup2' } });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const result = await Promise.race([
+      client.call('interactive', 'hello', { cwd: '/tmp', model: 'openai/gpt-5.5' }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timed out')), 500)),
+    ]);
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('apple');
+  });
+
   it('should reject question.asked without handler and continue processing', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -463,6 +463,23 @@ export class OpenCodeClient {
         const textOffsets = new Map<string, number>();
         const textContentParts = new Map<string, string>();
 
+        // Consume a raw text delta for a part: strip the prompt echo, stream the
+        // visible portion, accumulate it, and advance the part's raw offset in
+        // lockstep. Sharing this keeps content and offset consistent whether the
+        // text arrives via `message.part.delta` or a full-snapshot
+        // `message.part.updated` — some providers emit both for the same part.
+        const consumeTextDelta = (partId: string, rawDelta: string): void => {
+          if (!rawDelta) return;
+          const visibleDelta = stripPromptEcho(rawDelta, echoState);
+          if (visibleDelta) {
+            emitText(options.onStream, visibleDelta);
+            const previous = textContentParts.get(partId) ?? '';
+            textContentParts.set(partId, `${previous}${visibleDelta}`);
+          }
+          const prevOffset = textOffsets.get(partId) ?? 0;
+          textOffsets.set(partId, prevOffset + rawDelta.length);
+        };
+
         for await (const event of stream) {
           if (streamAbortController.signal.aborted) break;
           resetIdleTimeout();
@@ -480,17 +497,7 @@ export class OpenCodeClient {
               const prev = textOffsets.get(textPart.id) ?? 0;
               const rawDelta = delta
                 ?? (textPart.text.length > prev ? textPart.text.slice(prev) : '');
-
-              textOffsets.set(textPart.id, textPart.text.length);
-
-              if (rawDelta) {
-                const visibleDelta = stripPromptEcho(rawDelta, echoState);
-                if (visibleDelta) {
-                  emitText(options.onStream, visibleDelta);
-                  const previous = textContentParts.get(textPart.id) ?? '';
-                  textContentParts.set(textPart.id, `${previous}${visibleDelta}`);
-                }
-              }
+              consumeTextDelta(textPart.id, rawDelta);
               continue;
             }
 
@@ -506,17 +513,7 @@ export class OpenCodeClient {
               delta: string;
             };
             if (deltaProps.field === 'text' && deltaProps.delta) {
-              const visibleDelta = stripPromptEcho(deltaProps.delta, echoState);
-              if (visibleDelta) {
-                emitText(options.onStream, visibleDelta);
-                const previous = textContentParts.get(deltaProps.partID) ?? '';
-                textContentParts.set(deltaProps.partID, `${previous}${visibleDelta}`);
-              }
-              // Advance the raw offset so a later full-snapshot
-              // `message.part.updated` for the same part does not re-append the
-              // text already consumed here (some providers emit both).
-              const prevOffset = textOffsets.get(deltaProps.partID) ?? 0;
-              textOffsets.set(deltaProps.partID, prevOffset + deltaProps.delta.length);
+              consumeTextDelta(deltaProps.partID, deltaProps.delta);
             }
             continue;
           }

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -512,6 +512,11 @@ export class OpenCodeClient {
                 const previous = textContentParts.get(deltaProps.partID) ?? '';
                 textContentParts.set(deltaProps.partID, `${previous}${visibleDelta}`);
               }
+              // Advance the raw offset so a later full-snapshot
+              // `message.part.updated` for the same part does not re-append the
+              // text already consumed here (some providers emit both).
+              const prevOffset = textOffsets.get(deltaProps.partID) ?? 0;
+              textOffsets.set(deltaProps.partID, prevOffset + deltaProps.delta.length);
             }
             continue;
           }


### PR DESCRIPTION
## Summary

opencode プロバイダーで、`message.part.delta`（差分）と全文スナップショット `message.part.updated` の **両方** を同じ part に対して出すモデルにおいて、content が二重化する不具合を修正します。

`message.part.delta` 経路が raw オフセット `textOffsets` を進めていなかったため、後続の全文 `message.part.updated` が `text.slice(prev=0)` で全文を **再 append** していました。

```
part.updated text=""        → offset 0
part.delta   delta="apple"  → content="apple" だが offset は 0 のまま（バグ）
part.updated text="apple"   → slice(0)="apple" を再 append → "appleapple"
```

修正は `message.part.delta` 経路でもオフセットを delta 長だけ進めるだけ（+5 行）。これで後続スナップショットの slice が空になり二重化しません。

## 背景

opencode Zen の無料モデル（big-pickle 等）が応答しない事象の調査中に、代替として **OpenAI(codex OAuth)経由の GPT-5.5** を opencode から使えることが分かりました。その GPT-5.5 のストリームが `delta` と全文 `part.updated` を両方出すパターンで、本バグが顕在化しました（team-leader の decomposition JSON が `{...}{...}` に二重化して workflow が abort）。

claude プロバイダー（`src/infra/claude/stream-converter.ts`）は同種の二重化を「最終 content は full message から、delta は表示専用」という規律で回避済みで、opencode 側にその配慮が無かった形です。

## 影響範囲

- 変更は `src/infra/opencode/client.ts` の text 累積のみ。**他プロバイダー（claude/codex/claude-sdk/mock）は不変**
- delta のみ / 全文スナップショットのみのモデルは挙動不変
- ライブ表示の二重表示も解消（改善方向）

## Test plan

- [x] opencode 系 unit テスト 85 件全合格（回帰テスト 2 件追加）
- [x] `npm run lint` クリーン
- [x] `npm run build` 成功
- [x] opencode E2E（`TAKT_E2E_MODEL=openai/gpt-5.5`）: 修正前 9/10 → **修正後 10/10**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ストリーミングのテキスト処理で、差分と全体スナップショットの組合せによる重複追記や整合ズレが発生しないよう修正しました。

* **Tests**
  * 差分→スナップショットや連続差分を含むストリーミング挙動を検証するテストを追加し、正常に重複なく最終出力が得られることを確認しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->