### PR TITLE
[codex] Rename Finding Contract peer review workflow

### DIFF
--- a/builtins/en/workflows/peer-review-with-fc.yaml
+++ b/builtins/en/workflows/peer-review-with-fc.yaml
@@ -1,8 +1,8 @@
-name: takt-default-peer-review
-description: Experimental Finding Contract peer review for takt-default. Six parallel peer reviewers (+ ai-antipattern-review-2nd) ⇄ fix loop.
+name: peer-review-with-fc
+description: Experimental Finding Contract peer review. Six parallel peer reviewers (+ ai-antipattern-review-2nd) ⇄ fix loop.
 finding_contract:
-  ledger_path: .takt/findings/takt-default-peer-review.json
-  raw_findings_path: .takt/findings/takt-default-peer-review/raw
+  ledger_path: .takt/findings/peer-review-with-fc.json
+  raw_findings_path: .takt/findings/peer-review-with-fc/raw
   manager:
     persona: findings-manager
     instruction: findings-manager

--- a/builtins/en/workflows/takt-default-with-fc.yaml
+++ b/builtins/en/workflows/takt-default-with-fc.yaml
@@ -73,7 +73,7 @@ steps:
         next: ABORT
   - name: peer-review
     kind: workflow_call
-    call: takt-default-peer-review
+    call: peer-review-with-fc
     rules:
       - condition: COMPLETE
         next: supervise

--- a/builtins/ja/workflows/peer-review-with-fc.yaml
+++ b/builtins/ja/workflows/peer-review-with-fc.yaml
@@ -1,8 +1,8 @@
-name: takt-default-peer-review
-description: takt-default 用の実験的 Finding Contract ピアレビュー。6 並列ピアレビュー（+ ai-antipattern-review-2nd）⇄ 修正 ループ。
+name: peer-review-with-fc
+description: 実験的 Finding Contract ピアレビュー。6 並列ピアレビュー（+ ai-antipattern-review-2nd）⇄ 修正 ループ。
 finding_contract:
-  ledger_path: .takt/findings/takt-default-peer-review.json
-  raw_findings_path: .takt/findings/takt-default-peer-review/raw
+  ledger_path: .takt/findings/peer-review-with-fc.json
+  raw_findings_path: .takt/findings/peer-review-with-fc/raw
   manager:
     persona: findings-manager
     instruction: findings-manager

--- a/builtins/ja/workflows/takt-default-with-fc.yaml
+++ b/builtins/ja/workflows/takt-default-with-fc.yaml
@@ -73,7 +73,7 @@ steps:
         next: ABORT
   - name: peer-review
     kind: workflow_call
-    call: takt-default-peer-review
+    call: peer-review-with-fc
     rules:
       - condition: COMPLETE
         next: supervise

--- a/src/__tests__/builtin-takt-default-provider-options.test.ts
+++ b/src/__tests__/builtin-takt-default-provider-options.test.ts
@@ -248,13 +248,13 @@ describe('builtin takt-default provider_options refs', () => {
       expect(normalized.findingContract).toBeUndefined();
     });
 
-    it(`${locale} takt-default peer-review subworkflow should enable Finding Contract`, () => {
-      const workflow = loadBuiltinWorkflow(locale, 'takt-default-peer-review.yaml');
+    it(`${locale} peer-review-with-fc subworkflow should enable Finding Contract`, () => {
+      const workflow = loadBuiltinWorkflow(locale, 'peer-review-with-fc.yaml');
       const normalized = normalizeBuiltinWorkflow(workflow, locale);
 
       expect(workflow.finding_contract).toEqual({
-        ledger_path: '.takt/findings/takt-default-peer-review.json',
-        raw_findings_path: '.takt/findings/takt-default-peer-review/raw',
+        ledger_path: '.takt/findings/peer-review-with-fc.json',
+        raw_findings_path: '.takt/findings/peer-review-with-fc/raw',
         manager: {
           persona: 'findings-manager',
           instruction: 'findings-manager',
@@ -262,8 +262,8 @@ describe('builtin takt-default provider_options refs', () => {
         },
       });
       expect(normalized.findingContract).toMatchObject({
-        ledgerPath: '.takt/findings/takt-default-peer-review.json',
-        rawFindingsPath: '.takt/findings/takt-default-peer-review/raw',
+        ledgerPath: '.takt/findings/peer-review-with-fc.json',
+        rawFindingsPath: '.takt/findings/peer-review-with-fc/raw',
         manager: {
           persona: 'findings-manager',
           personaDisplayName: 'findings-manager',
@@ -306,8 +306,8 @@ describe('builtin takt-default provider_options refs', () => {
       expect(formats).toEqual([...PEER_REVIEW_OUTPUT_CONTRACTS]);
     });
 
-    it(`${locale} takt-default peer-review should use Finding Contract-specific output contracts`, () => {
-      const workflow = loadBuiltinWorkflow(locale, 'takt-default-peer-review.yaml');
+    it(`${locale} peer-review-with-fc should use Finding Contract-specific output contracts`, () => {
+      const workflow = loadBuiltinWorkflow(locale, 'peer-review-with-fc.yaml');
       const reviewers = workflow.steps?.find((step) => step.name === 'reviewers')?.parallel ?? [];
       const formats = reviewers.flatMap((step) =>
         (step.output_contracts?.report ?? [])


### PR DESCRIPTION
## Summary
- Rename the Finding Contract peer review workflow from `takt-default-peer-review` to `peer-review-with-fc` in both Japanese and English builtins.
- Update `takt-default-with-fc` to call `peer-review-with-fc`.
- Rename the Finding Contract ledger paths and update tests to match the generic workflow name.

## Rationale
The workflow is not specific to `takt-default`; it is the Finding Contract-enabled variant of `peer-review`. The generic name makes the call graph clearer and avoids suggesting that FC must be configured on the parent workflow.

## Validation
- `npm run build`
- `npm test -- src/__tests__/builtin-takt-default-provider-options.test.ts src/__tests__/builtin-workflow-resources.test.ts src/__tests__/workflowDiscovery.test.ts`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ピアレビューワークフローが Finding Contract 対応版に更新されました。

* **改善**
  * ワークフローのパス参照が最適化されました。

* **テスト**
  * Finding Contract 機能の検証テストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->