### PR TITLE
[#768] fix-parallel-review-errors

### DIFF
--- a/src/__tests__/engine-parallel-failure.test.ts
+++ b/src/__tests__/engine-parallel-failure.test.ts
@@ -1,16 +1,6 @@
-/**
- * WorkflowEngine integration tests: parallel step partial failure handling.
- *
- * Covers:
- * - One sub-step fails while another succeeds → workflow continues
- * - All sub-steps fail → workflow aborts
- * - Failed sub-step is recorded as error with error message
- */
-
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync } from 'node:fs';
-
-// --- Mock setup (must be before imports that use these modules) ---
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 
 vi.mock('../agents/runner.js', () => ({
   runAgent: vi.fn(),
@@ -31,12 +21,11 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
 }));
 
-// --- Imports (after mocks) ---
-
 import { WorkflowEngine } from '../core/workflow/index.js';
 import { runAgent } from '../agents/runner.js';
 import { detectMatchedRule } from '../core/workflow/evaluation/index.js';
 import { needsStatusJudgmentPhase, runStatusJudgmentPhase } from '../core/workflow/phase-runner.js';
+import { initDebugLogger, resetDebugLogger } from '../shared/utils/index.js';
 import {
   makeResponse,
   makeStep,
@@ -47,10 +36,6 @@ import {
 } from './engine-test-helpers.js';
 import type { WorkflowConfig } from '../core/models/index.js';
 
-/**
- * Build a workflow config that goes directly to a parallel step:
- * parallel-step (arch-review + security-review) → done
- */
 function buildParallelOnlyConfig(): WorkflowConfig {
   return {
     name: 'test-parallel-failure',
@@ -62,26 +47,26 @@ function buildParallelOnlyConfig(): WorkflowConfig {
         parallel: [
           makeStep('arch-review', {
             rules: [
-              makeRule('done', 'COMPLETE'),
+              makeRule('approved', 'COMPLETE'),
               makeRule('needs_fix', 'fix'),
             ],
           }),
           makeStep('security-review', {
             rules: [
-              makeRule('done', 'COMPLETE'),
+              makeRule('approved', 'COMPLETE'),
               makeRule('needs_fix', 'fix'),
             ],
           }),
         ],
         rules: [
-          makeRule('any("done")', 'done', {
-            isAggregateCondition: true,
-            aggregateType: 'any',
-            aggregateConditionText: 'done',
-          }),
-          makeRule('all("needs_fix")', 'fix', {
+          makeRule('all("approved")', 'done', {
             isAggregateCondition: true,
             aggregateType: 'all',
+            aggregateConditionText: 'approved',
+          }),
+          makeRule('any("needs_fix")', 'fix', {
+            isAggregateCondition: true,
+            aggregateType: 'any',
             aggregateConditionText: 'needs_fix',
           }),
         ],
@@ -110,64 +95,67 @@ describe('WorkflowEngine Integration: Parallel Step Partial Failure', () => {
   });
 
   afterEach(() => {
+    resetDebugLogger();
     if (existsSync(tmpDir)) {
       rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
-  it('should continue when one sub-step fails but another succeeds', async () => {
+  it('should abort with parent error when one sub-step rejects and another approves', async () => {
     const config = buildParallelOnlyConfig();
     const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
 
     const mock = vi.mocked(runAgent);
-    // arch-review fails (exit code 1)
     mock.mockRejectedValueOnce(new Error('Claude Code process exited with code 1'));
-    // security-review succeeds
     mock.mockImplementationOnce(async (persona, task, options) => {
       options?.onPromptResolved?.({
         systemPrompt: typeof persona === 'string' ? persona : '',
         userInstruction: task,
       });
-      return makeResponse({ persona: 'security-review', content: 'Security review passed' });
-    });
-    // done step
-    mock.mockImplementationOnce(async (persona, task, options) => {
-      options?.onPromptResolved?.({
-        systemPrompt: typeof persona === 'string' ? persona : '',
-        userInstruction: task,
-      });
-      return makeResponse({ persona: 'done', content: 'Completed' });
+      return makeResponse({ persona: 'security-review', content: '[SECURITY-REVIEW:1] approved' });
     });
 
     mockDetectMatchedRuleSequence([
-      // security-review sub-step rule match (arch-review has no match — it failed)
-      { index: 0, method: 'phase1_tag' },  // security-review → done
-      { index: 0, method: 'aggregate' },   // reviewers → any("done") matches
-      { index: 0, method: 'phase1_tag' },  // done → COMPLETE
+      { index: 0, method: 'phase1_tag' },
     ]);
+
+    const abortFn = vi.fn();
+    engine.on('workflow:abort', abortFn);
 
     const state = await engine.run();
 
-    expect(state.status).toBe('completed');
+    expect(state.status).toBe('aborted');
+    expect(abortFn).toHaveBeenCalledOnce();
+    const reason = abortFn.mock.calls[0]![1] as string;
+    expect(reason).toContain('Step "reviewers" failed');
+    expect(reason).toContain('arch-review');
+    expect(reason).toContain('Claude Code process exited with code 1');
+    expect(reason).not.toContain('Status not found for step "reviewers"');
 
-    // arch-review should be recorded as error
+    const reviewersOutput = state.stepOutputs.get('reviewers');
+    expect(reviewersOutput).toBeDefined();
+    expect(reviewersOutput!.status).toBe('error');
+    expect(reviewersOutput!.content).toContain('arch-review');
+    expect(reviewersOutput!.content).toContain('status: error');
+    expect(reviewersOutput!.content).toContain('failureCategory: none');
+    expect(reviewersOutput!.content).toContain('Claude Code process exited with code 1');
+    expect(reviewersOutput!.content).toContain('aggregate');
+
     const archReviewOutput = state.stepOutputs.get('arch-review');
     expect(archReviewOutput).toBeDefined();
     expect(archReviewOutput!.status).toBe('error');
     expect(archReviewOutput!.error).toContain('exit');
 
-    // security-review should be recorded as done
     const securityReviewOutput = state.stepOutputs.get('security-review');
     expect(securityReviewOutput).toBeDefined();
     expect(securityReviewOutput!.status).toBe('done');
   });
 
-  it('should abort when all sub-steps fail', async () => {
+  it('should report all rejected sub-step errors through the parent error response', async () => {
     const config = buildParallelOnlyConfig();
     const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
 
     const mock = vi.mocked(runAgent);
-    // Both fail
     mock.mockRejectedValueOnce(new Error('Claude Code process exited with code 1'));
     mock.mockRejectedValueOnce(new Error('Claude Code process exited with code 1'));
 
@@ -179,10 +167,20 @@ describe('WorkflowEngine Integration: Parallel Step Partial Failure', () => {
     expect(state.status).toBe('aborted');
     expect(abortFn).toHaveBeenCalledOnce();
     const reason = abortFn.mock.calls[0]![1] as string;
-    expect(reason).toContain('All parallel sub-steps failed');
+    expect(reason).toContain('Step "reviewers" failed');
+    expect(reason).toContain('arch-review');
+    expect(reason).toContain('security-review');
+    expect(reason).not.toContain('All parallel sub-steps failed');
+
+    const reviewersOutput = state.stepOutputs.get('reviewers');
+    expect(reviewersOutput).toBeDefined();
+    expect(reviewersOutput!.status).toBe('error');
+    expect(reviewersOutput!.content).toContain('arch-review');
+    expect(reviewersOutput!.content).toContain('security-review');
+    expect(reviewersOutput!.content).toContain('status: error');
   });
 
-  it('should preserve the rate limit message in workflow abort reason when all sub-steps fail with it', async () => {
+  it('should preserve rejected sub-step error detail in the parent diagnostic', async () => {
     const config = buildParallelOnlyConfig();
     const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
 
@@ -198,8 +196,12 @@ describe('WorkflowEngine Integration: Parallel Step Partial Failure', () => {
     expect(state.status).toBe('aborted');
     expect(abortFn).toHaveBeenCalledOnce();
     const reason = abortFn.mock.calls[0]![1] as string;
-    expect(reason).toContain('All parallel sub-steps failed');
     expect(reason).toContain('Rate limit exceeded. Please try again later.');
+    expect(reason).not.toContain('Status not found for step "reviewers"');
+
+    const reviewersOutput = state.stepOutputs.get('reviewers');
+    expect(reviewersOutput).toBeDefined();
+    expect(reviewersOutput!.content).toContain('Rate limit exceeded. Please try again later.');
   });
 
   it('should record failed sub-step error message in stepOutputs', async () => {
@@ -213,19 +215,10 @@ describe('WorkflowEngine Integration: Parallel Step Partial Failure', () => {
         systemPrompt: typeof persona === 'string' ? persona : '',
         userInstruction: task,
       });
-      return makeResponse({ persona: 'security-review', content: 'OK' });
-    });
-    mock.mockImplementationOnce(async (persona, task, options) => {
-      options?.onPromptResolved?.({
-        systemPrompt: typeof persona === 'string' ? persona : '',
-        userInstruction: task,
-      });
-      return makeResponse({ persona: 'done', content: 'Done' });
+      return makeResponse({ persona: 'security-review', content: '[SECURITY-REVIEW:1] approved' });
     });
 
     mockDetectMatchedRuleSequence([
-      { index: 0, method: 'phase1_tag' },
-      { index: 0, method: 'aggregate' },
       { index: 0, method: 'phase1_tag' },
     ]);
 
@@ -235,6 +228,110 @@ describe('WorkflowEngine Integration: Parallel Step Partial Failure', () => {
     expect(archReviewOutput).toBeDefined();
     expect(archReviewOutput!.error).toBe('Session resume failed');
     expect(archReviewOutput!.content).toBe('');
+
+    const reviewersOutput = state.stepOutputs.get('reviewers');
+    expect(reviewersOutput).toBeDefined();
+    expect(reviewersOutput!.status).toBe('error');
+    expect(reviewersOutput!.error).toContain('Session resume failed');
+  });
+
+  it('should redact sensitive rejected sub-step error detail from parent abort reason', async () => {
+    const config = buildParallelOnlyConfig();
+    const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+    const debugLogFile = join(tmpDir, 'parallel-debug.log');
+    initDebugLogger({ enabled: true, logFile: debugLogFile }, tmpDir);
+
+    const mock = vi.mocked(runAgent);
+    mock.mockRejectedValueOnce(new Error('Provider failed with api_key=top-secret and Authorization: Bearer sk-secret123456'));
+    mock.mockImplementationOnce(async (persona, task, options) => {
+      options?.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({ persona: 'security-review', content: '[SECURITY-REVIEW:1] approved' });
+    });
+
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' },
+    ]);
+
+    const abortFn = vi.fn();
+    engine.on('workflow:abort', abortFn);
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('aborted');
+    expect(abortFn).toHaveBeenCalledOnce();
+    const reason = abortFn.mock.calls[0]![1] as string;
+    expect(reason).toContain('api_key=[REDACTED]');
+    expect(reason).toContain('Authorization: Bearer [REDACTED]');
+    expect(reason).not.toContain('top-secret');
+    expect(reason).not.toContain('sk-secret123456');
+
+    const reviewersOutput = state.stepOutputs.get('reviewers');
+    expect(reviewersOutput?.error).toBe(reviewersOutput?.content);
+    expect(reviewersOutput?.content).not.toContain('top-secret');
+    expect(reviewersOutput?.content).not.toContain('sk-secret123456');
+
+    const debugLog = readFileSync(debugLogFile, 'utf-8');
+    expect(debugLog).toContain('api_key=[REDACTED]');
+    expect(debugLog).toContain('Authorization: Bearer [REDACTED]');
+    expect(debugLog).not.toContain('top-secret');
+    expect(debugLog).not.toContain('sk-secret123456');
+  });
+
+  it('should promote a blocked sub-step to blocked parent response', async () => {
+    const config = buildParallelOnlyConfig();
+    const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+
+    const mock = vi.mocked(runAgent);
+    mock.mockImplementationOnce(async (persona, task, options) => {
+      options?.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({
+        persona: 'arch-review',
+        status: 'blocked',
+        content: 'Need user clarification before review can continue',
+      });
+    });
+    mock.mockImplementationOnce(async (persona, task, options) => {
+      options?.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({ persona: 'security-review', content: '[SECURITY-REVIEW:1] approved' });
+    });
+
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' },
+    ]);
+
+    const blockedFn = vi.fn();
+    const abortFn = vi.fn();
+    engine.on('step:blocked', blockedFn);
+    engine.on('workflow:abort', abortFn);
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('aborted');
+    expect(blockedFn).toHaveBeenCalledOnce();
+    expect(abortFn).toHaveBeenCalledOnce();
+
+    const reviewersOutput = state.stepOutputs.get('reviewers');
+    expect(reviewersOutput).toBeDefined();
+    expect(reviewersOutput!.status).toBe('blocked');
+    expect(reviewersOutput!.content).toContain('arch-review');
+    expect(reviewersOutput!.content).toContain('status: blocked');
+    expect(reviewersOutput!.content).toContain('failureCategory: none');
+    expect(reviewersOutput!.content).toContain('Need user clarification before review can continue');
+    expect(reviewersOutput!.content).toContain('aggregate');
+    expect(state.previousResponseSourcePath).toMatch(
+      /^\.takt\/runs\/test-report-dir\/context\/previous_responses\/reviewers\.1\.\d{8}T\d{6}Z\.md$/,
+    );
+    const snapshot = readFileSync(join(tmpDir, state.previousResponseSourcePath!), 'utf-8');
+    expect(snapshot).toBe(reviewersOutput!.content);
   });
 
   it('should fallback to phase1 rule evaluation when sub-step phase3 throws', async () => {
@@ -275,9 +372,9 @@ describe('WorkflowEngine Integration: Parallel Step Partial Failure', () => {
     });
 
     mockDetectMatchedRuleSequence([
-      { index: 0, method: 'phase1_tag' }, // arch-review fallback
-      { index: 0, method: 'aggregate' },  // reviewers aggregate
-      { index: 0, method: 'phase1_tag' }, // done -> COMPLETE
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'aggregate' },
+      { index: 0, method: 'phase1_tag' },
     ]);
 
     const state = await engine.run();

--- a/src/__tests__/engine-rate-limit-fallback.test.ts
+++ b/src/__tests__/engine-rate-limit-fallback.test.ts
@@ -63,7 +63,7 @@ function makeRateLimitedResponse(
 ): AgentResponse {
   return makeResponse({
     persona: 'plan',
-    status: 'rate_limited' as never,
+    status: 'rate_limited',
     content: '',
     error: 'Rate limit exceeded. Please try again later.',
     errorKind: 'rate_limit',
@@ -639,7 +639,6 @@ describe('WorkflowEngine rate limit fallback', () => {
   });
 
   it('parallel sub-step が rate_limited の場合は all-failed abort ではなく fallback provider で再実行する', async () => {
-    // Given
     const engine = new WorkflowEngine(parallelStepConfig(), tmpDir, 'test task', createEngineOptions(tmpDir, {
       rateLimitFallback: {
         switchChain: [{ provider: 'codex', model: 'gpt-5' }],
@@ -657,10 +656,8 @@ describe('WorkflowEngine rate limit fallback', () => {
       { index: 0, method: 'aggregate' },
     ]);
 
-    // When
     const state = await engine.run();
 
-    // Then
     expect(state.status).toBe('completed');
     expect(state.iteration).toBe(1);
     expect(state.stepIterations.get('reviewers')).toBe(1);
@@ -673,9 +670,17 @@ describe('WorkflowEngine rate limit fallback', () => {
     expect(prompts[2]).toContain('Fallback Execution');
     expect(prompts[2]).toContain('claude');
     expect(prompts[2]).toContain('codex');
+    expect(prompts[2]).toContain('arch-review');
+    expect(prompts[2]).toContain('security-review');
+    expect(prompts[2]).toContain('Aggregate rules were not evaluated');
+    expect(prompts[2]).toContain('Rate limit exceeded. Please try again later.');
     expect(prompts[3]).toContain('Fallback Execution');
     expect(prompts[3]).toContain('claude');
     expect(prompts[3]).toContain('codex');
+    expect(prompts[3]).toContain('arch-review');
+    expect(prompts[3]).toContain('security-review');
+    expect(prompts[3]).toContain('Aggregate rules were not evaluated');
+    expect(prompts[3]).toContain('Rate limit exceeded. Please try again later.');
     expect(runAgent).toHaveBeenCalledTimes(4);
     expect(detectMatchedRule).toHaveBeenCalledTimes(3);
   });

--- a/src/__tests__/engine-rate-limit-report-session.test.ts
+++ b/src/__tests__/engine-rate-limit-report-session.test.ts
@@ -40,7 +40,7 @@ function makeResponse(overrides: Partial<AgentResponse>): AgentResponse {
 
 function makeRateLimitedResponse(): AgentResponse {
   return makeResponse({
-    status: 'rate_limited' as never,
+    status: 'rate_limited',
     content: '',
     error: 'Rate limit exceeded. Please try again later.',
     errorKind: 'rate_limit',

--- a/src/__tests__/engine-workflow-call.test.ts
+++ b/src/__tests__/engine-workflow-call.test.ts
@@ -236,7 +236,7 @@ steps:
     engine = new WorkflowEngine(config, tmpDir, 'Relay rate limit', createWorkflowCallOptions(tmpDir));
     const rateLimited = makeResponse({
       persona: 'reviewer',
-      status: 'rate_limited' as never,
+      status: 'rate_limited',
       content: '',
       error: 'Rate limit exceeded. Please try again later.',
       errorKind: 'rate_limit',
@@ -307,7 +307,7 @@ steps:
     mockRunAgentSequence([
       makeResponse({
         persona: 'reviewer',
-        status: 'rate_limited' as never,
+        status: 'rate_limited',
         content: '',
         error: 'Rate limit exceeded. Please try again later.',
         errorKind: 'rate_limit',
@@ -375,7 +375,7 @@ steps:
     mockRunAgentSequence([
       makeResponse({
         persona: 'reviewer',
-        status: 'rate_limited' as never,
+        status: 'rate_limited',
         content: '',
         error: 'Rate limit exceeded. Please try again later.',
         errorKind: 'rate_limit',

--- a/src/__tests__/parallel-runner-terminal-status.test.ts
+++ b/src/__tests__/parallel-runner-terminal-status.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ParallelRunner, type ParallelRunnerDeps } from '../core/workflow/engine/ParallelRunner.js';
+import type { AgentResponse, WorkflowState, WorkflowStep } from '../core/models/index.js';
+import { makeRule, makeStep } from './test-helpers.js';
+
+vi.mock('../agents/agent-usecases.js', () => ({
+  executeAgent: vi.fn(),
+}));
+
+vi.mock('../core/workflow/evaluation/index.js', () => ({
+  detectMatchedRule: vi.fn(),
+}));
+
+vi.mock('../core/workflow/phase-runner.js', () => ({
+  needsStatusJudgmentPhase: vi.fn().mockReturnValue(false),
+  runReportPhase: vi.fn().mockResolvedValue(undefined),
+  runStatusJudgmentPhase: vi.fn().mockResolvedValue({ tag: '', ruleIndex: 0, method: 'auto_select' }),
+}));
+
+import { executeAgent } from '../agents/agent-usecases.js';
+import { detectMatchedRule } from '../core/workflow/evaluation/index.js';
+
+function makeState(): WorkflowState {
+  return {
+    workflowName: 'test-workflow',
+    currentStep: 'reviewers',
+    iteration: 1,
+    stepOutputs: new Map(),
+    structuredOutputs: new Map(),
+    systemContexts: new Map(),
+    effectResults: new Map(),
+    userInputs: [],
+    personaSessions: new Map(),
+    stepIterations: new Map(),
+    status: 'running',
+  };
+}
+
+function makeAgentResponse(overrides: Partial<AgentResponse>): AgentResponse {
+  return {
+    persona: 'test-agent',
+    status: 'done',
+    content: '[STEP:1] approved',
+    timestamp: new Date('2026-05-29T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function makeReviewStep(name: string): WorkflowStep {
+  return makeStep({
+    name,
+    persona: name,
+    instruction: `Run ${name}`,
+    rules: [
+      makeRule('approved', 'COMPLETE'),
+      makeRule('needs_fix', 'fix'),
+    ],
+  });
+}
+
+function makeParallelStep(): WorkflowStep {
+  return makeStep({
+    name: 'reviewers',
+    instruction: 'Run parallel reviewers',
+    parallel: [
+      makeReviewStep('ai-antipattern-review-2nd'),
+      makeReviewStep('security-review'),
+    ],
+    rules: [
+      makeRule('all("approved")', 'COMPLETE', {
+        isAggregateCondition: true,
+        aggregateType: 'all',
+        aggregateConditionText: 'approved',
+      }),
+      makeRule('any("needs_fix")', 'fix', {
+        isAggregateCondition: true,
+        aggregateType: 'any',
+        aggregateConditionText: 'needs_fix',
+      }),
+    ],
+  });
+}
+
+function makeRunner(): { runner: ParallelRunner; deps: ParallelRunnerDeps } {
+  const deps: ParallelRunnerDeps = {
+    optionsBuilder: {
+      buildAgentOptions: vi.fn().mockReturnValue({}),
+      buildPhaseRunnerContext: vi.fn().mockReturnValue({}),
+      resolveStepProviderModel: vi.fn().mockReturnValue({ provider: 'claude', model: 'claude-sonnet' }),
+    } as unknown as ParallelRunnerDeps['optionsBuilder'],
+    stepExecutor: {
+      buildInstruction: vi.fn((step: WorkflowStep) => `instruction:${step.name}`),
+      emitStepReports: vi.fn(),
+      persistPreviousResponseSnapshot: vi.fn(),
+    } as unknown as ParallelRunnerDeps['stepExecutor'],
+    engineOptions: {
+      projectCwd: '/tmp/project',
+    },
+    getCwd: () => '/tmp/project',
+    getReportDir: () => '.takt/runs/test/reports',
+    getInteractive: () => false,
+    detectRuleIndex: vi.fn(),
+    structuredCaller: {
+      evaluateCondition: vi.fn(),
+      judgeStatus: vi.fn(),
+      decomposeTask: vi.fn(),
+      requestMoreParts: vi.fn(),
+    },
+    runQualityGates: vi.fn().mockResolvedValue({ ok: true }),
+  };
+  return { runner: new ParallelRunner(deps), deps };
+}
+
+function queueAgentResponse(response: AgentResponse): void {
+  vi.mocked(executeAgent).mockImplementationOnce(async (_persona, instruction, options) => {
+    options.onPromptResolved?.({
+      systemPrompt: 'system prompt',
+      userInstruction: instruction,
+    });
+    return response;
+  });
+}
+
+function queueAgentRejection(error: Error): void {
+  vi.mocked(executeAgent).mockImplementationOnce(async (_persona, instruction, options) => {
+    options.onPromptResolved?.({
+      systemPrompt: 'system prompt',
+      userInstruction: instruction,
+    });
+    throw error;
+  });
+}
+
+describe('ParallelRunner terminal sub-step statuses', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(detectMatchedRule).mockImplementation(async (step) => {
+      return step.name === 'security-review'
+        ? { index: 0, method: 'phase1_tag' }
+        : undefined;
+    });
+  });
+
+  it('returns parent error when one sub-step returns error and another approves', async () => {
+    const { runner } = makeRunner();
+    const step = makeParallelStep();
+    const state = makeState();
+    queueAgentResponse(makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'error',
+      content: 'Reconnecting... 2/5',
+      error: 'timeout waiting for child process to exit',
+      failureCategory: 'provider_error',
+    }));
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      content: '[SECURITY-REVIEW:1] approved',
+    }));
+
+    const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
+
+    expect(result.response.status).toBe('error');
+    expect(result.response.persona).toBe('reviewers');
+    expect(result.response.error).toContain('timeout waiting for child process to exit');
+    expect(result.response.failureCategory).toBe('provider_error');
+    expect(result.response.content).toContain('ai-antipattern-review-2nd');
+    expect(result.response.content).toContain('status: error');
+    expect(result.response.content).toContain('failureCategory: provider_error');
+    expect(result.response.content).toContain('timeout waiting for child process to exit');
+    expect(result.response.content).toContain('aggregate');
+    expect(state.stepOutputs.get('reviewers')).toBe(result.response);
+    expect(state.lastOutput).toBe(result.response);
+  });
+
+  it('returns parent error with rejected promise detail', async () => {
+    const { runner } = makeRunner();
+    const step = makeParallelStep();
+    const state = makeState();
+    queueAgentRejection(new Error('Session resume failed'));
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      content: '[SECURITY-REVIEW:1] approved',
+    }));
+
+    const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
+
+    expect(result.response.status).toBe('error');
+    expect(result.response.error).toContain('Session resume failed');
+    expect(result.response.content).toContain('ai-antipattern-review-2nd');
+    expect(result.response.content).toContain('status: error');
+    expect(result.response.content).toContain('failureCategory: none');
+    expect(result.response.content).toContain('Session resume failed');
+    expect(state.stepOutputs.get('ai-antipattern-review-2nd')?.error).toBe('Session resume failed');
+  });
+
+  it('returns parent blocked when one sub-step blocks and no sub-step errors', async () => {
+    const { runner, deps } = makeRunner();
+    vi.mocked(deps.stepExecutor.persistPreviousResponseSnapshot).mockImplementation(
+      (targetState, stepName, stepIteration, content) => {
+        targetState.previousResponseSourcePath = `.takt/runs/test/context/previous_responses/${stepName}.${stepIteration}.snapshot.md`;
+        expect(content).toContain('Need user input before review can continue');
+      },
+    );
+    const step = makeParallelStep();
+    const state = makeState();
+    queueAgentResponse(makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'blocked',
+      content: 'Need user input before review can continue',
+    }));
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      content: '[SECURITY-REVIEW:1] approved',
+    }));
+
+    const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
+
+    expect(result.response.status).toBe('blocked');
+    expect(result.response.persona).toBe('reviewers');
+    expect(result.response.content).toContain('ai-antipattern-review-2nd');
+    expect(result.response.content).toContain('status: blocked');
+    expect(result.response.content).toContain('failureCategory: none');
+    expect(result.response.content).toContain('Need user input before review can continue');
+    expect(result.response.content).toContain('aggregate');
+    expect(state.stepOutputs.get('reviewers')).toBe(result.response);
+    expect(state.lastOutput).toBe(result.response);
+    expect(deps.stepExecutor.persistPreviousResponseSnapshot).toHaveBeenCalledWith(
+      state,
+      'reviewers',
+      1,
+      result.response.content,
+    );
+    expect(state.previousResponseSourcePath).toBe('.takt/runs/test/context/previous_responses/reviewers.1.snapshot.md');
+  });
+
+  it('returns parent rate_limited with sub-step diagnostics and rate limit metadata', async () => {
+    const { runner } = makeRunner();
+    const step = makeParallelStep();
+    const state = makeState();
+    const rateLimitInfo = {
+      provider: 'claude' as const,
+      detectedAt: new Date('2026-05-29T00:00:00.000Z'),
+      source: 'stream_marker' as const,
+      resetAtRaw: '2:30pm (Asia/Tokyo)',
+    };
+    queueAgentResponse(makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'rate_limited',
+      content: '',
+      error: 'Rate limit exceeded. Please try again later.',
+      errorKind: 'rate_limit',
+      rateLimitInfo,
+    }));
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      content: '[SECURITY-REVIEW:1] approved',
+    }));
+
+    const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
+
+    expect(result.response.status).toBe('rate_limited');
+    expect(result.response.persona).toBe('reviewers');
+    expect(result.response.errorKind).toBe('rate_limit');
+    expect(result.response.rateLimitInfo).toBe(rateLimitInfo);
+    expect(result.providerInfo?.provider).toBe('claude');
+    expect(result.response.content).toContain('ai-antipattern-review-2nd');
+    expect(result.response.content).toContain('status: rate_limited');
+    expect(result.response.content).toContain('failureCategory: none');
+    expect(result.response.content).toContain('rateLimitInfo: provider=claude, source=stream_marker');
+    expect(result.response.content).toContain('Rate limit exceeded. Please try again later.');
+    expect(result.response.content).toContain('aggregate');
+    expect(result.response.error).toBe(result.response.content);
+    expect(state.stepOutputs.get('reviewers')).toBe(result.response);
+    expect(state.lastOutput).toBe(result.response);
+    expect(state.previousResponseSourcePath).toBeUndefined();
+  });
+
+  it('keeps every terminal sub-step in parent rate_limited diagnostics', async () => {
+    const { runner } = makeRunner();
+    const step = makeParallelStep();
+    const state = makeState();
+    const rateLimitInfo = {
+      provider: 'claude' as const,
+      detectedAt: new Date('2026-05-29T00:00:00.000Z'),
+      source: 'stream_marker' as const,
+    };
+    queueAgentResponse(makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'rate_limited',
+      content: '',
+      error: 'Rate limit exceeded for ai reviewer.',
+      errorKind: 'rate_limit',
+      rateLimitInfo,
+    }));
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      status: 'error',
+      content: '',
+      error: 'Security reviewer failed after retry.',
+      failureCategory: 'provider_error',
+    }));
+
+    const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
+
+    expect(result.response.status).toBe('rate_limited');
+    expect(result.response.error).toBe(result.response.content);
+    expect(result.response.content).toContain('ai-antipattern-review-2nd');
+    expect(result.response.content).toContain('status: rate_limited');
+    expect(result.response.content).toContain('Rate limit exceeded for ai reviewer.');
+    expect(result.response.content).toContain('security-review');
+    expect(result.response.content).toContain('status: error');
+    expect(result.response.content).toContain('failureCategory: provider_error');
+    expect(result.response.content).toContain('Security reviewer failed after retry.');
+  });
+
+  it('redacts sensitive sub-step error details from parent diagnostics', async () => {
+    const { runner } = makeRunner();
+    const step = makeParallelStep();
+    const state = makeState();
+    queueAgentResponse(makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'error',
+      content: '',
+      error: 'Provider failed with api_key=top-secret and Authorization: Bearer sk-secret123456',
+    }));
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      content: '[SECURITY-REVIEW:1] approved',
+    }));
+
+    const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
+
+    expect(result.response.status).toBe('error');
+    expect(result.response.content).toContain('api_key=[REDACTED]');
+    expect(result.response.content).toContain('Authorization: Bearer [REDACTED]');
+    expect(result.response.content).not.toContain('top-secret');
+    expect(result.response.content).not.toContain('sk-secret123456');
+    expect(result.response.error).toBe(result.response.content);
+  });
+});

--- a/src/__tests__/report-phase-retry.test.ts
+++ b/src/__tests__/report-phase-retry.test.ts
@@ -479,7 +479,7 @@ describe('runReportPhase retry with new session', () => {
     const ctx = createContext(reportDir);
     const response: AgentResponse = {
       persona: 'coder',
-      status: 'rate_limited' as never,
+      status: 'rate_limited',
       content: '',
       timestamp: new Date('2026-02-11T00:05:00Z'),
       error: RATE_LIMIT_MESSAGE,

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -26,8 +26,19 @@ import type { RuntimeStepResolution } from '../types.js';
 import type { ParallelLoggerOptions } from './parallel-logger.js';
 import type { StructuredCaller } from '../../../agents/structured-caller.js';
 import type { QualityGateRunResult } from '../quality-gates/types.js';
+import { sanitizeSensitiveText } from '../../../shared/utils/sensitiveText.js';
 
 const log = createLogger('parallel-runner');
+
+type ParallelSubStepResult = {
+  subStep: WorkflowStep;
+  response: AgentResponse;
+  instruction: string;
+  providerInfo?: StepRunResult['providerInfo'];
+  qualityGateFailure?: boolean;
+};
+
+type ParallelTerminalStatus = 'error' | 'blocked' | 'rate_limited';
 
 /**
  * Simple semaphore for controlling concurrency.
@@ -300,13 +311,13 @@ export class ParallelRunner {
     );
 
     // Map settled results: fulfilled → as-is, rejected → error AgentResponse
-    const subResults = settled.map((result, index) => {
+    const subResults: ParallelSubStepResult[] = settled.map((result, index) => {
       if (result.status === 'fulfilled') {
         return result.value;
       }
       const failedStep = subSteps[index]!;
       const errorMsg = getErrorMessage(result.reason);
-      log.error('Sub-step failed', { step: failedStep.name, error: errorMsg });
+      log.error('Sub-step failed', { step: failedStep.name, error: sanitizeSensitiveText(errorMsg) });
       const errorResponse: AgentResponse = {
         persona: failedStep.name,
         status: 'error',
@@ -318,23 +329,44 @@ export class ParallelRunner {
       return { subStep: failedStep, response: errorResponse, instruction: '', providerInfo: undefined };
     });
 
-    const rateLimitedResult = subResults.find((r) => r.response.status === 'rate_limited');
+    const terminalResults = this.collectTerminalResults(subResults);
+    const rateLimitedResult = terminalResults.find((r) => r.response.status === 'rate_limited');
     if (rateLimitedResult) {
-      const rateLimitedResponse: AgentResponse = {
-        ...rateLimitedResult.response,
-        persona: step.name,
-      };
-      state.stepOutputs.set(step.name, rateLimitedResponse);
-      state.lastOutput = rateLimitedResponse;
-      return {
-        response: rateLimitedResponse,
-        instruction: rateLimitedResult.instruction,
-        providerInfo: rateLimitedResult.providerInfo,
-        consumedStepIterations: [
-          step.name,
-          ...subResults.map((result) => result.subStep.name),
-        ],
-      };
+      return this.createTerminalParentResult({
+        step,
+        state,
+        stepIteration,
+        subResults,
+        terminalResults,
+        status: 'rate_limited',
+        providerInfo: rateLimitedResult.providerInfo ?? parentPm,
+      });
+    }
+
+    const errorResults = terminalResults.filter((r) => r.response.status === 'error');
+    if (errorResults.length > 0) {
+      return this.createTerminalParentResult({
+        step,
+        state,
+        stepIteration,
+        subResults,
+        terminalResults,
+        status: 'error',
+        providerInfo: errorResults[0]?.providerInfo ?? parentPm,
+      });
+    }
+
+    const blockedResults = terminalResults.filter((r) => r.response.status === 'blocked');
+    if (blockedResults.length > 0) {
+      return this.createTerminalParentResult({
+        step,
+        state,
+        stepIteration,
+        subResults,
+        terminalResults: blockedResults,
+        status: 'blocked',
+        providerInfo: blockedResults[0]?.providerInfo ?? parentPm,
+      });
     }
 
     const qualityGateFailure = subResults.find((r) => (
@@ -360,13 +392,6 @@ export class ParallelRunner {
           stepIteration,
         },
       };
-    }
-
-    // If all sub-steps failed (error-originated), throw
-    const allFailed = subResults.every(r => r.response.error != null);
-    if (allFailed) {
-      const errors = subResults.map(r => `${r.subStep.name}: ${r.response.error}`).join('; ');
-      throw new Error(`All parallel sub-steps failed: ${errors}`);
     }
 
     // Print completion summary
@@ -441,6 +466,106 @@ export class ParallelRunner {
     }
 
     return options;
+  }
+
+  private createTerminalParentResult(options: {
+    step: WorkflowStep;
+    state: WorkflowState;
+    stepIteration: number;
+    subResults: ParallelSubStepResult[];
+    terminalResults: ParallelSubStepResult[];
+    status: ParallelTerminalStatus;
+    providerInfo: StepRunResult['providerInfo'];
+  }): StepRunResult {
+    const content = this.buildTerminalDiagnostic(
+      options.step,
+      options.terminalResults,
+      options.status,
+    );
+    const failureCategory = this.firstFailureCategory(options.terminalResults);
+    const response: AgentResponse = {
+      persona: options.step.name,
+      status: options.status,
+      content,
+      timestamp: new Date(),
+      ...(options.status === 'error' || options.status === 'rate_limited' ? { error: content } : {}),
+      ...(failureCategory && { failureCategory }),
+      ...this.firstRateLimitMetadata(options.terminalResults),
+    };
+
+    options.state.stepOutputs.set(options.step.name, response);
+    options.state.lastOutput = response;
+    if (options.status === 'blocked') {
+      this.deps.stepExecutor.persistPreviousResponseSnapshot(
+        options.state,
+        options.step.name,
+        options.stepIteration,
+        response.content,
+      );
+    }
+
+    return {
+      response,
+      instruction: options.subResults.map((result) => result.instruction).join('\n\n'),
+      providerInfo: options.providerInfo,
+      consumedStepIterations: [
+        options.step.name,
+        ...options.subResults.map((result) => result.subStep.name),
+      ],
+    };
+  }
+
+  private collectTerminalResults(results: ParallelSubStepResult[]): ParallelSubStepResult[] {
+    return results.filter((result) => (
+      result.response.status === 'error'
+      || result.response.status === 'blocked'
+      || result.response.status === 'rate_limited'
+    ));
+  }
+
+  private buildTerminalDiagnostic(
+    step: WorkflowStep,
+    terminalResults: ParallelSubStepResult[],
+    status: ParallelTerminalStatus,
+  ): string {
+    const detailLines = terminalResults.map((result) => {
+      const failureCategory = result.response.failureCategory ?? 'none';
+      const detail = sanitizeSensitiveText(result.response.error ?? result.response.content);
+      const lines = [
+        `- sub-step: ${result.subStep.name}`,
+        `  status: ${result.response.status}`,
+        `  failureCategory: ${failureCategory}`,
+      ];
+      if (result.response.rateLimitInfo) {
+        lines.push(`  rateLimitInfo: provider=${result.response.rateLimitInfo.provider}, source=${result.response.rateLimitInfo.source}`);
+      }
+      lines.push(`  detail: ${detail}`);
+      return lines.join('\n');
+    });
+
+    return [
+      `Parallel step "${step.name}" returned ${status} because one or more sub-steps ended in a non-rule terminal status.`,
+      'Aggregate rules were not evaluated as a normal review result because terminal sub-step statuses',
+      'do not represent matched aggregate conditions such as all("approved") or any("needs_fix").',
+      '',
+      'Sub-step diagnostics:',
+      ...detailLines,
+    ].join('\n');
+  }
+
+  private firstFailureCategory(results: ParallelSubStepResult[]): AgentResponse['failureCategory'] | undefined {
+    return results.find((result) => result.response.failureCategory)?.response.failureCategory;
+  }
+
+  private firstRateLimitMetadata(results: ParallelSubStepResult[]): Pick<AgentResponse, 'errorKind' | 'rateLimitInfo'> {
+    const rateLimitedResult = results.find((result) => result.response.status === 'rate_limited');
+    if (!rateLimitedResult) {
+      return {};
+    }
+    return {
+      ...(rateLimitedResult.response.errorKind && { errorKind: rateLimitedResult.response.errorKind }),
+      ...(rateLimitedResult.response.rateLimitInfo && { rateLimitInfo: rateLimitedResult.response.rateLimitInfo }),
+    };
   }
 
 }


### PR DESCRIPTION
## Summary

## 背景

PR #767 は Issue #758 の Codex SDK `Reconnecting...` 系エラー retry を修正するものだが、調査中に別の workflow aggregation 問題が見つかった。

対象ログ例:

```text
/Users/nrs/work/git/takt-worktrees/20260527T0119-fix-command-gates/.takt/runs/20260527-050529-implement-using-only-the-files-d1188v/logs/20260527-140530-yo4y0l.jsonl
```

該当 run では `peer-review` の `reviewers` 並列ステップで、7 reviewer 中 6 reviewer は最終的に approve していた。

```text
testing-review              [TESTING-REVIEW:1]
security-review             [SECURITY-REVIEW:1]
coding-review               [CODING-REVIEW:1]
arch-review                 [ARCH-REVIEW:1]
requirements-review         [REQUIREMENTS-REVIEW:1]
qa-review                   [QA-REVIEW:1]
```

一方で `ai-antipattern-review-2nd` だけが Phase 1 で provider error になっていた。

```text
ai-antipattern-review-2nd phase 1 execute error
Reconnecting... 2/5 (timeout waiting for child process to exit)
```

その後、親の `reviewers` ステップは aggregate rule にマッチできず、次のエラーで `peer-review` 全体が ABORT した。

```text
Step execution failed: Status not found for step "reviewers": no rule matched after all detection phases
Workflow aborted by step transition
```

## 問題

`builtins/*/workflows/peer-review.yaml` の `reviewers` は現在、以下の2ルールだけで親ステップを判定している。

```yaml
rules:
  - condition: all("approved")
    next: COMPLETE
  - condition: any("needs_fix")
    next: fix
```

そのため、並列 sub-step の一部が `error` / `blocked` / その他の非判定状態で終わると、`all("approved")` も `any("needs_fix")` も false になり、実際の原因が provider/sub-step error であるにもかかわらず、最終診断が `Status not found for step "reviewers"` になってしまう。

これはユーザーにとって原因が分かりにくく、retry すべき外部要因なのか、review finding なのか、workflow 定義不備なのかを切り分けにくい。

## 関連 Issue との差分

- #758 は Codex SDK の `Reconnecting...` を retryable transient failure として扱う問題。直接原因の provider error を減らす対応であり、この Issue の aggregation 診断問題とは別。
- #444 は Phase 3 status judgment の throw が fallback をバイパスする問題。今回のケースは Phase 3 以前に sub-step が `error` になり、親 aggregate rule が非判定状態を扱えない問題。
- #716 は rate limit fallback の参考実装案。今回の対象は rate limit に限らない parallel sub-step error の扱い。

## 期待する挙動

- 並列 sub-step の一部が `error` / `blocked` / `rate_limited` などで終了した場合、親 parallel step が `Status not found` ではなく、原因を明示した結果を返す。
- 少なくとも次の情報が診断に含まれる。
  - 失敗した sub-step 名
  - sub-step の status / failureCategory / error
  - aggregate rule が未成立になった理由
- `all("approved")` / `any("needs_fix")` のどちらにも該当しない状態を、workflow 定義の曖昧な未マッチとして扱わない。

## 実装方針案

候補は複数あり得る。

1. `ParallelRunner` が sub-step error を検出した時点で、親 step response を `error` / `rate_limited` / `blocked` として短絡する。
2. aggregate evaluator に sub-step error 用の明示的な扱いを追加し、親 step の診断を改善する。
3. workflow YAML に `any("error")` のような条件を足すのではなく、エンジン側で non-rule terminal state を first-class に扱う。

現状の `AggregateEvaluator` は sub-step の `matchedRuleIndex` と rule condition だけを見るため、`matchedRuleIndex` がない `error` は aggregate 条件から事実上無視される。この構造を見直す必要がある。

## 受け入れ条件

- parallel sub-step の一部が `error` になった場合に、親 step が `Status not found for step "reviewers"` で abort しない。
- 失敗した sub-step 名と error 内容がユーザー向けログ / session log に明示される。
- `all("approved")` / `any("needs_fix")` の正常系・fix loop 系の既存挙動は維持される。
- `ParallelRunner` または aggregate evaluation の unit/integration test に、1 sub-step error + 他 sub-step approved のケースを追加する。
- rate limit / blocked など既存の専用 status は既存ポリシーを壊さずに扱う。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 並列ステップの失敗時に機密情報（APIキー等）が適切にマスクされるよう改善
  * 並列サブステップのエラー情報が親ステップに正しく反映されるよう修正
  * レート制限エラーの処理と情報伝播を改善

* **テスト**
  * 並列ステップの端末ステータス集約動作を検証する包括的なテスト追加
  * 並列失敗パターンのテストカバレッジ拡張

* **リファクタ**
  * テストコード内の型アサーション削除による可読性向上

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrslib/takt/pull/770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->