### PR TITLE
Release v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.42.0] - 2026-05-20
+
+### Added
+
+- `claude-terminal` provider added (#727). A new way to run Claude that drives an interactive Claude Code CLI session inside a tmux pane and reads results back from the session transcript, instead of calling the Anthropic SDK (`claude-sdk`) or the headless CLI (`claude`). Select it with `--provider claude-terminal` or in config. It supports structured output, MCP servers, and allowed-tools, and surfaces permission / ask-user-question prompts back through the terminal. Provider options live under `provider_options.claude_terminal` (`backend: tmux`, `timeout_ms`, `keep_session`, `transcript_poll_interval_ms`). Requires `tmux` to be installed; `maxTurns` is not supported, and API usage figures are unavailable because the terminal transcript does not expose them
+- Opt-in OpenTelemetry observability added (#706, #745). Set `observability.enabled: true` in `~/.takt/config.yaml` (global) or `.takt/config.yaml` (project) — also overridable via the `TAKT_observability__enabled` env var — to emit OTel spans for workflow execution. Each run produces a `workflow.<name>` span with child `step.<name>` spans carrying attributes such as workflow / step name, step type, iteration counts, the resolved provider / model (and their config source), and final status (including abort kind). Spans are emitted as a non-blocking "shadow" alongside normal execution and never alter run behavior. The foundation initializes the OTel Node SDK (service name `takt`) but ships no exporter, so you wire up your own collector via the standard `OTEL_*` environment variables. Off by default
+- `/accept` interactive command added (#733). In interactive assistant mode, `/accept` takes the most recent assistant response verbatim and runs it as the task, without re-summarizing through `/go`. If there is no assistant response yet, it asks you to describe the task first
+- Assistant init files added (#734). List project context files under `assistant.init_files` in `.takt/config.yaml` and they are loaded automatically into every interactive assistant conversation as an "Assistant Init Context" section, so project-specific context (architecture notes, conventions, custom instructions) is included without manual setup. Paths must be relative and inside the project; sensitive files (`.env*`, `.pem`, `.key`, `.npmrc`, `.netrc`, `.git/`, etc.) are rejected, with limits of 16 files, 256 KB per file, and 1 MB total
+- GitHub PR review threads are now classified by resolution state (#746). When TAKT feeds PR review comments into a task, threads are split into Active, Outdated-but-unresolved, and Resolved/Outdated sections, each annotated with who resolved it and whether it is outdated. A review policy directs the agent to focus on active threads, re-check outdated-unresolved ones for current relevance, and skip resolved threads unless the same issue still persists in the code — so already-handled feedback is not re-litigated
+- Enqueue effect `base_branch` can create the branch on demand (#725). The system-workflow enqueue effect's `base_branch` now accepts an object form `{ name, create_if_missing: { from, push } }` in addition to a plain string. When the named base branch does not exist, TAKT creates it from `from` (and pushes it when `push: true`). The builtin `auto-improvement-loop` uses this to create its `improve` base branch from `main` automatically, so the loop runs without manual branch setup
+
+### Changed
+
+- Builtin review facets refined (en + ja). CQRS-ES knowledge gained guidance on event evolution and abstraction boundaries; the AI-antipattern, coding, QA, review, and testing policies tightened their REJECT / APPROVE criteria; and frontend knowledge plus the frontend-review output contract gained canonical-state guidance. These sharpen what the builtin reviewers enforce without changing workflow structure
+
+### Fixed
+
+- OpenCode responses no longer duplicate content when the SDK emits both incremental deltas and a full snapshot (#749). The two streams were previously concatenated, so the assistant text appeared twice in the response
+- Provider rate-limit messages are now preserved instead of being flattened into a generic process error (#730). When a provider reports a rate limit, the original message survives through the response so the cause is visible
+
+### Internal
+
+- Configuration docs and validation error messages aligned to snake_case (#747). The config reference and error text used camelCase names (`workflowArpeggio`, `syncConflictResolver`, `taktProviders`, …) that never matched the actual snake_case YAML keys (`workflow_arpeggio`, `sync_conflict_resolver`, `takt_providers`, …) the parser expects. Documentation and messages now show the keys TAKT actually reads. No behavior or schema change
+- CodeRabbit integration added for repository reviews — `.coderabbit.yaml` configuration, TAKT facets referenced as `code_guidelines`, probe-based config tuning, and a sponsor mention (#737, #738, #742, #744)
+- CI consolidated and retriggered on `/review`. The four `issue_comment`-driven workflows were merged into a single `pr-comment-commands.yml`, and the takt-review comment trigger moved from `/takt-review` to `/review` (#726, #728, #736)
+- Documentation reorganized: added a Design Philosophy page and an External Integrations page, refreshed the workflows guide (including `workflows.ja.md`), and removed stale internal docs (data-flow, provider-sandbox, report-phase-permissions, agents) (#723, #729, #739)
+- Removed brittle non-executable asset tests (README terminology / instruction-template checks) and added testing-policy guidance discouraging such tests (#730)
+
 ## [0.41.0] - 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ These providers run via SDK (no CLI required, Node.js only):
 These providers require an external CLI:
 
 - `claude` — [Claude Code](https://claude.ai/code)
+- `claude-terminal` — [Claude Code](https://claude.ai/code) driven in an interactive terminal session (also requires [`tmux`](https://github.com/tmux/tmux))
 - `copilot` — [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)
 - `cursor` — [Cursor Agent](https://docs.cursor.com/)
 
@@ -183,7 +184,7 @@ See the [CLI Reference](./docs/cli-reference.md) for all commands and options.
 Minimal `~/.takt/config.yaml`:
 
 ```yaml
-provider: claude    # claude, claude-sdk, codex, opencode, cursor, or copilot
+provider: claude    # claude, claude-sdk, claude-terminal, codex, opencode, cursor, or copilot
 model: sonnet       # passed directly to provider
 language: en        # en or ja
 ```

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,34 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.42.0] - 2026-05-20
+
+### Added
+
+- `claude-terminal` プロバイダを追加 (#727)。Anthropic SDK（`claude-sdk`）や headless CLI（`claude`）を呼ぶのではなく、tmux ペイン内で対話型 Claude Code CLI セッションを起動し、セッションのトランスクリプトから結果を読み取る新しい実行方式。`--provider claude-terminal` または設定ファイルで選択する。structured output / MCP サーバ / allowed-tools に対応し、権限確認や ask-user-question のプロンプトはターミナル経由で受け渡しする。プロバイダオプションは `provider_options.claude_terminal` 配下（`backend: tmux`, `timeout_ms`, `keep_session`, `transcript_poll_interval_ms`）。利用には `tmux` のインストールが必要で、`maxTurns` は非対応、トランスクリプトに含まれないため API 使用量は取得できない
+- オプトインの OpenTelemetry オブザーバビリティを追加 (#706, #745)。`~/.takt/config.yaml`（グローバル）または `.takt/config.yaml`（プロジェクト）で `observability.enabled: true` を設定する（環境変数 `TAKT_observability__enabled` でも上書き可）と、ワークフロー実行の OTel スパンを出力する。各 run は `workflow.<name>` スパンを生成し、その子として `step.<name>` スパンが付き、ワークフロー / ステップ名・ステップ種別・iteration 回数・解決された provider / model（とその設定ソース）・最終ステータス（abort 種別を含む）といった属性を持つ。スパンは通常実行と並走する非ブロッキングの「シャドウ」として出力され、run の挙動は一切変えない。基盤は OTel Node SDK（サービス名 `takt`）を初期化するが exporter は同梱しないため、標準の `OTEL_*` 環境変数で自前のコレクタに接続する。デフォルトは無効
+- `/accept` 対話コマンドを追加 (#733)。対話アシスタントモードで、`/accept` は直近のアシスタント発言をそのままタスクとして実行する（`/go` による要約を経由しない）。アシスタント発言がまだ無い場合は、先にタスク内容を入力するよう促す
+- アシスタント init ファイルを追加 (#734)。`.takt/config.yaml` の `assistant.init_files` にプロジェクトのコンテキストファイルを列挙すると、対話アシスタントの会話ごとに「Assistant Init Context」セクションとして自動的に読み込まれる。これによりアーキテクチャメモ・規約・独自指示などのプロジェクト固有コンテキストを毎回手作業で渡さずに済む。パスはプロジェクト内の相対パスに限られ、機微なファイル（`.env*`, `.pem`, `.key`, `.npmrc`, `.netrc`, `.git/` など）は拒否される。上限は 16 ファイル / 1 ファイル 256 KB / 合計 1 MB
+- GitHub PR のレビュースレッドを解決状態で分類するようにした (#746)。PR レビューコメントをタスクに取り込む際、スレッドを Active・Outdated だが未解決・解決済み / Outdated の各セクションに分け、それぞれ誰が解決したか・outdated かどうかを注記する。レビューポリシーにより、エージェントは active スレッドに集中し、outdated だが未解決のものは現在も該当するか再確認し、解決済みスレッドは同じ問題がコードに残っていない限りスキップする。これにより対応済みのフィードバックを蒸し返さない
+- enqueue effect の `base_branch` でブランチを必要時に作成できるようにした (#725)。システムワークフローの enqueue effect の `base_branch` が、従来の文字列に加えてオブジェクト形式 `{ name, create_if_missing: { from, push } }` を受け付けるようになった。指定したベースブランチが存在しない場合、TAKT が `from` から作成する（`push: true` のときは push も行う）。ビルトインの `auto-improvement-loop` はこれを使って `improve` ベースブランチを `main` から自動作成するため、手動のブランチ準備なしでループを実行できる
+
+### Changed
+
+- ビルトインのレビュー系ファセットを補強（en + ja）。`cqrs-es` ナレッジにイベント進化と抽象境界に関するガイダンスを追加し、ai-antipattern / coding / qa / review / testing ポリシーの REJECT / APPROVE 基準を強化、frontend ナレッジと frontend-review 出力契約に canonical state（正規の状態）に関するガイダンスを追加した。ワークフロー構造は変えずに、ビルトインレビューワが何を強制するかを精緻化している
+
+### Fixed
+
+- OpenCode の応答で、SDK が差分（delta）と全文スナップショットの両方を出すときにコンテンツが二重化する問題を修正 (#749)。従来は両ストリームを連結していたため、アシスタントのテキストが応答に二重に現れていた
+- プロバイダの rate-limit メッセージを、汎用的なプロセスエラーに潰さずに保持するようにした (#730)。プロバイダが rate limit を報告した際、元のメッセージが応答を通じて残るため原因が見えるようになる
+
+### Internal
+
+- 設定ドキュメントとバリデーションエラーメッセージの表記を snake_case に統一 (#747)。設定リファレンスとエラー文が camelCase 名（`workflowArpeggio`, `syncConflictResolver`, `taktProviders` ……）を使っていたが、これらはパーサが実際に期待する snake_case の YAML キー（`workflow_arpeggio`, `sync_conflict_resolver`, `takt_providers` ……）とは一致していなかった。ドキュメントとメッセージが TAKT が実際に読み取るキーを示すようになった。挙動・スキーマの変更はない
+- リポジトリレビュー向けに CodeRabbit 連携を追加。`.coderabbit.yaml` 設定、TAKT ファセットを `code_guidelines` として参照、probe 結果に基づく設定チューニング、スポンサー記載 (#737, #738, #742, #744)
+- CI を統合し、トリガーを `/review` に変更。`issue_comment` 駆動の 4 ワークフローを単一の `pr-comment-commands.yml` に統合し、takt-review のコメントトリガーを `/takt-review` から `/review` に変更した (#726, #728, #736)
+- ドキュメントを再編成。Design Philosophy ページと External Integrations ページを追加し、workflows ガイド（`workflows.ja.md` を含む）を最新化、古い内部ドキュメント（data-flow / provider-sandbox / report-phase-permissions / agents）を削除した (#723, #729, #739)
+- 実行されない成果物に対する脆いテスト（README 用語 / instruction テンプレートのチェック）を削除し、testing ポリシーにそうしたテストを避ける指針を追加 (#730)
+
 ## [0.41.0] - 2026-05-14
 
 ### Added

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -39,6 +39,7 @@ workflow で工程を定義し、persona・policy・knowledge・instruction・ou
 次のプロバイダーを使う場合は外部 CLI のインストールが必要です:
 
 - `claude` — [Claude Code](https://claude.ai/code)
+- `claude-terminal` — [Claude Code](https://claude.ai/code) を対話型ターミナルセッションで駆動（[`tmux`](https://github.com/tmux/tmux) も必要）
 - `copilot` — [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)
 - `cursor` — [Cursor Agent](https://docs.cursor.com/)
 
@@ -186,7 +187,7 @@ workflow ファイルの正式ディレクトリ名は `workflows/` です。
 最小限の `~/.takt/config.yaml` は次の通りです。
 
 ```yaml
-provider: codex    # claude, claude-sdk, codex, opencode, cursor, or copilot
+provider: codex    # claude, claude-sdk, claude-terminal, codex, opencode, cursor, or copilot
 model: gpt-5.5       # プロバイダーにそのまま渡されます
 language: ja        # en or ja
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Workflow Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- `claude-terminal` provider (#727) — drives an interactive Claude Code CLI session inside a tmux pane and reads results from the session transcript. Select via `--provider claude-terminal`. Supports structured output / MCP servers / allowed-tools; options under `provider_options.claude_terminal`. Requires `tmux`; `maxTurns` and API usage figures are unavailable.
- Opt-in OpenTelemetry observability (#706, #745) — `observability.enabled: true` emits `workflow.<name>` / `step.<name>` shadow spans (provider/model resolution, iteration counts, status). No exporter bundled; wire your own collector via `OTEL_*`. Off by default.
- `/accept` interactive command (#733) — runs the latest assistant response verbatim as the task without `/go` summarization.
- Assistant init files (#734) — `assistant.init_files` auto-loads project context files into every interactive assistant conversation (relative paths only; sensitive files rejected; 16 files / 256 KB / 1 MB limits).
- PR review threads classified by resolution state (#746) — Active / Outdated-unresolved / Resolved sections so handled feedback is not re-litigated.
- Enqueue effect `base_branch.create_if_missing` (#725) — creates the base branch from a source branch on demand; `auto-improvement-loop` auto-creates its `improve` branch from `main`.

### Changed

- Builtin review facets refined (CQRS-ES event evolution, AI-antipattern / coding / QA / review / testing policies, frontend canonical-state guidance).

### Fixed

- OpenCode content no longer duplicated when SDK emits both deltas and a full snapshot (#749).
- Provider rate-limit messages preserved instead of flattened to a generic process error (#730).

### Internal

- Config docs and validation error messages aligned to snake_case (#747) — corrects misleading camelCase names; no behavior/schema change.
- CodeRabbit integration (#737, #738, #742, #744).
- CI consolidated into `pr-comment-commands.yml`; takt-review trigger moved to `/review` (#726, #728, #736).
- Docs reorganized — Design Philosophy & External Integrations pages added, workflows guide refreshed, stale internal docs removed (#723, #729, #739).
- Removed brittle non-executable asset tests (#730).

## Commits

- 27c05d39 fix(opencode): delta と全文スナップショット両出し時の content 二重化を修正 (#749)
- 3382ee80 fix: stabilize claude-terminal tmux input (#748)
- f2f0560d [#741] add-pr-thread-state-filter-1 (#746)
- cffe4902 設定ファイルで利用するキー表記を `snake_case` に統一する (#747)
- f6b5e854 feat: add workflow step otel shadow spans (#745)
- ada8a5d1 chore(coderabbit): tune review config based on probe results (#744)
- 5cc880ec docs: add CodeRabbit as sponsor (#742)
- b771168f CHANGELOG.md / CHANGELOG.ja.md の非翻訳内容差分を解消する (#739)
- fb230eb9 [#721] add-claude-terminal-provider (#727)
- e666e417 docs: add design philosophy
- 219b207e chore(coderabbit): TAKT facets を code_guidelines として参照 (#738)
- 56372717 [#732] add-assistant-init-files (#734)
- 63ab0829 chore: CodeRabbit 設定ファイルを追加 (#737)
- 207853b6 chore(ci): issue_comment 駆動の 4 ワークフローを 1 つに統合 (#736)
- d1e8ed24 takt: implement-accept-command (#733)
- d39fffc7 fix: preserve provider rate limit messages (#730)
- 6d8736ba docs: ドキュメント整理と takt-sdd 追加、workflows ガイドの最新化 (#729)
- c72e0c3e chore(ci): takt-review のトリガーコマンドを /takt-review から /review に変更 (#728)
- 3bbb1a4e chore(ci): takt-review を /takt-review コメントトリガーに変更 (#726)
- 598bf88d takt: add-base-branch-creation (#725)
- efbc7957 [codex] feat: opt-in observability foundation を追加 (#706)
- 7e90491d Refine event evolution and abstraction facets
- c4406389 Refine reusable facet policies
- 3c6ac5f3 Add canonical state guidance to frontend facets
- 799b5ec9 docs: add External Integrations page referencing community examples (#723)

## Closes

(No open issues — all referenced issues are already closed and PRs are merged.)