### PR TITLE
[#838] return-interactive-prompt

### DIFF
--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -46,6 +46,10 @@ takt hello
 3. AI との会話でタスク内容を精緻化
 4. `/go` でタスク指示を確定（`/go 追加の指示` のように追記も可能）、または `/play <task>` でタスクを即座に実行
 5. 実行（workflow 実行、PR 作成）
+6. 結果サマリーの後に `Continue? [Y/n]` に回答
+7. `Y` なら最初のインタラクティブプロンプトに戻り、`n` なら終了
+
+continue prompt は通常のインタラクティブ実行で、completed / failed / aborted / exceeded などの終端結果の後にだけ表示されます。`--pipeline`、直接の `--task` 実行、quiet mode、non-TTY / CI 実行、自動化向けの経路では表示されません。
 
 ### インタラクティブモードの種類
 
@@ -91,6 +95,15 @@ Requirements:
 Proceed with these task instructions? (Y/n) y
 
 [Workflow の実行を開始...]
+
+Task completed
+Continue? [Y/n] y
+
+Select workflow:
+  > default (current)
+    Development/
+    Research/
+    Cancel
 ```
 
 ## 直接タスク実行

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -46,6 +46,10 @@ takt hello
 3. Refine task content through conversation with AI
 4. Finalize task instructions with `/go` (you can also add additional instructions like `/go additional instructions`), or use `/play <task>` to execute a task immediately
 5. Execute (run workflow, create PR)
+6. After the result summary, answer `Continue? [Y/n]`
+7. `Y` returns to the initial interactive prompt; `n` exits
+
+The continue prompt is only shown for normal interactive execution after terminal results such as completed, failed, aborted, or exceeded. It is not shown for `--pipeline`, direct `--task` execution, quiet mode, non-TTY/CI execution, or paths intended for automation.
 
 ### Interactive Mode Variants
 
@@ -91,6 +95,15 @@ Requirements:
 Proceed with these task instructions? (Y/n) y
 
 [Workflow execution starts...]
+
+Task completed
+Continue? [Y/n] y
+
+Select workflow:
+  > default (current)
+    Development/
+    Research/
+    Cancel
 ```
 
 ## Direct Task Execution

--- a/src/__tests__/ask-user-question-handler.test.ts
+++ b/src/__tests__/ask-user-question-handler.test.ts
@@ -50,7 +50,11 @@ describe('createAskUserQuestionHandler', () => {
   const originalTouchTty = process.env.TAKT_TEST_FLG_TOUCH_TTY;
 
   afterEach(() => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalIsTTY,
+      writable: true,
+      configurable: true,
+    });
     if (originalNoTty === undefined) {
       delete process.env.TAKT_NO_TTY;
     } else {
@@ -64,7 +68,7 @@ describe('createAskUserQuestionHandler', () => {
   });
 
   it('should return a handler when TTY is available', () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true, configurable: true });
     delete process.env.TAKT_NO_TTY;
     delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
 
@@ -74,7 +78,7 @@ describe('createAskUserQuestionHandler', () => {
   });
 
   it('should return a deny handler when no TTY is available', () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true });
     delete process.env.TAKT_NO_TTY;
     delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
 
@@ -84,7 +88,7 @@ describe('createAskUserQuestionHandler', () => {
   });
 
   it('should return a deny handler when TAKT_NO_TTY=1', () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true, configurable: true });
     process.env.TAKT_NO_TTY = '1';
     delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
 
@@ -93,7 +97,7 @@ describe('createAskUserQuestionHandler', () => {
   });
 
   it('deny handler should throw AskUserQuestionDeniedError', () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true });
     delete process.env.TAKT_NO_TTY;
     delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
 
@@ -412,7 +416,11 @@ describe('buildSdkOptions — AskUserQuestion hooks registration', () => {
   const originalTouchTty = process.env.TAKT_TEST_FLG_TOUCH_TTY;
 
   afterEach(() => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalIsTTY,
+      writable: true,
+      configurable: true,
+    });
     if (originalNoTty === undefined) {
       delete process.env.TAKT_NO_TTY;
     } else {
@@ -426,7 +434,7 @@ describe('buildSdkOptions — AskUserQuestion hooks registration', () => {
   });
 
   it('should auto-register PreToolUse hooks in non-TTY when no handler is provided', () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true });
     delete process.env.TAKT_NO_TTY;
     delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
 
@@ -438,7 +446,7 @@ describe('buildSdkOptions — AskUserQuestion hooks registration', () => {
   });
 
   it('should register hooks in TTY when no handler is provided', () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true, configurable: true });
     delete process.env.TAKT_NO_TTY;
     delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
 
@@ -450,7 +458,7 @@ describe('buildSdkOptions — AskUserQuestion hooks registration', () => {
   });
 
   it('non-TTY auto-deny hook should return decision: block for AskUserQuestion', async () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true });
     delete process.env.TAKT_NO_TTY;
     delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
 
@@ -474,7 +482,7 @@ describe('buildSdkOptions — AskUserQuestion hooks registration', () => {
   });
 
   it('should use explicit handler when provided, even in non-TTY', () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true });
     delete process.env.TAKT_NO_TTY;
     delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
 

--- a/src/__tests__/cli-routing-issue-resolve.test.ts
+++ b/src/__tests__/cli-routing-issue-resolve.test.ts
@@ -30,14 +30,18 @@ const {
   mockCheckCliStatus,
   mockFetchIssue,
   mockGetWorkflowDescription,
+  mockPromptContinueAfterTaskResult,
   mockResolveAgentOverrides,
   mockResolveAssistantConfigLayers,
+  mockShouldPromptForInteractiveContinue,
 } = vi.hoisted(() => ({
   mockCheckCliStatus: vi.fn(),
   mockFetchIssue: vi.fn(),
   mockGetWorkflowDescription: vi.fn(() => ({ name: 'default', description: 'test workflow', workflowStructure: '', stepPreviews: [] })),
+  mockPromptContinueAfterTaskResult: vi.fn(),
   mockResolveAgentOverrides: vi.fn(),
   mockResolveAssistantConfigLayers: vi.fn(() => ({ local: {}, global: {} })),
+  mockShouldPromptForInteractiveContinue: vi.fn(),
 }));
 
 vi.mock('../infra/git/index.js', () => ({
@@ -75,6 +79,8 @@ vi.mock('../features/interactive/index.js', () => ({
   loadRunSessionContext: vi.fn(),
   listRecentRuns: vi.fn(() => []),
   normalizeTaskHistorySummary: vi.fn((items: unknown[]) => items),
+  shouldPromptForInteractiveContinue: (...args: unknown[]) => mockShouldPromptForInteractiveContinue(...args),
+  promptContinueAfterTaskResult: (...args: unknown[]) => mockPromptContinueAfterTaskResult(...args),
   dispatchConversationAction: vi.fn(async (result: { action: string }, handlers: Record<string, (r: unknown) => unknown>) => {
     return handlers[result.action](result);
   }),
@@ -158,6 +164,27 @@ const mockIsDirectTask = vi.mocked(isDirectTask);
 const mockInfo = vi.mocked(info);
 const mockError = vi.mocked(error);
 const mockTaskRunnerListAllTaskItems = vi.mocked(mockListAllTaskItems);
+const completedTaskResult = { success: true, status: 'completed' } as const;
+const failedTaskResult = { success: false, status: 'failed', reason: 'Task failed' } as const;
+const abortedTaskResult = {
+  success: false,
+  status: 'failed',
+  reason: 'Workflow aborted by step transition',
+} as const;
+const exceededTaskResult = {
+  success: false,
+  status: 'exceeded',
+  exceededInfo: {
+    currentStep: 'reviewers',
+    newMaxSteps: 60,
+    currentIteration: 30,
+  },
+} as const;
+const interruptedTaskResult = {
+  success: false,
+  status: 'interrupted',
+  reason: 'Workflow interrupted by user (SIGINT)',
+} as const;
 
 function createMockIssue(number: number): Issue {
   return {
@@ -177,6 +204,7 @@ beforeEach(() => {
   }
   // Default setup
   mockDetermineWorkflow.mockResolvedValue('default');
+  mockSelectAndExecuteTask.mockResolvedValue(completedTaskResult);
   mockGetWorkflowDescription.mockReturnValue({ name: 'default', description: 'test workflow', workflowStructure: '', stepPreviews: [] });
   mockInteractiveMode.mockResolvedValue({ action: 'execute', task: 'summarized task' });
   mockPassthroughMode.mockResolvedValue({ action: 'execute', task: 'passthrough task' });
@@ -185,6 +213,8 @@ beforeEach(() => {
   mockSelectInteractiveMode.mockResolvedValue('assistant');
   mockIsDirectTask.mockReturnValue(false);
   mockResolveAgentOverrides.mockReturnValue(undefined);
+  mockShouldPromptForInteractiveContinue.mockReturnValue(false);
+  mockPromptContinueAfterTaskResult.mockResolvedValue(false);
   mockParseIssueNumbers.mockReturnValue([]);
   mockTaskRunnerListAllTaskItems.mockReturnValue([]);
   mockIsStaleRunningTask.mockReturnValue(false);
@@ -255,6 +285,7 @@ describe('Issue resolution in routing', () => {
         expect.objectContaining({
           workflow: 'migration-workflow',
           interactiveUserInput: true,
+          exitOnFailure: false,
           skipTaskList: true,
         }),
         undefined,
@@ -750,6 +781,330 @@ describe('Issue resolution in routing', () => {
 
       // Then: selectAndExecuteTask should NOT be called
       expect(mockSelectAndExecuteTask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('interactive continue prompt', () => {
+    it('should return to the initial interactive prompt when the user chooses to continue', async () => {
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockPromptContinueAfterTaskResult
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      mockInteractiveMode
+        .mockResolvedValueOnce({ action: 'execute', task: 'first task' })
+        .mockResolvedValueOnce({ action: 'execute', task: 'second task' });
+
+      await executeDefaultAction('add feature');
+
+      expect(mockSelectInteractiveMode).toHaveBeenCalledTimes(2);
+      expect(mockInteractiveMode).toHaveBeenNthCalledWith(
+        1,
+        '/test/cwd',
+        { userMessage: 'add feature' },
+        expect.anything(),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(mockInteractiveMode).toHaveBeenNthCalledWith(
+        2,
+        '/test/cwd',
+        undefined,
+        expect.anything(),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(mockSelectAndExecuteTask).toHaveBeenCalledTimes(2);
+      expect(mockSelectAndExecuteTask).toHaveBeenNthCalledWith(
+        1,
+        '/test/cwd',
+        'first task',
+        expect.objectContaining({
+          workflow: 'default',
+          interactiveUserInput: true,
+          interactiveMetadata: { confirmed: true, task: 'first task' },
+          skipTaskList: true,
+          exitOnFailure: false,
+        }),
+        undefined,
+      );
+      expect(mockSelectAndExecuteTask).toHaveBeenNthCalledWith(
+        2,
+        '/test/cwd',
+        'second task',
+        expect.objectContaining({
+          workflow: 'default',
+          interactiveUserInput: true,
+          interactiveMetadata: { confirmed: true, task: 'second task' },
+          skipTaskList: true,
+          exitOnFailure: false,
+        }),
+        undefined,
+      );
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(1, true, 'en');
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(2, true, 'en');
+    });
+
+    it('should return to the initial interactive prompt after a persona mode execute action', async () => {
+      mockSelectInteractiveMode
+        .mockResolvedValueOnce('persona')
+        .mockResolvedValueOnce('assistant');
+      mockGetWorkflowDescription.mockReturnValue({
+        name: 'default',
+        description: 'test workflow',
+        workflowStructure: '',
+        stepPreviews: [],
+        firstStep: {
+          personaContent: 'You are a coder.',
+          personaDisplayName: 'Coder',
+          allowedTools: ['Read'],
+        },
+      });
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockPromptContinueAfterTaskResult
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      mockInteractiveMode.mockResolvedValueOnce({ action: 'execute', task: 'follow up task' });
+
+      await executeDefaultAction('use persona mode');
+
+      expect(mockSelectInteractiveMode).toHaveBeenCalledTimes(2);
+      expect(mockPersonaMode).toHaveBeenCalledWith(
+        '/test/cwd',
+        expect.anything(),
+        { userMessage: 'use persona mode' },
+        expect.anything(),
+      );
+      expect(mockInteractiveMode).toHaveBeenNthCalledWith(
+        1,
+        '/test/cwd',
+        undefined,
+        expect.anything(),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(mockShouldPromptForInteractiveContinue).toHaveBeenNthCalledWith(1, { selectedMode: 'persona' });
+      expect(mockShouldPromptForInteractiveContinue).toHaveBeenNthCalledWith(2, { selectedMode: 'assistant' });
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(1, true, 'en');
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(2, true, 'en');
+    });
+
+    it('should return to the initial interactive prompt after a passthrough mode execute action', async () => {
+      mockSelectInteractiveMode
+        .mockResolvedValueOnce('passthrough')
+        .mockResolvedValueOnce('assistant');
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockPromptContinueAfterTaskResult
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      mockInteractiveMode.mockResolvedValueOnce({ action: 'execute', task: 'follow up task' });
+
+      await executeDefaultAction('use passthrough mode');
+
+      expect(mockSelectInteractiveMode).toHaveBeenCalledTimes(2);
+      expect(mockPassthroughMode).toHaveBeenCalledWith('en', 'use passthrough mode');
+      expect(mockInteractiveMode).toHaveBeenNthCalledWith(
+        1,
+        '/test/cwd',
+        undefined,
+        expect.anything(),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(mockShouldPromptForInteractiveContinue).toHaveBeenNthCalledWith(1, { selectedMode: 'passthrough' });
+      expect(mockShouldPromptForInteractiveContinue).toHaveBeenNthCalledWith(2, { selectedMode: 'assistant' });
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(1, true, 'en');
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(2, true, 'en');
+    });
+
+    it('should exit normally after a successful run when the user declines to continue', async () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockPromptContinueAfterTaskResult.mockResolvedValue(false);
+
+      await executeDefaultAction();
+
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenCalledWith(true, 'en');
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(mockInteractiveMode).toHaveBeenCalledTimes(1);
+      exitSpy.mockRestore();
+    });
+
+    it('should preserve failure exit code when the user declines to continue after a failed run', async () => {
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockPromptContinueAfterTaskResult.mockResolvedValue(false);
+      mockSelectAndExecuteTask.mockResolvedValue(failedTaskResult);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+
+      await expect(executeDefaultAction()).rejects.toThrow('process.exit called');
+
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenCalledWith(false, 'en');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it('should return to the initial interactive prompt after a failed run when the user chooses to continue', async () => {
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockPromptContinueAfterTaskResult
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      mockSelectAndExecuteTask
+        .mockResolvedValueOnce(failedTaskResult)
+        .mockResolvedValueOnce(completedTaskResult);
+      mockInteractiveMode
+        .mockResolvedValueOnce({ action: 'execute', task: 'failing task' })
+        .mockResolvedValueOnce({ action: 'execute', task: 'recovery task' });
+
+      await executeDefaultAction('retry broken workflow');
+
+      expect(mockSelectInteractiveMode).toHaveBeenCalledTimes(2);
+      expect(mockInteractiveMode).toHaveBeenNthCalledWith(
+        1,
+        '/test/cwd',
+        { userMessage: 'retry broken workflow' },
+        expect.anything(),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(mockInteractiveMode).toHaveBeenNthCalledWith(
+        2,
+        '/test/cwd',
+        undefined,
+        expect.anything(),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(1, false, 'en');
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(2, true, 'en');
+    });
+
+    it('should return to the initial interactive prompt after a non-SIGINT aborted run when the user continues', async () => {
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockPromptContinueAfterTaskResult
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      mockSelectAndExecuteTask
+        .mockResolvedValueOnce(abortedTaskResult)
+        .mockResolvedValueOnce(completedTaskResult);
+      mockInteractiveMode
+        .mockResolvedValueOnce({ action: 'execute', task: 'aborted task' })
+        .mockResolvedValueOnce({ action: 'execute', task: 'follow up task' });
+
+      await executeDefaultAction('retry aborted workflow');
+
+      expect(mockSelectInteractiveMode).toHaveBeenCalledTimes(2);
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(1, false, 'en');
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(2, true, 'en');
+      expect(mockInteractiveMode).toHaveBeenNthCalledWith(
+        2,
+        '/test/cwd',
+        undefined,
+        expect.anything(),
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should prompt after an exceeded run and return to the initial interactive prompt when the user continues', async () => {
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockPromptContinueAfterTaskResult
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      mockSelectAndExecuteTask
+        .mockResolvedValueOnce(exceededTaskResult)
+        .mockResolvedValueOnce(completedTaskResult);
+      mockInteractiveMode
+        .mockResolvedValueOnce({ action: 'execute', task: 'limited task' })
+        .mockResolvedValueOnce({ action: 'execute', task: 'follow up task' });
+
+      await executeDefaultAction('run limited workflow');
+
+      expect(mockSelectInteractiveMode).toHaveBeenCalledTimes(2);
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(1, false, 'en');
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenNthCalledWith(2, true, 'en');
+      expect(mockInteractiveMode).toHaveBeenNthCalledWith(
+        2,
+        '/test/cwd',
+        undefined,
+        expect.anything(),
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should treat execution errors as failed runs before asking whether to continue', async () => {
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockPromptContinueAfterTaskResult.mockResolvedValue(false);
+      mockSelectAndExecuteTask.mockRejectedValue(new Error('workflow crashed'));
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+
+      await expect(executeDefaultAction()).rejects.toThrow('process.exit called');
+
+      expect(mockPromptContinueAfterTaskResult).toHaveBeenCalledWith(false, 'en');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it('should preserve failure exit code without prompting when execution is interrupted by SIGINT', async () => {
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockSelectAndExecuteTask.mockResolvedValue(interruptedTaskResult);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+
+      try {
+        await expect(executeDefaultAction()).rejects.toThrow('process.exit called');
+
+        expect(mockSelectAndExecuteTask).toHaveBeenCalledTimes(1);
+        expect(mockPromptContinueAfterTaskResult).not.toHaveBeenCalled();
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      } finally {
+        exitSpy.mockRestore();
+      }
+    });
+
+    it('should not prompt for direct --task execution', async () => {
+      mockOpts.task = 'scripted task';
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+
+      await executeDefaultAction();
+
+      expect(mockSelectAndExecuteTask).toHaveBeenCalledWith(
+        '/test/cwd',
+        'scripted task',
+        expect.objectContaining({
+          workflow: undefined,
+          skipTaskList: true,
+        }),
+        undefined,
+      );
+      expect(mockSelectInteractiveMode).not.toHaveBeenCalled();
+      expect(mockShouldPromptForInteractiveContinue).not.toHaveBeenCalled();
+      expect(mockPromptContinueAfterTaskResult).not.toHaveBeenCalled();
+    });
+
+    it('should not prompt after an execute action selected from quiet mode', async () => {
+      mockSelectInteractiveMode.mockResolvedValueOnce('quiet');
+      mockShouldPromptForInteractiveContinue.mockReturnValue(false);
+
+      await executeDefaultAction();
+
+      expect(mockQuietMode).toHaveBeenCalledTimes(1);
+      expect(mockSelectAndExecuteTask).toHaveBeenCalledTimes(1);
+      expect(mockPromptContinueAfterTaskResult).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/cli-routing-pr-resolve.test.ts
+++ b/src/__tests__/cli-routing-pr-resolve.test.ts
@@ -24,19 +24,23 @@ const {
   mockFetchIssue,
   mockFetchPrReviewComments,
   mockGetWorkflowDescription,
+  mockPromptContinueAfterTaskResult,
   mockResolveConfigValues,
   mockResolveAssistantConfigLayers,
   mockLoadPersonaSessions,
   mockResolveAgentOverrides,
+  mockShouldPromptForInteractiveContinue,
 } = vi.hoisted(() => ({
   mockCheckCliStatus: vi.fn(),
   mockFetchIssue: vi.fn(),
   mockFetchPrReviewComments: vi.fn(),
   mockGetWorkflowDescription: vi.fn(() => ({ name: 'default', description: 'test workflow', workflowStructure: '', stepPreviews: [] })),
+  mockPromptContinueAfterTaskResult: vi.fn(),
   mockResolveConfigValues: vi.fn(() => ({ language: 'en', interactivePreviewSteps: 3, provider: 'claude' })),
   mockResolveAssistantConfigLayers: vi.fn(() => ({ local: {}, global: {} })),
   mockLoadPersonaSessions: vi.fn(() => ({})),
   mockResolveAgentOverrides: vi.fn(),
+  mockShouldPromptForInteractiveContinue: vi.fn(),
 }));
 
 vi.mock('../infra/git/index.js', () => ({
@@ -76,6 +80,8 @@ vi.mock('../features/interactive/index.js', () => ({
   loadRunSessionContext: vi.fn(),
   listRecentRuns: vi.fn(() => []),
   normalizeTaskHistorySummary: vi.fn((items: unknown[]) => items),
+  shouldPromptForInteractiveContinue: (...args: unknown[]) => mockShouldPromptForInteractiveContinue(...args),
+  promptContinueAfterTaskResult: (...args: unknown[]) => mockPromptContinueAfterTaskResult(...args),
   dispatchConversationAction: vi.fn(async (result: { action: string }, handlers: Record<string, (r: unknown) => unknown>) => {
     return handlers[result.action](result);
   }),
@@ -151,6 +157,7 @@ const mockSaveTaskFromInteractive = vi.mocked(saveTaskFromInteractive);
 const mockCreateIssueAndSaveTask = vi.mocked(createIssueAndSaveTask);
 const mockResolveConfigValuesFn = mockResolveConfigValues;
 const mockLoadPersonaSessionsFn = mockLoadPersonaSessions;
+const completedTaskResult = { success: true, status: 'completed' } as const;
 
 const testAttachment = {
   placeholder: '[Image #1]',
@@ -178,6 +185,7 @@ beforeEach(() => {
     delete mockOpts[key];
   }
   mockDetermineWorkflow.mockResolvedValue('default');
+  mockSelectAndExecuteTask.mockResolvedValue(completedTaskResult);
   mockGetWorkflowDescription.mockReturnValue({ name: 'default', description: 'test workflow', workflowStructure: '', stepPreviews: [] });
   mockInteractiveMode.mockResolvedValue({ action: 'execute', task: 'summarized task' });
   mockPassthroughMode.mockResolvedValue({ action: 'execute', task: 'passthrough task' });
@@ -190,6 +198,8 @@ beforeEach(() => {
   mockResolveAssistantConfigLayers.mockReturnValue({ local: {}, global: {} });
   mockLoadPersonaSessionsFn.mockReturnValue({});
   mockResolveAgentOverrides.mockReturnValue(undefined);
+  mockShouldPromptForInteractiveContinue.mockReturnValue(false);
+  mockPromptContinueAfterTaskResult.mockResolvedValue(false);
 });
 
 describe('interactive image attachment routing', () => {
@@ -578,6 +588,29 @@ describe('PR resolution in routing', () => {
           workflow: 'migration-workflow',
         }),
       );
+
+      Object.defineProperty(programModule, 'pipelineMode', { value: originalPipelineMode, writable: true });
+    });
+
+    it('should not call interactive continue prompt helpers in pipeline mode', async () => {
+      const programModule = await import('../app/cli/program.js');
+      const originalPipelineMode = programModule.pipelineMode;
+      Object.defineProperty(programModule, 'pipelineMode', { value: true, writable: true });
+
+      mockOpts.workflow = 'default';
+      mockShouldPromptForInteractiveContinue.mockReturnValue(true);
+      mockExecutePipeline.mockResolvedValue(0);
+
+      await executeDefaultAction();
+
+      expect(mockExecutePipeline).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflow: 'default',
+        }),
+      );
+      expect(mockSelectInteractiveMode).not.toHaveBeenCalled();
+      expect(mockShouldPromptForInteractiveContinue).not.toHaveBeenCalled();
+      expect(mockPromptContinueAfterTaskResult).not.toHaveBeenCalled();
 
       Object.defineProperty(programModule, 'pipelineMode', { value: originalPipelineMode, writable: true });
     });

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -124,6 +124,15 @@ describe('label integrity', () => {
     expect(ui).toHaveProperty('acceptNoAssistant');
   });
 
+  it('contains interactive task completion continue labels', () => {
+    expect(getLabel('interactive.taskResult.completed', 'en')).toBe('Task completed');
+    expect(getLabel('interactive.taskResult.failed', 'en')).toBe('Task failed');
+    expect(getLabel('interactive.taskResult.continuePrompt', 'en')).toBe('Continue?');
+    expect(() => getLabel('interactive.taskResult.completed', 'ja')).not.toThrow();
+    expect(() => getLabel('interactive.taskResult.failed', 'ja')).not.toThrow();
+    expect(() => getLabel('interactive.taskResult.continuePrompt', 'ja')).not.toThrow();
+  });
+
   it('contains all expected workflow keys in en', () => {
     expect(() => getLabel('workflow.iterationLimit.maxReached')).not.toThrow();
     expect(() => getLabel('workflow.iterationLimit.currentStep')).not.toThrow();
@@ -147,6 +156,9 @@ describe('label integrity', () => {
       'interactive.ui.introQuiet',
       'interactive.ui.introPassthrough',
       'interactive.ui.cancelled',
+      'interactive.taskResult.completed',
+      'interactive.taskResult.failed',
+      'interactive.taskResult.continuePrompt',
       'interactive.ui.acceptNoAssistant',
       'interactive.commands.accept',
       'workflow.iterationLimit.maxReached',

--- a/src/__tests__/interactiveContinuePrompt.test.ts
+++ b/src/__tests__/interactiveContinuePrompt.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppContext, setQuietMode } from '../shared/context.js';
+
+vi.mock('../features/interactive/lineEditor.js', () => ({
+  readMultilineInput: vi.fn(),
+}));
+
+vi.mock('../shared/ui/index.js', () => ({
+  info: vi.fn(),
+}));
+
+import { readMultilineInput } from '../features/interactive/lineEditor.js';
+import {
+  promptContinueAfterTaskResult,
+  shouldPromptForInteractiveContinue,
+} from '../features/interactive/continuePrompt.js';
+import { info } from '../shared/ui/index.js';
+
+const mockReadMultilineInput = vi.mocked(readMultilineInput);
+const mockInfo = vi.mocked(info);
+
+let originalIsTTY: boolean | undefined;
+let originalNoTty: string | undefined;
+let originalTouchTty: string | undefined;
+let originalCi: string | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  AppContext.resetInstance();
+  originalIsTTY = process.stdin.isTTY;
+  originalNoTty = process.env.TAKT_NO_TTY;
+  originalTouchTty = process.env.TAKT_TEST_FLG_TOUCH_TTY;
+  originalCi = process.env.CI;
+  Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+  delete process.env.TAKT_NO_TTY;
+  delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
+  delete process.env.CI;
+});
+
+afterEach(() => {
+  AppContext.resetInstance();
+  Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+  if (originalNoTty === undefined) {
+    delete process.env.TAKT_NO_TTY;
+  } else {
+    process.env.TAKT_NO_TTY = originalNoTty;
+  }
+  if (originalTouchTty === undefined) {
+    delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
+  } else {
+    process.env.TAKT_TEST_FLG_TOUCH_TTY = originalTouchTty;
+  }
+  if (originalCi === undefined) {
+    delete process.env.CI;
+  } else {
+    process.env.CI = originalCi;
+  }
+});
+
+describe('shouldPromptForInteractiveContinue', () => {
+  it.each(['assistant', 'persona', 'passthrough'] as const)(
+    'returns true for normal interactive TTY %s mode',
+    (selectedMode) => {
+      setQuietMode(false);
+
+      const result = shouldPromptForInteractiveContinue({ selectedMode });
+
+      expect(result).toBe(true);
+    },
+  );
+
+  it('returns false for selected quiet mode', () => {
+    setQuietMode(false);
+
+    const result = shouldPromptForInteractiveContinue({ selectedMode: 'quiet' });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for global quiet mode', () => {
+    setQuietMode(true);
+
+    const result = shouldPromptForInteractiveContinue({ selectedMode: 'assistant' });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for non-TTY execution', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    setQuietMode(false);
+
+    const result = shouldPromptForInteractiveContinue({ selectedMode: 'assistant' });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for CI execution even when stdin is TTY', () => {
+    process.env.CI = 'true';
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    setQuietMode(false);
+
+    const result = shouldPromptForInteractiveContinue({ selectedMode: 'assistant' });
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('promptContinueAfterTaskResult', () => {
+  it('prints completed status and accepts empty input as continue', async () => {
+    mockReadMultilineInput.mockResolvedValue('');
+
+    const result = await promptContinueAfterTaskResult(true, 'en');
+
+    expect(result).toBe(true);
+    expect(mockInfo).toHaveBeenCalledWith('Task completed');
+    expect(mockReadMultilineInput).toHaveBeenCalledWith('Continue? [Y/n]');
+  });
+
+  it('prints failed status and returns false for no input', async () => {
+    mockReadMultilineInput.mockResolvedValue('n');
+
+    const result = await promptContinueAfterTaskResult(false, 'en');
+
+    expect(result).toBe(false);
+    expect(mockInfo).toHaveBeenCalledWith('Task failed');
+    expect(mockReadMultilineInput).toHaveBeenCalledWith('Continue? [Y/n]');
+  });
+
+  it.each(['y', 'Y', 'yes', 'YES'])('accepts %s as continue', async (input) => {
+    mockReadMultilineInput.mockResolvedValue(input);
+
+    const result = await promptContinueAfterTaskResult(true, 'en');
+
+    expect(result).toBe(true);
+  });
+
+  it('treats EOF or Ctrl-C as exit', async () => {
+    mockReadMultilineInput.mockResolvedValue(null);
+
+    const result = await promptContinueAfterTaskResult(true, 'en');
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/__tests__/selectAndExecute-autoPr.test.ts
+++ b/src/__tests__/selectAndExecute-autoPr.test.ts
@@ -72,6 +72,12 @@ vi.mock('../infra/github/index.js', () => ({
 
 vi.mock('../features/tasks/execute/taskExecution.js', () => ({
   executeTask: (...args: unknown[]) => mockExecuteTask(...args),
+  executeTaskWithResult: async (...args: unknown[]) => {
+    const result = await mockExecuteTask(...args);
+    return typeof result === 'boolean'
+      ? { success: result, ...(result ? {} : { reason: 'Task failed' }) }
+      : result;
+  },
 }));
 
 vi.mock('../features/workflowSelection/index.js', () => ({
@@ -99,10 +105,11 @@ beforeEach(() => {
 
 describe('selectAndExecuteTask (execute path)', () => {
   it('should execute in-place without worktree setup or PR prompts', async () => {
-    await selectAndExecuteTask('/project', 'test task', {
+    const result = await selectAndExecuteTask('/project', 'test task', {
       workflow: 'default',
     });
 
+    expect(result).toEqual({ success: true, status: 'completed' });
     expect(mockAutoCommitAndPush).not.toHaveBeenCalled();
     expect(mockAddTask).toHaveBeenCalledWith('test task', { workflow: 'default' });
     expect(mockExecuteTask).toHaveBeenCalledWith(
@@ -160,10 +167,11 @@ describe('selectAndExecuteTask (execute path)', () => {
   it('should record task and complete when executeTask returns true', async () => {
     mockExecuteTask.mockResolvedValue(true);
 
-    await selectAndExecuteTask('/project', 'test task', {
+    const result = await selectAndExecuteTask('/project', 'test task', {
       workflow: 'default',
     });
 
+    expect(result).toEqual({ success: true, status: 'completed' });
     expect(mockAddTask).toHaveBeenCalledWith('test task', { workflow: 'default' });
     expect(mockCompleteTask).toHaveBeenCalledTimes(1);
     expect(mockFailTask).not.toHaveBeenCalled();
@@ -180,6 +188,26 @@ describe('selectAndExecuteTask (execute path)', () => {
       workflow: 'default',
     })).rejects.toThrow('process exit');
 
+    expect(mockAddTask).toHaveBeenCalledWith('test task', { workflow: 'default' });
+    expect(mockFailTask).toHaveBeenCalledTimes(1);
+    expect(mockCompleteTask).not.toHaveBeenCalled();
+    processExitSpy.mockRestore();
+  });
+
+  it('should return false without exiting when exitOnFailure is disabled', async () => {
+    mockExecuteTask.mockResolvedValue(false);
+
+    const processExitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process exit');
+    }) as (code?: string | number | null | undefined) => never);
+
+    const result = await selectAndExecuteTask('/project', 'test task', {
+      workflow: 'default',
+      exitOnFailure: false,
+    });
+
+    expect(result).toEqual({ success: false, status: 'failed', reason: 'Task failed' });
+    expect(processExitSpy).not.toHaveBeenCalled();
     expect(mockAddTask).toHaveBeenCalledWith('test task', { workflow: 'default' });
     expect(mockFailTask).toHaveBeenCalledTimes(1);
     expect(mockCompleteTask).not.toHaveBeenCalled();

--- a/src/__tests__/selectAndExecute-skipTaskList.test.ts
+++ b/src/__tests__/selectAndExecute-skipTaskList.test.ts
@@ -14,7 +14,8 @@ const {
   mockExecuteTask,
   mockPersistTaskResult,
   mockPersistTaskError,
-  mockBuildBooleanTaskResult,
+  mockBuildTaskResult,
+  mockPersistExceededTaskResult,
 } = vi.hoisted(() => ({
   mockAddTask: vi.fn(() => ({
     name: 'test-task',
@@ -27,7 +28,8 @@ const {
   mockExecuteTask: vi.fn(),
   mockPersistTaskResult: vi.fn(),
   mockPersistTaskError: vi.fn(),
-  mockBuildBooleanTaskResult: vi.fn(() => ({ task: 'mock-result' })),
+  mockBuildTaskResult: vi.fn(() => ({ task: 'mock-result' })),
+  mockPersistExceededTaskResult: vi.fn(),
 }));
 
 vi.mock('../shared/prompt/index.js', () => ({
@@ -79,10 +81,17 @@ vi.mock('../infra/github/index.js', () => ({
 
 vi.mock('../features/tasks/execute/taskExecution.js', () => ({
   executeTask: (...args: unknown[]) => mockExecuteTask(...args),
+  executeTaskWithResult: async (...args: unknown[]) => {
+    const result = await mockExecuteTask(...args);
+    return typeof result === 'boolean'
+      ? { success: result, ...(result ? {} : { reason: 'Task failed' }) }
+      : result;
+  },
 }));
 
 vi.mock('../features/tasks/execute/taskResultHandler.js', () => ({
-  buildBooleanTaskResult: (...args: unknown[]) => mockBuildBooleanTaskResult(...args),
+  buildTaskResult: (...args: unknown[]) => mockBuildTaskResult(...args),
+  persistExceededTaskResult: (...args: unknown[]) => mockPersistExceededTaskResult(...args),
   persistTaskResult: (...args: unknown[]) => mockPersistTaskResult(...args),
   persistTaskError: (...args: unknown[]) => mockPersistTaskError(...args),
 }));
@@ -117,11 +126,12 @@ function createTempProject(): string {
 
 describe('skipTaskList option in selectAndExecuteTask', () => {
   it('skipTaskList: true の場合はタスクリストに追加しない', async () => {
-    await selectAndExecuteTask('/project', 'test task', {
+    const result = await selectAndExecuteTask('/project', 'test task', {
       workflow: 'default',
       skipTaskList: true,
     });
 
+    expect(result).toEqual({ success: true, status: 'completed' });
     expect(mockAddTask).not.toHaveBeenCalled();
     expect(mockPersistTaskResult).not.toHaveBeenCalled();
     expect(mockExecuteTask).toHaveBeenCalled();
@@ -170,7 +180,7 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
     });
 
     expect(mockAddTask).toHaveBeenCalled();
-    expect(mockBuildBooleanTaskResult).toHaveBeenCalled();
+    expect(mockBuildTaskResult).toHaveBeenCalled();
     expect(mockPersistTaskResult).toHaveBeenCalled();
     expect(mockExecuteTask).toHaveBeenCalled();
   });
@@ -373,6 +383,186 @@ describe('skipTaskList option in selectAndExecuteTask', () => {
     expect(fs.existsSync(path.join(projectCwd, '.takt', 'tasks'))).toBe(false);
     expect(fs.existsSync(path.join(projectCwd, '.takt', 'runs', executeArg.reportDirName, 'context', 'task'))).toBe(true);
     expect(mockPersistTaskResult).not.toHaveBeenCalled();
+  });
+
+  it('skipTaskList: true かつ exitOnFailure: false では taskSuccess false を戻り値で返す', async () => {
+    mockExecuteTask.mockResolvedValue(false);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit:1');
+    }) as never);
+
+    try {
+      const result = await selectAndExecuteTask('/project', 'test task', {
+        workflow: 'default',
+        skipTaskList: true,
+        exitOnFailure: false,
+      });
+
+      expect(result).toEqual({ success: false, status: 'failed', reason: 'Task failed' });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(mockAddTask).not.toHaveBeenCalled();
+      expect(mockPersistTaskResult).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('skipTaskList: true かつ exitOnFailure: false では non-SIGINT aborted を failed として返す', async () => {
+    mockExecuteTask.mockResolvedValue({
+      success: false,
+      reason: 'Workflow aborted by step transition',
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit:1');
+    }) as never);
+
+    try {
+      const result = await selectAndExecuteTask('/project', 'test task', {
+        workflow: 'default',
+        skipTaskList: true,
+        exitOnFailure: false,
+      });
+
+      expect(result).toEqual({
+        success: false,
+        status: 'failed',
+        reason: 'Workflow aborted by step transition',
+      });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(mockAddTask).not.toHaveBeenCalled();
+      expect(mockPersistTaskResult).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('skipTaskList: true かつ exitOnFailure: false では user_interrupted を interrupted として返す', async () => {
+    mockExecuteTask.mockResolvedValue({
+      success: false,
+      reason: 'user_interrupted',
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit:1');
+    }) as never);
+
+    try {
+      const result = await selectAndExecuteTask('/project', 'test task', {
+        workflow: 'default',
+        skipTaskList: true,
+        exitOnFailure: false,
+      });
+
+      expect(result).toEqual({
+        success: false,
+        status: 'interrupted',
+        reason: 'user_interrupted',
+      });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(mockAddTask).not.toHaveBeenCalled();
+      expect(mockPersistTaskResult).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('skipTaskList: true かつ exitOnFailure: false では SIGINT reason を interrupted として返す', async () => {
+    mockExecuteTask.mockResolvedValue({
+      success: false,
+      reason: 'Workflow interrupted by user (SIGINT)',
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit:1');
+    }) as never);
+
+    try {
+      const result = await selectAndExecuteTask('/project', 'test task', {
+        workflow: 'default',
+        skipTaskList: true,
+        exitOnFailure: false,
+      });
+
+      expect(result).toEqual({
+        success: false,
+        status: 'interrupted',
+        reason: 'Workflow interrupted by user (SIGINT)',
+      });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(mockAddTask).not.toHaveBeenCalled();
+      expect(mockPersistTaskResult).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('skipTaskList: true かつ exitOnFailure: false では SIGINT 文言を含む通常失敗 reason を failed として返す', async () => {
+    const reason = 'Task failed: Workflow interrupted by user (SIGINT) was mentioned by provider';
+    mockExecuteTask.mockResolvedValue({
+      success: false,
+      reason,
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit:1');
+    }) as never);
+
+    try {
+      const result = await selectAndExecuteTask('/project', 'test task', {
+        workflow: 'default',
+        skipTaskList: true,
+        exitOnFailure: false,
+      });
+
+      expect(result).toEqual({
+        success: false,
+        status: 'failed',
+        reason,
+      });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(mockAddTask).not.toHaveBeenCalled();
+      expect(mockPersistTaskResult).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('skipTaskList: false かつ exitOnFailure: false では exceeded を保存して戻り値で返す', async () => {
+    const exceededInfo = {
+      currentStep: 'reviewers',
+      newMaxSteps: 60,
+      currentIteration: 30,
+    };
+    mockExecuteTask.mockResolvedValue({
+      success: false,
+      exceeded: true,
+      exceededInfo,
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit:1');
+    }) as never);
+
+    try {
+      const result = await selectAndExecuteTask('/project', 'test task', {
+        workflow: 'default',
+        skipTaskList: false,
+        exitOnFailure: false,
+      });
+
+      expect(result).toEqual({
+        success: false,
+        status: 'exceeded',
+        exceededInfo,
+      });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(mockAddTask).toHaveBeenCalled();
+      expect(mockPersistExceededTaskResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: 'test-task' }),
+        exceededInfo,
+      );
+      expect(mockBuildTaskResult).not.toHaveBeenCalled();
+      expect(mockPersistTaskResult).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 
   it('attachments 付き skipTaskList: false で addTask が失敗した場合は prepared spec と staged spec を削除する', async () => {

--- a/src/app/cli/interactiveLoop.ts
+++ b/src/app/cli/interactiveLoop.ts
@@ -1,0 +1,296 @@
+import { checkoutBranch } from '../../infra/task/index.js';
+import {
+  getWorkflowDescription,
+  loadPersonaSessions,
+  resolveConfigValues,
+} from '../../infra/config/index.js';
+import { resolvePersonaSessionId } from '../../infra/config/project/sessionStore.js';
+import { resolveAssistantProviderModelFromConfig } from '../../core/config/provider-resolution.js';
+import { INTERACTIVE_MODES, type InteractiveMode } from '../../core/models/index.js';
+import { getLabel } from '../../shared/i18n/index.js';
+import { error as logError, info, success } from '../../shared/ui/index.js';
+import { getErrorMessage } from '../../shared/utils/index.js';
+import { resolveAssistantConfigLayers } from '../../features/interactive/assistantConfig.js';
+import {
+  createIssueAndSaveTask,
+  determineWorkflow,
+  promptLabelSelection,
+  saveTaskFromInteractive,
+  selectAndExecuteTask,
+  type SelectAndExecuteTaskResult,
+  type SelectAndExecuteOptions,
+  type TaskExecutionOptions,
+} from '../../features/tasks/index.js';
+import {
+  dispatchConversationAction,
+  interactiveMode,
+  passthroughMode,
+  personaMode,
+  promptContinueAfterTaskResult,
+  quietMode,
+  resolveLanguage,
+  selectInteractiveMode,
+  shouldPromptForInteractiveContinue,
+  type InteractiveModeAction,
+  type InteractiveModeResult,
+} from '../../features/interactive/index.js';
+import { loadTaskHistory } from './taskHistory.js';
+
+interface RunInteractiveLoopOptions {
+  cwd: string;
+  selectOptions: SelectAndExecuteOptions;
+  directTask?: string;
+  sourceContext?: string;
+  prBranch?: string;
+  prBaseBranch?: string;
+  prNumber?: number;
+  sourceIssueNumber?: number;
+  continuePreviousSession: boolean;
+  agentOverrides?: TaskExecutionOptions;
+}
+
+type ConversationDispatchResult =
+  | { action: 'executed'; result: SelectAndExecuteTaskResult }
+  | { action: 'done' };
+
+export async function runInteractiveLoop(options: RunInteractiveLoopOptions): Promise<void> {
+  const globalConfig = resolveConfigValues(
+    options.cwd,
+    ['language', 'interactivePreviewSteps'],
+  );
+  const lang = resolveLanguage(globalConfig.language);
+  let firstIteration = true;
+
+  while (true) {
+    const currentDirectTask = firstIteration ? options.directTask : undefined;
+    const currentSourceContext = firstIteration ? options.sourceContext : undefined;
+    const currentPrBranch = firstIteration ? options.prBranch : undefined;
+    const currentPrBaseBranch = firstIteration ? options.prBaseBranch : undefined;
+    const currentPrNumber = firstIteration ? options.prNumber : undefined;
+    const currentSourceIssueNumber = firstIteration ? options.sourceIssueNumber : undefined;
+
+    const workflowId = await determineWorkflow(options.cwd, options.selectOptions.workflow);
+    if (workflowId === null) {
+      info(getLabel('interactive.ui.cancelled', lang));
+      return;
+    }
+
+    const workflowDesc = getWorkflowDescription(workflowId, options.cwd, globalConfig.interactivePreviewSteps);
+    const availableInteractiveModes = currentSourceContext && !currentDirectTask
+      ? INTERACTIVE_MODES.filter((mode) => mode !== 'passthrough')
+      : INTERACTIVE_MODES;
+    const selectedMode = await selectInteractiveMode(
+      lang,
+      workflowDesc.interactiveMode,
+      availableInteractiveModes,
+    );
+    if (selectedMode === null) {
+      info(getLabel('interactive.ui.cancelled', lang));
+      return;
+    }
+
+    const workflowContext = {
+      name: workflowDesc.name,
+      description: workflowDesc.description,
+      workflowStructure: workflowDesc.workflowStructure,
+      stepPreviews: workflowDesc.stepPreviews,
+      taskHistory: loadTaskHistory(options.cwd, lang),
+    };
+    const interactiveSeed = currentDirectTask || currentSourceContext
+      ? {
+        ...(currentDirectTask ? { userMessage: currentDirectTask } : {}),
+        ...(currentSourceContext ? { sourceContext: currentSourceContext } : {}),
+      }
+      : undefined;
+
+    const result = await runSelectedInteractiveMode({
+      cwd: options.cwd,
+      selectedMode,
+      workflowDesc,
+      workflowContext,
+      interactiveSeed,
+      directTask: currentDirectTask,
+      prBranch: currentPrBranch,
+      continuePreviousSession: firstIteration && options.continuePreviousSession,
+      agentOverrides: options.agentOverrides,
+      lang,
+    });
+
+    const dispatchResult = await dispatchConversationAction<InteractiveModeAction, ConversationDispatchResult>(result, {
+      execute: async ({ task: confirmedTask }) => {
+        const baseExecutionOptions = createExecutionOptionsBase(
+          options.selectOptions,
+          firstIteration,
+        );
+        const executionOptions: SelectAndExecuteOptions = {
+          ...baseExecutionOptions,
+          interactiveUserInput: true,
+          workflow: workflowId,
+          interactiveMetadata: { confirmed: true, task: confirmedTask },
+          skipTaskList: true,
+          exitOnFailure: false,
+          ...(result.attachments ? { attachments: result.attachments } : {}),
+        };
+
+        if (currentPrBranch) {
+          info(`Fetching and checking out PR branch: ${currentPrBranch}`);
+          checkoutBranch(options.cwd, currentPrBranch);
+          success(`Checked out PR branch: ${currentPrBranch}`);
+        }
+
+        try {
+          const taskResult = await selectAndExecuteTask(
+            options.cwd,
+            confirmedTask,
+            executionOptions,
+            options.agentOverrides,
+          );
+          return { action: 'executed', result: taskResult } as const;
+        } catch (error) {
+          logError(getErrorMessage(error));
+          return { action: 'executed', result: { success: false, status: 'failed' } } as const;
+        }
+      },
+      create_issue: async ({ task: confirmedTask }) => {
+        const labels = await promptLabelSelection(lang);
+        await createIssueAndSaveTask(options.cwd, confirmedTask, workflowId, {
+          confirmAtEndMessage: 'Add this issue to tasks?',
+          labels,
+          ...(result.attachments ? { attachments: result.attachments } : {}),
+        });
+        return { action: 'done' } as const;
+      },
+      save_task: async ({ task: confirmedTask }) => {
+        const presetSettings = currentPrBranch
+          ? {
+            worktree: true as const,
+            branch: currentPrBranch,
+            autoPr: true,
+            ...(currentPrBaseBranch ? { baseBranch: currentPrBaseBranch } : {}),
+          }
+          : undefined;
+        await saveTaskFromInteractive(options.cwd, confirmedTask, workflowId, {
+          presetSettings,
+          ...(currentPrNumber !== undefined ? { prNumber: currentPrNumber } : {}),
+          ...(currentSourceIssueNumber !== undefined ? { issue: currentSourceIssueNumber } : {}),
+          ...(result.attachments ? { attachments: result.attachments } : {}),
+        });
+        return { action: 'done' } as const;
+      },
+      cancel: () => ({ action: 'done' }) as const,
+    }) as ConversationDispatchResult;
+
+    if (dispatchResult.action !== 'executed') {
+      return;
+    }
+    if (dispatchResult.result.status === 'interrupted') {
+      process.exit(1);
+    }
+    if (!shouldPromptForInteractiveContinue({ selectedMode })) {
+      if (!dispatchResult.result.success) {
+        process.exit(1);
+      }
+      return;
+    }
+
+    const shouldContinue = await promptContinueAfterTaskResult(dispatchResult.result.success, lang);
+    if (!shouldContinue) {
+      if (!dispatchResult.result.success) {
+        process.exit(1);
+      }
+      return;
+    }
+
+    firstIteration = false;
+  }
+}
+
+function createExecutionOptionsBase(
+  selectOptions: SelectAndExecuteOptions,
+  includeTraceTaskContext: boolean,
+): SelectAndExecuteOptions {
+  if (includeTraceTaskContext) {
+    return selectOptions;
+  }
+
+  return {
+    ...(selectOptions.workflow !== undefined ? { workflow: selectOptions.workflow } : {}),
+    ...(selectOptions.interactiveUserInput !== undefined ? { interactiveUserInput: selectOptions.interactiveUserInput } : {}),
+    ...(selectOptions.interactiveMetadata !== undefined ? { interactiveMetadata: selectOptions.interactiveMetadata } : {}),
+    ...(selectOptions.skipTaskList !== undefined ? { skipTaskList: selectOptions.skipTaskList } : {}),
+    ...(selectOptions.exitOnFailure !== undefined ? { exitOnFailure: selectOptions.exitOnFailure } : {}),
+    ...(selectOptions.attachments !== undefined ? { attachments: selectOptions.attachments } : {}),
+  };
+}
+
+interface RunSelectedInteractiveModeOptions {
+  cwd: string;
+  selectedMode: InteractiveMode;
+  workflowDesc: ReturnType<typeof getWorkflowDescription>;
+  workflowContext: Parameters<typeof interactiveMode>[2];
+  interactiveSeed: Parameters<typeof interactiveMode>[1];
+  directTask?: string;
+  prBranch?: string;
+  continuePreviousSession: boolean;
+  agentOverrides?: TaskExecutionOptions;
+  lang: ReturnType<typeof resolveLanguage>;
+}
+
+async function runSelectedInteractiveMode(options: RunSelectedInteractiveModeOptions): Promise<InteractiveModeResult> {
+  switch (options.selectedMode) {
+    case 'assistant':
+      return runAssistantMode(options);
+
+    case 'passthrough':
+      return passthroughMode(options.lang, options.directTask);
+
+    case 'quiet':
+      return quietMode(options.cwd, options.interactiveSeed, options.workflowContext);
+
+    case 'persona':
+      if (!options.workflowDesc.firstStep) {
+        info(getLabel('interactive.ui.personaFallback', options.lang));
+        return interactiveMode(options.cwd, options.interactiveSeed, options.workflowContext);
+      }
+      return personaMode(options.cwd, options.workflowDesc.firstStep, options.interactiveSeed, options.workflowContext);
+  }
+}
+
+async function runAssistantMode(options: RunSelectedInteractiveModeOptions): Promise<InteractiveModeResult> {
+  let selectedSessionId: string | undefined;
+  if (options.continuePreviousSession) {
+    const { provider: providerType } = resolveAssistantProviderModelFromConfig(
+      resolveAssistantConfigLayers(options.cwd),
+      {
+        provider: options.agentOverrides?.provider,
+        model: options.agentOverrides?.model,
+      },
+    );
+    if (!providerType) {
+      throw new Error('Provider is not configured.');
+    }
+    const savedSessions = loadPersonaSessions(options.cwd, providerType);
+    const savedSessionId = resolvePersonaSessionId(savedSessions, 'interactive', providerType);
+    if (savedSessionId) {
+      selectedSessionId = savedSessionId;
+    } else {
+      info(getLabel('interactive.continueNoSession', options.lang));
+    }
+  }
+
+  const interactiveOpts = options.prBranch ? { excludeActions: ['create_issue'] as const } : undefined;
+  const assistantModeOptions = {
+    ...interactiveOpts,
+    ...(options.agentOverrides?.provider ? { provider: options.agentOverrides.provider } : {}),
+    ...(options.agentOverrides?.model ? { model: options.agentOverrides.model } : {}),
+  };
+
+  return interactiveMode(
+    options.cwd,
+    options.interactiveSeed,
+    options.workflowContext,
+    selectedSessionId,
+    undefined,
+    Object.keys(assistantModeOptions).length > 0 ? assistantModeOptions : undefined,
+  );
+}

--- a/src/app/cli/routing.ts
+++ b/src/app/cli/routing.ts
@@ -1,33 +1,12 @@
-import { info, success, error as logError } from '../../shared/ui/index.js';
+import { error as logError } from '../../shared/ui/index.js';
 import { getErrorMessage } from '../../shared/utils/index.js';
-import { getLabel } from '../../shared/i18n/index.js';
-import { checkoutBranch } from '../../infra/task/index.js';
-import { selectAndExecuteTask, determineWorkflow, saveTaskFromInteractive, createIssueAndSaveTask, promptLabelSelection, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
+import { selectAndExecuteTask, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
 import { executePipeline } from '../../features/pipeline/index.js';
-import {
-  interactiveMode,
-  selectInteractiveMode,
-  passthroughMode,
-  quietMode,
-  personaMode,
-  resolveLanguage,
-  dispatchConversationAction,
-  type InteractiveModeResult,
-} from '../../features/interactive/index.js';
-import { INTERACTIVE_MODES } from '../../core/models/index.js';
-import {
-  getWorkflowDescription,
-  resolveConfigValue,
-  resolveConfigValues,
-  loadPersonaSessions,
-} from '../../infra/config/index.js';
-import { resolvePersonaSessionId } from '../../infra/config/project/sessionStore.js';
-import { resolveAssistantProviderModelFromConfig } from '../../core/config/provider-resolution.js';
-import { resolveAssistantConfigLayers } from '../../features/interactive/assistantConfig.js';
+import { resolveConfigValue } from '../../infra/config/index.js';
 import { program, resolvedCwd, pipelineMode } from './program.js';
 import { resolveAgentOverrides, resolveWorkflowCliOption } from './helpers.js';
-import { loadTaskHistory } from './taskHistory.js';
 import { resolveIssueInput, resolvePrInput } from './routing-inputs.js';
+import { runInteractiveLoop } from './interactiveLoop.js';
 
 export async function executeDefaultAction(task?: string): Promise<void> {
   const opts = program.opts();
@@ -140,148 +119,17 @@ export async function executeDefaultAction(task?: string): Promise<void> {
     }
   }
 
-  const globalConfig = resolveConfigValues(
-    resolvedCwd,
-    ['language', 'interactivePreviewSteps'],
-  );
-  const lang = resolveLanguage(globalConfig.language);
-
-  const workflowId = await determineWorkflow(resolvedCwd, selectOptions.workflow);
-  if (workflowId === null) {
-    info(getLabel('interactive.ui.cancelled', lang));
-    return;
-  }
-
-  const previewCount = globalConfig.interactivePreviewSteps;
-  const workflowDesc = getWorkflowDescription(workflowId, resolvedCwd, previewCount);
-
-  const availableInteractiveModes = sourceContext && !directTask
-    ? INTERACTIVE_MODES.filter((mode) => mode !== 'passthrough')
-    : INTERACTIVE_MODES;
-  const selectedMode = await selectInteractiveMode(
-    lang,
-    workflowDesc.interactiveMode,
-    availableInteractiveModes,
-  );
-  if (selectedMode === null) {
-    info(getLabel('interactive.ui.cancelled', lang));
-    return;
-  }
-
-  const workflowContext = {
-    name: workflowDesc.name,
-    description: workflowDesc.description,
-    workflowStructure: workflowDesc.workflowStructure,
-    stepPreviews: workflowDesc.stepPreviews,
-    taskHistory: loadTaskHistory(resolvedCwd, lang),
-  };
-  const interactiveSeed = directTask || sourceContext
-    ? {
-      ...(directTask ? { userMessage: directTask } : {}),
-      ...(sourceContext ? { sourceContext } : {}),
-    }
-    : undefined;
-  let result: InteractiveModeResult;
-
-  switch (selectedMode) {
-    case 'assistant': {
-      let selectedSessionId: string | undefined;
-      if (opts.continue === true) {
-        const { provider: providerType } = resolveAssistantProviderModelFromConfig(
-          resolveAssistantConfigLayers(resolvedCwd),
-          {
-            provider: agentOverrides?.provider,
-            model: agentOverrides?.model,
-          },
-        );
-        if (!providerType) {
-          throw new Error('Provider is not configured.');
-        }
-        const savedSessions = loadPersonaSessions(resolvedCwd, providerType);
-        const savedSessionId = resolvePersonaSessionId(savedSessions, 'interactive', providerType);
-        if (savedSessionId) {
-          selectedSessionId = savedSessionId;
-        } else {
-          info(getLabel('interactive.continueNoSession', lang));
-        }
-      }
-      const interactiveOpts = prBranch ? { excludeActions: ['create_issue'] as const } : undefined;
-      const assistantModeOptions = {
-        ...interactiveOpts,
-        ...(agentOverrides?.provider ? { provider: agentOverrides.provider } : {}),
-        ...(agentOverrides?.model ? { model: agentOverrides.model } : {}),
-      };
-      result = await interactiveMode(
-        resolvedCwd,
-        interactiveSeed,
-        workflowContext,
-        selectedSessionId,
-        undefined,
-        Object.keys(assistantModeOptions).length > 0 ? assistantModeOptions : undefined,
-      );
-      break;
-    }
-
-    case 'passthrough':
-      result = await passthroughMode(lang, directTask);
-      break;
-
-    case 'quiet':
-      result = await quietMode(resolvedCwd, interactiveSeed, workflowContext);
-      break;
-
-    case 'persona': {
-      if (!workflowDesc.firstStep) {
-        info(getLabel('interactive.ui.personaFallback', lang));
-        result = await interactiveMode(resolvedCwd, interactiveSeed, workflowContext);
-      } else {
-        result = await personaMode(resolvedCwd, workflowDesc.firstStep, interactiveSeed, workflowContext);
-      }
-      break;
-    }
-  }
-
-  await dispatchConversationAction(result, {
-    execute: async ({ task: confirmedTask }) => {
-      if (prBranch) {
-        info(`Fetching and checking out PR branch: ${prBranch}`);
-        checkoutBranch(resolvedCwd, prBranch);
-        success(`Checked out PR branch: ${prBranch}`);
-      }
-      selectOptions.interactiveUserInput = true;
-      selectOptions.workflow = workflowId;
-      selectOptions.interactiveMetadata = { confirmed: true, task: confirmedTask };
-      selectOptions.skipTaskList = true;
-      if (result.attachments) {
-        selectOptions.attachments = result.attachments;
-      }
-      await selectAndExecuteTask(resolvedCwd, confirmedTask, selectOptions, agentOverrides);
-    },
-    create_issue: async ({ task: confirmedTask }) => {
-      const labels = await promptLabelSelection(lang);
-      await createIssueAndSaveTask(resolvedCwd, confirmedTask, workflowId, {
-        confirmAtEndMessage: 'Add this issue to tasks?',
-        labels,
-        ...(result.attachments ? { attachments: result.attachments } : {}),
-      });
-    },
-    save_task: async ({ task: confirmedTask }) => {
-      const presetSettings = prBranch
-        ? {
-          worktree: true as const,
-          branch: prBranch,
-          autoPr: true,
-          ...(prBaseBranch ? { baseBranch: prBaseBranch } : {}),
-        }
-        : undefined;
-      await saveTaskFromInteractive(resolvedCwd, confirmedTask, workflowId, {
-        presetSettings,
-        ...(prNumber !== undefined ? { prNumber } : {}),
-        ...(sourceIssueNumber !== undefined ? { issue: sourceIssueNumber } : {}),
-        ...(result.attachments ? { attachments: result.attachments } : {}),
-      });
-    },
-    cancel: () => undefined,
+  await runInteractiveLoop({
+    cwd: resolvedCwd,
+    selectOptions,
+    directTask,
+    sourceContext,
+    prBranch,
+    prBaseBranch,
+    prNumber,
+    sourceIssueNumber,
+    continuePreviousSession: opts.continue === true,
+    agentOverrides,
   });
 }
 

--- a/src/features/interactive/continuePrompt.ts
+++ b/src/features/interactive/continuePrompt.ts
@@ -1,0 +1,39 @@
+import type { InteractiveMode, Language } from '../../core/models/index.js';
+import { getLabel } from '../../shared/i18n/index.js';
+import { resolveTtyPolicy } from '../../shared/prompt/tty.js';
+import { isQuietMode } from '../../shared/context.js';
+import { info } from '../../shared/ui/index.js';
+import { readMultilineInput } from './lineEditor.js';
+
+export interface InteractiveContinuePromptOptions {
+  selectedMode: InteractiveMode;
+}
+
+export function shouldPromptForInteractiveContinue(options: InteractiveContinuePromptOptions): boolean {
+  if (options.selectedMode === 'quiet') {
+    return false;
+  }
+  if (isQuietMode()) {
+    return false;
+  }
+  if (isCiEnvironment()) {
+    return false;
+  }
+  return resolveTtyPolicy().useTty;
+}
+
+function isCiEnvironment(): boolean {
+  const value = process.env.CI;
+  return value !== undefined && value !== '' && value !== '0' && value !== 'false';
+}
+
+export async function promptContinueAfterTaskResult(success: boolean, lang: Language): Promise<boolean> {
+  info(getLabel(success ? 'interactive.taskResult.completed' : 'interactive.taskResult.failed', lang));
+  const input = await readMultilineInput(`${getLabel('interactive.taskResult.continuePrompt', lang)} [Y/n]`);
+  if (input === null) {
+    return false;
+  }
+
+  const normalizedInput = input.trim().toLowerCase();
+  return normalizedInput === '' || normalizedInput === 'y' || normalizedInput === 'yes';
+}

--- a/src/features/interactive/index.ts
+++ b/src/features/interactive/index.ts
@@ -29,3 +29,8 @@ export { runTaskRetryMode, runDirectRetryMode, buildRetryTemplateVars, type Retr
 export { dispatchConversationAction, type ConversationActionResult } from './actionDispatcher.js';
 export { findPreviousOrderContent } from './orderReader.js';
 export { type InteractiveImageAttachment } from './imageAttachments.js';
+export {
+  shouldPromptForInteractiveContinue,
+  promptContinueAfterTaskResult,
+  type InteractiveContinuePromptOptions,
+} from './continuePrompt.js';

--- a/src/features/tasks/execute/selectAndExecute.ts
+++ b/src/features/tasks/execute/selectAndExecute.ts
@@ -9,17 +9,60 @@ import { statusLine } from '../../../shared/ui/StatusLine.js';
 import { createLogger } from '../../../shared/utils/index.js';
 import { generateExecutionReportDir } from '../../../core/workflow/run/run-slug.js';
 import { sanitizeTerminalText } from '../../../shared/utils/text.js';
-import { executeTask } from './taskExecution.js';
-import type { TaskExecutionOptions, WorktreeConfirmationResult, SelectAndExecuteOptions } from './types.js';
+import { executeTaskWithResult } from './taskExecution.js';
+import type {
+  SelectAndExecuteTaskResult,
+  TaskExecutionOptions,
+  WorktreeConfirmationResult,
+  SelectAndExecuteOptions,
+  WorkflowExecutionResult,
+} from './types.js';
 import { selectWorkflow } from '../../workflowSelection/index.js';
-import { buildBooleanTaskResult, persistTaskError, persistTaskResult } from './taskResultHandler.js';
+import {
+  buildTaskResult,
+  persistExceededTaskResult,
+  persistTaskError,
+  persistTaskResult,
+} from './taskResultHandler.js';
 import { prepareTaskSpecDirectory, cleanupPreparedTaskSpec } from '../attachments.js';
 import { cleanupStagedTaskSpec, stageTaskSpecForExecution, type StagedTaskSpec } from './taskSpecContext.js';
 import { buildTraceTaskMetadata } from './traceTaskMetadata.js';
 
-export type { WorktreeConfirmationResult, SelectAndExecuteOptions };
+export type { WorktreeConfirmationResult, SelectAndExecuteOptions, SelectAndExecuteTaskResult };
 
 const log = createLogger('selectAndExecute');
+const USER_INTERRUPT_REASON = 'Workflow interrupted by user (SIGINT)';
+
+function toSelectAndExecuteTaskResult(result: WorkflowExecutionResult): SelectAndExecuteTaskResult {
+  if (result.success) {
+    return { success: true, status: 'completed' };
+  }
+  if (isUserInterruptedResult(result)) {
+    return {
+      success: false,
+      status: 'interrupted',
+      ...(result.reason ? { reason: result.reason } : {}),
+    };
+  }
+  if (result.exceeded && result.exceededInfo) {
+    return {
+      success: false,
+      status: 'exceeded',
+      ...(result.reason ? { reason: result.reason } : {}),
+      exceededInfo: result.exceededInfo,
+    };
+  }
+  return {
+    success: false,
+    status: 'failed',
+    ...(result.reason ? { reason: result.reason } : {}),
+  };
+}
+
+function isUserInterruptedResult(result: WorkflowExecutionResult): boolean {
+  return result.reason === 'user_interrupted'
+    || result.reason === USER_INTERRUPT_REASON;
+}
 
 function cleanupTransientTaskSpecs(
   preparedSpecTaskDir: string | undefined,
@@ -94,12 +137,12 @@ export async function selectAndExecuteTask(
   task: string,
   options?: SelectAndExecuteOptions,
   agentOverrides?: TaskExecutionOptions,
-): Promise<void> {
+): Promise<SelectAndExecuteTaskResult> {
   const workflowIdentifier = await determineWorkflow(cwd, options?.workflow);
 
   if (workflowIdentifier === null) {
     info('Cancelled');
-    return;
+    return { success: false, status: 'failed', reason: 'Cancelled' };
   }
 
   const execCwd = cwd;
@@ -138,9 +181,9 @@ export async function selectAndExecuteTask(
   const startedAt = new Date().toISOString();
 
   statusLine.start('Running...');
-  let taskSuccess: boolean;
+  let workflowResult: WorkflowExecutionResult;
   try {
-    taskSuccess = await executeTask({
+    workflowResult = await executeTaskWithResult({
       task: stagedSpec?.taskPrompt ?? task,
       cwd: execCwd,
       workflowIdentifier,
@@ -177,18 +220,25 @@ export async function selectAndExecuteTask(
   const completedAt = new Date().toISOString();
 
   if (taskRecord) {
-    const taskResult = buildBooleanTaskResult({
-      task: taskRecord,
-      taskSuccess,
-      successResponse: 'Task completed successfully',
-      failureResponse: 'Task failed',
-      startedAt,
-      completedAt,
-    });
-    persistTaskResult(taskRunner, taskResult);
+    if (workflowResult.exceeded && workflowResult.exceededInfo) {
+      persistExceededTaskResult(taskRunner, taskRecord, workflowResult.exceededInfo);
+    } else {
+      const taskResult = buildTaskResult({
+        task: taskRecord,
+        runResult: workflowResult,
+        startedAt,
+        completedAt,
+      });
+      persistTaskResult(taskRunner, taskResult);
+    }
   }
 
-  if (!taskSuccess) {
-    process.exit(1);
+  const taskResult = toSelectAndExecuteTaskResult(workflowResult);
+  if (!taskResult.success) {
+    if (options?.exitOnFailure !== false) {
+      process.exit(1);
+    }
   }
+
+  return taskResult;
 }

--- a/src/features/tasks/execute/types.ts
+++ b/src/features/tasks/execute/types.ts
@@ -37,6 +37,15 @@ export interface WorkflowExecutionResult {
   exceededInfo?: ExceededInfo;
 }
 
+export type SelectAndExecuteTaskStatus = 'completed' | 'failed' | 'exceeded' | 'interrupted';
+
+export interface SelectAndExecuteTaskResult {
+  success: boolean;
+  status: SelectAndExecuteTaskStatus;
+  reason?: string;
+  exceededInfo?: ExceededInfo;
+}
+
 /** Metadata from interactive mode, passed through to NDJSON logging */
 export interface InteractiveMetadata {
   /** Whether the user confirmed with /go */
@@ -211,6 +220,8 @@ export interface SelectAndExecuteOptions {
   interactiveMetadata?: InteractiveMetadata;
   /** Skip adding task to tasks.yaml */
   skipTaskList?: boolean;
+  /** Exit the process when task execution fails. Defaults to true. */
+  exitOnFailure?: boolean;
   /** Images pasted during interactive task input. */
   attachments?: TaskAttachment[];
   /** Source metadata for direct trace discovery when no task record exists. */

--- a/src/features/tasks/index.ts
+++ b/src/features/tasks/index.ts
@@ -13,6 +13,7 @@ export {
   confirmAndCreateWorktree,
   determineWorkflow,
   type SelectAndExecuteOptions,
+  type SelectAndExecuteTaskResult,
   type WorktreeConfirmationResult,
 } from './execute/selectAndExecute.js';
 export { postExecutionFlow, type PostExecutionOptions } from './execute/postExecution.js';

--- a/src/shared/i18n/labels_en.yaml
+++ b/src/shared/i18n/labels_en.yaml
@@ -63,6 +63,10 @@ interactive:
     userStopped: "⚠️ Previous task was interrupted by user"
     workflow: "Workflow: {workflowName}"
     timestamp: "Executed: {timestamp}"
+  taskResult:
+    completed: "Task completed"
+    failed: "Task failed"
+    continuePrompt: "Continue?"
   commands:
     accept: "Accept latest assistant response"
     play: "Run a task immediately"

--- a/src/shared/i18n/labels_ja.yaml
+++ b/src/shared/i18n/labels_ja.yaml
@@ -63,6 +63,10 @@ interactive:
     userStopped: "⚠️ 前回のタスクはユーザーによって中断されました"
     workflow: "使用ワークフロー: {workflowName}"
     timestamp: "実行時刻: {timestamp}"
+  taskResult:
+    completed: "タスクが完了しました"
+    failed: "タスクが失敗しました"
+    continuePrompt: "続行しますか？"
   commands:
     accept: "最新のアシスタント発言を採用"
     play: "タスクを即実行する"


### PR DESCRIPTION
## Summary

## Problem

When TAKT is used interactively, a workflow/task run exits back to the shell after completion or failure. This forces the user to run `takt` again for the next operation, even during an interactive session where they are repeatedly adding, running, inspecting, or retrying tasks.

This is inconvenient for manual review/fix workflows where the user wants to keep working in TAKT after each run.

## Goal

For normal interactive TAKT usage, return to the interactive prompt after a workflow/task finishes.

The user should be asked whether to continue:

```text
Task completed
Continue? [Y/n]
```

or:

```text
Task failed
Continue? [Y/n]
```

If the user chooses yes, TAKT should return to the initial interactive prompt/menu. If the user chooses no, TAKT exits as it does today.

## Scope

Apply this only to interactive usage, such as invoking `takt` without a non-interactive command path and entering the existing interactive flow.

Do not change behavior for scripted or pipeline execution.

## Non-goals

- Do not add a new `takt interactive` subcommand for this issue.
- Do not implement a command REPL or slash-command shell.
- Do not add AI command routing.
- Do not change pipeline execution semantics.

## Expected behavior

In interactive mode:

1. User starts TAKT interactively.
2. User selects or enters an operation that runs a task/workflow.
3. The workflow completes, fails, aborts, or exceeds limits.
4. TAKT prints the result summary as today.
5. TAKT asks whether to continue.
6. If yes, TAKT returns to the initial interactive prompt/menu.
7. If no, TAKT exits normally.

## Modes that must not prompt

Do not ask `Continue?` in non-interactive or automation-oriented paths, including:

- `--pipeline`
- direct one-shot commands such as `takt add --pr ...`
- direct run/resume commands intended for scripts
- quiet mode
- CI/non-TTY execution
- any mode where prompting would block automation

## Failure handling

The continue prompt should be shown for terminal workflow results such as:

- completed
- failed
- aborted
- exceeded

The prompt should not hide the failure. The previous run result must remain visible before the continue question.

## Ctrl-C / EOF

- Ctrl-C should exit the interactive loop cleanly.
- Ctrl-D / EOF should exit cleanly.
- If a workflow is currently running, preserve the existing interrupt behavior unless this issue explicitly needs a small adaptation.

## Implementation notes

Prefer wrapping the existing interactive flow in a loop rather than introducing a new command mode.

The loop should be guarded by an explicit interactive-mode check so that non-interactive code paths cannot accidentally prompt.

Avoid calling `process.exit()` deep inside the interactive flow if that prevents returning to the top prompt. If needed, refactor those exits into returned status values only for the interactive path.

## Acceptance criteria

- Running TAKT in normal interactive mode returns to the initial prompt after a task/workflow completes when the user answers yes.
- The same happens after a failed/aborted/exceeded run.
- Answering no exits normally.
- `--pipeline` and direct scripted commands do not prompt.
- Quiet/non-TTY execution does not prompt.
- Existing one-shot CLI behavior remains unchanged.
- Tests cover both continue and exit paths for interactive mode, plus at least one non-interactive path that must not prompt.

## Execution Report

Workflow `takt-default` completed successfully.

Closes #838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * インタラクティブモードでタスク実行完了後に「Continue? [Y/n]」プロンプトを表示するようになりました。ユーザーは続行または終了を選択できます。このプロンプトはパイプライン実行、自動化経路、非TTY環境では表示されません。

* **Documentation**
  * CLI リファレンスを更新し、インタラクティブ継続プロンプトの仕様と表示条件を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->