### PR TITLE
[codex] update faceted-prompting dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-DwPC0QQXFDEVNmLPaLOlVQW2KrowZq2b3IRBpucNb/k=";
+            npmDepsHash = "sha256-54o5yTLiPDVHc2f9UCtOsDsAqkvfmX+47lFoMN0YLYI=";
             nodejs = nodejs;
 
             meta = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "cross-spawn": "^7.0.6",
-        "faceted-prompting": "^0.1.0",
+        "faceted-prompting": "^0.5.0",
         "traced-config": "^0.3.0",
         "update-notifier": "^7.3.1",
         "wanakana": "^5.3.1",
@@ -46,7 +46,7 @@
         "vitest": "^2.0.0"
       },
       "engines": {
-        "node": ">=18.19.0"
+        "node": ">=20.6.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -3548,12 +3548,32 @@
       }
     },
     "node_modules/faceted-prompting": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/faceted-prompting/-/faceted-prompting-0.1.0.tgz",
-      "integrity": "sha512-nFXVRwIvIWgVMLGlY2XO83D/BRSJ177ecIqyARisxHsUWBnJXpGSRIIe/O+Nbp+YMRRCaMwC04bxUaRFRpM4kw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/faceted-prompting/-/faceted-prompting-0.5.0.tgz",
+      "integrity": "sha512-pP6Nd07KSn1cwH6yMDqszSx/J9JSx1FkmucvWMBFKiavxD18QBjQ56QgQSbmGeRp2lxDtRnHALnp03Kk78N84g==",
       "license": "MIT",
+      "dependencies": {
+        "traced-config": "^0.1.0",
+        "update-notifier": "^7.3.1",
+        "yaml": "^2.9.0"
+      },
+      "bin": {
+        "facet": "bin/facet"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/faceted-prompting/node_modules/traced-config": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/traced-config/-/traced-config-0.1.0.tgz",
+      "integrity": "sha512-GW8EZPMEDNWQfAubJ5qU5hVk5DawKRPrysQQlztsIuGIUsNWV51/Rc5RXViD5xbhFPeSqqwcRnVIStfpjm2JaA==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5635,9 +5655,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "traced-config": "^0.3.0",
     "update-notifier": "^7.3.1",
     "wanakana": "^5.3.1",
-    "yaml": "^2.8.3",
+    "yaml": "^2.9.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "homepage": "https://github.com/nrslib/takt#readme",
   "type": "module",
   "engines": {
-    "node": ">=18.19.0"
+    "node": ">=20.6.0"
   },
   "files": [
     "dist/",
@@ -89,7 +89,7 @@
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "cross-spawn": "^7.0.6",
-    "faceted-prompting": "^0.1.0",
+    "faceted-prompting": "^0.5.0",
     "traced-config": "^0.3.0",
     "update-notifier": "^7.3.1",
     "wanakana": "^5.3.1",

--- a/src/__tests__/dependency-versions.test.ts
+++ b/src/__tests__/dependency-versions.test.ts
@@ -137,7 +137,7 @@ describe('dependency versions', () => {
     }
   });
 
-  it('declares Node support compatible with OpenTelemetry dependency engines', () => {
+  it('declares Node support compatible with runtime dependency engines', () => {
     const packageJson = readPackageJson();
     const packageLock = readPackageLock();
     const dependencies = packageJson.dependencies;
@@ -149,21 +149,10 @@ describe('dependency versions', () => {
       throw new Error('package.json engines.node is required');
     }
 
-    expect(rootNodeRange).toBe('>=18.19.0');
+    expect(rootNodeRange).toBe('>=20.6.0');
 
     const rootMinimum = getMinimumNodeVersion(rootNodeRange);
-    const otelDependencies = [
-      '@opentelemetry/api',
-      '@opentelemetry/exporter-metrics-otlp-http',
-      '@opentelemetry/exporter-trace-otlp-http',
-      '@opentelemetry/sdk-metrics',
-      '@opentelemetry/sdk-node',
-      '@opentelemetry/sdk-trace-base',
-    ] as const;
-    const incompatibleDependencies = otelDependencies.flatMap((dependencyName) => {
-      if (!dependencies[dependencyName]) {
-        throw new Error(`${dependencyName} is missing from package.json dependencies`);
-      }
+    const incompatibleDependencies = Object.keys(dependencies).sort().flatMap((dependencyName) => {
       const lockedPackage = getLockedPackage(packageLock, `node_modules/${dependencyName}`);
       const dependencyNodeRange = lockedPackage.engines?.node;
       if (!dependencyNodeRange) {
@@ -181,10 +170,10 @@ describe('dependency versions', () => {
     expect(incompatibleDependencies).toEqual([]);
   });
 
-  it('locks yaml to the patched 2.8.3 release', () => {
+  it('locks yaml to the patched 2.9.0 release', () => {
     const packageLock = readPackageLock();
 
-    expect(packageLock.packages?.['node_modules/yaml']?.version).toBe('2.8.3');
+    expect(packageLock.packages?.['node_modules/yaml']?.version).toBe('2.9.0');
   });
 
   it('locks runtime transitive dependencies to patched security releases', () => {

--- a/src/__tests__/dependency-versions.test.ts
+++ b/src/__tests__/dependency-versions.test.ts
@@ -173,8 +173,10 @@ describe('dependency versions', () => {
   });
 
   it('locks yaml to the patched 2.9.0 release', () => {
+    const packageJson = readPackageJson();
     const packageLock = readPackageLock();
 
+    expect(packageJson.dependencies?.yaml).toBe('^2.9.0');
     expect(packageLock.packages?.['node_modules/yaml']?.version).toBe('2.9.0');
   });
 
@@ -190,7 +192,7 @@ describe('dependency versions', () => {
     expect(getLockedPackage(packageLock, 'node_modules/qs').version).toBe('6.15.2');
   });
 
-  it('locks test runner transitive dependencies to Node 18 compatible patched security releases', () => {
+  it('locks test runner transitive dependencies to patched security releases', () => {
     const packageJson = readPackageJson();
     const packageLock = readPackageLock();
 


### PR DESCRIPTION
## Summary

- Raise TAKT's Node engine floor to `>=20.6.0` to match runtime dependency requirements.
- Update `faceted-prompting` from `^0.1.0` to `^0.5.0` so TAKT can consume the latest prompt composition APIs.
- Refresh dependency-version tests for the new runtime engine floor and `yaml@2.9.0` lock.
- Align TAKT's direct `yaml` dependency range with the locked patched release.

## Validation

- `npm run build`
- `npx vitest run src/__tests__/dependency-versions.test.ts`
- `npm test` (496 files / 7008 tests)
- `git diff --check`

## Notes

Local `git push` is unavailable in this environment because GitHub HTTPS credentials are not configured, so the final PR branch updates were applied through the GitHub connector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Node.js の最小バージョン要件を更新しました
  * 複数の依存パッケージをアップデートしました
  * ビルド設定とテスト検証を最新化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->