### PR TITLE
[codex] Tag builtin workflow steps

### DIFF
--- a/builtins/en/workflows/audit-architecture-backend.yaml
+++ b/builtins/en/workflows/audit-architecture-backend.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     knowledge:
       - backend
@@ -40,6 +42,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge:
@@ -60,6 +64,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     policy: review
     knowledge:
@@ -75,6 +81,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge:

--- a/builtins/en/workflows/audit-architecture-dual.yaml
+++ b/builtins/en/workflows/audit-architecture-dual.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     knowledge:
       - frontend
@@ -41,6 +43,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge:
@@ -62,6 +66,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     policy: review
     knowledge:
@@ -78,6 +84,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge:

--- a/builtins/en/workflows/audit-architecture-frontend.yaml
+++ b/builtins/en/workflows/audit-architecture-frontend.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     knowledge:
       - frontend
@@ -41,6 +43,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     persona: frontend-reviewer
     policy: review
     knowledge:
@@ -62,6 +66,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     policy: review
     knowledge:
@@ -78,6 +84,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: frontend-reviewer
     policy: review
     knowledge:

--- a/builtins/en/workflows/audit-architecture.yaml
+++ b/builtins/en/workflows/audit-architecture.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     knowledge: architecture
     instruction: architecture-audit-plan
@@ -38,6 +40,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge: architecture
@@ -56,6 +60,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     policy: review
     knowledge: architecture
@@ -69,6 +75,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge: architecture

--- a/builtins/en/workflows/audit-e2e.yaml
+++ b/builtins/en/workflows/audit-e2e.yaml
@@ -29,6 +29,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: test-planner
     policy: testing
     knowledge:
@@ -47,6 +49,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     edit: false
     persona: testing-reviewer
     policy:
@@ -69,6 +73,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -83,6 +89,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     edit: false
     persona: testing-reviewer
     policy:

--- a/builtins/en/workflows/audit-security.yaml
+++ b/builtins/en/workflows/audit-security.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     instruction: audit-security-plan
     edit: false
@@ -35,6 +37,8 @@ steps:
         next: audit
 
   - name: audit
+    tags:
+      - review
     persona: security-reviewer
     knowledge: security
     instruction: audit-security-team-leader
@@ -52,6 +56,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     knowledge: security
     instruction: audit-security-supervise
@@ -63,6 +69,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: security-reviewer
     knowledge: security
     instruction: audit-security-review

--- a/builtins/en/workflows/audit-unit.yaml
+++ b/builtins/en/workflows/audit-unit.yaml
@@ -29,6 +29,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: test-planner
     policy: testing
@@ -49,6 +51,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     edit: false
     persona: testing-reviewer
     policy:
@@ -71,6 +75,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -85,6 +91,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     edit: false
     persona: testing-reviewer
     policy:

--- a/builtins/en/workflows/auto-improvement-loop.yaml
+++ b/builtins/en/workflows/auto-improvement-loop.yaml
@@ -51,6 +51,8 @@ steps:
         next: plan_fresh_improvement
 
   - name: plan_from_issue
+    tags:
+      - plan
     persona: supervisor
     knowledge:
       - architecture
@@ -136,6 +138,8 @@ steps:
         next: ABORT
 
   - name: plan_fresh_improvement
+    tags:
+      - plan
     persona: supervisor
     knowledge:
       - architecture
@@ -210,6 +214,8 @@ steps:
         next: ABORT
 
   - name: plan_from_existing_pr
+    tags:
+      - plan
     persona: supervisor
     knowledge:
       - architecture

--- a/builtins/en/workflows/backend-cqrs-mini.yaml
+++ b/builtins/en/workflows/backend-cqrs-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge:
@@ -52,6 +54,8 @@ steps:
         - name: plan.md
           format: plan
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -91,8 +95,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -115,6 +123,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: supervisor
         policy: review
@@ -153,8 +163,12 @@ steps:
       - condition: any("Requirements unmet, tests failing")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -182,6 +196,8 @@ steps:
           - condition: Cannot proceed, insufficient info
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -213,6 +229,8 @@ steps:
       - condition: any("No fix needed (verified target files/spec)", "Cannot proceed, insufficient info")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -245,6 +263,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/backend-cqrs.yaml
+++ b/builtins/en/workflows/backend-cqrs.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge:
@@ -61,6 +63,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -101,6 +105,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -142,6 +148,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -166,6 +174,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -198,6 +208,8 @@ steps:
       - condition: Unable to proceed with fixes
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -214,8 +226,12 @@ steps:
         next: reviewers_1
     instruction: arbitrate
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -239,6 +255,8 @@ steps:
             - name: cqrs-es-review.md
               format: cqrs-es-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -264,6 +282,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -291,8 +311,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -314,6 +338,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -336,6 +362,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -357,6 +385,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -385,6 +415,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -415,6 +447,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -441,6 +475,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/backend-mini.yaml
+++ b/builtins/en/workflows/backend-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge:
@@ -51,6 +53,8 @@ steps:
         - name: plan.md
           format: plan
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -89,8 +93,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -113,6 +121,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: supervisor
         policy: review
@@ -150,8 +160,12 @@ steps:
       - condition: any("Requirements unmet, tests failing")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -178,6 +192,8 @@ steps:
           - condition: Cannot proceed, insufficient info
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -208,6 +224,8 @@ steps:
       - condition: any("No fix needed (verified target files/spec)", "Cannot proceed, insufficient info")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -239,6 +257,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/backend.yaml
+++ b/builtins/en/workflows/backend.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge:
@@ -60,6 +62,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -99,6 +103,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -139,6 +145,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -163,6 +171,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -194,6 +204,8 @@ steps:
       - condition: Unable to proceed with fixes
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -210,8 +222,12 @@ steps:
         next: reviewers_1
     instruction: arbitrate
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -235,6 +251,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -260,6 +278,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -287,8 +307,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -310,6 +334,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -332,6 +358,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -353,6 +381,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -381,6 +411,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -410,6 +442,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -436,6 +470,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/compound-eye.yaml
+++ b/builtins/en/workflows/compound-eye.yaml
@@ -10,8 +10,12 @@ max_steps: 10
 initial_step: evaluate
 steps:
   - name: evaluate
+    tags:
+      - review
     parallel:
       - name: claude-eye
+        tags:
+          - review
         edit: false
         persona: coder
         provider: claude-sdk
@@ -53,6 +57,8 @@ steps:
                 - {action}
                 ```
       - name: codex-eye
+        tags:
+          - review
         edit: false
         persona: coder
         provider: codex
@@ -97,6 +103,8 @@ steps:
       - condition: any("done")
         next: synthesize
   - name: synthesize
+    tags:
+      - review
     edit: false
     persona: supervisor
     provider_options:

--- a/builtins/en/workflows/deep-research.yaml
+++ b/builtins/en/workflows/deep-research.yaml
@@ -10,6 +10,8 @@ max_steps: 15
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     persona: research-planner
     policy: research
     knowledge: research
@@ -28,6 +30,8 @@ steps:
       - condition: Insufficient information to create a plan
         next: ABORT
   - name: dig
+    tags:
+      - plan
     persona: research-digger
     policy: research
     knowledge: research
@@ -61,6 +65,8 @@ steps:
       - condition: Unable to conduct research
         next: ABORT
   - name: analyze
+    tags:
+      - plan
     persona: research-analyzer
     policy: research
     knowledge: research
@@ -81,6 +87,8 @@ steps:
       - condition: Sufficiently investigated
         next: supervise
   - name: supervise
+    tags:
+      - review
     persona: research-supervisor
     policy: research
     knowledge: research

--- a/builtins/en/workflows/default-draft.yaml
+++ b/builtins/en/workflows/default-draft.yaml
@@ -33,6 +33,8 @@ loop_monitors:
           next: COMPLETE
 steps:
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -73,6 +75,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -97,6 +101,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/default-high.yaml
+++ b/builtins/en/workflows/default-high.yaml
@@ -10,6 +10,8 @@ max_steps: 50
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -39,6 +41,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -105,6 +109,8 @@ steps:
       - condition: ABORT
         next: ABORT
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/default-mini.yaml
+++ b/builtins/en/workflows/default-mini.yaml
@@ -10,6 +10,8 @@ max_steps: 30
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture

--- a/builtins/en/workflows/default-peer-review.yaml
+++ b/builtins/en/workflows/default-peer-review.yaml
@@ -28,8 +28,12 @@ loop_monitors:
           next: ABORT
 steps:
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -51,6 +55,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -73,6 +79,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -94,6 +102,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -118,6 +128,8 @@ steps:
             - name: coding-review.md
               format: coding-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: supervisor
         policy: review
@@ -147,6 +159,8 @@ steps:
       - condition: any("needs_fix", "AI-specific issues found", "needs_fix", "needs_fix", "Requirements unmet, tests failing, build errors")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/default.yaml
+++ b/builtins/en/workflows/default.yaml
@@ -10,6 +10,8 @@ max_steps: 30
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -39,6 +41,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/draft.yaml
+++ b/builtins/en/workflows/draft.yaml
@@ -42,6 +42,8 @@ loop_monitors:
           next: COMPLETE
 steps:
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -86,6 +88,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -104,6 +108,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -125,6 +131,8 @@ steps:
         next: ai-antipattern-no-fix
     instruction: ai-antipattern-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review

--- a/builtins/en/workflows/dual-cqrs-mini.yaml
+++ b/builtins/en/workflows/dual-cqrs-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -55,6 +57,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -97,8 +101,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -121,6 +129,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: dual-supervisor
         policy: review
@@ -160,8 +170,12 @@ steps:
       - condition: any("Requirements unmet, tests failing")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -191,6 +205,8 @@ steps:
           - condition: Cannot proceed, insufficient info
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -224,6 +240,8 @@ steps:
       - condition: any("No fix needed (verified target files/spec)", "Cannot proceed, insufficient info")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -259,6 +277,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/dual-cqrs.yaml
+++ b/builtins/en/workflows/dual-cqrs.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -64,6 +66,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -108,6 +112,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -132,6 +138,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -167,6 +175,8 @@ steps:
       - condition: Unable to proceed with fixes
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -183,8 +193,12 @@ steps:
         next: reviewers
     instruction: arbitrate
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -208,6 +222,8 @@ steps:
             - name: cqrs-es-review.md
               format: cqrs-es-review
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -231,6 +247,8 @@ steps:
             - name: frontend-review.md
               format: frontend-review
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -252,6 +270,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -274,6 +294,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -296,6 +318,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -317,6 +341,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -345,6 +371,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -378,6 +406,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -404,6 +434,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/dual-mini.yaml
+++ b/builtins/en/workflows/dual-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -54,6 +56,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -95,8 +99,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -119,6 +127,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: dual-supervisor
         policy: review
@@ -157,8 +167,12 @@ steps:
       - condition: any("Requirements unmet, tests failing")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -187,6 +201,8 @@ steps:
           - condition: Cannot proceed, insufficient info
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -219,6 +235,8 @@ steps:
       - condition: any("No fix needed (verified target files/spec)", "Cannot proceed, insufficient info")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -253,6 +271,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/dual.yaml
+++ b/builtins/en/workflows/dual.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -68,6 +70,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -109,6 +113,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -172,6 +178,8 @@ steps:
       - When design references exist, verify major screens element by element for layout, copy, color, and spacing
       - When design references exist, record any platform-driven deviations in the decision log
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -196,6 +204,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -232,6 +242,8 @@ steps:
       - condition: Unable to proceed with fixes
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -248,8 +260,12 @@ steps:
         next: reviewers_1
     instruction: arbitrate
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -275,6 +291,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -301,6 +319,8 @@ steps:
             - name: frontend-review.md
               format: frontend-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -327,6 +347,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -354,8 +376,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -378,6 +404,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -401,6 +429,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -422,6 +452,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -450,6 +482,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -486,6 +520,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review

--- a/builtins/en/workflows/frontend-maintenance.yaml
+++ b/builtins/en/workflows/frontend-maintenance.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -65,6 +67,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -107,6 +111,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -151,6 +157,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -178,6 +186,8 @@ steps:
     knowledge:
       - existing-system
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -213,6 +223,8 @@ steps:
       - condition: Unable to proceed with fixes
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy:
@@ -233,8 +245,12 @@ steps:
     knowledge:
       - existing-system
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy:
@@ -262,6 +278,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -289,6 +307,8 @@ steps:
             - name: frontend-review.md
               format: frontend-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -316,6 +336,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -346,8 +368,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy:
@@ -373,6 +399,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -398,6 +426,8 @@ steps:
         knowledge:
           - existing-system
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -419,6 +449,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -447,6 +479,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -480,6 +514,8 @@ steps:
         next: plan
     instruction: fix-maintenance
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy:
@@ -510,6 +546,8 @@ steps:
     knowledge:
       - existing-system
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/frontend-mini.yaml
+++ b/builtins/en/workflows/frontend-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -53,6 +55,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -92,8 +96,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -116,6 +124,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: supervisor
         policy: review
@@ -153,8 +163,12 @@ steps:
       - condition: any("Requirements unmet, tests failing")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -182,6 +196,8 @@ steps:
           - condition: Cannot proceed, insufficient info
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -213,6 +229,8 @@ steps:
       - condition: any("No fix needed (verified target files/spec)", "Cannot proceed, insufficient info")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -245,6 +263,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/frontend.yaml
+++ b/builtins/en/workflows/frontend.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -63,6 +65,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -103,6 +107,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -145,6 +151,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -169,6 +177,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -202,6 +212,8 @@ steps:
       - condition: Unable to proceed with fixes
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -218,8 +230,12 @@ steps:
         next: reviewers_1
     instruction: arbitrate
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -244,6 +260,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -269,6 +287,8 @@ steps:
             - name: frontend-review.md
               format: frontend-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -294,6 +314,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -321,8 +343,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -344,6 +370,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -366,6 +394,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -387,6 +417,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -415,6 +447,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -446,6 +480,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -472,6 +508,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/magi.yaml
+++ b/builtins/en/workflows/magi.yaml
@@ -17,6 +17,8 @@ max_steps: 5
 initial_step: melchior
 steps:
   - name: melchior
+    tags:
+      - review
     persona: melchior
     instruction: |
       # MAGI System Initiated
@@ -47,6 +49,8 @@ steps:
       - condition: Judgment completed
         next: balthasar
   - name: balthasar
+    tags:
+      - review
     persona: balthasar
     instruction: |
       # MAGI System Continuing
@@ -81,6 +85,8 @@ steps:
       - condition: Judgment completed
         next: casper
   - name: casper
+    tags:
+      - review
     persona: casper
     instruction: |
       # MAGI System Final Deliberation

--- a/builtins/en/workflows/peer-review-with-fc.yaml
+++ b/builtins/en/workflows/peer-review-with-fc.yaml
@@ -42,8 +42,12 @@ loop_monitors:
           next: COMPLETE
 steps:
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -60,6 +64,8 @@ steps:
             - name: architect-review.md
               format: architecture-review-finding-contract
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -75,6 +81,8 @@ steps:
             - name: security-review.md
               format: security-review-finding-contract
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -91,6 +99,8 @@ steps:
             - name: qa-review.md
               format: qa-review-finding-contract
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -110,6 +120,8 @@ steps:
             - name: testing-review.md
               format: testing-review-finding-contract
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -124,6 +136,8 @@ steps:
             - name: pure-review.md
               format: pure-review-finding-contract
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -141,6 +155,8 @@ steps:
             - name: coding-review.md
               format: coding-review-finding-contract
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -168,6 +184,8 @@ steps:
       - condition: findings.conflicts.count > 0
         return: need_replan
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/peer-review.yaml
+++ b/builtins/en/workflows/peer-review.yaml
@@ -35,8 +35,12 @@ loop_monitors:
           next: COMPLETE
 steps:
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -53,6 +57,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -68,6 +74,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -84,6 +92,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -103,6 +113,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -117,6 +129,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -134,6 +148,8 @@ steps:
             - name: coding-review.md
               format: coding-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -155,6 +171,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/research.yaml
+++ b/builtins/en/workflows/research.yaml
@@ -17,6 +17,8 @@ max_steps: 10
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     persona: research-planner
     policy: research
     knowledge: research
@@ -27,6 +29,8 @@ steps:
       - condition: Insufficient information to create a plan
         next: ABORT
   - name: dig
+    tags:
+      - plan
     persona: research-digger
     policy: research
     knowledge: research
@@ -37,6 +41,8 @@ steps:
       - condition: Unable to conduct research
         next: ABORT
   - name: supervise
+    tags:
+      - review
     persona: research-supervisor
     policy: research
     knowledge: research

--- a/builtins/en/workflows/review-backend-cqrs.yaml
+++ b/builtins/en/workflows/review-backend-cqrs.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -60,6 +66,8 @@ steps:
           - condition: needs_fix
 
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -84,6 +92,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -106,6 +116,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -129,6 +141,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -150,6 +164,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -180,6 +196,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-backend.yaml
+++ b/builtins/en/workflows/review-backend.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -60,6 +66,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -82,6 +90,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -105,6 +115,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -126,6 +138,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -156,6 +170,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-default.yaml
+++ b/builtins/en/workflows/review-default.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -38,8 +40,12 @@ steps:
           - {Question 2}
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -63,6 +69,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -86,6 +94,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -110,6 +120,8 @@ steps:
           - condition: needs_fix
 
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -137,6 +149,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -159,6 +173,8 @@ steps:
           - condition: needs_fix
 
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -189,6 +205,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-dual-cqrs.yaml
+++ b/builtins/en/workflows/review-dual-cqrs.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -61,6 +67,8 @@ steps:
           - condition: needs_fix
 
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -85,6 +93,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -109,6 +119,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -131,6 +143,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -154,6 +168,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -175,6 +191,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -205,6 +223,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-dual.yaml
+++ b/builtins/en/workflows/review-dual.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -61,6 +67,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -85,6 +93,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -107,6 +117,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -130,6 +142,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -151,6 +165,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -181,6 +197,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-fix-backend-cqrs.yaml
+++ b/builtins/en/workflows/review-fix-backend-cqrs.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -73,6 +79,8 @@ steps:
           - condition: needs_fix
 
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -97,6 +105,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -119,6 +129,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -142,6 +154,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -163,6 +177,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -193,6 +209,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -224,6 +242,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -251,6 +271,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/review-fix-backend.yaml
+++ b/builtins/en/workflows/review-fix-backend.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -73,6 +79,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -95,6 +103,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -118,6 +128,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -139,6 +151,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -169,6 +183,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -199,6 +215,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -226,6 +244,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/review-fix-default.yaml
+++ b/builtins/en/workflows/review-fix-default.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -51,8 +53,12 @@ steps:
           - {Question 2}
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -76,6 +82,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -99,6 +107,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -123,6 +133,8 @@ steps:
           - condition: needs_fix
 
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -150,6 +162,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -172,6 +186,8 @@ steps:
           - condition: needs_fix
 
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -202,6 +218,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -231,6 +249,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -258,6 +278,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/review-fix-dual-cqrs.yaml
+++ b/builtins/en/workflows/review-fix-dual-cqrs.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -74,6 +80,8 @@ steps:
           - condition: needs_fix
 
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -98,6 +106,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -122,6 +132,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -144,6 +156,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -167,6 +181,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -188,6 +204,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -218,6 +236,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -252,6 +272,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -279,6 +301,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/review-fix-dual.yaml
+++ b/builtins/en/workflows/review-fix-dual.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -74,6 +80,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -98,6 +106,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -120,6 +130,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -143,6 +155,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -164,6 +178,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -194,6 +210,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -227,6 +245,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -254,6 +274,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/review-fix-frontend.yaml
+++ b/builtins/en/workflows/review-fix-frontend.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -73,6 +79,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -97,6 +105,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -119,6 +129,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -142,6 +154,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -163,6 +177,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -193,6 +209,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -224,6 +242,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -251,6 +271,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/review-fix-takt-default.yaml
+++ b/builtins/en/workflows/review-fix-takt-default.yaml
@@ -36,6 +36,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -63,8 +65,12 @@ steps:
           - {Question 2}
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -90,6 +96,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -113,6 +121,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -137,6 +147,8 @@ steps:
           - condition: needs_fix
 
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -164,6 +176,8 @@ steps:
           - condition: needs_fix
 
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -188,6 +202,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -210,6 +226,8 @@ steps:
           - condition: needs_fix
 
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -240,6 +258,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -269,6 +289,8 @@ steps:
         next: ABORT
 
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -293,6 +315,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -323,6 +347,8 @@ steps:
         next: ai-antipattern-no-fix
     instruction: ai-antipattern-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -339,6 +365,8 @@ steps:
         next: reviewers
     instruction: arbitrate
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -367,6 +395,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/review-frontend.yaml
+++ b/builtins/en/workflows/review-frontend.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -60,6 +66,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -84,6 +92,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -106,6 +116,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -129,6 +141,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -150,6 +164,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -180,6 +196,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-takt-default.yaml
+++ b/builtins/en/workflows/review-takt-default.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -38,8 +40,12 @@ steps:
           - {Question 2}
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -65,6 +71,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -88,6 +96,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -112,6 +122,8 @@ steps:
           - condition: needs_fix
 
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -139,6 +151,8 @@ steps:
           - condition: needs_fix
 
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -163,6 +177,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -185,6 +201,8 @@ steps:
           - condition: needs_fix
 
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -215,6 +233,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/takt-default-refresh-all.yaml
+++ b/builtins/en/workflows/takt-default-refresh-all.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     session: refresh
@@ -65,6 +67,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     session: refresh
@@ -105,6 +109,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -160,6 +166,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     session: refresh
@@ -185,6 +193,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -216,6 +226,8 @@ steps:
         next: ai-antipattern-no-fix
     instruction: ai-antipattern-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     session: refresh
@@ -233,8 +245,12 @@ steps:
         next: reviewers
     instruction: arbitrate
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         session: refresh
@@ -260,6 +276,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         session: refresh
@@ -283,6 +301,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         session: refresh
@@ -307,6 +327,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         session: refresh
@@ -334,6 +356,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         session: refresh
@@ -356,6 +380,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -383,6 +409,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     session: refresh
@@ -412,6 +440,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     session: refresh

--- a/builtins/en/workflows/takt-default-refresh-fast.yaml
+++ b/builtins/en/workflows/takt-default-refresh-fast.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -64,6 +66,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     session: refresh
@@ -104,6 +108,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -159,6 +165,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     session: refresh
@@ -184,6 +192,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -215,6 +225,8 @@ steps:
         next: ai-antipattern-no-fix
     instruction: ai-antipattern-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -231,8 +243,12 @@ steps:
         next: reviewers
     instruction: arbitrate
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         session: refresh
@@ -258,6 +274,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         session: refresh
@@ -281,6 +299,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         session: refresh
@@ -305,6 +325,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         session: refresh
@@ -332,6 +354,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         session: refresh
@@ -354,6 +378,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -381,6 +407,8 @@ steps:
       - condition: any(\"needs_fix\")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     session: refresh
@@ -410,6 +438,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/takt-default-with-fc.yaml
+++ b/builtins/en/workflows/takt-default-with-fc.yaml
@@ -10,6 +10,8 @@ max_steps: 50
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -32,6 +34,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -82,6 +86,8 @@ steps:
       - condition: ABORT
         next: ABORT
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/takt-default.yaml
+++ b/builtins/en/workflows/takt-default.yaml
@@ -10,6 +10,8 @@ max_steps: 50
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -32,6 +34,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -82,6 +86,8 @@ steps:
       - condition: ABORT
         next: ABORT
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/terraform.yaml
+++ b/builtins/en/workflows/terraform.yaml
@@ -10,6 +10,8 @@ max_steps: 15
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: terraform-aws
@@ -35,6 +37,8 @@ steps:
         - name: plan.md
           format: plan
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: terraform-coder
     policy:
@@ -72,8 +76,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: tf_review
+        tags:
+          - review
         edit: false
         persona: terraform-reviewer
         policy:
@@ -98,6 +106,8 @@ steps:
             - name: terraform-review.md
               format: terraform-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -120,6 +130,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -141,6 +153,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -169,6 +183,8 @@ steps:
       - condition: any("Convention violations found", "AI-specific issues found", "needs_fix")
         next: supervise
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -202,8 +218,12 @@ steps:
           format: summary
           use_judge: false
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: terraform-coder
         policy:
@@ -225,6 +245,8 @@ steps:
           - condition: Cannot determine, insufficient info
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: terraform-coder
         policy:
@@ -250,6 +272,8 @@ steps:
       - condition: any("No fix needed (target file/spec verified)", "Cannot determine, insufficient info", "Cannot proceed with fix")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: terraform-coder
     policy:
@@ -276,6 +300,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: terraform-coder
     policy:

--- a/builtins/ja/workflows/audit-architecture-backend.yaml
+++ b/builtins/ja/workflows/audit-architecture-backend.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     knowledge:
       - backend
@@ -40,6 +42,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge:
@@ -60,6 +64,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     policy: review
     knowledge:
@@ -75,6 +81,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge:

--- a/builtins/ja/workflows/audit-architecture-dual.yaml
+++ b/builtins/ja/workflows/audit-architecture-dual.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     knowledge:
       - frontend
@@ -41,6 +43,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge:
@@ -62,6 +66,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     policy: review
     knowledge:
@@ -78,6 +84,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge:

--- a/builtins/ja/workflows/audit-architecture-frontend.yaml
+++ b/builtins/ja/workflows/audit-architecture-frontend.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     knowledge:
       - frontend
@@ -41,6 +43,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     persona: frontend-reviewer
     policy: review
     knowledge:
@@ -62,6 +66,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     policy: review
     knowledge:
@@ -78,6 +84,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: frontend-reviewer
     policy: review
     knowledge:

--- a/builtins/ja/workflows/audit-architecture.yaml
+++ b/builtins/ja/workflows/audit-architecture.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     knowledge: architecture
     instruction: architecture-audit-plan
@@ -38,6 +40,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge: architecture
@@ -56,6 +60,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     policy: review
     knowledge: architecture
@@ -69,6 +75,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: architecture-reviewer
     policy: review
     knowledge: architecture

--- a/builtins/ja/workflows/audit-e2e.yaml
+++ b/builtins/ja/workflows/audit-e2e.yaml
@@ -29,6 +29,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: test-planner
     policy: testing
     knowledge:
@@ -47,6 +49,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     edit: false
     persona: testing-reviewer
     policy:
@@ -69,6 +73,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -83,6 +89,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     edit: false
     persona: testing-reviewer
     policy:

--- a/builtins/ja/workflows/audit-security.yaml
+++ b/builtins/ja/workflows/audit-security.yaml
@@ -23,6 +23,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     persona: planner
     instruction: audit-security-plan
     edit: false
@@ -35,6 +37,8 @@ steps:
         next: audit
 
   - name: audit
+    tags:
+      - review
     persona: security-reviewer
     knowledge: security
     instruction: audit-security-team-leader
@@ -52,6 +56,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     persona: supervisor
     knowledge: security
     instruction: audit-security-supervise
@@ -63,6 +69,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     persona: security-reviewer
     knowledge: security
     instruction: audit-security-review

--- a/builtins/ja/workflows/audit-unit.yaml
+++ b/builtins/ja/workflows/audit-unit.yaml
@@ -29,6 +29,8 @@ loop_monitors:
 
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: test-planner
     policy: testing
@@ -49,6 +51,8 @@ steps:
         next: ABORT
 
   - name: audit
+    tags:
+      - review
     edit: false
     persona: testing-reviewer
     policy:
@@ -71,6 +75,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -85,6 +91,8 @@ steps:
         next: review
 
   - name: review
+    tags:
+      - review
     edit: false
     persona: testing-reviewer
     policy:

--- a/builtins/ja/workflows/auto-improvement-loop.yaml
+++ b/builtins/ja/workflows/auto-improvement-loop.yaml
@@ -51,6 +51,8 @@ steps:
         next: plan_fresh_improvement
 
   - name: plan_from_issue
+    tags:
+      - plan
     persona: supervisor
     knowledge:
       - architecture
@@ -136,6 +138,8 @@ steps:
         next: ABORT
 
   - name: plan_fresh_improvement
+    tags:
+      - plan
     persona: supervisor
     knowledge:
       - architecture
@@ -210,6 +214,8 @@ steps:
         next: ABORT
 
   - name: plan_from_existing_pr
+    tags:
+      - plan
     persona: supervisor
     knowledge:
       - architecture

--- a/builtins/ja/workflows/backend-cqrs-mini.yaml
+++ b/builtins/ja/workflows/backend-cqrs-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge:
@@ -52,6 +54,8 @@ steps:
         - name: plan.md
           format: plan
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -91,8 +95,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -115,6 +123,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: supervisor
         policy: review
@@ -153,8 +163,12 @@ steps:
       - condition: any("要求未達成、テスト失敗、ビルドエラー")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -182,6 +196,8 @@ steps:
           - condition: 判断できない、情報不足
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -213,6 +229,8 @@ steps:
       - condition: any("修正不要（指摘対象ファイル/仕様の確認済み）", "判断できない、情報不足", "修正を進行できない")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -245,6 +263,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/backend-cqrs.yaml
+++ b/builtins/ja/workflows/backend-cqrs.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge:
@@ -61,6 +63,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -101,6 +105,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -142,6 +148,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -166,6 +174,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -198,6 +208,8 @@ steps:
       - condition: 修正を進行できない
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -214,8 +226,12 @@ steps:
         next: reviewers_1
     instruction: arbitrate
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -239,6 +255,8 @@ steps:
             - name: cqrs-es-review.md
               format: cqrs-es-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -264,6 +282,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -291,8 +311,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -314,6 +338,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -336,6 +362,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -357,6 +385,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -385,6 +415,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -415,6 +447,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -441,6 +475,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/backend-mini.yaml
+++ b/builtins/ja/workflows/backend-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge:
@@ -51,6 +53,8 @@ steps:
         - name: plan.md
           format: plan
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -89,8 +93,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -113,6 +121,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: supervisor
         policy: review
@@ -150,8 +160,12 @@ steps:
       - condition: any("要求未達成、テスト失敗、ビルドエラー")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -178,6 +192,8 @@ steps:
           - condition: 判断できない、情報不足
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -208,6 +224,8 @@ steps:
       - condition: any("修正不要（指摘対象ファイル/仕様の確認済み）", "判断できない、情報不足", "修正を進行できない")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -239,6 +257,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/backend.yaml
+++ b/builtins/ja/workflows/backend.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge:
@@ -60,6 +62,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -99,6 +103,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -139,6 +145,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -163,6 +171,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -194,6 +204,8 @@ steps:
       - condition: 修正を進行できない
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -210,8 +222,12 @@ steps:
         next: reviewers_1
     instruction: arbitrate
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -235,6 +251,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -260,6 +278,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -287,8 +307,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -310,6 +334,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -332,6 +358,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -353,6 +381,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -381,6 +411,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -410,6 +442,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -436,6 +470,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/compound-eye.yaml
+++ b/builtins/ja/workflows/compound-eye.yaml
@@ -10,8 +10,12 @@ max_steps: 10
 initial_step: evaluate
 steps:
   - name: evaluate
+    tags:
+      - review
     parallel:
       - name: claude-eye
+        tags:
+          - review
         edit: false
         persona: coder
         provider: claude-sdk
@@ -52,6 +56,8 @@ steps:
                 - {action}
                 ```
       - name: codex-eye
+        tags:
+          - review
         edit: false
         persona: coder
         provider: codex
@@ -95,6 +101,8 @@ steps:
       - condition: any("done")
         next: synthesize
   - name: synthesize
+    tags:
+      - review
     edit: false
     persona: supervisor
     provider_options:

--- a/builtins/ja/workflows/deep-research.yaml
+++ b/builtins/ja/workflows/deep-research.yaml
@@ -10,6 +10,8 @@ max_steps: 15
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     persona: research-planner
     policy: research
     knowledge: research
@@ -28,6 +30,8 @@ steps:
       - condition: 情報が不足しており計画を立てられない
         next: ABORT
   - name: dig
+    tags:
+      - plan
     persona: research-digger
     policy: research
     knowledge: research
@@ -61,6 +65,8 @@ steps:
       - condition: 調査を実行できない
         next: ABORT
   - name: analyze
+    tags:
+      - plan
     persona: research-analyzer
     policy: research
     knowledge: research
@@ -81,6 +87,8 @@ steps:
       - condition: 十分に掘り下げた
         next: supervise
   - name: supervise
+    tags:
+      - review
     persona: research-supervisor
     policy: research
     knowledge: research

--- a/builtins/ja/workflows/default-draft.yaml
+++ b/builtins/ja/workflows/default-draft.yaml
@@ -33,6 +33,8 @@ loop_monitors:
           next: COMPLETE
 steps:
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -73,6 +75,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -97,6 +101,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/default-high.yaml
+++ b/builtins/ja/workflows/default-high.yaml
@@ -10,6 +10,8 @@ max_steps: 50
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -39,6 +41,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -105,6 +109,8 @@ steps:
       - condition: ABORT
         next: ABORT
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/default-mini.yaml
+++ b/builtins/ja/workflows/default-mini.yaml
@@ -10,6 +10,8 @@ max_steps: 30
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture

--- a/builtins/ja/workflows/default-peer-review.yaml
+++ b/builtins/ja/workflows/default-peer-review.yaml
@@ -28,8 +28,12 @@ loop_monitors:
           next: ABORT
 steps:
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -51,6 +55,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -73,6 +79,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -94,6 +102,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -118,6 +128,8 @@ steps:
             - name: coding-review.md
               format: coding-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: supervisor
         policy: review
@@ -147,6 +159,8 @@ steps:
       - condition: any("needs_fix", "AI特有の問題あり", "needs_fix", "needs_fix", "要求未達成、テスト失敗、ビルドエラー")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/default.yaml
+++ b/builtins/ja/workflows/default.yaml
@@ -10,6 +10,8 @@ max_steps: 30
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -39,6 +41,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/draft.yaml
+++ b/builtins/ja/workflows/draft.yaml
@@ -42,6 +42,8 @@ loop_monitors:
           next: COMPLETE
 steps:
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -86,6 +88,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -104,6 +108,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -125,6 +131,8 @@ steps:
         next: ai-antipattern-no-fix
     instruction: ai-antipattern-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review

--- a/builtins/ja/workflows/dual-cqrs-mini.yaml
+++ b/builtins/ja/workflows/dual-cqrs-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -55,6 +57,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -97,8 +101,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -121,6 +129,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: dual-supervisor
         policy: review
@@ -160,8 +170,12 @@ steps:
       - condition: any("要求未達成、テスト失敗、ビルドエラー")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -191,6 +205,8 @@ steps:
           - condition: 判断できない、情報不足
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -224,6 +240,8 @@ steps:
       - condition: any("修正不要（指摘対象ファイル/仕様の確認済み）", "判断できない、情報不足", "修正を進行できない")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -259,6 +277,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/dual-cqrs.yaml
+++ b/builtins/ja/workflows/dual-cqrs.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -64,6 +66,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -108,6 +112,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -132,6 +138,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -167,6 +175,8 @@ steps:
       - condition: 修正を進行できない
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -183,8 +193,12 @@ steps:
         next: reviewers
     instruction: arbitrate
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -208,6 +222,8 @@ steps:
             - name: cqrs-es-review.md
               format: cqrs-es-review
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -231,6 +247,8 @@ steps:
             - name: frontend-review.md
               format: frontend-review
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -252,6 +270,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -274,6 +294,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -296,6 +318,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -317,6 +341,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -345,6 +371,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -378,6 +406,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -404,6 +434,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/dual-mini.yaml
+++ b/builtins/ja/workflows/dual-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -54,6 +56,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -95,8 +99,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -119,6 +127,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: dual-supervisor
         policy: review
@@ -157,8 +167,12 @@ steps:
       - condition: any("要求未達成、テスト失敗、ビルドエラー")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -187,6 +201,8 @@ steps:
           - condition: 判断できない、情報不足
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -219,6 +235,8 @@ steps:
       - condition: any("修正不要（指摘対象ファイル/仕様の確認済み）", "判断できない、情報不足", "修正を進行できない")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -253,6 +271,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/dual.yaml
+++ b/builtins/ja/workflows/dual.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -68,6 +70,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -109,6 +113,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -172,6 +178,8 @@ steps:
       - デザイン参照がある場合、主要画面のレイアウト・文言・色・間隔を要素単位で照合したこと
       - デザイン参照がある場合、プラットフォーム制約による差分は決定ログに明記したこと
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -196,6 +204,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -232,6 +242,8 @@ steps:
       - condition: 修正を進行できない
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -248,8 +260,12 @@ steps:
         next: reviewers_1
     instruction: arbitrate
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -275,6 +291,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -301,6 +319,8 @@ steps:
             - name: frontend-review.md
               format: frontend-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -327,6 +347,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -354,8 +376,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -378,6 +404,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -401,6 +429,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -422,6 +452,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -450,6 +482,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -486,6 +520,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review

--- a/builtins/ja/workflows/frontend-maintenance.yaml
+++ b/builtins/ja/workflows/frontend-maintenance.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -65,6 +67,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -107,6 +111,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -151,6 +157,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -178,6 +186,8 @@ steps:
     knowledge:
       - existing-system
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -213,6 +223,8 @@ steps:
       - condition: 修正を進行できない
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy:
@@ -233,8 +245,12 @@ steps:
     knowledge:
       - existing-system
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy:
@@ -262,6 +278,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -289,6 +307,8 @@ steps:
             - name: frontend-review.md
               format: frontend-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -316,6 +336,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -346,8 +368,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy:
@@ -373,6 +399,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -398,6 +426,8 @@ steps:
         knowledge:
           - existing-system
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -419,6 +449,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -447,6 +479,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -480,6 +514,8 @@ steps:
         next: plan
     instruction: fix-maintenance
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy:
@@ -510,6 +546,8 @@ steps:
     knowledge:
       - existing-system
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/frontend-mini.yaml
+++ b/builtins/ja/workflows/frontend-mini.yaml
@@ -23,6 +23,8 @@ loop_monitors:
           next: supervise_fix
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -53,6 +55,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -92,8 +96,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -116,6 +124,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: supervise
+        tags:
+          - review
         edit: false
         persona: supervisor
         policy: review
@@ -153,8 +163,12 @@ steps:
       - condition: any("要求未達成、テスト失敗、ビルドエラー")
         next: supervise_fix
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -182,6 +196,8 @@ steps:
           - condition: 判断できない、情報不足
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: coder
         policy:
@@ -213,6 +229,8 @@ steps:
       - condition: any("修正不要（指摘対象ファイル/仕様の確認済み）", "判断できない、情報不足", "修正を進行できない")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -245,6 +263,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/frontend.yaml
+++ b/builtins/ja/workflows/frontend.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     policy:
@@ -63,6 +65,8 @@ steps:
         - name: plan.md
           format: plan-frontend
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -103,6 +107,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -145,6 +151,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -169,6 +177,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -202,6 +212,8 @@ steps:
       - condition: 修正を進行できない
         next: ai-antipattern-no-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -218,8 +230,12 @@ steps:
         next: reviewers_1
     instruction: arbitrate
   - name: reviewers_1
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -244,6 +260,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -269,6 +287,8 @@ steps:
             - name: frontend-review.md
               format: frontend-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -294,6 +314,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -321,8 +343,12 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: reviewers_2
+    tags:
+      - review
     parallel:
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -344,6 +370,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -366,6 +394,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -387,6 +417,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -415,6 +447,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -446,6 +480,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -472,6 +508,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/magi.yaml
+++ b/builtins/ja/workflows/magi.yaml
@@ -17,6 +17,8 @@ max_steps: 5
 initial_step: melchior
 steps:
   - name: melchior
+    tags:
+      - review
     persona: melchior
     instruction: |
       # MAGI System 起動
@@ -47,6 +49,8 @@ steps:
       - condition: 判定を完了した
         next: balthasar
   - name: balthasar
+    tags:
+      - review
     persona: balthasar
     instruction: |
       # MAGI System 継続
@@ -81,6 +85,8 @@ steps:
       - condition: 判定を完了した
         next: casper
   - name: casper
+    tags:
+      - review
     persona: casper
     instruction: |
       # MAGI System 最終審議

--- a/builtins/ja/workflows/peer-review-with-fc.yaml
+++ b/builtins/ja/workflows/peer-review-with-fc.yaml
@@ -42,8 +42,12 @@ loop_monitors:
           next: COMPLETE
 steps:
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -60,6 +64,8 @@ steps:
             - name: architect-review.md
               format: architecture-review-finding-contract
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -75,6 +81,8 @@ steps:
             - name: security-review.md
               format: security-review-finding-contract
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -91,6 +99,8 @@ steps:
             - name: qa-review.md
               format: qa-review-finding-contract
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -110,6 +120,8 @@ steps:
             - name: testing-review.md
               format: testing-review-finding-contract
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -124,6 +136,8 @@ steps:
             - name: pure-review.md
               format: pure-review-finding-contract
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -141,6 +155,8 @@ steps:
             - name: coding-review.md
               format: coding-review-finding-contract
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -168,6 +184,8 @@ steps:
       - condition: findings.conflicts.count > 0
         return: need_replan
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/peer-review.yaml
+++ b/builtins/ja/workflows/peer-review.yaml
@@ -35,8 +35,12 @@ loop_monitors:
           next: COMPLETE
 steps:
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -53,6 +57,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -68,6 +74,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -84,6 +92,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -103,6 +113,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -117,6 +129,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -134,6 +148,8 @@ steps:
             - name: coding-review.md
               format: coding-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -155,6 +171,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/research.yaml
+++ b/builtins/ja/workflows/research.yaml
@@ -17,6 +17,8 @@ max_steps: 10
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     persona: research-planner
     policy: research
     knowledge: research
@@ -27,6 +29,8 @@ steps:
       - condition: 情報が不足しており計画を立てられない
         next: ABORT
   - name: dig
+    tags:
+      - plan
     persona: research-digger
     policy: research
     knowledge: research
@@ -37,6 +41,8 @@ steps:
       - condition: 調査を実行できない
         next: ABORT
   - name: supervise
+    tags:
+      - review
     persona: research-supervisor
     policy: research
     knowledge: research

--- a/builtins/ja/workflows/review-backend-cqrs.yaml
+++ b/builtins/ja/workflows/review-backend-cqrs.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -60,6 +66,8 @@ steps:
           - condition: needs_fix
 
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -84,6 +92,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -106,6 +116,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -129,6 +141,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -150,6 +164,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -180,6 +196,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-backend.yaml
+++ b/builtins/ja/workflows/review-backend.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -60,6 +66,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -82,6 +90,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -105,6 +115,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -126,6 +138,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -156,6 +170,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-default.yaml
+++ b/builtins/ja/workflows/review-default.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -38,8 +40,12 @@ steps:
           - {質問2}
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -63,6 +69,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -86,6 +94,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -110,6 +120,8 @@ steps:
           - condition: needs_fix
 
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -137,6 +149,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -159,6 +173,8 @@ steps:
           - condition: needs_fix
 
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -189,6 +205,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-dual-cqrs.yaml
+++ b/builtins/ja/workflows/review-dual-cqrs.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -61,6 +67,8 @@ steps:
           - condition: needs_fix
 
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -85,6 +93,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -109,6 +119,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -131,6 +143,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -154,6 +168,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -175,6 +191,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -205,6 +223,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-dual.yaml
+++ b/builtins/ja/workflows/review-dual.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -61,6 +67,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -85,6 +93,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -107,6 +117,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -130,6 +142,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -151,6 +165,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -181,6 +197,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-fix-backend-cqrs.yaml
+++ b/builtins/ja/workflows/review-fix-backend-cqrs.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -73,6 +79,8 @@ steps:
           - condition: needs_fix
 
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -97,6 +105,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -119,6 +129,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -142,6 +154,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -163,6 +177,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -193,6 +209,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -224,6 +242,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -251,6 +271,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/review-fix-backend.yaml
+++ b/builtins/ja/workflows/review-fix-backend.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -73,6 +79,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -95,6 +103,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -118,6 +128,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -139,6 +151,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -169,6 +183,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -199,6 +215,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -226,6 +244,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/review-fix-default.yaml
+++ b/builtins/ja/workflows/review-fix-default.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -51,8 +53,12 @@ steps:
           - {質問2}
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -76,6 +82,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -99,6 +107,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -123,6 +133,8 @@ steps:
           - condition: needs_fix
 
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -150,6 +162,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -172,6 +186,8 @@ steps:
           - condition: needs_fix
 
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -202,6 +218,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -231,6 +249,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -258,6 +278,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/review-fix-dual-cqrs.yaml
+++ b/builtins/ja/workflows/review-fix-dual-cqrs.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -74,6 +80,8 @@ steps:
           - condition: needs_fix
 
       - name: cqrs-es-review
+        tags:
+          - review
         edit: false
         persona: cqrs-es-reviewer
         policy: review
@@ -98,6 +106,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -122,6 +132,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -144,6 +156,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -167,6 +181,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -188,6 +204,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -218,6 +236,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -252,6 +272,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -279,6 +301,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/review-fix-dual.yaml
+++ b/builtins/ja/workflows/review-fix-dual.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -74,6 +80,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -98,6 +106,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -120,6 +130,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -143,6 +155,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -164,6 +178,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -194,6 +210,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -227,6 +245,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -254,6 +274,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/review-fix-frontend.yaml
+++ b/builtins/ja/workflows/review-fix-frontend.yaml
@@ -24,6 +24,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -47,8 +49,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -73,6 +79,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -97,6 +105,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -119,6 +129,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -142,6 +154,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -163,6 +177,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -193,6 +209,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -224,6 +242,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: dual-supervisor
     policy: review
@@ -251,6 +271,8 @@ steps:
           use_judge: false
 
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -36,6 +36,8 @@ loop_monitors:
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -63,8 +65,12 @@ steps:
           - {質問2}
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -90,6 +96,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -113,6 +121,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -137,6 +147,8 @@ steps:
           - condition: needs_fix
 
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -164,6 +176,8 @@ steps:
           - condition: needs_fix
 
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -188,6 +202,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -210,6 +226,8 @@ steps:
           - condition: needs_fix
 
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -240,6 +258,8 @@ steps:
         next: fix
 
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -269,6 +289,8 @@ steps:
         next: ABORT
 
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     policy:
@@ -293,6 +315,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -323,6 +347,8 @@ steps:
         next: ai-antipattern-no-fix
     instruction: ai-antipattern-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -339,6 +365,8 @@ steps:
         next: reviewers
     instruction: arbitrate
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -367,6 +395,8 @@ steps:
           format: summary
           use_judge: false
   - name: fix_supervisor
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/review-frontend.yaml
+++ b/builtins/ja/workflows/review-frontend.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -34,8 +36,12 @@ steps:
         next: ABORT
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -60,6 +66,8 @@ steps:
           - condition: needs_fix
 
       - name: frontend-review
+        tags:
+          - review
         edit: false
         persona: frontend-reviewer
         policy:
@@ -84,6 +92,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -106,6 +116,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -129,6 +141,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -150,6 +164,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -180,6 +196,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-takt-default.yaml
+++ b/builtins/ja/workflows/review-takt-default.yaml
@@ -11,6 +11,8 @@ initial_step: gather
 
 steps:
   - name: gather
+    tags:
+      - plan
     edit: false
     persona: planner
     provider_options:
@@ -38,8 +40,12 @@ steps:
           - {質問2}
 
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         policy: review
@@ -65,6 +71,8 @@ steps:
           - condition: needs_fix
 
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         policy: review
@@ -88,6 +96,8 @@ steps:
           - condition: needs_fix
 
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         policy:
@@ -112,6 +122,8 @@ steps:
           - condition: needs_fix
 
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         policy:
@@ -139,6 +151,8 @@ steps:
           - condition: needs_fix
 
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -163,6 +177,8 @@ steps:
           - condition: needs_fix
 
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -185,6 +201,8 @@ steps:
           - condition: needs_fix
 
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -215,6 +233,8 @@ steps:
         next: supervise
 
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/takt-default-refresh-all.yaml
+++ b/builtins/ja/workflows/takt-default-refresh-all.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     session: refresh
@@ -65,6 +67,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     session: refresh
@@ -105,6 +109,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -160,6 +166,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     session: refresh
@@ -185,6 +193,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -216,6 +226,8 @@ steps:
         next: ai-antipattern-no-fix
     instruction: ai-antipattern-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     session: refresh
@@ -233,8 +245,12 @@ steps:
         next: reviewers
     instruction: arbitrate
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         session: refresh
@@ -260,6 +276,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         session: refresh
@@ -283,6 +301,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         session: refresh
@@ -307,6 +327,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         session: refresh
@@ -334,6 +356,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         session: refresh
@@ -356,6 +380,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -383,6 +409,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     session: refresh
@@ -412,6 +440,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     session: refresh

--- a/builtins/ja/workflows/takt-default-refresh-fast.yaml
+++ b/builtins/ja/workflows/takt-default-refresh-fast.yaml
@@ -35,6 +35,8 @@ loop_monitors:
           next: supervise
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -64,6 +66,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     session: refresh
@@ -104,6 +108,8 @@ steps:
         - name: test-report.md
           format: test-report
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -159,6 +165,8 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: ai-antipattern-review-1st
+    tags:
+      - review
     edit: false
     persona: ai-antipattern-reviewer
     session: refresh
@@ -184,6 +192,8 @@ steps:
         - name: ai-antipattern-review.md
           format: ai-antipattern-review
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -215,6 +225,8 @@ steps:
         next: ai-antipattern-no-fix
     instruction: ai-antipattern-fix
   - name: ai-antipattern-no-fix
+    tags:
+      - review
     edit: false
     persona: architecture-reviewer
     policy: review
@@ -231,8 +243,12 @@ steps:
         next: reviewers
     instruction: arbitrate
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: arch-review
+        tags:
+          - review
         edit: false
         persona: architecture-reviewer
         session: refresh
@@ -258,6 +274,8 @@ steps:
             - name: architect-review.md
               format: architecture-review
       - name: security-review
+        tags:
+          - review
         edit: false
         persona: security-reviewer
         session: refresh
@@ -281,6 +299,8 @@ steps:
             - name: security-review.md
               format: security-review
       - name: qa-review
+        tags:
+          - review
         edit: false
         persona: qa-reviewer
         session: refresh
@@ -305,6 +325,8 @@ steps:
             - name: qa-review.md
               format: qa-review
       - name: testing-review
+        tags:
+          - review
         edit: false
         persona: testing-reviewer
         session: refresh
@@ -332,6 +354,8 @@ steps:
             - name: testing-review.md
               format: testing-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         session: refresh
@@ -354,6 +378,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -381,6 +407,8 @@ steps:
       - condition: any("needs_fix")
         next: fix
   - name: fix
+    tags:
+      - coding
     edit: true
     persona: coder
     session: refresh
@@ -410,6 +438,8 @@ steps:
         next: plan
     instruction: fix
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/takt-default-with-fc.yaml
+++ b/builtins/ja/workflows/takt-default-with-fc.yaml
@@ -10,6 +10,8 @@ max_steps: 50
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -32,6 +34,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -82,6 +86,8 @@ steps:
       - condition: ABORT
         next: ABORT
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/takt-default.yaml
+++ b/builtins/ja/workflows/takt-default.yaml
@@ -10,6 +10,8 @@ max_steps: 50
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: architecture
@@ -32,6 +34,8 @@ steps:
         - name: plan.md
           format: plan
   - name: write_tests
+    tags:
+      - coding
     edit: true
     persona: coder
     policy:
@@ -82,6 +86,8 @@ steps:
       - condition: ABORT
         next: ABORT
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/terraform.yaml
+++ b/builtins/ja/workflows/terraform.yaml
@@ -10,6 +10,8 @@ max_steps: 15
 initial_step: plan
 steps:
   - name: plan
+    tags:
+      - plan
     edit: false
     persona: planner
     knowledge: terraform-aws
@@ -35,6 +37,8 @@ steps:
         - name: plan.md
           format: plan
   - name: implement
+    tags:
+      - coding
     edit: true
     persona: terraform-coder
     policy:
@@ -72,8 +76,12 @@ steps:
         - name: coder-decisions.md
           format: coder-decisions
   - name: reviewers
+    tags:
+      - review
     parallel:
       - name: tf_review
+        tags:
+          - review
         edit: false
         persona: terraform-reviewer
         policy:
@@ -98,6 +106,8 @@ steps:
             - name: terraform-review.md
               format: terraform-review
       - name: ai-antipattern-review-2nd
+        tags:
+          - review
         edit: false
         persona: ai-antipattern-reviewer
         policy:
@@ -120,6 +130,8 @@ steps:
             - name: ai-antipattern-review.md
               format: ai-antipattern-review
       - name: pure-review
+        tags:
+          - review
         edit: false
         persona: pure-reviewer
         policy: review
@@ -141,6 +153,8 @@ steps:
             - name: pure-review.md
               format: pure-review
       - name: coding-review
+        tags:
+          - review
         edit: false
         persona: coding-reviewer
         policy:
@@ -169,6 +183,8 @@ steps:
       - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix")
         next: supervise
   - name: supervise
+    tags:
+      - review
     edit: false
     persona: supervisor
     policy: review
@@ -202,8 +218,12 @@ steps:
           format: summary
           use_judge: false
   - name: fix_both
+    tags:
+      - coding
     parallel:
       - name: ai-antipattern-fix-parallel
+        tags:
+          - coding
         edit: true
         persona: terraform-coder
         policy:
@@ -225,6 +245,8 @@ steps:
           - condition: 判断できない、情報不足
         instruction: ai-antipattern-fix
       - name: supervise_fix_parallel
+        tags:
+          - coding
         edit: true
         persona: terraform-coder
         policy:
@@ -250,6 +272,8 @@ steps:
       - condition: any("修正不要（指摘対象ファイル/仕様の確認済み）", "判断できない、情報不足", "修正を進行できない")
         next: implement
   - name: ai-antipattern-fix
+    tags:
+      - coding
     edit: true
     persona: terraform-coder
     policy:
@@ -276,6 +300,8 @@ steps:
         next: implement
     instruction: ai-antipattern-fix
   - name: supervise_fix
+    tags:
+      - coding
     edit: true
     persona: terraform-coder
     policy:


### PR DESCRIPTION
## Summary

- Add `tags` to builtin workflow agent steps in both English and Japanese workflow definitions.
- Group steps into `plan`, `coding`, and `review` so provider routing can target broad workflow roles instead of exact persona names.
- Leave `system` and `workflow_call` steps untagged because those step kinds do not allow `tags`.

## Classification

- `plan`: planning, gathering, research, and analysis steps.
- `coding`: implementation, test writing, fix, and fix-supervision steps that edit code.
- `review`: reviewer, audit, supervision, arbitration, and no-fix decision steps.

## Validation

- `git diff --check`
- `npm test -- provider-routing.test.ts review-workflow.test.ts workflow-call-schema.test.ts system-workflow-schema.test.ts`

## Notes

`gh auth status` currently reports the local `gh` token as invalid, so this PR was created via the GitHub app after pushing the branch with git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 複数のワークフロー定義において、各ステップに分類用メタデータタグを追加しました。計画・コーディング・レビュー段階を plan / coding / review で明示し、ワークフロー管理の詳細化を実現します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->