### PR TITLE
docs: add README status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # TAKT
 
-🇯🇵 [日本語ドキュメント](./docs/README.ja.md) | 💬 [Discord Community](https://discord.gg/R2Xz3uYWxD)
+<p align="center">
+  <a href="https://www.npmjs.com/package/takt"><img src="https://img.shields.io/npm/v/takt?label=npm" alt="npm version"></a>
+  <a href="https://github.com/nrslib/takt/stargazers"><img src="https://img.shields.io/github/stars/nrslib/takt?logo=github&label=stars" alt="GitHub stars"></a>
+  <a href="https://github.com/nrslib/takt/actions/workflows/ci.yml"><img src="https://github.com/nrslib/takt/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/nrslib/takt" alt="license"></a>
+  <a href="https://discord.gg/R2Xz3uYWxD"><img src="https://img.shields.io/badge/dynamic/json?label=discord&query=approximate_member_count&url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FR2Xz3uYWxD%3Fwith_counts%3Dtrue&suffix=%20members&logo=discord&logoColor=white&color=5865F2" alt="Discord members"></a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./docs/README.ja.md">日本語</a>
+</p>
 
 **Stop babysitting AI coding agents.**
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,6 +1,17 @@
 # TAKT
 
-[English](../README.md) | 💬 [Discord コミュニティ](https://discord.gg/R2Xz3uYWxD)
+<p align="center">
+  <a href="https://www.npmjs.com/package/takt"><img src="https://img.shields.io/npm/v/takt?label=npm" alt="npm version"></a>
+  <a href="https://github.com/nrslib/takt/stargazers"><img src="https://img.shields.io/github/stars/nrslib/takt?logo=github&label=stars" alt="GitHub stars"></a>
+  <a href="https://github.com/nrslib/takt/actions/workflows/ci.yml"><img src="https://github.com/nrslib/takt/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/github/license/nrslib/takt" alt="license"></a>
+  <a href="https://discord.gg/R2Xz3uYWxD"><img src="https://img.shields.io/badge/dynamic/json?label=discord&query=approximate_member_count&url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FR2Xz3uYWxD%3Fwith_counts%3Dtrue&suffix=%20members&logo=discord&logoColor=white&color=5865F2" alt="Discord members"></a>
+</p>
+
+<p align="center">
+  <a href="../README.md">English</a> |
+  <a href="./README.ja.md">日本語</a>
+</p>
 
 **AI コーディングエージェントの見張り番をやめる。**
 


### PR DESCRIPTION
## Summary
- add npm, stars, CI, license, and Discord badges to the English and Japanese README headers
- align the language switcher as `English | 日本語`
- use the Discord invite API through a dynamic Shields badge so member counts update automatically

## Tests
- Not run (documentation-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * READMEヘッダーを再構成し、npmバージョン、GitHubスター、CI状態、ライセンス、Discordメンバー数を視覚的バッジで表示するようにしました。複数言語のドキュメントへのナビゲーションが改善され、プロジェクト情報へのアクセスが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->