### PR TITLE
fix: allow read tools in opencode readonly mode

### DIFF
--- a/src/__tests__/opencode-types.test.ts
+++ b/src/__tests__/opencode-types.test.ts
@@ -66,8 +66,17 @@ describe('OpenCode permissions', () => {
     expect(buildOpenCodePermissionConfig('full')).toBe('allow');
   });
 
-  it('should build deny config for readonly mode', () => {
-    expect(buildOpenCodePermissionConfig('readonly')).toBe('deny');
+  it('should build read-only config for readonly mode', () => {
+    expect(buildOpenCodePermissionConfig('readonly')).toMatchObject({
+      read: 'allow',
+      glob: 'allow',
+      grep: 'allow',
+      edit: 'deny',
+      write: 'deny',
+      bash: 'deny',
+      task: 'deny',
+      question: 'deny',
+    });
   });
 
   it('should build ruleset for edit mode', () => {
@@ -85,10 +94,28 @@ describe('OpenCode permissions', () => {
     });
   });
 
+  it('should build ruleset for readonly mode with read-only tools allowed', () => {
+    const ruleset = buildOpenCodePermissionRuleset('readonly');
+    expect(ruleset.find((rule) => rule.permission === 'read')).toEqual({
+      permission: 'read',
+      pattern: '**',
+      action: 'allow',
+    });
+    expect(ruleset.find((rule) => rule.permission === 'glob')?.action).toBe('allow');
+    expect(ruleset.find((rule) => rule.permission === 'grep')?.action).toBe('allow');
+    expect(ruleset.find((rule) => rule.permission === 'edit')?.action).toBe('deny');
+    expect(ruleset.find((rule) => rule.permission === 'write')?.action).toBe('deny');
+    expect(ruleset.find((rule) => rule.permission === 'bash')?.action).toBe('deny');
+    expect(ruleset.find((rule) => rule.permission === 'task')?.action).toBe('deny');
+    expect(ruleset.find((rule) => rule.permission === 'question')?.action).toBe('deny');
+  });
+
   it('should force allow web tools when networkAccess=true', () => {
     const ruleset = buildOpenCodePermissionRuleset('readonly', true);
     expect(ruleset.find((rule) => rule.permission === 'webfetch')?.action).toBe('allow');
     expect(ruleset.find((rule) => rule.permission === 'websearch')?.action).toBe('allow');
+    expect(ruleset.find((rule) => rule.permission === 'read')?.action).toBe('allow');
+    expect(ruleset.find((rule) => rule.permission === 'edit')?.action).toBe('deny');
   });
 
   it('should force deny web tools when networkAccess=false', () => {

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -51,7 +51,14 @@ function buildPermissionMap(mode?: PermissionMode): OpenCodePermissionMap {
     question: 'deny',
   };
 
-  if (mode === 'readonly') return allDeny;
+  if (mode === 'readonly') {
+    return {
+      ...allDeny,
+      read: 'allow',
+      glob: 'allow',
+      grep: 'allow',
+    };
+  }
 
   if (mode === 'full') {
     return {
@@ -121,7 +128,6 @@ export function buildOpenCodePermissionConfig(
   networkAccess?: boolean,
 ): OpenCodePermissionAction | Record<string, OpenCodePermissionAction> {
   if (networkAccess === undefined) {
-    if (mode === 'readonly') return 'deny';
     if (mode === 'full') return 'allow';
   }
   return applyNetworkAccessOverride(buildPermissionMap(mode), networkAccess);


### PR DESCRIPTION
## Summary
- allow OpenCode readonly mode to use read, glob, and grep
- keep mutating tools, bash, task, and question denied in readonly mode
- update OpenCode permission tests for readonly and network overrides

## Tests
- npm test -- --run src/__tests__/opencode-types.test.ts src/__tests__/opencode-client-cleanup.test.ts
- npm run lint
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * readonlyモード時の権限設定を改善しました。read/glob/grepのみアクセスを許可し、その他の操作は制限されます。

* **Tests**
  * readonlyモード時の権限検証テストを拡充し、より詳細な権限チェックを実施するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->