### PR TITLE
Release v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.44.0] - 2026-06-03
+
+### Added
+
+- `kiro` provider added (#773). TAKT can now drive the Kiro CLI as an AI agent provider alongside Claude, Codex, OpenCode, Cursor, and Copilot. Select it with `--provider kiro` or in config. Authentication uses `kiro_api_key` in config (or the `TAKT_KIRO_API_KEY` env var), and the CLI binary can be overridden via `kiro_cli_path` / `TAKT_KIRO_CLI_PATH`.
+- OpenTelemetry observability gained working exporters and richer spans (#753). Building on the span foundation shipped in 0.42.0, observability now emits a local `monitor.json` of per-run workflow metrics (enable with `observability.monitor: true`) and a shadow session log derived from OTel spans (`observability.sessionLogExporter: true`), and the span set was extended to cover phase execution and status-judgment (judge) phases. Exporters are routed per run id and the shadow session log keeps redaction parity with the canonical NDJSON session log, so sensitive agent output stays sanitized. Still off by default behind `observability.enabled: true`.
+
+### Changed
+
+- Coding review extended to all builtin review and development workflows. The coding-review parallel sub-step (the `coding-reviewer` persona with the `review-coding` instruction and `coding-review` output contract) — previously only on `default-peer-review` — is now appended to every builtin review / review-fix workflow and to the parallel reviewer waves of the development workflows (backend, frontend, dual, terraform, and their variants). It is a general-purpose, near-instruction-less pass that flags implementation bugs, regressions, security risks, and missing tests using the model's own coding judgment. The intentionally-minimal `*-mini` and `compound-eye` variants are left unchanged.
+
+### Fixed
+
+- Codex `Reconnecting...` events no longer abort the run (#775). A transient reconnect from the Codex SDK could surface as a fatal provider error and tear down the whole workflow; the Codex client now treats it as a recoverable reconnect and retries.
+- Worktree-clone isolation hardened (#778). Fixes to the `git clone --shared` isolation path and clone execution, including normalized gitdir isolation handling, so worktree-isolated tasks stay properly isolated from the main repository.
+
+### Internal
+
+- Repository quality gates wired into TAKT's own `.takt/config.yaml` so the dogfooded review/dev steps run the build, lint, unit, and mock-E2E checks via a command gate.
+
 ## [0.43.0] - 2026-05-29
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,26 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.44.0] - 2026-06-03
+
+### Added
+
+- `kiro` プロバイダーを追加 (#773)。Claude・Codex・OpenCode・Cursor・Copilot に加えて、Kiro CLI を AI エージェントプロバイダーとして利用できるようになった。`--provider kiro` または設定で選択する。認証は設定の `kiro_api_key`（または環境変数 `TAKT_KIRO_API_KEY`）を使い、CLI バイナリは `kiro_cli_path` / `TAKT_KIRO_CLI_PATH` で上書きできる
+- OpenTelemetry オブザーバビリティに動作するエクスポーターとスパンの拡充を追加 (#753)。0.42.0 で導入したスパン基盤の上に、実行ごとのワークフローメトリクスをローカルの `monitor.json` に出力する機能（`observability.monitor: true` で有効化）と、OTel スパンから派生するシャドウセッションログ（`observability.sessionLogExporter: true`）を追加し、スパンの対象をフェーズ実行とステータス判定（judge）フェーズにも拡張した。エクスポーターは実行 ID ごとにルーティングされ、シャドウセッションログは正規の NDJSON セッションログとレダクションの整合性を保つため、機微なエージェント出力はサニタイズされたままになる。引き続き `observability.enabled: true` の背後でデフォルト無効
+
+### Changed
+
+- コーディングレビューをすべてのビルトインのレビュー・開発ワークフローに拡張。これまで `default-peer-review` のみに含まれていた coding-review 並列サブステップ（`review-coding` インストラクションと `coding-review` 出力契約を持つ `coding-reviewer` ペルソナ）を、すべてのビルトインの review / review-fix ワークフローと、開発ワークフロー（backend・frontend・dual・terraform とその派生）の並列レビューワーウェーブに追加した。モデル自身のコーディング判断を用いて実装上のバグ・リグレッション・セキュリティリスク・テスト不足を指摘する、ほぼインストラクションを持たない汎用パスである。意図的に最小構成の `*-mini` と `compound-eye` の派生はそのままにしている
+
+### Fixed
+
+- Codex の `Reconnecting...` イベントで実行が中断されなくなった (#775)。Codex SDK の一時的な再接続が致命的なプロバイダーエラーとして表面化し、ワークフロー全体を停止させることがあったが、回復可能な再接続として扱い再試行するようになった
+- ワークツリークローンの分離を強化 (#778)。`git clone --shared` の分離パスとクローン実行に対する修正（gitdir 分離処理の正規化を含む）により、ワークツリー分離タスクがメインリポジトリから正しく分離された状態を保つ
+
+### Internal
+
+- TAKT 自身の `.takt/config.yaml` にリポジトリの品質ゲートを組み込み、ドッグフーディングしているレビュー・開発ステップがコマンドゲート経由で build・lint・ユニット・モック E2E のチェックを実行するようにした
+
 ## [0.43.0] - 2026-05-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.141",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "TAKT: TAKT Agent Koordination Topology - AI Agent Workflow Orchestration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- `kiro` provider added (#773). TAKT can now drive the Kiro CLI as an AI agent provider alongside Claude, Codex, OpenCode, Cursor, and Copilot. Select it with `--provider kiro` or in config. Authentication uses `kiro_api_key` in config (or the `TAKT_KIRO_API_KEY` env var), and the CLI binary can be overridden via `kiro_cli_path` / `TAKT_KIRO_CLI_PATH`.
- OpenTelemetry observability gained working exporters and richer spans (#753). Building on the span foundation shipped in 0.42.0, observability now emits a local `monitor.json` of per-run workflow metrics (enable with `observability.monitor: true`) and a shadow session log derived from OTel spans (`observability.sessionLogExporter: true`), and the span set was extended to cover phase execution and status-judgment (judge) phases. Exporters are routed per run id and the shadow session log keeps redaction parity with the canonical NDJSON session log. Still off by default behind `observability.enabled: true`.

### Changed

- Coding review extended to all builtin review and development workflows. The coding-review parallel sub-step (the `coding-reviewer` persona with the `review-coding` instruction and `coding-review` output contract) — previously only on `default-peer-review` — is now appended to every builtin review / review-fix workflow and to the parallel reviewer waves of the development workflows. The `*-mini` and `compound-eye` variants are left unchanged.

### Fixed

- Codex `Reconnecting...` events no longer abort the run (#775).
- Worktree-clone isolation hardened (#778).

### Internal

- Repository quality gates wired into TAKT's own `.takt/config.yaml`.

## Commits

- chore: add takt quality command gate
- [#778] fix-source-review-issues (#779)
- [#773] add-kiro-provider (#776)
- feat(observability): add opt-in OpenTelemetry spans, session logs, and metrics (#753)
- takt: fix-codex-reconnect (#775)
- feat: add coding review to all review and dev workflows

## Closes

No open issues to close (all referenced issues already closed).