### PR TITLE
[#802] fix-cursor-enoent-retry

### DIFF
--- a/src/__tests__/StreamDisplay.test.ts
+++ b/src/__tests__/StreamDisplay.test.ts
@@ -247,6 +247,21 @@ describe('StreamDisplay', () => {
       expect(fullOutput).toContain('Error message');
       expect(fullOutput).not.toContain('\x1b[31m');
     });
+
+    it('should strip ANSI and OSC codes from result error content', () => {
+      const display = new StreamDisplay('test-agent', false);
+      display.showResult(false, '\x1b]52;c;secret\x07Cursor failed: \x1b[41mparse error\x1b[0m');
+
+      const errorLine = consoleLogSpy.mock.calls.find(
+        (call) => typeof call[0] === 'string' && (call[0] as string).includes('Cursor failed'),
+      );
+      expect(errorLine).toBeDefined();
+      const fullOutput = errorLine!.join(' ');
+      expect(fullOutput).toContain('Cursor failed: parse error');
+      expect(fullOutput).not.toContain('secret');
+      expect(fullOutput).not.toContain('\x1b]52');
+      expect(fullOutput).not.toContain('\x1b[41m');
+    });
   });
 
   describe('showToolUse spinner suppression', () => {

--- a/src/__tests__/cursor-client.test.ts
+++ b/src/__tests__/cursor-client.test.ts
@@ -391,14 +391,29 @@ describe('callCursor', () => {
   });
 
   it('should return parse error when stdout is not valid JSON', async () => {
+    const onStream = vi.fn();
     mockSpawnWithScenario({
       stdout: 'not-json',
       code: 0,
     });
 
-    const result = await callCursor('coder', 'implement feature', { cwd: '/repo' });
+    const result = await callCursor('coder', 'implement feature', {
+      cwd: '/repo',
+      sessionId: 'sess-parse-error',
+      onStream,
+    });
 
     expect(result.status).toBe('error');
     expect(result.content).toContain('Failed to parse cursor-agent JSON output');
+    expect(result.sessionId).toBe('sess-parse-error');
+    expect(onStream).toHaveBeenCalledWith({
+      type: 'result',
+      data: {
+        result: '',
+        success: false,
+        error: expect.stringContaining('Failed to parse cursor-agent JSON output'),
+        sessionId: 'sess-parse-error',
+      },
+    });
   });
 });

--- a/src/__tests__/cursor-client.test.ts
+++ b/src/__tests__/cursor-client.test.ts
@@ -29,6 +29,12 @@ type MockChildProcess = EventEmitter & {
   kill: ReturnType<typeof vi.fn>;
 };
 
+const CURSOR_CONFIG_RENAME_ENOENT =
+  "Error: ENOENT: no such file or directory, rename '/home/user/.cursor/cli-config.json.tmp' -> '/home/user/.cursor/cli-config.json'";
+const CURSOR_CONFIG_NON_RENAME_ENOENT =
+  "Error: ENOENT: no such file or directory, open '/home/user/.cursor/cli-config.json.tmp'";
+const CURSOR_CONFIG_RENAME_ENOENT_ATTEMPTS = 9;
+
 function createMockChildProcess(): MockChildProcess {
   const child = new EventEmitter() as MockChildProcess;
   child.stdout = new EventEmitter();
@@ -37,8 +43,16 @@ function createMockChildProcess(): MockChildProcess {
   return child;
 }
 
-function mockSpawnWithScenario(scenario: SpawnScenario): void {
+function mockSpawnWithScenarios(scenarios: SpawnScenario[]): void {
+  let scenarioIndex = 0;
+
   mockSpawn.mockImplementation((_cmd: string, _args: string[], _options: object) => {
+    const scenario = scenarios[scenarioIndex];
+    scenarioIndex += 1;
+    if (!scenario) {
+      throw new Error(`Missing cursor spawn scenario for attempt ${scenarioIndex}`);
+    }
+
     const child = createMockChildProcess();
 
     queueMicrotask(() => {
@@ -62,6 +76,10 @@ function mockSpawnWithScenario(scenario: SpawnScenario): void {
   });
 }
 
+function mockSpawnWithScenario(scenario: SpawnScenario): void {
+  mockSpawnWithScenarios([scenario]);
+}
+
 describe('callCursor', () => {
   const originalEnv = {
     CURSOR_API_KEY: process.env.CURSOR_API_KEY,
@@ -77,6 +95,9 @@ describe('callCursor', () => {
   });
 
   afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+
     for (const [key, value] of Object.entries(originalEnv)) {
       if (value === undefined) {
         delete process.env[key];
@@ -214,6 +235,8 @@ describe('callCursor', () => {
 
     expect(result.status).toBe('error');
     expect(result.content).toContain('cursor-agent binary not found');
+    expect(result.failureCategory).toBeUndefined();
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
   });
 
   it('should classify authentication errors', async () => {
@@ -227,6 +250,8 @@ describe('callCursor', () => {
     expect(result.status).toBe('error');
     expect(result.content).toContain('cursor-agent login');
     expect(result.content).toContain('TAKT_CURSOR_API_KEY');
+    expect(result.failureCategory).toBeUndefined();
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
   });
 
   it('should classify non-zero exits', async () => {
@@ -240,6 +265,129 @@ describe('callCursor', () => {
     expect(result.status).toBe('error');
     expect(result.content).toContain('code 2');
     expect(result.content).toContain('unexpected failure');
+    expect(result.failureCategory).toBeUndefined();
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry cli-config rename ENOENT and return successful retry result', async () => {
+    vi.useFakeTimers();
+    mockSpawnWithScenarios([
+      {
+        code: 1,
+        stderr: `${'x'.repeat(450)}${CURSOR_CONFIG_RENAME_ENOENT}`,
+      },
+      {
+        stdout: JSON.stringify({ content: 'retry succeeded', sessionId: 'sess-after-retry' }),
+        code: 0,
+      },
+    ]);
+
+    const resultPromise = callCursor('coding-review', 'review changes', {
+      cwd: '/repo',
+      sessionId: 'sess-before-retry',
+    });
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await resultPromise;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('retry succeeded');
+    expect(result.sessionId).toBe('sess-after-retry');
+  });
+
+  it('should stop cli-config rename ENOENT retry when aborted during retry delay', async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    const onStream = vi.fn();
+    mockSpawnWithScenarios([
+      {
+        code: 1,
+        stderr: CURSOR_CONFIG_RENAME_ENOENT,
+      },
+      {
+        stdout: JSON.stringify({ content: 'should not run' }),
+        code: 0,
+      },
+    ]);
+
+    const resultPromise = callCursor('coding-review', 'review changes', {
+      cwd: '/repo',
+      sessionId: 'sess-aborted-retry',
+      abortSignal: abortController.signal,
+      onStream,
+    });
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+
+    abortController.abort();
+    const result = await resultPromise;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('error');
+    expect(result.content).toBe('Cursor execution aborted');
+    expect(result.failureCategory).toBeUndefined();
+    expect(onStream).toHaveBeenCalledWith({
+      type: 'result',
+      data: {
+        result: '',
+        success: false,
+        error: 'Cursor execution aborted',
+        sessionId: 'sess-aborted-retry',
+      },
+    });
+  });
+
+  it('should not retry cli-config ENOENT when it is not a rename failure', async () => {
+    vi.useFakeTimers();
+    mockSpawnWithScenario({
+      code: 1,
+      stderr: CURSOR_CONFIG_NON_RENAME_ENOENT,
+    });
+
+    const result = await callCursor('coding-review', 'review changes', { cwd: '/repo' });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('error');
+    expect(result.failureCategory).toBeUndefined();
+    expect(result.content).toContain('code 1');
+    expect(result.content).toContain('cli-config.json.tmp');
+  });
+
+  it('should return provider_error when cli-config rename ENOENT retry attempts are exhausted', async () => {
+    vi.useFakeTimers();
+    const onStream = vi.fn();
+    mockSpawnWithScenarios(Array.from({ length: CURSOR_CONFIG_RENAME_ENOENT_ATTEMPTS }, () => ({
+      code: 1,
+      stderr: CURSOR_CONFIG_RENAME_ENOENT,
+    })));
+
+    const resultPromise = callCursor('coding-review', 'review changes', {
+      cwd: '/repo',
+      sessionId: 'sess-retry-exhausted',
+      onStream,
+    });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(CURSOR_CONFIG_RENAME_ENOENT_ATTEMPTS);
+    expect(result.status).toBe('error');
+    expect(result.failureCategory).toBe('provider_error');
+    expect(result.content).toContain('code 1');
+    expect(result.content).toContain('cli-config.json.tmp');
+    expect(result.content).toContain('cli-config.json');
+    expect(onStream).toHaveBeenCalledWith({
+      type: 'result',
+      data: expect.objectContaining({
+        success: false,
+        error: expect.stringContaining('cli-config.json.tmp'),
+        failureCategory: 'provider_error',
+      }),
+    });
   });
 
   it('should return parse error when stdout is not valid JSON', async () => {

--- a/src/infra/cursor/client.ts
+++ b/src/infra/cursor/client.ts
@@ -5,6 +5,7 @@
 import type { AgentResponse } from '../../core/models/index.js';
 import { crossSpawn, getErrorMessage } from '../../shared/utils/index.js';
 import { buildEnvWithNestedObservabilitySnapshot } from '../../shared/telemetry/index.js';
+import { AGENT_FAILURE_CATEGORIES, type AgentFailureCategory } from '../../shared/types/agent-failure.js';
 import type { CursorCallOptions } from './types.js';
 
 export type { CursorCallOptions } from './types.js';
@@ -14,6 +15,9 @@ const CURSOR_ABORTED_MESSAGE = 'Cursor execution aborted';
 const CURSOR_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const CURSOR_FORCE_KILL_DELAY_MS_DEFAULT = 1_000;
 const CURSOR_ERROR_DETAIL_MAX_LENGTH = 400;
+const CURSOR_CLI_CONFIG_RENAME_MAX_RETRIES = 8;
+const CURSOR_CLI_CONFIG_RENAME_RETRY_BASE_DELAY_MS = 1_000;
+const CURSOR_CLI_CONFIG_RENAME_RETRY_MAX_DELAY_MS = 30_000;
 
 function resolveForceKillDelayMs(): number {
   const raw = process.env.TAKT_CURSOR_FORCE_KILL_DELAY_MS;
@@ -346,6 +350,50 @@ function isAuthenticationError(error: CursorExecError): boolean {
   return patterns.some((pattern) => message.includes(pattern));
 }
 
+function isCursorCliConfigRenameEnoent(error: CursorExecError): boolean {
+  if (error.code !== 1) {
+    return false;
+  }
+
+  const detail = [
+    error.message,
+    error.stderr,
+    error.stdout,
+  ].filter((value): value is string => typeof value === 'string').join('\n');
+
+  return /\bENOENT\b/i.test(detail)
+    && /\brename\b/i.test(detail)
+    && /cli-config\.json\.tmp/i.test(detail)
+    && /(?:->|to)\s*['"]?[^'"\r\n]*cli-config\.json(?:['"]|\s|$)/i.test(detail);
+}
+
+async function waitForCursorCliConfigRenameRetryDelay(attempt: number, signal?: AbortSignal): Promise<void> {
+  const delayMs = Math.min(
+    CURSOR_CLI_CONFIG_RENAME_RETRY_BASE_DELAY_MS * (2 ** Math.max(0, attempt - 1)),
+    CURSOR_CLI_CONFIG_RENAME_RETRY_MAX_DELAY_MS,
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+
+    const onAbort = (): void => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener('abort', onAbort);
+      reject(signal?.reason ?? new Error(CURSOR_ABORTED_MESSAGE));
+    };
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 function classifyExecutionError(error: CursorExecError, options: CursorCallOptions): string {
   if (options.abortSignal?.aborted || error.name === 'AbortError') {
     return CURSOR_ABORTED_MESSAGE;
@@ -397,67 +445,117 @@ function parseCursorOutput(stdout: string): { content: string; sessionId?: strin
   return { content, sessionId };
 }
 
+function toCursorExecError(rawError: unknown): CursorExecError {
+  if (rawError instanceof Error) {
+    return rawError as CursorExecError;
+  }
+
+  return createExecError(getErrorMessage(rawError));
+}
+
+function emitCursorErrorResult(
+  options: CursorCallOptions,
+  message: string,
+  failureCategory?: AgentFailureCategory,
+): void {
+  if (!options.onStream) {
+    return;
+  }
+
+  options.onStream({
+    type: 'result',
+    data: {
+      result: '',
+      success: false,
+      error: message,
+      sessionId: options.sessionId ?? '',
+      ...(failureCategory ? { failureCategory } : {}),
+    },
+  });
+}
+
+function buildCursorErrorResponse(
+  agentType: string,
+  message: string,
+  options: CursorCallOptions,
+  failureCategory?: AgentFailureCategory,
+): AgentResponse {
+  return {
+    persona: agentType,
+    status: 'error',
+    content: message,
+    timestamp: new Date(),
+    sessionId: options.sessionId,
+    ...(failureCategory ? { error: message, failureCategory } : {}),
+  };
+}
+
 /**
  * Client for Cursor Agent CLI interactions.
  */
 export class CursorClient {
   async call(agentType: string, prompt: string, options: CursorCallOptions): Promise<AgentResponse> {
     const args = buildArgs(prompt, options);
+    let cliConfigRenameRetryCount = 0;
 
-    try {
-      const { stdout } = await execCursor(args, options);
-      const parsed = parseCursorOutput(stdout);
-      if ('error' in parsed) {
+    while (true) {
+      try {
+        const { stdout } = await execCursor(args, options);
+        const parsed = parseCursorOutput(stdout);
+        if ('error' in parsed) {
+          return {
+            persona: agentType,
+            status: 'error',
+            content: parsed.error,
+            timestamp: new Date(),
+            sessionId: options.sessionId,
+          };
+        }
+
+        const sessionId = parsed.sessionId ?? options.sessionId;
+        if (options.onStream) {
+          options.onStream({ type: 'text', data: { text: parsed.content } });
+          options.onStream({
+            type: 'result',
+            data: {
+              result: parsed.content,
+              success: true,
+              sessionId: sessionId ?? '',
+            },
+          });
+        }
+
         return {
           persona: agentType,
-          status: 'error',
-          content: parsed.error,
+          status: 'done',
+          content: parsed.content,
           timestamp: new Date(),
-          sessionId: options.sessionId,
+          sessionId,
         };
-      }
+      } catch (rawError) {
+        const error = toCursorExecError(rawError);
+        if (
+          isCursorCliConfigRenameEnoent(error)
+          && cliConfigRenameRetryCount < CURSOR_CLI_CONFIG_RENAME_MAX_RETRIES
+        ) {
+          cliConfigRenameRetryCount += 1;
+          try {
+            await waitForCursorCliConfigRenameRetryDelay(cliConfigRenameRetryCount, options.abortSignal);
+          } catch (delayError) {
+            const message = classifyExecutionError(toCursorExecError(delayError), options);
+            emitCursorErrorResult(options, message);
+            return buildCursorErrorResponse(agentType, message, options);
+          }
+          continue;
+        }
 
-      const sessionId = parsed.sessionId ?? options.sessionId;
-      if (options.onStream) {
-        options.onStream({ type: 'text', data: { text: parsed.content } });
-        options.onStream({
-          type: 'result',
-          data: {
-            result: parsed.content,
-            success: true,
-            sessionId: sessionId ?? '',
-          },
-        });
+        const message = classifyExecutionError(error, options);
+        const failureCategory = isCursorCliConfigRenameEnoent(error)
+          ? AGENT_FAILURE_CATEGORIES.PROVIDER_ERROR
+          : undefined;
+        emitCursorErrorResult(options, message, failureCategory);
+        return buildCursorErrorResponse(agentType, message, options, failureCategory);
       }
-
-      return {
-        persona: agentType,
-        status: 'done',
-        content: parsed.content,
-        timestamp: new Date(),
-        sessionId,
-      };
-    } catch (rawError) {
-      const error = rawError as CursorExecError;
-      const message = classifyExecutionError(error, options);
-      if (options.onStream) {
-        options.onStream({
-          type: 'result',
-          data: {
-            result: '',
-            success: false,
-            error: message,
-            sessionId: options.sessionId ?? '',
-          },
-        });
-      }
-      return {
-        persona: agentType,
-        status: 'error',
-        content: message,
-        timestamp: new Date(),
-        sessionId: options.sessionId,
-      };
     }
   }
 

--- a/src/infra/cursor/client.ts
+++ b/src/infra/cursor/client.ts
@@ -503,13 +503,8 @@ export class CursorClient {
         const { stdout } = await execCursor(args, options);
         const parsed = parseCursorOutput(stdout);
         if ('error' in parsed) {
-          return {
-            persona: agentType,
-            status: 'error',
-            content: parsed.error,
-            timestamp: new Date(),
-            sessionId: options.sessionId,
-          };
+          emitCursorErrorResult(options, parsed.error);
+          return buildCursorErrorResponse(agentType, parsed.error, options);
         }
 
         const sessionId = parsed.sessionId ?? options.sessionId;

--- a/src/shared/ui/StreamDisplay.ts
+++ b/src/shared/ui/StreamDisplay.ts
@@ -238,7 +238,7 @@ export class StreamDisplay {
     } else {
       console.log(chalk.red('✗ Failed'));
       if (error) {
-        console.log(chalk.red(`  ${error}`));
+        console.log(chalk.red(`  ${stripAnsi(error)}`));
       }
     }
   }


### PR DESCRIPTION
## Summary

## 背景

`provider: cursor` で builtin workflow の `review-fix-backend` を実行すると、`reviewers` 並列ステップで cursor-agent が4プロセス同時に起動します（arch-review / security-review / qa-review / coding-review）。

このとき cursor-agent はグローバル設定の `~/.cursor/cli-config.json` を「一時ファイルに書いてから rename」する方式で更新するのですが、エラーに現れる一時ファイル名が `cli-config.json.tmp` 固定のため、並列プロセス間で取り合いになっていると見ています。先に rename したプロセスが一時ファイルを持っていってしまい、残りが ENOENT で exit code 1 になる、という推測です。

```text
Error: ENOENT: no such file or directory, rename '/home/<user>/.cursor/cli-config.json.tmp' -> '/home/<user>/.cursor/cli-config.json'
```

## 実際のログ

#770 の診断改善のおかげで、どこで何が起きたかははっきり出ています。

```text
[ERROR] Error: Parallel step "reviewers" returned error because one or more sub-steps ended in a non-rule terminal status.
Aggregate rules were not evaluated as a normal review result because terminal sub-step statuses
do not represent matched aggregate conditions such as all("approved") or any("needs_fix").

Sub-step diagnostics:
- sub-step: coding-review
  status: error
  failureCategory: none
  detail: Cursor Agent CLI exited with code 1: Error: ENOENT: no such file or directory, rename '/home/kurisu/.cursor/cli-config.json.tmp' -> '/home/kurisu/.cursor/cli-config.json'
[ERROR] Workflow aborted after 4 iterations (220m 14s): Step "reviewers" failed: ...
```

session log（jsonl）上のイベントはこの順でした。

```text
phase_complete  step=coding-review  status=error   (iteration 4)
step_complete   step=reviewers      status=error
workflow_abort
```

## 問題

このエラーはタイミング依存の一時障害で、レビュー結果でも環境の異常でもありません。手元で確認した範囲では:

- `~/.cursor/` は健全でした（権限・ディスク容量とも問題なし）。エラー発生の数分後には、別の cursor-agent プロセスが同じファイルを正常に更新しています
- 同一 run 内でも、iteration 2 の並列レビュー4本は全て無事通過し、iteration 4 で coding-review だけが ENOENT になりました。発生は間欠的です
- 同じタスクをそのまま再実行したところ、並列レビューを2巡しても一度も再発せず進行しています
- 一方、過去の別タスク（peer-review workflow）でも同一の ENOENT で abort した記録が手元にあり、数日の間に少なくとも2回発生しています

つまり発生するかどうかは並列起動のタイミング次第で、3時間半走った run が終盤のレビュー1本のせいで丸ごと失われることがあります。これが正直いちばんつらい点です。

現状の `src/infra/cursor/client.ts` ではこのエラーが `Cursor Agent CLI exited with code ${code}: ${detail}` として終端エラー扱いになっており、transient の分類がありません。

## 関連 Issue との差分

- #768 / #770 は並列 sub-step error の診断改善です。本件のエラーメッセージはこの改善で出ているもので、診断自体は十分機能しています。この Issue はその先の「transient エラーとして分類してリトライする」話です
- #758 / #767 / #775 では Codex SDK の `Reconnecting...` を transient provider failure としてリトライするようになりました。cursor provider にも同じ枠組みがほしい、というのが本 Issue の趣旨です
- 補足として、#772（v0.44.0）で coding-review が全 review 系 workflow の並列段に追加され、cursor-agent の同時起動数が増えています。この競合を踏みやすくなったのはそれ以降だと思われます

## 期待する挙動

- `cli-config.json.tmp` rename の ENOENT（exit 1）を retryable な transient failure として分類し、sub-step を即 error 終端にせずリトライする
- リトライ上限に達した場合も、provider の一時障害だと分かる failureCategory が付く（現状は `failureCategory: none` です）

## 実装方針案

1. cursor client のエラー分類に stderr の `ENOENT` + `cli-config.json` パターンを transient として追加し、#767 と同様の retry でラップする
2. 並列 sub-step ごとに `CURSOR_CONFIG_DIR`（Cursor CLI 公式の設定ディレクトリ変更用環境変数。https://cursor.com/docs/cli/reference/configuration ）を分けて spawn し、設定ファイルの取り合い自体を起こさなくする。`cursor_api_key` 認証であれば設定分離の副作用も小さいと思われます
3. より簡易な緩和として、cursor-agent の spawn を provider 単位の mutex で直列化するオプションも考えられます

## 環境

| 項目 | 値 |
|---|---|
| takt | 0.44.0 |
| cursor-agent | 2026.06.04-5fd875e |
| OS | WSL2 (Linux 6.6.114.1-microsoft-standard-WSL2) |
| Node.js | v24.11.1 |
| workflow | builtin `review-fix-backend`（ja） |
| provider | cursor（global config で指定） |

## Execution Report

Workflow `takt-default` completed successfully.

Closes #802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 設定ファイルの一部失敗時に自動リトライする挙動を追加し、キャンセル時の中断処理を改善しました。
  * エラー分類と失敗通知がより明確になり、エラーメッセージ表示から端末制御コード（ANSI/OSC等）を除去するようにしました。

* **テスト**
  * 複数試行・中断・パースエラー等のシナリオを網羅するテストを拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->