### PR TITLE
[codex] Add takt-default with Finding Contract

### DIFF
--- a/builtins/en/workflow-categories.yaml
+++ b/builtins/en/workflow-categories.yaml
@@ -61,6 +61,7 @@ workflow_categories:
   🎵 TAKT Development:
     workflows:
       - takt-default
+      - takt-default-with-fc
       - takt-default-refresh-all
       - takt-default-refresh-fast
       - auto-improvement-loop

--- a/builtins/en/workflows/takt-default-with-fc.yaml
+++ b/builtins/en/workflows/takt-default-with-fc.yaml
@@ -1,5 +1,5 @@
-name: takt-default
-description: TAKT development workflow (plan -> write_tests -> draft (implement + AI self-review) -> peer-review (parallel reviewers + fix) -> supervise -> COMPLETE).
+name: takt-default-with-fc
+description: Finding Contract-enabled TAKT development workflow (plan -> write_tests -> draft (implement + AI self-review) -> peer-review (parallel reviewers + fix) -> supervise -> COMPLETE).
 workflow_config:
   provider_options:
     codex:
@@ -73,7 +73,7 @@ steps:
         next: ABORT
   - name: peer-review
     kind: workflow_call
-    call: peer-review
+    call: takt-default-peer-review
     rules:
       - condition: COMPLETE
         next: supervise

--- a/builtins/ja/workflow-categories.yaml
+++ b/builtins/ja/workflow-categories.yaml
@@ -61,6 +61,7 @@ workflow_categories:
   🎵 TAKT開発:
     workflows:
       - takt-default
+      - takt-default-with-fc
       - takt-default-refresh-all
       - takt-default-refresh-fast
       - auto-improvement-loop

--- a/builtins/ja/workflows/takt-default-with-fc.yaml
+++ b/builtins/ja/workflows/takt-default-with-fc.yaml
@@ -1,5 +1,5 @@
-name: takt-default
-description: TAKT development workflow (plan -> write_tests -> draft (implement + AI self-review) -> peer-review (parallel reviewers + fix) -> supervise -> COMPLETE).
+name: takt-default-with-fc
+description: Finding Contract 有効版の TAKT 開発ワークフロー（計画 → テスト作成 → draft（実装+AI自己レビュー） → peer-review（並列レビュー+修正） → 監督 → 完了）
 workflow_config:
   provider_options:
     codex:
@@ -16,16 +16,16 @@ steps:
     provider_options:
       extends: review-readonly
     rules:
-      - condition: Requirements are clear and implementable
+      - condition: 要件が明確で実装可能
         next: write_tests
-      - condition: User is asking a question (not an implementation task)
+      - condition: ユーザーが質問をしている（実装タスクではない）
         next: COMPLETE
-      - condition: Requirements unclear, insufficient info
+      - condition: 要件が不明確、情報不足
         next: ABORT
         appendix: |
-          Items to confirm:
-          - {question 1}
-          - {question 2}
+          確認事項:
+          - {質問1}
+          - {質問2}
     instruction: plan
     output_contracts:
       report:
@@ -47,13 +47,13 @@ steps:
     required_permission_mode: edit
     instruction: write-tests-first
     rules:
-      - condition: Tests written
+      - condition: テスト作成が完了した
         next: draft
-      - condition: Skip test writing because target is not yet implemented
+      - condition: テスト対象が未実装のためテスト作成をスキップする
         next: draft
-      - condition: Cannot proceed with writing tests
+      - condition: テスト作成を進行できない
         next: plan
-      - condition: User input required for confirmation
+      - condition: ユーザーへの確認事項があるためユーザー入力が必要
         next: write_tests
         requires_user_input: true
         interactive_only: true
@@ -73,7 +73,7 @@ steps:
         next: ABORT
   - name: peer-review
     kind: workflow_call
-    call: peer-review
+    call: takt-default-peer-review
     rules:
       - condition: COMPLETE
         next: supervise
@@ -90,9 +90,9 @@ steps:
       extends: review-readonly
     pass_previous_response: false
     rules:
-      - condition: All clear
+      - condition: すべて問題なし
         next: COMPLETE
-      - condition: Requirements unmet, tests failing, build errors
+      - condition: 要求未達成、テスト失敗、ビルドエラー
         next: plan
     instruction: supervise
     output_contracts:

--- a/builtins/ja/workflows/takt-default.yaml
+++ b/builtins/ja/workflows/takt-default.yaml
@@ -73,7 +73,7 @@ steps:
         next: ABORT
   - name: peer-review
     kind: workflow_call
-    call: takt-default-peer-review
+    call: peer-review
     rules:
       - condition: COMPLETE
         next: supervise


### PR DESCRIPTION
## Summary
- Restore `takt-default` to call the standard `peer-review` workflow.
- Add `takt-default-with-fc` as the Finding Contract-enabled variant in both Japanese and English builtins.
- Add the new workflow to the TAKT development workflow category.

## Rationale
Finding Contract is still experimental, so the default TAKT workflow should not opt into it implicitly. Users can now select `takt-default-with-fc` explicitly when they want the Finding Contract path.

## Validation
- `npm run build`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * TAKT開発用の新しいワークフローがカテゴリに追加されました。プランニング、テスト作成、ドラフト作成、ピアレビュー、監督のステップで構成されています。

* **改善**
  * ワークフロー内の処理フロー呼び出しが更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->