### PR TITLE
[#806] fix-rate-limit-detection

### DIFF
--- a/src/__tests__/claude-terminal-response-normalizer.test.ts
+++ b/src/__tests__/claude-terminal-response-normalizer.test.ts
@@ -118,24 +118,103 @@ describe('Claude terminal response normalizer', () => {
     });
   });
 
-  it('Given assistant text contains a rate limit error, When normalizing, Then source is error_text', () => {
+  it('Given assistant text starts with an HTTP 429 description, When normalizing, Then response remains done', () => {
+    const assistantText = 'HTTP 429: Too many requests';
+
     const result = normalizeClaudeTerminalResponse({
       agentName: 'coder',
       sessionId: 'claude-session-1',
-      assistantText: 'HTTP 429: Too many requests',
+      assistantText,
     });
 
     expect(result).toMatchObject({
       persona: 'coder',
-      status: 'rate_limited',
-      content: '',
-      errorKind: 'rate_limit',
+      status: 'done',
+      content: assistantText,
       sessionId: 'claude-session-1',
     });
-    expect(result.rateLimitInfo).toMatchObject({
-      provider: 'claude-terminal',
-      source: 'error_text',
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimitInfo).toBeUndefined();
+  });
+
+  it('Given assistant text references a line range ending in 429, When normalizing, Then response remains done', () => {
+    const assistantText = '| 42 | issue unresolved | `hoge_spec.rb:418-429` |';
+
+    const result = normalizeClaudeTerminalResponse({
+      agentName: 'coder',
+      sessionId: 'claude-session-1',
+      assistantText,
     });
+
+    expect(result).toMatchObject({
+      persona: 'coder',
+      status: 'done',
+      content: assistantText,
+      sessionId: 'claude-session-1',
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimitInfo).toBeUndefined();
+  });
+
+  it('Given assistant text documents rate limit fallback for issue 429, When normalizing, Then response remains done', () => {
+    const assistantText = 'Documented rate limit fallback behavior for issue 429.';
+
+    const result = normalizeClaudeTerminalResponse({
+      agentName: 'coder',
+      sessionId: 'claude-session-1',
+      assistantText,
+    });
+
+    expect(result).toMatchObject({
+      persona: 'coder',
+      status: 'done',
+      content: assistantText,
+      sessionId: 'claude-session-1',
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimitInfo).toBeUndefined();
+  });
+
+  it.each([
+    'Documented HTTP 429 Too Many Requests response handling.',
+    'HTTP 429 means Too Many Requests in the docs.',
+    'Status code 429 is Too Many Requests.',
+    'The reviewed code handles HTTP status code 429 with retry fallback.',
+    'The report says too many requests should trigger fallback only on provider errors.',
+  ])('Given assistant text explains %s, When normalizing, Then response remains done', (assistantText) => {
+    const result = normalizeClaudeTerminalResponse({
+      agentName: 'coder',
+      sessionId: 'claude-session-1',
+      assistantText,
+    });
+
+    expect(result).toMatchObject({
+      persona: 'coder',
+      status: 'done',
+      content: assistantText,
+      sessionId: 'claude-session-1',
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimitInfo).toBeUndefined();
+  });
+
+  it('Given assistant text contains only a reset time phrase, When normalizing, Then response remains done', () => {
+    const assistantText = 'The cache resets 5:00 after the scheduled maintenance window.';
+
+    const result = normalizeClaudeTerminalResponse({
+      agentName: 'coder',
+      sessionId: 'claude-session-1',
+      assistantText,
+    });
+
+    expect(result).toMatchObject({
+      persona: 'coder',
+      status: 'done',
+      content: assistantText,
+      sessionId: 'claude-session-1',
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimitInfo).toBeUndefined();
   });
 
   it('Given bridged permission request event, When normalizing final response, Then event does not force provider error', () => {

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -129,6 +129,39 @@ describe('OpenCodeClient retry', () => {
     expect(result.content).toBe('');
   });
 
+  it('session.error が RateLimitError 名だけを示す場合は retry せず rate_limited を返す', async () => {
+    runPlans = [
+      {
+        type: 'events',
+        events: [
+          {
+            type: 'session.error',
+            properties: {
+              sessionID: 'session-1',
+              error: { name: 'RateLimitError' },
+            },
+          },
+        ],
+      },
+    ];
+
+    const { sessionCreate, promptAsync, subscribe } = installOpenCodeMock();
+    const client = new OpenCodeClient();
+
+    const result = await client.call('coder', 'prompt', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+    });
+
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(promptAsync).toHaveBeenCalledTimes(1);
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('rate_limited');
+    expect(result.error).toBe('RateLimitError');
+    expect(result.errorKind).toBe('rate_limit');
+    expect(result.content).toBe('');
+  });
+
   it('ストリームの idle timeout を retry して成功を返す', async () => {
     vi.useFakeTimers();
 

--- a/src/infra/claude-terminal/response-normalizer.ts
+++ b/src/infra/claude-terminal/response-normalizer.ts
@@ -79,7 +79,7 @@ function createProviderErrorResponse(
 
 function createRateLimitedResponse(
   input: NormalizeClaudeTerminalResponseInput,
-  source: 'stream_marker' | 'error_text',
+  source: 'stream_marker',
 ): AgentResponse {
   emitResult(input.onStream, {
     result: '',

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -697,11 +697,11 @@ export class OpenCodeClient {
           if (sseEvent.type === 'session.error') {
             const errorProps = sseEvent.properties as {
               sessionID?: string;
-              error?: { name: string; data: { message: string } };
+              error?: unknown;
             };
             if (!errorProps.sessionID || errorProps.sessionID === sessionId) {
               success = false;
-              failureMessage = errorProps.error?.data?.message ?? 'OpenCode session error';
+              failureMessage = extractOpenCodeErrorMessage(errorProps.error) ?? 'OpenCode session error';
               diag.onStreamError('session.error', failureMessage);
               break;
             }

--- a/src/infra/rate-limit/detection.ts
+++ b/src/infra/rate-limit/detection.ts
@@ -3,9 +3,12 @@ import { RATE_LIMIT_ERROR_MESSAGE } from '../../core/models/response.js';
 import type { ProviderType } from '../../shared/types/provider.js';
 
 const RATE_LIMIT_ERROR_PATTERNS = [
-  /\bhttp\s+429\b/i,
-  /\b429\b/i,
-  /rate[_\s-]?limit/i,
+  /\bhttp\s+(?:status\s+)?(?:code\s+)?429\b/i,
+  /\bstatus\s+code\s+429\b/i,
+  /\b429\b[^\n\r]{0,40}\btoo many requests\b/i,
+  /\brate[_\s-]?limit(?:ed|[_\s-]+exceeded)\b/i,
+  /\brate[_\s-]?limit[_\s-]?error\b/i,
+  /\b(?:exceeded|hit|reached)\s+(?:a\s+|the\s+)?rate[_\s-]?limit\b/i,
   /too many requests/i,
   /out of extra usage/i,
   /usage_limit_exceeded/i,
@@ -14,7 +17,6 @@ const RATE_LIMIT_ERROR_PATTERNS = [
 const RATE_LIMIT_STREAM_MARKER_PATTERNS = [
   /out of extra usage/i,
   /usage_limit_exceeded/i,
-  /resets?\s+\d{1,2}:\d{2}\s*(?:am|pm)?/i,
 ] as const;
 
 export function containsRateLimitMarker(text: string | undefined): boolean {
@@ -31,12 +33,9 @@ export function containsRateLimitError(text: string | undefined): boolean {
   return RATE_LIMIT_ERROR_PATTERNS.some((pattern) => pattern.test(text));
 }
 
-export function resolveRateLimitTextSource(text: string | undefined): 'stream_marker' | 'error_text' | undefined {
+export function resolveRateLimitTextSource(text: string | undefined): 'stream_marker' | undefined {
   if (containsRateLimitMarker(text)) {
     return 'stream_marker';
-  }
-  if (containsRateLimitError(text)) {
-    return 'error_text';
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

claude codeのrate limitには余裕があるのに `hit a rate limit` のエラーで終了してしまいます。
claude codeに原因を調査してもらったら怪しい箇所があるようなので報告致します。

## 概要

`claude-terminal` プロバイダは、エージェントの**出力テキスト自体**を正規表現でパターンマッチして rate limit を判定しています。このパターンに `/\b429\b/i` のような広すぎるものが含まれているため、**正常に完走したステップの出力にたまたま「429」という数字（行番号・HTTP ステータスの説明文など）が含まれるだけで `rate_limited` と誤判定**され、fallback provider 未設定の場合はワークフロー全体が abort します。

## 環境

- takt: 0.44.0（0.45.0 の `dist/infra/rate-limit/detection.js` でも同一パターンを確認済み）
- provider: `claude-terminal`
- model: claude-fable-5

## 発生した事象

`supervise` ステップ（レビュー系ペルソナ）が最後まで正常に完走し「結果: APPROVE」のレポートを出力したにもかかわらず、status が `rate_limited` となりワークフローが中断しました。

```
[ERROR] Workflow aborted after 1 iterations (2m 32s): Step "supervise" hit a rate limit and no fallback provider is configured
```

ログの `phase_complete` イベントでは、`error` フィールドにエージェントの最終レポート全文（APPROVE 判定）が入った状態で `"status": "rate_limited"` になっていました。実際の API rate limit には達していません（使用量には余裕がある状態でした）。

## 原因

エージェントの出力レポートに、spec ファイルの**行番号範囲への参照**が含まれていました:

```
| 42 | hoge 未解決 → エラー報告＋終了コード 1 | ✅ | `hoge.rb:46,57`、`hoge_spec.rb:418-429` |
```

この `418-429` の「429」が `dist/infra/rate-limit/detection.js` の以下のパターンにマッチします:

```js
const RATE_LIMIT_ERROR_PATTERNS = [
    /\bhttp\s+429\b/i,
    /\b429\b/i,          // ← これが行番号 "418-429" の "429" にマッチ
    /rate[_\s-]?limit/i,
    /too many requests/i,
    /out of extra usage/i,
    /usage_limit_exceeded/i,
];
```

判定フロー:

1. `dist/infra/claude-terminal/response-normalizer.js` の `normalizeClaudeTerminalResponse()` が `resolveRateLimitTextSource(input.assistantText)` を呼ぶ
2. `assistantText`（エージェントの正常な最終出力）が `/\b429\b/i` にマッチし `'error_text'` が返る
3. `createRateLimitedResponse()` により `status: 'rate_limited'`, `content: ''` のレスポンスが生成され、正常な出力内容が破棄される
4. fallback provider が未設定のため `Step "supervise" hit a rate limit` でワークフロー abort

## 問題点

- `/\b429\b/i` は HTTP エラーコンテキストの裏付けなしに 3 桁の数字単体へマッチするため誤検出が容易に起きる。行番号・ポート番号・件数・価格など「429」が正常な出力に現れるケースは多い
- 同様に `/rate[_\s-]?limit/i` も、レビュー対象コードがリトライ処理や rate limit を扱っている場合（コードレビュー系ペルソナでは頻出）に正常なレポート文面へマッチする
- `RATE_LIMIT_STREAM_MARKER_PATTERNS` の `/resets?\s+\d{1,2}:\d{2}\s*(?:am|pm)?/i` も「resets 5:00」のような文面で誤検出し得る
- 誤検出時は正常に生成された `content` が空文字に差し替えられて破棄されるため、完走した作業結果が失われる

## Execution Report

Workflow `takt-default` completed successfully.

Closes #806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * レート制限検出の精度を改善し、誤検知を防止しました。

* **Refactor**
  * エラーメッセージ抽出ロジックの堅牢性を強化しました。

* **Tests**
  * レート制限検出とエラーハンドリングに関するテストケースを追加・拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->