### PR TITLE
fix(observability): capture Claude usage for phase events

### DIFF
--- a/src/__tests__/claude-executor-structured-output.test.ts
+++ b/src/__tests__/claude-executor-structured-output.test.ts
@@ -241,4 +241,25 @@ describe('QueryExecutor — structuredOutput 抽出', () => {
       reason: 'usage_not_available',
     });
   });
+
+  it('usage に必須 token が欠ける場合は usage_tokens_missing を返す', async () => {
+    mockQuery.mockReturnValue(createMockQuery([
+      {
+        type: 'result',
+        subtype: 'success',
+        result: 'done',
+        usage: {
+          input_tokens: 12,
+        },
+      },
+    ]));
+
+    const executor = new QueryExecutor();
+    const result = await executor.execute('test', { cwd: '/tmp' });
+
+    expect(result.providerUsage).toEqual({
+      usageMissing: true,
+      reason: 'usage_tokens_missing',
+    });
+  });
 });

--- a/src/__tests__/claude-headless-client.test.ts
+++ b/src/__tests__/claude-headless-client.test.ts
@@ -133,6 +133,38 @@ describe('callClaudeHeadless', () => {
     expect(res.content).toBe('ok');
   });
 
+  it('returns provider usage from the final stream-json result', async () => {
+    stubSpawn({
+      stdoutChunks: [
+        `${JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          result: 'ok',
+          usage: {
+            input_tokens: 12,
+            output_tokens: 3,
+            cache_creation_input_tokens: 5,
+            cache_read_input_tokens: 7,
+          },
+        })}\n`,
+      ],
+      closeCode: 0,
+    });
+
+    const res = await callClaudeHeadless('agent', 'hi', { cwd: '/tmp' });
+
+    expect(res.status).toBe('done');
+    expect(res.providerUsage).toEqual({
+      inputTokens: 12,
+      outputTokens: 3,
+      totalTokens: 15,
+      cachedInputTokens: 12,
+      cacheCreationInputTokens: 5,
+      cacheReadInputTokens: 7,
+      usageMissing: false,
+    });
+  });
+
   it('uses only the final result text when assistant content and result contain the same text', async () => {
     stubSpawn({
       stdoutChunks: [

--- a/src/__tests__/claude-headless-stream-json.test.ts
+++ b/src/__tests__/claude-headless-stream-json.test.ts
@@ -31,6 +31,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: true,
       error: undefined,
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
     expect(aggregateContentFromStdout(stdout)).toBe('ab');
   });
@@ -98,6 +99,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: false,
       error: 'partial answer',
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
   });
 
@@ -123,6 +125,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: false,
       error: 'final failure',
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
   });
 
@@ -148,6 +151,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: true,
       error: undefined,
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
   });
 
@@ -169,6 +173,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: false,
       error: 'explicit failure',
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
   });
 
@@ -188,6 +193,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: true,
       error: undefined,
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
   });
 
@@ -213,6 +219,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: true,
       error: undefined,
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
   });
 
@@ -237,6 +244,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: true,
       error: undefined,
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
   });
 
@@ -257,6 +265,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: false,
       error: 'explicit failure',
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
   });
 
@@ -277,6 +286,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: true,
       error: undefined,
       structuredOutput: { decision: 'approved' },
+      providerUsage: undefined,
     });
   });
 
@@ -297,6 +307,83 @@ describe('claude-headless stream-json line parsing', () => {
       success: true,
       error: undefined,
       structuredOutput: { decision: 'approved' },
+      providerUsage: undefined,
+    });
+  });
+
+  it('captures provider usage from the final result event', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'final answer',
+        usage: {
+          input_tokens: 2353,
+          output_tokens: 4,
+          cache_creation_input_tokens: 2021,
+          cache_read_input_tokens: 15821,
+        },
+      }),
+    ].join('\n');
+
+    expect(aggregateResultFromStdout(stdout)).toEqual({
+      content: 'final answer',
+      displayText: '',
+      hasResult: true,
+      success: true,
+      error: undefined,
+      structuredOutput: undefined,
+      providerUsage: {
+        inputTokens: 2353,
+        outputTokens: 4,
+        totalTokens: 2357,
+        cachedInputTokens: 17842,
+        cacheCreationInputTokens: 2021,
+        cacheReadInputTokens: 15821,
+        usageMissing: false,
+      },
+    });
+  });
+
+  it('captures provider usage when only one cache token field is present', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'final answer',
+        usage: {
+          input_tokens: 20,
+          output_tokens: 5,
+          cache_read_input_tokens: 7,
+        },
+      }),
+    ].join('\n');
+
+    expect(aggregateResultFromStdout(stdout).providerUsage).toEqual({
+      inputTokens: 20,
+      outputTokens: 5,
+      totalTokens: 25,
+      cachedInputTokens: 7,
+      cacheReadInputTokens: 7,
+      usageMissing: false,
+    });
+  });
+
+  it('marks provider usage missing when required token fields are absent', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'final answer',
+        usage: {
+          input_tokens: 20,
+        },
+      }),
+    ].join('\n');
+
+    expect(aggregateResultFromStdout(stdout).providerUsage).toEqual({
+      usageMissing: true,
+      reason: 'usage_tokens_missing',
     });
   });
 
@@ -317,6 +404,7 @@ describe('claude-headless stream-json line parsing', () => {
       success: true,
       error: undefined,
       structuredOutput: undefined,
+      providerUsage: undefined,
     });
   });
 

--- a/src/infra/claude-headless/result-response.ts
+++ b/src/infra/claude-headless/result-response.ts
@@ -128,5 +128,6 @@ export function buildClaudeHeadlessResponse(input: ClaudeHeadlessResponseInput):
     timestamp: new Date(),
     sessionId,
     structuredOutput,
+    providerUsage: parsed.providerUsage,
   };
 }

--- a/src/infra/claude-headless/stream-json-lines.ts
+++ b/src/infra/claude-headless/stream-json-lines.ts
@@ -1,7 +1,14 @@
+import { USAGE_MISSING_REASONS } from '../../core/logging/contracts.js';
+import type { ProviderUsageSnapshot } from '../../core/models/response.js';
+
 function toRecord(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
+}
+
+function toNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 function pickString(source: Record<string, unknown> | undefined, keys: string[]): string | undefined {
@@ -164,6 +171,44 @@ function extractStructuredOutput(event: Record<string, unknown>): Record<string,
   return toRecord(structuredOutput);
 }
 
+function extractProviderUsage(event: Record<string, unknown>): ProviderUsageSnapshot | undefined {
+  const usage = toRecord(event.usage);
+  if (!usage) {
+    return undefined;
+  }
+
+  const inputTokens = toNumber(usage.input_tokens);
+  const outputTokens = toNumber(usage.output_tokens);
+  const cacheCreationInputTokens = toNumber(usage.cache_creation_input_tokens);
+  const cacheReadInputTokens = toNumber(usage.cache_read_input_tokens);
+  if (inputTokens === undefined || outputTokens === undefined) {
+    return {
+      usageMissing: true,
+      reason: USAGE_MISSING_REASONS.TOKENS_MISSING,
+    };
+  }
+
+  const providerUsage: ProviderUsageSnapshot = {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    usageMissing: false,
+  };
+  const cachedInputTokens = cacheCreationInputTokens !== undefined && cacheReadInputTokens !== undefined
+    ? cacheCreationInputTokens + cacheReadInputTokens
+    : cacheReadInputTokens ?? cacheCreationInputTokens;
+  if (cachedInputTokens !== undefined) {
+    providerUsage.cachedInputTokens = cachedInputTokens;
+  }
+  if (cacheCreationInputTokens !== undefined) {
+    providerUsage.cacheCreationInputTokens = cacheCreationInputTokens;
+  }
+  if (cacheReadInputTokens !== undefined) {
+    providerUsage.cacheReadInputTokens = cacheReadInputTokens;
+  }
+  return providerUsage;
+}
+
 function isSuccessfulResultEvent(event: Record<string, unknown>): boolean {
   if (event.is_error === true || event.isError === true) {
     return false;
@@ -180,6 +225,7 @@ export interface StreamJsonStdoutResult {
   success: boolean;
   error?: string;
   structuredOutput?: Record<string, unknown>;
+  providerUsage?: ProviderUsageSnapshot;
 }
 
 export function aggregateResultFromStdout(stdout: string): StreamJsonStdoutResult {
@@ -189,6 +235,7 @@ export function aggregateResultFromStdout(stdout: string): StreamJsonStdoutResul
   let success = false;
   let error: string | undefined;
   let structuredOutput: Record<string, unknown> | undefined;
+  let providerUsage: ProviderUsageSnapshot | undefined;
 
   for (const line of stdout.split('\n')) {
     const parsed = parseStreamJsonLine(line);
@@ -211,6 +258,7 @@ export function aggregateResultFromStdout(stdout: string): StreamJsonStdoutResul
     success = isSuccessfulResultEvent(root);
     error = success ? undefined : extractResultError(root, resultContent);
     structuredOutput = extractStructuredOutput(root);
+    providerUsage = extractProviderUsage(root);
   }
 
   const normalizedDisplayText = displayText.trim();
@@ -223,6 +271,7 @@ export function aggregateResultFromStdout(stdout: string): StreamJsonStdoutResul
     success: fallbackSuccess,
     error,
     structuredOutput,
+    providerUsage,
   };
 }
 

--- a/src/infra/claude-headless/stream-json-lines.ts
+++ b/src/infra/claude-headless/stream-json-lines.ts
@@ -1,14 +1,10 @@
-import { USAGE_MISSING_REASONS } from '../../core/logging/contracts.js';
 import type { ProviderUsageSnapshot } from '../../core/models/response.js';
+import { extractClaudeProviderUsage } from '../claude/usage.js';
 
 function toRecord(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
-}
-
-function toNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 function pickString(source: Record<string, unknown> | undefined, keys: string[]): string | undefined {
@@ -171,44 +167,6 @@ function extractStructuredOutput(event: Record<string, unknown>): Record<string,
   return toRecord(structuredOutput);
 }
 
-function extractProviderUsage(event: Record<string, unknown>): ProviderUsageSnapshot | undefined {
-  const usage = toRecord(event.usage);
-  if (!usage) {
-    return undefined;
-  }
-
-  const inputTokens = toNumber(usage.input_tokens);
-  const outputTokens = toNumber(usage.output_tokens);
-  const cacheCreationInputTokens = toNumber(usage.cache_creation_input_tokens);
-  const cacheReadInputTokens = toNumber(usage.cache_read_input_tokens);
-  if (inputTokens === undefined || outputTokens === undefined) {
-    return {
-      usageMissing: true,
-      reason: USAGE_MISSING_REASONS.TOKENS_MISSING,
-    };
-  }
-
-  const providerUsage: ProviderUsageSnapshot = {
-    inputTokens,
-    outputTokens,
-    totalTokens: inputTokens + outputTokens,
-    usageMissing: false,
-  };
-  const cachedInputTokens = cacheCreationInputTokens !== undefined && cacheReadInputTokens !== undefined
-    ? cacheCreationInputTokens + cacheReadInputTokens
-    : cacheReadInputTokens ?? cacheCreationInputTokens;
-  if (cachedInputTokens !== undefined) {
-    providerUsage.cachedInputTokens = cachedInputTokens;
-  }
-  if (cacheCreationInputTokens !== undefined) {
-    providerUsage.cacheCreationInputTokens = cacheCreationInputTokens;
-  }
-  if (cacheReadInputTokens !== undefined) {
-    providerUsage.cacheReadInputTokens = cacheReadInputTokens;
-  }
-  return providerUsage;
-}
-
 function isSuccessfulResultEvent(event: Record<string, unknown>): boolean {
   if (event.is_error === true || event.isError === true) {
     return false;
@@ -258,7 +216,7 @@ export function aggregateResultFromStdout(stdout: string): StreamJsonStdoutResul
     success = isSuccessfulResultEvent(root);
     error = success ? undefined : extractResultError(root, resultContent);
     structuredOutput = extractStructuredOutput(root);
-    providerUsage = extractProviderUsage(root);
+    providerUsage = extractClaudeProviderUsage(root.usage);
   }
 
   const normalizedDisplayText = displayText.trim();

--- a/src/infra/claude/executor.ts
+++ b/src/infra/claude/executor.ts
@@ -36,11 +36,9 @@ import {
   containsRateLimitMarker,
   resolveRateLimitErrorMessage,
 } from '../rate-limit/detection.js';
+import { extractClaudeProviderUsage } from './usage.js';
 
 const log = createLogger('claude-sdk');
-function toNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
 
 function isRejectedRateLimitEvent(message: SDKRateLimitEvent): boolean {
   // SDK は rate_limit_event を情報イベントとして毎回流す。
@@ -83,45 +81,12 @@ function describeRateLimitSignal(message: SDKMessage): string | undefined {
 
 function extractProviderUsage(resultMsg: SDKResultMessage): ProviderUsageSnapshot {
   const rawUsage = (resultMsg as unknown as { usage?: unknown }).usage;
-  if (!rawUsage || typeof rawUsage !== 'object') {
+  const providerUsage = extractClaudeProviderUsage(rawUsage);
+  if (!providerUsage) {
     return {
       usageMissing: true,
       reason: USAGE_MISSING_REASONS.NOT_AVAILABLE,
     };
-  }
-
-  const usage = rawUsage as Record<string, unknown>;
-  const inputTokens = toNumber(usage.input_tokens);
-  const outputTokens = toNumber(usage.output_tokens);
-  const cacheCreationInputTokens = toNumber(usage.cache_creation_input_tokens);
-  const cacheReadInputTokens = toNumber(usage.cache_read_input_tokens);
-  if (inputTokens === undefined || outputTokens === undefined) {
-    return {
-      usageMissing: true,
-      reason: USAGE_MISSING_REASONS.TOKENS_MISSING,
-    };
-  }
-  const totalTokens = inputTokens + outputTokens;
-  const cachedInputTokens = (
-    cacheCreationInputTokens !== undefined && cacheReadInputTokens !== undefined
-      ? cacheCreationInputTokens + cacheReadInputTokens
-      : cacheReadInputTokens ?? cacheCreationInputTokens
-  );
-
-  const providerUsage: ProviderUsageSnapshot = {
-    inputTokens,
-    outputTokens,
-    totalTokens,
-    usageMissing: false,
-  };
-  if (cachedInputTokens !== undefined) {
-    providerUsage.cachedInputTokens = cachedInputTokens;
-  }
-  if (cacheCreationInputTokens !== undefined) {
-    providerUsage.cacheCreationInputTokens = cacheCreationInputTokens;
-  }
-  if (cacheReadInputTokens !== undefined) {
-    providerUsage.cacheReadInputTokens = cacheReadInputTokens;
   }
   return providerUsage;
 }

--- a/src/infra/claude/usage.ts
+++ b/src/infra/claude/usage.ts
@@ -1,0 +1,50 @@
+import { USAGE_MISSING_REASONS } from '../../core/logging/contracts.js';
+import type { ProviderUsageSnapshot } from '../../core/models/response.js';
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function toNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function extractClaudeProviderUsage(rawUsage: unknown): ProviderUsageSnapshot | undefined {
+  const usage = toRecord(rawUsage);
+  if (!usage) {
+    return undefined;
+  }
+
+  const inputTokens = toNumber(usage.input_tokens);
+  const outputTokens = toNumber(usage.output_tokens);
+  const cacheCreationInputTokens = toNumber(usage.cache_creation_input_tokens);
+  const cacheReadInputTokens = toNumber(usage.cache_read_input_tokens);
+  if (inputTokens === undefined || outputTokens === undefined) {
+    return {
+      usageMissing: true,
+      reason: USAGE_MISSING_REASONS.TOKENS_MISSING,
+    };
+  }
+
+  const providerUsage: ProviderUsageSnapshot = {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    usageMissing: false,
+  };
+  const cachedInputTokens = cacheCreationInputTokens !== undefined && cacheReadInputTokens !== undefined
+    ? cacheCreationInputTokens + cacheReadInputTokens
+    : cacheReadInputTokens ?? cacheCreationInputTokens;
+  if (cachedInputTokens !== undefined) {
+    providerUsage.cachedInputTokens = cachedInputTokens;
+  }
+  if (cacheCreationInputTokens !== undefined) {
+    providerUsage.cacheCreationInputTokens = cacheCreationInputTokens;
+  }
+  if (cacheReadInputTokens !== undefined) {
+    providerUsage.cacheReadInputTokens = cacheReadInputTokens;
+  }
+  return providerUsage;
+}


### PR DESCRIPTION
## Summary

- Capture `usage` from Claude Code CLI stream-json `result` events and pass it through `providerUsage`.
- Share Claude usage normalization between the Claude SDK provider and Claude headless provider.
- Mark Claude SDK responses with incomplete required token fields as `usageMissing` instead of producing partial usage.

## Context

This is stacked on #785 (`codex/otel-usage-events-exporter-docs`). During local verification, `provider: claude` emitted phase usage events with `usage_missing=true` even though Claude Code CLI returned token usage in the stream-json result event. The headless parser was not propagating that usage into the agent response.

## Verification

- `npm test -- --run src/__tests__/claude-headless-stream-json.test.ts src/__tests__/claude-headless-client.test.ts src/__tests__/claude-executor-structured-output.test.ts`
- `npm run build`
- `npm run lint`
- Local `--provider claude` workflow after build emitted `usage_missing=false` phase usage events with token totals.