### PR TITLE
fix: route TAKT review-fix supervisor findings

### DIFF
--- a/builtins/en/workflows/review-fix-takt-default.yaml
+++ b/builtins/en/workflows/review-fix-takt-default.yaml
@@ -1,5 +1,5 @@
 name: review-fix-takt-default
-description: "TAKT-focused multi-perspective review + fix loop (6-parallel initial review, AI antipattern pre-review on fix iterations)"
+description: "TAKT-focused multi-perspective review + fix loop (6-parallel initial review, AI antipattern pre-review on fix iterations, supervisor-finding fixes)"
 workflow_config:
   provider_options:
     codex:
@@ -334,7 +334,7 @@ steps:
       - condition: All checks passed
         next: COMPLETE
       - condition: Requirements unmet, tests failing, build errors
-        next: ABORT
+        next: fix_supervisor
     output_contracts:
       report:
         - name: supervisor-validation.md
@@ -342,3 +342,31 @@ steps:
         - name: summary.md
           format: summary
           use_judge: false
+  - name: fix_supervisor
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+    knowledge:
+      - takt
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+          - WebSearch
+          - WebFetch
+    required_permission_mode: edit
+    instruction: fix-supervisor
+    pass_previous_response: false
+    rules:
+      - condition: Fixes for supervisor findings complete
+        next: supervise
+      - condition: Unable to proceed with fixes
+        next: supervise

--- a/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -1,5 +1,5 @@
 name: review-fix-takt-default
-description: TAKT開発向け多角レビュー＋修正ループ（初回6並列レビュー、修正後はAIアンチパターン事前レビュー＋5並列レビュー）
+description: TAKT開発向け多角レビュー＋修正ループ（初回6並列レビュー、修正後はAIアンチパターン事前レビュー＋5並列レビュー、監督者指摘の再修正）
 workflow_config:
   provider_options:
     codex:
@@ -334,7 +334,7 @@ steps:
       - condition: すべて問題なし
         next: COMPLETE
       - condition: 要求未達成、テスト失敗、ビルドエラー
-        next: ABORT
+        next: fix_supervisor
     output_contracts:
       report:
         - name: supervisor-validation.md
@@ -342,3 +342,31 @@ steps:
         - name: summary.md
           format: summary
           use_judge: false
+  - name: fix_supervisor
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+    knowledge:
+      - takt
+      - architecture
+    provider_options:
+      claude:
+        allowed_tools:
+          - Read
+          - Glob
+          - Grep
+          - Edit
+          - Write
+          - Bash
+          - WebSearch
+          - WebFetch
+    required_permission_mode: edit
+    instruction: fix-supervisor
+    pass_previous_response: false
+    rules:
+      - condition: 監督者の指摘に対する修正が完了した
+        next: supervise
+      - condition: 修正を進行できない
+        next: supervise

--- a/src/__tests__/it-workflow-patterns.test.ts
+++ b/src/__tests__/it-workflow-patterns.test.ts
@@ -564,6 +564,65 @@ describe('Workflow Patterns IT: review-fix workflow', () => {
 
     expect(state.status).toBe('completed');
   });
+
+  it('all review-fix workflows route supervisor findings through fix_supervisor', () => {
+    const workflowNames = [
+      'review-fix-default',
+      'review-fix-frontend',
+      'review-fix-backend',
+      'review-fix-dual',
+      'review-fix-backend-cqrs',
+      'review-fix-dual-cqrs',
+      'review-fix-takt-default',
+    ];
+
+    for (const workflowName of workflowNames) {
+      const config = loadWorkflow(workflowName, testDir);
+      expect(config, `${workflowName} should load`).not.toBeNull();
+
+      const supervise = config!.steps.find((step) => step.name === 'supervise');
+      expect(supervise, `${workflowName} should define supervise`).toBeDefined();
+      expect(
+        supervise?.rules?.some((rule) => rule.next === 'fix_supervisor'),
+        `${workflowName} supervise should route findings to fix_supervisor`,
+      ).toBe(true);
+
+      const fixSupervisor = config!.steps.find((step) => step.name === 'fix_supervisor');
+      expect(fixSupervisor, `${workflowName} should define fix_supervisor`).toBeDefined();
+      expect(fixSupervisor?.rules?.length, `${workflowName} fix_supervisor should have rules`).toBeGreaterThan(0);
+      expect(
+        fixSupervisor?.rules?.every((rule) => rule.next === 'supervise'),
+        `${workflowName} fix_supervisor should return to supervise`,
+      ).toBe(true);
+    }
+  });
+
+  it('TAKT review-fix supervisor path: supervise detects issues → fix_supervisor → supervise → COMPLETE', async () => {
+    const config = loadWorkflow('review-fix-takt-default', testDir);
+    expect(config).not.toBeNull();
+
+    setMockScenario([
+      { persona: 'planner', status: 'done', content: '[GATHER:1]\n\nReview target gathered.' },
+      // 6 parallel reviewers: all approved
+      { persona: 'architecture-reviewer', status: 'done', content: 'approved' },
+      { persona: 'security-reviewer', status: 'done', content: 'approved' },
+      { persona: 'qa-reviewer', status: 'done', content: 'approved' },
+      { persona: 'testing-reviewer', status: 'done', content: 'approved' },
+      { persona: 'ai-antipattern-reviewer', status: 'done', content: 'approved' },
+      { persona: 'requirements-reviewer', status: 'done', content: 'approved' },
+      // Supervisor: issues detected -> fix_supervisor
+      { persona: 'supervisor', status: 'done', content: '[SUPERVISE:2]\n\nRequirements unmet, tests failing, build errors.' },
+      // fix_supervisor: fixes complete -> back to supervise
+      { persona: 'coder', status: 'done', content: '[FIX_SUPERVISOR:1]\n\nFixes for supervisor findings complete.' },
+      // Supervisor: ready to merge
+      { persona: 'supervisor', status: 'done', content: '[SUPERVISE:1]\n\nAll checks passed.' },
+    ]);
+
+    const engine = createEngine(config!, testDir, 'Review TAKT PR');
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+  });
 });
 
 describe('Workflow Patterns IT: frontend-review-fix workflow (fix loop)', () => {


### PR DESCRIPTION
## Summary

- route review-fix-takt-default supervisor failures to fix_supervisor instead of aborting
- add ja/en fix_supervisor steps for the TAKT review-fix workflow
- add workflow pattern coverage for all review-fix supervisor remediation loops

## Verification

- npm test -- --run src/__tests__/it-workflow-patterns.test.ts
- npm test -- --run
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワークフローにスーパーバイザーからの指摘に対する専用の修正ステップを追加しました。エラー時に自動中止せず、修正ループで対応できるようになります。

* **テスト**
  * ワークフローの新しい修正ロジックを検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->