### PR TITLE
fix: log OpenCode permission requests

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -727,6 +727,69 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(result.content).toContain('permission reply timed out');
   });
 
+  it('should emit permission_asked stream event before replying to OpenCode permission request', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const stream = new MockEventStream([
+      {
+        type: 'permission.asked',
+        properties: {
+          id: 'perm-1',
+          sessionID: 'session-permission',
+          permission: 'bash',
+          patterns: ['**'],
+          metadata: { command: 'npm test' },
+          always: [],
+        },
+      },
+      {
+        type: 'session.idle',
+        properties: { sessionID: 'session-permission' },
+      },
+    ]);
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-permission' } });
+    const disposeInstance = vi.fn().mockResolvedValue({ data: {} });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+    const permissionReply = vi.fn().mockResolvedValue({ data: {} });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: disposeInstance },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: permissionReply },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const onStream = vi.fn();
+    const client = new OpenCodeClient();
+    await client.call('coder', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      permissionMode: 'readonly',
+      onStream,
+    });
+
+    expect(onStream).toHaveBeenCalledWith({
+      type: 'permission_asked',
+      data: {
+        requestId: 'perm-1',
+        sessionId: 'session-permission',
+        permission: 'bash',
+        patterns: ['**'],
+        always: [],
+        reply: 'reject',
+      },
+    });
+    expect(permissionReply).toHaveBeenCalledWith({
+      requestID: 'perm-1',
+      directory: '/tmp',
+      reply: 'reject',
+    }, expect.any(Object));
+  });
+
   it('should reuse shared server for parallel calls with same config', async () => {
     const { OpenCodeClient, resetSharedServer } = await import('../infra/opencode/client.js');
     resetSharedServer();

--- a/src/__tests__/opencode-stream-handler.test.ts
+++ b/src/__tests__/opencode-stream-handler.test.ts
@@ -10,6 +10,7 @@ import {
   emitThinking,
   emitToolUse,
   emitToolResult,
+  emitPermissionAsked,
   emitResult,
   handlePartUpdated,
   type OpenCodeStreamEvent,
@@ -126,6 +127,33 @@ describe('emitToolResult', () => {
     expect(onStream).toHaveBeenCalledWith({
       type: 'tool_result',
       data: { content: 'command not found', isError: true },
+    });
+  });
+});
+
+describe('emitPermissionAsked', () => {
+  it('should emit permission_asked event', () => {
+    const onStream = vi.fn();
+
+    emitPermissionAsked(onStream, {
+      requestId: 'perm-1',
+      sessionId: 'session-1',
+      permission: 'bash',
+      patterns: ['**'],
+      always: [],
+      reply: 'reject',
+    });
+
+    expect(onStream).toHaveBeenCalledWith({
+      type: 'permission_asked',
+      data: {
+        requestId: 'perm-1',
+        sessionId: 'session-1',
+        permission: 'bash',
+        patterns: ['**'],
+        always: [],
+        reply: 'reject',
+      },
     });
   });
 });

--- a/src/__tests__/parallel-logger.test.ts
+++ b/src/__tests__/parallel-logger.test.ts
@@ -285,6 +285,32 @@ describe('ParallelLogger', () => {
       expect(parentEvents[0]).toBe(errorEvent);
     });
 
+    it('should delegate permission_asked event to parent callback', () => {
+      const parentEvents: StreamEvent[] = [];
+      const logger = new ParallelLogger({
+        subStepNames: ['sub-a'],
+        parentOnStream: (event) => parentEvents.push(event),
+        writeFn,
+      });
+      const handler = logger.createStreamHandler('sub-a', 0);
+
+      const permissionEvent: StreamEvent = {
+        type: 'permission_asked',
+        data: {
+          requestId: 'perm-1',
+          sessionId: 'sess-1',
+          permission: 'bash',
+          patterns: ['**'],
+          always: [],
+          reply: 'reject',
+        },
+      };
+      handler(permissionEvent);
+
+      expect(parentEvents).toHaveLength(1);
+      expect(parentEvents[0]).toBe(permissionEvent);
+    });
+
     it('should not crash when no parent callback for delegated events', () => {
       const logger = new ParallelLogger({
         subStepNames: ['sub-a'],

--- a/src/__tests__/providerEventLogger.test.ts
+++ b/src/__tests__/providerEventLogger.test.ts
@@ -108,6 +108,48 @@ describe('providerEventLogger', () => {
     expect(logger.filepath.endsWith('-usage-events.jsonl')).toBe(false);
   });
 
+  it('should normalize permission_asked events for provider logs', () => {
+    const logger = createProviderEventLogger({
+      logsDir: tempDir,
+      sessionId: 'session-permission',
+      runId: 'run-permission',
+      provider: 'opencode',
+      step: 'reviewers',
+      enabled: true,
+    });
+
+    const wrapped = logger.wrapCallback();
+
+    wrapped({
+      type: 'permission_asked',
+      data: {
+        requestId: 'perm-1',
+        sessionId: 'opencode-session-1',
+        permission: 'bash',
+        patterns: ['**'],
+        always: [],
+        reply: 'reject',
+      },
+    });
+
+    const lines = readFileSync(logger.filepath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+
+    const parsed = JSON.parse(lines[0]!) as {
+      event_type: string;
+      session_id?: string;
+      request_id?: string;
+      data: Record<string, unknown>;
+    };
+
+    expect(parsed.event_type).toBe('permission_asked');
+    expect(parsed.session_id).toBe('opencode-session-1');
+    expect(parsed.request_id).toBe('perm-1');
+    expect(parsed.data['permission']).toBe('bash');
+    expect(parsed.data['patterns']).toEqual(['**']);
+    expect(parsed.data['reply']).toBe('reject');
+  });
+
   it('should update step and provider for subsequent events', () => {
     const logger = createProviderEventLogger({
       logsDir: tempDir,

--- a/src/core/workflow/engine/parallel-logger.ts
+++ b/src/core/workflow/engine/parallel-logger.ts
@@ -137,7 +137,7 @@ export class ParallelLogger {
    *
    * - `text`: buffered line-by-line with prefix
    * - `tool_use`, `tool_result`, `tool_output`, `thinking`: prefixed per-line, no buffering
-   * - `init`, `result`, `error`: delegated to parent callback (no prefix)
+   * - `init`, `result`, `error`, diagnostics: delegated to parent callback (no prefix)
    */
   createStreamHandler(subStepName: string, index: number): StreamCallback {
     const prefix = this.buildPrefix(subStepName, index);
@@ -157,6 +157,7 @@ export class ParallelLogger {
 
         case 'init':
         case 'result':
+        case 'permission_asked':
         case 'assistant_error':
         case 'rate_limit':
         case 'error':

--- a/src/infra/opencode/OpenCodeStreamHandler.ts
+++ b/src/infra/opencode/OpenCodeStreamHandler.ts
@@ -199,6 +199,21 @@ export function emitToolResult(
   onStream({ type: 'tool_result', data: { content, isError } });
 }
 
+export function emitPermissionAsked(
+  onStream: StreamCallback | undefined,
+  data: {
+    requestId: string;
+    sessionId: string;
+    permission: string;
+    patterns: string[];
+    always: string[];
+    reply: string;
+  },
+): void {
+  if (!onStream) return;
+  onStream({ type: 'permission_asked', data });
+}
+
 export function emitResult(
   onStream: StreamCallback | undefined,
   success: boolean,

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -24,6 +24,7 @@ import {
   createStreamTrackingState,
   emitInit,
   emitText,
+  emitPermissionAsked,
   emitResult,
   handlePartUpdated,
 } from './OpenCodeStreamHandler.js';
@@ -522,12 +523,23 @@ export class OpenCodeClient {
             const permProps = sseEvent.properties as {
               id: string;
               sessionID: string;
+              permission?: string;
+              patterns?: string[];
+              always?: string[];
             };
             if (permProps.sessionID === sessionId) {
               try {
                 const reply = options.permissionMode
                   ? mapToOpenCodePermissionReply(options.permissionMode)
                   : 'once';
+                emitPermissionAsked(options.onStream, {
+                  requestId: permProps.id,
+                  sessionId: permProps.sessionID,
+                  permission: permProps.permission ?? '',
+                  patterns: Array.isArray(permProps.patterns) ? permProps.patterns : [],
+                  always: Array.isArray(permProps.always) ? permProps.always : [],
+                  reply,
+                });
                 await withTimeout(
                   (signal) => opencodeApiClient!.permission.reply({
                     requestID: permProps.id,

--- a/src/shared/types/provider.ts
+++ b/src/shared/types/provider.ts
@@ -41,6 +41,15 @@ export interface StreamToolOutputEventData {
   output: string;
 }
 
+export interface StreamPermissionAskedEventData {
+  requestId: string;
+  sessionId: string;
+  permission: string;
+  patterns: string[];
+  always: string[];
+  reply: string;
+}
+
 export interface StreamTextEventData {
   text: string;
 }
@@ -83,6 +92,7 @@ export type StreamEvent =
   | { type: 'tool_use'; data: StreamToolUseEventData }
   | { type: 'tool_result'; data: StreamToolResultEventData }
   | { type: 'tool_output'; data: StreamToolOutputEventData }
+  | { type: 'permission_asked'; data: StreamPermissionAskedEventData }
   | { type: 'text'; data: StreamTextEventData }
   | { type: 'thinking'; data: StreamThinkingEventData }
   | { type: 'result'; data: StreamResultEventData }

--- a/src/shared/ui/StreamDisplay.ts
+++ b/src/shared/ui/StreamDisplay.ts
@@ -279,6 +279,7 @@ export class StreamDisplay {
         case 'result':
           this.showResult(event.data.success, event.data.error);
           break;
+        case 'permission_asked':
         case 'assistant_error':
         case 'rate_limit':
         case 'error':


### PR DESCRIPTION
## Summary
- add a provider stream event for OpenCode permission requests
- emit permission request details before replying to OpenCode permission prompts
- preserve permission events through parallel sub-step logging so provider-events can diagnose reviewer failures

## Notes
- logs requestId, sessionId, permission, patterns, always, and reply
- intentionally does not log OpenCode permission metadata because it may include tool inputs

## Tests
- npm test -- --run src/__tests__/opencode-stream-handler.test.ts src/__tests__/opencode-client-cleanup.test.ts src/__tests__/providerEventLogger.test.ts src/__tests__/parallel-logger.test.ts
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * OpenCodeの権限要求イベント（`permission_asked`）のストリーム通知機能を追加しました。権限情報と応答方針の詳細がイベントデータに含まれるようになりました。

* **Tests**
  * 権限要求イベントの処理・正規化・委譲に関する複数のテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->