### PR TITLE
[#854] add-team-leader-part-tags

### DIFF
--- a/builtins/en/workflows/draft.yaml
+++ b/builtins/en/workflows/draft.yaml
@@ -43,7 +43,7 @@ loop_monitors:
 steps:
   - name: implement
     tags:
-      - coding
+      - leader
     edit: true
     persona: coder
     policy:
@@ -57,6 +57,8 @@ steps:
     required_permission_mode: edit
     team_leader:
       max_parts: 2
+      part_tags:
+        - coding
       part_persona: coder
       part_edit: true
       part_permission_mode: edit

--- a/builtins/ja/workflows/draft.yaml
+++ b/builtins/ja/workflows/draft.yaml
@@ -43,7 +43,7 @@ loop_monitors:
 steps:
   - name: implement
     tags:
-      - coding
+      - leader
     edit: true
     persona: coder
     policy:
@@ -57,6 +57,8 @@ steps:
     required_permission_mode: edit
     team_leader:
       max_parts: 2
+      part_tags:
+        - coding
       part_persona: coder
       part_edit: true
       part_permission_mode: edit

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -236,6 +236,7 @@ CSV / JSON などのデータソースを反復し、同じ step テンプレー
       max_concurrency: 2
       max_total_parts: 8
       timeout_ms: 600000
+      part_tags: [coding]
       part_persona: coder
       part_edit: true
       part_permission_mode: edit
@@ -249,7 +250,7 @@ CSV / JSON などのデータソースを反復し、同じ step テンプレー
 
 大きなタスクを「事前にユニット境界を決めなくても並列で進められる単位」に分解したいときに便利です。
 
-`max_concurrency` は同時に実行する part 数、`max_total_parts` はその step 全体で計画できる総 part 数（最大 20）を制御します。旧名の `max_parts` は互換性のため `max_concurrency` として扱われます。
+`max_concurrency` は同時に実行する part 数、`max_total_parts` はその step 全体で計画できる総 part 数（最大 20）を制御します。旧名の `max_parts` は互換性のため `max_concurrency` として扱われます。`part_tags` は生成される part step の provider routing tag です。未指定時は親 step の `tags` を継承します。空文字や空白のみの tag は無効です。`part_tags` は通常の `provider_routing.tags` として解決されるため、`part_persona` による persona routing より優先されます。
 
 ### Workflow Call Step（サブワークフロー）
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -237,6 +237,7 @@ The agent acts as a leader: it decomposes the task into independent sub-parts at
       max_concurrency: 2
       max_total_parts: 8
       timeout_ms: 600000
+      part_tags: [coding]
       part_persona: coder
       part_edit: true
       part_permission_mode: edit
@@ -250,7 +251,7 @@ The agent acts as a leader: it decomposes the task into independent sub-parts at
 
 Useful for breaking one large task into independent units that can run in parallel without you having to know the unit boundaries up-front.
 
-`max_concurrency` controls how many parts run at the same time. `max_total_parts` controls the total number of parts the leader may plan across the workflow step, up to 20. The older `max_parts` key is still accepted as the compatibility name for `max_concurrency`.
+`max_concurrency` controls how many parts run at the same time. `max_total_parts` controls the total number of parts the leader may plan across the workflow step, up to 20. The older `max_parts` key is still accepted as the compatibility name for `max_concurrency`. `part_tags` sets provider routing tags on generated part steps. When omitted, parts inherit the parent step's `tags`. Empty and whitespace-only tags are invalid. `part_tags` is resolved through normal `provider_routing.tags`, so tag routing takes priority over persona routing from `part_persona`.
 
 ### Workflow Call Step (subworkflow)
 

--- a/src/__tests__/provider-routing.test.ts
+++ b/src/__tests__/provider-routing.test.ts
@@ -491,6 +491,109 @@ describe('provider_routing provider_options resolution', () => {
       },
     });
   });
+
+  it('Given team_leader parent tags and part_tags differ, When resolving provider/model, Then parent and part route separately', () => {
+    const parentStep = createStep({
+      name: 'implement',
+      persona: 'leader',
+      providerRoutingPersonaKey: 'leader',
+      tags: ['leader'],
+      teamLeader: {
+        persona: 'planner',
+        maxConcurrency: 3,
+        maxTotalParts: 20,
+        refillThreshold: 0,
+        timeoutMs: 900000,
+        partPersona: 'coder',
+        partTags: ['coding'],
+      },
+    });
+    const part: PartDefinition = {
+      id: 'api',
+      title: 'API',
+      instruction: 'implement api',
+    };
+    const providerRouting = {
+      tags: {
+        leader: { provider: 'codex' as const, model: 'gpt-5.5' },
+        coding: { provider: 'opencode' as const, model: 'ollama-cloud/qwen3-coder-next' },
+      },
+    };
+
+    const partStep = createPartStep(parentStep, part);
+
+    expect(parentStep.tags).toEqual(['leader']);
+    expect(partStep).toMatchObject({
+      name: 'implement.api',
+      providerRoutingPersonaKey: 'coder',
+      tags: ['coding'],
+    });
+    expect(resolveStepProviderModel({
+      step: parentStep,
+      provider: 'mock',
+      model: 'project-model',
+      providerRouting,
+    } as Parameters<typeof resolveStepProviderModel>[0])).toMatchObject({
+      provider: 'codex',
+      model: 'gpt-5.5',
+      providerSource: 'provider_routing.tags',
+      modelSource: 'provider_routing.tags',
+    });
+    expect(resolveStepProviderModel({
+      step: partStep,
+      provider: 'mock',
+      model: 'project-model',
+      providerRouting,
+    } as Parameters<typeof resolveStepProviderModel>[0])).toMatchObject({
+      provider: 'opencode',
+      model: 'ollama-cloud/qwen3-coder-next',
+      providerSource: 'provider_routing.tags',
+      modelSource: 'provider_routing.tags',
+    });
+  });
+
+  it('Given team_leader part_persona and part_tags, When resolving provider/model, Then tag routing wins over persona routing', () => {
+    const parentStep = createStep({
+      name: 'implement',
+      persona: 'leader',
+      providerRoutingPersonaKey: 'leader',
+      tags: ['leader'],
+      teamLeader: {
+        persona: 'planner',
+        maxConcurrency: 3,
+        maxTotalParts: 20,
+        refillThreshold: 0,
+        timeoutMs: 900000,
+        partPersona: 'coder',
+        partTags: ['coding'],
+      },
+    });
+    const part: PartDefinition = {
+      id: 'api',
+      title: 'API',
+      instruction: 'implement api',
+    };
+    const partStep = createPartStep(parentStep, part);
+
+    expect(resolveStepProviderModel({
+      step: partStep,
+      provider: 'mock',
+      model: 'project-model',
+      providerRouting: {
+        personas: {
+          coder: { provider: 'codex', model: 'persona-model' },
+        },
+        tags: {
+          coding: { provider: 'opencode', model: 'ollama-cloud/qwen3-coder-next' },
+        },
+      },
+    } as Parameters<typeof resolveStepProviderModel>[0])).toMatchObject({
+      provider: 'opencode',
+      model: 'ollama-cloud/qwen3-coder-next',
+      providerSource: 'provider_routing.tags',
+      modelSource: 'provider_routing.tags',
+    });
+  });
 });
 
 describe('provider_routing config normalization', () => {

--- a/src/__tests__/team-leader-common.test.ts
+++ b/src/__tests__/team-leader-common.test.ts
@@ -3,6 +3,61 @@ import type { PartDefinition, WorkflowStep } from '../core/models/types.js';
 import { createPartStep } from '../core/workflow/engine/team-leader-common.js';
 
 describe('createPartStep', () => {
+  it('Given teamLeader.partTags, When creating a part step, Then part tags replace parent tags', () => {
+    const step: WorkflowStep = {
+      name: 'implement',
+      persona: 'leader',
+      personaDisplayName: 'leader',
+      tags: ['leader'],
+      instruction: 'decompose work',
+      passPreviousResponse: false,
+      teamLeader: {
+        persona: 'leader',
+        maxConcurrency: 3,
+        maxTotalParts: 20,
+        refillThreshold: 0,
+        timeoutMs: 900000,
+        partTags: ['coding'],
+      },
+    };
+    const part: PartDefinition = {
+      id: 'part-1',
+      title: 'API',
+      instruction: 'implement api',
+    };
+
+    const partStep = createPartStep(step, part);
+
+    expect(partStep.tags).toEqual(['coding']);
+  });
+
+  it('Given no teamLeader.partTags, When creating a part step, Then parent tags are inherited', () => {
+    const step: WorkflowStep = {
+      name: 'implement',
+      persona: 'leader',
+      personaDisplayName: 'leader',
+      tags: ['leader'],
+      instruction: 'decompose work',
+      passPreviousResponse: false,
+      teamLeader: {
+        persona: 'leader',
+        maxConcurrency: 3,
+        maxTotalParts: 20,
+        refillThreshold: 0,
+        timeoutMs: 900000,
+      },
+    };
+    const part: PartDefinition = {
+      id: 'part-1',
+      title: 'API',
+      instruction: 'implement api',
+    };
+
+    const partStep = createPartStep(step, part);
+
+    expect(partStep.tags).toEqual(['leader']);
+  });
+
   it('keeps parent providerOptions intact so part option resolution stays in OptionsBuilder', () => {
     // Given
     const step: WorkflowStep = {

--- a/src/__tests__/team-leader-runner-structured-caller.test.ts
+++ b/src/__tests__/team-leader-runner-structured-caller.test.ts
@@ -207,6 +207,142 @@ describe('TeamLeaderRunner with structuredCaller', () => {
     );
   });
 
+  it('Given teamLeader.partTags, When running multiple decomposed parts, Then each part step gets part tags without changing aggregated output', async () => {
+    mockExecuteAgent.mockImplementation(async (_persona, instruction: string) => {
+      if (instruction.includes('Implement API')) {
+        return {
+          persona: 'coder',
+          status: 'done',
+          content: 'API done',
+          timestamp: new Date('2026-04-01T00:00:00.000Z'),
+        };
+      }
+      if (instruction.includes('Implement UI')) {
+        return {
+          persona: 'coder',
+          status: 'done',
+          content: 'UI done',
+          timestamp: new Date('2026-04-01T00:01:00.000Z'),
+        };
+      }
+      throw new Error(`Unexpected instruction: ${instruction}`);
+    });
+    const resolveStepProviderModel = vi.fn().mockImplementation((stepArg: WorkflowStep) => {
+      if (stepArg.name === 'implement') {
+        return { provider: 'codex', model: 'gpt-5.5' };
+      }
+      return { provider: 'opencode', model: 'ollama-cloud/qwen3-coder-next' };
+    });
+
+    const structuredCaller = {
+      decomposeTask: vi.fn().mockImplementation(async (_instruction, _maxTotalParts, options) => {
+        options.onPromptResolved?.({
+          systemPrompt: 'team-leader-system',
+          userInstruction: 'leader instruction',
+        });
+        return [
+          { id: 'part-1', title: 'API', instruction: 'Implement API' },
+          { id: 'part-2', title: 'UI', instruction: 'Implement UI' },
+        ];
+      }),
+      requestMoreParts: vi.fn().mockResolvedValue({
+        done: true,
+        reasoning: 'enough',
+        parts: [],
+      }),
+    };
+    const buildAgentOptions = vi.fn().mockReturnValue({ cwd: '/tmp/project' });
+    const runner = new TeamLeaderRunner({
+      optionsBuilder: {
+        buildAgentOptions,
+        buildBaseOptions: vi.fn().mockReturnValue({}),
+        buildPhase1WorkflowMeta: vi.fn().mockReturnValue(undefined),
+        resolveStepProviderModel,
+      },
+      stepExecutor: {
+        buildInstruction: vi.fn().mockReturnValue('leader instruction'),
+        applyPostExecutionPhases: vi.fn(async (_step, _state, _iteration, response) => response),
+        persistPreviousResponseSnapshot: vi.fn(),
+        emitStepReports: vi.fn(),
+      },
+      engineOptions: {
+        projectCwd: '/tmp/project',
+        structuredCaller,
+      },
+      getCwd: () => '/tmp/project',
+      getWorkflowName: () => 'workflow',
+      getInteractive: () => false,
+    } as ConstructorParameters<typeof TeamLeaderRunner>[0] & {
+      engineOptions: { projectCwd: string; structuredCaller: typeof structuredCaller };
+    });
+
+    const step: WorkflowStep = {
+      name: 'implement',
+      persona: 'coder',
+      personaDisplayName: 'coder',
+      tags: ['leader'],
+      instruction: 'Task: {task}',
+      passPreviousResponse: true,
+      teamLeader: {
+        persona: 'team-leader',
+        maxConcurrency: 2,
+        maxTotalParts: 20,
+        refillThreshold: 0,
+        timeoutMs: 1000,
+        partPersona: 'coder',
+        partTags: ['coding', 'edit'],
+      },
+      rules: [{ condition: 'done', next: 'COMPLETE' }],
+    };
+    const state: WorkflowState = {
+      workflowName: 'workflow',
+      currentStep: 'implement',
+      iteration: 1,
+      stepOutputs: new Map(),
+      structuredOutputs: new Map(),
+      systemContexts: new Map(),
+      effectResults: new Map(),
+      lastOutput: undefined,
+      previousResponseSourcePath: undefined,
+      userInputs: [],
+      personaSessions: new Map(),
+      stepIterations: new Map(),
+      status: 'running',
+    };
+
+    const result = await runner.runTeamLeaderStep(
+      step,
+      state,
+      'implement feature',
+      5,
+      vi.fn(),
+    );
+
+    expect(resolveStepProviderModel.mock.calls.map(([stepArg]) => ({
+      name: stepArg.name,
+      tags: stepArg.tags,
+    }))).toEqual([
+      { name: 'implement', tags: ['leader'] },
+      { name: 'implement.part-1', tags: ['coding', 'edit'] },
+      { name: 'implement.part-2', tags: ['coding', 'edit'] },
+    ]);
+    expect(buildAgentOptions.mock.calls.map(([stepArg]) => ({
+      name: stepArg.name,
+      tags: stepArg.tags,
+    }))).toEqual([
+      { name: 'implement.part-1', tags: ['coding', 'edit'] },
+      { name: 'implement.part-2', tags: ['coding', 'edit'] },
+    ]);
+    expect(result.response.status).toBe('done');
+    expect(result.response.content).toContain('## decomposition');
+    expect(result.response.content).toContain('"id": "part-1"');
+    expect(result.response.content).toContain('"id": "part-2"');
+    expect(result.response.content).toContain('## part-1: API');
+    expect(result.response.content).toContain('## part-2: UI');
+    expect(result.response.content).toContain('API done');
+    expect(result.response.content).toContain('UI done');
+  });
+
   it('takt-default の implement では process safety を leader prompt に渡す', async () => {
     mockExecuteAgent.mockResolvedValue({
       persona: 'coder',

--- a/src/__tests__/team-leader-schema-loader.test.ts
+++ b/src/__tests__/team-leader-schema-loader.test.ts
@@ -168,6 +168,25 @@ describe('team_leader schema', () => {
 
     expect(result.success).toBe(true);
   });
+
+  it('Given team_leader.part_tags, When parsing a step, Then part_tags are preserved', () => {
+    const raw = {
+      name: 'implement',
+      tags: ['leader'],
+      team_leader: {
+        part_tags: ['coding'],
+      },
+      instruction: 'decompose',
+    };
+
+    const result = WorkflowStepRawSchema.safeParse(raw);
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.data.team_leader?.part_tags).toEqual(['coding']);
+  });
 });
 
 describe('normalizeWorkflowConfig team_leader', () => {
@@ -184,6 +203,7 @@ describe('normalizeWorkflowConfig team_leader', () => {
             max_concurrency: 2,
             max_total_parts: 5,
             timeout_ms: 90000,
+            part_tags: [' coding ', 'review'],
             part_persona: 'coder',
             part_allowed_tools: ['Read', 'Edit'],
             part_edit: true,
@@ -205,6 +225,7 @@ describe('normalizeWorkflowConfig team_leader', () => {
       maxTotalParts: 5,
       refillThreshold: 0,
       timeoutMs: 90000,
+      partTags: ['coding', 'review'],
       partPersona: 'coder',
       partPersonaPath: undefined,
       partAllowedTools: ['Read', 'Edit'],
@@ -244,5 +265,23 @@ describe('normalizeWorkflowConfig team_leader', () => {
       partEdit: undefined,
       partPermissionMode: undefined,
     });
+  });
+
+  it('Given a blank team_leader.part_tags entry, When normalizing workflow config, Then it fails fast', () => {
+    const workflowDir = join(process.cwd(), 'src', '__tests__');
+    const raw = {
+      name: 'workflow',
+      steps: [
+        {
+          name: 'implement',
+          team_leader: {
+            part_tags: ['  '],
+          },
+          instruction: 'decompose',
+        },
+      ],
+    };
+
+    expect(() => normalizeWorkflowConfig(raw, workflowDir)).toThrow(/team_leader\.part_tags/);
   });
 });

--- a/src/core/models/part.ts
+++ b/src/core/models/part.ts
@@ -39,6 +39,7 @@ export interface TeamLeaderConfig {
   partPersona?: string;
   /** Resolved absolute path for part persona */
   partPersonaPath?: string;
+  partTags?: string[];
   /** Allowed tools for part agents */
   partAllowedTools?: string[];
   /** Whether part agents can edit files */

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -177,6 +177,7 @@ export const TeamLeaderConfigRawSchema = z.object({
   refill_threshold: z.number().int().min(0).optional(),
   timeout_ms: z.number().int().positive().optional(),
   part_persona: z.string().optional(),
+  part_tags: z.array(z.string().min(1)).optional(),
   part_allowed_tools: z.array(z.string()).optional(),
   part_edit: z.boolean().optional(),
   part_permission_mode: PermissionModeSchema.optional(),

--- a/src/core/workflow/engine/team-leader-common.ts
+++ b/src/core/workflow/engine/team-leader-common.ts
@@ -42,7 +42,7 @@ export function createPartStep(step: WorkflowStep, part: PartDefinition): Workfl
     personaPath: partPersonaPath,
     personaDisplayName: partPersonaDisplayName,
     providerRoutingPersonaKey,
-    tags: step.tags,
+    tags: step.teamLeader.partTags ?? step.tags,
     session: 'refresh',
     providerOptions: step.providerOptions,
     ...('directProviderOptions' in step || 'workflowProviderOptions' in step

--- a/src/infra/config/loaders/workflowStepFeaturesNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepFeaturesNormalizer.ts
@@ -86,6 +86,14 @@ export function normalizeTeamLeader(
 
   const { personaSpec, personaPath } = resolvePersona(raw.persona, sections, workflowDir, context);
   const { personaSpec: partPersona, personaPath: partPersonaPath } = resolvePersona(raw.part_persona, sections, workflowDir, context);
+  const partTags = raw.part_tags?.map((tag) => {
+    const normalizedTag = tag.trim();
+    if (normalizedTag.length === 0) {
+      throw new Error('team_leader.part_tags contains an empty entry');
+    }
+    return normalizedTag;
+  });
+
   return {
     persona: personaSpec,
     personaPath,
@@ -95,6 +103,7 @@ export function normalizeTeamLeader(
     timeoutMs: raw.timeout_ms ?? 900000,
     partPersona,
     partPersonaPath,
+    partTags,
     partAllowedTools: raw.part_allowed_tools,
     partEdit: raw.part_edit,
     partPermissionMode: raw.part_permission_mode,


### PR DESCRIPTION
## Summary

## 背景

`provider_routing.tags.coding` で coding step を OpenCode/Ollama Cloud に流すと、`team_leader` step の親実行も同じ `coding` tag で routing される。

`team_leader` の親実行は、実装そのものではなく part 分解 JSON を作る coordinator/leader 処理であり、実装 part よりも structured output の安定性が重要になる。弱い/不安定な model に流すと、空配列などを返して `Team leader JSON must contain at least one part` で workflow が止まる。

実際に `draft` workflow の `implement` step が `tags: [coding]` だったため、親の team leader 分解も OpenCode/Ollama に流れ、以下のような出力で abort した。

```text
Without access to the task files ..., I cannot determine the specific decomposition.
```json
[]
```

## 現状の問題

現在は `team_leader` 親 step と生成される part step の routing を分ける口がない。

さらに `createPartStep()` は親 step の tags を part にそのまま引き継いでいる。

```ts
// src/core/workflow/engine/team-leader-common.ts
tags: step.tags,
```

そのため、親に `leader` tag を追加して Codex に戻そうとしても、part も同じ tag を継承し、part まで Codex に流れてしまう。

## やりたいこと

`team_leader` 親 step と part step に別々の tags/provider routing を設定できるようにする。

代表的には以下を可能にしたい。

```yaml
- name: implement
  tags:
    - leader
  team_leader:
    part_tags:
      - coding
    part_persona: coder
    part_edit: true
```

```yaml
provider_routing:
  tags:
    leader:
      provider: codex
      model: gpt-5.5
    coding:
      provider: opencode
      model: ollama-cloud/qwen3-coder-next
```

この場合:

- team leader 親 step: `leader` tag で Codex に routing
- generated part step: `coding` tag で OpenCode/Ollama に routing

## 仕様案

### 1. `team_leader.part_tags` を追加する

```yaml
team_leader:
  part_tags:
    - coding
```

- `part_tags` は string array
- 空文字は禁止
- 指定された場合、part step の `tags` は `part_tags` を使う
- 未指定の場合は後方互換のため現在どおり親 step の `tags` を継承する

### 2. parent tags は通常の step tags として維持する

```yaml
- name: implement
  tags:
    - leader
  team_leader:
    part_tags:
      - coding
```

親 step は `tags: [leader]` のみで routing される。

### 3. provider_routing の優先順位は既存どおり

既存の優先順位は維持する。

```text
step direct > provider_routing.steps > provider_routing.tags > provider_routing.personas > persona_providers > workflow/global fallback
```

part step は生成後の step 名と `part_tags` で通常どおり解決される。

### 4. part persona routing との併用

既存どおり、`part_persona` がある場合は `providerRoutingPersonaKey` に `part_persona` を使う。

`part_tags` は persona routing より優先される tags routing として使う。

## 実装箇所候補

- schema: `TeamLeaderConfigRawSchema`
- type: `TeamLeaderConfig`
- normalizer: `normalizeTeamLeader()`
- part step generation: `createPartStep()`
- tests:
  - schema loader test
  - provider routing test for team_leader parent/part split
  - engine/team leader part generation test if needed

## 期待される実装イメージ

```ts
// createPartStep()
tags: step.teamLeader.partTags ?? step.tags,
```

## 完了条件

- `team_leader.part_tags` を workflow YAML で指定できる
- parent step の `tags` と part step の `tags` を別々に routing できる
- `part_tags` 未指定時は既存挙動を維持する
- `part_tags` の invalid value は schema/normalization で明確にエラーになる
- provider routing test で以下を確認する
  - parent `tags: [leader]` は Codex に routing
  - part `part_tags: [coding]` は OpenCode/Ollama に routing
- builtin `draft` workflow などで、team leader 親を安定 model、part を coding model に分けられる

## Execution Report

Workflow `takt-default` completed successfully.

Closes #854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * チームリーダーステップでパート生成時に`part_tags`を設定可能に。親ステップとは異なるタグをパートに割り当てでき、より細かいプロバイダ/モデルルーティング制御が実現します。

* **Documentation**
  * チームリーダーステップの`part_tags`動作および優先順位に関する説明を拡張。

* **Tests**
  * プロバイダルーティングとチームリーダー機能の包括的なテストケースを追加し、機能の信頼性を強化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->