### PR TITLE
[#813] improve-tempo-trace-discovery

### DIFF
--- a/docs/observability.ja.md
+++ b/docs/observability.ja.md
@@ -33,6 +33,16 @@ takt run
 
 Grafana は `http://127.0.0.1:3000` で開き、`takt` service を確認します。trace は既存の workflow span tree（`workflow.<name>` の下に `step.<name>`、さらに phase / judge span）として表示され、metric はローカルの `monitor.json` 出力と並走して送信されます。
 
+workflow がまだ実行中の場合、OpenTelemetry exporter は長時間生存する root `workflow.<name>` span が終了する前に、完了済みの child span を送信することがあります。Tempo でその active trace を見つけやすくするため、TAKT は root workflow span の下に短命の `workflow_start.<workflowName>` span も送信します。この補助 span は `takt.workflow.status = running` を含む workflow / run 属性を持ちますが、root、step、phase、judge span を置き換えたり改名したりしません。trace discovery 専用であり、shadow session log の canonical record には変換されません。
+
+active workflow を探す Tempo TraceQL filter 例:
+
+```traceql
+{ resource.service.name = "takt" && span."takt.workflow.name" = "takt-default" }
+{ resource.service.name = "takt" && span."takt.run.id" = "<run-id>" }
+{ resource.service.name = "takt" && name =~ "workflow_start\\..*" }
+```
+
 OTLP export には base endpoint が必要です。
 
 | 環境変数 | 用途 |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -33,6 +33,16 @@ When `observability.enabled: true` and `OTEL_EXPORTER_OTLP_ENDPOINT` is set, TAK
 
 Open Grafana at `http://127.0.0.1:3000` and inspect the `takt` service. Traces use the existing workflow span tree (`workflow.<name>` with `step.<name>` and phase or judge spans below it), and metrics are exported alongside the local `monitor.json` stream.
 
+While a workflow is still running, OpenTelemetry exporters can deliver completed child spans before the long-lived root `workflow.<name>` span has ended. To make those active traces discoverable in Tempo, TAKT also emits a short-lived `workflow_start.<workflowName>` span under the root workflow span. This helper span carries the workflow and run attributes, including `takt.workflow.status = running`, but it does not replace or rename the root, step, phase, or judge spans. It is used only for trace discovery and is not converted into a canonical shadow session log record.
+
+Useful Tempo TraceQL filters for active workflows include:
+
+```traceql
+{ resource.service.name = "takt" && span."takt.workflow.name" = "takt-default" }
+{ resource.service.name = "takt" && span."takt.run.id" = "<run-id>" }
+{ resource.service.name = "takt" && name =~ "workflow_start\\..*" }
+```
+
 The base endpoint is required for OTLP export:
 
 | Environment variable | Purpose |

--- a/src/__tests__/span-to-ndjson-mapper.test.ts
+++ b/src/__tests__/span-to-ndjson-mapper.test.ts
@@ -139,6 +139,35 @@ describe('span-to-ndjson mapper', () => {
     })).toBeUndefined();
   });
 
+  it('skips workflow_start discoverability spans for shadow session log parity', () => {
+    const span: SpanSnapshot = {
+      name: 'workflow_start.default',
+      startTime: [1_778_777_200, 0],
+      endTime: [1_778_777_200, 1_000_000],
+      attributes: {
+        'takt.run.id': 'run-1',
+        'takt.workflow.name': 'default',
+        'takt.workflow.status': 'running',
+      },
+    };
+
+    expect(mapSpanStartToNdjson(span)).toBeUndefined();
+    expect(mapSpanEndToNdjson(span)).toBeUndefined();
+  });
+
+  it('does not treat workflow_start spans with terminal-looking attributes as workflow records', () => {
+    const span: SpanSnapshot = {
+      name: 'workflow_start.default',
+      endTime: [1_778_777_300, 0],
+      attributes: {
+        'takt.workflow.status': 'completed',
+        'takt.workflow.iterations': 3,
+      },
+    };
+
+    expect(mapSpanEndToNdjson(span)).toBeUndefined();
+  });
+
   it('skips nested workflow terminal spans for shadow session log parity', () => {
     expect(mapSpanEndToNdjson({
       name: 'workflow.child',

--- a/src/__tests__/workflowSpans.test.ts
+++ b/src/__tests__/workflowSpans.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import type { WorkflowStep } from '../core/models/types.js';
 import type { StepRunResult } from '../core/workflow/types.js';
 
@@ -51,6 +52,23 @@ type MetricRecord = {
   value: number;
   attributes: Record<string, unknown>;
 };
+
+class CapturingSpanExporter implements SpanExporter {
+  readonly spans: ReadableSpan[] = [];
+
+  export(spans: ReadableSpan[], resultCallback: Parameters<SpanExporter['export']>[1]): void {
+    this.spans.push(...spans);
+    resultCallback({ code: 0 });
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+}
 
 async function loadWorkflowSpansWithMockedApi() {
   vi.resetModules();
@@ -106,6 +124,35 @@ async function loadWorkflowSpansWithMockedApi() {
   return { module, spans, metricRecords };
 }
 
+async function loadWorkflowSpansWithRealSdk() {
+  vi.resetModules();
+  vi.doUnmock('@opentelemetry/api');
+
+  const [{ context, trace }, { NodeSDK }, { SimpleSpanProcessor }] = await Promise.all([
+    import('@opentelemetry/api'),
+    import('@opentelemetry/sdk-node'),
+    import('@opentelemetry/sdk-trace-base'),
+  ]);
+  trace.disable();
+  context.disable();
+
+  const exporter = new CapturingSpanExporter();
+  const sdk = new NodeSDK({
+    autoDetectResources: false,
+    instrumentations: [],
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  sdk.start();
+
+  const module = await import('../core/workflow/observability/workflowSpans.js');
+  const shutdown = async () => {
+    await sdk.shutdown();
+    trace.disable();
+    context.disable();
+  };
+  return { module, exporter, shutdown };
+}
+
 function makeStep(overrides: Partial<WorkflowStep> = {}): WorkflowStep {
   return {
     name: 'implement',
@@ -132,6 +179,22 @@ function makeDoneResult(): StepRunResult {
       modelSource: 'global',
     },
   };
+}
+
+function findSpan(spans: FakeSpan[], name: string): FakeSpan {
+  const span = spans.find((item) => item.name === name);
+  if (!span) {
+    throw new Error(`Expected span ${name} to exist`);
+  }
+  return span;
+}
+
+function findReadableSpan(spans: ReadableSpan[], name: string): ReadableSpan {
+  const span = spans.find((item) => item.name === name);
+  if (!span) {
+    throw new Error(`Expected span ${name} to exist`);
+  }
+  return span;
 }
 
 describe('workflow OpenTelemetry spans', () => {
@@ -171,9 +234,8 @@ describe('workflow OpenTelemetry spans', () => {
       resumeDepth: 1,
     }, async () => ({ done: true }), () => ({ status: 'completed' }));
 
-    expect(spans).toHaveLength(1);
-    expect(spans[0]?.name).toBe('workflow.test-workflow');
-    expect(spans[0]?.attributes).toMatchObject({
+    const workflowSpan = findSpan(spans, 'workflow.test-workflow');
+    expect(workflowSpan.attributes).toMatchObject({
       'takt.run.id': 'run-1',
       'takt.workflow.name': 'test-workflow',
       'takt.workflow.initial_step': 'implement',
@@ -183,7 +245,7 @@ describe('workflow OpenTelemetry spans', () => {
       'takt.workflow.resume_depth': 1,
       'takt.workflow.status': 'completed',
     });
-    expect(spans[0]?.ended).toBe(true);
+    expect(workflowSpan.ended).toBe(true);
     expect(metricRecords).toEqual([
       expect.objectContaining({
         instrument: 'counter',
@@ -207,6 +269,134 @@ describe('workflow OpenTelemetry spans', () => {
     ]);
   });
 
+  it('emits a short-lived workflow_start span before workflow execution continues', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+
+    await module.runWithWorkflowSpan({
+      enabled: true,
+      runId: 'run-1',
+      workflowName: 'test-workflow',
+      initialStep: 'implement',
+      stepCount: 2,
+      maxSteps: 3,
+      runMode: 'full',
+      resumeDepth: 0,
+    }, async () => {
+      const workflowSpan = findSpan(spans, 'workflow.test-workflow');
+      const startSpan = findSpan(spans, 'workflow_start.test-workflow');
+
+      expect(workflowSpan.ended).toBe(false);
+      expect(startSpan.ended).toBe(true);
+      expect(startSpan.parentName).toBe('workflow.test-workflow');
+      expect(startSpan.attributes).toMatchObject({
+        'takt.run.id': 'run-1',
+        'takt.workflow.name': 'test-workflow',
+        'takt.workflow.initial_step': 'implement',
+        'takt.workflow.step_count': 2,
+        'takt.workflow.max_steps': 3,
+        'takt.workflow.run_mode': 'full',
+        'takt.workflow.resume_depth': 0,
+        'takt.workflow.status': 'running',
+      });
+
+      return { done: true };
+    }, () => ({ status: 'completed' }));
+
+    expect(spans.map((span) => span.name)).toEqual([
+      'workflow.test-workflow',
+      'workflow_start.test-workflow',
+    ]);
+  });
+
+  it('exports workflow_start before the root workflow span ends with the real OpenTelemetry SDK', async () => {
+    const { module, exporter, shutdown } = await loadWorkflowSpansWithRealSdk();
+
+    try {
+      await module.runWithWorkflowSpan({
+        enabled: true,
+        runId: 'run-1',
+        workflowName: 'test-workflow',
+        initialStep: 'implement',
+        stepCount: 2,
+        maxSteps: 3,
+        runMode: 'full',
+        resumeDepth: 0,
+      }, async () => {
+        expect(exporter.spans.map((span) => span.name)).toEqual(['workflow_start.test-workflow']);
+        expect(exporter.spans[0]?.attributes).toMatchObject({
+          'takt.run.id': 'run-1',
+          'takt.workflow.name': 'test-workflow',
+          'takt.workflow.status': 'running',
+        });
+
+        return { done: true };
+      }, () => ({ status: 'completed' }));
+
+      expect(exporter.spans.map((span) => span.name)).toEqual([
+        'workflow_start.test-workflow',
+        'workflow.test-workflow',
+      ]);
+      const startSpan = findReadableSpan(exporter.spans, 'workflow_start.test-workflow');
+      const workflowSpan = findReadableSpan(exporter.spans, 'workflow.test-workflow');
+      expect(startSpan.parentSpanContext?.spanId).toBe(workflowSpan.spanContext().spanId);
+      expect(workflowSpan.attributes).toMatchObject({
+        'takt.run.id': 'run-1',
+        'takt.workflow.name': 'test-workflow',
+        'takt.workflow.status': 'completed',
+      });
+    } finally {
+      await shutdown();
+    }
+  });
+
+  it('emits workflow_start before failing execution so the active trace stays discoverable', async () => {
+    const { module, spans, metricRecords } = await loadWorkflowSpansWithMockedApi();
+    const error = new Error('workflow failed before first step');
+
+    await expect(
+      module.runWithWorkflowSpan({
+        enabled: true,
+        runId: 'run-1',
+        workflowName: 'test-workflow',
+        initialStep: 'implement',
+        stepCount: 2,
+        maxSteps: 3,
+        runMode: 'full',
+        resumeDepth: 0,
+      }, async () => {
+        const startSpan = findSpan(spans, 'workflow_start.test-workflow');
+        expect(startSpan.ended).toBe(true);
+        throw error;
+      }, () => ({ status: 'completed' })),
+    ).rejects.toThrow('workflow failed before first step');
+
+    const workflowSpan = findSpan(spans, 'workflow.test-workflow');
+    const startSpan = findSpan(spans, 'workflow_start.test-workflow');
+    expect(spans.map((span) => span.name)).toEqual([
+      'workflow.test-workflow',
+      'workflow_start.test-workflow',
+    ]);
+    expect(startSpan.parentName).toBe('workflow.test-workflow');
+    expect(startSpan.attributes).toMatchObject({
+      'takt.run.id': 'run-1',
+      'takt.workflow.name': 'test-workflow',
+      'takt.workflow.status': 'running',
+    });
+    expect(workflowSpan.status).toEqual({ code: 2, message: 'workflow failed before first step' });
+    expect(workflowSpan.exceptions).toEqual([error]);
+    expect(workflowSpan.ended).toBe(true);
+    expect(metricRecords).toContainEqual(expect.objectContaining({
+      instrument: 'counter',
+      name: 'takt.workflow.runs',
+      value: 1,
+      attributes: expect.objectContaining({
+        'takt.run.id': 'run-1',
+        'takt.workflow.name': 'test-workflow',
+        'takt.workflow.status': 'error',
+      }) as unknown,
+    }));
+  });
+
   it('sanitizes the workflow abort reason before recording it on the span', async () => {
     const { module, spans } = await loadWorkflowSpansWithMockedApi();
 
@@ -226,8 +416,7 @@ describe('workflow OpenTelemetry spans', () => {
       abortReason: 'Step "implement" failed: secret content',
     }));
 
-    expect(spans).toHaveLength(1);
-    expect(spans[0]?.attributes).toMatchObject({
+    expect(findSpan(spans, 'workflow.test-workflow').attributes).toMatchObject({
       'takt.workflow.status': 'aborted',
       'takt.workflow.abort.kind': 'step_error',
       'takt.workflow.abort.reason': 'Step "implement" failed: [REDACTED] content',
@@ -260,10 +449,12 @@ describe('workflow OpenTelemetry spans', () => {
 
     expect(spans.map((span) => span.name)).toEqual([
       'workflow.test-workflow',
+      'workflow_start.test-workflow',
       'step.implement',
     ]);
-    expect(spans[1]?.parentName).toBe('workflow.test-workflow');
-    expect(spans[1]?.attributes).toMatchObject({
+    const stepSpan = findSpan(spans, 'step.implement');
+    expect(stepSpan.parentName).toBe('workflow.test-workflow');
+    expect(stepSpan.attributes).toMatchObject({
       'takt.workflow.name': 'test-workflow',
       'takt.step.name': 'implement',
       'takt.step.type': 'agent',
@@ -275,7 +466,7 @@ describe('workflow OpenTelemetry spans', () => {
       'takt.model.name': 'gpt-5',
       'takt.model.source': 'global',
     });
-    expect(spans[1]?.ended).toBe(true);
+    expect(stepSpan.ended).toBe(true);
     expect(metricRecords).toContainEqual(expect.objectContaining({
       instrument: 'counter',
       name: 'takt.workflow.step.runs',

--- a/src/core/workflow/observability/workflowSpans.ts
+++ b/src/core/workflow/observability/workflowSpans.ts
@@ -117,9 +117,10 @@ export async function runWithWorkflowSpan<T>(
 
   const startedAt = Date.now();
   return runInSpan(
-    buildSpanName('workflow', params.workflowName),
+    buildWorkflowSpanName(params),
     buildWorkflowAttributes(params),
     async (span) => {
+      recordWorkflowStartSpan(params);
       try {
         const result = await execute();
         const outcome = getOutcome(result);
@@ -147,7 +148,7 @@ export async function runWithStepSpan(
 
   const startedAt = Date.now();
   return runInSpan(
-    buildSpanName('step', params.step.name),
+    buildStepSpanName(params),
     buildStepAttributes(params),
     async (span) => {
       try {
@@ -217,6 +218,17 @@ export function recordJudgeStageSpan(params: JudgeStageSpanParams): void {
     if (params.entry.status === 'error') {
       span.setStatus({ code: SpanStatusCode.ERROR, message: `judge stage ${params.entry.status}` });
     }
+  } finally {
+    span.end();
+  }
+}
+
+function recordWorkflowStartSpan(params: WorkflowSpanParams): void {
+  const span = tracer.startSpan(buildWorkflowStartSpanName(params), {
+    attributes: buildWorkflowAttributes(params),
+  });
+  try {
+    span.setAttributes({ 'takt.workflow.status': 'running' });
   } finally {
     span.end();
   }
@@ -530,16 +542,24 @@ function recordSpanError(span: Span, error: unknown): void {
   span.setStatus({ code: SpanStatusCode.ERROR, message });
 }
 
-function buildSpanName(prefix: 'workflow' | 'step', name: string): string {
-  return `${prefix}.${name || 'unknown'}`;
+function buildWorkflowSpanName(params: WorkflowSpanParams): string {
+  return `workflow.${params.workflowName}`;
+}
+
+function buildStepSpanName(params: StepSpanParams): string {
+  return `step.${params.step.name}`;
+}
+
+function buildWorkflowStartSpanName(params: WorkflowSpanParams): string {
+  return `workflow_start.${params.workflowName}`;
 }
 
 function buildPhaseSpanName(params: PhaseSpanParams): string {
-  return `phase.${params.step.name || 'unknown'}.${params.phaseName}`;
+  return `phase.${params.step.name}.${params.phaseName}`;
 }
 
 function buildJudgeStageSpanName(params: JudgeStageSpanParams): string {
-  return `judge_stage.${params.step.name || 'unknown'}.${params.entry.stage}.${params.entry.method}`;
+  return `judge_stage.${params.step.name}.${params.entry.stage}.${params.entry.method}`;
 }
 
 function compactAttributes(attributes: AttributeInput): Attributes {


### PR DESCRIPTION
## Summary

## Summary

Grafana Tempo shows in-progress TAKT traces with child spans but without the root workflow span, which makes the trace table hard to interpret. The table can show `<root span not yet received>` for Service and an empty Name even though step/phase spans are visible.

## Observed Behavior

For an active parent workflow trace, Tempo showed:

- Service: `<root span not yet received>`
- Name: blank in the trace table
- Trace detail title: `takt: step.gather`
- Child spans such as:
  - `step.gather`
  - `phase.gather.execute`
  - `phase.gather.report`
  - `phase.gather.judge`
  - `judge_stage.gather.1.structured_output`

The local OTEL shadow log included `workflow_start`, but the workflow had not completed yet, so the root `workflow.<name>` span had not ended/exported.

## Expected Behavior

Users should be able to identify an active TAKT workflow trace in Tempo while it is still running.

At minimum, the Tempo trace table and trace detail should make it clear which TAKT workflow/run is being observed, without requiring the root span to have already ended.

## Likely Cause

OpenTelemetry exporters generally emit spans when they end. The TAKT root workflow span is long-lived and only ends when the workflow completes. Child step/phase spans end earlier, so Tempo receives child spans before the root span and displays `<root span not yet received>`.

## Suggested Direction

Consider one or more of the following:

- Add enough workflow/run attributes to step and phase spans to make active traces easy to search and identify.
- Document a recommended Tempo query for active workflows, such as searching by `resource.service.name = "takt"` plus `takt.workflow.name` / `takt.run.id` / `name =~ "step\\..*"`.
- Consider an explicit short-lived span or event that marks `workflow_start` for discoverability while the long-lived root span is still open.
- Ensure `service.name = takt` and workflow/run metadata are consistently present on spans that are exported before workflow completion.

## Notes

This is distinct from nested/runtime child runs missing telemetry entirely. That bug is tracked separately in #812.

## Execution Report

Workflow `takt-default` completed successfully.

Closes #813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * オブザーバビリティドキュメント（日本語・英語版）を更新。Tempo でアクティブなワークフロー実行状況を追跡しやすくするための新しい観測機能と TraceQL フィルター例を追加しました。

* **New Features**
  * ワークフロー開始時に追加の観測スパンを生成し、実行中のワークフロー検出を改善しました。

* **Tests**
  * ワークフロースパン検証とスパン変換テストケースを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->