### PR TITLE
fix: detect claude-terminal prompt with v2.1 placeholder hint

### DIFF
--- a/src/__tests__/claude-terminal-tmux-backend.test.ts
+++ b/src/__tests__/claude-terminal-tmux-backend.test.ts
@@ -198,6 +198,50 @@ describe('TmuxTerminalBackend', () => {
     ]);
   });
 
+  it('Given Claude trust dialog with numbered menu, When pasteText is called, Then trust dialog is not treated as ready and prompt is only pasted after transition to real input', async () => {
+    const backend = new TmuxTerminalBackend();
+    const stdinWrites: string[] = [];
+    const trustDialogPane = [
+      '────────────────────────────────────────',
+      '❯ 1. Yes, I trust this folder',
+      '  2. No, exit',
+    ].join('\n');
+    const realReadyPane = [
+      '────────────────────────────────────────',
+      '❯ Try "refactor routing.ts"',
+      '────────────────────────────────────────',
+    ].join('\n');
+    const capturedPanes = [
+      trustDialogPane,
+      trustDialogPane,
+      realReadyPane,
+      realReadyPane,
+      'pasted prompt',
+    ];
+    mockSpawn.mockImplementation(() => createSpawnChild(stdinWrites, 0, ''));
+    mockExecFile.mockImplementation((_file, args, _options, callback) => {
+      if (args[0] === 'capture-pane') {
+        callback(null, { stdout: capturedPanes.shift() ?? 'pasted prompt', stderr: '' });
+        return;
+      }
+      callback(null, { stdout: '', stderr: '' });
+    });
+
+    await backend.pasteText({ id: 'tmux-session', name: 'takt-session' }, 'implement task');
+
+    expect(stdinWrites).toEqual(['implement task']);
+    expect(mockExecFile.mock.calls.map((call) => call[1][0])).toEqual([
+      'capture-pane',
+      'capture-pane',
+      'capture-pane',
+      'capture-pane',
+      'paste-buffer',
+      'capture-pane',
+      'send-keys',
+      'delete-buffer',
+    ]);
+  });
+
   it('Given Claude v2.1 pane with placeholder hint after prompt char, When pasteText is called, Then prompt is detected as ready', async () => {
     const backend = new TmuxTerminalBackend();
     const stdinWrites: string[] = [];

--- a/src/__tests__/claude-terminal-tmux-backend.test.ts
+++ b/src/__tests__/claude-terminal-tmux-backend.test.ts
@@ -198,6 +198,42 @@ describe('TmuxTerminalBackend', () => {
     ]);
   });
 
+  it('Given Claude v2.1 pane with placeholder hint after prompt char, When pasteText is called, Then prompt is detected as ready', async () => {
+    const backend = new TmuxTerminalBackend();
+    const stdinWrites: string[] = [];
+    const v21ReadyPane = [
+      '────────────────────────────────────────',
+      '❯ Try "refactor routing.ts"',
+      '────────────────────────────────────────',
+      '  ⏵⏵ auto mode on · ◉ xhigh · /effort',
+    ].join('\n');
+    const capturedPanes = [
+      v21ReadyPane,
+      v21ReadyPane,
+      'implement task',
+    ];
+    mockSpawn.mockImplementation(() => createSpawnChild(stdinWrites, 0, ''));
+    mockExecFile.mockImplementation((_file, args, _options, callback) => {
+      if (args[0] === 'capture-pane') {
+        callback(null, { stdout: capturedPanes.shift() ?? 'implement task', stderr: '' });
+        return;
+      }
+      callback(null, { stdout: '', stderr: '' });
+    });
+
+    await backend.pasteText({ id: 'tmux-session', name: 'takt-session' }, 'implement task');
+
+    expect(stdinWrites).toEqual(['implement task']);
+    expect(mockExecFile.mock.calls.map((call) => call[1][0])).toEqual([
+      'capture-pane',
+      'capture-pane',
+      'paste-buffer',
+      'capture-pane',
+      'send-keys',
+      'delete-buffer',
+    ]);
+  });
+
   it('Given tmux paste-buffer fails after loading prompt, When pasteText rejects, Then tmux buffer is deleted', async () => {
     const backend = new TmuxTerminalBackend();
     const stdinWrites: string[] = [];

--- a/src/infra/claude-terminal/tmux-backend.ts
+++ b/src/infra/claude-terminal/tmux-backend.ts
@@ -13,7 +13,7 @@ const PANE_CHANGE_TIMEOUT_MS = 5000;
 const PANE_POLL_INTERVAL_MS = 100;
 const CLAUDE_READY_TAIL_LINES = 3;
 const CLAUDE_BUSY_PATTERN = /(Running|thinking|Searching|Reading|Writing|Editing|Crunched)/i;
-const CLAUDE_PROMPT_PATTERN = /^[❯❱>](?:\s|$)/;
+const CLAUDE_PROMPT_PATTERN = /^[❯❱>](?:\s+(?!\d+\.\s)|$)/;
 
 function getProperty(error: object, property: string): unknown {
   return (error as Record<string, unknown>)[property];

--- a/src/infra/claude-terminal/tmux-backend.ts
+++ b/src/infra/claude-terminal/tmux-backend.ts
@@ -13,7 +13,7 @@ const PANE_CHANGE_TIMEOUT_MS = 5000;
 const PANE_POLL_INTERVAL_MS = 100;
 const CLAUDE_READY_TAIL_LINES = 3;
 const CLAUDE_BUSY_PATTERN = /(Running|thinking|Searching|Reading|Writing|Editing|Crunched)/i;
-const CLAUDE_PROMPT_PATTERN = /^[❯❱>]$/;
+const CLAUDE_PROMPT_PATTERN = /^[❯❱>](?:\s|$)/;
 
 function getProperty(error: object, property: string): unknown {
   return (error as Record<string, unknown>)[property];


### PR DESCRIPTION
## Summary

- `provider: claude-terminal` の tmux backend が Claude Code v2.1.x のプロンプト UI と非互換で、入力欄を検出できず 60s で `Timed out waiting for Claude terminal input prompt.` と落ちる問題を修正
- 検出パターン `^[❯❱>]$` を `^[❯❱>](?:\s|$)` に緩和し、`❯ Try "..."` 形式でも ready と判定されるように
- 同パターンに対する回帰テストを追加

Refs #765

## 背景

Claude Code v2.0 系では tmux pane 末尾に `❯` 単独の行が出ていたが、v2.1.x で入力欄が `❯ Try "refactor routing.ts"` のようなプレースホルダ付き表記に変わった（pane の hex dump で `e2 9d af  c2 a0  54 72 79 ...` を確認）。`isClaudeInputReady` は `.trim()` 後の各行が `^[❯❱>]$` に完全一致するかを見ていたため、v2.1 以降では永久に ready と判定されなくなっていた。

BUSY 判定 (`Running|thinking|Searching|Reading|Writing|Editing|Crunched`) は別途行われており、プレースホルダ文字列 (`Try ...`) はそのいずれにも一致しないため、緩和による誤検出は発生しない。

## Test plan

- [x] `npm run build` 成功
- [x] `npm run lint` 成功
- [x] `npm test`: 6154 tests passed
- [x] `npm run test:e2e:mock`: 107 tests passed
- [x] 新規回帰テスト `Given Claude v2.1 pane with placeholder hint after prompt char, ...` が通る
- [ ] reviewer 側で実環境 (Claude Code v2.1.x + tmux) における `takt --pipeline -t "..." -w default` の通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Claude v2.1 環境でのプロンプト認識を改善しました。プロンプト直後の空白やヒント表示を正しく扱い、入力準備の検出が安定します。
* 貼り付け動作に関する追加テストを導入し、信頼ダイアログ表示時やプロンプト直後のヒントがある場合でも期待どおりに入力が渡されることを検証しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->