### PR TITLE
fix: allow OpenCode doom_loop permission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.170",
         "@openai/codex-sdk": "^0.137.0",
-        "@opencode-ai/sdk": "^1.14.24",
+        "@opencode-ai/sdk": "^1.17.3",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/sdk-metrics": "^2.7.1",
         "@opentelemetry/sdk-node": "^0.218.0",
@@ -1060,9 +1060,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.14.24",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.24.tgz",
-      "integrity": "sha512-hZWc1jx+gtZBM6Mff9iOMlXM1at9BbAGg0uNrQk8DuXpd8K19fu942emojdInO2zy0jC5/wWggsi7GJu7HMp/w==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.3.tgz",
+      "integrity": "sha512-oXrEjOuP3+J9pPNw3cmOnRma/xiVQ4WIIvGd6YkhPQgqqi2PnD/b1qfNY0AMead3QfNhKwKdDM4QFJdN2LpByg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.170",
     "@openai/codex-sdk": "^0.137.0",
-    "@opencode-ai/sdk": "^1.14.24",
+    "@opencode-ai/sdk": "^1.17.3",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/sdk-metrics": "^2.7.1",
     "@opentelemetry/sdk-node": "^0.218.0",

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -790,6 +790,69 @@ describe('OpenCodeClient stream cleanup', () => {
     }, expect.any(Object));
   });
 
+  it('should allow OpenCode doom loop permission once in readonly mode', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const stream = new MockEventStream([
+      {
+        type: 'permission.asked',
+        properties: {
+          id: 'perm-doom-loop',
+          sessionID: 'session-doom-loop',
+          permission: 'doom_loop',
+          patterns: ['invalid'],
+          metadata: {},
+          always: ['invalid'],
+        },
+      },
+      {
+        type: 'session.idle',
+        properties: { sessionID: 'session-doom-loop' },
+      },
+    ]);
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-doom-loop' } });
+    const disposeInstance = vi.fn().mockResolvedValue({ data: {} });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+    const permissionReply = vi.fn().mockResolvedValue({ data: {} });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: disposeInstance },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: permissionReply },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const onStream = vi.fn();
+    const client = new OpenCodeClient();
+    await client.call('coder', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      permissionMode: 'readonly',
+      onStream,
+    });
+
+    expect(onStream).toHaveBeenCalledWith({
+      type: 'permission_asked',
+      data: {
+        requestId: 'perm-doom-loop',
+        sessionId: 'session-doom-loop',
+        permission: 'doom_loop',
+        patterns: ['invalid'],
+        always: ['invalid'],
+        reply: 'once',
+      },
+    });
+    expect(permissionReply).toHaveBeenCalledWith({
+      requestID: 'perm-doom-loop',
+      directory: '/tmp',
+      reply: 'once',
+    }, expect.any(Object));
+  });
+
   it('should reuse shared server for parallel calls with same config', async () => {
     const { OpenCodeClient, resetSharedServer } = await import('../infra/opencode/client.js');
     resetSharedServer();

--- a/src/__tests__/opencode-types.test.ts
+++ b/src/__tests__/opencode-types.test.ts
@@ -44,6 +44,14 @@ describe('resolveOpenCodePermissionReply', () => {
     expect(resolveOpenCodePermissionReply('readonly', 'doom_loop')).toBe('once');
   });
 
+  it('should allow OpenCode doom loop continuation once in edit mode', () => {
+    expect(resolveOpenCodePermissionReply('edit', 'doom_loop')).toBe('once');
+  });
+
+  it('should allow OpenCode doom loop continuation once in full mode', () => {
+    expect(resolveOpenCodePermissionReply('full', 'doom_loop')).toBe('once');
+  });
+
   it('should default to once when permission mode is not configured', () => {
     expect(resolveOpenCodePermissionReply(undefined, 'bash')).toBe('once');
   });

--- a/src/__tests__/opencode-types.test.ts
+++ b/src/__tests__/opencode-types.test.ts
@@ -8,6 +8,7 @@ import {
   buildOpenCodePermissionRuleset,
   mapToOpenCodePermissionReply,
   mapToOpenCodeTools,
+  resolveOpenCodePermissionReply,
 } from '../infra/opencode/types.js';
 import type { PermissionMode } from '../core/models/index.js';
 
@@ -31,6 +32,20 @@ describe('mapToOpenCodePermissionReply', () => {
     modes.forEach((mode, index) => {
       expect(mapToOpenCodePermissionReply(mode)).toBe(expectedReplies[index]);
     });
+  });
+});
+
+describe('resolveOpenCodePermissionReply', () => {
+  it('should keep readonly tool permissions rejected', () => {
+    expect(resolveOpenCodePermissionReply('readonly', 'bash')).toBe('reject');
+  });
+
+  it('should allow OpenCode doom loop continuation once even in readonly mode', () => {
+    expect(resolveOpenCodePermissionReply('readonly', 'doom_loop')).toBe('once');
+  });
+
+  it('should default to once when permission mode is not configured', () => {
+    expect(resolveOpenCodePermissionReply(undefined, 'bash')).toBe('once');
   });
 });
 

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -13,7 +13,7 @@ import { createLogger, getErrorMessage, createStreamDiagnostics, parseStructured
 import { parseProviderModel } from '../../shared/utils/providerModel.js';
 import {
   buildOpenCodePermissionRuleset,
-  mapToOpenCodePermissionReply,
+  resolveOpenCodePermissionReply,
   mapToOpenCodeTools,
   type OpenCodeCallOptions,
 } from './types.js';
@@ -529,9 +529,7 @@ export class OpenCodeClient {
             };
             if (permProps.sessionID === sessionId) {
               try {
-                const reply = options.permissionMode
-                  ? mapToOpenCodePermissionReply(options.permissionMode)
-                  : 'once';
+                const reply = resolveOpenCodePermissionReply(options.permissionMode, permProps.permission);
                 emitPermissionAsked(options.onStream, {
                   requestId: permProps.id,
                   sessionId: permProps.sessionID,

--- a/src/infra/opencode/index.ts
+++ b/src/infra/opencode/index.ts
@@ -3,5 +3,5 @@
  */
 
 export { OpenCodeClient, callOpenCode, callOpenCodeCustom } from './client.js';
-export { mapToOpenCodePermissionReply } from './types.js';
+export { mapToOpenCodePermissionReply, resolveOpenCodePermissionReply } from './types.js';
 export type { OpenCodeCallOptions, OpenCodePermissionReply } from './types.js';

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -20,6 +20,18 @@ export function mapToOpenCodePermissionReply(mode: PermissionMode): OpenCodePerm
   return mapping[mode];
 }
 
+const OPEN_CODE_DOOM_LOOP_PERMISSION = 'doom_loop';
+
+export function resolveOpenCodePermissionReply(
+  mode: PermissionMode | undefined,
+  permission?: string,
+): OpenCodePermissionReply {
+  if (permission === OPEN_CODE_DOOM_LOOP_PERMISSION) {
+    return 'once';
+  }
+  return mode ? mapToOpenCodePermissionReply(mode) : 'once';
+}
+
 const OPEN_CODE_PERMISSION_KEYS = [
   'read',
   'glob',


### PR DESCRIPTION
## Summary
- bump @opencode-ai/sdk from ^1.14.24 to ^1.17.3
- allow OpenCode `doom_loop` permission prompts once, even in readonly mode
- keep regular readonly tool permissions such as `bash` rejected

## Tests
- npm test -- --run src/__tests__/opencode-types.test.ts src/__tests__/opencode-client-cleanup.test.ts src/__tests__/opencode-stream-handler.test.ts src/__tests__/providerEventLogger.test.ts src/__tests__/parallel-logger.test.ts
- npm run build
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 権限制御の応答決定を改善し、特定の権限に対する自動応答ルールを追加しました。

* **Chores**
  * 依存パッケージを最新版へ更新しました。

* **Tests**
  * 権限応答とストリーム挙動を検証するテストケースを追加・拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->