### PR TITLE
[#799] split-team-leader-limits

### DIFF
--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -218,7 +218,8 @@ CSV / JSON などのデータソースを反復し、同じ step テンプレー
 ```yaml
   - name: implement
     team_leader:
-      max_parts: 3
+      max_concurrency: 2
+      max_total_parts: 8
       timeout_ms: 600000
       part_persona: coder
       part_edit: true
@@ -232,6 +233,8 @@ CSV / JSON などのデータソースを反復し、同じ step テンプレー
 ```
 
 大きなタスクを「事前にユニット境界を決めなくても並列で進められる単位」に分解したいときに便利です。
+
+`max_concurrency` は同時に実行する part 数、`max_total_parts` はその step 全体で計画できる総 part 数（最大 20）を制御します。旧名の `max_parts` は互換性のため `max_concurrency` として扱われます。
 
 ### Workflow Call Step（サブワークフロー）
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -219,7 +219,8 @@ The agent acts as a leader: it decomposes the task into independent sub-parts at
 ```yaml
   - name: implement
     team_leader:
-      max_parts: 3
+      max_concurrency: 2
+      max_total_parts: 8
       timeout_ms: 600000
       part_persona: coder
       part_edit: true
@@ -233,6 +234,8 @@ The agent acts as a leader: it decomposes the task into independent sub-parts at
 ```
 
 Useful for breaking one large task into independent units that can run in parallel without you having to know the unit boundaries up-front.
+
+`max_concurrency` controls how many parts run at the same time. `max_total_parts` controls the total number of parts the leader may plan across the workflow step, up to 20. The older `max_parts` key is still accepted as the compatibility name for `max_concurrency`.
 
 ### Workflow Call Step (subworkflow)
 

--- a/e2e/fixtures/scenarios/team-leader-worker-pool.json
+++ b/e2e/fixtures/scenarios/team-leader-worker-pool.json
@@ -6,31 +6,9 @@
     "structured_output": {
       "parts": [
         { "id": "wp-1", "title": "Create wp-1.txt", "instruction": "Create wp-1.txt with content wp-1.txt" },
-        { "id": "wp-2", "title": "Create wp-2.txt", "instruction": "Create wp-2.txt with content wp-2.txt" }
-      ]
-    }
-  },
-  {
-    "persona": "agents/test-team-leader-worker-pool",
-    "status": "done",
-    "content": "add-3-4",
-    "structured_output": {
-      "done": false,
-      "reasoning": "Two more files remain after the first batch begins finishing",
-      "parts": [
+        { "id": "wp-2", "title": "Create wp-2.txt", "instruction": "Create wp-2.txt with content wp-2.txt" },
         { "id": "wp-3", "title": "Create wp-3.txt", "instruction": "Create wp-3.txt with content wp-3.txt" },
-        { "id": "wp-4", "title": "Create wp-4.txt", "instruction": "Create wp-4.txt with content wp-4.txt" }
-      ]
-    }
-  },
-  {
-    "persona": "agents/test-team-leader-worker-pool",
-    "status": "done",
-    "content": "add-5",
-    "structured_output": {
-      "done": false,
-      "reasoning": "One final file remains",
-      "parts": [
+        { "id": "wp-4", "title": "Create wp-4.txt", "instruction": "Create wp-4.txt with content wp-4.txt" },
         { "id": "wp-5", "title": "Create wp-5.txt", "instruction": "Create wp-5.txt with content wp-5.txt" }
       ]
     }

--- a/e2e/specs/team-leader-worker-pool.e2e.ts
+++ b/e2e/specs/team-leader-worker-pool.e2e.ts
@@ -82,7 +82,7 @@ describe('E2E: Team leader worker-pool dynamic scheduling', () => {
     expect(stepComplete).toBeDefined();
 
     const initialContent = String(initialDecomposition?.content ?? '');
-    expect(countPartsFromJson(initialContent)).toBe(2);
+    expect(countPartsFromJson(initialContent)).toBe(5);
 
     const content = String(stepComplete?.content ?? '');
     expect(countPartSections(content)).toBeGreaterThanOrEqual(5);

--- a/src/__tests__/agent-usecases.test.ts
+++ b/src/__tests__/agent-usecases.test.ts
@@ -21,7 +21,7 @@ vi.mock('../agents/runner.js', () => ({
 vi.mock('../infra/resources/schema-loader.js', () => ({
   loadJudgmentSchema: vi.fn(() => ({ type: 'judgment' })),
   loadEvaluationSchema: vi.fn(() => ({ type: 'evaluation' })),
-  loadDecompositionSchema: vi.fn((maxParts: number) => ({ type: 'decomposition', maxParts })),
+  loadDecompositionSchema: vi.fn((maxTotalParts: number) => ({ type: 'decomposition', maxTotalParts })),
   loadMorePartsSchema: vi.fn((maxAdditionalParts: number) => ({ type: 'more-parts', maxAdditionalParts })),
 }));
 
@@ -385,7 +385,7 @@ describe('agent-usecases', () => {
       allowedTools: [],
       permissionMode: 'readonly',
       maxTurns: 5,
-      outputSchema: { type: 'decomposition', maxParts: 3 },
+      outputSchema: { type: 'decomposition', maxTotalParts: 3 },
     }));
   });
 

--- a/src/__tests__/engine-rate-limit-fallback.test.ts
+++ b/src/__tests__/engine-rate-limit-fallback.test.ts
@@ -124,7 +124,8 @@ function teamLeaderStepConfig(): WorkflowConfig {
         instruction: 'Implement feature',
         teamLeader: {
           persona: '../personas/team-leader.md',
-          maxParts: 1,
+          maxConcurrency: 1,
+          maxTotalParts: 20,
           refillThreshold: 0,
           timeoutMs: 10000,
           partPersona: '../personas/coder.md',
@@ -889,7 +890,8 @@ describe('WorkflowEngine rate limit fallback', () => {
           outputContracts: [{ name: 'implement.md', format: 'markdown' }],
           teamLeader: {
             persona: '../personas/team-leader.md',
-            maxParts: 1,
+            maxConcurrency: 1,
+            maxTotalParts: 20,
             refillThreshold: 0,
             timeoutMs: 10000,
             partPersona: '../personas/coder.md',

--- a/src/__tests__/engine-rate-limit-report-session.test.ts
+++ b/src/__tests__/engine-rate-limit-report-session.test.ts
@@ -92,7 +92,8 @@ function buildTeamLeaderReportConfig(): WorkflowConfig {
         outputContracts: [{ name: 'implement.md', useJudge: false }],
         teamLeader: {
           persona: '../personas/team-leader.md',
-          maxParts: 1,
+          maxConcurrency: 1,
+          maxTotalParts: 20,
           refillThreshold: 0,
           timeoutMs: 10000,
           partPersona: '../personas/coder.md',

--- a/src/__tests__/engine-team-leader-report-phase.test.ts
+++ b/src/__tests__/engine-team-leader-report-phase.test.ts
@@ -63,7 +63,7 @@ function createStructuredCaller(): StructuredCaller {
       }
       return -1;
     },
-    decomposeTask: async (instruction, _maxParts, options) => {
+    decomposeTask: async (instruction, _maxTotalParts, options) => {
       options.onPromptResolved?.({
         systemPrompt: options.persona ?? 'testing-reviewer',
         userInstruction: instruction,
@@ -98,7 +98,8 @@ function createConfig(): WorkflowConfig {
         instruction: 'Audit task: {task}',
         passPreviousResponse: false,
         teamLeader: {
-          maxParts: 1,
+          maxConcurrency: 1,
+          maxTotalParts: 20,
           refillThreshold: 0,
           timeoutMs: 1_000,
           partPersona: 'testing-reviewer',

--- a/src/__tests__/engine-team-leader.test.ts
+++ b/src/__tests__/engine-team-leader.test.ts
@@ -39,7 +39,8 @@ function buildTeamLeaderConfig(): WorkflowConfig {
         instruction: 'Task: {task}',
         teamLeader: {
           persona: '../personas/team-leader.md',
-          maxParts: 3,
+          maxConcurrency: 3,
+          maxTotalParts: 20,
           refillThreshold: 0,
           timeoutMs: 10000,
           partPersona: '../personas/coder.md',

--- a/src/__tests__/schema-loader.test.ts
+++ b/src/__tests__/schema-loader.test.ts
@@ -87,11 +87,12 @@ describe('schema-loader', () => {
     expect(readFileSyncMock).toHaveBeenCalledTimes(1);
   });
 
-  it('loadDecompositionSchema は不正な maxParts を拒否する', async () => {
+  it('loadDecompositionSchema は不正な maxTotalParts を拒否する', async () => {
     const { loadDecompositionSchema } = await import('../infra/resources/schema-loader.js');
 
-    expect(() => loadDecompositionSchema(0)).toThrow('maxParts must be a positive integer: 0');
-    expect(() => loadDecompositionSchema(-1)).toThrow('maxParts must be a positive integer: -1');
+    expect(() => loadDecompositionSchema(0)).toThrow('maxTotalParts must be a positive integer: 0');
+    expect(() => loadDecompositionSchema(-1)).toThrow('maxTotalParts must be a positive integer: -1');
+    expect(() => loadDecompositionSchema(21)).toThrow('maxTotalParts must be less than or equal to 20: 21');
   });
 
   it('loadMorePartsSchema は maxItems を注入し、呼び出しごとに独立したオブジェクトを返す', async () => {

--- a/src/__tests__/task-decomposer.test.ts
+++ b/src/__tests__/task-decomposer.test.ts
@@ -39,7 +39,7 @@ describe('parseParts', () => {
     const content = '```json\n[{"id":"a","title":"A","instruction":"Do A"},{"id":"b","title":"B","instruction":"Do B"}]\n```';
 
     expect(() => parseParts(content, 1)).toThrow(
-      'Team leader produced too many parts: 2 > 1',
+      'Team leader produced too many total parts: 2 > max_total_parts 1',
     );
   });
 

--- a/src/__tests__/team-leader-budget-errors.test.ts
+++ b/src/__tests__/team-leader-budget-errors.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isPlanningBudgetError } from '../core/workflow/engine/team-leader-budget-errors.js';
+
+describe('isPlanningBudgetError', () => {
+  it('既知の parts 予算超過エラーだけを planning budget error として扱う', () => {
+    expect(isPlanningBudgetError(new Error('Initial team leader parts exceed max_total_parts: 3 > 2'))).toBe(true);
+    expect(isPlanningBudgetError(new Error('Team leader planned parts exceed max_total_parts: 4 > 3'))).toBe(true);
+    expect(isPlanningBudgetError(new Error('Team leader produced too many total parts: 2 > max_total_parts 1'))).toBe(true);
+    expect(isPlanningBudgetError(new Error('Structured output produced too many total parts: 6 > max_total_parts 5'))).toBe(true);
+    expect(isPlanningBudgetError(new Error('Structured output produced too many parts: 2 > 1'))).toBe(true);
+  });
+
+  it('max_total_parts を含むだけの無関係なエラーは planning budget error にしない', () => {
+    expect(isPlanningBudgetError(new Error('Failed to load max_total_parts from workflow config'))).toBe(false);
+    expect(isPlanningBudgetError(new Error('max_total_parts must be less than or equal to 20: 21'))).toBe(false);
+    expect(isPlanningBudgetError('Team leader planned parts exceed max_total_parts: 4 > 3')).toBe(false);
+  });
+});

--- a/src/__tests__/team-leader-common.test.ts
+++ b/src/__tests__/team-leader-common.test.ts
@@ -29,7 +29,8 @@ describe('createPartStep', () => {
       },
       teamLeader: {
         persona: 'leader',
-        maxParts: 3,
+        maxConcurrency: 3,
+        maxTotalParts: 20,
         refillThreshold: 0,
         timeoutMs: 900000,
       },
@@ -57,7 +58,8 @@ describe('createPartStep', () => {
       passPreviousResponse: false,
       teamLeader: {
         persona: 'leader',
-        maxParts: 3,
+        maxConcurrency: 3,
+        maxTotalParts: 20,
         refillThreshold: 0,
         timeoutMs: 600000,
         partPersona: 'coder',

--- a/src/__tests__/team-leader-execution.test.ts
+++ b/src/__tests__/team-leader-execution.test.ts
@@ -23,6 +23,57 @@ function makeResult(part: PartDefinition): PartResult {
 }
 
 describe('runTeamLeaderExecution', () => {
+  it('初回5パートを最大2並列で順次実行する', async () => {
+    const parts = ['p1', 'p2', 'p3', 'p4', 'p5'].map(makePart);
+    let activeParts = 0;
+    let maxActiveParts = 0;
+
+    const runPart = vi.fn(async (part: PartDefinition) => {
+      activeParts += 1;
+      maxActiveParts = Math.max(maxActiveParts, activeParts);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      activeParts -= 1;
+      return makeResult(part);
+    });
+    const requestMoreParts = vi.fn().mockResolvedValue({
+      done: true,
+      reasoning: 'initial parts cover all work',
+      parts: [],
+    });
+
+    const result = await runTeamLeaderExecution({
+      initialParts: parts,
+      maxConcurrency: 2,
+      refillThreshold: 0,
+      maxTotalParts: 5,
+      runPart,
+      requestMoreParts,
+    });
+
+    expect(result.plannedParts.map((part) => part.id)).toEqual(['p1', 'p2', 'p3', 'p4', 'p5']);
+    expect(result.partResults.map((result) => result.part.id).sort()).toEqual(['p1', 'p2', 'p3', 'p4', 'p5']);
+    expect(runPart).toHaveBeenCalledTimes(5);
+    expect(maxActiveParts).toBe(2);
+  });
+
+  it('初回パート数が maxTotalParts を超える場合は実行前にエラーにする', async () => {
+    const parts = ['p1', 'p2', 'p3'].map(makePart);
+    const runPart = vi.fn(async (part: PartDefinition) => makeResult(part));
+    const requestMoreParts = vi.fn();
+
+    await expect(runTeamLeaderExecution({
+      initialParts: parts,
+      maxConcurrency: 2,
+      refillThreshold: 0,
+      maxTotalParts: 2,
+      runPart,
+      requestMoreParts,
+    })).rejects.toThrow('Initial team leader parts exceed max_total_parts: 3 > 2');
+
+    expect(runPart).not.toHaveBeenCalled();
+    expect(requestMoreParts).not.toHaveBeenCalled();
+  });
+
   it('refill threshold 到達時に追加パートを取り込んで完了する', async () => {
     const part1 = makePart('p1');
     const part2 = makePart('p2');
@@ -55,6 +106,53 @@ describe('runTeamLeaderExecution', () => {
     expect(runPart).toHaveBeenCalledTimes(3);
     expect(requestMoreParts).toHaveBeenCalledTimes(2);
     expect(result.partResults.some((r) => r.part.id === part3.id)).toBe(true);
+  });
+
+  it('追加パートが残り maxTotalParts 予算を超える場合はエラーにする', async () => {
+    const parts = ['p1', 'p2'].map(makePart);
+    const runPart = vi.fn(async (part: PartDefinition) => makeResult(part));
+    const requestMoreParts = vi.fn().mockResolvedValue({
+      done: false,
+      reasoning: 'too many new parts',
+      parts: [makePart('p3'), makePart('p4')],
+    });
+
+    await expect(runTeamLeaderExecution({
+      initialParts: parts,
+      maxConcurrency: 1,
+      refillThreshold: 1,
+      maxTotalParts: 3,
+      runPart,
+      requestMoreParts,
+    })).rejects.toThrow('Team leader planned parts exceed max_total_parts: 4 > 3');
+
+    expect(requestMoreParts).toHaveBeenCalledWith({
+      partResults: [expect.objectContaining({ part: parts[0] })],
+      scheduledIds: ['p1', 'p2'],
+      remainingPartBudget: 1,
+      unfinishedScheduledPartCount: 1,
+    });
+  });
+
+  it('追加パート数超過の planning error は握りつぶさず伝播する', async () => {
+    const parts = ['p1', 'p2'].map(makePart);
+    const runPart = vi.fn(async (part: PartDefinition) => makeResult(part));
+    const requestMoreParts = vi.fn().mockRejectedValue(
+      new Error('Structured output produced too many parts: 2 > 1'),
+    );
+    const onPlanningError = vi.fn();
+
+    await expect(runTeamLeaderExecution({
+      initialParts: parts,
+      maxConcurrency: 1,
+      refillThreshold: 1,
+      maxTotalParts: 3,
+      runPart,
+      requestMoreParts,
+      onPlanningError,
+    })).rejects.toThrow('Structured output produced too many parts: 2 > 1');
+
+    expect(onPlanningError).not.toHaveBeenCalled();
   });
 
   it('重複IDだけ返された場合は追加せず終了する', async () => {

--- a/src/__tests__/team-leader-prompt-guidance.test.ts
+++ b/src/__tests__/team-leader-prompt-guidance.test.ts
@@ -25,6 +25,16 @@ describe('team leader decomposition guidance', () => {
     expect(prompt).toContain('parts.length === 1');
   });
 
+  it('Given structured decomposition, When building the Japanese prompt, Then it describes max parts as a total limit instead of concurrency', () => {
+    const prompt = buildDecomposePrompt('実装タスク', 5, 'ja');
+
+    expect(prompt).toContain('返してよい総 parts 数');
+    expect(prompt).toContain('1 以上 5 以下');
+    expect(prompt).toContain('同時実行数ではない');
+    expect(prompt).toContain('上限遵守');
+    expect(prompt).toContain('検証分離や責務分解より優先');
+  });
+
   it('Given prompt-based decomposition, When building the English prompt, Then it requires responsibility boundaries and staged verification', () => {
     const prompt = buildPromptBasedDecomposePrompt('implement feature', 4, 'en');
 
@@ -36,6 +46,16 @@ describe('team leader decomposition guidance', () => {
     expect(prompt).toContain('npm run test:e2e:mock');
     expect(prompt).toContain('Do not duplicate');
     expect(prompt).toContain('parts.length === 1');
+  });
+
+  it('Given prompt-based decomposition, When building the English prompt, Then it describes max parts as a total limit instead of concurrency', () => {
+    const prompt = buildPromptBasedDecomposePrompt('implement feature', 5, 'en');
+
+    expect(prompt).toContain('total number of parts');
+    expect(prompt).toContain('between 1 and 5');
+    expect(prompt).toContain('not a concurrency limit');
+    expect(prompt).toContain('Respecting this limit takes precedence');
+    expect(prompt).toContain('verification separation or responsibility boundaries');
   });
 
   it('Given feedback planning, When building more-parts prompts, Then it keeps heavy quality gates out of implementation continuations', () => {

--- a/src/__tests__/team-leader-runner-structured-caller.test.ts
+++ b/src/__tests__/team-leader-runner-structured-caller.test.ts
@@ -52,7 +52,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
     });
 
     const structuredCaller = {
-      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
         options.onPromptResolved?.({
           systemPrompt: 'team-leader-system',
           userInstruction: 'leader instruction',
@@ -114,7 +114,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       },
       teamLeader: {
         persona: 'team-leader',
-        maxParts: 2,
+        maxConcurrency: 2,
+        maxTotalParts: 20,
         refillThreshold: 0,
         timeoutMs: 1000,
         partPersona: 'coder',
@@ -153,7 +154,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
     expect(result.response.content).toContain('part-1');
     expect(structuredCaller.decomposeTask).toHaveBeenCalledWith(
       'leader instruction',
-      2,
+      20,
       expect.objectContaining({
         cwd: '/tmp/project',
         model: 'opencode/zai-coding-plan/glm-5.1',
@@ -219,7 +220,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
     });
 
     const structuredCaller = {
-      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
         options.onPromptResolved?.({
           systemPrompt: 'team-leader-system',
           userInstruction: 'leader instruction',
@@ -281,7 +282,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       passPreviousResponse: true,
       teamLeader: {
         persona: 'team-leader',
-        maxParts: 2,
+        maxConcurrency: 2,
+        maxTotalParts: 20,
         refillThreshold: 0,
         timeoutMs: 1000,
         partPersona: 'coder',
@@ -332,7 +334,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
     });
 
     const structuredCaller = {
-      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
         options.onPromptResolved?.({
           systemPrompt: 'team-leader-system',
           userInstruction: 'leader instruction',
@@ -403,7 +405,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       passPreviousResponse: true,
       teamLeader: {
         persona: 'team-leader',
-        maxParts: 2,
+        maxConcurrency: 2,
+        maxTotalParts: 20,
         refillThreshold: 0,
         timeoutMs: 1000,
         partPersona: 'coder',
@@ -452,7 +455,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       .mockReturnValueOnce({ provider: 'claude', model: 'sonnet' });
 
     const structuredCaller = {
-      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
         options.onPromptResolved?.({
           systemPrompt: 'team-leader-system',
           userInstruction: 'leader instruction',
@@ -524,7 +527,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       },
       teamLeader: {
         persona: 'team-leader',
-        maxParts: 2,
+        maxConcurrency: 2,
+        maxTotalParts: 20,
         refillThreshold: 0,
         timeoutMs: 1000,
         partPersona: 'coder',
@@ -606,7 +610,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       .mockReturnValueOnce({ provider: 'opencode', model: 'opencode/zai-coding-plan/glm-5.1' });
 
     const structuredCaller = {
-      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
         options.onPromptResolved?.({
           systemPrompt: 'team-leader-system',
           userInstruction: 'leader instruction',
@@ -655,7 +659,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       passPreviousResponse: true,
       teamLeader: {
         persona: 'team-leader',
-        maxParts: 2,
+        maxConcurrency: 2,
+        maxTotalParts: 20,
         refillThreshold: 0,
         timeoutMs: 1000,
         partPersona: 'coder',
@@ -703,7 +708,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       .mockReturnValueOnce({ provider: 'cursor', model: 'cursor-fast' });
 
     const structuredCaller = {
-      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
         options.onPromptResolved?.({
           systemPrompt: 'team-leader-system',
           userInstruction: 'leader instruction',
@@ -757,7 +762,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       passPreviousResponse: true,
       teamLeader: {
         persona: 'team-leader',
-        maxParts: 2,
+        maxConcurrency: 2,
+        maxTotalParts: 20,
         refillThreshold: 0,
         timeoutMs: 1000,
         partPersona: 'coder',
@@ -816,7 +822,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       timestamp: new Date('2026-04-01T00:00:00.000Z'),
     });
     const structuredCaller = {
-      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
         options.onPromptResolved?.({
           systemPrompt: 'team-leader-system',
           userInstruction: 'leader instruction',
@@ -865,7 +871,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       passPreviousResponse: true,
       teamLeader: {
         persona: 'team-leader',
-        maxParts: 2,
+        maxConcurrency: 2,
+        maxTotalParts: 20,
         refillThreshold: 0,
         timeoutMs: 1000,
         partPersona: 'coder',
@@ -956,7 +963,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         passPreviousResponse: true,
         teamLeader: {
           persona: 'team-leader',
-          maxParts: 1,
+          maxConcurrency: 1,
+          maxTotalParts: 20,
           refillThreshold: 0,
           timeoutMs: 1000,
           partPersona: 'coder',
@@ -993,7 +1001,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
 
       const onPhaseStart = vi.fn();
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',
@@ -1028,7 +1036,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
 
       const onPhaseStart = vi.fn();
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',
@@ -1047,7 +1055,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
   });
 
   describe('timeout feedback failure fallback', () => {
-    function buildStep(maxParts: number): WorkflowStep {
+    function buildStep(maxConcurrency: number, maxTotalParts = 20): WorkflowStep {
       return {
         name: 'implement',
         persona: 'coder',
@@ -1056,7 +1064,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         passPreviousResponse: true,
         teamLeader: {
           persona: 'team-leader',
-          maxParts,
+          maxConcurrency,
+          maxTotalParts,
           refillThreshold: 0,
           timeoutMs: 1000,
           partPersona: 'coder',
@@ -1125,6 +1134,108 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       return { promise, resolve };
     }
 
+    it('Runner 経由でも maxConcurrency を超えて part を同時実行しない', async () => {
+      const part1 = createDeferredResponse();
+      const part2 = createDeferredResponse();
+      const part3 = createDeferredResponse();
+      mockExecuteAgent.mockImplementation((_persona, executedInstruction: string) => {
+        if (executedInstruction.includes('Implement first area')) return part1.promise;
+        if (executedInstruction.includes('Implement second area')) return part2.promise;
+        if (executedInstruction.includes('Implement third area')) return part3.promise;
+        throw new Error(`Unexpected instruction: ${executedInstruction}`);
+      });
+      const structuredCaller = {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
+          options.onPromptResolved?.({
+            systemPrompt: 'team-leader-system',
+            userInstruction: 'leader instruction',
+          });
+          return [
+            { id: 'part-1', title: 'Implementation 1', instruction: 'Implement first area' },
+            { id: 'part-2', title: 'Implementation 2', instruction: 'Implement second area' },
+            { id: 'part-3', title: 'Implementation 3', instruction: 'Implement third area' },
+          ];
+        }),
+        requestMoreParts: vi.fn().mockResolvedValue({ done: true, reasoning: 'complete', parts: [] }),
+      };
+
+      const runnerPromise = buildRunner(structuredCaller).runTeamLeaderStep(
+        buildStep(2),
+        buildState(),
+        'implement feature',
+        5,
+        vi.fn(),
+      );
+
+      await vi.waitFor(() => {
+        expect(mockExecuteAgent).toHaveBeenCalledTimes(2);
+      });
+      expect(mockExecuteAgent.mock.calls[0]?.[1]).toContain('Implement first area');
+      expect(mockExecuteAgent.mock.calls[1]?.[1]).toContain('Implement second area');
+
+      part1.resolve({
+        persona: 'coder',
+        status: 'done',
+        content: 'Part 1 completed',
+        timestamp: new Date('2026-04-01T00:00:00.000Z'),
+      });
+      await vi.waitFor(() => {
+        expect(mockExecuteAgent).toHaveBeenCalledTimes(3);
+      });
+      expect(mockExecuteAgent.mock.calls[2]?.[1]).toContain('Implement third area');
+
+      part2.resolve({
+        persona: 'coder',
+        status: 'done',
+        content: 'Part 2 completed',
+        timestamp: new Date('2026-04-01T00:00:30.000Z'),
+      });
+      part3.resolve({
+        persona: 'coder',
+        status: 'done',
+        content: 'Part 3 completed',
+        timestamp: new Date('2026-04-01T00:01:00.000Z'),
+      });
+
+      const result = await runnerPromise;
+
+      expect(result.response.status).toBe('done');
+      expect(result.response.content).toContain('Part 1 completed');
+      expect(result.response.content).toContain('Part 2 completed');
+      expect(result.response.content).toContain('Part 3 completed');
+    });
+
+    it('part_timeout 後の feedback が残予算超過を投げた場合は timeout fallback に変換しない', async () => {
+      mockExecuteAgent.mockResolvedValueOnce({
+        persona: 'coder',
+        status: 'error',
+        content: '',
+        error: 'Part timeout after 1000ms',
+        failureCategory: AGENT_FAILURE_CATEGORIES.PART_TIMEOUT,
+        timestamp: new Date('2026-04-01T00:00:00.000Z'),
+      });
+      const structuredCaller = {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
+          options.onPromptResolved?.({
+            systemPrompt: 'team-leader-system',
+            userInstruction: 'leader instruction',
+          });
+          return [{ id: 'part-1', title: 'Implementation', instruction: 'Implement everything' }];
+        }),
+        requestMoreParts: vi.fn().mockRejectedValue(new Error('Structured output produced too many parts: 2 > 1')),
+      };
+
+      await expect(buildRunner(structuredCaller).runTeamLeaderStep(
+        buildStep(1, 2),
+        buildState(),
+        'implement feature',
+        5,
+        vi.fn(),
+      )).rejects.toThrow('Structured output produced too many parts: 2 > 1');
+
+      expect(mockExecuteAgent).toHaveBeenCalledTimes(1);
+    });
+
     it('Given part_timeout and feedback failure, When running team leader step, Then a continuation part completes the step', async () => {
       mockExecuteAgent
         .mockResolvedValueOnce({
@@ -1142,7 +1253,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
           timestamp: new Date('2026-04-01T00:01:00.000Z'),
         });
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',
@@ -1192,7 +1303,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
           timestamp: new Date('2026-04-01T00:01:00.000Z'),
         });
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',
@@ -1251,7 +1362,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
           timestamp: new Date('2026-04-01T00:01:30.000Z'),
         });
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',
@@ -1318,7 +1429,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
           timestamp: new Date('2026-04-01T00:01:30.000Z'),
         });
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',
@@ -1377,7 +1488,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
           timestamp: new Date('2026-04-01T00:01:00.000Z'),
         });
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',
@@ -1421,7 +1532,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         throw new Error(`Unexpected instruction: ${executedInstruction}`);
       });
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',
@@ -1510,7 +1621,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         throw new Error(`Unexpected instruction: ${executedInstruction}`);
       });
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',
@@ -1598,7 +1709,7 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         timestamp: new Date('2026-04-01T00:00:00.000Z'),
       });
       const structuredCaller = {
-        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxParts, options) => {
+        decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
           options.onPromptResolved?.({
             systemPrompt: 'team-leader-system',
             userInstruction: 'leader instruction',

--- a/src/__tests__/team-leader-schema-loader.test.ts
+++ b/src/__tests__/team-leader-schema-loader.test.ts
@@ -19,6 +19,28 @@ describe('team_leader schema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('max_concurrency と max_total_parts の設定を受け付ける', () => {
+    const raw = {
+      name: 'implement',
+      team_leader: {
+        persona: 'team-leader',
+        max_concurrency: 2,
+        max_total_parts: 5,
+        timeout_ms: 120000,
+      },
+      instruction: 'decompose',
+    };
+
+    const result = WorkflowStepRawSchema.safeParse(raw);
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    const teamLeader = result.data.team_leader as Record<string, unknown>;
+    expect(teamLeader.max_concurrency).toBe(2);
+    expect(teamLeader.max_total_parts).toBe(5);
+  });
+
   it('max_parts > 3 は拒否する', () => {
     const raw = {
       name: 'implement',
@@ -32,11 +54,65 @@ describe('team_leader schema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('max_concurrency > 3 は拒否する', () => {
+    const raw = {
+      name: 'implement',
+      team_leader: {
+        max_concurrency: 4,
+      },
+      instruction: 'decompose',
+    };
+
+    const result = WorkflowStepRawSchema.safeParse(raw);
+    expect(result.success).toBe(false);
+  });
+
+  it('max_total_parts > 20 は拒否する', () => {
+    const raw = {
+      name: 'implement',
+      team_leader: {
+        max_total_parts: 21,
+      },
+      instruction: 'decompose',
+    };
+
+    const result = WorkflowStepRawSchema.safeParse(raw);
+    expect(result.success).toBe(false);
+  });
+
+  it('max_parts と max_concurrency の同時指定は拒否する', () => {
+    const raw = {
+      name: 'implement',
+      team_leader: {
+        max_parts: 2,
+        max_concurrency: 2,
+      },
+      instruction: 'decompose',
+    };
+
+    const result = WorkflowStepRawSchema.safeParse(raw);
+    expect(result.success).toBe(false);
+  });
+
   it('refill_threshold > max_parts は拒否する', () => {
     const raw = {
       name: 'implement',
       team_leader: {
         max_parts: 2,
+        refill_threshold: 3,
+      },
+      instruction: 'decompose',
+    };
+
+    const result = WorkflowStepRawSchema.safeParse(raw);
+    expect(result.success).toBe(false);
+  });
+
+  it('refill_threshold > max_concurrency は拒否する', () => {
+    const raw = {
+      name: 'implement',
+      team_leader: {
+        max_concurrency: 2,
         refill_threshold: 3,
       },
       instruction: 'decompose',
@@ -95,7 +171,7 @@ describe('team_leader schema', () => {
 });
 
 describe('normalizeWorkflowConfig team_leader', () => {
-  it('team_leader を内部形式へ正規化する', () => {
+  it('team_leader の新しい上限設定を内部形式へ正規化する', () => {
     const workflowDir = join(process.cwd(), 'src', '__tests__');
     const raw = {
       name: 'workflow',
@@ -105,7 +181,8 @@ describe('normalizeWorkflowConfig team_leader', () => {
           allow_git_commit: true,
           team_leader: {
             persona: 'team-leader',
-            max_parts: 2,
+            max_concurrency: 2,
+            max_total_parts: 5,
             timeout_ms: 90000,
             part_persona: 'coder',
             part_allowed_tools: ['Read', 'Edit'],
@@ -124,7 +201,8 @@ describe('normalizeWorkflowConfig team_leader', () => {
     expect(step!.teamLeader).toEqual({
       persona: 'team-leader',
       personaPath: undefined,
-      maxParts: 2,
+      maxConcurrency: 2,
+      maxTotalParts: 5,
       refillThreshold: 0,
       timeoutMs: 90000,
       partPersona: 'coder',
@@ -132,6 +210,39 @@ describe('normalizeWorkflowConfig team_leader', () => {
       partAllowedTools: ['Read', 'Edit'],
       partEdit: true,
       partPermissionMode: 'edit',
+    });
+  });
+
+  it('旧名 max_parts を maxConcurrency として正規化する', () => {
+    const workflowDir = join(process.cwd(), 'src', '__tests__');
+    const raw = {
+      name: 'workflow',
+      steps: [
+        {
+          name: 'implement',
+          team_leader: {
+            max_parts: 2,
+          },
+          instruction: 'decompose',
+        },
+      ],
+    };
+
+    const config = normalizeWorkflowConfig(raw, workflowDir);
+    const step = config.steps[0];
+    expect(step).toBeDefined();
+    expect(step!.teamLeader).toEqual({
+      persona: undefined,
+      personaPath: undefined,
+      maxConcurrency: 2,
+      maxTotalParts: 20,
+      refillThreshold: 0,
+      timeoutMs: 900000,
+      partPersona: undefined,
+      partPersonaPath: undefined,
+      partAllowedTools: undefined,
+      partEdit: undefined,
+      partPermissionMode: undefined,
     });
   });
 });

--- a/src/__tests__/team-leader-structured-output.test.ts
+++ b/src/__tests__/team-leader-structured-output.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { toPartDefinitions } from '../agents/team-leader-structured-output.js';
+
+function makeRawPart(id: string): Record<string, string> {
+  return {
+    id,
+    title: `Title ${id}`,
+    instruction: `Do ${id}`,
+  };
+}
+
+describe('toPartDefinitions', () => {
+  it('総 parts 数の上限内なら5パートを受け付ける', () => {
+    const rawParts = ['p1', 'p2', 'p3', 'p4', 'p5'].map(makeRawPart);
+
+    const result = toPartDefinitions(rawParts, 5);
+
+    expect(result.map((part) => part.id)).toEqual(['p1', 'p2', 'p3', 'p4', 'p5']);
+  });
+
+  it('総 parts 数の上限を超えたら明確なエラーにする', () => {
+    const rawParts = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'].map(makeRawPart);
+
+    expect(() => toPartDefinitions(rawParts, 5)).toThrow(
+      'Structured output produced too many total parts: 6 > max_total_parts 5',
+    );
+  });
+});

--- a/src/__tests__/workflow-dual-parallel.test.ts
+++ b/src/__tests__/workflow-dual-parallel.test.ts
@@ -145,7 +145,8 @@ describe('dual workflow parallel structure', () => {
     const implement = workflow!.steps.find((s) => s.name === 'implement');
     expect(implement).toBeDefined();
     expect(implement!.teamLeader).toBeDefined();
-    expect(implement!.teamLeader!.maxParts).toBe(2);
+    expect(implement!.teamLeader!.maxConcurrency).toBe(2);
+    expect(implement!.teamLeader!.maxTotalParts).toBe(20);
   });
 
   it('should not have fix_supervisor step', () => {

--- a/src/agents/decompose-task-usecase.ts
+++ b/src/agents/decompose-task-usecase.ts
@@ -38,10 +38,10 @@ export const TEAM_LEADER_MAX_TURNS = 5;
 
 export async function decomposeTask(
   instruction: string,
-  maxParts: number,
+  maxTotalParts: number,
   options: DecomposeTaskOptions,
 ): Promise<PartDefinition[]> {
-  const response = await runAgent(options.persona, buildDecomposePrompt(instruction, maxParts, options.language), {
+  const response = await runAgent(options.persona, buildDecomposePrompt(instruction, maxTotalParts, options.language), {
     cwd: options.cwd,
     personaPath: options.personaPath,
     language: options.language,
@@ -52,7 +52,7 @@ export async function decomposeTask(
     allowedTools: [],
     permissionMode: 'readonly',
     ...buildMaxTurnsOption(options.provider, options.resolvedProvider, TEAM_LEADER_MAX_TURNS),
-    outputSchema: loadDecompositionSchema(maxParts),
+    outputSchema: loadDecompositionSchema(maxTotalParts),
     onStream: options.onStream,
     workflowMeta: options.workflowMeta,
     onPromptResolved: options.onPromptResolved,
@@ -65,10 +65,10 @@ export async function decomposeTask(
 
   const parts = response.structuredOutput?.parts;
   if (parts != null) {
-    return toPartDefinitions(parts, maxParts);
+    return toPartDefinitions(parts, maxTotalParts);
   }
 
-  return parseParts(response.content, maxParts);
+  return parseParts(response.content, maxTotalParts);
 }
 
 export async function requestMoreParts(

--- a/src/agents/structured-caller/capability-aware-structured-caller.ts
+++ b/src/agents/structured-caller/capability-aware-structured-caller.ts
@@ -59,15 +59,15 @@ export class CapabilityAwareStructuredCaller extends DefaultStructuredCaller {
 
   async decomposeTask(
     instruction: string,
-    maxParts: number,
+    maxTotalParts: number,
     options: DecomposeTaskOptions,
   ): Promise<PartDefinition[]> {
     const provider = resolveProvider(options.provider, options.resolvedProvider);
     if (shouldUsePromptBased(provider)) {
-      return this.promptBased.decomposeTask(instruction, maxParts, options);
+      return this.promptBased.decomposeTask(instruction, maxTotalParts, options);
     }
 
-    return super.decomposeTask(instruction, maxParts, options);
+    return super.decomposeTask(instruction, maxTotalParts, options);
   }
 
   async requestMoreParts(

--- a/src/agents/structured-caller/contracts.ts
+++ b/src/agents/structured-caller/contracts.ts
@@ -18,7 +18,7 @@ export interface StructuredCaller {
 
   decomposeTask(
     instruction: string,
-    maxParts: number,
+    maxTotalParts: number,
     options: DecomposeTaskOptions,
   ): Promise<PartDefinition[]>;
 

--- a/src/agents/structured-caller/default-structured-caller.ts
+++ b/src/agents/structured-caller/default-structured-caller.ts
@@ -43,10 +43,10 @@ export class DefaultStructuredCaller implements StructuredCaller {
 
   async decomposeTask(
     instruction: string,
-    maxParts: number,
+    maxTotalParts: number,
     options: DecomposeTaskOptions,
   ): Promise<PartDefinition[]> {
-    return decomposeTask(instruction, maxParts, options);
+    return decomposeTask(instruction, maxTotalParts, options);
   }
 
   async requestMoreParts(

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -158,10 +158,10 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
 
   async decomposeTask(
     instruction: string,
-    maxParts: number,
+    maxTotalParts: number,
     options: DecomposeTaskOptions,
   ): Promise<PartDefinition[]> {
-    const prompt = buildPromptBasedDecomposePrompt(instruction, maxParts, options.language);
+    const prompt = buildPromptBasedDecomposePrompt(instruction, maxTotalParts, options.language);
 
     return withRetry(async () => {
       const response = await runAgent(options.persona, prompt, {
@@ -185,7 +185,7 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
         throw new Error(`Team leader failed: ${detail}`);
       }
 
-      return parseParts(response.content, maxParts);
+      return parseParts(response.content, maxTotalParts);
     });
   }
 

--- a/src/agents/team-leader-structured-output.ts
+++ b/src/agents/team-leader-structured-output.ts
@@ -11,15 +11,15 @@ function summarizePartContent(content: string): string {
   return `${content.slice(0, maxLength)}\n...[truncated]`;
 }
 
-export function toPartDefinitions(raw: unknown, maxParts: number): PartDefinition[] {
+export function toPartDefinitions(raw: unknown, maxTotalParts: number): PartDefinition[] {
   if (!Array.isArray(raw)) {
     throw new Error('Structured output "parts" must be an array');
   }
   if (raw.length === 0) {
     throw new Error('Structured output "parts" must not be empty');
   }
-  if (raw.length > maxParts) {
-    throw new Error(`Structured output produced too many parts: ${raw.length} > ${maxParts}`);
+  if (raw.length > maxTotalParts) {
+    throw new Error(`Structured output produced too many total parts: ${raw.length} > max_total_parts ${maxTotalParts}`);
   }
 
   const parts = raw.map((entry, index) => parsePartDefinitionEntry(entry, index));
@@ -56,12 +56,14 @@ export function toMorePartsResponse(raw: unknown, maxAdditionalParts: number): M
   };
 }
 
-function buildDecomposeBasePrompt(instruction: string, maxParts: number, language?: Language): string {
+function buildDecomposeBasePrompt(instruction: string, maxTotalParts: number, language?: Language): string {
   if (language === 'ja') {
     return [
       '以下はタスク分解専用の指示です。タスクを実行せず、分解だけを行ってください。',
       '- ツールは使用しない',
-      `- パート数は 1 以上 ${maxParts} 以下`,
+      `- 返してよい総 parts 数は 1 以上 ${maxTotalParts} 以下`,
+      '- この上限は同時実行数ではない',
+      '- 上限遵守を、検証分離や責務分解より優先する',
       '- パートは互いに独立させる',
       '- まず並行可能な責務境界を探す',
       '- 「実装と検証」のような巨大な単一 part を避ける',
@@ -79,7 +81,9 @@ function buildDecomposeBasePrompt(instruction: string, maxParts: number, languag
   return [
     'This is decomposition-only planning. Do not execute the task.',
     '- Do not use any tool',
-    `- Produce between 1 and ${maxParts} independent parts`,
+    `- Produce a total number of parts between 1 and ${maxTotalParts}`,
+    '- This limit is not a concurrency limit',
+    '- Respecting this limit takes precedence over verification separation or responsibility boundaries',
     '- Keep each part self-contained',
     '- First look for parallelizable responsibility boundaries',
     '- Avoid oversized single parts such as "implementation and verification"',
@@ -154,15 +158,15 @@ function buildMorePartsBasePrompt(
 
 export function buildDecomposePrompt(
   instruction: string,
-  maxParts: number,
+  maxTotalParts: number,
   language?: Language,
 ): string {
-  return buildDecomposeBasePrompt(instruction, maxParts, language);
+  return buildDecomposeBasePrompt(instruction, maxTotalParts, language);
 }
 
 export function buildPromptBasedDecomposePrompt(
   instruction: string,
-  maxParts: number,
+  maxTotalParts: number,
   language?: Language,
 ): string {
   const outputInstruction = language === 'ja'
@@ -181,7 +185,7 @@ export function buildPromptBasedDecomposePrompt(
         '- Each item must include {"id","title","instruction"}',
       ];
 
-  return `${buildDecomposeBasePrompt(instruction, maxParts, language)}\n${outputInstruction.join('\n')}`;
+  return `${buildDecomposeBasePrompt(instruction, maxTotalParts, language)}\n${outputInstruction.join('\n')}`;
 }
 
 export function buildMorePartsPrompt(

--- a/src/core/models/part.ts
+++ b/src/core/models/part.ts
@@ -29,7 +29,8 @@ export interface TeamLeaderConfig {
   /** Resolved absolute path for team leader persona */
   personaPath?: string;
   /** Maximum number of parts to run in parallel */
-  maxParts: number;
+  maxConcurrency: number;
+  maxTotalParts: number;
   /** Trigger additional planning when queued parts drop to this threshold or below */
   refillThreshold: number;
   /** Default timeout for parts in milliseconds */

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -26,6 +26,7 @@ import {
   isAggregateConditionExpression,
   isAiConditionExpression,
 } from './workflow-condition-expression.js';
+import { MAX_TEAM_LEADER_MAX_TOTAL_PARTS } from '../../shared/constants.js';
 
 const RESERVED_WORKFLOW_CALL_RESULTS = ['COMPLETE', 'ABORT'] as const;
 
@@ -151,20 +152,34 @@ export const ArpeggioConfigRawSchema = z.object({
 /** Team leader configuration schema for dynamic part decomposition */
 export const TeamLeaderConfigRawSchema = z.object({
   persona: z.string().optional(),
-  max_parts: z.number().int().positive().max(3).optional().default(3),
-  refill_threshold: z.number().int().min(0).optional().default(0),
-  timeout_ms: z.number().int().positive().optional().default(900000),
+  max_parts: z.number().int().positive().max(3).optional(),
+  max_concurrency: z.number().int().positive().max(3).optional(),
+  max_total_parts: z.number().int().positive().max(MAX_TEAM_LEADER_MAX_TOTAL_PARTS).optional(),
+  refill_threshold: z.number().int().min(0).optional(),
+  timeout_ms: z.number().int().positive().optional(),
   part_persona: z.string().optional(),
   part_allowed_tools: z.array(z.string()).optional(),
   part_edit: z.boolean().optional(),
   part_permission_mode: PermissionModeSchema.optional(),
-}).refine(
-  (data) => data.refill_threshold <= data.max_parts,
-  {
-    message: "'refill_threshold' must be less than or equal to 'max_parts'",
-    path: ['refill_threshold'],
-  },
-);
+}).superRefine((data, ctx) => {
+  if (data.max_parts !== undefined && data.max_concurrency !== undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['max_concurrency'],
+      message: "'max_parts' and 'max_concurrency' cannot be specified together",
+    });
+  }
+
+  const maxConcurrency = data.max_concurrency ?? data.max_parts ?? 3;
+  const refillThreshold = data.refill_threshold ?? 0;
+  if (refillThreshold > maxConcurrency) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['refill_threshold'],
+      message: "'refill_threshold' must be less than or equal to team leader concurrency",
+    });
+  }
+});
 
 /** Sub-step schema for parallel execution */
 export const ParallelSubStepRawSchema = z.object({

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -27,9 +27,9 @@ import type { RuntimeStepResolution, StepRunResult } from '../types.js';
 import { buildTeamLeaderErrorPartResult, runTeamLeaderPart } from './team-leader-part-runner.js';
 import { runWithPhaseSpan } from '../observability/workflowSpans.js';
 import { buildPhaseExecutionId } from '../../../shared/utils/phaseExecutionId.js';
+import { isPlanningBudgetError } from './team-leader-budget-errors.js';
 
 const log = createLogger('team-leader-runner');
-const MAX_TOTAL_PARTS = 20;
 
 export interface TeamLeaderRunnerDeps {
   readonly optionsBuilder: OptionsBuilder;
@@ -133,7 +133,7 @@ export class TeamLeaderRunner {
         providerInfo: leaderProviderInfo,
         getPromptParts: () => resolvedPromptParts,
       },
-      () => structuredCaller.decomposeTask(instruction, teamLeaderConfig.maxParts, {
+      () => structuredCaller.decomposeTask(instruction, teamLeaderConfig.maxTotalParts, {
         cwd: this.deps.getCwd(),
         persona: leaderStep.persona,
         personaPath: leaderStep.personaPath,
@@ -189,9 +189,9 @@ export class TeamLeaderRunner {
 
     const { plannedParts, partResults } = await runTeamLeaderExecution({
       initialParts: parts,
-      maxConcurrency: teamLeaderConfig.maxParts,
+      maxConcurrency: teamLeaderConfig.maxConcurrency,
       refillThreshold: teamLeaderConfig.refillThreshold,
-      maxTotalParts: MAX_TOTAL_PARTS,
+      maxTotalParts: teamLeaderConfig.maxTotalParts,
       onPartQueued: (part) => {
         parallelLogger?.addSubStep(part.id);
       },
@@ -263,6 +263,10 @@ export class TeamLeaderRunner {
             },
           );
         } catch (error) {
+          if (isPlanningBudgetError(error)) {
+            throw error;
+          }
+
           const timeoutFallback = createTimeoutContinuationFeedback({
             partResults: currentResults,
             scheduledIds,

--- a/src/core/workflow/engine/task-decomposer.ts
+++ b/src/core/workflow/engine/task-decomposer.ts
@@ -25,7 +25,7 @@ function parseJsonBlock(content: string): unknown {
   }
 }
 
-export function parseParts(content: string, maxParts: number): PartDefinition[] {
+export function parseParts(content: string, maxTotalParts: number): PartDefinition[] {
   const parsed = parseJsonBlock(content);
   if (!Array.isArray(parsed)) {
     throw new Error('Team leader JSON must be an array');
@@ -33,8 +33,8 @@ export function parseParts(content: string, maxParts: number): PartDefinition[] 
   if (parsed.length === 0) {
     throw new Error('Team leader JSON must contain at least one part');
   }
-  if (parsed.length > maxParts) {
-    throw new Error(`Team leader produced too many parts: ${parsed.length} > ${maxParts}`);
+  if (parsed.length > maxTotalParts) {
+    throw new Error(`Team leader produced too many total parts: ${parsed.length} > max_total_parts ${maxTotalParts}`);
   }
 
   const parts = parsed.map((entry, index) => parsePartDefinitionEntry(entry, index));

--- a/src/core/workflow/engine/team-leader-budget-errors.ts
+++ b/src/core/workflow/engine/team-leader-budget-errors.ts
@@ -3,6 +3,10 @@ export function isPlanningBudgetError(error: unknown): boolean {
     return false;
   }
 
-  return error.message.includes('max_total_parts')
-    || /^Structured output produced too many parts: \d+ > \d+$/.test(error.message);
+  const message = error.message;
+  return /^Initial team leader parts exceed max_total_parts: \d+ > \d+$/.test(message)
+    || /^Team leader planned parts exceed max_total_parts: \d+ > \d+$/.test(message)
+    || /^Team leader produced too many total parts: \d+ > max_total_parts \d+$/.test(message)
+    || /^Structured output produced too many total parts: \d+ > max_total_parts \d+$/.test(message)
+    || /^Structured output produced too many parts: \d+ > \d+$/.test(message);
 }

--- a/src/core/workflow/engine/team-leader-budget-errors.ts
+++ b/src/core/workflow/engine/team-leader-budget-errors.ts
@@ -1,0 +1,8 @@
+export function isPlanningBudgetError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return error.message.includes('max_total_parts')
+    || /^Structured output produced too many parts: \d+ > \d+$/.test(error.message);
+}

--- a/src/core/workflow/engine/team-leader-execution.ts
+++ b/src/core/workflow/engine/team-leader-execution.ts
@@ -1,7 +1,7 @@
 import type { MorePartsResponse } from '../../../agents/agent-usecases.js';
 import type { PartDefinition, PartResult } from '../../models/types.js';
-
-const DEFAULT_MAX_TOTAL_PARTS = 20;
+import { DEFAULT_TEAM_LEADER_MAX_TOTAL_PARTS } from '../../../shared/constants.js';
+import { isPlanningBudgetError } from './team-leader-budget-errors.js';
 
 export interface TeamLeaderExecutionOptions {
   initialParts: PartDefinition[];
@@ -38,7 +38,11 @@ export interface TeamLeaderExecutionResult {
 export async function runTeamLeaderExecution(
   options: TeamLeaderExecutionOptions,
 ): Promise<TeamLeaderExecutionResult> {
-  const maxTotalParts = options.maxTotalParts ?? DEFAULT_MAX_TOTAL_PARTS;
+  const maxTotalParts = options.maxTotalParts ?? DEFAULT_TEAM_LEADER_MAX_TOTAL_PARTS;
+  if (options.initialParts.length > maxTotalParts) {
+    throw new Error(`Initial team leader parts exceed max_total_parts: ${options.initialParts.length} > ${maxTotalParts}`);
+  }
+
   const queue: PartDefinition[] = [...options.initialParts];
   const plannedParts: PartDefinition[] = [...options.initialParts];
   const partResults: PartResult[] = [];
@@ -114,6 +118,7 @@ export async function runTeamLeaderExecution(
         return;
       }
 
+      assertPlannedPartsWithinLimit(plannedParts.length, newParts.length, maxTotalParts);
       plannedParts.push(...newParts);
       queue.push(...newParts);
       deferredDoneReason = undefined;
@@ -123,6 +128,9 @@ export async function runTeamLeaderExecution(
         totalPlanned: plannedParts.length,
       });
     } catch (error) {
+      if (isPlanningBudgetError(error)) {
+        throw error;
+      }
       options.onPlanningError?.(error);
       leaderDone = true;
     }
@@ -165,4 +173,15 @@ export async function runTeamLeaderExecution(
 
 function isSuccessfulPartResult(result: PartResult): boolean {
   return result.response.status === 'done';
+}
+
+function assertPlannedPartsWithinLimit(
+  currentPlannedCount: number,
+  newPartCount: number,
+  maxTotalParts: number,
+): void {
+  const totalPlannedParts = currentPlannedCount + newPartCount;
+  if (totalPlannedParts > maxTotalParts) {
+    throw new Error(`Team leader planned parts exceed max_total_parts: ${totalPlannedParts} > ${maxTotalParts}`);
+  }
 }

--- a/src/infra/config/loaders/workflowStepFeaturesNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepFeaturesNormalizer.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../core/models/index.js';
 import type { FacetResolutionContext, ResolvedSectionMap, WorkflowSections } from './resource-resolver.js';
 import { resolvePersona, resolveRefToContent } from './resource-resolver.js';
+import { DEFAULT_TEAM_LEADER_MAX_TOTAL_PARTS } from '../../../shared/constants.js';
 
 type RawStep = z.output<typeof WorkflowStepRawSchema>;
 
@@ -88,9 +89,10 @@ export function normalizeTeamLeader(
   return {
     persona: personaSpec,
     personaPath,
-    maxParts: raw.max_parts,
-    refillThreshold: raw.refill_threshold,
-    timeoutMs: raw.timeout_ms,
+    maxConcurrency: raw.max_concurrency ?? raw.max_parts ?? 3,
+    maxTotalParts: raw.max_total_parts ?? DEFAULT_TEAM_LEADER_MAX_TOTAL_PARTS,
+    refillThreshold: raw.refill_threshold ?? 0,
+    timeoutMs: raw.timeout_ms ?? 900000,
     partPersona,
     partPersonaPath,
     partAllowedTools: raw.part_allowed_tools,

--- a/src/infra/resources/schema-loader.ts
+++ b/src/infra/resources/schema-loader.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getResourcesDir } from './index.js';
+import { MAX_TEAM_LEADER_MAX_TOTAL_PARTS } from '../../shared/constants.js';
 
 type JsonSchema = Record<string, unknown>;
 
@@ -30,9 +31,12 @@ export function loadEvaluationSchema(): JsonSchema {
   return loadSchema('evaluation.json');
 }
 
-export function loadDecompositionSchema(maxParts: number): JsonSchema {
-  if (!Number.isInteger(maxParts) || maxParts <= 0) {
-    throw new Error(`maxParts must be a positive integer: ${maxParts}`);
+export function loadDecompositionSchema(maxTotalParts: number): JsonSchema {
+  if (!Number.isInteger(maxTotalParts) || maxTotalParts <= 0) {
+    throw new Error(`maxTotalParts must be a positive integer: ${maxTotalParts}`);
+  }
+  if (maxTotalParts > MAX_TEAM_LEADER_MAX_TOTAL_PARTS) {
+    throw new Error(`maxTotalParts must be less than or equal to ${MAX_TEAM_LEADER_MAX_TOTAL_PARTS}: ${maxTotalParts}`);
   }
 
   const schema = cloneSchema(loadSchema('decomposition.json'));
@@ -45,7 +49,7 @@ export function loadDecompositionSchema(maxParts: number): JsonSchema {
     throw new Error('decomposition schema is invalid: parts is missing');
   }
 
-  (rawParts as Record<string, unknown>).maxItems = maxParts;
+  (rawParts as Record<string, unknown>).maxItems = maxTotalParts;
   return schema;
 }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -11,6 +11,9 @@ export const DEFAULT_WORKFLOW_NAME = 'default';
 /** Default language for new installations */
 export const DEFAULT_LANGUAGE: Language = 'en';
 
+export const DEFAULT_TEAM_LEADER_MAX_TOTAL_PARTS = 20;
+export const MAX_TEAM_LEADER_MAX_TOTAL_PARTS = 20;
+
 /** Slash commands recognized in interactive mode */
 export const SlashCommand = {
   Accept: '/accept',


### PR DESCRIPTION
## Summary

## 背景

OpenCode 実行時に、`draft` workflow の `team_leader.max_parts: 2` に対してモデルが 5 parts を返し、以下のエラーで workflow が abort した。

```text
Structured output produced too many parts: 5 > 2
Workflow aborted by step transition
```

ログを見ると、モデルが返した 5 parts は `utility / PR処理 / pipeline / add command / tests` という自然な責務分解だった。一方、現在の TAKT は `max_parts` を以下の2つの意味で同時に使っている。

- 初回 decomposition の最大 parts 数
- team leader の並列実行数 `maxConcurrency`

そのため、「2並列で実行したい」だけなのに「総 parts 数も2個まで」に制限され、自然な分解が即 abort になる。

## 問題

現在の主な該当箇所:

- `src/core/workflow/engine/TeamLeaderRunner.ts`
  - `structuredCaller.decomposeTask(instruction, teamLeaderConfig.maxParts, ...)`
  - `maxConcurrency: teamLeaderConfig.maxParts`
- `src/agents/team-leader-structured-output.ts`
  - `raw.length > maxParts` で structured output を即エラーにする
- `src/infra/resources/schema-loader.ts`
  - decomposition schema の `maxItems` に `maxParts` を注入する
- `builtins/ja/workflows/draft.yaml` / `builtins/en/workflows/draft.yaml`
  - `team_leader.max_parts: 2`

`runTeamLeaderExecution` 自体は queue を持っており、`initialParts` が 5 個でも `maxConcurrency: 2` なら `2 + 2 + 1` で自然に消化できる構造になっている。

## 方針

`max_parts` の責務を整理し、少なくとも以下の概念を分離する。

- `max_concurrency`: 同時に実行する part 数
- `max_total_parts`: workflow 全体で許容する総 part 数
- 初回 decomposition の schema / prompt 上限は `max_total_parts` を使う
- 実行キューの並列数は `max_concurrency` を使う

互換性のため、既存の `max_parts` は当面 `max_concurrency` として扱う、または migration 方針を明確にする。

## 実装タスク

- workflow schema に `max_concurrency` / `max_total_parts` を追加する
- 既存 `max_parts` との互換性ルールを定義する
- `TeamLeaderRunner` で decomposition 上限と実行並列数を分離する
- `loadDecompositionSchema()` に渡す上限を総 part 数に変更する
- `buildDecomposePrompt()` の文言を修正する
  - 「同時実行数」ではなく「返してよい総 parts 数」を明示する
  - 検証分離や責務分解よりも上限遵守を優先することを明記する
- `requestMoreParts` 側の `maxAdditionalParts` との整合を確認する
- 既存 workflow の `max_parts` 設定が壊れないことをテストする
- 5 parts を返しても 2並列で順次消化されるテストを追加する

## 受け入れ条件

- `team_leader.max_parts: 2` 相当の並列数設定で、初回 decomposition が 5 parts を返しても即 abort しない
- parts は queue に積まれ、最大2件ずつ実行される
- 総 parts 数は `max_total_parts` で制限される
- `max_total_parts` 超過時は明確なエラーになる
- プロンプトが `max_concurrency` と `max_total_parts` を混同しない
- 既存の team leader workflow が後方互換で動作する

## 補足

短期回避として `max_parts` を増やすことはできるが、並列数まで増えるため実行負荷が上がる。今回の修正では「総分解数」と「並列数」を分け、5 parts を 2並列で消化できるようにする。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Team Leader Step の設定説明を更新し、同時実行上限（max_concurrency）と総パート上限（max_total_parts、最大20）を明示。旧キー max_parts は互換名として扱う旨を追記。

* **Refactor**
  * チームリーダー設定を max_concurrency / max_total_parts に分離し、既定値適用を明確化。

* **Bug Fixes / Runtime**
  * 総パート数超過時の検証とエラーメッセージを強化し、計画フェーズでの超過エラーが適切に伝播するよう変更。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->