### PR TITLE
[#751] add-image-attachments

### DIFF
--- a/e2e/helpers/isolated-env.ts
+++ b/e2e/helpers/isolated-env.ts
@@ -91,6 +91,7 @@ export function createIsolatedEnv(): IsolatedEnv {
 
   const taktDir = join(baseDir, '.takt');
   const gitConfigPath = join(baseDir, '.gitconfig');
+  const worktreeDir = join(baseDir, 'worktrees');
 
   // Create TAKT config directory and config.yaml
   mkdirSync(taktDir, { recursive: true });
@@ -103,10 +104,14 @@ export function createIsolatedEnv(): IsolatedEnv {
   const config = provider
     ? {
       ...baseConfig,
+      worktree_dir: worktreeDir,
       provider,
       ...(model ? { model } : {}),
     }
-    : baseConfig;
+    : {
+      ...baseConfig,
+      worktree_dir: worktreeDir,
+    };
   writeConfigFile(taktDir, config);
 
   // Create isolated Git config file

--- a/e2e/helpers/takt-runner.ts
+++ b/e2e/helpers/takt-runner.ts
@@ -35,6 +35,14 @@ function getTaktBinPath(): string {
   return resolve(__dirname, '../../bin/takt');
 }
 
+export function formatTaktRunResult(result: TaktRunResult): string {
+  return [
+    `exitCode: ${result.exitCode}`,
+    `stdout:\n${result.stdout}`,
+    `stderr:\n${result.stderr}`,
+  ].join('\n\n');
+}
+
 /**
  * Prepend --provider <provider> to args if provider is specified
  * and args do not already contain --provider.

--- a/e2e/specs/list-non-interactive.e2e.ts
+++ b/e2e/specs/list-non-interactive.e2e.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 import { createIsolatedEnv, type IsolatedEnv } from '../helpers/isolated-env';
 import { createTestRepo, type TestRepo } from '../helpers/test-repo';
-import { runTakt } from '../helpers/takt-runner';
+import { formatTaktRunResult, runTakt } from '../helpers/takt-runner';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -210,10 +210,13 @@ describe('E2E: List tasks non-interactive (takt list)', () => {
       timeout: 240_000,
     });
 
-    expect(runResult.exitCode).toBe(0);
+    expect(runResult.exitCode, formatTaktRunResult(runResult)).toBe(0);
 
     const taskMeta = readTaskMeta(testRepo.path, taskName);
-    expect(taskMeta.status).toBe('completed');
+    expect(
+      taskMeta.status,
+      `taskMeta:\n${JSON.stringify(taskMeta, null, 2)}\n\n${formatTaktRunResult(runResult)}`,
+    ).toBe('completed');
     expect(taskMeta.branch).toMatch(/^takt\//);
     expect(taskMeta.worktree_path).toBeTruthy();
 
@@ -235,7 +238,7 @@ describe('E2E: List tasks non-interactive (takt list)', () => {
       timeout: 240_000,
     });
 
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode, formatTaktRunResult(result)).toBe(0);
 
     const stagedFiles = execFileSync('git', ['diff', '--cached', '--name-only'], {
       cwd: testRepo.path,
@@ -266,10 +269,13 @@ describe('E2E: List tasks non-interactive (takt list)', () => {
       timeout: 240_000,
     });
 
-    expect(runResult.exitCode).toBe(0);
+    expect(runResult.exitCode, formatTaktRunResult(runResult)).toBe(0);
 
     const taskMeta = readTaskMeta(testRepo.path, taskName);
-    expect(taskMeta.status).toBe('completed');
+    expect(
+      taskMeta.status,
+      `taskMeta:\n${JSON.stringify(taskMeta, null, 2)}\n\n${formatTaktRunResult(runResult)}`,
+    ).toBe('completed');
     expect(taskMeta.branch).toMatch(/^takt\//);
     expect(taskMeta.worktree_path).toBeTruthy();
 
@@ -284,7 +290,7 @@ describe('E2E: List tasks non-interactive (takt list)', () => {
       timeout: 240_000,
     });
 
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode, formatTaktRunResult(result)).toBe(0);
 
     const syncedFile = execFileSync('git', ['show', `${taskMeta.branch!}:ROOT_SYNC.txt`], {
       cwd: testRepo.path,

--- a/e2e/specs/repertoire-real.e2e.ts
+++ b/e2e/specs/repertoire-real.e2e.ts
@@ -6,7 +6,7 @@ import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { createIsolatedEnv, type IsolatedEnv } from '../helpers/isolated-env';
-import { runTakt } from '../helpers/takt-runner';
+import { formatTaktRunResult, runTakt } from '../helpers/takt-runner';
 
 type LockFile = {
   source?: string;
@@ -251,7 +251,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         input: 'y\n',
         timeout: 240_000,
       });
-      expect(firstResult.exitCode).toBe(0);
+      expect(firstResult.exitCode, formatTaktRunResult(firstResult)).toBe(0);
 
       const secondResult = runTakt({
         args: ['repertoire', 'add', `github:${FIXTURE_REPO}@${FIXTURE_REF}`],
@@ -261,7 +261,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         timeout: 240_000,
       });
 
-      expect(secondResult.exitCode).toBe(0);
+      expect(secondResult.exitCode, formatTaktRunResult(secondResult)).toBe(0);
       expect(secondResult.stdout).toContain('既にインストールされています');
     },
     240_000,
@@ -277,7 +277,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         input: 'y\n',
         timeout: 240_000,
       });
-      expect(firstResult.exitCode).toBe(0);
+      expect(firstResult.exitCode, formatTaktRunResult(firstResult)).toBe(0);
 
       const packageDir = join(
         isolatedEnv.taktDir,
@@ -294,7 +294,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         timeout: 240_000,
       });
 
-      expect(secondResult.exitCode).toBe(0);
+      expect(secondResult.exitCode, formatTaktRunResult(secondResult)).toBe(0);
       expect(existsSync(`${packageDir}.tmp`)).toBe(false);
       expect(existsSync(`${packageDir}.bak`)).toBe(false);
       expect(existsSync(join(packageDir, '.takt-repertoire-lock.yaml'))).toBe(true);
@@ -312,7 +312,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         input: 'y\n',
         timeout: 240_000,
       });
-      expect(firstResult.exitCode).toBe(0);
+      expect(firstResult.exitCode, formatTaktRunResult(firstResult)).toBe(0);
 
       const lockPath = join(
         isolatedEnv.taktDir,
@@ -331,7 +331,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         timeout: 240_000,
       });
 
-      expect(secondResult.exitCode).toBe(0);
+      expect(secondResult.exitCode, formatTaktRunResult(secondResult)).toBe(0);
       const afterLock = readYamlFile<LockFile>(lockPath);
       expect(afterLock.commit).toBe(originalLock.commit);
       expect(afterLock.imported_at).toBe(originalLock.imported_at);
@@ -349,7 +349,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         input: 'y\n',
         timeout: 240_000,
       });
-      expect(firstResult.exitCode).toBe(0);
+      expect(firstResult.exitCode, formatTaktRunResult(firstResult)).toBe(0);
 
       const packageDir = join(
         isolatedEnv.taktDir,
@@ -368,7 +368,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         timeout: 240_000,
       });
 
-      expect(secondResult.exitCode).toBe(0);
+      expect(secondResult.exitCode, formatTaktRunResult(secondResult)).toBe(0);
       expect(existsSync(`${packageDir}.tmp`)).toBe(false);
     },
     240_000,
@@ -384,7 +384,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         input: 'y\n',
         timeout: 240_000,
       });
-      expect(firstResult.exitCode).toBe(0);
+      expect(firstResult.exitCode, formatTaktRunResult(firstResult)).toBe(0);
 
       const packageDir = join(
         isolatedEnv.taktDir,
@@ -403,7 +403,7 @@ describe('E2E: takt repertoire (real GitHub fixtures)', () => {
         timeout: 240_000,
       });
 
-      expect(secondResult.exitCode).toBe(0);
+      expect(secondResult.exitCode, formatTaktRunResult(secondResult)).toBe(0);
       expect(existsSync(`${packageDir}.bak`)).toBe(false);
     },
     240_000,

--- a/src/__tests__/cli-routing-pr-resolve.test.ts
+++ b/src/__tests__/cli-routing-pr-resolve.test.ts
@@ -124,7 +124,7 @@ vi.mock('../app/cli/helpers.js', () => ({
   resolveWorkflowCliOption: vi.fn((opts: Record<string, unknown>) => typeof opts.workflow === 'string' ? opts.workflow : undefined),
 }));
 
-import { selectAndExecuteTask, determineWorkflow, saveTaskFromInteractive } from '../features/tasks/index.js';
+import { selectAndExecuteTask, determineWorkflow, saveTaskFromInteractive, createIssueAndSaveTask } from '../features/tasks/index.js';
 import {
   interactiveMode,
   passthroughMode,
@@ -148,8 +148,15 @@ const mockSelectInteractiveMode = vi.mocked(selectInteractiveMode);
 const mockExecutePipeline = vi.mocked(executePipeline);
 const mockLogError = vi.mocked(logError);
 const mockSaveTaskFromInteractive = vi.mocked(saveTaskFromInteractive);
+const mockCreateIssueAndSaveTask = vi.mocked(createIssueAndSaveTask);
 const mockResolveConfigValuesFn = mockResolveConfigValues;
 const mockLoadPersonaSessionsFn = mockLoadPersonaSessions;
+
+const testAttachment = {
+  placeholder: '[Image #1]',
+  tempPath: '/tmp/takt/session-1/attachments/image-1.png',
+  fileName: 'image-1.png',
+};
 
 function createMockPrReview(overrides: Partial<PrReviewData & { baseRefName?: string }> = {}): PrReviewData {
   return {
@@ -183,6 +190,79 @@ beforeEach(() => {
   mockResolveAssistantConfigLayers.mockReturnValue({ local: {}, global: {} });
   mockLoadPersonaSessionsFn.mockReturnValue({});
   mockResolveAgentOverrides.mockReturnValue(undefined);
+});
+
+describe('interactive image attachment routing', () => {
+  it('should pass attachments from interactive execute result to selectAndExecuteTask', async () => {
+    mockInteractiveMode.mockResolvedValue({
+      action: 'execute',
+      task: 'Use [Image #1] as reference.',
+      attachments: [testAttachment],
+    } satisfies InteractiveModeResult);
+
+    await executeDefaultAction();
+
+    expect(mockSelectAndExecuteTask).toHaveBeenCalledWith(
+      '/test/cwd',
+      'Use [Image #1] as reference.',
+      expect.objectContaining({
+        attachments: [testAttachment],
+      }),
+      undefined,
+    );
+  });
+
+  it('should pass attachments from interactive save_task result to saveTaskFromInteractive', async () => {
+    mockInteractiveMode.mockResolvedValue({
+      action: 'save_task',
+      task: 'Use [Image #1] as reference.',
+      attachments: [testAttachment],
+    } satisfies InteractiveModeResult);
+
+    await executeDefaultAction();
+
+    expect(mockSaveTaskFromInteractive).toHaveBeenCalledWith(
+      '/test/cwd',
+      'Use [Image #1] as reference.',
+      'default',
+      expect.objectContaining({
+        attachments: [testAttachment],
+      }),
+    );
+  });
+
+  it('should pass attachments from interactive create_issue result to createIssueAndSaveTask', async () => {
+    mockInteractiveMode.mockResolvedValue({
+      action: 'create_issue',
+      task: 'Use [Image #1] as reference.',
+      attachments: [testAttachment],
+    } satisfies InteractiveModeResult);
+
+    await executeDefaultAction();
+
+    expect(mockCreateIssueAndSaveTask).toHaveBeenCalledWith(
+      '/test/cwd',
+      'Use [Image #1] as reference.',
+      'default',
+      expect.objectContaining({
+        attachments: [testAttachment],
+      }),
+    );
+  });
+
+  it('should not promote pasted image attachments when interactive input is cancelled', async () => {
+    mockInteractiveMode.mockResolvedValue({
+      action: 'cancel',
+      task: '',
+      attachments: [testAttachment],
+    } satisfies InteractiveModeResult);
+
+    await executeDefaultAction();
+
+    expect(mockSelectAndExecuteTask).not.toHaveBeenCalled();
+    expect(mockSaveTaskFromInteractive).not.toHaveBeenCalled();
+    expect(mockCreateIssueAndSaveTask).not.toHaveBeenCalled();
+  });
 });
 
 describe('PR resolution in routing', () => {

--- a/src/__tests__/clone.test.ts
+++ b/src/__tests__/clone.test.ts
@@ -1317,3 +1317,36 @@ describe('resolveCloneBaseDir parent-not-writable fallback', () => {
     expect(result.path).not.toContain('.takt/worktrees');
   });
 });
+
+describe('auto clone path allocation', () => {
+  it('should allocate a suffixed path when the generated clone path already exists', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.123Z'));
+    mockResolveConfigValue.mockReturnValue('/tmp/takt-worktrees');
+    vi.mocked(fs.existsSync).mockImplementation((value: fs.PathLike) => (
+      String(value) === '/tmp/takt-worktrees/20260101T0000-test-task'
+    ));
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'show-ref') throw new Error('not found');
+      if (argsArr[0] === 'symbolic-ref') return Buffer.from('refs/remotes/origin/main\n');
+      if (argsArr[0] === 'clone') return Buffer.from('');
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config' && argsArr[1] === '--local') throw new Error('not set');
+      if (argsArr[0] === 'config') return Buffer.from('');
+      if (argsArr[0] === 'checkout') return Buffer.from('');
+      return Buffer.from('');
+    });
+
+    try {
+      const result = new CloneManager().createSharedClone('/project', {
+        worktree: true,
+        taskSlug: 'test-task',
+      });
+
+      expect(result.path).toBe('/tmp/takt-worktrees/20260101T0000-test-task-2');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/__tests__/conversationLoop-resume.test.ts
+++ b/src/__tests__/conversationLoop-resume.test.ts
@@ -8,6 +8,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   setupRawStdin,
   restoreStdin,
@@ -120,6 +123,7 @@ import { initializeSession } from '../features/interactive/sessionInitialization
 const mockGetProvider = vi.mocked(getProvider);
 const mockSelectOption = vi.mocked(selectOption);
 const mockLogInfo = vi.mocked(logInfo);
+const attachmentSessionDirs = new Set<string>();
 
 // --- Helpers ---
 
@@ -162,7 +166,20 @@ beforeEach(() => {
 
 afterEach(() => {
   restoreStdin();
+  for (const sessionDir of attachmentSessionDirs) {
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+  }
+  attachmentSessionDirs.clear();
 });
+
+function createOscImagePaste(): string {
+  const imageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  return `\x1B]1337;File=inline=1;name=reference.png;size=${imageData.length}:${imageData.toString('base64')}\x07`;
+}
+
+function trackAttachmentSession(tempPath: string): void {
+  attachmentSessionDirs.add(path.dirname(path.dirname(tempPath)));
+}
 
 // =================================================================
 // initializeSession: no implicit session auto-load
@@ -351,6 +368,63 @@ describe('/go command', () => {
     // Then: summary call must NOT inherit the conversation session
     expect(capture.sessionIds[1]).toBeUndefined();
     expect(result.action).toBe('execute');
+  });
+
+  it('should return pasted image attachments after image input and /go', async () => {
+    setupRawStdin([
+      `use ${createOscImagePaste()} please\r`,
+      '/go\r',
+    ]);
+
+    const { provider, capture } = createScenarioProvider([
+      { content: 'AI response using [Image #1].' },
+      { content: 'Generated task using [Image #1].' },
+    ]);
+
+    const ctx: SessionContext = {
+      provider: provider as SessionContext['provider'],
+      providerType: 'mock' as SessionContext['providerType'],
+      model: undefined,
+      lang: 'en',
+      personaName: 'interactive',
+      sessionId: undefined,
+    };
+
+    const result = await runConversationLoop('/test', ctx, defaultStrategy, undefined, undefined);
+
+    expect(capture.callCount).toBe(2);
+    expect(capture.prompts[0]).toContain('use [Image #1] please');
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('Generated task using [Image #1].');
+    expect(result.attachments?.[0]?.fileName).toBe('image-1.png');
+    expect(result.attachments?.[0]).not.toHaveProperty('relativePath');
+    expect(result.attachments?.[0]?.tempPath).toBeDefined();
+    trackAttachmentSession(result.attachments![0]!.tempPath);
+    expect(fs.existsSync(result.attachments![0]!.tempPath)).toBe(true);
+  });
+
+  it('should not create formal task assets when image input is cancelled', async () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-cancel-image-test-'));
+    try {
+      setupRawStdin([
+        `use ${createOscImagePaste()} please\r`,
+        '/cancel\r',
+      ]);
+
+      setupProvider(['AI response using [Image #1].']);
+      const ctx = createSessionContext();
+
+      const result = await runConversationLoop(projectRoot, ctx, defaultStrategy, undefined, undefined);
+
+      expect(result.action).toBe('cancel');
+      expect(result.attachments?.[0]?.fileName).toBe('image-1.png');
+      expect(result.attachments?.[0]?.tempPath).toBeDefined();
+      trackAttachmentSession(result.attachments![0]!.tempPath);
+      expect(fs.existsSync(path.join(projectRoot, '.takt', 'tasks'))).toBe(false);
+      expect(fs.existsSync(path.join(projectRoot, '.takt', 'runs'))).toBe(false);
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 
   it('should include assistant init context only in the first regular AI prompt', async () => {

--- a/src/__tests__/imageAttachments.test.ts
+++ b/src/__tests__/imageAttachments.test.ts
@@ -1,0 +1,140 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildInteractiveResultWithAttachments,
+  createImageAttachmentStore,
+  createImagePasteHandler,
+  createSessionImageAttachmentStore,
+} from '../features/interactive/imageAttachments.js';
+
+const tempRoots = new Set<string>();
+
+afterEach(() => {
+  for (const root of tempRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  tempRoots.clear();
+});
+
+function createTempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-image-attachments-test-'));
+  tempRoots.add(root);
+  return root;
+}
+
+describe('createImageAttachmentStore', () => {
+  it('should save pasted images under the session tmp attachment directory', async () => {
+    const tmpRoot = createTempRoot();
+    const store = createImageAttachmentStore({
+      tmpRoot,
+      sessionId: 'session-abc',
+    });
+    const imageData = Buffer.from('png-data');
+
+    const attachment = await store.saveImage(imageData, 'image/png');
+
+    expect(attachment).toEqual({
+      placeholder: '[Image #1]',
+      tempPath: path.join(tmpRoot, 'takt', 'session-abc', 'attachments', 'image-1.png'),
+      fileName: 'image-1.png',
+    });
+    expect(fs.readFileSync(attachment.tempPath)).toEqual(imageData);
+  });
+
+  it('should assign stable placeholders and relative paths in paste order', async () => {
+    const tmpRoot = createTempRoot();
+    const store = createImageAttachmentStore({
+      tmpRoot,
+      sessionId: 'session-abc',
+    });
+
+    const first = await store.saveImage(Buffer.from('first'), 'image/png');
+    const second = await store.saveImage(Buffer.from('second'), 'image/png');
+
+    expect(first.placeholder).toBe('[Image #1]');
+    expect(first.fileName).toBe('image-1.png');
+    expect(second.placeholder).toBe('[Image #2]');
+    expect(second.fileName).toBe('image-2.png');
+    expect(store.listAttachments()).toEqual([first, second]);
+  });
+
+  it('should create session attachment directories and pasted files with private permissions', async () => {
+    const tmpRoot = createTempRoot();
+    const store = createImageAttachmentStore({
+      tmpRoot,
+      sessionId: 'session-private',
+    });
+
+    const attachment = await store.saveImage(Buffer.from('private'), 'image/png');
+
+    const sessionDir = path.join(tmpRoot, 'takt', 'session-private');
+    const attachmentDir = path.join(sessionDir, 'attachments');
+    expect(fs.statSync(sessionDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(attachmentDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(attachment.tempPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('should create a process session store in the OS tmp directory', async () => {
+    const store = createSessionImageAttachmentStore();
+
+    const attachment = await store.saveImage(Buffer.from('session'), 'image/png');
+    tempRoots.add(path.dirname(path.dirname(attachment.tempPath)));
+
+    expect(attachment.placeholder).toBe('[Image #1]');
+    expect(attachment.fileName).toBe('image-1.png');
+    expect(attachment.tempPath.startsWith(path.join(os.tmpdir(), 'takt') + path.sep)).toBe(true);
+    expect(fs.readFileSync(attachment.tempPath)).toEqual(Buffer.from('session'));
+  });
+
+  it('should create a paste handler that stores images and returns placeholders', async () => {
+    const tmpRoot = createTempRoot();
+    const store = createImageAttachmentStore({
+      tmpRoot,
+      sessionId: 'session-paste',
+    });
+    const onImagePaste = createImagePasteHandler(store);
+
+    const placeholder = await onImagePaste({
+      data: Buffer.from('paste'),
+      mimeType: 'image/png',
+    });
+
+    expect(placeholder).toBe('[Image #1]');
+    const [attachment] = store.listAttachments();
+    expect(attachment?.tempPath).toBe(path.join(tmpRoot, 'takt', 'session-paste', 'attachments', 'image-1.png'));
+    expect(fs.readFileSync(attachment!.tempPath)).toEqual(Buffer.from('paste'));
+  });
+});
+
+describe('buildInteractiveResultWithAttachments', () => {
+  it('should not add attachments when no images were pasted', () => {
+    const tmpRoot = createTempRoot();
+    const store = createImageAttachmentStore({
+      tmpRoot,
+      sessionId: 'session-empty-result',
+    });
+
+    const result = buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, store);
+
+    expect(result).toEqual({ action: 'cancel', task: '' });
+  });
+
+  it('should include pasted image attachments on the interactive result', async () => {
+    const tmpRoot = createTempRoot();
+    const store = createImageAttachmentStore({
+      tmpRoot,
+      sessionId: 'session-result',
+    });
+    const attachment = await store.saveImage(Buffer.from('result-image'), 'image/png');
+
+    const result = buildInteractiveResultWithAttachments({ action: 'execute', task: 'Use [Image #1].' }, store);
+
+    expect(result).toEqual({
+      action: 'execute',
+      task: 'Use [Image #1].',
+      attachments: [attachment],
+    });
+  });
+});

--- a/src/__tests__/inlineImagePaste.test.ts
+++ b/src/__tests__/inlineImagePaste.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { OSC_IMAGE_PREFIX, parseInlineImageSequence } from '../features/interactive/inlineImagePaste.js';
+
+const PNG_DATA = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+function buildInlineImageSequence(params: string[], data: Buffer, terminator: string): string {
+  return `${OSC_IMAGE_PREFIX}${params.join(';')}:${data.toString('base64')}${terminator}`;
+}
+
+describe('parseInlineImageSequence', () => {
+  it('should parse an inline PNG image terminated by ST', () => {
+    const input = [
+      'before ',
+      buildInlineImageSequence(['inline=1', 'name=reference.png', `size=${PNG_DATA.length}`], PNG_DATA, '\x1B\\'),
+      ' after',
+    ].join('');
+    const start = input.indexOf(OSC_IMAGE_PREFIX);
+
+    const result = parseInlineImageSequence(input, start);
+
+    expect(result.status).toBe('image');
+    if (result.status !== 'image') {
+      throw new Error('Expected parsed inline image.');
+    }
+    expect(result.image.mimeType).toBe('image/png');
+    expect(result.image.data).toEqual(PNG_DATA);
+    expect(result.sequenceEnd).toBe(input.indexOf(' after'));
+  });
+
+  it('should leave non-inline OSC 1337 file sequences as passthrough', () => {
+    const input = `${buildInlineImageSequence(['name=reference.png', `size=${PNG_DATA.length}`], PNG_DATA, '\x07')}after`;
+
+    const result = parseInlineImageSequence(input, 0);
+
+    expect(result).toEqual({
+      status: 'passthrough',
+      sequenceEnd: input.indexOf('after'),
+    });
+  });
+
+  it('should reject pasted image data that does not match the declared size', () => {
+    const input = buildInlineImageSequence(['inline=1', 'name=reference.png', `size=${PNG_DATA.length + 1}`], PNG_DATA, '\x07');
+
+    expect(() => parseInlineImageSequence(input, 0)).toThrow('Pasted inline image data does not match its declared size.');
+  });
+
+  it('should return incomplete for unterminated inline image input within the pending limit', () => {
+    const input = `${OSC_IMAGE_PREFIX}inline=1;name=reference.png;size=${PNG_DATA.length}:${PNG_DATA.toString('base64')}`;
+
+    const result = parseInlineImageSequence(input, 0);
+
+    expect(result).toEqual({ status: 'incomplete' });
+  });
+});

--- a/src/__tests__/instructMode.test.ts
+++ b/src/__tests__/instructMode.test.ts
@@ -3,6 +3,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { setupRawStdin, restoreStdin, toRawInputs, createMockProvider } from './helpers/stdinSimulator.js';
 
 vi.mock('../infra/config/global/globalConfig.js', () => ({
@@ -83,6 +85,7 @@ const mockGetProvider = vi.mocked(getProvider);
 const mockSelectOption = vi.mocked(selectOption);
 const mockInfo = vi.mocked(info);
 const mockLoadTemplate = vi.mocked(loadTemplate);
+const attachmentSessionDirs = new Set<string>();
 
 function setupMockProvider(responses: string[]): void {
   const { provider } = createMockProvider(responses);
@@ -96,7 +99,20 @@ beforeEach(() => {
 
 afterEach(() => {
   restoreStdin();
+  for (const sessionDir of attachmentSessionDirs) {
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+  }
+  attachmentSessionDirs.clear();
 });
+
+function createOscImagePaste(): string {
+  const imageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  return `\x1B]1337;File=inline=1;name=reference.png;size=${imageData.length}:${imageData.toString('base64')}\x07`;
+}
+
+function trackAttachmentSession(tempPath: string): void {
+  attachmentSessionDirs.add(path.dirname(path.dirname(tempPath)));
+}
 
 describe('runInstructMode', () => {
   it('should return action=cancel when user types /cancel', async () => {
@@ -148,6 +164,23 @@ describe('runInstructMode', () => {
 
     expect(result.action).toBe('save_task');
     expect(result.task).toBe('Summarized task.');
+  });
+
+  it('should preserve pasted image attachments from the conversation loop', async () => {
+    setupRawStdin([
+      `use ${createOscImagePaste()}\r`,
+      '/go\r',
+    ]);
+    setupMockProvider(['response', 'Use [Image #1].']);
+
+    const result = await runInstructMode('/project', 'branch context', 'feature-branch', 'my-task', 'Do something', '');
+
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('Use [Image #1].');
+    expect(result.attachments?.[0]?.fileName).toBe('image-1.png');
+    expect(result.attachments?.[0]?.tempPath).toBeDefined();
+    trackAttachmentSession(result.attachments![0]!.tempPath);
+    expect(fs.existsSync(result.attachments![0]!.tempPath)).toBe(true);
   });
 
   it('should continue editing when user selects continue', async () => {

--- a/src/__tests__/interactive-mode.test.ts
+++ b/src/__tests__/interactive-mode.test.ts
@@ -2,6 +2,8 @@
  * Tests for interactive mode variants (assistant, persona, quiet, passthrough)
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Mocks ──────────────────────────────────────────────
@@ -60,6 +62,7 @@ const mockGetProvider = vi.mocked(getProvider);
 const mockSelectOptionWithDefault = vi.mocked(selectOptionWithDefault);
 const mockSelectOption = vi.mocked(selectOption);
 const mockInfo = vi.mocked(info);
+const attachmentSessionDirs = new Set<string>();
 
 // ── Stdin helpers (same pattern as interactive.test.ts) ──
 
@@ -182,7 +185,20 @@ beforeEach(() => {
 
 afterEach(() => {
   restoreStdin();
+  for (const sessionDir of attachmentSessionDirs) {
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+  }
+  attachmentSessionDirs.clear();
 });
+
+function createOscImagePaste(): string {
+  const imageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  return `\x1B]1337;File=inline=1;name=reference.png;size=${imageData.length}:${imageData.toString('base64')}\x07`;
+}
+
+function trackAttachmentSession(tempPath: string): void {
+  attachmentSessionDirs.add(path.dirname(path.dirname(tempPath)));
+}
 
 // ── InteractiveMode type & constants tests ──
 
@@ -344,6 +360,20 @@ describe('passthroughMode', () => {
     expect(result.task).toBe('implement login feature');
   });
 
+  it('should return pasted image attachments with placeholders in task text', async () => {
+    setupRawStdin([`use ${createOscImagePaste()} please\r`]);
+
+    const result = await passthroughMode('en');
+
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('use [Image #1] please');
+    expect(result.attachments?.[0]?.fileName).toBe('image-1.png');
+    expect(result.attachments?.[0]).not.toHaveProperty('relativePath');
+    expect(result.attachments?.[0]?.tempPath).toBeDefined();
+    trackAttachmentSession(result.attachments![0]!.tempPath);
+    expect(fs.existsSync(result.attachments![0]!.tempPath)).toBe(true);
+  });
+
   it('should trim whitespace from user input', async () => {
     // Given
     setupRawStdin(toRawInputs(['  my task  ']));
@@ -442,6 +472,22 @@ describe('quietMode', () => {
     // Then
     expect(result.action).toBe('execute');
     expect(result.task).toBe('Fix the bug instruction.');
+  });
+
+  it('should return pasted image attachments from prompted quiet input', async () => {
+    setupRawStdin([`use ${createOscImagePaste()} please\r`]);
+    setupMockProvider(['Generated task using [Image #1].']);
+    mockSelectOption.mockResolvedValue('execute');
+
+    const result = await quietMode('/project');
+
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('Generated task using [Image #1].');
+    expect(result.attachments?.[0]?.fileName).toBe('image-1.png');
+    expect(result.attachments?.[0]).not.toHaveProperty('relativePath');
+    expect(result.attachments?.[0]?.tempPath).toBeDefined();
+    trackAttachmentSession(result.attachments![0]!.tempPath);
+    expect(fs.existsSync(result.attachments![0]!.tempPath)).toBe(true);
   });
 
   it('should include workflow context in summary generation', async () => {

--- a/src/__tests__/lineEditor.test.ts
+++ b/src/__tests__/lineEditor.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { parseInputData, createEscapeParser, type InputCallbacks } from '../features/interactive/lineEditor.js';
+import {
+  parseInputData,
+  createEscapeParser,
+  readMultilineInput,
+  type InputCallbacks,
+} from '../features/interactive/lineEditor.js';
 import type { CompletionCandidate, CompletionProvider } from '../features/interactive/completionMenu.js';
 import { MAX_INLINE_IMAGE_BYTES, MAX_PENDING_INLINE_IMAGE_CHARS } from '../features/interactive/inlineImagePaste.js';
 
@@ -205,6 +210,7 @@ describe('readMultilineInput cursor navigation', () => {
   let savedColumns: number | undefined;
   let columnsOverridden = false;
   let stdoutCalls: string[];
+  let emitRawInput: ((data: string) => void) | null = null;
 
   function setupRawStdin(rawInputs: string[], termColumns?: number): void {
     savedIsTTY = process.stdin.isTTY;
@@ -243,14 +249,17 @@ describe('readMultilineInput cursor navigation', () => {
     process.stdin.on = vi.fn(((event: string, handler: (...args: unknown[]) => void) => {
       if (event === 'data') {
         currentHandler = handler as (data: Buffer) => void;
-        while (inputIndex < rawInputs.length) {
-          const data = rawInputs[inputIndex]!;
-          inputIndex += 1;
+        emitRawInput = (data: string) => {
           queueMicrotask(() => {
             if (currentHandler) {
               currentHandler(Buffer.from(data, 'utf-8'));
             }
           });
+        };
+        while (inputIndex < rawInputs.length) {
+          const data = rawInputs[inputIndex]!;
+          inputIndex += 1;
+          emitRawInput(data);
         }
       }
       return process.stdin;
@@ -259,6 +268,7 @@ describe('readMultilineInput cursor navigation', () => {
     process.stdin.removeListener = vi.fn(((event: string) => {
       if (event === 'data') {
         currentHandler = null;
+        emitRawInput = null;
       }
       return process.stdin;
     }) as typeof process.stdin.removeListener);
@@ -289,9 +299,14 @@ describe('readMultilineInput cursor navigation', () => {
 
   afterEach(() => {
     restoreStdin();
+    vi.useRealTimers();
   });
 
-  // We need to dynamically import after mocking stdin
+  async function flushQueuedInput(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
   async function callReadMultilineInput(
     prompt: string,
     options?: {
@@ -299,7 +314,6 @@ describe('readMultilineInput cursor navigation', () => {
       onImagePaste?: (image: { mimeType: string; data: Buffer }) => Promise<string>;
     },
   ): Promise<string | null> {
-    const { readMultilineInput } = await import('../features/interactive/lineEditor.js');
     return readMultilineInput(prompt, options);
   }
 
@@ -460,6 +474,31 @@ describe('readMultilineInput cursor navigation', () => {
 
       expect(result).toBe('Use [Image #1]');
       expect(onImagePaste).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not keep a second Esc timeout after resolving a bare Esc with image paste enabled', async () => {
+      vi.useFakeTimers();
+      setupRawStdin([]);
+      const resultPromise = callReadMultilineInput('> ', {
+        completionProvider: testCompletionProvider,
+        onImagePaste: vi.fn(async () => '[Image #1]'),
+      });
+      await flushQueuedInput();
+
+      emitRawInput?.('/ca');
+      await flushQueuedInput();
+      emitRawInput?.('\x1B');
+      await flushQueuedInput();
+
+      expect(vi.getTimerCount()).toBe(1);
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(vi.getTimerCount()).toBe(0);
+      emitRawInput?.('\r');
+      await flushQueuedInput();
+      await vi.advanceTimersByTimeAsync(0);
+
+      await expect(resultPromise).resolves.toBe('/ca');
     });
   });
 

--- a/src/__tests__/lineEditor.test.ts
+++ b/src/__tests__/lineEditor.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parseInputData, createEscapeParser, type InputCallbacks } from '../features/interactive/lineEditor.js';
 import type { CompletionCandidate, CompletionProvider } from '../features/interactive/completionMenu.js';
+import { MAX_INLINE_IMAGE_BYTES, MAX_PENDING_INLINE_IMAGE_CHARS } from '../features/interactive/inlineImagePaste.js';
 
 function createCallbacks(): InputCallbacks & { calls: string[] } {
   const calls: string[] = [];
@@ -242,9 +243,9 @@ describe('readMultilineInput cursor navigation', () => {
     process.stdin.on = vi.fn(((event: string, handler: (...args: unknown[]) => void) => {
       if (event === 'data') {
         currentHandler = handler as (data: Buffer) => void;
-        if (inputIndex < rawInputs.length) {
+        while (inputIndex < rawInputs.length) {
           const data = rawInputs[inputIndex]!;
-          inputIndex++;
+          inputIndex += 1;
           queueMicrotask(() => {
             if (currentHandler) {
               currentHandler(Buffer.from(data, 'utf-8'));
@@ -295,6 +296,7 @@ describe('readMultilineInput cursor navigation', () => {
     prompt: string,
     options?: {
       completionProvider?: CompletionProvider;
+      onImagePaste?: (image: { mimeType: string; data: Buffer }) => Promise<string>;
     },
   ): Promise<string | null> {
     const { readMultilineInput } = await import('../features/interactive/lineEditor.js');
@@ -320,6 +322,144 @@ describe('readMultilineInput cursor navigation', () => {
       const result = await callReadMultilineInput('> ');
 
       expect(result).toBe('first\nsecond');
+    });
+  });
+
+  describe('image paste', () => {
+    it('should insert the returned placeholder at the cursor position', async () => {
+      const imageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const onImagePaste = vi.fn(async (image: { mimeType: string; data: Buffer }) => {
+        expect(image.mimeType).toBe('image/png');
+        expect(image.data.equals(imageData)).toBe(true);
+        return '[Image #1]';
+      });
+      setupRawStdin([
+        `before \x1B]1337;File=inline=1;name=reference.png;size=${imageData.length}:${imageData.toString('base64')}\x07 after\r`,
+      ]);
+
+      const result = await callReadMultilineInput('> ', { onImagePaste });
+
+      expect(result).toBe('before [Image #1] after');
+      expect(onImagePaste).toHaveBeenCalledTimes(1);
+    });
+
+    it('should infer pasted image type from a base64-encoded OSC 1337 name', async () => {
+      const imageData = Buffer.from('GIF89a-data');
+      const fileName = Buffer.from('reference.gif').toString('base64');
+      const onImagePaste = vi.fn(async (image: { mimeType: string; data: Buffer }) => {
+        expect(image.mimeType).toBe('image/gif');
+        expect(image.data.equals(imageData)).toBe(true);
+        return '[Image #1]';
+      });
+      setupRawStdin([
+        `before \x1B]1337;File=inline=1;name=${fileName};size=${imageData.length}:${imageData.toString('base64')}\x07 after\r`,
+      ]);
+
+      const result = await callReadMultilineInput('> ', { onImagePaste });
+
+      expect(result).toBe('before [Image #1] after');
+      expect(onImagePaste).toHaveBeenCalledTimes(1);
+    });
+
+    it('should detect pasted images when the OSC prefix is split across chunks', async () => {
+      const imageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const onImagePaste = vi.fn(async (image: { mimeType: string; data: Buffer }) => {
+        expect(image.mimeType).toBe('image/png');
+        expect(image.data.equals(imageData)).toBe(true);
+        return '[Image #1]';
+      });
+
+      setupRawStdin([
+        'before \x1B',
+        ']1337;',
+        `File=inline=1;name=reference.png;size=${imageData.length}:${imageData.toString('base64')}\x07 after\r`,
+      ]);
+
+      const result = await callReadMultilineInput('> ', { onImagePaste });
+
+      expect(result).toBe('before [Image #1] after');
+      expect(onImagePaste).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject pasted inline images when only the filename extension claims an image type', async () => {
+      const imageData = Buffer.from('not-an-image');
+      const onImagePaste = vi.fn(async () => '[Image #1]');
+      setupRawStdin([
+        `\x1B]1337;File=inline=1;name=reference.png;size=${imageData.length}:${imageData.toString('base64')}\x07`,
+      ]);
+
+      await expect(callReadMultilineInput('> ', { onImagePaste })).rejects.toThrow(
+        'Unsupported pasted inline image type',
+      );
+      expect(onImagePaste).not.toHaveBeenCalled();
+    });
+
+    it('should reject pasted inline images when filename extension and magic bytes disagree', async () => {
+      const imageData = Buffer.from('GIF89a-data');
+      const onImagePaste = vi.fn(async () => '[Image #1]');
+      setupRawStdin([
+        `\x1B]1337;File=inline=1;name=reference.png;size=${imageData.length}:${imageData.toString('base64')}\x07`,
+      ]);
+
+      await expect(callReadMultilineInput('> ', { onImagePaste })).rejects.toThrow(
+        'filename type does not match image data',
+      );
+      expect(onImagePaste).not.toHaveBeenCalled();
+    });
+
+    it('should reject pasted inline images when only OSC 1337 type claims an image MIME type', async () => {
+      const imageData = Buffer.from('not-an-image');
+      const onImagePaste = vi.fn(async () => '[Image #1]');
+      setupRawStdin([
+        `\x1B]1337;File=inline=1;type=image/png;size=${imageData.length}:${imageData.toString('base64')}\x07`,
+      ]);
+
+      await expect(callReadMultilineInput('> ', { onImagePaste })).rejects.toThrow(
+        'Unsupported pasted inline image type',
+      );
+      expect(onImagePaste).not.toHaveBeenCalled();
+    });
+
+    it('should reject pasted inline images above the declared size limit before decoding', async () => {
+      const imageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const onImagePaste = vi.fn(async () => '[Image #1]');
+      setupRawStdin([
+        `\x1B]1337;File=inline=1;name=reference.png;size=${MAX_INLINE_IMAGE_BYTES + 1}:${imageData.toString('base64')}\x07`,
+      ]);
+
+      await expect(callReadMultilineInput('> ', { onImagePaste })).rejects.toThrow(
+        'Pasted inline image exceeds',
+      );
+      expect(onImagePaste).not.toHaveBeenCalled();
+    });
+
+    it('should reject unterminated pasted inline image sequences above the pending limit', async () => {
+      const onImagePaste = vi.fn(async () => '[Image #1]');
+      setupRawStdin([
+        `\x1B]1337;File=${'x'.repeat(MAX_PENDING_INLINE_IMAGE_CHARS)}`,
+      ]);
+
+      await expect(callReadMultilineInput('> ', { onImagePaste })).rejects.toThrow(
+        'pending limit',
+      );
+      expect(onImagePaste).not.toHaveBeenCalled();
+    });
+
+    it('should process later input after async image placeholder insertion completes', async () => {
+      const imageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const onImagePaste = vi.fn(async () => {
+        await Promise.resolve();
+        return '[Image #1]';
+      });
+      setupRawStdin([
+        `Use \x1B]1337;File=inline=1;name=reference.png;size=${imageData.length}:${imageData.toString('base64')}\x07`,
+        '\r',
+      ]);
+
+      const result = await callReadMultilineInput('> ', { onImagePaste });
+
+      expect(result).toBe('Use [Image #1]');
+      expect(onImagePaste).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/__tests__/resolveTask.test.ts
+++ b/src/__tests__/resolveTask.test.ts
@@ -8,6 +8,7 @@ import * as runOrderContent from '../core/workflow/run/order-content.js';
 import { invalidateGlobalConfigCache } from '../infra/config/global/globalConfig.js';
 import { invalidateAllResolvedConfigCache } from '../infra/config/resolveConfigValue.js';
 import { unexpectedWorkflowKey } from '../../test/helpers/unknown-contract-test-keys.js';
+import { generateExecutionReportDir } from '../core/workflow/run/run-slug.js';
 
 const mockGetGitProvider = vi.hoisted(() => vi.fn());
 let originalTaktConfigDir: string | undefined;
@@ -22,6 +23,7 @@ import { resolveTaskExecution, resolveTaskIssue } from '../features/tasks/execut
 const tempRoots = new Set<string>();
 
 afterEach(() => {
+  vi.useRealTimers();
   for (const root of tempRoots) {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -506,7 +508,7 @@ describe('resolveTaskExecution', () => {
     });
 
     const result = await resolveTaskExecutionStrict(task, root);
-    const expectedReportOrderPath = path.join(root, '.takt', 'runs', 'issue-task-123', 'context', 'task', 'order.md');
+    const expectedReportOrderPath = path.join(root, '.takt', 'runs', result.reportDirName, 'context', 'task', 'order.md');
 
     expect(result).toMatchObject({
       execCwd: root,
@@ -516,12 +518,45 @@ describe('resolveTaskExecution', () => {
       draftPr: false,
       orderContent: '# task instruction',
       shouldPublishBranchToOrigin: true,
-      reportDirName: 'issue-task-123',
       issueNumber: 12345,
-      taskPrompt: expect.stringContaining('Primary spec: `.takt/runs/issue-task-123/context/task/order.md`'),
+      taskPrompt: expect.stringContaining(`Primary spec: \`.takt/runs/${result.reportDirName}/context/task/order.md\``),
     });
+    expect(result.reportDirName).not.toBe('issue-task-123');
     expect(fs.existsSync(expectedReportOrderPath)).toBe(true);
     expect(fs.readFileSync(expectedReportOrderPath, 'utf-8')).toBe('# task instruction');
+  });
+
+  it('should create separate run contexts when executing the same task_dir repeatedly', async () => {
+    const root = createTempProjectDir();
+    const taskDir = '.takt/tasks/reused-task-123';
+    const sourceTaskDir = path.join(root, taskDir);
+    fs.mkdirSync(sourceTaskDir, { recursive: true });
+    fs.writeFileSync(path.join(sourceTaskDir, 'order.md'), '# reused task instruction');
+
+    const task = createTask({
+      taskDir,
+      content: 'Run reused task',
+      data: {
+        task: 'Run reused task',
+        workflow: 'default',
+      },
+    });
+    vi.spyOn(Math, 'random')
+      .mockReturnValueOnce(0.1)
+      .mockReturnValueOnce(0.2);
+
+    const first = await resolveTaskExecutionStrict(task, root);
+    const second = await resolveTaskExecutionStrict(task, root);
+
+    expect(first.reportDirName).not.toBe('reused-task-123');
+    expect(second.reportDirName).not.toBe('reused-task-123');
+    expect(second.reportDirName).not.toBe(first.reportDirName);
+    expect(fs.readFileSync(path.join(root, '.takt', 'runs', first.reportDirName, 'context', 'task', 'order.md'), 'utf-8')).toBe(
+      '# reused task instruction',
+    );
+    expect(fs.readFileSync(path.join(root, '.takt', 'runs', second.reportDirName, 'context', 'task', 'order.md'), 'utf-8')).toBe(
+      '# reused task instruction',
+    );
   });
 
   it('should stage order.md into the worktree run context and return order content', async () => {
@@ -557,7 +592,7 @@ describe('resolveTaskExecution', () => {
     });
 
     const result = await resolveTaskExecutionStrict(task, root);
-    const stagedOrderPath = path.join(worktreePath, '.takt', 'runs', 'worktree-task-123', 'context', 'task', 'order.md');
+    const stagedOrderPath = path.join(worktreePath, '.takt', 'runs', result.reportDirName, 'context', 'task', 'order.md');
 
     expect(result).toMatchObject({
       execCwd: worktreePath,
@@ -566,13 +601,63 @@ describe('resolveTaskExecution', () => {
       autoPr: true,
       draftPr: false,
       shouldPublishBranchToOrigin: true,
-      reportDirName: 'worktree-task-123',
       branch: 'feature/worktree-task-123',
       worktreePath,
       orderContent,
-      taskPrompt: expect.stringContaining('Primary spec: `.takt/runs/worktree-task-123/context/task/order.md`'),
+      taskPrompt: expect.stringContaining(`Primary spec: \`.takt/runs/${result.reportDirName}/context/task/order.md\``),
     });
+    expect(result.reportDirName).not.toBe('worktree-task-123');
     expect(fs.readFileSync(stagedOrderPath, 'utf-8')).toBe(orderContent);
+
+    mockCreateSharedClone.mockRestore();
+    mockResolveBaseBranch.mockRestore();
+  });
+
+  it('should sequence worktree reportDirName against existing run directories in execCwd', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-16T01:02:03.000Z'));
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const root = createTempProjectDir();
+    const worktreePath = createTempProjectDir();
+    const taskDir = '.takt/tasks/worktree-collision-task';
+    const sourceTaskDir = path.join(root, taskDir);
+    const orderContent = '# worktree collision instruction';
+    const taskContent = 'Run worktree task';
+    fs.mkdirSync(sourceTaskDir, { recursive: true });
+    fs.writeFileSync(path.join(sourceTaskDir, 'order.md'), orderContent);
+
+    const existingReportDirName = generateExecutionReportDir(worktreePath, taskContent);
+    fs.mkdirSync(path.join(worktreePath, '.takt', 'runs', existingReportDirName), { recursive: true });
+
+    const task = createTask({
+      slug: 'worktree-collision-task',
+      content: taskContent,
+      taskDir,
+      data: ({
+        task: taskContent,
+        workflow: 'default',
+        worktree: true,
+        branch: 'feature/worktree-collision-task',
+      } as unknown) as NonNullable<TaskInfo['data']>,
+      worktreePath: undefined,
+      status: 'pending',
+    });
+
+    const mockResolveBaseBranch = vi.spyOn(infraTask, 'resolveBaseBranch').mockReturnValue({
+      branch: 'main',
+    });
+    const mockCreateSharedClone = vi.spyOn(infraTask, 'createSharedCloneAbortable').mockResolvedValue({
+      path: worktreePath,
+      branch: 'feature/worktree-collision-task',
+    });
+
+    const result = await resolveTaskExecutionStrict(task, root);
+
+    expect(result.reportDirName).toBe(`${existingReportDirName}-2`);
+    expect(fs.existsSync(path.join(worktreePath, '.takt', 'runs', existingReportDirName, 'context', 'task', 'order.md'))).toBe(false);
+    expect(fs.readFileSync(path.join(worktreePath, '.takt', 'runs', result.reportDirName, 'context', 'task', 'order.md'), 'utf-8')).toBe(
+      orderContent,
+    );
 
     mockCreateSharedClone.mockRestore();
     mockResolveBaseBranch.mockRestore();
@@ -596,12 +681,10 @@ describe('resolveTaskExecution', () => {
       } as unknown) as NonNullable<TaskInfo['data']>,
     });
 
-    const stagedOrderPath = path.join(root, '.takt', 'runs', 'symlink-task-123', 'context', 'task', 'order.md');
-
     await expect(resolveTaskExecutionStrict(task, root)).rejects.toThrow(
       `Task spec file must be a regular file: ${path.join(sourceTaskDir, 'order.md')}`,
     );
-    expect(fs.existsSync(stagedOrderPath)).toBe(false);
+    expect(fs.existsSync(path.join(root, '.takt', 'runs', 'symlink-task-123'))).toBe(false);
   });
 
   it('should not read run context order content when task_dir is absent', async () => {

--- a/src/__tests__/retrySlashCommand.test.ts
+++ b/src/__tests__/retrySlashCommand.test.ts
@@ -8,8 +8,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   setupRawStdin,
@@ -96,6 +96,7 @@ import { info } from '../shared/ui/index.js';
 
 const mockGetProvider = vi.mocked(getProvider);
 const mockInfo = vi.mocked(info);
+const attachmentSessionDirs = new Set<string>();
 
 function createTmpDir(): string {
   const dir = join(tmpdir(), `takt-retry-cmd-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -107,6 +108,15 @@ function setupProvider(responses: string[]): MockProviderCapture {
   const { provider, capture } = createMockProvider(responses);
   mockGetProvider.mockReturnValue(provider);
   return capture;
+}
+
+function createOscImagePaste(): string {
+  const imageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+  return `\x1B]1337;File=inline=1;name=reference.png;size=${imageData.length}:${imageData.toString('base64')}\x07`;
+}
+
+function trackAttachmentSession(tempPath: string): void {
+  attachmentSessionDirs.add(dirname(dirname(tempPath)));
 }
 
 function buildRetryContext(overrides?: Partial<RetryContext>): RetryContext {
@@ -146,6 +156,10 @@ describe('/retry slash command', () => {
   afterEach(() => {
     restoreStdin();
     rmSync(tmpDir, { recursive: true, force: true });
+    for (const sessionDir of attachmentSessionDirs) {
+      rmSync(sessionDir, { recursive: true, force: true });
+    }
+    attachmentSessionDirs.clear();
   });
 
   it('should route previous order content through action selection when /retry is used', async () => {
@@ -196,6 +210,24 @@ describe('/retry slash command', () => {
     const systemPrompt = capture.systemPrompts[0]!;
     expect(systemPrompt).toContain('Previous Order');
     expect(systemPrompt).toContain(orderContent);
+  });
+
+  it('should preserve pasted image attachments from the retry conversation loop', async () => {
+    setupRawStdin([
+      `use ${createOscImagePaste()}\r`,
+      '/go\r',
+    ]);
+    setupProvider(['response', 'Retry using [Image #1].']);
+
+    const retryContext = buildRetryContext();
+    const result = await runRetryMode(tmpDir, retryContext, null);
+
+    expect(result.action).toBe('execute');
+    expect(result.task).toBe('Retry using [Image #1].');
+    expect(result.attachments?.[0]?.fileName).toBe('image-1.png');
+    expect(result.attachments?.[0]?.tempPath).toBeDefined();
+    trackAttachmentSession(result.attachments![0]!.tempPath);
+    expect(existsSync(result.attachments![0]!.tempPath)).toBe(true);
   });
 
   it('should not include order section when no order content', async () => {

--- a/src/__tests__/retryTaskSpecAttachments.test.ts
+++ b/src/__tests__/retryTaskSpecAttachments.test.ts
@@ -1,0 +1,102 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  cleanupPreparedRetryTaskSpec,
+  prepareRetryTaskSpecWithAttachments,
+} from '../features/tasks/list/retryTaskSpecAttachments.js';
+import type { TaskAttachment } from '../features/tasks/attachments.js';
+
+const tempRoots = new Set<string>();
+
+afterEach(() => {
+  for (const root of tempRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  tempRoots.clear();
+});
+
+function createTempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-retry-attachments-test-'));
+  tempRoots.add(root);
+  return root;
+}
+
+function createAttachment(root: string, content: string): TaskAttachment {
+  const tempDir = path.join(root, 'tmp-attachments');
+  fs.mkdirSync(tempDir, { recursive: true });
+  const tempPath = path.join(tempDir, 'image-1.png');
+  fs.writeFileSync(tempPath, content, 'utf-8');
+  return {
+    placeholder: '[Image #1]',
+    tempPath,
+    fileName: 'image-1.png',
+  };
+}
+
+describe('prepareRetryTaskSpecWithAttachments', () => {
+  it('should copy existing task_dir attachments and renumber newly pasted images', () => {
+    const projectDir = createTempRoot();
+    const sourceTaskDirRelative = '.takt/tasks/source-task';
+    const sourceTaskDir = path.join(projectDir, sourceTaskDirRelative);
+    fs.mkdirSync(path.join(sourceTaskDir, 'attachments'), { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceTaskDir, 'order.md'),
+      [
+        'Original task with [Image #1].',
+        '',
+        '## 添付画像',
+        '',
+        '- [Image #1]: `attachments/image-1.png`',
+      ].join('\n'),
+      'utf-8',
+    );
+    fs.writeFileSync(path.join(sourceTaskDir, 'attachments', 'image-1.png'), 'old-image', 'utf-8');
+    const attachment = createAttachment(projectDir, 'new-image');
+
+    const prepared = prepareRetryTaskSpecWithAttachments(
+      projectDir,
+      'display-only content',
+      'Use [Image #1].',
+      [attachment],
+      sourceTaskDirRelative,
+    );
+
+    expect(prepared).toBeDefined();
+    if (!prepared) {
+      throw new Error('Prepared retry task spec is required.');
+    }
+    const preparedTaskDir = prepared.taskDir;
+    const orderContent = fs.readFileSync(path.join(preparedTaskDir, 'order.md'), 'utf-8');
+    expect(orderContent).toContain('Original task with [Image #1].');
+    expect(orderContent).toContain('Use [Image #2].');
+    expect(orderContent).toContain('- [Image #1]: `attachments/image-1.png`');
+    expect(orderContent).toContain('- [Image #2]: `attachments/image-2.png`');
+    expect(fs.readFileSync(path.join(preparedTaskDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('old-image');
+    expect(fs.readFileSync(path.join(preparedTaskDir, 'attachments', 'image-2.png'), 'utf-8')).toBe('new-image');
+
+    cleanupPreparedRetryTaskSpec(prepared);
+  });
+
+  it('should reject symlinked task_dir order.md before preparing retry attachments', () => {
+    const projectDir = createTempRoot();
+    const sourceTaskDirRelative = '.takt/tasks/source-task';
+    const sourceTaskDir = path.join(projectDir, sourceTaskDirRelative);
+    const linkedOrderPath = path.join(projectDir, 'linked-order.md');
+    const attachment = createAttachment(projectDir, 'new-image');
+    fs.mkdirSync(sourceTaskDir, { recursive: true });
+    fs.writeFileSync(linkedOrderPath, 'External order', 'utf-8');
+    fs.symlinkSync(linkedOrderPath, path.join(sourceTaskDir, 'order.md'));
+
+    expect(() =>
+      prepareRetryTaskSpecWithAttachments(
+        projectDir,
+        'display-only content',
+        'Use [Image #1].',
+        [attachment],
+        sourceTaskDirRelative,
+      )).toThrow(`Task spec file must be a regular file: ${path.join(sourceTaskDir, 'order.md')}`);
+    expect(fs.readdirSync(path.join(projectDir, '.takt', 'tasks'))).toEqual(['source-task']);
+  });
+});

--- a/src/__tests__/retryTaskSpecAttachments.test.ts
+++ b/src/__tests__/retryTaskSpecAttachments.test.ts
@@ -79,6 +79,36 @@ describe('prepareRetryTaskSpecWithAttachments', () => {
     cleanupPreparedRetryTaskSpec(prepared);
   });
 
+  it('should renumber newly pasted images against existing content without task_dir', () => {
+    const projectDir = createTempRoot();
+    const attachment = createAttachment(projectDir, 'new-image');
+
+    const prepared = prepareRetryTaskSpecWithAttachments(
+      projectDir,
+      [
+        'Original task with [Image #1].',
+        '',
+        '## 添付画像',
+        '',
+        '- [Image #1]: `attachments/image-1.png`',
+      ].join('\n'),
+      'Use [Image #1].',
+      [attachment],
+    );
+
+    expect(prepared).toBeDefined();
+    if (!prepared) {
+      throw new Error('Prepared retry task spec is required.');
+    }
+    const orderContent = fs.readFileSync(path.join(prepared.taskDir, 'order.md'), 'utf-8');
+    expect(orderContent).toContain('Original task with [Image #1].');
+    expect(orderContent).toContain('Use [Image #2].');
+    expect(orderContent).toContain('- [Image #2]: `attachments/image-2.png`');
+    expect(fs.readFileSync(path.join(prepared.taskDir, 'attachments', 'image-2.png'), 'utf-8')).toBe('new-image');
+
+    cleanupPreparedRetryTaskSpec(prepared);
+  });
+
   it('should reject symlinked task_dir order.md before preparing retry attachments', () => {
     const projectDir = createTempRoot();
     const sourceTaskDirRelative = '.takt/tasks/source-task';

--- a/src/__tests__/reviewerCommentPolicy557.test.ts
+++ b/src/__tests__/reviewerCommentPolicy557.test.ts
@@ -18,6 +18,8 @@ describe('reviewer comment policy (#557)', () => {
     'saveTaskFile.test.ts',
     'taskListSerializer.test.ts',
     'nffHintDry557.test.ts',
+    'inlineImagePaste.test.ts',
+    'imageAttachments.test.ts',
     'reviewerCommentPolicy557.test.ts',
   ] as const) {
     it(`${file} has no // Given/When/Then explanation comment lines`, () => {

--- a/src/__tests__/run-slug.test.ts
+++ b/src/__tests__/run-slug.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { generateExecutionReportDir } from '../core/workflow/run/run-slug.js';
+
+describe('generateExecutionReportDir', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('should keep task execution report names separate from existing run directories', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-report-dir-test-'));
+
+    try {
+      const first = generateExecutionReportDir(root, 'Use saved task spec');
+      fs.mkdirSync(path.join(root, '.takt', 'runs', first), { recursive: true });
+      const second = generateExecutionReportDir(root, 'Use saved task spec');
+
+      expect(second).not.toBe(first);
+      expect(second).toBe(`${first}-2`);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/runAllTasks-concurrency.test.ts
+++ b/src/__tests__/runAllTasks-concurrency.test.ts
@@ -408,7 +408,8 @@ describe('runAllTasks concurrency', () => {
 
       const executionOrder: string[] = [];
 
-      // Each task takes about 300ms. Sequential execution exceeds 600ms, while parallel execution stays around 300ms.
+      // Each task remains pending until its timer fires. Sequential execution would record
+      // end:slow-1 before start:slow-2, so order is enough to prove concurrency.
       mockExecuteWorkflow.mockImplementation((_config, task) => {
         executionOrder.push(`start:${task}`);
         return new Promise((resolve) => {
@@ -424,9 +425,7 @@ describe('runAllTasks concurrency', () => {
         .mockReturnValueOnce([]);
 
       // When
-      const startTime = Date.now();
       await runAllTasks('/project');
-      const elapsed = Date.now() - startTime;
 
       // Then: Both tasks started before either completed (concurrent execution)
       expect(executionOrder.slice(0, 2)).toEqual([
@@ -434,9 +433,6 @@ describe('runAllTasks concurrency', () => {
         'start:Task: slow-2',
       ]);
       expect(executionOrder.findIndex((entry) => entry.startsWith('end:'))).toBe(2);
-      // Elapsed time remains a secondary guard: concurrent execution should stay well below
-      // the 600ms sequential baseline even on slower CI runners.
-      expect(elapsed).toBeLessThan(550);
     });
 
     it('should fill slots immediately when a task completes (no batch waiting)', async () => {

--- a/src/__tests__/saveTaskFile.test.ts
+++ b/src/__tests__/saveTaskFile.test.ts
@@ -294,6 +294,38 @@ describe('saveTaskFile', () => {
 
     expectNoTaskArtifacts(testDir);
   });
+
+  it('should reject symlink attachment tempPath and clean up task artifacts', async () => {
+    const sourcePath = path.join(testDir, 'source-image.png');
+    const symlinkPath = path.join(testDir, 'linked-image.png');
+    fs.writeFileSync(sourcePath, 'png-data', 'utf-8');
+    fs.symlinkSync(sourcePath, symlinkPath);
+
+    await expect(saveTaskFile(testDir, 'Use [Image #1].', {
+      attachments: [{
+        placeholder: '[Image #1]',
+        tempPath: symlinkPath,
+        fileName: 'image-1.png',
+      }],
+    })).rejects.toThrow(`Task attachment source must be a regular file: ${symlinkPath}`);
+
+    expectNoTaskArtifacts(testDir);
+  });
+
+  it('should reject directory attachment tempPath and clean up task artifacts', async () => {
+    const directoryPath = path.join(testDir, 'image-directory');
+    fs.mkdirSync(directoryPath);
+
+    await expect(saveTaskFile(testDir, 'Use [Image #1].', {
+      attachments: [{
+        placeholder: '[Image #1]',
+        tempPath: directoryPath,
+        fileName: 'image-1.png',
+      }],
+    })).rejects.toThrow(`Task attachment source must be a regular file: ${directoryPath}`);
+
+    expectNoTaskArtifacts(testDir);
+  });
 });
 
 describe('saveTaskFromInteractive', () => {

--- a/src/__tests__/saveTaskFile.test.ts
+++ b/src/__tests__/saveTaskFile.test.ts
@@ -4,6 +4,10 @@ import * as path from 'node:path';
 import { tmpdir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
 
+const { mockCreateIssue } = vi.hoisted(() => ({
+  mockCreateIssue: vi.fn(),
+}));
+
 vi.mock('../infra/task/summarize.js', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   summarizeTaskName: vi.fn().mockImplementation((content: string) => {
@@ -43,9 +47,15 @@ vi.mock('../infra/task/index.js', async (importOriginal) => ({
   branchExists: vi.fn().mockReturnValue(true),
 }));
 
+vi.mock('../infra/git/index.js', () => ({
+  getGitProvider: () => ({
+    createIssue: (...args: unknown[]) => mockCreateIssue(...args),
+  }),
+}));
+
 import { success, info } from '../shared/ui/index.js';
 import { confirm, promptInput } from '../shared/prompt/index.js';
-import { saveTaskFile, saveTaskFromInteractive } from '../features/tasks/add/index.js';
+import { createIssueAndSaveTask, saveTaskFile, saveTaskFromInteractive } from '../features/tasks/add/index.js';
 import { getCurrentBranch, branchExists } from '../infra/task/index.js';
 import { summarizeTaskName } from '../infra/task/summarize.js';
 
@@ -69,6 +79,24 @@ function expectNoTaskArtifacts(testDir: string): void {
   expect(fs.existsSync(path.join(testDir, '.takt', 'tasks'))).toBe(false);
 }
 
+interface TestTaskAttachment {
+  placeholder: string;
+  tempPath: string;
+  fileName: string;
+}
+
+function createTempAttachment(root: string, fileName: string, content: string): TestTaskAttachment {
+  const sourceDir = path.join(root, 'tmp-attachments');
+  fs.mkdirSync(sourceDir, { recursive: true });
+  const tempPath = path.join(sourceDir, fileName);
+  fs.writeFileSync(tempPath, content, 'utf-8');
+  return {
+    placeholder: '[Image #1]',
+    tempPath,
+    fileName,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
@@ -76,6 +104,7 @@ beforeEach(() => {
   testDir = fs.mkdtempSync(path.join(tmpdir(), 'takt-test-save-'));
   mockGetCurrentBranch.mockReturnValue('main');
   mockBranchExists.mockReturnValue(true);
+  mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/owner/repo/issues/42' });
 });
 
 afterEach(() => {
@@ -234,6 +263,37 @@ describe('saveTaskFile', () => {
     expect(fs.readFileSync(path.join(testDir, String(tasks[0]?.task_dir), 'order.md'), 'utf-8')).toContain('Same title');
     expect(fs.readFileSync(path.join(testDir, String(tasks[1]?.task_dir), 'order.md'), 'utf-8')).toContain('Same title');
   });
+
+  it('should promote image attachments and append relative paths to order.md', async () => {
+    const attachment = createTempAttachment(testDir, 'image-1.png', 'png-data');
+
+    await saveTaskFile(testDir, 'Use [Image #1] as the visual reference.', {
+      attachments: [attachment],
+    });
+
+    const task = loadTasks(testDir).tasks[0]!;
+    const taskDir = path.join(testDir, String(task.task_dir));
+    const orderContent = fs.readFileSync(path.join(taskDir, 'order.md'), 'utf-8');
+
+    expect(orderContent).toContain('Use [Image #1] as the visual reference.');
+    expect(orderContent).toContain('## 添付画像');
+    expect(orderContent).toContain('- [Image #1]: `attachments/image-1.png`');
+    expect(fs.readFileSync(path.join(taskDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('png-data');
+  });
+
+  it('should not create task artifacts when attachment promotion fails', async () => {
+    const attachment: TestTaskAttachment = {
+      placeholder: '[Image #1]',
+      tempPath: path.join(testDir, 'missing-image-1.png'),
+      fileName: 'image-1.png',
+    };
+
+    await expect(saveTaskFile(testDir, 'Use [Image #1].', {
+      attachments: [attachment],
+    })).rejects.toThrow();
+
+    expectNoTaskArtifacts(testDir);
+  });
 });
 
 describe('saveTaskFromInteractive', () => {
@@ -286,6 +346,24 @@ describe('saveTaskFromInteractive', () => {
     expect(task.issue).toBe(42);
   });
 
+  it('should persist image attachments when saving an interactive task with preset settings', async () => {
+    const attachment = createTempAttachment(testDir, 'image-1.png', 'interactive-image');
+
+    await saveTaskFromInteractive(testDir, 'Review [Image #1].', 'default', {
+      presetSettings: { worktree: true, autoPr: false, draftPr: false },
+      attachments: [attachment],
+    });
+
+    const task = loadTasks(testDir).tasks[0]!;
+    const taskDir = path.join(testDir, String(task.task_dir));
+    const orderContent = fs.readFileSync(path.join(taskDir, 'order.md'), 'utf-8');
+    expect(task.workflow).toBe('default');
+    expect(task.worktree).toBe(true);
+    expect(orderContent).toContain('Review [Image #1].');
+    expect(orderContent).toContain('- [Image #1]: `attachments/image-1.png`');
+    expect(fs.readFileSync(path.join(taskDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('interactive-image');
+  });
+
   describe('with confirmAtEndMessage', () => {
     it('should not save task when user declines confirmAtEndMessage', async () => {
       mockConfirm.mockResolvedValueOnce(false);
@@ -328,5 +406,31 @@ describe('saveTaskFromInteractive', () => {
 
     const task = loadTasks(testDir).tasks[0]!;
     expect(task.base_branch).toBe('feature/custom-base');
+  });
+});
+
+describe('createIssueAndSaveTask', () => {
+  it('should persist issue task attachments through interactive save', async () => {
+    const attachment = createTempAttachment(testDir, 'image-1.png', 'issue-image');
+    mockPromptInput.mockResolvedValueOnce('');
+    mockPromptInput.mockResolvedValueOnce('');
+    mockConfirm.mockResolvedValueOnce(false);
+
+    await createIssueAndSaveTask(testDir, 'Review [Image #1].', 'default', {
+      attachments: [attachment],
+    });
+
+    expect(mockCreateIssue).toHaveBeenCalledWith(
+      { title: 'Review [Image #1].', body: 'Review [Image #1].', labels: undefined },
+      testDir,
+    );
+    const task = loadTasks(testDir).tasks[0]!;
+    const taskDir = path.join(testDir, String(task.task_dir));
+    const orderContent = fs.readFileSync(path.join(taskDir, 'order.md'), 'utf-8');
+    expect(task.issue).toBe(42);
+    expect(task.workflow).toBe('default');
+    expect(orderContent).toContain('Review [Image #1].');
+    expect(orderContent).toContain('- [Image #1]: `attachments/image-1.png`');
+    expect(fs.readFileSync(path.join(taskDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('issue-image');
   });
 });

--- a/src/__tests__/selectAndExecute-skipTaskList.test.ts
+++ b/src/__tests__/selectAndExecute-skipTaskList.test.ts
@@ -6,6 +6,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { generateExecutionReportDir } from '../core/workflow/run/run-slug.js';
 import { generateReportDir } from '../shared/utils/reportDir.js';
 
 const {
@@ -101,6 +102,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
   for (const root of tempRoots) {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -225,14 +227,57 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
     const addTaskOptions = mockAddTask.mock.calls[0]?.[1] as {
       task_dir: string;
     };
-    expect(addTaskOptions.task_dir).toBe(`.takt/tasks/${executeArg.reportDirName}`);
+    expect(addTaskOptions.task_dir).not.toBe(`.takt/tasks/${executeArg.reportDirName}`);
 
     const taskSpecDir = path.join(projectCwd, addTaskOptions.task_dir);
+    const runContextTaskDir = path.join(projectCwd, '.takt', 'runs', executeArg.reportDirName, 'context', 'task');
     expect(fs.readFileSync(path.join(taskSpecDir, 'order.md'), 'utf-8')).toContain(
       '- [Image #1]: `attachments/image-1.png`',
     );
     expect(fs.readFileSync(path.join(taskSpecDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('png-data');
+    expect(fs.readFileSync(path.join(runContextTaskDir, 'order.md'), 'utf-8')).toContain(
+      '- [Image #1]: `attachments/image-1.png`',
+    );
+    expect(fs.readFileSync(path.join(runContextTaskDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('png-data');
     expect(mockPersistTaskResult).toHaveBeenCalled();
+  });
+
+  it('attachments 付き skipTaskList: false の連続実行では run context を再利用しない', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-16T01:02:03.000Z'));
+    vi.spyOn(Math, 'random')
+      .mockReturnValueOnce(0.1)
+      .mockReturnValueOnce(0.2);
+
+    const projectCwd = createTempProject();
+    const tempAttachmentDir = path.join(projectCwd, 'tmp-attachments');
+    fs.mkdirSync(tempAttachmentDir, { recursive: true });
+    const tempPath = path.join(tempAttachmentDir, 'image-1.png');
+    fs.writeFileSync(tempPath, 'png-data', 'utf-8');
+    const task = 'Use [Image #1] as reference.';
+    const options = {
+      workflow: 'default',
+      skipTaskList: false,
+      attachments: [{
+        placeholder: '[Image #1]',
+        tempPath,
+        fileName: 'image-1.png',
+      }],
+    };
+
+    await selectAndExecuteTask(projectCwd, task, options);
+    await selectAndExecuteTask(projectCwd, task, options);
+
+    const firstExecuteArg = mockExecuteTask.mock.calls[0]?.[0] as { reportDirName: string };
+    const secondExecuteArg = mockExecuteTask.mock.calls[1]?.[0] as { reportDirName: string };
+    const firstTaskOptions = mockAddTask.mock.calls[0]?.[1] as { task_dir: string };
+    const secondTaskOptions = mockAddTask.mock.calls[1]?.[1] as { task_dir: string };
+
+    expect(firstExecuteArg.reportDirName).not.toBe(secondExecuteArg.reportDirName);
+    expect(firstTaskOptions.task_dir).not.toBe(`.takt/tasks/${firstExecuteArg.reportDirName}`);
+    expect(secondTaskOptions.task_dir).not.toBe(`.takt/tasks/${secondExecuteArg.reportDirName}`);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', firstExecuteArg.reportDirName, 'context', 'task', 'order.md'))).toBe(true);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', secondExecuteArg.reportDirName, 'context', 'task', 'order.md'))).toBe(true);
   });
 
   it('attachments 付き skipTaskList: true で executeTask が失敗しても prepared task spec を削除する', async () => {
@@ -256,7 +301,7 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
     ).rejects.toThrow('Task execution failed');
 
     const executeArg = mockExecuteTask.mock.calls[0]?.[0] as { reportDirName: string };
-    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', executeArg.reportDirName))).toBe(false);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks'))).toBe(false);
     expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', executeArg.reportDirName, 'context', 'task'))).toBe(false);
     expect(mockPersistTaskError).not.toHaveBeenCalled();
   });
@@ -289,7 +334,7 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
     }
 
     const executeArg = mockExecuteTask.mock.calls[0]?.[0] as { reportDirName: string };
-    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', executeArg.reportDirName))).toBe(false);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks'))).toBe(false);
     expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', executeArg.reportDirName, 'context', 'task'))).toBe(false);
     expect(mockPersistTaskResult).not.toHaveBeenCalled();
   });
@@ -300,7 +345,9 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
 
     const projectCwd = createTempProject();
     const task = 'Use [Image #1] as reference.';
-    const reportDirName = generateReportDir(task);
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const taskSpecSlug = generateReportDir(task);
+    const reportDirName = generateExecutionReportDir(projectCwd, task);
     const tempAttachmentDir = path.join(projectCwd, 'tmp-attachments');
     const tempPath = path.join(tempAttachmentDir, 'image-1.png');
     fs.mkdirSync(tempAttachmentDir, { recursive: true });
@@ -321,7 +368,7 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
       }),
     ).rejects.toThrow('addTask failed');
 
-    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', reportDirName))).toBe(false);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', taskSpecSlug))).toBe(false);
     expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', reportDirName))).toBe(false);
     expect(mockExecuteTask).not.toHaveBeenCalled();
   });
@@ -332,12 +379,12 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
 
     const projectCwd = createTempProject();
     const task = 'Use [Image #1] as reference.';
-    const reportDirName = generateReportDir(task);
-    const blockedContextPath = path.join(projectCwd, '.takt', 'runs', reportDirName, 'context');
+    const taskSpecSlug = generateReportDir(task);
+    const blockedRunsPath = path.join(projectCwd, '.takt', 'runs');
     const tempAttachmentDir = path.join(projectCwd, 'tmp-attachments');
     const tempPath = path.join(tempAttachmentDir, 'image-1.png');
-    fs.mkdirSync(path.dirname(blockedContextPath), { recursive: true });
-    fs.writeFileSync(blockedContextPath, 'not-a-directory', 'utf-8');
+    fs.mkdirSync(path.dirname(blockedRunsPath), { recursive: true });
+    fs.writeFileSync(blockedRunsPath, 'not-a-directory', 'utf-8');
     fs.mkdirSync(tempAttachmentDir, { recursive: true });
     fs.writeFileSync(tempPath, 'png-data', 'utf-8');
 
@@ -353,8 +400,7 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
       }),
     ).rejects.toThrow();
 
-    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', reportDirName))).toBe(false);
-    expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', reportDirName, 'context', 'task', 'order.md'))).toBe(false);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', taskSpecSlug))).toBe(false);
     expect(mockExecuteTask).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/selectAndExecute-skipTaskList.test.ts
+++ b/src/__tests__/selectAndExecute-skipTaskList.test.ts
@@ -167,6 +167,16 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
     fs.mkdirSync(tempAttachmentDir, { recursive: true });
     const tempPath = path.join(tempAttachmentDir, 'image-1.png');
     fs.writeFileSync(tempPath, 'png-data', 'utf-8');
+    mockExecuteTask.mockImplementationOnce(async (arg: {
+      reportDirName: string;
+    }) => {
+      const runContextTaskDir = path.join(projectCwd, '.takt', 'runs', arg.reportDirName, 'context', 'task');
+      expect(fs.readFileSync(path.join(runContextTaskDir, 'order.md'), 'utf-8')).toContain(
+        '- [Image #1]: `attachments/image-1.png`',
+      );
+      expect(fs.readFileSync(path.join(runContextTaskDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('png-data');
+      return true;
+    });
 
     await selectAndExecuteTask(projectCwd, 'Use [Image #1] as reference.', {
       workflow: 'default',
@@ -188,10 +198,132 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
     expect(executeArg.reportDirName).toBeDefined();
 
     const runContextTaskDir = path.join(projectCwd, '.takt', 'runs', executeArg.reportDirName, 'context', 'task');
-    expect(fs.readFileSync(path.join(runContextTaskDir, 'order.md'), 'utf-8')).toContain(
+    expect(fs.existsSync(runContextTaskDir)).toBe(false);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', executeArg.reportDirName))).toBe(false);
+  });
+
+  it('attachments 付き skipTaskList: false では task record が参照する task spec を残す', async () => {
+    const projectCwd = createTempProject();
+    const tempAttachmentDir = path.join(projectCwd, 'tmp-attachments');
+    fs.mkdirSync(tempAttachmentDir, { recursive: true });
+    const tempPath = path.join(tempAttachmentDir, 'image-1.png');
+    fs.writeFileSync(tempPath, 'png-data', 'utf-8');
+
+    await selectAndExecuteTask(projectCwd, 'Use [Image #1] as reference.', {
+      workflow: 'default',
+      skipTaskList: false,
+      attachments: [{
+        placeholder: '[Image #1]',
+        tempPath,
+        fileName: 'image-1.png',
+      }],
+    });
+
+    const executeArg = mockExecuteTask.mock.calls[0]?.[0] as {
+      reportDirName: string;
+    };
+    const addTaskOptions = mockAddTask.mock.calls[0]?.[1] as {
+      task_dir: string;
+    };
+    expect(addTaskOptions.task_dir).toBe(`.takt/tasks/${executeArg.reportDirName}`);
+
+    const taskSpecDir = path.join(projectCwd, addTaskOptions.task_dir);
+    expect(fs.readFileSync(path.join(taskSpecDir, 'order.md'), 'utf-8')).toContain(
       '- [Image #1]: `attachments/image-1.png`',
     );
-    expect(fs.readFileSync(path.join(runContextTaskDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('png-data');
+    expect(fs.readFileSync(path.join(taskSpecDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('png-data');
+    expect(mockPersistTaskResult).toHaveBeenCalled();
+  });
+
+  it('attachments 付き skipTaskList: true で executeTask が失敗しても prepared task spec を削除する', async () => {
+    const projectCwd = createTempProject();
+    const tempAttachmentDir = path.join(projectCwd, 'tmp-attachments');
+    fs.mkdirSync(tempAttachmentDir, { recursive: true });
+    const tempPath = path.join(tempAttachmentDir, 'image-1.png');
+    fs.writeFileSync(tempPath, 'png-data', 'utf-8');
+    mockExecuteTask.mockRejectedValue(new Error('Task execution failed'));
+
+    await expect(
+      selectAndExecuteTask(projectCwd, 'Use [Image #1] as reference.', {
+        workflow: 'default',
+        skipTaskList: true,
+        attachments: [{
+          placeholder: '[Image #1]',
+          tempPath,
+          fileName: 'image-1.png',
+        }],
+      }),
+    ).rejects.toThrow('Task execution failed');
+
+    const executeArg = mockExecuteTask.mock.calls[0]?.[0] as { reportDirName: string };
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', executeArg.reportDirName))).toBe(false);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', executeArg.reportDirName, 'context', 'task'))).toBe(false);
+    expect(mockPersistTaskError).not.toHaveBeenCalled();
+  });
+
+  it('attachments 付き skipTaskList: true で taskSuccess が false でも prepared task spec を削除する', async () => {
+    const projectCwd = createTempProject();
+    const tempAttachmentDir = path.join(projectCwd, 'tmp-attachments');
+    fs.mkdirSync(tempAttachmentDir, { recursive: true });
+    const tempPath = path.join(tempAttachmentDir, 'image-1.png');
+    fs.writeFileSync(tempPath, 'png-data', 'utf-8');
+    mockExecuteTask.mockResolvedValue(false);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit:1');
+    }) as never);
+
+    try {
+      await expect(
+        selectAndExecuteTask(projectCwd, 'Use [Image #1] as reference.', {
+          workflow: 'default',
+          skipTaskList: true,
+          attachments: [{
+            placeholder: '[Image #1]',
+            tempPath,
+            fileName: 'image-1.png',
+          }],
+        }),
+      ).rejects.toThrow('process.exit:1');
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const executeArg = mockExecuteTask.mock.calls[0]?.[0] as { reportDirName: string };
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', executeArg.reportDirName))).toBe(false);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', executeArg.reportDirName, 'context', 'task'))).toBe(false);
+    expect(mockPersistTaskResult).not.toHaveBeenCalled();
+  });
+
+  it('attachments 付き skipTaskList: false で addTask が失敗した場合は prepared spec と staged spec を削除する', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-16T01:02:03.000Z'));
+
+    const projectCwd = createTempProject();
+    const task = 'Use [Image #1] as reference.';
+    const reportDirName = generateReportDir(task);
+    const tempAttachmentDir = path.join(projectCwd, 'tmp-attachments');
+    const tempPath = path.join(tempAttachmentDir, 'image-1.png');
+    fs.mkdirSync(tempAttachmentDir, { recursive: true });
+    fs.writeFileSync(tempPath, 'png-data', 'utf-8');
+    mockAddTask.mockImplementationOnce(() => {
+      throw new Error('addTask failed');
+    });
+
+    await expect(
+      selectAndExecuteTask(projectCwd, task, {
+        workflow: 'default',
+        skipTaskList: false,
+        attachments: [{
+          placeholder: '[Image #1]',
+          tempPath,
+          fileName: 'image-1.png',
+        }],
+      }),
+    ).rejects.toThrow('addTask failed');
+
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', reportDirName))).toBe(false);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', reportDirName))).toBe(false);
+    expect(mockExecuteTask).not.toHaveBeenCalled();
   });
 
   it('attachments の staging に失敗した場合は prepared task spec を削除する', async () => {

--- a/src/__tests__/selectAndExecute-skipTaskList.test.ts
+++ b/src/__tests__/selectAndExecute-skipTaskList.test.ts
@@ -2,7 +2,11 @@
  * Tests for skipTaskList option in selectAndExecuteTask
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { generateReportDir } from '../shared/utils/reportDir.js';
 
 const {
   mockAddTask,
@@ -41,6 +45,7 @@ vi.mock('../infra/task/index.js', () => ({
   autoCommitAndPush: vi.fn(),
   summarizeTaskName: vi.fn(),
   resolveBaseBranch: vi.fn(() => ({ branch: 'main' })),
+  buildTaskInstruction: vi.fn((_taskDir: string, orderFile: string) => `Primary spec: \`${orderFile}\`.`),
   TaskRunner: vi.fn(() => ({
     addTask: (...args: unknown[]) => mockAddTask(...args),
   })),
@@ -87,10 +92,26 @@ vi.mock('../features/workflowSelection/index.js', () => ({
 
 import { selectAndExecuteTask } from '../features/tasks/execute/selectAndExecute.js';
 
+const tempRoots = new Set<string>();
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockExecuteTask.mockResolvedValue(true);
 });
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const root of tempRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  tempRoots.clear();
+});
+
+function createTempProject(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-select-execute-test-'));
+  tempRoots.add(root);
+  return root;
+}
 
 describe('skipTaskList option in selectAndExecuteTask', () => {
   it('skipTaskList: true の場合はタスクリストに追加しない', async () => {
@@ -138,6 +159,71 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
 
     expect(mockAddTask).not.toHaveBeenCalled();
     expect(mockPersistTaskError).not.toHaveBeenCalled();
+  });
+
+  it('attachments 付き skipTaskList: true では run context の order.md と添付を executeTask に渡す', async () => {
+    const projectCwd = createTempProject();
+    const tempAttachmentDir = path.join(projectCwd, 'tmp-attachments');
+    fs.mkdirSync(tempAttachmentDir, { recursive: true });
+    const tempPath = path.join(tempAttachmentDir, 'image-1.png');
+    fs.writeFileSync(tempPath, 'png-data', 'utf-8');
+
+    await selectAndExecuteTask(projectCwd, 'Use [Image #1] as reference.', {
+      workflow: 'default',
+      skipTaskList: true,
+      attachments: [{
+        placeholder: '[Image #1]',
+        tempPath,
+        fileName: 'image-1.png',
+      }],
+    });
+
+    expect(mockAddTask).not.toHaveBeenCalled();
+    const executeArg = mockExecuteTask.mock.calls[0]?.[0] as {
+      task: string;
+      reportDirName: string;
+    };
+    expect(executeArg.task).toContain('Primary spec:');
+    expect(executeArg.task).toContain('context/task/order.md');
+    expect(executeArg.reportDirName).toBeDefined();
+
+    const runContextTaskDir = path.join(projectCwd, '.takt', 'runs', executeArg.reportDirName, 'context', 'task');
+    expect(fs.readFileSync(path.join(runContextTaskDir, 'order.md'), 'utf-8')).toContain(
+      '- [Image #1]: `attachments/image-1.png`',
+    );
+    expect(fs.readFileSync(path.join(runContextTaskDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('png-data');
+  });
+
+  it('attachments の staging に失敗した場合は prepared task spec を削除する', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-16T01:02:03.000Z'));
+
+    const projectCwd = createTempProject();
+    const task = 'Use [Image #1] as reference.';
+    const reportDirName = generateReportDir(task);
+    const blockedContextPath = path.join(projectCwd, '.takt', 'runs', reportDirName, 'context');
+    const tempAttachmentDir = path.join(projectCwd, 'tmp-attachments');
+    const tempPath = path.join(tempAttachmentDir, 'image-1.png');
+    fs.mkdirSync(path.dirname(blockedContextPath), { recursive: true });
+    fs.writeFileSync(blockedContextPath, 'not-a-directory', 'utf-8');
+    fs.mkdirSync(tempAttachmentDir, { recursive: true });
+    fs.writeFileSync(tempPath, 'png-data', 'utf-8');
+
+    await expect(
+      selectAndExecuteTask(projectCwd, task, {
+        workflow: 'default',
+        skipTaskList: true,
+        attachments: [{
+          placeholder: '[Image #1]',
+          tempPath,
+          fileName: 'image-1.png',
+        }],
+      }),
+    ).rejects.toThrow();
+
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks', reportDirName))).toBe(false);
+    expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', reportDirName, 'context', 'task', 'order.md'))).toBe(false);
+    expect(mockExecuteTask).not.toHaveBeenCalled();
   });
 
   it('skipTaskList: false でエラー時は persistTaskError を呼ぶ', async () => {

--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -618,6 +618,26 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(file.tasks[0]?.retry_note).toBe('retry note');
   });
 
+  it('should persist task_dir as the only task spec source when requeueing task', () => {
+    runner.addTask('Task A');
+    const task = runner.claimNextTasks(1)[0]!;
+    runner.failTask({
+      task,
+      success: false,
+      response: 'Boom',
+      executionLog: [],
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+    });
+
+    runner.requeueTask(task.name, ['failed'], undefined, 'retry note', undefined, undefined, '.takt/tasks/retry-task');
+
+    const file = loadTasksFile(testDir);
+    expect(file.tasks[0]?.task_dir).toBe('.takt/tasks/retry-task');
+    expect(file.tasks[0]?.content).toBeUndefined();
+    expect(file.tasks[0]?.content_file).toBeUndefined();
+  });
+
   it('should persist canonical workflow and start_movement keys when starting re-execution', () => {
     runner.addTask('Task A', { workflow: 'default' });
     const task = runner.claimNextTasks(1)[0]!;
@@ -643,6 +663,38 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(file.tasks[0]?.start_movement).toBe('implement');
     expect(file.tasks[0]?.start_step).toBeUndefined();
     expect(file.tasks[0]?.retry_note).toBe('retry note');
+  });
+
+  it('should persist task_dir as the only task spec source when starting re-execution', () => {
+    runner.addTask('Task A');
+    const task = runner.claimNextTasks(1)[0]!;
+    runner.failTask({
+      task,
+      success: false,
+      response: 'Boom',
+      executionLog: [],
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+    });
+    mkdirSync(join(testDir, '.takt', 'tasks', 'retry-task'), { recursive: true });
+    writeFileSync(join(testDir, '.takt', 'tasks', 'retry-task', 'order.md'), 'Task A retry', 'utf-8');
+
+    const restarted = runner.startReExecution(
+      task.name,
+      ['failed'],
+      undefined,
+      'retry note',
+      undefined,
+      undefined,
+      '.takt/tasks/retry-task',
+    );
+
+    expect(restarted.status).toBe('running');
+    expect(restarted.taskDir).toBe('.takt/tasks/retry-task');
+    const file = loadTasksFile(testDir);
+    expect(file.tasks[0]?.task_dir).toBe('.takt/tasks/retry-task');
+    expect(file.tasks[0]?.content).toBeUndefined();
+    expect(file.tasks[0]?.content_file).toBeUndefined();
   });
 
   it('should persist selected workflow when starting re-execution', () => {

--- a/src/__tests__/taskInstructionActions.test.ts
+++ b/src/__tests__/taskInstructionActions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockExistsSync,
+  mockReadFileSync,
   mockStartReExecution,
   mockRequeueTask,
   mockExecuteAndCompleteTask,
@@ -22,8 +23,11 @@ const {
   mockIsWorkflowPath,
   mockLoadWorkflowByIdentifier,
   mockLoadAllStandaloneWorkflowsWithSources,
+  mockPrepareTaskSpecDirectory,
+  mockCleanupPreparedTaskSpec,
 } = vi.hoisted(() => ({
   mockExistsSync: vi.fn(() => true),
+  mockReadFileSync: vi.fn(),
   mockStartReExecution: vi.fn(),
   mockRequeueTask: vi.fn(),
   mockExecuteAndCompleteTask: vi.fn(),
@@ -52,11 +56,14 @@ const {
     ['default', {}],
     ['selected-workflow', {}],
   ])),
+  mockPrepareTaskSpecDirectory: vi.fn(),
+  mockCleanupPreparedTaskSpec: vi.fn(),
 }));
 
 vi.mock('node:fs', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
 }));
 
 vi.mock('node:child_process', async (importOriginal) => ({
@@ -117,6 +124,15 @@ vi.mock('../features/tasks/execute/taskExecution.js', () => ({
   executeAndCompleteTask: (...args: unknown[]) => mockExecuteAndCompleteTask(...args),
 }));
 
+vi.mock('../features/tasks/attachments.js', () => ({
+  prepareTaskSpecDirectory: (...args: unknown[]) => mockPrepareTaskSpecDirectory(...args),
+  cleanupPreparedTaskSpec: (...args: unknown[]) => mockCleanupPreparedTaskSpec(...args),
+}));
+
+vi.mock('../features/tasks/taskSpecFile.js', () => ({
+  readTaskSpecFile: (sourceOrderPath: string) => mockReadFileSync(sourceOrderPath, 'utf-8'),
+}));
+
 vi.mock('../shared/ui/index.js', () => ({
   info: vi.fn(),
   error: vi.fn(),
@@ -136,11 +152,19 @@ import { instructBranch } from '../features/tasks/list/taskActions.js';
 import { error as logError } from '../shared/ui/index.js';
 
 const mockLogError = vi.mocked(logError);
+const testAttachment = {
+  placeholder: '[Image #1]',
+  tempPath: '/tmp/takt/session-1/attachments/image-1.png',
+  fileName: 'image-1.png',
+};
 
 describe('instructBranch direct execution flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('readFileSync should not be called by default');
+    });
 
     mockSelectWorkflow.mockResolvedValue('default');
     mockRunInstructMode.mockResolvedValue({ action: 'execute', task: '追加指示A' });
@@ -179,6 +203,11 @@ describe('instructBranch direct execution flow', () => {
       data: { task: 'done' },
     });
     mockExecuteAndCompleteTask.mockResolvedValue(true);
+    mockPrepareTaskSpecDirectory.mockReturnValue({
+      taskDir: '/project/.takt/tasks/done-task',
+      taskDirRelative: '.takt/tasks/done-task',
+      taskDirSlug: 'done-task',
+    });
   });
 
   it('should execute directly via startReExecution instead of requeuing', async () => {
@@ -199,8 +228,164 @@ describe('instructBranch direct execution flow', () => {
       ['completed', 'failed'],
       undefined,
       '既存ノート\n\n追加指示A',
+      undefined,
+      undefined,
+      undefined,
     );
     expect(mockExecuteAndCompleteTask).toHaveBeenCalled();
+  });
+
+  it('should promote image attachments for instructed direct execution', async () => {
+    mockRunInstructMode.mockResolvedValue({
+      action: 'execute',
+      task: 'Use [Image #1].',
+      attachments: [testAttachment],
+    });
+    mockDispatchConversationAction.mockImplementation(async (_result, handlers) =>
+      handlers.execute({ task: 'Use [Image #1].' }));
+
+    await instructBranch('/project', {
+      kind: 'completed',
+      name: 'done-task',
+      createdAt: '2026-02-14T00:00:00.000Z',
+      filePath: '/project/.takt/tasks.yaml',
+      content: 'done',
+      branch: 'takt/done-task',
+      worktreePath: '/project/.takt/worktrees/done-task',
+      data: { task: 'done' },
+    });
+
+    expect(mockPrepareTaskSpecDirectory).toHaveBeenCalledWith(
+      '/project',
+      ['done', '', '## 追加指示', '', 'Use [Image #1].'].join('\n'),
+      [testAttachment],
+    );
+    expect(mockStartReExecution).toHaveBeenCalledWith(
+      'done-task',
+      ['completed', 'failed'],
+      undefined,
+      'Use [Image #1].',
+      undefined,
+      undefined,
+      '.takt/tasks/done-task',
+    );
+  });
+
+  it('should promote image attachments for instructed save_task requeue', async () => {
+    mockRunInstructMode.mockResolvedValue({
+      action: 'save_task',
+      task: 'Use [Image #1].',
+      attachments: [testAttachment],
+    });
+    mockDispatchConversationAction.mockImplementation(async (_result, handlers) =>
+      handlers.save_task({ task: 'Use [Image #1].' }));
+
+    await instructBranch('/project', {
+      kind: 'completed',
+      name: 'done-task',
+      createdAt: '2026-02-14T00:00:00.000Z',
+      filePath: '/project/.takt/tasks.yaml',
+      content: 'done',
+      branch: 'takt/done-task',
+      worktreePath: '/project/.takt/worktrees/done-task',
+      data: { task: 'done' },
+    });
+
+    expect(mockRequeueTask).toHaveBeenCalledWith(
+      'done-task',
+      ['completed', 'failed'],
+      undefined,
+      'Use [Image #1].',
+      undefined,
+      undefined,
+      '.takt/tasks/done-task',
+    );
+    expect(mockPrepareTaskSpecDirectory).toHaveBeenCalledWith(
+      '/project',
+      ['done', '', '## 追加指示', '', 'Use [Image #1].'].join('\n'),
+      [testAttachment],
+    );
+  });
+
+  it('should preserve task_dir order content when instructed task has image attachments', async () => {
+    mockReadFileSync.mockReturnValue(['Full order', 'Second line'].join('\n'));
+    mockRunInstructMode.mockResolvedValue({
+      action: 'save_task',
+      task: 'Use [Image #1].',
+      attachments: [testAttachment],
+    });
+    mockDispatchConversationAction.mockImplementation(async (_result, handlers) =>
+      handlers.save_task({ task: 'Use [Image #1].' }));
+
+    await instructBranch('/project', {
+      kind: 'completed',
+      name: 'done-task',
+      createdAt: '2026-02-14T00:00:00.000Z',
+      filePath: '/project/.takt/tasks.yaml',
+      content: 'Implement using only the files in `.takt/tasks/done-task`.',
+      taskDir: '.takt/tasks/done-task',
+      branch: 'takt/done-task',
+      worktreePath: '/project/.takt/worktrees/done-task',
+      data: { task: 'Implement using only the files in `.takt/tasks/done-task`.' },
+    });
+
+    expect(mockReadFileSync).toHaveBeenCalledWith('/project/.takt/tasks/done-task/order.md', 'utf-8');
+    expect(mockPrepareTaskSpecDirectory).toHaveBeenCalledWith(
+      '/project',
+      ['Full order', 'Second line', '', '## 追加指示', '', 'Use [Image #1].'].join('\n'),
+      [testAttachment],
+      { sourceTaskDir: '/project/.takt/tasks/done-task' },
+    );
+  });
+
+  it('should renumber instructed attachments when task_dir order already references images', async () => {
+    mockReadFileSync.mockReturnValue([
+      'Full order with [Image #1].',
+      '',
+      '## 添付画像',
+      '',
+      '- [Image #1]: `attachments/image-1.png`',
+    ].join('\n'));
+    mockRunInstructMode.mockResolvedValue({
+      action: 'save_task',
+      task: 'Use [Image #1].',
+      attachments: [testAttachment],
+    });
+    mockDispatchConversationAction.mockImplementation(async (_result, handlers) =>
+      handlers.save_task({ task: 'Use [Image #1].' }));
+
+    await instructBranch('/project', {
+      kind: 'completed',
+      name: 'done-task',
+      createdAt: '2026-02-14T00:00:00.000Z',
+      filePath: '/project/.takt/tasks.yaml',
+      content: 'Implement using only the files in `.takt/tasks/done-task`.',
+      taskDir: '.takt/tasks/done-task',
+      branch: 'takt/done-task',
+      worktreePath: '/project/.takt/worktrees/done-task',
+      data: { task: 'Implement using only the files in `.takt/tasks/done-task`.' },
+    });
+
+    expect(mockPrepareTaskSpecDirectory).toHaveBeenCalledWith(
+      '/project',
+      [
+        'Full order with [Image #1].',
+        '',
+        '## 添付画像',
+        '',
+        '- [Image #1]: `attachments/image-1.png`',
+        '',
+        '## 追加指示',
+        '',
+        'Use [Image #2].',
+      ].join('\n'),
+      [{
+        ...testAttachment,
+        placeholder: '[Image #2]',
+        fileName: 'image-2.png',
+      }],
+      { sourceTaskDir: '/project/.takt/tasks/done-task' },
+    );
   });
 
   it('should execute with selected workflow without mutating taskInfo', async () => {
@@ -394,6 +579,9 @@ describe('instructBranch direct execution flow', () => {
       ['completed', 'failed'],
       undefined,
       '追加指示A',
+      undefined,
+      undefined,
+      undefined,
     );
   });
 
@@ -579,7 +767,15 @@ describe('instructBranch direct execution flow', () => {
     });
 
     expect(result).toBe(true);
-    expect(mockRequeueTask).toHaveBeenCalledWith('done-task', ['completed', 'failed'], undefined, '追加指示A');
+    expect(mockRequeueTask).toHaveBeenCalledWith(
+      'done-task',
+      ['completed', 'failed'],
+      undefined,
+      '追加指示A',
+      undefined,
+      undefined,
+      undefined,
+    );
     expect(mockStartReExecution).not.toHaveBeenCalled();
     expect(mockExecuteAndCompleteTask).not.toHaveBeenCalled();
   });
@@ -599,6 +795,14 @@ describe('instructBranch direct execution flow', () => {
     });
 
     expect(result).toBe(true);
-    expect(mockRequeueTask).toHaveBeenCalledWith('done-task', ['completed', 'failed'], undefined, '既存ノート\n\n追加指示A');
+    expect(mockRequeueTask).toHaveBeenCalledWith(
+      'done-task',
+      ['completed', 'failed'],
+      undefined,
+      '既存ノート\n\n追加指示A',
+      undefined,
+      undefined,
+      undefined,
+    );
   });
 });

--- a/src/__tests__/taskInstructionActions.test.ts
+++ b/src/__tests__/taskInstructionActions.test.ts
@@ -206,7 +206,6 @@ describe('instructBranch direct execution flow', () => {
     mockPrepareTaskSpecDirectory.mockReturnValue({
       taskDir: '/project/.takt/tasks/done-task',
       taskDirRelative: '.takt/tasks/done-task',
-      taskDirSlug: 'done-task',
     });
   });
 

--- a/src/__tests__/taskRetryActions.test.ts
+++ b/src/__tests__/taskRetryActions.test.ts
@@ -3,6 +3,7 @@ import { attachWorkflowSourcePath, attachWorkflowTrustInfo } from '../infra/conf
 
 const {
   mockExistsSync,
+  mockReadFileSync,
   mockSelectWorkflow,
   mockSelectOptionWithDefault,
   mockConfirm,
@@ -24,8 +25,11 @@ const {
   mockStatus,
   mockIsWorkflowPath,
   mockLoadAllStandaloneWorkflowsWithSources,
+  mockPrepareTaskSpecDirectory,
+  mockCleanupPreparedTaskSpec,
 } = vi.hoisted(() => ({
   mockExistsSync: vi.fn(() => true),
+  mockReadFileSync: vi.fn(),
   mockSelectWorkflow: vi.fn(),
   mockSelectOptionWithDefault: vi.fn(),
   mockConfirm: vi.fn(),
@@ -58,11 +62,14 @@ const {
   mockStatus: vi.fn(),
   mockIsWorkflowPath: vi.fn(() => false),
   mockLoadAllStandaloneWorkflowsWithSources: vi.fn(() => new Map<string, unknown>([['default', {}]])),
+  mockPrepareTaskSpecDirectory: vi.fn(),
+  mockCleanupPreparedTaskSpec: vi.fn(),
 }));
 
 vi.mock('node:fs', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
 }));
 
 vi.mock('../features/workflowSelection/index.js', () => ({
@@ -132,6 +139,15 @@ vi.mock('../features/tasks/execute/taskExecution.js', () => ({
   executeAndCompleteTask: (...args: unknown[]) => mockExecuteAndCompleteTask(...args),
 }));
 
+vi.mock('../features/tasks/attachments.js', () => ({
+  prepareTaskSpecDirectory: (...args: unknown[]) => mockPrepareTaskSpecDirectory(...args),
+  cleanupPreparedTaskSpec: (...args: unknown[]) => mockCleanupPreparedTaskSpec(...args),
+}));
+
+vi.mock('../features/tasks/taskSpecFile.js', () => ({
+  readTaskSpecFile: (sourceOrderPath: string) => mockReadFileSync(sourceOrderPath, 'utf-8'),
+}));
+
 vi.mock('../shared/i18n/index.js', () => ({
   getLabel: vi.fn((key: string, _lang?: string, vars?: Record<string, string>) => {
     if (vars?.workflow) {
@@ -178,9 +194,18 @@ const autoRequeueNote = [
   'ユーザーがリキューしたため、問題は対処済みと考えられます。',
 ].join('\n');
 
+const testAttachment = {
+  placeholder: '[Image #1]',
+  tempPath: '/tmp/takt/session-1/attachments/image-1.png',
+  fileName: 'image-1.png',
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockExistsSync.mockReturnValue(true);
+  mockReadFileSync.mockImplementation(() => {
+    throw new Error('readFileSync should not be called by default');
+  });
 
   mockConfirm.mockResolvedValue(true);
   mockSelectWorkflow.mockResolvedValue('default');
@@ -205,6 +230,11 @@ beforeEach(() => {
     data: { task: 'Do something', workflow: 'default' },
   });
   mockExecuteAndCompleteTask.mockResolvedValue(true);
+  mockPrepareTaskSpecDirectory.mockReturnValue({
+    taskDir: '/project/.takt/tasks/my-task',
+    taskDirRelative: '.takt/tasks/my-task',
+    taskDirSlug: 'my-task',
+  });
 });
 
 describe('requeueFailedTask', () => {
@@ -544,8 +574,102 @@ describe('retryFailedTask', () => {
       '追加指示A',
       undefined,
       undefined,
+      undefined,
     );
     expect(mockExecuteAndCompleteTask).toHaveBeenCalled();
+  });
+
+  it('should promote image attachments for retry direct execution', async () => {
+    const task = makeFailedTask();
+    mockRunRetryMode.mockResolvedValue({
+      action: 'execute',
+      task: 'Use [Image #1].',
+      attachments: [testAttachment],
+    });
+
+    await retryFailedTask(task, '/project');
+
+    expect(mockPrepareTaskSpecDirectory).toHaveBeenCalledWith(
+      '/project',
+      ['Do something', '', '## 追加指示', '', 'Use [Image #1].'].join('\n'),
+      [testAttachment],
+    );
+    expect(mockStartReExecution).toHaveBeenCalledWith(
+      'my-task',
+      ['failed'],
+      undefined,
+      'Use [Image #1].',
+      undefined,
+      undefined,
+      '.takt/tasks/my-task',
+    );
+  });
+
+  it('should preserve task_dir order content when retry task has image attachments', async () => {
+    const task = makeFailedTask({
+      content: 'Implement using only the files in `.takt/tasks/my-task`.',
+      taskDir: '.takt/tasks/my-task',
+      data: { task: 'Implement using only the files in `.takt/tasks/my-task`.', workflow: 'default' },
+    });
+    mockReadFileSync.mockReturnValue(['Original order', 'Second line'].join('\n'));
+    mockRunRetryMode.mockResolvedValue({
+      action: 'save_task',
+      task: 'Use [Image #1].',
+      attachments: [testAttachment],
+    });
+
+    await retryFailedTask(task, '/project');
+
+    expect(mockReadFileSync).toHaveBeenCalledWith('/project/.takt/tasks/my-task/order.md', 'utf-8');
+    expect(mockPrepareTaskSpecDirectory).toHaveBeenCalledWith(
+      '/project',
+      ['Original order', 'Second line', '', '## 追加指示', '', 'Use [Image #1].'].join('\n'),
+      [testAttachment],
+      { sourceTaskDir: '/project/.takt/tasks/my-task' },
+    );
+  });
+
+  it('should renumber retry attachments when task_dir order already references images', async () => {
+    const task = makeFailedTask({
+      content: 'Implement using only the files in `.takt/tasks/my-task`.',
+      taskDir: '.takt/tasks/my-task',
+      data: { task: 'Implement using only the files in `.takt/tasks/my-task`.', workflow: 'default' },
+    });
+    mockReadFileSync.mockReturnValue([
+      'Original order with [Image #1].',
+      '',
+      '## 添付画像',
+      '',
+      '- [Image #1]: `attachments/image-1.png`',
+    ].join('\n'));
+    mockRunRetryMode.mockResolvedValue({
+      action: 'save_task',
+      task: 'Use [Image #1].',
+      attachments: [testAttachment],
+    });
+
+    await retryFailedTask(task, '/project');
+
+    expect(mockPrepareTaskSpecDirectory).toHaveBeenCalledWith(
+      '/project',
+      [
+        'Original order with [Image #1].',
+        '',
+        '## 添付画像',
+        '',
+        '- [Image #1]: `attachments/image-1.png`',
+        '',
+        '## 追加指示',
+        '',
+        'Use [Image #2].',
+      ].join('\n'),
+      [{
+        ...testAttachment,
+        placeholder: '[Image #2]',
+        fileName: 'image-2.png',
+      }],
+      { sourceTaskDir: '/project/.takt/tasks/my-task' },
+    );
   });
 
   it('should execute with selected workflow without mutating taskInfo', async () => {
@@ -568,6 +692,7 @@ describe('retryFailedTask', () => {
       '追加指示A',
       undefined,
       'selected-workflow',
+      undefined,
     );
     const executeArg = mockExecuteAndCompleteTask.mock.calls[0]?.[0];
     expect(executeArg).not.toBe(originalTaskInfo);
@@ -779,6 +904,7 @@ describe('retryFailedTask', () => {
       '追加指示A',
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -816,6 +942,7 @@ describe('retryFailedTask', () => {
       'implement',
       '追加指示A',
       resumePoint,
+      undefined,
       undefined,
     );
   });
@@ -855,6 +982,7 @@ describe('retryFailedTask', () => {
       '追加指示A',
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -870,6 +998,7 @@ describe('retryFailedTask', () => {
       '追加指示A',
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -883,6 +1012,7 @@ describe('retryFailedTask', () => {
       ['failed'],
       undefined,
       '既存ノート\n\n追加指示A',
+      undefined,
       undefined,
       undefined,
     );
@@ -1114,9 +1244,36 @@ describe('retryFailedTask', () => {
       '追加指示A',
       undefined,
       undefined,
+      undefined,
     );
     expect(mockStartReExecution).not.toHaveBeenCalled();
     expect(mockExecuteAndCompleteTask).not.toHaveBeenCalled();
+  });
+
+  it('should promote image attachments for retry save_task requeue', async () => {
+    const task = makeFailedTask();
+    mockRunRetryMode.mockResolvedValue({
+      action: 'save_task',
+      task: 'Use [Image #1].',
+      attachments: [testAttachment],
+    });
+
+    await retryFailedTask(task, '/project');
+
+    expect(mockRequeueTask).toHaveBeenCalledWith(
+      'my-task',
+      ['failed'],
+      undefined,
+      'Use [Image #1].',
+      undefined,
+      undefined,
+      '.takt/tasks/my-task',
+    );
+    expect(mockPrepareTaskSpecDirectory).toHaveBeenCalledWith(
+      '/project',
+      ['Do something', '', '## 追加指示', '', 'Use [Image #1].'].join('\n'),
+      [testAttachment],
+    );
   });
 
   it('should pass selected workflow when save_task uses a different workflow', async () => {
@@ -1134,6 +1291,7 @@ describe('retryFailedTask', () => {
       '追加指示A',
       undefined,
       'selected-workflow',
+      undefined,
     );
   });
 
@@ -1177,6 +1335,7 @@ describe('retryFailedTask', () => {
       '追加指示A',
       resumePoint,
       undefined,
+      undefined,
     );
     expect(mockStartReExecution).not.toHaveBeenCalled();
   });
@@ -1201,6 +1360,7 @@ describe('retryFailedTask', () => {
       ['failed'],
       undefined,
       '既存ノート\n\n追加指示A',
+      undefined,
       undefined,
       undefined,
     );

--- a/src/__tests__/taskRetryActions.test.ts
+++ b/src/__tests__/taskRetryActions.test.ts
@@ -233,7 +233,6 @@ beforeEach(() => {
   mockPrepareTaskSpecDirectory.mockReturnValue({
     taskDir: '/project/.takt/tasks/my-task',
     taskDirRelative: '.takt/tasks/my-task',
-    taskDirSlug: 'my-task',
   });
 });
 

--- a/src/__tests__/taskSpecContext.test.ts
+++ b/src/__tests__/taskSpecContext.test.ts
@@ -39,6 +39,31 @@ describe('stageTaskSpecForExecution', () => {
     expect(fs.readFileSync(stagedOrderPath, 'utf-8')).toBe(orderContent);
   });
 
+  it('run コンテキストへ task 添付画像を配置する', () => {
+    const projectCwd = createTempProjectDir();
+    const execCwd = createTempProjectDir();
+    const taskDir = '.takt/tasks/spec-task';
+    const sourceTaskDir = path.join(projectCwd, taskDir);
+    const orderContent = [
+      '# Task',
+      '',
+      'Use [Image #1] as the reference.',
+      '',
+      '## 添付画像',
+      '',
+      '- [Image #1]: `attachments/image-1.png`',
+    ].join('\n');
+    fs.mkdirSync(path.join(sourceTaskDir, 'attachments'), { recursive: true });
+    fs.writeFileSync(path.join(sourceTaskDir, 'order.md'), orderContent, 'utf-8');
+    fs.writeFileSync(path.join(sourceTaskDir, 'attachments', 'image-1.png'), 'png-data', 'utf-8');
+
+    const result = stageTaskSpecForExecution(projectCwd, execCwd, taskDir, '20260216-spec-task');
+    const stagedAttachmentPath = path.join(execCwd, '.takt', 'runs', '20260216-spec-task', 'context', 'task', 'attachments', 'image-1.png');
+
+    expect(result.taskPrompt).toContain('Primary spec: `.takt/runs/20260216-spec-task/context/task/order.md`.');
+    expect(fs.readFileSync(stagedAttachmentPath, 'utf-8')).toBe('png-data');
+  });
+
   it('symlink の order.md は拒否する', () => {
     const projectCwd = createTempProjectDir();
     const execCwd = createTempProjectDir();
@@ -56,6 +81,28 @@ describe('stageTaskSpecForExecution', () => {
       `Task spec file must be a regular file: ${path.join(sourceTaskDir, 'order.md')}`,
     );
     expect(fs.existsSync(stagedOrderPath)).toBe(false);
+  });
+
+  it('symlink の attachments ディレクトリは拒否する', () => {
+    const projectCwd = createTempProjectDir();
+    const execCwd = createTempProjectDir();
+    const taskDir = '.takt/tasks/spec-task';
+    const sourceTaskDir = path.join(projectCwd, taskDir);
+    const externalAttachmentDir = path.join(projectCwd, 'external-attachments');
+    fs.mkdirSync(sourceTaskDir, { recursive: true });
+    fs.mkdirSync(externalAttachmentDir, { recursive: true });
+    fs.writeFileSync(path.join(sourceTaskDir, 'order.md'), '# Task\n\nUse [Image #1].', 'utf-8');
+    fs.writeFileSync(path.join(externalAttachmentDir, 'image-1.png'), 'outside-data', 'utf-8');
+    fs.symlinkSync(externalAttachmentDir, path.join(sourceTaskDir, 'attachments'));
+
+    const stagedAttachmentPath = path.join(execCwd, '.takt', 'runs', '20260216-spec-task', 'context', 'task', 'attachments', 'image-1.png');
+    const stagedOrderPath = path.join(execCwd, '.takt', 'runs', '20260216-spec-task', 'context', 'task', 'order.md');
+    const stagedTaskDir = path.dirname(stagedOrderPath);
+
+    expect(() => stageTaskSpecForExecution(projectCwd, execCwd, taskDir, '20260216-spec-task')).toThrow(/Task attachments/);
+    expect(fs.existsSync(stagedTaskDir)).toBe(false);
+    expect(fs.existsSync(stagedOrderPath)).toBe(false);
+    expect(fs.existsSync(stagedAttachmentPath)).toBe(false);
   });
 });
 

--- a/src/app/cli/routing.ts
+++ b/src/app/cli/routing.ts
@@ -240,6 +240,9 @@ export async function executeDefaultAction(task?: string): Promise<void> {
       selectOptions.workflow = workflowId;
       selectOptions.interactiveMetadata = { confirmed: true, task: confirmedTask };
       selectOptions.skipTaskList = true;
+      if (result.attachments) {
+        selectOptions.attachments = result.attachments;
+      }
       await selectAndExecuteTask(resolvedCwd, confirmedTask, selectOptions, agentOverrides);
     },
     create_issue: async ({ task: confirmedTask }) => {
@@ -247,6 +250,7 @@ export async function executeDefaultAction(task?: string): Promise<void> {
       await createIssueAndSaveTask(resolvedCwd, confirmedTask, workflowId, {
         confirmAtEndMessage: 'Add this issue to tasks?',
         labels,
+        ...(result.attachments ? { attachments: result.attachments } : {}),
       });
     },
     save_task: async ({ task: confirmedTask }) => {
@@ -258,7 +262,10 @@ export async function executeDefaultAction(task?: string): Promise<void> {
           ...(prBaseBranch ? { baseBranch: prBaseBranch } : {}),
         }
         : undefined;
-      await saveTaskFromInteractive(resolvedCwd, confirmedTask, workflowId, { presetSettings });
+      await saveTaskFromInteractive(resolvedCwd, confirmedTask, workflowId, {
+        presetSettings,
+        ...(result.attachments ? { attachments: result.attachments } : {}),
+      });
     },
     cancel: () => undefined,
   });

--- a/src/core/workflow/run/run-slug.ts
+++ b/src/core/workflow/run/run-slug.ts
@@ -1,0 +1,23 @@
+import * as fs from 'node:fs';
+
+import { generateReportDir } from '../../../shared/utils/reportDir.js';
+import { buildRunPaths } from './run-paths.js';
+
+function generateReportDirSuffix(): string {
+  return Math.random().toString(36).slice(2, 8).padEnd(6, '0');
+}
+
+export function generateExecutionReportDir(cwd: string, task: string): string {
+  const baseSlug = `${generateReportDir(task)}-${generateReportDirSuffix()}`;
+  let sequence = 1;
+  let slug = baseSlug;
+  let runRootAbs = buildRunPaths(cwd, slug).runRootAbs;
+
+  while (fs.existsSync(runRootAbs)) {
+    sequence += 1;
+    slug = `${baseSlug}-${sequence}`;
+    runRootAbs = buildRunPaths(cwd, slug).runRootAbs;
+  }
+
+  return slug;
+}

--- a/src/features/interactive/conversationLoop.ts
+++ b/src/features/interactive/conversationLoop.ts
@@ -38,6 +38,7 @@ import {
   createSessionLogMeta,
 } from './conversationLogMeta.js';
 import { prependInitialPromptContext } from './promptSections.js';
+import { buildInteractiveResultWithAttachments, createSessionImageAttachmentStore } from './imageAttachments.js';
 
 export { type CallAIResult, type SessionContext, callAIWithRetry } from './aiCaller.js';
 
@@ -131,6 +132,7 @@ export async function runConversationLoop(
   const ui = getLabelObject<InteractiveUIText>('interactive.ui', ctx.lang);
   const conversationLabel = getLabel('interactive.conversationLabel', ctx.lang);
   const noTranscript = getLabel('interactive.noTranscript', ctx.lang);
+  const attachmentStore = createSessionImageAttachmentStore();
 
   info(strategy.introMessage);
   if (sessionId) {
@@ -162,7 +164,7 @@ export async function runConversationLoop(
       return null;
     }
     log.info('Conversation action selected', { action: selectedAction, messageCount: history.length });
-    return { action: selectedAction, task };
+    return buildInteractiveResultWithAttachments({ action: selectedAction, task }, attachmentStore);
   }
 
   const commandAvailability: CommandAvailability = {
@@ -171,12 +173,12 @@ export async function runConversationLoop(
   };
 
   while (true) {
-    const input = await readInteractiveInput(chalk.green('> '), ctx.lang, commandAvailability);
+    const input = await readInteractiveInput(chalk.green('> '), ctx.lang, commandAvailability, attachmentStore);
 
     if (input === null) {
       blankLine();
       info(ui.cancelled);
-      return { action: 'cancel', task: '' };
+      return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
     }
 
     const trimmed = input.trim();
@@ -208,7 +210,7 @@ export async function runConversationLoop(
           error(result.content);
           blankLine();
           history.pop();
-          return { action: 'cancel', task: '' };
+          return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
         }
         history.push({ role: 'assistant', content: result.content });
         blankLine();
@@ -225,7 +227,7 @@ export async function runConversationLoop(
           info(ui.acceptNoAssistant);
           continue;
         }
-        return { action: 'execute', task: assistantMessage.content };
+        return buildInteractiveResultWithAttachments({ action: 'execute', task: assistantMessage.content }, attachmentStore);
       }
 
       case SlashCommand.Play: {
@@ -234,7 +236,7 @@ export async function runConversationLoop(
           continue;
         }
         log.info('Play command', createPlayCommandLogMeta(match.text));
-        return { action: 'execute', task: match.text };
+        return buildInteractiveResultWithAttachments({ action: 'execute', task: match.text }, attachmentStore);
       }
 
       case SlashCommand.Retry: {
@@ -292,7 +294,7 @@ export async function runConversationLoop(
         if (!summaryResult.success) {
           error(summaryResult.content);
           blankLine();
-          return { action: 'cancel', task: '' };
+          return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
         }
         const task = summaryResult.content.trim();
         const selectedAction = await handleSummaryAction(task);
@@ -309,12 +311,12 @@ export async function runConversationLoop(
           continue;
         }
         log.info('Replay command');
-        return { action: 'execute', task: strategy.previousOrderContent };
+        return buildInteractiveResultWithAttachments({ action: 'execute', task: strategy.previousOrderContent }, attachmentStore);
       }
 
       case SlashCommand.Cancel: {
         info(ui.cancelled);
-        return { action: 'cancel', task: '' };
+        return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
       }
 
       case SlashCommand.Resume: {

--- a/src/features/interactive/imageAttachments.ts
+++ b/src/features/interactive/imageAttachments.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { InteractiveModeResult } from './interactive.js';
+import type { ImagePasteHandler } from './inlineImagePaste.js';
+
+export interface InteractiveImageAttachment {
+  placeholder: string;
+  tempPath: string;
+  fileName: string;
+}
+
+export interface ImageAttachmentStore {
+  saveImage(data: Buffer, mimeType: string): Promise<InteractiveImageAttachment>;
+  listAttachments(): InteractiveImageAttachment[];
+}
+
+export interface ImageAttachmentStoreOptions {
+  tmpRoot: string;
+  sessionId: string;
+}
+
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+
+function extensionForMimeType(mimeType: string): string {
+  switch (mimeType) {
+    case 'image/png':
+      return 'png';
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/gif':
+      return 'gif';
+    case 'image/webp':
+      return 'webp';
+    default:
+      throw new Error(`Unsupported pasted image type: ${mimeType}`);
+  }
+}
+
+function ensurePrivateDirectory(directoryPath: string): void {
+  fs.mkdirSync(directoryPath, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  fs.chmodSync(directoryPath, PRIVATE_DIRECTORY_MODE);
+}
+
+export function buildInteractiveResultWithAttachments(
+  result: InteractiveModeResult,
+  attachmentStore: ImageAttachmentStore,
+): InteractiveModeResult {
+  const attachments = attachmentStore.listAttachments();
+  return {
+    ...result,
+    ...(attachments.length > 0 ? { attachments } : {}),
+  };
+}
+
+export function createImageAttachmentStore(
+  options: ImageAttachmentStoreOptions,
+): ImageAttachmentStore {
+  if (options.tmpRoot.length === 0) {
+    throw new Error('Image attachment tmpRoot is required.');
+  }
+  if (options.sessionId.length === 0) {
+    throw new Error('Image attachment sessionId is required.');
+  }
+
+  let attachments: InteractiveImageAttachment[] = [];
+  const sessionDir = path.join(options.tmpRoot, 'takt', options.sessionId);
+  const attachmentDir = path.join(sessionDir, 'attachments');
+
+  return {
+    async saveImage(data: Buffer, mimeType: string): Promise<InteractiveImageAttachment> {
+      const index = attachments.length + 1;
+      const fileName = `image-${index}.${extensionForMimeType(mimeType)}`;
+      const tempPath = path.join(attachmentDir, fileName);
+      const attachment: InteractiveImageAttachment = {
+        placeholder: `[Image #${index}]`,
+        tempPath,
+        fileName,
+      };
+
+      ensurePrivateDirectory(sessionDir);
+      ensurePrivateDirectory(attachmentDir);
+      fs.writeFileSync(tempPath, data, { mode: PRIVATE_FILE_MODE, flag: 'wx' });
+      attachments = [...attachments, attachment];
+      return attachment;
+    },
+
+    listAttachments(): InteractiveImageAttachment[] {
+      return [...attachments];
+    },
+  };
+}
+
+export function createSessionImageAttachmentStore(): ImageAttachmentStore {
+  return createImageAttachmentStore({
+    tmpRoot: os.tmpdir(),
+    sessionId: randomUUID(),
+  });
+}
+
+export function createImagePasteHandler(attachmentStore: ImageAttachmentStore): ImagePasteHandler {
+  return async (image) => {
+    const attachment = await attachmentStore.saveImage(image.data, image.mimeType);
+    return attachment.placeholder;
+  };
+}

--- a/src/features/interactive/index.ts
+++ b/src/features/interactive/index.ts
@@ -28,3 +28,4 @@ export { listRecentRuns, findRunForTask, loadRunSessionContext, formatRunSession
 export { runRetryMode, buildRetryTemplateVars, type RetryContext, type RetryFailureInfo, type RetryRunInfo } from './retryMode.js';
 export { dispatchConversationAction, type ConversationActionResult } from './actionDispatcher.js';
 export { findPreviousOrderContent } from './orderReader.js';
+export { type InteractiveImageAttachment } from './imageAttachments.js';

--- a/src/features/interactive/inlineImagePaste.ts
+++ b/src/features/interactive/inlineImagePaste.ts
@@ -1,0 +1,165 @@
+export interface PastedImage {
+  mimeType: string;
+  data: Buffer;
+}
+
+export type ImagePasteHandler = (image: PastedImage) => Promise<string>;
+
+export const OSC_IMAGE_PREFIX = '\x1B]1337;File=';
+export const MAX_INLINE_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_PENDING_INLINE_IMAGE_CHARS = Math.ceil(MAX_INLINE_IMAGE_BYTES / 3) * 4 + 1024;
+
+export type InlineImageSequence =
+  | { status: 'incomplete' }
+  | { status: 'passthrough'; sequenceEnd: number }
+  | { status: 'image'; image: PastedImage; sequenceEnd: number };
+
+function getParamValue(params: string[], name: string): string | null {
+  const prefix = `${name}=`;
+  const param = params.find((value) => value.startsWith(prefix));
+  return param ? param.slice(prefix.length) : null;
+}
+
+function isBase64Encoded(value: string, decoded: string): boolean {
+  return Buffer.from(decoded, 'utf8').toString('base64').replace(/=+$/, '') === value.replace(/=+$/, '');
+}
+
+function decodeInlineFileName(value: string): string {
+  const decoded = Buffer.from(value, 'base64').toString('utf8');
+  return isBase64Encoded(value, decoded) ? decoded : value;
+}
+
+function inferMimeTypeFromName(nameParam: string | null): string | null {
+  if (!nameParam) {
+    return null;
+  }
+
+  const fileName = decodeInlineFileName(nameParam).toLowerCase();
+  if (fileName.endsWith('.png')) return 'image/png';
+  if (fileName.endsWith('.jpg') || fileName.endsWith('.jpeg')) return 'image/jpeg';
+  if (fileName.endsWith('.gif')) return 'image/gif';
+  if (fileName.endsWith('.webp')) return 'image/webp';
+  return null;
+}
+
+function inferMimeTypeFromMagicBytes(data: Buffer): string | null {
+  if (data.length >= 4 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
+    return 'image/png';
+  }
+  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (data.subarray(0, 6).equals(Buffer.from('GIF87a')) || data.subarray(0, 6).equals(Buffer.from('GIF89a'))) {
+    return 'image/gif';
+  }
+  if (data.length >= 12 && data.subarray(0, 4).equals(Buffer.from('RIFF')) && data.subarray(8, 12).equals(Buffer.from('WEBP'))) {
+    return 'image/webp';
+  }
+  return null;
+}
+
+function validateDeclaredSize(params: string[], encodedData: string): void {
+  const sizeParam = getParamValue(params, 'size');
+  if (!sizeParam) {
+    return;
+  }
+
+  const declaredSize = Number.parseInt(sizeParam, 10);
+  if (!Number.isSafeInteger(declaredSize) || declaredSize < 0) {
+    throw new Error(`Invalid pasted inline image size: ${sizeParam}`);
+  }
+  if (declaredSize > MAX_INLINE_IMAGE_BYTES) {
+    throw new Error(`Pasted inline image exceeds the ${MAX_INLINE_IMAGE_BYTES} byte limit.`);
+  }
+
+  const maxEncodedLength = Math.ceil(declaredSize / 3) * 4 + 4;
+  if (encodedData.length > maxEncodedLength) {
+    throw new Error('Pasted inline image data is larger than its declared size.');
+  }
+}
+
+function decodeImageData(params: string[], encodedData: string): Buffer {
+  validateDeclaredSize(params, encodedData);
+  if (encodedData.length > Math.ceil(MAX_INLINE_IMAGE_BYTES / 3) * 4 + 4) {
+    throw new Error(`Pasted inline image exceeds the ${MAX_INLINE_IMAGE_BYTES} byte limit.`);
+  }
+
+  const imageData = Buffer.from(encodedData, 'base64');
+  if (imageData.length > MAX_INLINE_IMAGE_BYTES) {
+    throw new Error(`Pasted inline image exceeds the ${MAX_INLINE_IMAGE_BYTES} byte limit.`);
+  }
+
+  const sizeParam = getParamValue(params, 'size');
+  if (sizeParam && imageData.length !== Number.parseInt(sizeParam, 10)) {
+    throw new Error('Pasted inline image data does not match its declared size.');
+  }
+  return imageData;
+}
+
+function resolveInlineImageMimeType(params: string[], data: Buffer): string {
+  const mimeType = inferMimeTypeFromMagicBytes(data);
+  if (!mimeType) {
+    throw new Error('Unsupported pasted inline image type. Expected PNG, JPEG, GIF, or WebP data.');
+  }
+
+  const nameMimeType = inferMimeTypeFromName(getParamValue(params, 'name'));
+  if (nameMimeType && nameMimeType !== mimeType) {
+    throw new Error(`Pasted inline image filename type does not match image data: ${nameMimeType} !== ${mimeType}`);
+  }
+
+  return mimeType;
+}
+
+function findTerminator(input: string, start: number): { index: number; length: number } | null {
+  const belIndex = input.indexOf('\x07', start);
+  const stIndex = input.indexOf('\x1B\\', start);
+  if (belIndex === -1 && stIndex === -1) {
+    return null;
+  }
+  if (belIndex !== -1 && (stIndex === -1 || belIndex < stIndex)) {
+    return { index: belIndex, length: 1 };
+  }
+  return { index: stIndex, length: 2 };
+}
+
+export function assertPendingInlineImageWithinLimit(pendingInput: string): void {
+  if (pendingInput.length > MAX_PENDING_INLINE_IMAGE_CHARS) {
+    throw new Error(`Pasted inline image sequence exceeds the ${MAX_PENDING_INLINE_IMAGE_CHARS} character pending limit.`);
+  }
+}
+
+export function parseInlineImageSequence(input: string, start: number): InlineImageSequence {
+  if (!input.startsWith(OSC_IMAGE_PREFIX, start)) {
+    throw new Error(`Expected OSC 1337 inline image sequence at offset ${start}.`);
+  }
+
+  const payloadStart = start + OSC_IMAGE_PREFIX.length;
+  const terminator = findTerminator(input, payloadStart);
+  if (!terminator) {
+    assertPendingInlineImageWithinLimit(input.slice(start));
+    return { status: 'incomplete' };
+  }
+
+  const payload = input.slice(payloadStart, terminator.index);
+  const sequenceEnd = terminator.index + terminator.length;
+  const separatorIndex = payload.indexOf(':');
+  if (separatorIndex === -1) {
+    return { status: 'passthrough', sequenceEnd };
+  }
+
+  const params = payload.slice(0, separatorIndex).split(';');
+  if (!params.includes('inline=1')) {
+    return { status: 'passthrough', sequenceEnd };
+  }
+
+  const encodedData = payload.slice(separatorIndex + 1);
+  const imageData = decodeImageData(params, encodedData);
+  return {
+    status: 'image',
+    image: {
+      mimeType: resolveInlineImageMimeType(params, imageData),
+      data: imageData,
+    },
+    sequenceEnd,
+  };
+}

--- a/src/features/interactive/interactive.ts
+++ b/src/features/interactive/interactive.ts
@@ -34,6 +34,7 @@ import {
   selectSummaryAction,
 } from './interactive-summary.js';
 import { type RunSessionContext, formatRunSessionForPrompt } from './runSessionReader.js';
+import type { InteractiveImageAttachment } from './imageAttachments.js';
 
 /** Shape of interactive UI text */
 export interface InteractiveUIText {
@@ -222,4 +223,6 @@ export interface InteractiveModeResult {
   action: InteractiveModeAction;
   /** The assembled task text (only meaningful when action is not 'cancel') */
   task: string;
+  /** Images pasted during interactive input and referenced by placeholder. */
+  attachments?: InteractiveImageAttachment[];
 }

--- a/src/features/interactive/interactiveInput.ts
+++ b/src/features/interactive/interactiveInput.ts
@@ -3,6 +3,7 @@ import { getLabel } from '../../shared/i18n/index.js';
 import { readMultilineInput } from './lineEditor.js';
 import { filterSlashCommands, type CommandAvailability } from './slashCommandRegistry.js';
 import type { CompletionCandidate, CompletionContext, CompletionProvider } from './completionMenu.js';
+import { createImagePasteHandler, type ImageAttachmentStore } from './imageAttachments.js';
 
 /**
  * Build localized slash-command completion candidates for the current input.
@@ -70,7 +71,11 @@ export const readInteractiveInput = (
   prompt: string,
   lang: Language,
   availability?: CommandAvailability,
+  imageAttachmentStore?: ImageAttachmentStore,
 ): Promise<string | null> =>
   readMultilineInput(prompt, {
     completionProvider: createSlashCommandCompletionProvider(lang, availability),
+    ...(imageAttachmentStore ? {
+      onImagePaste: createImagePasteHandler(imageAttachmentStore),
+    } : {}),
   });

--- a/src/features/interactive/lineEditor.ts
+++ b/src/features/interactive/lineEditor.ts
@@ -12,6 +12,13 @@ import { StringDecoder } from 'node:string_decoder';
 import { stripAnsi, getDisplayWidth } from '../../shared/utils/text.js';
 import { createCompletionController } from './completionController.js';
 import type { CompletionProvider } from './completionMenu.js';
+import {
+  assertPendingInlineImageWithinLimit,
+  OSC_IMAGE_PREFIX,
+  parseInlineImageSequence,
+  type ImagePasteHandler,
+  type PastedImage,
+} from './inlineImagePaste.js';
 
 /** Escape sequences for terminal protocol control */
 const PASTE_BRACKET_ENABLE = '\x1B[?2004h';
@@ -27,6 +34,22 @@ const ESC_PASTE_END = '[201~';
 const ESC_SHIFT_ENTER = '[13;2u';
 
 type InputState = 'normal' | 'paste';
+
+function splitTrailingInlineImagePrefix(input: string): { ready: string; pending: string } {
+  const maxCandidateLength = Math.min(OSC_IMAGE_PREFIX.length - 1, input.length);
+
+  for (let length = maxCandidateLength; length > 0; length--) {
+    const candidate = input.slice(input.length - length);
+    if (candidate.startsWith('\x1B') && OSC_IMAGE_PREFIX.startsWith(candidate)) {
+      return {
+        ready: input.slice(0, input.length - length),
+        pending: candidate,
+      };
+    }
+  }
+
+  return { ready: input, pending: '' };
+}
 
 /**
  * Decode Kitty CSI-u key sequence into a control character.
@@ -275,6 +298,7 @@ export function readMultilineInput(
   prompt: string,
   options?: {
     completionProvider?: CompletionProvider;
+    onImagePaste?: ImagePasteHandler;
   },
 ): Promise<string | null> {
   if (!process.stdin.isTTY) {
@@ -304,7 +328,7 @@ export function readMultilineInput(
     });
   }
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let buffer = '';
     let cursorPos = 0;
     let state: InputState = 'normal';
@@ -511,6 +535,7 @@ export function readMultilineInput(
     }
 
     function cleanup(): void {
+      clearInlineImagePrefixTimer();
       escParser.flush();
       completion.hide();
       process.stdin.removeListener('data', onData);
@@ -659,6 +684,116 @@ export function readMultilineInput(
     // --- Input dispatch ---
 
     const utf8Decoder = new StringDecoder('utf8');
+    let pendingInlineImage = '';
+    let inlineImagePrefixTimer: ReturnType<typeof setTimeout> | null = null;
+    let inputQueue = Promise.resolve();
+    let settled = false;
+
+    function clearInlineImagePrefixTimer(): void {
+      if (inlineImagePrefixTimer !== null) {
+        clearTimeout(inlineImagePrefixTimer);
+        inlineImagePrefixTimer = null;
+      }
+    }
+
+    function flushAmbiguousInlineImagePrefix(): void {
+      clearInlineImagePrefixTimer();
+      if (pendingInlineImage.length === 0) {
+        return;
+      }
+      const pending = pendingInlineImage;
+      pendingInlineImage = '';
+      escParser.feed(pending);
+    }
+
+    function holdPendingInlineImage(pending: string): void {
+      clearInlineImagePrefixTimer();
+      assertPendingInlineImageWithinLimit(pending);
+      pendingInlineImage = pending;
+      if (pending === '\x1B') {
+        inlineImagePrefixTimer = setTimeout(flushAmbiguousInlineImagePrefix, ESC_AMBIGUITY_TIMEOUT_MS);
+      }
+    }
+
+    function finish(value: string | null): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(value);
+    }
+
+    function fail(error: unknown): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    }
+
+    function insertText(text: string): void {
+      insertAt(cursorPos, text);
+      cursorPos += text.length;
+      process.stdout.write(text);
+      rerenderFromCursor();
+    }
+
+    async function handleInlineImage(image: PastedImage): Promise<void> {
+      if (!options?.onImagePaste) {
+        return;
+      }
+      completion.hide();
+      const placeholder = await options.onImagePaste({
+        mimeType: image.mimeType,
+        data: image.data,
+      });
+      if (settled) {
+        return;
+      }
+      insertText(placeholder);
+      completion.update();
+    }
+
+    async function feedInputWithImages(input: string): Promise<void> {
+      clearInlineImagePrefixTimer();
+      const currentInput = pendingInlineImage + input;
+      pendingInlineImage = '';
+      let offset = 0;
+
+      while (offset < currentInput.length) {
+        const imageStart = currentInput.indexOf(OSC_IMAGE_PREFIX, offset);
+        if (imageStart === -1) {
+          const tail = splitTrailingInlineImagePrefix(currentInput.slice(offset));
+          if (tail.ready.length > 0) {
+            escParser.feed(tail.ready);
+          }
+          if (tail.pending.length > 0) {
+            holdPendingInlineImage(tail.pending);
+          }
+          return;
+        }
+
+        if (imageStart > offset) {
+          escParser.feed(currentInput.slice(offset, imageStart));
+        }
+
+        const sequence = parseInlineImageSequence(currentInput, imageStart);
+        if (sequence.status === 'incomplete') {
+          const pending = currentInput.slice(imageStart);
+          holdPendingInlineImage(pending);
+          return;
+        }
+
+        if (sequence.status === 'image') {
+          await handleInlineImage(sequence.image);
+        } else {
+          escParser.feed(currentInput.slice(imageStart, sequence.sequenceEnd));
+        }
+        offset = sequence.sequenceEnd;
+      }
+    }
 
     const escParser = createEscapeParser({
           onPasteStart() { state = 'paste'; completion.hide(); },
@@ -818,15 +953,13 @@ export function readMultilineInput(
             if (ch === '\r' || ch === '\n') {
               completion.acceptSelection();
               process.stdout.write('\n');
-              cleanup();
-              resolve(buffer);
+              finish(buffer);
               return;
             }
             // Cancel
             if (ch === '\x03' || ch === '\x04') {
               process.stdout.write('\n');
-              cleanup();
-              resolve(null);
+              finish(null);
               return;
             }
             // Editing
@@ -858,10 +991,16 @@ export function readMultilineInput(
       try {
         const str = utf8Decoder.write(data);
         if (!str) return;
-        escParser.feed(str);
-      } catch {
-        cleanup();
-        resolve(null);
+        inputQueue = inputQueue
+          .then(() => {
+            if (settled) {
+              return undefined;
+            }
+            return feedInputWithImages(str);
+          })
+          .catch(fail);
+      } catch (error) {
+        fail(error);
       }
     }
 

--- a/src/features/interactive/lineEditor.ts
+++ b/src/features/interactive/lineEditor.ts
@@ -704,6 +704,9 @@ export function readMultilineInput(
       const pending = pendingInlineImage;
       pendingInlineImage = '';
       escParser.feed(pending);
+      if (pending === '\x1B') {
+        escParser.flush();
+      }
     }
 
     function holdPendingInlineImage(pending: string): void {

--- a/src/features/interactive/passthroughMode.ts
+++ b/src/features/interactive/passthroughMode.ts
@@ -10,6 +10,11 @@ import { info, blankLine } from '../../shared/ui/index.js';
 import { getLabel } from '../../shared/i18n/index.js';
 import { readMultilineInput } from './lineEditor.js';
 import type { InteractiveModeResult } from './interactive.js';
+import {
+  buildInteractiveResultWithAttachments,
+  createImagePasteHandler,
+  createSessionImageAttachmentStore,
+} from './imageAttachments.js';
 
 /**
  * Run passthrough mode: collect user input and return it as-is.
@@ -29,22 +34,26 @@ export async function passthroughMode(
     return { action: 'execute', task: initialInput };
   }
 
+  const attachmentStore = createSessionImageAttachmentStore();
+
   info(getLabel('interactive.ui.introPassthrough', lang));
   blankLine();
 
-  const input = await readMultilineInput(chalk.green('> '));
+  const input = await readMultilineInput(chalk.green('> '), {
+    onImagePaste: createImagePasteHandler(attachmentStore),
+  });
 
   if (input === null) {
     blankLine();
     info(getLabel('interactive.ui.cancelled', lang));
-    return { action: 'cancel', task: '' };
+    return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
   }
 
   const trimmed = input.trim();
   if (!trimmed) {
     info(getLabel('interactive.ui.cancelled', lang));
-    return { action: 'cancel', task: '' };
+    return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
   }
 
-  return { action: 'execute', task: trimmed };
+  return buildInteractiveResultWithAttachments({ action: 'execute', task: trimmed }, attachmentStore);
 }

--- a/src/features/interactive/quietMode.ts
+++ b/src/features/interactive/quietMode.ts
@@ -25,6 +25,11 @@ import {
   callAIWithRetry,
 } from './conversationLoop.js';
 import { initializeSession } from './sessionInitialization.js';
+import {
+  buildInteractiveResultWithAttachments,
+  createImagePasteHandler,
+  createSessionImageAttachmentStore,
+} from './imageAttachments.js';
 
 const log = createLogger('quiet-mode');
 
@@ -49,6 +54,7 @@ export async function quietMode(
 ): Promise<InteractiveModeResult> {
   const ctx = initializeSession(cwd, 'interactive');
   const sourceContext = initialInput?.sourceContext;
+  const attachmentStore = createSessionImageAttachmentStore();
   const history: ConversationMessage[] = initialInput?.userMessage
     ? [{ role: 'user', content: initialInput.userMessage }]
     : [];
@@ -57,16 +63,18 @@ export async function quietMode(
     info(getLabel('interactive.ui.introQuiet', ctx.lang));
     blankLine();
 
-    const input = await readMultilineInput(chalk.green('> '));
+    const input = await readMultilineInput(chalk.green('> '), {
+      onImagePaste: createImagePasteHandler(attachmentStore),
+    });
     if (input === null) {
       blankLine();
       info(getLabel('interactive.ui.cancelled', ctx.lang));
-      return { action: 'cancel', task: '' };
+      return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
     }
     const trimmed = input.trim();
     if (!trimmed) {
       info(getLabel('interactive.ui.cancelled', ctx.lang));
-      return { action: 'cancel', task: '' };
+      return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
     }
     history.push({ role: 'user', content: trimmed });
   }
@@ -80,7 +88,7 @@ export async function quietMode(
 
   if (!summaryPrompt) {
     info(getLabel('interactive.ui.noConversation', ctx.lang));
-    return { action: 'cancel', task: '' };
+    return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
   }
 
   const { result } = await callAIWithRetry(
@@ -89,13 +97,13 @@ export async function quietMode(
   );
 
   if (!result) {
-    return { action: 'cancel', task: '' };
+    return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
   }
 
   if (!result.success) {
     error(result.content);
     blankLine();
-    return { action: 'cancel', task: '' };
+    return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
   }
 
   const task = result.content.trim();
@@ -103,9 +111,9 @@ export async function quietMode(
 
   const selectedAction = await selectPostSummaryAction(task, ui.proposed, ui);
   if (selectedAction === 'continue' || selectedAction === null) {
-    return { action: 'cancel', task: '' };
+    return buildInteractiveResultWithAttachments({ action: 'cancel', task: '' }, attachmentStore);
   }
 
   log.info('Quiet mode action selected', { action: selectedAction });
-  return { action: selectedAction, task };
+  return buildInteractiveResultWithAttachments({ action: selectedAction, task }, attachmentStore);
 }

--- a/src/features/interactive/retryMode.ts
+++ b/src/features/interactive/retryMode.ts
@@ -141,8 +141,16 @@ export async function runRetryMode(
   const result = await runConversationLoop(cwd, ctx, strategy, retryContext.workflowContext, undefined);
 
   if (result.action === 'cancel') {
-    return { action: 'cancel', task: '' };
+    return {
+      action: 'cancel',
+      task: '',
+      ...(result.attachments ? { attachments: result.attachments } : {}),
+    };
   }
 
-  return { action: result.action as InstructModeResult['action'], task: result.task };
+  return {
+    action: result.action as InstructModeResult['action'],
+    task: result.task,
+    ...(result.attachments ? { attachments: result.attachments } : {}),
+  };
 }

--- a/src/features/tasks/add/index.ts
+++ b/src/features/tasks/add/index.ts
@@ -5,7 +5,6 @@
  */
 
 import * as path from 'node:path';
-import * as fs from 'node:fs';
 import { promptInput, confirm, selectOption } from '../../../shared/prompt/index.js';
 import { info, error, withProgress } from '../../../shared/ui/index.js';
 import { getLabel } from '../../../shared/i18n/index.js';
@@ -18,12 +17,17 @@ import {
   resolveTaskWorkflowValue,
 } from '../../../infra/task/index.js';
 import { determineWorkflow } from '../execute/selectAndExecute.js';
-import { createLogger, getErrorMessage, generateReportDir } from '../../../shared/utils/index.js';
+import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
 import { isIssueReference, resolveIssueTask, parseIssueNumbers, formatPrReviewAsTask, getGitProvider } from '../../../infra/git/index.js';
 import type { PrReviewData } from '../../../infra/git/index.js';
 import { firstLine } from '../../../infra/task/naming.js';
 import { extractTitle, createIssueFromTask } from './issueTask.js';
 import { displayTaskCreationResult, promptWorktreeSettings, type WorktreeSettings } from './worktree-settings.js';
+import {
+  cleanupPreparedTaskSpec,
+  prepareTaskSpecDirectory,
+  type TaskAttachment,
+} from '../attachments.js';
 export { extractTitle, createIssueFromTask };
 
 const log = createLogger('add-task');
@@ -39,19 +43,8 @@ type SaveTaskOptions = {
   managedPr?: boolean;
   shouldPublishBranchToOrigin?: boolean;
   prNumber?: number;
+  attachments?: TaskAttachment[];
 };
-
-function resolveUniqueTaskSlug(cwd: string, baseSlug: string): string {
-  let sequence = 1;
-  let slug = baseSlug;
-  let taskDir = path.join(cwd, '.takt', 'tasks', slug);
-  while (fs.existsSync(taskDir)) {
-    sequence += 1;
-    slug = `${baseSlug}-${sequence}`;
-    taskDir = path.join(cwd, '.takt', 'tasks', slug);
-  }
-  return slug;
-}
 
 function buildValidatedTaskConfig(options?: SaveTaskOptions): Omit<TaskFileData, 'task'> {
   const resolvedWorkflow = options ? resolveTaskWorkflowValue(options) : undefined;
@@ -74,14 +67,6 @@ function buildValidatedTaskConfig(options?: SaveTaskOptions): Omit<TaskFileData,
   });
 }
 
-function cleanupFailedTaskDir(taskDir: string): void {
-  fs.rmSync(taskDir, { recursive: true, force: true });
-  const tasksDir = path.dirname(taskDir);
-  if (fs.existsSync(tasksDir) && fs.readdirSync(tasksDir).length === 0) {
-    fs.rmdirSync(tasksDir);
-  }
-}
-
 /**
  * Save a task entry to .takt/tasks.yaml.
  *
@@ -97,22 +82,17 @@ export async function saveTaskFile(
   const config = buildValidatedTaskConfig(options);
   const slug = await summarizeTaskName(taskContent, { cwd });
   const summary = firstLine(taskContent);
-  const taskDirSlug = resolveUniqueTaskSlug(cwd, generateReportDir(taskContent));
-  const taskDir = path.join(cwd, '.takt', 'tasks', taskDirSlug);
-  const taskDirRelative = `.takt/tasks/${taskDirSlug}`;
-  const orderPath = path.join(taskDir, 'order.md');
-  fs.mkdirSync(taskDir, { recursive: true });
-  fs.writeFileSync(orderPath, taskContent, 'utf-8');
+  const preparedSpec = prepareTaskSpecDirectory(cwd, taskContent, options?.attachments);
   let created;
   try {
     created = runner.addTask(taskContent, {
       ...config,
-      task_dir: taskDirRelative,
+      task_dir: preparedSpec.taskDirRelative,
       slug,
       summary,
     });
   } catch (error) {
-    cleanupFailedTaskDir(taskDir);
+    cleanupPreparedTaskSpec(preparedSpec.taskDir);
     throw error;
   }
   const tasksFile = path.join(cwd, '.takt', 'tasks.yaml');
@@ -156,7 +136,12 @@ export async function saveTaskFromInteractive(
   cwd: string,
   task: string,
   workflow?: string,
-  options?: { issue?: number; confirmAtEndMessage?: string; presetSettings?: WorktreeSettings },
+  options?: {
+    issue?: number;
+    confirmAtEndMessage?: string;
+    presetSettings?: WorktreeSettings;
+    attachments?: TaskAttachment[];
+  },
 ): Promise<void> {
   if (options?.confirmAtEndMessage) {
     const approved = await confirm(options.confirmAtEndMessage, true);
@@ -165,7 +150,12 @@ export async function saveTaskFromInteractive(
     }
   }
   const settings = options?.presetSettings ?? await promptWorktreeSettings(cwd);
-  const created = await saveTaskFile(cwd, task, { workflow, issue: options?.issue, ...settings });
+  const created = await saveTaskFile(cwd, task, {
+    workflow,
+    issue: options?.issue,
+    ...settings,
+    ...(options?.attachments ? { attachments: options.attachments } : {}),
+  });
   displayTaskCreationResult(created, settings, workflow);
 }
 
@@ -173,7 +163,7 @@ export async function createIssueAndSaveTask(
   cwd: string,
   task: string,
   workflow?: string,
-  options?: { confirmAtEndMessage?: string; labels?: string[] },
+  options?: { confirmAtEndMessage?: string; labels?: string[]; attachments?: TaskAttachment[] },
 ): Promise<void> {
   const issueNumber = createIssueFromTask(task, { labels: options?.labels, cwd });
   if (issueNumber === undefined) {
@@ -182,6 +172,7 @@ export async function createIssueAndSaveTask(
   await saveTaskFromInteractive(cwd, task, workflow, {
     issue: issueNumber,
     confirmAtEndMessage: options?.confirmAtEndMessage,
+    ...(options?.attachments ? { attachments: options.attachments } : {}),
   });
 }
 

--- a/src/features/tasks/attachments.ts
+++ b/src/features/tasks/attachments.ts
@@ -11,7 +11,6 @@ export interface TaskAttachment {
 export interface PreparedTaskSpec {
   taskDir: string;
   taskDirRelative: string;
-  taskDirSlug: string;
 }
 
 export interface PrepareTaskSpecOptions {
@@ -159,7 +158,7 @@ export function prepareTaskSpecDirectory(
     throw error;
   }
 
-  return { taskDir, taskDirRelative, taskDirSlug };
+  return { taskDir, taskDirRelative };
 }
 
 export function copyTaskAttachmentsToRunContext(sourceTaskDir: string, runContextTaskDir: string): void {

--- a/src/features/tasks/attachments.ts
+++ b/src/features/tasks/attachments.ts
@@ -52,6 +52,13 @@ function validateTaskAttachment(attachment: TaskAttachment): void {
   }
 }
 
+function validateTaskAttachmentTempFile(attachment: TaskAttachment): void {
+  const stats = fs.lstatSync(attachment.tempPath);
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error(`Task attachment source must be a regular file: ${attachment.tempPath}`);
+  }
+}
+
 export function promoteTaskAttachments(
   taskDir: string,
   attachments?: readonly TaskAttachment[],
@@ -65,6 +72,7 @@ export function promoteTaskAttachments(
 
   for (const attachment of attachments) {
     validateTaskAttachment(attachment);
+    validateTaskAttachmentTempFile(attachment);
     const destinationPath = path.join(taskDir, getTaskAttachmentRelativePath(attachment));
     if (fs.existsSync(destinationPath)) {
       throw new Error(`Task attachment destination already exists: ${destinationPath}`);

--- a/src/features/tasks/attachments.ts
+++ b/src/features/tasks/attachments.ts
@@ -1,0 +1,169 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { generateReportDir } from '../../shared/utils/index.js';
+
+export interface TaskAttachment {
+  placeholder: string;
+  tempPath: string;
+  fileName: string;
+}
+
+export interface PreparedTaskSpec {
+  taskDir: string;
+  taskDirRelative: string;
+  taskDirSlug: string;
+}
+
+export interface PrepareTaskSpecOptions {
+  sourceTaskDir?: string;
+}
+
+function hasAttachments(attachments: readonly TaskAttachment[] | undefined): attachments is readonly TaskAttachment[] {
+  return attachments !== undefined && attachments.length > 0;
+}
+
+export function buildTaskOrderContent(
+  taskContent: string,
+  attachments?: readonly TaskAttachment[],
+): string {
+  if (!hasAttachments(attachments)) {
+    return taskContent;
+  }
+
+  const attachmentLines = attachments.map((attachment) =>
+    `- ${attachment.placeholder}: \`${getTaskAttachmentRelativePath(attachment)}\``,
+  );
+  return [
+    taskContent.trimEnd(),
+    '',
+    '## 添付画像',
+    '',
+    ...attachmentLines,
+  ].join('\n');
+}
+
+function getTaskAttachmentRelativePath(attachment: TaskAttachment): string {
+  return path.posix.join('attachments', attachment.fileName);
+}
+
+function validateTaskAttachment(attachment: TaskAttachment): void {
+  if (attachment.fileName.includes('/') || attachment.fileName.includes('\\') || attachment.fileName === '') {
+    throw new Error(`Invalid task attachment file name: ${attachment.fileName}`);
+  }
+}
+
+export function promoteTaskAttachments(
+  taskDir: string,
+  attachments?: readonly TaskAttachment[],
+): void {
+  if (!hasAttachments(attachments)) {
+    return;
+  }
+
+  const attachmentsDir = path.join(taskDir, 'attachments');
+  fs.mkdirSync(attachmentsDir, { recursive: true });
+
+  for (const attachment of attachments) {
+    validateTaskAttachment(attachment);
+    const destinationPath = path.join(taskDir, getTaskAttachmentRelativePath(attachment));
+    if (fs.existsSync(destinationPath)) {
+      throw new Error(`Task attachment destination already exists: ${destinationPath}`);
+    }
+    fs.copyFileSync(attachment.tempPath, destinationPath);
+  }
+}
+
+export function resolveUniqueTaskSpecSlug(cwd: string, taskContent: string): string {
+  const baseSlug = generateReportDir(taskContent);
+  let sequence = 1;
+  let slug = baseSlug;
+  let taskDir = path.join(cwd, '.takt', 'tasks', slug);
+  while (fs.existsSync(taskDir)) {
+    sequence += 1;
+    slug = `${baseSlug}-${sequence}`;
+    taskDir = path.join(cwd, '.takt', 'tasks', slug);
+  }
+  return slug;
+}
+
+export function cleanupPreparedTaskSpec(taskDir: string): void {
+  fs.rmSync(taskDir, { recursive: true, force: true });
+  const tasksDir = path.dirname(taskDir);
+  if (fs.existsSync(tasksDir) && fs.readdirSync(tasksDir).length === 0) {
+    fs.rmdirSync(tasksDir);
+  }
+}
+
+function copyAttachmentEntry(sourcePath: string, destinationPath: string): void {
+  const stats = fs.lstatSync(sourcePath);
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Task attachments must not contain symlinks: ${sourcePath}`);
+  }
+  if (stats.isDirectory()) {
+    fs.mkdirSync(destinationPath, { recursive: true });
+    for (const entry of fs.readdirSync(sourcePath)) {
+      copyAttachmentEntry(path.join(sourcePath, entry), path.join(destinationPath, entry));
+    }
+    return;
+  }
+  if (!stats.isFile()) {
+    throw new Error(`Task attachments must be regular files or directories: ${sourcePath}`);
+  }
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  fs.copyFileSync(sourcePath, destinationPath);
+}
+
+function copyExistingTaskAttachments(sourceTaskDir: string, taskDir: string): void {
+  const sourceAttachmentsDir = path.join(sourceTaskDir, 'attachments');
+  if (!fs.existsSync(sourceAttachmentsDir)) {
+    return;
+  }
+
+  const stats = fs.lstatSync(sourceAttachmentsDir);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new Error(`Task attachments must be a regular directory: ${sourceAttachmentsDir}`);
+  }
+
+  copyAttachmentEntry(sourceAttachmentsDir, path.join(taskDir, 'attachments'));
+}
+
+export function prepareTaskSpecDirectory(
+  cwd: string,
+  taskContent: string,
+  attachments?: readonly TaskAttachment[],
+  options?: PrepareTaskSpecOptions,
+): PreparedTaskSpec {
+  const taskDirSlug = resolveUniqueTaskSpecSlug(cwd, taskContent);
+  const taskDir = path.join(cwd, '.takt', 'tasks', taskDirSlug);
+  const taskDirRelative = `.takt/tasks/${taskDirSlug}`;
+  const orderContent = buildTaskOrderContent(taskContent, attachments);
+  const orderPath = path.join(taskDir, 'order.md');
+
+  fs.mkdirSync(taskDir, { recursive: true });
+  try {
+    if (options?.sourceTaskDir) {
+      copyExistingTaskAttachments(options.sourceTaskDir, taskDir);
+    }
+    promoteTaskAttachments(taskDir, attachments);
+    fs.writeFileSync(orderPath, orderContent, 'utf-8');
+  } catch (error) {
+    cleanupPreparedTaskSpec(taskDir);
+    throw error;
+  }
+
+  return { taskDir, taskDirRelative, taskDirSlug };
+}
+
+export function copyTaskAttachmentsToRunContext(sourceTaskDir: string, runContextTaskDir: string): void {
+  const sourceAttachmentsDir = path.join(sourceTaskDir, 'attachments');
+  if (!fs.existsSync(sourceAttachmentsDir)) {
+    return;
+  }
+
+  const stats = fs.lstatSync(sourceAttachmentsDir);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new Error(`Task attachments must be a regular directory: ${sourceAttachmentsDir}`);
+  }
+
+  copyAttachmentEntry(sourceAttachmentsDir, path.join(runContextTaskDir, 'attachments'));
+}

--- a/src/features/tasks/execute/resolveTask.ts
+++ b/src/features/tasks/execute/resolveTask.ts
@@ -19,6 +19,7 @@ import { getGitProvider, type Issue } from '../../../infra/git/index.js';
 import { withProgress } from '../../../shared/ui/index.js';
 import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
 import { generateReportDir } from '../../../shared/utils/reportDir.js';
+import { generateExecutionReportDir } from '../../../core/workflow/run/run-slug.js';
 import { getTaskSlugFromTaskDir } from '../../../shared/utils/taskPaths.js';
 import { stageTaskSpecForExecution } from './taskSpecContext.js';
 import { resolveReusedWorktreeExecution } from './reusedWorktree.js';
@@ -166,7 +167,6 @@ export async function resolveTaskExecution(
     if (!taskSlug) {
       throw new Error(`Invalid task_dir format: ${task.taskDir}`);
     }
-    reportDirName = taskSlug;
   }
 
   if (data.worktree) {
@@ -216,13 +216,14 @@ export async function resolveTaskExecution(
     }
   }
 
-  if (task.taskDir && reportDirName) {
+  if (task.taskDir) {
+    reportDirName = generateExecutionReportDir(execCwd, task.content);
     const stagedTaskSpec = stageTaskSpecForExecution(defaultCwd, execCwd, task.taskDir, reportDirName);
     taskPrompt = stagedTaskSpec.taskPrompt;
     orderContent = stagedTaskSpec.orderContent;
   }
 
-  const resolvedReportDirName = reportDirName ?? generateReportDir(taskPrompt ?? task.content);
+  const resolvedReportDirName = reportDirName ?? generateReportDir(task.content);
   const retryResume = resolveRetryResume(
     workflowIdentifier,
     defaultCwd,

--- a/src/features/tasks/execute/selectAndExecute.ts
+++ b/src/features/tasks/execute/selectAndExecute.ts
@@ -13,11 +13,26 @@ import type { TaskExecutionOptions, WorktreeConfirmationResult, SelectAndExecute
 import { selectWorkflow } from '../../workflowSelection/index.js';
 import { buildBooleanTaskResult, persistTaskError, persistTaskResult } from './taskResultHandler.js';
 import { prepareTaskSpecDirectory, cleanupPreparedTaskSpec } from '../attachments.js';
-import { stageTaskSpecForExecution } from './taskSpecContext.js';
+import { cleanupStagedTaskSpec, stageTaskSpecForExecution, type StagedTaskSpec } from './taskSpecContext.js';
 
 export type { WorktreeConfirmationResult, SelectAndExecuteOptions };
 
 const log = createLogger('selectAndExecute');
+
+function cleanupTransientTaskSpecs(
+  preparedSpecTaskDir: string | undefined,
+  stagedSpec: StagedTaskSpec | undefined,
+): void {
+  try {
+    if (stagedSpec) {
+      cleanupStagedTaskSpec(stagedSpec);
+    }
+  } finally {
+    if (preparedSpecTaskDir) {
+      cleanupPreparedTaskSpec(preparedSpecTaskDir);
+    }
+  }
+}
 
 export async function determineWorkflow(cwd: string, override?: string): Promise<string | null> {
   if (override) {
@@ -90,7 +105,7 @@ export async function selectAndExecuteTask(
   const taskRunner = new TaskRunner(cwd, { onWarning: warn });
   let taskRecord: Awaited<ReturnType<TaskRunner['addTask']>> | null = null;
   let preparedSpec: ReturnType<typeof prepareTaskSpecDirectory> | undefined;
-  let stagedSpec: ReturnType<typeof stageTaskSpecForExecution> | undefined;
+  let stagedSpec: StagedTaskSpec | undefined;
   try {
     preparedSpec = options?.attachments && options.attachments.length > 0
       ? prepareTaskSpecDirectory(cwd, task, options.attachments)
@@ -111,12 +126,12 @@ export async function selectAndExecuteTask(
         ...(preparedSpec ? { task_dir: preparedSpec.taskDirRelative } : {}),
       });
     } catch (error) {
-      if (preparedSpec) {
-        cleanupPreparedTaskSpec(preparedSpec.taskDir);
-      }
+      cleanupTransientTaskSpecs(preparedSpec?.taskDir, stagedSpec);
       throw error;
     }
   }
+  const preparedSpecTaskDirToCleanup = options?.skipTaskList === true ? preparedSpec?.taskDir : undefined;
+  const stagedSpecToCleanup = options?.skipTaskList === true ? stagedSpec : undefined;
   const startedAt = new Date().toISOString();
 
   statusLine.start('Running...');
@@ -142,6 +157,7 @@ export async function selectAndExecuteTask(
     throw err;
   } finally {
     statusLine.stop();
+    cleanupTransientTaskSpecs(preparedSpecTaskDirToCleanup, stagedSpecToCleanup);
   }
 
   const completedAt = new Date().toISOString();

--- a/src/features/tasks/execute/selectAndExecute.ts
+++ b/src/features/tasks/execute/selectAndExecute.ts
@@ -12,6 +12,8 @@ import { executeTask } from './taskExecution.js';
 import type { TaskExecutionOptions, WorktreeConfirmationResult, SelectAndExecuteOptions } from './types.js';
 import { selectWorkflow } from '../../workflowSelection/index.js';
 import { buildBooleanTaskResult, persistTaskError, persistTaskResult } from './taskResultHandler.js';
+import { prepareTaskSpecDirectory, cleanupPreparedTaskSpec } from '../attachments.js';
+import { stageTaskSpecForExecution } from './taskSpecContext.js';
 
 export type { WorktreeConfirmationResult, SelectAndExecuteOptions };
 
@@ -87,10 +89,33 @@ export async function selectAndExecuteTask(
   log.info('Starting task execution', { workflow: workflowIdentifier, worktree: false });
   const taskRunner = new TaskRunner(cwd, { onWarning: warn });
   let taskRecord: Awaited<ReturnType<TaskRunner['addTask']>> | null = null;
+  let preparedSpec: ReturnType<typeof prepareTaskSpecDirectory> | undefined;
+  let stagedSpec: ReturnType<typeof stageTaskSpecForExecution> | undefined;
+  try {
+    preparedSpec = options?.attachments && options.attachments.length > 0
+      ? prepareTaskSpecDirectory(cwd, task, options.attachments)
+      : undefined;
+    stagedSpec = preparedSpec
+      ? stageTaskSpecForExecution(cwd, execCwd, preparedSpec.taskDirRelative, preparedSpec.taskDirSlug)
+      : undefined;
+  } catch (error) {
+    if (preparedSpec) {
+      cleanupPreparedTaskSpec(preparedSpec.taskDir);
+    }
+    throw error;
+  }
   if (options?.skipTaskList !== true) {
-    taskRecord = taskRunner.addTask(task, {
-      workflow: workflowIdentifier,
-    });
+    try {
+      taskRecord = taskRunner.addTask(task, {
+        workflow: workflowIdentifier,
+        ...(preparedSpec ? { task_dir: preparedSpec.taskDirRelative } : {}),
+      });
+    } catch (error) {
+      if (preparedSpec) {
+        cleanupPreparedTaskSpec(preparedSpec.taskDir);
+      }
+      throw error;
+    }
   }
   const startedAt = new Date().toISOString();
 
@@ -98,13 +123,14 @@ export async function selectAndExecuteTask(
   let taskSuccess: boolean;
   try {
     taskSuccess = await executeTask({
-      task,
+      task: stagedSpec?.taskPrompt ?? task,
       cwd: execCwd,
       workflowIdentifier,
       projectCwd: cwd,
       agentOverrides,
       interactiveUserInput: options?.interactiveUserInput === true,
       interactiveMetadata: options?.interactiveMetadata,
+      ...(preparedSpec ? { reportDirName: preparedSpec.taskDirSlug } : {}),
     });
   } catch (err) {
     const completedAt = new Date().toISOString();

--- a/src/features/tasks/execute/selectAndExecute.ts
+++ b/src/features/tasks/execute/selectAndExecute.ts
@@ -7,6 +7,7 @@ import { createSharedClone, summarizeTaskName, resolveBaseBranch, TaskRunner } f
 import { info, error, warn, withProgress } from '../../../shared/ui/index.js';
 import { statusLine } from '../../../shared/ui/StatusLine.js';
 import { createLogger } from '../../../shared/utils/index.js';
+import { generateExecutionReportDir } from '../../../core/workflow/run/run-slug.js';
 import { sanitizeTerminalText } from '../../../shared/utils/text.js';
 import { executeTask } from './taskExecution.js';
 import type { TaskExecutionOptions, WorktreeConfirmationResult, SelectAndExecuteOptions } from './types.js';
@@ -106,13 +107,15 @@ export async function selectAndExecuteTask(
   let taskRecord: Awaited<ReturnType<TaskRunner['addTask']>> | null = null;
   let preparedSpec: ReturnType<typeof prepareTaskSpecDirectory> | undefined;
   let stagedSpec: StagedTaskSpec | undefined;
+  let reportDirName: string | undefined;
   try {
     preparedSpec = options?.attachments && options.attachments.length > 0
       ? prepareTaskSpecDirectory(cwd, task, options.attachments)
       : undefined;
-    stagedSpec = preparedSpec
-      ? stageTaskSpecForExecution(cwd, execCwd, preparedSpec.taskDirRelative, preparedSpec.taskDirSlug)
-      : undefined;
+    if (preparedSpec) {
+      reportDirName = generateExecutionReportDir(execCwd, task);
+      stagedSpec = stageTaskSpecForExecution(cwd, execCwd, preparedSpec.taskDirRelative, reportDirName);
+    }
   } catch (error) {
     if (preparedSpec) {
       cleanupPreparedTaskSpec(preparedSpec.taskDir);
@@ -145,7 +148,7 @@ export async function selectAndExecuteTask(
       agentOverrides,
       interactiveUserInput: options?.interactiveUserInput === true,
       interactiveMetadata: options?.interactiveMetadata,
-      ...(preparedSpec ? { reportDirName: preparedSpec.taskDirSlug } : {}),
+      ...(reportDirName ? { reportDirName } : {}),
     });
   } catch (err) {
     const completedAt = new Date().toISOString();

--- a/src/features/tasks/execute/taskSpecContext.ts
+++ b/src/features/tasks/execute/taskSpecContext.ts
@@ -5,8 +5,22 @@ import { buildTaskInstruction } from '../../../infra/task/index.js';
 import { copyTaskAttachmentsToRunContext } from '../attachments.js';
 import { readTaskSpecFile } from '../taskSpecFile.js';
 
+export interface StagedTaskSpec {
+  taskPrompt: string;
+  orderContent: string;
+  contextTaskDir: string;
+  contextDir: string;
+  runRootDir: string;
+}
+
 function getTaskSpecPath(projectCwd: string, taskDir: string): string {
   return path.join(projectCwd, taskDir, 'order.md');
+}
+
+function removeEmptyDirectory(directory: string): void {
+  if (fs.existsSync(directory) && fs.readdirSync(directory).length === 0) {
+    fs.rmdirSync(directory);
+  }
 }
 
 export function stageTaskSpecForExecution(
@@ -14,7 +28,7 @@ export function stageTaskSpecForExecution(
   execCwd: string,
   taskDir: string,
   reportDirName: string,
-): { taskPrompt: string; orderContent: string } {
+): StagedTaskSpec {
   const sourceTaskDir = path.join(projectCwd, taskDir);
   const sourceOrderPath = getTaskSpecPath(projectCwd, taskDir);
   const orderContent = readTaskSpecFile(sourceOrderPath);
@@ -32,5 +46,14 @@ export function stageTaskSpecForExecution(
   return {
     taskPrompt: buildTaskInstruction(runPaths.contextTaskRel, runPaths.contextTaskOrderRel),
     orderContent,
+    contextTaskDir: runPaths.contextTaskAbs,
+    contextDir: runPaths.contextAbs,
+    runRootDir: runPaths.runRootAbs,
   };
+}
+
+export function cleanupStagedTaskSpec(stagedSpec: StagedTaskSpec): void {
+  fs.rmSync(stagedSpec.contextTaskDir, { recursive: true, force: true });
+  removeEmptyDirectory(stagedSpec.contextDir);
+  removeEmptyDirectory(stagedSpec.runRootDir);
 }

--- a/src/features/tasks/execute/taskSpecContext.ts
+++ b/src/features/tasks/execute/taskSpecContext.ts
@@ -2,48 +2,11 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { buildRunPaths } from '../../../core/workflow/run/run-paths.js';
 import { buildTaskInstruction } from '../../../infra/task/index.js';
+import { copyTaskAttachmentsToRunContext } from '../attachments.js';
+import { readTaskSpecFile } from '../taskSpecFile.js';
 
 function getTaskSpecPath(projectCwd: string, taskDir: string): string {
   return path.join(projectCwd, taskDir, 'order.md');
-}
-
-function buildMissingTaskSpecError(sourceOrderPath: string): Error {
-  return new Error(`Task spec file is missing: ${sourceOrderPath}`);
-}
-
-function buildInvalidTaskSpecError(sourceOrderPath: string): Error {
-  return new Error(`Task spec file must be a regular file: ${sourceOrderPath}`);
-}
-
-function readTaskSpecForStaging(sourceOrderPath: string): string {
-  let fileDescriptor: number | undefined;
-  try {
-    const sourceStats = fs.lstatSync(sourceOrderPath);
-    if (!sourceStats.isFile()) {
-      throw buildInvalidTaskSpecError(sourceOrderPath);
-    }
-
-    fileDescriptor = fs.openSync(sourceOrderPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
-    const descriptorStats = fs.fstatSync(fileDescriptor);
-    if (!descriptorStats.isFile()) {
-      throw buildInvalidTaskSpecError(sourceOrderPath);
-    }
-
-    return fs.readFileSync(fileDescriptor, 'utf-8');
-  } catch (error) {
-    const errorCode = (error as NodeJS.ErrnoException).code;
-    if (errorCode === 'ENOENT') {
-      throw buildMissingTaskSpecError(sourceOrderPath);
-    }
-    if (errorCode === 'ELOOP') {
-      throw buildInvalidTaskSpecError(sourceOrderPath);
-    }
-    throw error;
-  } finally {
-    if (fileDescriptor !== undefined) {
-      fs.closeSync(fileDescriptor);
-    }
-  }
 }
 
 export function stageTaskSpecForExecution(
@@ -52,12 +15,19 @@ export function stageTaskSpecForExecution(
   taskDir: string,
   reportDirName: string,
 ): { taskPrompt: string; orderContent: string } {
+  const sourceTaskDir = path.join(projectCwd, taskDir);
   const sourceOrderPath = getTaskSpecPath(projectCwd, taskDir);
-  const orderContent = readTaskSpecForStaging(sourceOrderPath);
+  const orderContent = readTaskSpecFile(sourceOrderPath);
   const runPaths = buildRunPaths(execCwd, reportDirName);
 
-  fs.mkdirSync(runPaths.contextTaskAbs, { recursive: true });
-  fs.writeFileSync(runPaths.contextTaskOrderAbs, orderContent, 'utf-8');
+  try {
+    fs.mkdirSync(runPaths.contextTaskAbs, { recursive: true });
+    fs.writeFileSync(runPaths.contextTaskOrderAbs, orderContent, 'utf-8');
+    copyTaskAttachmentsToRunContext(sourceTaskDir, runPaths.contextTaskAbs);
+  } catch (error) {
+    fs.rmSync(runPaths.contextTaskAbs, { recursive: true, force: true });
+    throw error;
+  }
 
   return {
     taskPrompt: buildTaskInstruction(runPaths.contextTaskRel, runPaths.contextTaskOrderRel),

--- a/src/features/tasks/execute/types.ts
+++ b/src/features/tasks/execute/types.ts
@@ -13,6 +13,7 @@ import type {
   ProviderOptionsSource,
   ProviderResolutionSource,
 } from '../../../core/workflow/provider-options-trace.js';
+import type { TaskAttachment } from '../attachments.js';
 
 /** Info captured when iteration limit is hit in non-interactive mode */
 export interface ExceededInfo {
@@ -195,4 +196,6 @@ export interface SelectAndExecuteOptions {
   interactiveMetadata?: InteractiveMetadata;
   /** Skip adding task to tasks.yaml */
   skipTaskList?: boolean;
+  /** Images pasted during interactive task input. */
+  attachments?: TaskAttachment[];
 }

--- a/src/features/tasks/list/instructMode.ts
+++ b/src/features/tasks/list/instructMode.ts
@@ -15,6 +15,7 @@ import { initializeSession } from '../../interactive/sessionInitialization.js';
 import {
   resolveLanguage,
   formatStepPreviews,
+  type InteractiveModeResult,
   type WorkflowContext,
 } from '../../interactive/interactive.js';
 import { buildInteractivePolicyPrompt } from '../../interactive/policyPrompt.js';
@@ -29,6 +30,7 @@ export type InstructModeAction = 'execute' | 'save_task' | 'cancel';
 export interface InstructModeResult {
   action: InstructModeAction;
   task: string;
+  attachments?: InteractiveModeResult['attachments'];
 }
 
 export interface InstructUIText {
@@ -48,6 +50,22 @@ export interface InstructUIText {
 }
 
 const INSTRUCT_TOOLS = ['Read', 'Glob', 'Grep', 'Bash', 'WebSearch', 'WebFetch'];
+
+function toInstructModeResult(result: InteractiveModeResult): InstructModeResult {
+  if (result.action === 'cancel') {
+    return {
+      action: 'cancel',
+      task: '',
+      ...(result.attachments ? { attachments: result.attachments } : {}),
+    };
+  }
+
+  return {
+    action: result.action as InstructModeAction,
+    task: result.task,
+    ...(result.attachments ? { attachments: result.attachments } : {}),
+  };
+}
 
 function buildInstructTemplateVars(
   branchContext: string,
@@ -131,9 +149,5 @@ export async function runInstructMode(
 
   const result = await runConversationLoop(cwd, ctx, strategy, workflowContext, undefined);
 
-  if (result.action === 'cancel') {
-    return { action: 'cancel', task: '' };
-  }
-
-  return { action: result.action as InstructModeAction, task: result.task };
+  return toInstructModeResult(result);
 }

--- a/src/features/tasks/list/retryTaskSpecAttachments.ts
+++ b/src/features/tasks/list/retryTaskSpecAttachments.ts
@@ -1,0 +1,120 @@
+import * as path from 'node:path';
+import { prepareTaskSpecDirectory, cleanupPreparedTaskSpec } from '../attachments.js';
+import type { TaskAttachment } from '../attachments.js';
+import { readTaskSpecFile } from '../taskSpecFile.js';
+
+export interface PreparedRetryTaskSpec {
+  taskDir: string;
+  taskDirRelative: string;
+}
+
+function hasAttachments(attachments: readonly TaskAttachment[] | undefined): attachments is readonly TaskAttachment[] {
+  return attachments !== undefined && attachments.length > 0;
+}
+
+function buildRetryTaskSpecContent(taskContent: string, retryNote: string): string {
+  return [
+    taskContent.trimEnd(),
+    '',
+    '## 追加指示',
+    '',
+    retryNote,
+  ].join('\n');
+}
+
+function resolveTaskDirPath(projectDir: string, taskDir: string): string {
+  return path.join(projectDir, taskDir);
+}
+
+function resolveRetryTaskSpecBaseContent(
+  projectDir: string,
+  taskContent: string,
+  taskDir: string | undefined,
+): string {
+  if (!taskDir) {
+    return taskContent;
+  }
+
+  return readTaskSpecFile(path.join(resolveTaskDirPath(projectDir, taskDir), 'order.md'));
+}
+
+function getImageAttachmentExtension(fileName: string): string {
+  const ext = path.extname(fileName);
+  if (ext === '') {
+    throw new Error(`Task attachment file must have an extension: ${fileName}`);
+  }
+  return ext;
+}
+
+function resolveMaxImageIndex(content: string): number {
+  const matches = content.matchAll(/\[Image #(\d+)\]|attachments\/image-(\d+)\.[A-Za-z0-9]+/g);
+  let maxIndex = 0;
+  for (const match of matches) {
+    const rawIndex = match[1] ?? match[2];
+    if (rawIndex === undefined) {
+      continue;
+    }
+    maxIndex = Math.max(maxIndex, Number(rawIndex));
+  }
+  return maxIndex;
+}
+
+function renumberRetryAttachments(
+  baseContent: string,
+  retryNote: string,
+  attachments: readonly TaskAttachment[],
+): { retryNote: string; attachments: TaskAttachment[] } {
+  let nextImageIndex = resolveMaxImageIndex(baseContent) + 1;
+  const placeholderReplacements = new Map<string, string>();
+  const adjustedAttachments = attachments.map((attachment) => {
+    const placeholder = `[Image #${nextImageIndex}]`;
+    const fileName = `image-${nextImageIndex}${getImageAttachmentExtension(attachment.fileName)}`;
+    nextImageIndex += 1;
+    placeholderReplacements.set(attachment.placeholder, placeholder);
+    return {
+      ...attachment,
+      placeholder,
+      fileName,
+    };
+  });
+  const adjustedRetryNote = retryNote.replace(/\[Image #\d+\]/g, (placeholder) =>
+    placeholderReplacements.get(placeholder) ?? placeholder);
+  return { retryNote: adjustedRetryNote, attachments: adjustedAttachments };
+}
+
+export function prepareRetryTaskSpecWithAttachments(
+  projectDir: string,
+  taskContent: string,
+  retryNote: string,
+  attachments: readonly TaskAttachment[] | undefined,
+  taskDir?: string,
+): PreparedRetryTaskSpec | undefined {
+  if (!hasAttachments(attachments)) {
+    return undefined;
+  }
+
+  const taskSpecBaseContent = resolveRetryTaskSpecBaseContent(projectDir, taskContent, taskDir);
+  const adjusted = taskDir
+    ? renumberRetryAttachments(taskSpecBaseContent, retryNote, attachments)
+    : { retryNote, attachments };
+  const taskSpecContent = buildRetryTaskSpecContent(taskSpecBaseContent, adjusted.retryNote);
+  const prepareArgs: Parameters<typeof prepareTaskSpecDirectory> = taskDir
+    ? [
+      projectDir,
+      taskSpecContent,
+      adjusted.attachments,
+      { sourceTaskDir: resolveTaskDirPath(projectDir, taskDir) },
+    ]
+    : [projectDir, taskSpecContent, adjusted.attachments];
+  const preparedSpec = prepareTaskSpecDirectory(...prepareArgs);
+  return {
+    taskDir: preparedSpec.taskDir,
+    taskDirRelative: preparedSpec.taskDirRelative,
+  };
+}
+
+export function cleanupPreparedRetryTaskSpec(preparedSpec: PreparedRetryTaskSpec | undefined): void {
+  if (preparedSpec) {
+    cleanupPreparedTaskSpec(preparedSpec.taskDir);
+  }
+}

--- a/src/features/tasks/list/retryTaskSpecAttachments.ts
+++ b/src/features/tasks/list/retryTaskSpecAttachments.ts
@@ -94,9 +94,7 @@ export function prepareRetryTaskSpecWithAttachments(
   }
 
   const taskSpecBaseContent = resolveRetryTaskSpecBaseContent(projectDir, taskContent, taskDir);
-  const adjusted = taskDir
-    ? renumberRetryAttachments(taskSpecBaseContent, retryNote, attachments)
-    : { retryNote, attachments };
+  const adjusted = renumberRetryAttachments(taskSpecBaseContent, retryNote, attachments);
   const taskSpecContent = buildRetryTaskSpecContent(taskSpecBaseContent, adjusted.retryNote);
   const prepareArgs: Parameters<typeof prepareTaskSpecDirectory> = taskDir
     ? [

--- a/src/features/tasks/list/taskInstructionActions.ts
+++ b/src/features/tasks/list/taskInstructionActions.ts
@@ -28,6 +28,10 @@ import {
 } from './requeueHelpers.js';
 import { executeAndCompleteTask } from '../execute/taskExecution.js';
 import { prepareTaskForExecution } from './prepareTaskForExecution.js';
+import {
+  cleanupPreparedRetryTaskSpec,
+  prepareRetryTaskSpecWithAttachments,
+} from './retryTaskSpecAttachments.js';
 
 const log = createLogger('list-tasks');
 
@@ -134,8 +138,16 @@ export async function instructBranch(
 
   const executeWithInstruction = async (instruction: string): Promise<boolean> => {
     const retryNote = appendRetryNote(target.data?.retry_note, instruction);
+    const preparedSpec = prepareRetryTaskSpecWithAttachments(projectDir, target.content, retryNote, result.attachments, target.taskDir);
+    const taskDir = preparedSpec?.taskDirRelative;
     const runner = new TaskRunner(projectDir);
-    const taskInfo = runner.startReExecution(target.name, ['completed', 'failed'], undefined, retryNote);
+    let taskInfo: ReturnType<TaskRunner['startReExecution']>;
+    try {
+      taskInfo = runner.startReExecution(target.name, ['completed', 'failed'], undefined, retryNote, undefined, undefined, taskDir);
+    } catch (error) {
+      cleanupPreparedRetryTaskSpec(preparedSpec);
+      throw error;
+    }
     const taskForExecution = prepareTaskForExecution(taskInfo, selectedWorkflow);
 
     log.info('Starting re-execution of instructed task', {
@@ -156,8 +168,15 @@ export async function instructBranch(
     execute: async ({ task }) => executeWithInstruction(task),
     save_task: async ({ task }) => {
       const retryNote = appendRetryNote(target.data?.retry_note, task);
+      const preparedSpec = prepareRetryTaskSpecWithAttachments(projectDir, target.content, retryNote, result.attachments, target.taskDir);
+      const taskDir = preparedSpec?.taskDirRelative;
       const runner = new TaskRunner(projectDir);
-      runner.requeueTask(target.name, ['completed', 'failed'], undefined, retryNote);
+      try {
+        runner.requeueTask(target.name, ['completed', 'failed'], undefined, retryNote, undefined, undefined, taskDir);
+      } catch (error) {
+        cleanupPreparedRetryTaskSpec(preparedSpec);
+        throw error;
+      }
       info(`Task "${target.name}" has been requeued.`);
       return true;
     },

--- a/src/features/tasks/list/taskRetryActions.ts
+++ b/src/features/tasks/list/taskRetryActions.ts
@@ -34,6 +34,10 @@ import {
   selectWorkflowWithOptionalReuse,
 } from './requeueHelpers.js';
 import { prepareTaskForExecution } from './prepareTaskForExecution.js';
+import {
+  cleanupPreparedRetryTaskSpec,
+  prepareRetryTaskSpecWithAttachments,
+} from './retryTaskSpecAttachments.js';
 import { sanitizeTerminalText } from '../../../shared/utils/text.js';
 import { workflowEntryMatchesWorkflow } from '../../../core/workflow/workflow-reference.js';
 
@@ -379,29 +383,44 @@ export async function retryFailedTask(
   }
 
   const retryNote = appendRetryNote(task.data?.retry_note, retryResult.task);
+  const preparedSpec = prepareRetryTaskSpecWithAttachments(projectDir, task.content, retryNote, retryResult.attachments, task.taskDir);
+  const taskDir = preparedSpec?.taskDirRelative;
   const runner = new TaskRunner(projectDir);
 
   if (retryResult.action === 'save_task') {
-    runner.requeueTask(
+    try {
+      runner.requeueTask(
+        task.name,
+        ['failed'],
+        selection.startStep,
+        retryNote,
+        selection.selectedResumePoint,
+        selection.selectedWorkflowOverride,
+        taskDir,
+      );
+    } catch (error) {
+      cleanupPreparedRetryTaskSpec(preparedSpec);
+      throw error;
+    }
+    info(`Task "${sanitizeTerminalText(task.name)}" has been requeued.`);
+    return true;
+  }
+
+  let taskInfo: ReturnType<TaskRunner['startReExecution']>;
+  try {
+    taskInfo = runner.startReExecution(
       task.name,
       ['failed'],
       selection.startStep,
       retryNote,
       selection.selectedResumePoint,
       selection.selectedWorkflowOverride,
+      taskDir,
     );
-    info(`Task "${sanitizeTerminalText(task.name)}" has been requeued.`);
-    return true;
+  } catch (error) {
+    cleanupPreparedRetryTaskSpec(preparedSpec);
+    throw error;
   }
-
-  const taskInfo = runner.startReExecution(
-    task.name,
-    ['failed'],
-    selection.startStep,
-    retryNote,
-    selection.selectedResumePoint,
-    selection.selectedWorkflowOverride,
-  );
   const taskForExecution = prepareTaskForExecution(taskInfo, selection.selectedWorkflow);
 
   log.info('Starting re-execution of failed task', {

--- a/src/features/tasks/taskSpecFile.ts
+++ b/src/features/tasks/taskSpecFile.ts
@@ -1,0 +1,40 @@
+import * as fs from 'node:fs';
+
+function buildMissingTaskSpecError(sourceOrderPath: string): Error {
+  return new Error(`Task spec file is missing: ${sourceOrderPath}`);
+}
+
+function buildInvalidTaskSpecError(sourceOrderPath: string): Error {
+  return new Error(`Task spec file must be a regular file: ${sourceOrderPath}`);
+}
+
+export function readTaskSpecFile(sourceOrderPath: string): string {
+  let fileDescriptor: number | undefined;
+  try {
+    const sourceStats = fs.lstatSync(sourceOrderPath);
+    if (!sourceStats.isFile()) {
+      throw buildInvalidTaskSpecError(sourceOrderPath);
+    }
+
+    fileDescriptor = fs.openSync(sourceOrderPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    const descriptorStats = fs.fstatSync(fileDescriptor);
+    if (!descriptorStats.isFile()) {
+      throw buildInvalidTaskSpecError(sourceOrderPath);
+    }
+
+    return fs.readFileSync(fileDescriptor, 'utf-8');
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === 'ENOENT') {
+      throw buildMissingTaskSpecError(sourceOrderPath);
+    }
+    if (errorCode === 'ELOOP') {
+      throw buildInvalidTaskSpecError(sourceOrderPath);
+    }
+    throw error;
+  } finally {
+    if (fileDescriptor !== undefined) {
+      fs.closeSync(fileDescriptor);
+    }
+  }
+}

--- a/src/infra/task/clone.ts
+++ b/src/infra/task/clone.ts
@@ -78,7 +78,26 @@ export class CloneManager {
         : path.resolve(projectDir, options.worktree);
     }
 
-    return path.join(CloneManager.resolveCloneBaseDir(projectDir), dirName);
+    return CloneManager.resolveAvailableClonePath(
+      CloneManager.resolveCloneBaseDir(projectDir),
+      dirName,
+    );
+  }
+
+  private static resolveAvailableClonePath(baseDir: string, dirName: string): string {
+    const firstCandidate = path.join(baseDir, dirName);
+    if (!fs.existsSync(firstCandidate)) {
+      return firstCandidate;
+    }
+
+    for (let suffix = 2; suffix <= 100; suffix += 1) {
+      const candidate = path.join(baseDir, `${dirName}-${suffix}`);
+      if (!fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw new Error(`Unable to allocate clone path in ${baseDir} for ${dirName}`);
   }
 
   private static resolveBranchName(options: WorktreeOptions): string {
@@ -204,7 +223,10 @@ export class CloneManager {
     CloneManager.resolveBaseBranch(projectDir);
 
     const timestamp = CloneManager.generateTimestamp();
-    const clonePath = path.join(CloneManager.resolveCloneBaseDir(projectDir), `tmp-${timestamp}`);
+    const clonePath = CloneManager.resolveAvailableClonePath(
+      CloneManager.resolveCloneBaseDir(projectDir),
+      `tmp-${timestamp}`,
+    );
 
     log.info('Creating temp clone for branch', { path: clonePath, branch });
 

--- a/src/infra/task/runner.ts
+++ b/src/infra/task/runner.ts
@@ -124,8 +124,9 @@ export class TaskRunner {
     retryNote?: string,
     resumePoint?: WorkflowResumePoint,
     workflow?: string,
+    taskDir?: string,
   ): string {
-    return this.retry.requeueTask(taskRef, allowedStatuses, startStep, retryNote, resumePoint, workflow);
+    return this.retry.requeueTask(taskRef, allowedStatuses, startStep, retryNote, resumePoint, workflow, taskDir);
   }
 
   startReExecution(
@@ -135,8 +136,9 @@ export class TaskRunner {
     retryNote?: string,
     resumePoint?: WorkflowResumePoint,
     workflow?: string,
+    taskDir?: string,
   ): TaskInfo {
-    return this.retry.startReExecution(taskRef, allowedStatuses, startStep, retryNote, resumePoint, workflow);
+    return this.retry.startReExecution(taskRef, allowedStatuses, startStep, retryNote, resumePoint, workflow, taskDir);
   }
 
   deleteTask(name: string, kind: 'pending' | 'failed' | 'completed' | 'exceeded' | 'pr_failed'): void {

--- a/src/infra/task/taskRecordMutations.ts
+++ b/src/infra/task/taskRecordMutations.ts
@@ -72,10 +72,16 @@ export function buildRetryTaskRecord(
   retryNote: string | undefined,
   resumePoint: WorkflowResumePoint | undefined,
   workflow: string | undefined,
+  taskDir: string | undefined,
 ): TaskRecord {
+  const taskSpecSource = taskDir
+    ? { content: undefined, content_file: undefined, task_dir: taskDir }
+    : {};
+
   return {
     ...task,
     ...(workflow ? { workflow } : {}),
+    ...taskSpecSource,
     status,
     started_at: status === 'running' ? nowIso() : null,
     completed_at: null,

--- a/src/infra/task/taskRetryService.ts
+++ b/src/infra/task/taskRetryService.ts
@@ -32,6 +32,7 @@ export class TaskRetryService {
     retryNote?: string,
     resumePoint?: WorkflowResumePoint,
     workflow?: string,
+    taskDir?: string,
   ): TaskInfo {
     const taskName = normalizeTaskRef(taskRef);
     let found: TaskRecord | undefined;
@@ -47,7 +48,7 @@ export class TaskRetryService {
       }
 
       const target = current.tasks[index]!;
-      const updated = buildRetryTaskRecord(target, 'running', startStep, retryNote, resumePoint, workflow);
+      const updated = buildRetryTaskRecord(target, 'running', startStep, retryNote, resumePoint, workflow, taskDir);
 
       found = updated;
       return { tasks: replaceTaskAtIndex(current.tasks, index, updated) };
@@ -63,6 +64,7 @@ export class TaskRetryService {
     retryNote?: string,
     resumePoint?: WorkflowResumePoint,
     workflow?: string,
+    taskDir?: string,
   ): string {
     const taskName = normalizeTaskRef(taskRef);
 
@@ -77,7 +79,7 @@ export class TaskRetryService {
       }
 
       const target = current.tasks[index]!;
-      const updated = buildRetryTaskRecord(target, 'pending', startStep, retryNote, resumePoint, workflow);
+      const updated = buildRetryTaskRecord(target, 'pending', startStep, retryNote, resumePoint, workflow, taskDir);
 
       return { tasks: replaceTaskAtIndex(current.tasks, index, updated) };
     });


### PR DESCRIPTION
## Summary

## 概要

インタラクティブ入力中にクリップボード画像を貼り付けたとき、会話本文には `[Image #N]` のような参照を挿入し、画像ファイルは task 添付として扱えるようにしたい。

最初の実装では provider API へ画像を multimodal input として直接渡すことは扱わない。画像はファイルとして保存し、指示書には相対パスを記載して、provider/agent がそのファイルを読む前提にする。

## 背景

現在は、Codex の `[Image #1]` のように、インタラクティブな指示作成中に画像を貼り付けて、その画像を最終的な指示書へ含める仕組みがない。

TAKT では `/go` 前の会話中はまだ task も run も存在しないため、画像を `.takt/tasks` や `.takt/runs` に直接置くことはできない。

## 仕様方針

### 1. `/go` 前は OS tmp に保存する

インタラクティブ会話中に貼り付けた画像は、OS の tmp 配下に TAKT セッション用の一時ディレクトリを作って保存する。

例:

```text
$TMPDIR/takt/<session-id>/attachments/image-1.png
$TMPDIR/takt/<session-id>/attachments/image-2.png
```

この一時領域は永続データではない。`/go` せずにキャンセルした場合やプロセス終了後に消えてもよい。

### 2. 会話本文には placeholder を挿入する

画像貼り付け時、入力欄または会話本文には次のような placeholder を挿入する。

```text
[Image #1]
```

内部的には `[Image #1]` と tmp 上の実ファイルを対応付けて保持する。

### 3. `/go` で task 化するときに attachments へ昇格する

`/go` により正式な task を作成する時点で、tmp 上の画像を task directory へ移動またはコピーする。

例:

```text
.takt/tasks/<task-id>/
  order.md
  attachments/
    image-1.png
    image-2.png
```

生成される `order.md` には、指示書からの相対パスで添付画像を記載する。

例:

```md
## 添付画像

- [Image #1]: `attachments/image-1.png`
- [Image #2]: `attachments/image-2.png`
```

相対パスにすることで、task directory と run context の両方で同じ `order.md` が成立するようにする。

### 4. run context へ attachments をコピーする

`takt run` 時は、`order.md` だけでなく `attachments/` も run context へコピーする。

例:

```text
<takt-worktree>/.takt/runs/<run-id>/context/task/
  order.md
  attachments/
    image-1.png
    image-2.png
```

provider/agent は `order.md` 内の `attachments/image-1.png` を読めば画像を確認できる。

## 非目的

- `/go` 前のインタラクティブ会話と添付画像を永続復元すること
- tmp 上の画像を長期間保持すること
- 初回実装で provider API へ画像を multimodal input として直接渡すこと
- GitHub Issue 上で画像を GitHub attachment URL に変換すること

GitHub Issue への画像アップロードや multimodal input 直渡しは、必要になれば別 Issue として扱う。

## 受け入れ条件

- インタラクティブ入力中に画像を貼り付けると `[Image #N]` が挿入される
- `/go` 前の画像ファイルは OS tmp 配下の TAKT セッション一時領域に保存される
- `/go` で task を作ると、画像が `.takt/tasks/<task-id>/attachments/` に移動またはコピーされる
- 生成される `order.md` に `attachments/image-N.png` の相対パスが記載される
- `takt run` 時に task attachments が run context へコピーされる
- provider/agent が run context 内の相対パスから画像を読める
- `/go` せずキャンセルした一時画像は正式な task 資産として残らない

## Execution Report

Workflow `takt-default` completed successfully.

Closes #751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 対話モードで端末から画像貼付が可能に。貼付画像はセッションごとに安全に保存され、実行・保存・イシュー作成・リトライ等の操作で添付として引き継がれます。
* **Behavior Changes**
  * 添付画像の永続化・昇格・番号付け・検証が強化され、不正なパスやシンボリックリンクは拒否されます。実行レポート名とクローン先は衝突回避で一意化されます。
* **Tests**
  * インライン貼付解析、セッション添付保存、添付付きの保存/実行/リトライ動作を網羅する多数のテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->