### PR TITLE
[#778] fix-source-review-issues

### DIFF
--- a/src/__tests__/clone-isolation.test.ts
+++ b/src/__tests__/clone-isolation.test.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createSharedClone } from '../infra/task/clone.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function createTempDir(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-clone-isolation-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+function runGit(cwd: string, args: string[]): Buffer {
+  return execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function createSourceRepo(tempDir: string): string {
+  const repoDir = path.join(tempDir, 'source-main-repository');
+  fs.mkdirSync(repoDir);
+  runGit(repoDir, ['init', '--quiet']);
+  runGit(repoDir, ['config', 'user.email', 'takt@example.com']);
+  runGit(repoDir, ['config', 'user.name', 'TAKT Test']);
+  fs.writeFileSync(path.join(repoDir, 'README.md'), 'initial\n');
+  runGit(repoDir, ['add', 'README.md']);
+  runGit(repoDir, ['commit', '--quiet', '-m', 'initial']);
+  return repoDir;
+}
+
+function rewriteGitFileToRelativeGitdir(worktreeDir: string): void {
+  const gitFile = path.join(worktreeDir, '.git');
+  const prefix = 'gitdir: ';
+  const content = fs.readFileSync(gitFile, 'utf-8').trim();
+  if (!content.startsWith(prefix)) {
+    throw new Error(`Unexpected linked worktree .git file: ${content}`);
+  }
+
+  const gitdir = content.slice(prefix.length);
+  const absoluteGitdir = path.resolve(worktreeDir, gitdir);
+  fs.writeFileSync(gitFile, `${prefix}${path.relative(worktreeDir, absoluteGitdir)}\n`);
+}
+
+function filesContaining(rootDir: string, needle: string): string[] {
+  const matches: string[] = [];
+  const needleBuffer = Buffer.from(needle);
+
+  function scan(dir: string): void {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        scan(entryPath);
+        continue;
+      }
+      if (entry.isFile() && fs.readFileSync(entryPath).includes(needleBuffer)) {
+        matches.push(path.relative(rootDir, entryPath));
+      }
+    }
+  }
+
+  scan(rootDir);
+  return matches.sort();
+}
+
+describe('shared clone generated metadata isolation', () => {
+  it('does not leave the source repo path in clone .git metadata for local branch clones', () => {
+    const tempDir = createTempDir();
+    const sourceRepo = createSourceRepo(tempDir);
+    const clonePath = path.join(tempDir, 'local-branch-clone');
+
+    runGit(sourceRepo, ['branch', 'feature/local-only']);
+
+    createSharedClone(sourceRepo, {
+      worktree: clonePath,
+      taskSlug: 'local-isolation',
+      branch: 'feature/local-only',
+    });
+
+    expect(filesContaining(path.join(clonePath, '.git'), sourceRepo)).toEqual([]);
+  });
+
+  it('does not leave the source repo path in clone .git metadata for remote tracking branch fetches', () => {
+    const tempDir = createTempDir();
+    const sourceRepo = createSourceRepo(tempDir);
+    const clonePath = path.join(tempDir, 'remote-branch-clone');
+    const branch = 'feature/remote-only';
+
+    runGit(sourceRepo, ['update-ref', `refs/remotes/origin/${branch}`, 'HEAD']);
+
+    createSharedClone(sourceRepo, {
+      worktree: clonePath,
+      taskSlug: 'remote-isolation',
+      branch,
+    });
+
+    expect(filesContaining(path.join(clonePath, '.git'), sourceRepo)).toEqual([]);
+    expect(fs.existsSync(path.join(clonePath, '.git', 'FETCH_HEAD'))).toBe(false);
+  });
+
+  it('clones a real linked worktree with a relative gitdir without exposing source paths in clone metadata', () => {
+    const tempDir = createTempDir();
+    const sourceRepo = createSourceRepo(tempDir);
+    const linkedWorktree = path.join(tempDir, 'linked-worktree');
+    const clonePath = path.join(tempDir, 'linked-worktree-clone');
+    const branch = 'feature/linked-worktree-source';
+
+    runGit(sourceRepo, ['worktree', 'add', '--quiet', '-b', branch, linkedWorktree, 'HEAD']);
+    rewriteGitFileToRelativeGitdir(linkedWorktree);
+
+    expect(process.cwd()).not.toBe(sourceRepo);
+    expect(process.cwd()).not.toBe(path.dirname(linkedWorktree));
+    createSharedClone(linkedWorktree, {
+      worktree: clonePath,
+      taskSlug: 'linked-worktree-isolation',
+      branch,
+    });
+
+    const cloneGitDir = path.join(clonePath, '.git');
+    expect(filesContaining(cloneGitDir, sourceRepo)).toEqual([]);
+    expect(filesContaining(cloneGitDir, linkedWorktree)).toEqual([]);
+    expect(filesContaining(cloneGitDir, tempDir)).toEqual([]);
+    expect(fs.existsSync(path.join(cloneGitDir, 'FETCH_HEAD'))).toBe(false);
+  });
+});

--- a/src/__tests__/clone-isolation.test.ts
+++ b/src/__tests__/clone-isolation.test.ts
@@ -44,8 +44,13 @@ function rewriteGitFileToRelativeGitdir(worktreeDir: string): void {
   }
 
   const gitdir = content.slice(prefix.length);
-  const absoluteGitdir = path.resolve(worktreeDir, gitdir);
-  fs.writeFileSync(gitFile, `${prefix}${path.relative(worktreeDir, absoluteGitdir)}\n`);
+  const absoluteGitdir = path.isAbsolute(gitdir)
+    ? gitdir
+    : path.resolve(worktreeDir, gitdir);
+  fs.writeFileSync(
+    gitFile,
+    `${prefix}${path.relative(fs.realpathSync(worktreeDir), fs.realpathSync(absoluteGitdir))}\n`,
+  );
 }
 
 function filesContaining(rootDir: string, needle: string): string[] {

--- a/src/__tests__/clone.test.ts
+++ b/src/__tests__/clone.test.ts
@@ -19,6 +19,7 @@ vi.mock('node:fs', () => ({
     mkdtempSync: vi.fn(),
     writeFileSync: vi.fn(),
     readFileSync: vi.fn(),
+    statSync: vi.fn(() => ({ isFile: () => false })),
     realpathSync: vi.fn((value: string) => value),
     existsSync: vi.fn(),
     rmSync: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock('node:fs', () => ({
   mkdtempSync: vi.fn(),
   writeFileSync: vi.fn(),
   readFileSync: vi.fn(),
+  statSync: vi.fn(() => ({ isFile: () => false })),
   realpathSync: vi.fn((value: string) => value),
   existsSync: vi.fn(),
   rmSync: vi.fn(),
@@ -65,7 +67,13 @@ import { execFileSync, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { loadProjectConfig, resolveConfigValue } from '../infra/config/index.js';
-import { CloneManager, createSharedClone, createTempCloneForBranch, cleanupOrphanedClone } from '../infra/task/clone.js';
+import {
+  CloneManager,
+  createSharedClone,
+  createSharedCloneAbortable,
+  createTempCloneForBranch,
+  cleanupOrphanedClone,
+} from '../infra/task/clone.js';
 
 const mockExecFileSync = vi.mocked(execFileSync);
 const mockSpawn = vi.mocked(spawn);
@@ -74,6 +82,8 @@ const mockResolveConfigValue = vi.mocked(resolveConfigValue);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(fs.statSync).mockImplementation(() => ({ isFile: () => false }) as unknown as fs.Stats);
+  vi.mocked(fs.readFileSync).mockReset();
   mockLoadProjectConfig.mockReturnValue({});
   mockResolveConfigValue.mockReturnValue(undefined);
 });
@@ -100,6 +110,115 @@ function mockGitSpawn(
     return child as never;
   });
 }
+
+describe('worktree reference resolution', () => {
+  const linkedWorktreePath = path.resolve('workspace', 'linked');
+  const mainRepoPath = path.resolve('workspace', 'main');
+
+  function setupWorktreeCloneCapture(): string[][] {
+    const cloneCalls: string[][] = [];
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+
+      if (argsArr[0] === 'symbolic-ref' && argsArr[1] === 'refs/remotes/origin/HEAD') {
+        return 'refs/remotes/origin/main\n';
+      }
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--abbrev-ref' && argsArr[2] === 'HEAD') {
+        return 'main\n';
+      }
+      if (argsArr[0] === 'fetch') return Buffer.from('');
+      if (argsArr[0] === 'clone') {
+        cloneCalls.push([...argsArr]);
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config') {
+        if (argsArr[1] === '--local') throw new Error('not set');
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'show-ref') {
+        throw new Error('branch not found');
+      }
+      if (argsArr[0] === 'checkout') return Buffer.from('');
+
+      return Buffer.from('');
+    });
+
+    return cloneCalls;
+  }
+
+  it('should resolve a relative worktree gitdir from the .git file directory', () => {
+    const cloneCalls = setupWorktreeCloneCapture();
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as unknown as fs.Stats);
+    vi.mocked(fs.readFileSync).mockReturnValue('gitdir: ../main/.git/worktrees/linked\n');
+
+    createSharedClone(linkedWorktreePath, {
+      worktree: '/tmp/clone-dest',
+      taskSlug: 'relative-gitdir',
+    });
+
+    expect(cloneCalls).toHaveLength(1);
+    const referenceIndex = cloneCalls[0]!.indexOf('--reference');
+    expect(referenceIndex).toBeGreaterThanOrEqual(0);
+    expect(cloneCalls[0]![referenceIndex + 1]).toBe(mainRepoPath);
+  });
+
+  it('should use the same relative worktree gitdir resolution for abortable clone', async () => {
+    const cloneCalls: string[][] = [];
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+
+      if (argsArr[0] === 'symbolic-ref' && argsArr[1] === 'refs/remotes/origin/HEAD') {
+        return 'refs/remotes/origin/main\n';
+      }
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config') {
+        if (argsArr[1] === '--local') throw new Error('not set');
+        return Buffer.from('');
+      }
+
+      return Buffer.from('');
+    });
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as unknown as fs.Stats);
+    vi.mocked(fs.readFileSync).mockReturnValue('gitdir: ../main/.git/worktrees/linked\n');
+    mockSpawn.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        pid: number;
+        kill: ReturnType<typeof vi.fn>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 12345;
+      child.kill = vi.fn();
+
+      if (argsArr[0] === 'clone') {
+        cloneCalls.push([...argsArr]);
+      }
+
+      setImmediate(() => {
+        const exitCode = argsArr[0] === 'show-ref' ? 1 : 0;
+        child.emit('close', exitCode);
+      });
+
+      return child as never;
+    });
+
+    await createSharedCloneAbortable(linkedWorktreePath, {
+      worktree: '/tmp/abortable-clone-dest',
+      taskSlug: 'relative-gitdir-abortable',
+    });
+
+    expect(cloneCalls).toHaveLength(1);
+    const referenceIndex = cloneCalls[0]!.indexOf('--reference');
+    expect(referenceIndex).toBeGreaterThanOrEqual(0);
+    expect(cloneCalls[0]![referenceIndex + 1]).toBe(mainRepoPath);
+  });
+});
 
 describe('cloneAndIsolate git config propagation', () => {
   /**

--- a/src/__tests__/clone.test.ts
+++ b/src/__tests__/clone.test.ts
@@ -111,6 +111,14 @@ function mockGitSpawn(
   });
 }
 
+function serializedCloneLogs(): string {
+  return JSON.stringify({
+    info: mockLogInfo.mock.calls,
+    debug: mockLogDebug.mock.calls,
+    error: mockLogError.mock.calls,
+  });
+}
+
 describe('worktree reference resolution', () => {
   const linkedWorktreePath = path.resolve('workspace', 'linked');
   const mainRepoPath = path.resolve('workspace', 'main');
@@ -129,6 +137,9 @@ describe('worktree reference resolution', () => {
       }
       if (argsArr[0] === 'fetch') return Buffer.from('');
       if (argsArr[0] === 'clone') {
+        if (argsArr.includes('--reference')) {
+          throw new Error('fatal: reference repository is a linked checkout and is not supported yet');
+        }
         cloneCalls.push([...argsArr]);
         return Buffer.from('');
       }
@@ -148,7 +159,7 @@ describe('worktree reference resolution', () => {
     return cloneCalls;
   }
 
-  it('should resolve a relative worktree gitdir from the .git file directory', () => {
+  it('should let git resolve a relative worktree gitdir without exposing the main repo path', () => {
     const cloneCalls = setupWorktreeCloneCapture();
     vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as unknown as fs.Stats);
     vi.mocked(fs.readFileSync).mockReturnValue('gitdir: ../main/.git/worktrees/linked\n');
@@ -159,12 +170,14 @@ describe('worktree reference resolution', () => {
     });
 
     expect(cloneCalls).toHaveLength(1);
-    const referenceIndex = cloneCalls[0]!.indexOf('--reference');
-    expect(referenceIndex).toBeGreaterThanOrEqual(0);
-    expect(cloneCalls[0]![referenceIndex + 1]).toBe(mainRepoPath);
+    expect(cloneCalls[0]).not.toContain('--reference');
+    expect(cloneCalls[0]).not.toContain('--dissociate');
+    expect(cloneCalls[0]).toContain(linkedWorktreePath);
+    expect(vi.mocked(fs.readFileSync)).not.toHaveBeenCalled();
+    expect(serializedCloneLogs()).not.toContain(mainRepoPath);
   });
 
-  it('should use the same relative worktree gitdir resolution for abortable clone', async () => {
+  it('should use the same git-owned worktree resolution for abortable clone without exposing the main repo path', async () => {
     const cloneCalls: string[][] = [];
 
     mockExecFileSync.mockImplementation((_cmd, args) => {
@@ -197,6 +210,13 @@ describe('worktree reference resolution', () => {
       child.kill = vi.fn();
 
       if (argsArr[0] === 'clone') {
+        if (argsArr.includes('--reference')) {
+          child.stderr.emit('data', 'fatal: reference repository is a linked checkout and is not supported yet');
+          setImmediate(() => {
+            child.emit('close', 1);
+          });
+          return child as never;
+        }
         cloneCalls.push([...argsArr]);
       }
 
@@ -214,9 +234,11 @@ describe('worktree reference resolution', () => {
     });
 
     expect(cloneCalls).toHaveLength(1);
-    const referenceIndex = cloneCalls[0]!.indexOf('--reference');
-    expect(referenceIndex).toBeGreaterThanOrEqual(0);
-    expect(cloneCalls[0]![referenceIndex + 1]).toBe(mainRepoPath);
+    expect(cloneCalls[0]).not.toContain('--reference');
+    expect(cloneCalls[0]).not.toContain('--dissociate');
+    expect(cloneCalls[0]).toContain(linkedWorktreePath);
+    expect(vi.mocked(fs.readFileSync)).not.toHaveBeenCalled();
+    expect(serializedCloneLogs()).not.toContain(mainRepoPath);
   });
 });
 
@@ -844,6 +866,108 @@ describe('branchExists remote tracking branch fallback', () => {
     expect(checkoutCalls[0]).toEqual(['checkout', 'feature/remote-only']);
   });
 
+  it('should sanitize remote branch fetch errors before throwing', () => {
+    const hiddenProjectDir = '/hidden/main';
+    const branch = 'feature/remote-fetch-failure';
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+
+      if (argsArr[0] === 'fetch' && argsArr.includes('--no-write-fetch-head') && argsArr.includes(hiddenProjectDir)) {
+        const error = new Error(`fatal: fetch from ${hiddenProjectDir} failed`);
+        (error as Error & { stderr: Buffer }).stderr = Buffer.from(`fatal: ${hiddenProjectDir} is not accessible`);
+        throw error;
+      }
+      if (argsArr[0] === 'fetch') return Buffer.from('');
+      if (argsArr[0] === 'show-ref') {
+        const ref = argsArr[3];
+        if (typeof ref === 'string' && ref.startsWith('refs/remotes/origin/')) {
+          return Buffer.from('');
+        }
+        throw new Error('branch not found');
+      }
+      if (argsArr[0] === 'clone') return Buffer.from('');
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config') {
+        if (argsArr[1] === '--local') throw new Error('not set');
+        return Buffer.from('');
+      }
+
+      return Buffer.from('');
+    });
+
+    let thrown: Error | undefined;
+    try {
+      createSharedClone(hiddenProjectDir, {
+        worktree: '/tmp/remote-fetch-failure',
+        taskSlug: 'remote-fetch-failure',
+        branch,
+      });
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toBe('Git remote branch fetch failed');
+    expect(thrown?.message).not.toContain(hiddenProjectDir);
+    expect(serializedCloneLogs()).not.toContain(hiddenProjectDir);
+  });
+
+  it('should sanitize abortable remote branch fetch errors before throwing', async () => {
+    const hiddenProjectDir = '/hidden/main';
+    const branch = 'feature/abortable-remote-fetch-failure';
+
+    mockSpawn.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        pid: number;
+        kill: ReturnType<typeof vi.fn>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 12345;
+      child.kill = vi.fn();
+
+      setImmediate(() => {
+        if (argsArr[0] === 'fetch' && argsArr.includes('--no-write-fetch-head') && argsArr.includes(hiddenProjectDir)) {
+          child.stderr.emit('data', `fatal: fetch from ${hiddenProjectDir} failed`);
+          child.emit('close', 1);
+          return;
+        }
+        child.emit('close', 0);
+      });
+
+      return child as never;
+    });
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config') {
+        if (argsArr[1] === '--local') throw new Error('not set');
+        return Buffer.from('');
+      }
+      return Buffer.from('');
+    });
+
+    let thrown: Error | undefined;
+    try {
+      await createSharedCloneAbortable(hiddenProjectDir, {
+        worktree: '/tmp/abortable-remote-fetch-failure',
+        taskSlug: 'abortable-remote-fetch-failure',
+        branch,
+      });
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toBe('Git remote branch fetch failed');
+    expect(thrown?.message).not.toContain(hiddenProjectDir);
+    expect(serializedCloneLogs()).not.toContain(hiddenProjectDir);
+  });
+
   it('should create new branch when neither local nor remote tracking branch exists', () => {
     const cloneCalls: string[][] = [];
     const checkoutCalls: string[][] = [];
@@ -1013,6 +1137,102 @@ describe('branchExists remote tracking branch fallback', () => {
 });
 
 describe('prefetch existing branch on origin before clone (#557)', () => {
+  it('should not expose the source path when sync prefetch fails', () => {
+    const hiddenProjectDir = '/hidden/main';
+    const branch = 'feature/prefetch-failure';
+
+    mockExecFileSync.mockImplementation((_cmd, args, opts) => {
+      const argsArr = args as string[];
+      const cwd = (opts as { cwd?: string } | undefined)?.cwd;
+
+      if (argsArr[0] === 'fetch' && cwd === hiddenProjectDir && argsArr[1] === 'origin') {
+        throw new Error(`fatal: ${hiddenProjectDir} was not found`);
+      }
+      if (argsArr[0] === 'fetch') return Buffer.from('');
+      if (argsArr[0] === 'clone') return Buffer.from('');
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config') {
+        if (argsArr[1] === '--local') throw new Error('not set');
+        return Buffer.from('');
+      }
+      if (argsArr[0] === 'symbolic-ref' && argsArr[1] === 'refs/remotes/origin/HEAD') {
+        return 'refs/remotes/origin/main\n';
+      }
+      if (argsArr[0] === 'show-ref') {
+        throw new Error('branch not found');
+      }
+      if (argsArr[0] === 'rev-parse' && argsArr[1] === '--abbrev-ref') {
+        return 'main\n';
+      }
+      if (argsArr[0] === 'checkout') return Buffer.from('');
+
+      return Buffer.from('');
+    });
+
+    createSharedClone(hiddenProjectDir, {
+      worktree: '/tmp/prefetch-failure',
+      taskSlug: 'prefetch-failure',
+      branch,
+    });
+
+    expect(serializedCloneLogs()).not.toContain(hiddenProjectDir);
+  });
+
+  it('should not expose the source path when abortable prefetch fails', async () => {
+    const hiddenProjectDir = '/hidden/main';
+    const branch = 'feature/abortable-prefetch-failure';
+
+    mockSpawn.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        pid: number;
+        kill: ReturnType<typeof vi.fn>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 12345;
+      child.kill = vi.fn();
+
+      setImmediate(() => {
+        if (argsArr[0] === 'fetch' && argsArr[1] === 'origin') {
+          child.stderr.emit('data', `fatal: ${hiddenProjectDir} was not found`);
+          child.emit('close', 1);
+          return;
+        }
+        if (argsArr[0] === 'show-ref' && String(argsArr[3]).startsWith('refs/remotes/origin/')) {
+          child.emit('close', 1);
+          return;
+        }
+        if (argsArr[0] === 'show-ref' && String(argsArr[3]).startsWith('refs/heads/')) {
+          child.emit('close', 0);
+          return;
+        }
+        child.emit('close', 0);
+      });
+
+      return child as never;
+    });
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config') {
+        if (argsArr[1] === '--local') throw new Error('not set');
+        return Buffer.from('');
+      }
+      return Buffer.from('');
+    });
+
+    await createSharedCloneAbortable(hiddenProjectDir, {
+      worktree: '/tmp/abortable-prefetch-failure',
+      taskSlug: 'abortable-prefetch-failure',
+      branch,
+    });
+
+    expect(serializedCloneLogs()).not.toContain(hiddenProjectDir);
+  });
+
   it('should run fetch on project repo before clone when explicit branch is set (auto_fetch off)', () => {
     const opSequence: string[] = [];
 
@@ -1207,6 +1427,9 @@ describe('autoFetch: true — fetch, rev-parse origin/<branch>, reset --hard', (
 });
 
 describe('shallow clone fallback', () => {
+  const hiddenMainRepoPath = path.resolve('workspace', 'main');
+  const linkedWorktreePath = path.resolve('workspace', 'linked');
+
   function setupShallowCloneMock(options: {
     shallowError: boolean;
     otherError?: string;
@@ -1219,6 +1442,10 @@ describe('shallow clone fallback', () => {
       // git rev-parse --abbrev-ref HEAD
       if (argsArr[0] === 'rev-parse' && argsArr[1] === '--abbrev-ref' && argsArr[2] === 'HEAD') {
         return 'main\n';
+      }
+
+      if (argsArr[0] === 'symbolic-ref' && argsArr[1] === 'refs/remotes/origin/HEAD') {
+        return 'refs/remotes/origin/main\n';
       }
 
       // git clone
@@ -1272,10 +1499,122 @@ describe('shallow clone fallback', () => {
     return { cloneCalls };
   }
 
+  function setupAbortableShallowCloneMock(): { cloneCalls: string[][] } {
+    const cloneCalls: string[][] = [];
+
+    mockSpawn.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        pid: number;
+        kill: ReturnType<typeof vi.fn>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 12345;
+      child.kill = vi.fn();
+
+      if (argsArr[0] === 'clone') {
+        cloneCalls.push([...argsArr]);
+      }
+
+      setImmediate(() => {
+        if (argsArr[0] === 'fetch') {
+          child.emit('close', 1);
+          return;
+        }
+        if (argsArr[0] === 'show-ref' && String(argsArr[3]).startsWith('refs/remotes/origin/')) {
+          child.emit('close', 1);
+          return;
+        }
+        if (argsArr[0] === 'show-ref' && String(argsArr[3]).startsWith('refs/heads/')) {
+          child.emit('close', 0);
+          return;
+        }
+        if (argsArr[0] === 'clone' && argsArr.includes('--reference')) {
+          child.stderr.emit('data', 'fatal: reference repository is shallow');
+          child.emit('close', 1);
+          return;
+        }
+
+        child.emit('close', 0);
+      });
+
+      return child as never;
+    });
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config' && argsArr[1] === '--local') throw new Error('not set');
+      if (argsArr[0] === 'config') return Buffer.from('');
+      return Buffer.from('');
+    });
+
+    return { cloneCalls };
+  }
+
+  function setupAbortableCloneFailureMock(stderr: string): { cloneCalls: string[][] } {
+    const cloneCalls: string[][] = [];
+
+    mockSpawn.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        pid: number;
+        kill: ReturnType<typeof vi.fn>;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 12345;
+      child.kill = vi.fn();
+
+      if (argsArr[0] === 'clone') {
+        cloneCalls.push([...argsArr]);
+      }
+
+      setImmediate(() => {
+        if (argsArr[0] === 'fetch') {
+          child.emit('close', 1);
+          return;
+        }
+        if (argsArr[0] === 'show-ref' && String(argsArr[3]).startsWith('refs/remotes/origin/')) {
+          child.emit('close', 1);
+          return;
+        }
+        if (argsArr[0] === 'show-ref' && String(argsArr[3]).startsWith('refs/heads/')) {
+          child.emit('close', 0);
+          return;
+        }
+        if (argsArr[0] === 'clone') {
+          child.stderr.emit('data', stderr);
+          child.emit('close', 1);
+          return;
+        }
+
+        child.emit('close', 0);
+      });
+
+      return child as never;
+    });
+
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config' && argsArr[1] === '--local') throw new Error('not set');
+      if (argsArr[0] === 'config') return Buffer.from('');
+      return Buffer.from('');
+    });
+
+    return { cloneCalls };
+  }
+
   it('should fall back to clone without --reference when reference repository is shallow', () => {
     const { cloneCalls } = setupShallowCloneMock({ shallowError: true });
 
-    createSharedClone('/project', {
+    createSharedClone(linkedWorktreePath, {
       worktree: '/tmp/shallow-test',
       taskSlug: 'shallow-fallback',
     });
@@ -1295,11 +1634,76 @@ describe('shallow clone fallback', () => {
     expect(cloneCalls[0][cloneCalls[0].length - 1]).toBe('/tmp/shallow-test');
     expect(cloneCalls[1][cloneCalls[1].length - 1]).toBe('/tmp/shallow-test');
 
-    // Fallback was logged
-    expect(mockLogInfo).toHaveBeenCalledWith(
-      'Reference repository is shallow, retrying clone without --reference',
-      expect.objectContaining({ referenceRepo: expect.any(String) }),
+    expect(mockLogInfo).toHaveBeenCalledWith('Reference repository is shallow, retrying clone without --reference');
+    expect(serializedCloneLogs()).not.toContain(hiddenMainRepoPath);
+  });
+
+  it('should not expose the main repo path when abortable clone falls back from shallow reference', async () => {
+    const { cloneCalls } = setupAbortableShallowCloneMock();
+
+    await createSharedCloneAbortable(linkedWorktreePath, {
+      worktree: '/tmp/abortable-shallow-test',
+      taskSlug: 'shallow-fallback',
+      branch: 'feature/local-branch',
+    });
+
+    expect(cloneCalls).toHaveLength(2);
+    expect(cloneCalls[0]).toContain('--reference');
+    expect(cloneCalls[0]).toContain('--dissociate');
+    expect(cloneCalls[1]).not.toContain('--reference');
+    expect(cloneCalls[1]).not.toContain('--dissociate');
+    expect(mockLogInfo).toHaveBeenCalledWith('Reference repository is shallow, retrying clone without --reference');
+    expect(serializedCloneLogs()).not.toContain(hiddenMainRepoPath);
+  });
+
+  it('should sanitize non-shallow clone errors before throwing', () => {
+    const hiddenClonePath = '/tmp/sanitized-sync-clone';
+    const { cloneCalls } = setupShallowCloneMock({
+      shallowError: false,
+      otherError: `fatal: repository '${hiddenMainRepoPath}' does not exist while cloning ${hiddenClonePath}`,
+    });
+
+    let thrown: Error | undefined;
+    try {
+      createSharedClone(hiddenMainRepoPath, {
+        worktree: hiddenClonePath,
+        taskSlug: 'other-error',
+      });
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(cloneCalls).toHaveLength(1);
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toBe('Git clone failed');
+    expect(thrown?.message).not.toContain(hiddenMainRepoPath);
+    expect(thrown?.message).not.toContain(hiddenClonePath);
+    expect(serializedCloneLogs()).not.toContain(hiddenMainRepoPath);
+  });
+
+  it('should sanitize abortable non-shallow clone errors before throwing', async () => {
+    const hiddenClonePath = '/tmp/sanitized-abortable-clone';
+    const { cloneCalls } = setupAbortableCloneFailureMock(
+      `fatal: repository '${hiddenMainRepoPath}' does not exist while cloning ${hiddenClonePath}`,
     );
+
+    let thrown: Error | undefined;
+    try {
+      await createSharedCloneAbortable(hiddenMainRepoPath, {
+        worktree: hiddenClonePath,
+        taskSlug: 'other-error',
+        branch: 'feature/local-branch',
+      });
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(cloneCalls).toHaveLength(1);
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toBe('Git clone failed');
+    expect(thrown?.message).not.toContain(hiddenMainRepoPath);
+    expect(thrown?.message).not.toContain(hiddenClonePath);
+    expect(serializedCloneLogs()).not.toContain(hiddenMainRepoPath);
   });
 
   it('should not fall back on non-shallow clone errors', () => {
@@ -1313,7 +1717,7 @@ describe('shallow clone fallback', () => {
         worktree: '/tmp/other-error-test',
         taskSlug: 'other-error',
       });
-    }).toThrow('clone failed');
+    }).toThrow('Git clone failed');
   });
 
   it('should attempt --reference --dissociate clone first', () => {

--- a/src/__tests__/repertoire/add.test.ts
+++ b/src/__tests__/repertoire/add.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const {
+  mockMkdtempSync,
+  mockMkdirSync,
+  mockCopyFileSync,
+  mockExistsSync,
+  mockReadFileSync,
+  mockWriteFileSync,
+  mockRmSync,
+  mockExecFileSync,
+  mockResolveRef,
+  mockResolveRepertoireConfigPath,
+  mockAtomicReplace,
+  secureTempDir,
+} = vi.hoisted(() => ({
+  mockMkdtempSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockCopyFileSync: vi.fn(),
+  mockExistsSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockRmSync: vi.fn(),
+  mockExecFileSync: vi.fn(),
+  mockResolveRef: vi.fn(),
+  mockResolveRepertoireConfigPath: vi.fn(),
+  mockAtomicReplace: vi.fn(),
+  secureTempDir: '/secure/tmp/takt-import-a1b2c3',
+}));
+
+vi.mock('node:fs', () => ({
+  default: {
+    mkdtempSync: mockMkdtempSync,
+    mkdirSync: mockMkdirSync,
+    copyFileSync: mockCopyFileSync,
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    writeFileSync: mockWriteFileSync,
+    rmSync: mockRmSync,
+  },
+  mkdtempSync: mockMkdtempSync,
+  mkdirSync: mockMkdirSync,
+  copyFileSync: mockCopyFileSync,
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+  rmSync: mockRmSync,
+}));
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+vi.mock('../../infra/config/paths.js', () => ({
+  getRepertoirePackageDir: vi.fn(() => '/home/user/.takt/repertoire/@owner/repo'),
+}));
+
+vi.mock('../../features/repertoire/github-ref-resolver.js', () => ({
+  resolveRef: mockResolveRef,
+}));
+
+vi.mock('../../features/repertoire/tar-parser.js', () => ({
+  parseTarVerboseListing: vi.fn(() => ({
+    firstDirEntry: 'owner-repo-deadbeef',
+    includePaths: ['owner-repo-deadbeef/facets/personas/coder.md'],
+  })),
+}));
+
+vi.mock('../../features/repertoire/takt-repertoire-config.js', () => ({
+  parseTaktRepertoireConfig: vi.fn(() => ({ path: '.' })),
+  validateTaktRepertoirePath: vi.fn(),
+  validateMinVersion: vi.fn(),
+  isVersionCompatible: vi.fn(() => true),
+  checkPackageHasContentWithContext: vi.fn(),
+  validateRealpathInsideRoot: vi.fn(),
+  resolveRepertoireConfigPath: mockResolveRepertoireConfigPath,
+}));
+
+vi.mock('../../features/repertoire/file-filter.js', () => ({
+  collectCopyTargets: vi.fn(() => [{
+    absolutePath: `${secureTempDir}/extract/facets/personas/coder.md`,
+    relativePath: 'facets/personas/coder.md',
+  }]),
+}));
+
+vi.mock('../../features/repertoire/atomic-update.js', () => ({
+  cleanupResiduals: vi.fn(),
+  atomicReplace: mockAtomicReplace,
+}));
+
+vi.mock('../../features/repertoire/pack-summary.js', () => ({
+  summarizeFacetsByType: vi.fn(() => 'personas: 1'),
+  detectEditWorkflows: vi.fn(() => []),
+  formatEditWorkflowWarnings: vi.fn(() => []),
+}));
+
+vi.mock('../../shared/prompt/index.js', () => ({
+  confirm: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../shared/ui/index.js', () => ({
+  info: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock('../../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), error: vi.fn() }),
+}));
+
+import { repertoireAddCommand } from '../../commands/repertoire/add.js';
+
+describe('repertoireAddCommand temporary directory handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMkdtempSync.mockReturnValue(secureTempDir);
+    mockExistsSync.mockImplementation((target: string) => target === secureTempDir);
+    mockReadFileSync.mockReturnValue('path: .');
+    mockResolveRef.mockReturnValue('main');
+    mockResolveRepertoireConfigPath.mockReturnValue(join(secureTempDir, 'extract', '.takt', 'takt-repertoire.yaml'));
+    mockAtomicReplace.mockImplementation(async ({ install }: { install: () => Promise<void> }) => {
+      await install();
+    });
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'api') return Buffer.from('tarball');
+      if (args[0] === 'tvzf') {
+        return 'drwxr-xr-x  0 owner/repo 0 2026-06-01 12:00 owner-repo-deadbeef/\n'
+          + '-rw-r--r--  0 owner/repo 0 2026-06-01 12:00 owner-repo-deadbeef/facets/personas/coder.md\n';
+      }
+      return Buffer.from('');
+    });
+  });
+
+  it('should create import artifacts under a mkdtemp-created directory', async () => {
+    await repertoireAddCommand('github:owner/repo@main');
+
+    expect(mockMkdtempSync).toHaveBeenCalledWith(join(tmpdir(), 'takt-import-'));
+    expect(mockMkdirSync).toHaveBeenCalledWith(join(secureTempDir, 'extract'), { recursive: true });
+    expect(mockWriteFileSync).toHaveBeenCalledWith(join(secureTempDir, 'archive.tar.gz'), Buffer.from('tarball'));
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      join(secureTempDir, 'include.txt'),
+      'owner-repo-deadbeef/facets/personas/coder.md\n',
+    );
+    expect(mockResolveRepertoireConfigPath).toHaveBeenCalledWith(join(secureTempDir, 'extract'));
+  });
+
+  it('should clean up the mkdtemp-created directory once', async () => {
+    await repertoireAddCommand('github:owner/repo@main');
+
+    expect(mockRmSync).toHaveBeenCalledOnce();
+    expect(mockRmSync).toHaveBeenCalledWith(secureTempDir, { recursive: true, force: true });
+  });
+});

--- a/src/__tests__/repertoire/takt-repertoire-config-windows-boundary.test.ts
+++ b/src/__tests__/repertoire/takt-repertoire-config-windows-boundary.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  realpathSync: vi.fn((value: string) => value),
+}));
+
+vi.mock('node:path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:path')>();
+  return {
+    ...actual.win32,
+    default: actual.win32,
+    win32: actual.win32,
+    posix: actual.posix,
+  };
+});
+
+import { validateRealpathInsideRoot } from '../../features/repertoire/takt-repertoire-config.js';
+
+describe('validateRealpathInsideRoot windows path boundary', () => {
+  it('should allow a child path when realpath returns Windows separators', () => {
+    expect(() => validateRealpathInsideRoot(
+      'C:\\repo\\package',
+      'C:\\repo',
+    )).not.toThrow();
+  });
+
+  it('should reject a sibling path with the same root prefix', () => {
+    expect(() => validateRealpathInsideRoot(
+      'C:\\repo-sibling',
+      'C:\\repo',
+    )).toThrow();
+  });
+});

--- a/src/commands/repertoire/add.ts
+++ b/src/commands/repertoire/add.ts
@@ -6,7 +6,7 @@
  *   takt repertoire add github:{owner}/{repo}          (uses default branch)
  */
 
-import { mkdirSync, copyFileSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, copyFileSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -68,10 +68,10 @@ export async function repertoireAddCommand(spec: string): Promise<void> {
 
   const ref = resolveRef(specRef, owner, repo, execGh);
 
-  const tmpBase = join(tmpdir(), `takt-import-${Date.now()}`);
-  const tmpTarPath = `${tmpBase}.tar.gz`;
-  const tmpExtractDir = `${tmpBase}-extract`;
-  const tmpIncludeFile = `${tmpBase}-include.txt`;
+  const tmpBase = mkdtempSync(join(tmpdir(), 'takt-import-'));
+  const tmpTarPath = join(tmpBase, 'archive.tar.gz');
+  const tmpExtractDir = join(tmpBase, 'extract');
+  const tmpIncludeFile = join(tmpBase, 'include.txt');
 
   try {
     mkdirSync(tmpExtractDir, { recursive: true });
@@ -204,8 +204,6 @@ export async function repertoireAddCommand(spec: string): Promise<void> {
 
     success(`✅ ${owner}/${repo} @${ref} をインストールしました`);
   } finally {
-    if (existsSync(tmpTarPath)) rmSync(tmpTarPath, { force: true });
-    if (existsSync(tmpExtractDir)) rmSync(tmpExtractDir, { recursive: true, force: true });
-    if (existsSync(tmpIncludeFile)) rmSync(tmpIncludeFile, { force: true });
+    if (existsSync(tmpBase)) rmSync(tmpBase, { recursive: true, force: true });
   }
 }

--- a/src/features/repertoire/takt-repertoire-config.ts
+++ b/src/features/repertoire/takt-repertoire-config.ts
@@ -13,6 +13,7 @@
 import { existsSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
+import { isPathInside } from '../../shared/utils/index.js';
 import { TAKT_REPERTOIRE_MANIFEST_FILENAME } from './constants.js';
 
 export interface TaktRepertoireConfig {
@@ -191,7 +192,7 @@ export function validateRealpathInsideRoot(resolvedPath: string, repoRoot: strin
     throw new Error(`Path "${resolvedPath}" does not exist or cannot be resolved`);
   }
   const realRoot = realpathSync(repoRoot);
-  if (realPath !== realRoot && !realPath.startsWith(realRoot + '/')) {
+  if (!isPathInside(realRoot, realPath)) {
     throw new Error(
       `Security: path resolves to "${realPath}" which is outside the package root "${realRoot}"`,
     );

--- a/src/infra/task/clone-errors.ts
+++ b/src/infra/task/clone-errors.ts
@@ -1,0 +1,5 @@
+export const TASK_EXECUTION_ABORTED_MESSAGE = 'Task execution aborted';
+
+export function isTaskAbortError(error: unknown): boolean {
+  return error instanceof Error && error.message === TASK_EXECUTION_ABORTED_MESSAGE;
+}

--- a/src/infra/task/clone-exec.ts
+++ b/src/infra/task/clone-exec.ts
@@ -1,10 +1,18 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execFileSync, spawn } from 'node:child_process';
-import { createLogger } from '../../shared/utils/index.js';
+import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
 import { loadProjectConfig } from '../config/index.js';
+import { isTaskAbortError, TASK_EXECUTION_ABORTED_MESSAGE } from './clone-errors.js';
 
 const log = createLogger('clone');
+const CLONE_FAILED_MESSAGE = 'Git clone failed';
+const REMOTE_BRANCH_FETCH_FAILED_MESSAGE = 'Git remote branch fetch failed';
+const ISOLATED_GIT_ENV = {
+  GIT_CONFIG_COUNT: '1',
+  GIT_CONFIG_KEY_0: 'core.logAllRefUpdates',
+  GIT_CONFIG_VALUE_0: 'false',
+} as const;
 
 export function resolveCloneSubmoduleOptions(projectDir: string): { args: string[]; label: string; targets: string } {
   const config = loadProjectConfig(projectDir);
@@ -33,33 +41,102 @@ export function resolveCloneSubmoduleOptions(projectDir: string): { args: string
   };
 }
 
-function resolveMainRepo(projectDir: string): string {
-  const gitPath = path.join(projectDir, '.git');
-
+function isLinkedWorktree(projectDir: string): boolean {
   try {
-    const stats = fs.statSync(gitPath);
-    if (stats.isFile()) {
-      const content = fs.readFileSync(gitPath, 'utf-8');
-      const match = content.match(/^gitdir:\s*(.+)$/m);
-      if (match && match[1]) {
-        const gitDirPath = match[1].trim();
-        const gitDir = path.resolve(path.dirname(gitPath), gitDirPath);
-        const commonGitDir = path.resolve(gitDir, '..', '..');
-        const mainRepoPath = path.dirname(commonGitDir);
-        log.info('Detected worktree, using main repo', { worktree: projectDir, mainRepo: mainRepoPath });
-        return mainRepoPath;
-      }
-    }
-  } catch (err) {
-    log.debug('Failed to resolve main repo, using projectDir as-is', { error: String(err) });
+    return fs.statSync(path.join(projectDir, '.git')).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function getExecErrorStderr(error: unknown): string {
+  if (typeof error !== 'object' || error === null || !('stderr' in error)) {
+    return '';
   }
 
-  return projectDir;
+  const stderr = (error as { stderr?: unknown }).stderr;
+  if (Buffer.isBuffer(stderr)) {
+    return stderr.toString();
+  }
+  if (typeof stderr === 'string') {
+    return stderr;
+  }
+  return '';
+}
+
+function isShallowReferenceError(message: string): boolean {
+  return message.includes('reference repository is shallow');
+}
+
+function cloneFailedError(): Error {
+  return new Error(CLONE_FAILED_MESSAGE);
+}
+
+function isolatedGitEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, ...ISOLATED_GIT_ENV };
+}
+
+function runIsolatedGitCommandSync(gitCwd: string, args: string[]): Buffer {
+  return execFileSync('git', args, {
+    cwd: gitCwd,
+    stdio: 'pipe',
+    env: isolatedGitEnv(),
+  });
+}
+
+function runIsolatedGitCommandAbortable(
+  gitCwd: string,
+  args: string[],
+  abortSignal?: AbortSignal,
+): Promise<{ stdout: string; stderr: string }> {
+  return runGitCommandAbortable(gitCwd, args, abortSignal, isolatedGitEnv());
+}
+
+function cleanupPartialClone(clonePath: string): void {
+  try {
+    fs.rmSync(clonePath, { recursive: true, force: true });
+  } catch {
+    log.debug('Failed to cleanup partial clone before retry');
+  }
+}
+
+export function fetchRemoteBranchIntoIsolatedClone(projectDir: string, clonePath: string, branch: string): void {
+  try {
+    runIsolatedGitCommandSync(clonePath, [
+      'fetch',
+      '--no-write-fetch-head',
+      projectDir,
+      `refs/remotes/origin/${branch}:refs/heads/${branch}`,
+    ]);
+  } catch {
+    throw new Error(REMOTE_BRANCH_FETCH_FAILED_MESSAGE);
+  }
+}
+
+export async function fetchRemoteBranchIntoIsolatedCloneAbortable(
+  projectDir: string,
+  clonePath: string,
+  branch: string,
+  abortSignal?: AbortSignal,
+): Promise<void> {
+  try {
+    await runIsolatedGitCommandAbortable(clonePath, [
+      'fetch',
+      '--no-write-fetch-head',
+      projectDir,
+      `refs/remotes/origin/${branch}:refs/heads/${branch}`,
+    ], abortSignal);
+  } catch (err) {
+    if (isTaskAbortError(err)) {
+      throw err;
+    }
+    throw new Error(REMOTE_BRANCH_FETCH_FAILED_MESSAGE);
+  }
 }
 
 export function cloneAndIsolate(projectDir: string, clonePath: string, branch?: string): void {
-  const referenceRepo = resolveMainRepo(projectDir);
   const cloneSubmoduleOptions = resolveCloneSubmoduleOptions(projectDir);
+  const useReferenceClone = !isLinkedWorktree(projectDir);
 
   fs.mkdirSync(path.dirname(clonePath), { recursive: true });
 
@@ -71,25 +148,25 @@ export function cloneAndIsolate(projectDir: string, clonePath: string, branch?: 
     clonePath,
   ];
 
-  const referenceCloneArgs = ['clone', '--reference', referenceRepo, '--dissociate', ...commonArgs];
   const fallbackCloneArgs = ['clone', ...commonArgs];
+  const referenceCloneArgs = useReferenceClone
+    ? ['clone', '--reference', projectDir, '--dissociate', ...commonArgs]
+    : fallbackCloneArgs;
 
   try {
-    execFileSync('git', referenceCloneArgs, {
-      cwd: projectDir,
-      stdio: 'pipe',
-    });
+    runIsolatedGitCommandSync(projectDir, referenceCloneArgs);
   } catch (err) {
-    const stderr = ((err as { stderr?: Buffer }).stderr ?? Buffer.alloc(0)).toString();
-    if (stderr.includes('reference repository is shallow')) {
-      log.info('Reference repository is shallow, retrying clone without --reference', { referenceRepo });
-      try { fs.rmSync(clonePath, { recursive: true, force: true }); } catch (e) { log.debug('Failed to cleanup partial clone before retry', { clonePath, error: String(e) }); }
-      execFileSync('git', fallbackCloneArgs, {
-        cwd: projectDir,
-        stdio: 'pipe',
-      });
+    const stderr = getExecErrorStderr(err);
+    if (isShallowReferenceError(stderr)) {
+      log.info('Reference repository is shallow, retrying clone without --reference');
+      cleanupPartialClone(clonePath);
+      try {
+        runIsolatedGitCommandSync(projectDir, fallbackCloneArgs);
+      } catch {
+        throw cloneFailedError();
+      }
     } else {
-      throw err;
+      throw cloneFailedError();
     }
   }
 
@@ -132,10 +209,11 @@ export function runGitCommandAbortable(
   gitCwd: string,
   args: string[],
   abortSignal?: AbortSignal,
+  env?: NodeJS.ProcessEnv,
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     if (abortSignal?.aborted) {
-      reject(new Error('Task execution aborted'));
+      reject(new Error(TASK_EXECUTION_ABORTED_MESSAGE));
       return;
     }
 
@@ -143,6 +221,7 @@ export function runGitCommandAbortable(
       cwd: gitCwd,
       stdio: 'pipe',
       detached: true,
+      env,
     });
 
     let stdout = '';
@@ -181,7 +260,7 @@ export function runGitCommandAbortable(
         }
       }, 500);
       killTimer.unref?.();
-      rejectOnce(new Error('Task execution aborted'));
+      rejectOnce(new Error(TASK_EXECUTION_ABORTED_MESSAGE));
     };
 
     abortSignal?.addEventListener('abort', onAbort, { once: true });
@@ -196,7 +275,7 @@ export function runGitCommandAbortable(
     });
     child.on('close', (code) => {
       if (abortSignal?.aborted) {
-        rejectOnce(new Error('Task execution aborted'));
+        rejectOnce(new Error(TASK_EXECUTION_ABORTED_MESSAGE));
         return;
       }
       if (code === 0) {
@@ -214,7 +293,7 @@ function runGitCloneAbortable(
   args: string[],
   abortSignal?: AbortSignal,
 ): Promise<void> {
-  return runGitCommandAbortable(gitCwd, args, abortSignal).then(() => undefined);
+  return runIsolatedGitCommandAbortable(gitCwd, args, abortSignal).then(() => undefined);
 }
 
 export async function cloneAndIsolateAbortable(
@@ -223,8 +302,8 @@ export async function cloneAndIsolateAbortable(
   branch?: string,
   abortSignal?: AbortSignal,
 ): Promise<void> {
-  const referenceRepo = resolveMainRepo(projectDir);
   const cloneSubmoduleOptions = resolveCloneSubmoduleOptions(projectDir);
+  const useReferenceClone = !isLinkedWorktree(projectDir);
 
   fs.mkdirSync(path.dirname(clonePath), { recursive: true });
 
@@ -236,23 +315,32 @@ export async function cloneAndIsolateAbortable(
     clonePath,
   ];
 
-  const referenceCloneArgs = ['clone', '--reference', referenceRepo, '--dissociate', ...commonArgs];
   const fallbackCloneArgs = ['clone', ...commonArgs];
+  const referenceCloneArgs = useReferenceClone
+    ? ['clone', '--reference', projectDir, '--dissociate', ...commonArgs]
+    : fallbackCloneArgs;
 
   try {
     await runGitCloneAbortable(projectDir, referenceCloneArgs, abortSignal);
   } catch (err) {
-    const stderr = err instanceof Error ? err.message : String(err);
-    if (stderr.includes('reference repository is shallow')) {
-      log.info('Reference repository is shallow, retrying clone without --reference', { referenceRepo });
-      try {
-        fs.rmSync(clonePath, { recursive: true, force: true });
-      } catch (cleanupErr) {
-        log.debug('Failed to cleanup partial clone before retry', { clonePath, error: String(cleanupErr) });
-      }
-      await runGitCloneAbortable(projectDir, fallbackCloneArgs, abortSignal);
-    } else {
+    if (isTaskAbortError(err)) {
       throw err;
+    }
+
+    const stderr = getErrorMessage(err);
+    if (isShallowReferenceError(stderr)) {
+      log.info('Reference repository is shallow, retrying clone without --reference');
+      cleanupPartialClone(clonePath);
+      try {
+        await runGitCloneAbortable(projectDir, fallbackCloneArgs, abortSignal);
+      } catch (fallbackErr) {
+        if (isTaskAbortError(fallbackErr)) {
+          throw fallbackErr;
+        }
+        throw cloneFailedError();
+      }
+    } else {
+      throw cloneFailedError();
     }
   }
 

--- a/src/infra/task/clone-exec.ts
+++ b/src/infra/task/clone-exec.ts
@@ -42,9 +42,10 @@ function resolveMainRepo(projectDir: string): string {
       const content = fs.readFileSync(gitPath, 'utf-8');
       const match = content.match(/^gitdir:\s*(.+)$/m);
       if (match && match[1]) {
-        const worktreePath = match[1].trim();
-        const gitDir = path.resolve(worktreePath, '..', '..');
-        const mainRepoPath = path.dirname(gitDir);
+        const gitDirPath = match[1].trim();
+        const gitDir = path.resolve(path.dirname(gitPath), gitDirPath);
+        const commonGitDir = path.resolve(gitDir, '..', '..');
+        const mainRepoPath = path.dirname(commonGitDir);
         log.info('Detected worktree, using main repo', { worktree: projectDir, mainRepo: mainRepoPath });
         return mainRepoPath;
       }

--- a/src/infra/task/clone.ts
+++ b/src/infra/task/clone.ts
@@ -12,7 +12,14 @@ import {
   resolveBaseBranch as resolveBaseBranchInternal,
   resolveBaseBranchAbortable,
 } from './clone-base-branch.js';
-import { cloneAndIsolate, cloneAndIsolateAbortable, resolveCloneSubmoduleOptions, runGitCommandAbortable } from './clone-exec.js';
+import {
+  cloneAndIsolate,
+  cloneAndIsolateAbortable,
+  fetchRemoteBranchIntoIsolatedClone,
+  fetchRemoteBranchIntoIsolatedCloneAbortable,
+  resolveCloneSubmoduleOptions,
+  runGitCommandAbortable,
+} from './clone-exec.js';
 import { loadCloneMeta, removeCloneMeta as removeCloneMetaFile, saveCloneMeta as saveCloneMetaFile } from './clone-meta.js';
 import { syncProjectLocalTaktForRetry } from './projectLocalTaktSync.js';
 
@@ -138,18 +145,15 @@ export class CloneManager {
         cwd: projectDir,
         stdio: 'pipe',
       });
-    } catch (err) {
+    } catch {
       log.info('Failed to prefetch branch from origin, continuing', {
         branch,
-        error: String(err),
       });
     }
 
     if (remoteBranchExists(projectDir, branch)) {
       cloneAndIsolate(projectDir, clonePath);
-      execFileSync('git', ['fetch', projectDir, `refs/remotes/origin/${branch}:refs/heads/${branch}`], {
-        cwd: clonePath, stdio: 'pipe',
-      });
+      fetchRemoteBranchIntoIsolatedClone(projectDir, clonePath, branch);
       execFileSync('git', ['checkout', branch], { cwd: clonePath, stdio: 'pipe' });
     } else if (localBranchExists(projectDir, branch)) {
       cloneAndIsolate(projectDir, clonePath, branch);
@@ -185,20 +189,15 @@ export class CloneManager {
 
     try {
       await runGitCommandAbortable(projectDir, ['fetch', 'origin', branch], abortSignal);
-    } catch (err) {
+    } catch {
       log.info('Failed to prefetch branch from origin, continuing', {
         branch,
-        error: String(err),
       });
     }
 
     if (await remoteBranchExistsAbortable(projectDir, branch, abortSignal)) {
       await cloneAndIsolateAbortable(projectDir, clonePath, undefined, abortSignal);
-      await runGitCommandAbortable(
-        clonePath,
-        ['fetch', projectDir, `refs/remotes/origin/${branch}:refs/heads/${branch}`],
-        abortSignal,
-      );
+      await fetchRemoteBranchIntoIsolatedCloneAbortable(projectDir, clonePath, branch, abortSignal);
       await runGitCommandAbortable(clonePath, ['checkout', branch], abortSignal);
     } else if (await localBranchExistsAbortable(projectDir, branch, abortSignal)) {
       await cloneAndIsolateAbortable(projectDir, clonePath, branch, abortSignal);


### PR DESCRIPTION
## Summary

## 確認範囲
- `/home/opa/work/takt`
- 静的レビューのみ。テストや実行確認はしていません。
- 主に clone/exec と repertoire import 周辺を確認しました。

## Findings
1. **High:** worktree の `.git` relative `gitdir:` を process cwd 基準で解決しています。
   - 対象: `src/infra/task/clone-exec.ts:42`
   - Git の `gitdir:` 相対パスは `.git` ファイルのあるディレクトリ基準です。現在は `path.resolve(worktreePath, '..', '..')` と cwd 依存の解決になり、別ディレクトリから実行すると main repo を誤認して `--reference` clone が壊れます。`path.dirname(gitPath)` 基準で解決してください。

2. **Medium:** root 配下判定が `/` 固定で Windows path を壊します。
   - 対象: `src/features/repertoire/takt-repertoire-config.ts:194`
   - `realPath.startsWith(realRoot + '/')` は Windows の `\` separator で valid child path を拒否します。既存の path boundary helper か `path.sep`/`path.relative` ベースにしてください。

3. **Medium:** repertoire add の temp path が時刻ベースで予測可能です。
   - 対象: `src/commands/repertoire/add.ts:71`
   - shared temp dir に `takt-import-${Date.now()}` を作るため、衝突や symlink race の余地があります。`fs.mkdtempSync(path.join(tmpdir(), 'takt-import-'))` を使ってください。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * ワークツリー参照解決や参照クローンのフォールバック・abortable 挙動を検証するテストを追加
  * レポジトリ追加処理の一時展開・後片付けを検証するテストを追加
  * Windows パス境界の検証ロジックテストを追加
  * クローン隔離と内部パス露出防止を確認するテストを追加

* **バグ修正**
  * 一時ファイルのクリーンアップ処理を改善
  * フェッチ/クローン失敗時のエラーメッセージをサニタイズ・統一し、内部パスが露出しないよう修正

* **変更**
  * 実体パス検証ロジックをより堅牢な判定へ改善
<!-- end of auto-generated comment: release notes by coderabbit.ai -->