### PR TITLE
[#862] fix-takt-gitignore

### DIFF
--- a/e2e/specs/list-non-interactive.e2e.ts
+++ b/e2e/specs/list-non-interactive.e2e.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
@@ -226,10 +226,13 @@ describe('E2E: List tasks non-interactive (takt list)', () => {
       stdio: 'pipe',
     }).trim();
     expect(rootBranch).toContain(taskMeta.branch!);
-    execFileSync('git', ['branch', '-D', taskMeta.branch!], {
-      cwd: testRepo.path,
-      stdio: 'pipe',
-    });
+    execFileSync('git', ['add', '.takt/.gitignore'], { cwd: testRepo.path, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-m', 'test: track takt gitignore fixture'], { cwd: testRepo.path, stdio: 'pipe' });
+    execFileSync('git', ['checkout', taskMeta.branch!], { cwd: testRepo.path, stdio: 'pipe' });
+    appendFileSync(join(testRepo.path, 'README.md'), '\nE2E try merge passed\n', 'utf-8');
+    execFileSync('git', ['add', 'README.md'], { cwd: testRepo.path, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-m', 'test: add try merge fixture'], { cwd: testRepo.path, stdio: 'pipe' });
+    execFileSync('git', ['checkout', testRepo.branch], { cwd: testRepo.path, stdio: 'pipe' });
 
     const result = runTakt({
       args: ['list', '--non-interactive', '--action', 'try', '--branch', taskMeta.branch!],
@@ -251,7 +254,7 @@ describe('E2E: List tasks non-interactive (takt list)', () => {
       stdio: 'pipe',
     }).trim();
     expect(restoredBranch).toContain(taskMeta.branch!);
-    expect(stagedFiles.trim()).not.toBe('');
+    expect(stagedFiles.trim()).toBe('README.md');
   }, 240_000);
 
   it('should create a completed worktree task via mock run and merge from root', () => {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-tANxI74gnVXj594OTSVNWqRkrqPE6Unl2XJu1pzlmhs=";
+            npmDepsHash = "sha256-DwPC0QQXFDEVNmLPaLOlVQW2KrowZq2b3IRBpucNb/k=";
             nodejs = nodejs;
 
             meta = {

--- a/src/__tests__/claude-mcp-config.test.ts
+++ b/src/__tests__/claude-mcp-config.test.ts
@@ -1,5 +1,7 @@
 import { access, readFile, rm, stat } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { prepareClaudeMcpConfig } from '../infra/claude/mcp-config.js';
 
@@ -37,5 +39,37 @@ describe('prepareClaudeMcpConfig', () => {
 
     await prepared.cleanup();
     await expect(access(prepared.path!)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('Given TMPDIR points to a missing directory, When preparing MCP config, Then mkdtemp succeeds', async () => {
+    const originalTmpDir = process.env.TMPDIR;
+    const parentDir = mkdtempSync(join(tmpdir(), 'takt-claude-mcp-parent-'));
+    const missingTmpDir = join(parentDir, 'missing-tmp');
+    tempDirs.push(parentDir);
+    process.env.TMPDIR = missingTmpDir;
+
+    try {
+      const prepared = await prepareClaudeMcpConfig({
+        docs: { type: 'stdio', command: 'docs-mcp' },
+      });
+      expect(prepared.path).toMatch(/mcp-config\.json$/);
+      expect(prepared.path?.startsWith(missingTmpDir)).toBe(true);
+
+      const content = JSON.parse(await readFile(prepared.path!, 'utf-8'));
+      expect(content).toEqual({
+        mcpServers: {
+          docs: { type: 'stdio', command: 'docs-mcp' },
+        },
+      });
+
+      await prepared.cleanup();
+      await expect(access(prepared.path!)).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      if (originalTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = originalTmpDir;
+      }
+    }
   });
 });

--- a/src/__tests__/clipboardImage.test.ts
+++ b/src/__tests__/clipboardImage.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: mockExecFile,
+}));
+
+import { readClipboardImage } from '../features/interactive/clipboardImage.js';
+
+type ExecFilePromisified = (
+  file: string,
+  args: string[],
+  options: { timeout: number; maxBuffer: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+let originalTmpDir: string | undefined;
+const tempRoots = new Set<string>();
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+}
+
+function setExecFilePromisified(implementation: ExecFilePromisified): void {
+  const execFileWithPromisify = mockExecFile as unknown as {
+    [promisify.custom]: ExecFilePromisified;
+  };
+  execFileWithPromisify[promisify.custom] = implementation;
+}
+
+describe('readClipboardImage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalTmpDir = process.env.TMPDIR;
+    setPlatform('darwin');
+  });
+
+  afterEach(() => {
+    if (originalPlatform === undefined) {
+      delete (process as NodeJS.Process & { platform?: NodeJS.Platform }).platform;
+    } else {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+    if (originalTmpDir === undefined) {
+      delete process.env.TMPDIR;
+    } else {
+      process.env.TMPDIR = originalTmpDir;
+    }
+    for (const root of tempRoots) {
+      rmSync(root, { recursive: true, force: true });
+    }
+    tempRoots.clear();
+  });
+
+  it('should create a missing TMPDIR before reading clipboard image data', async () => {
+    const parentDir = mkdtempSync(join(tmpdir(), 'takt-clipboard-missing-tmp-parent-'));
+    tempRoots.add(parentDir);
+    const missingTmpDir = join(parentDir, 'missing', 'tmp');
+    process.env.TMPDIR = missingTmpDir;
+
+    const execFileAsync = vi.fn(async (file: string, args: string[]) => {
+      if (file !== 'osascript') {
+        throw new Error(`Unexpected clipboard command: ${file}`);
+      }
+      expect(existsSync(missingTmpDir)).toBe(true);
+      const pngPath = args[args.length - 2];
+      if (pngPath === undefined) {
+        throw new Error('Clipboard PNG path was not provided.');
+      }
+      writeFileSync(pngPath, Buffer.from('png-data'));
+      return { stdout: 'png\n', stderr: '' };
+    });
+    setExecFilePromisified(execFileAsync);
+
+    const image = await readClipboardImage();
+
+    expect(image).toEqual({
+      mimeType: 'image/png',
+      data: Buffer.from('png-data'),
+    });
+    expect(execFileAsync).toHaveBeenCalledWith(
+      'osascript',
+      expect.any(Array),
+      { timeout: 10_000, maxBuffer: 1024 * 1024 },
+    );
+  });
+});

--- a/src/__tests__/copilot-client.test.ts
+++ b/src/__tests__/copilot-client.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { EventEmitter } from 'node:events';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockSpawn, mockMkdtemp, mockReadFile, mockRm } = vi.hoisted(() => ({
@@ -496,6 +499,65 @@ describe('callCopilot', () => {
 
     expect(result.status).toBe('done');
     expect(result.sessionId).toBe('existing-session-id');
+  });
+
+  it('should create a missing TMPDIR before preparing the share file', async () => {
+    const originalTmpDir = process.env.TMPDIR;
+    const parentDir = mkdtempSync(join(tmpdir(), 'takt-copilot-missing-tmp-parent-'));
+    const missingTmpDir = join(parentDir, 'missing', 'tmp');
+    process.env.TMPDIR = missingTmpDir;
+    mockMkdtemp.mockImplementationOnce(async (prefix: string) => {
+      expect(prefix).toBe(join(missingTmpDir, 'takt-copilot-'));
+      expect(existsSync(missingTmpDir)).toBe(true);
+      return join(missingTmpDir, 'takt-copilot-share');
+    });
+    mockSpawnWithScenario({
+      stdout: 'done',
+      code: 0,
+    });
+
+    try {
+      const result = await callCopilot('coder', 'implement feature', { cwd: '/repo' });
+
+      expect(result.status).toBe('done');
+      expect(mockMkdtemp).toHaveBeenCalledWith(join(missingTmpDir, 'takt-copilot-'));
+    } finally {
+      if (originalTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = originalTmpDir;
+      }
+      rmSync(parentDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should continue without --share when TMPDIR cannot be created', async () => {
+    const originalTmpDir = process.env.TMPDIR;
+    const parentDir = mkdtempSync(join(tmpdir(), 'takt-copilot-invalid-tmp-parent-'));
+    const fileTmpDir = join(parentDir, 'tmp-file');
+    writeFileSync(fileTmpDir, 'not a directory\n', 'utf-8');
+    process.env.TMPDIR = fileTmpDir;
+    mockSpawnWithScenario({
+      stdout: 'done',
+      code: 0,
+    });
+
+    try {
+      const result = await callCopilot('coder', 'implement feature', { cwd: '/repo' });
+      const [, args] = mockSpawn.mock.calls[0] as [string, string[]];
+
+      expect(result.status).toBe('done');
+      expect(mockMkdtemp).not.toHaveBeenCalled();
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+      expect(args).not.toContain('--share');
+    } finally {
+      if (originalTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = originalTmpDir;
+      }
+      rmSync(parentDir, { recursive: true, force: true });
+    }
   });
 
   it('should redact credentials from error stderr', async () => {

--- a/src/__tests__/it-dotgitignore.test.ts
+++ b/src/__tests__/it-dotgitignore.test.ts
@@ -3,7 +3,7 @@
  *
  * Verifies that .takt/.gitignore patterns correctly track facet directories
  * (workflows, personas, policies, knowledge, instructions, output-contracts)
- * while ignoring runtime directories (tasks, logs, runs, completed).
+ * while ignoring runtime directories (tasks, logs, runs, completed, .runtime).
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -96,7 +96,7 @@ describe('dotgitignore patterns', () => {
   });
 
   it('should ignore runtime directories', () => {
-    const runtimeDirs = ['tasks', 'completed', 'logs', 'runs'];
+    const runtimeDirs = ['tasks', 'completed', 'logs', 'runs', '.runtime'];
     for (const dir of runtimeDirs) {
       mkdirSync(join(testDir, '.takt', dir), { recursive: true });
       writeFileSync(join(testDir, '.takt', dir, 'data.json'), '{}');
@@ -109,5 +109,21 @@ describe('dotgitignore patterns', () => {
       const runtimeFiles = tracked.filter(f => f.startsWith(`.takt/${dir}/`));
       expect(runtimeFiles).toEqual([]);
     }
+  });
+
+  it('Given runtime artifacts exist under .takt, When git status is checked, Then runtime and runs are ignored', () => {
+    mkdirSync(join(testDir, '.takt', '.runtime', 'tmp'), { recursive: true });
+    mkdirSync(join(testDir, '.takt', 'runs', 'test-run', 'reports'), { recursive: true });
+    writeFileSync(join(testDir, '.takt', '.runtime', 'tmp', 'cache.txt'), 'cache');
+    writeFileSync(join(testDir, '.takt', 'runs', 'test-run', 'reports', 'test-report.md'), '# Report');
+
+    const status = execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+    });
+
+    expect(status).toContain('.takt/.gitignore');
+    expect(status).not.toContain('.takt/.runtime/');
+    expect(status).not.toContain('.takt/runs/');
   });
 });

--- a/src/__tests__/it-stage-and-commit.test.ts
+++ b/src/__tests__/it-stage-and-commit.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
@@ -76,6 +76,30 @@ describe('stageAndCommit', () => {
     }).trim();
 
     expect(committedFiles).toBe('app.ts');
+  });
+
+  it('should commit .takt/.gitignore while leaving runtime artifacts uncommitted', () => {
+    const dotgitignore = readFileSync(join(__dirname, '..', '..', 'builtins', 'project', 'dotgitignore'), 'utf-8');
+    mkdirSync(join(testDir, '.takt', '.runtime', 'tmp'), { recursive: true });
+    mkdirSync(join(testDir, '.takt', 'runs', 'test-run', 'reports'), { recursive: true });
+    writeFileSync(join(testDir, '.takt', '.gitignore'), dotgitignore, 'utf-8');
+    writeFileSync(join(testDir, '.takt', '.runtime', 'tmp', 'cache.txt'), 'cache', 'utf-8');
+    writeFileSync(join(testDir, '.takt', 'runs', 'test-run', 'reports', 'test-report.md'), '# Report', 'utf-8');
+    writeFileSync(join(testDir, 'src.ts'), 'export const x = 1;', 'utf-8');
+
+    const hash = stageAndCommit(testDir, 'add worktree gitignore');
+    expect(hash).toBeDefined();
+
+    const committedFiles = execFileSync('git', ['diff-tree', '--no-commit-id', '-r', '--name-only', 'HEAD'], {
+      cwd: testDir,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    }).trim().split('\n').filter(Boolean).sort();
+
+    expect(committedFiles).toContain('.takt/.gitignore');
+    expect(committedFiles).toContain('src.ts');
+    expect(committedFiles).not.toContain('.takt/.runtime/tmp/cache.txt');
+    expect(committedFiles).not.toContain('.takt/runs/test-run/reports/test-report.md');
   });
 
   it('should return undefined when there are no changes', () => {

--- a/src/__tests__/projectLocalTaktSync.test.ts
+++ b/src/__tests__/projectLocalTaktSync.test.ts
@@ -1,24 +1,38 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { syncProjectLocalTaktForRetry } from '../infra/task/projectLocalTaktSync.js';
+import { ensureWorktreeTaktGitignore, syncProjectLocalTaktForRetry } from '../infra/task/projectLocalTaktSync.js';
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function readBuiltinProjectDotgitignore(): string {
+  return readFileSync(join(__dirname, '..', '..', 'builtins', 'project', 'dotgitignore'), 'utf-8');
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe('syncProjectLocalTaktForRetry', () => {
-  const tempDirs: string[] = [];
-
-  function createTempDir(prefix: string): string {
-    const dir = mkdtempSync(join(tmpdir(), prefix));
-    tempDirs.push(dir);
-    return dir;
-  }
-
-  afterEach(() => {
-    for (const dir of tempDirs.splice(0)) {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
   it('should sync .takt/quality-gates along with config.yaml for retry worktrees', () => {
     const projectDir = createTempDir('takt-sync-project-');
     const worktreePath = createTempDir('takt-sync-worktree-');
@@ -37,6 +51,45 @@ describe('syncProjectLocalTaktForRetry', () => {
     expect(readFileSync(join(worktreePath, '.takt', 'quality-gates', 'check.sh'), 'utf-8')).toBe(
       '#!/usr/bin/env bash\nnpm test\n',
     );
+  });
+
+  it('should create worktree .takt/.gitignore during retry sync', () => {
+    const projectDir = createTempDir('takt-sync-project-');
+    const worktreePath = createTempDir('takt-sync-worktree-');
+    mkdirSync(join(projectDir, '.takt'), { recursive: true });
+
+    syncProjectLocalTaktForRetry(projectDir, worktreePath);
+
+    expect(readFileSync(join(worktreePath, '.takt', '.gitignore'), 'utf-8')).toBe(readBuiltinProjectDotgitignore());
+  });
+
+  it('should preserve existing worktree .takt/.gitignore during retry sync', () => {
+    const projectDir = createTempDir('takt-sync-project-');
+    const worktreePath = createTempDir('takt-sync-worktree-');
+    const existing = '# custom ignore\nruns/\n';
+    mkdirSync(join(projectDir, '.takt'), { recursive: true });
+    mkdirSync(join(worktreePath, '.takt'), { recursive: true });
+    writeFileSync(join(worktreePath, '.takt', '.gitignore'), existing, 'utf-8');
+
+    syncProjectLocalTaktForRetry(projectDir, worktreePath);
+
+    expect(readFileSync(join(worktreePath, '.takt', '.gitignore'), 'utf-8')).toBe(existing);
+  });
+
+  it('should fail before creating worktree .takt/.gitignore when project .takt is a file', () => {
+    const projectDir = createTempDir('takt-sync-project-');
+    const worktreePath = createTempDir('takt-sync-worktree-');
+    const sourceTaktPath = join(projectDir, '.takt');
+    const targetTaktPath = join(worktreePath, '.takt');
+    const targetGitignorePath = join(worktreePath, '.takt', '.gitignore');
+    writeFileSync(sourceTaktPath, 'not a directory\n', 'utf-8');
+
+    expect(() => syncProjectLocalTaktForRetry(projectDir, worktreePath)).toThrow(
+      `Project-local .takt must be a directory: ${sourceTaktPath}`,
+    );
+
+    expect(existsSync(targetTaktPath)).toBe(false);
+    expect(existsSync(targetGitignorePath)).toBe(false);
   });
 
   it('should remove stale quality-gates directory when the project no longer has one', () => {
@@ -66,5 +119,112 @@ describe('syncProjectLocalTaktForRetry', () => {
       '#!/usr/bin/env bash\nexit 0\n',
     );
     expect(existsSync(join(worktreePath, '.takt', 'quality-gates', 'logs'))).toBe(false);
+  });
+});
+
+describe('ensureWorktreeTaktGitignore', () => {
+  it('Given a worktree without .takt/.gitignore, When ensuring takt gitignore, Then built-in project gitignore is created', () => {
+    const worktreePath = createTempDir('takt-gitignore-worktree-');
+
+    ensureWorktreeTaktGitignore(worktreePath);
+
+    expect(readFileSync(join(worktreePath, '.takt', '.gitignore'), 'utf-8')).toBe(readBuiltinProjectDotgitignore());
+  });
+
+  it('Given a worktree with existing .takt/.gitignore, When ensuring takt gitignore, Then existing content is preserved', () => {
+    const worktreePath = createTempDir('takt-gitignore-worktree-');
+    const taktDir = join(worktreePath, '.takt');
+    const existing = '# custom ignore\nruns/\n';
+    mkdirSync(taktDir, { recursive: true });
+    writeFileSync(join(taktDir, '.gitignore'), existing, 'utf-8');
+
+    ensureWorktreeTaktGitignore(worktreePath);
+
+    expect(readFileSync(join(taktDir, '.gitignore'), 'utf-8')).toBe(existing);
+  });
+
+  it('Given a missing worktree path, When ensuring takt gitignore, Then it fails before creating files', () => {
+    const parentDir = createTempDir('takt-gitignore-parent-');
+    const missingWorktreePath = join(parentDir, 'missing-worktree');
+
+    expect(() => ensureWorktreeTaktGitignore(missingWorktreePath)).toThrow(
+      `Worktree path must be an existing directory: ${missingWorktreePath}`,
+    );
+    expect(existsSync(missingWorktreePath)).toBe(false);
+  });
+
+  it('Given .takt is a file, When ensuring takt gitignore, Then it fails without replacing it', () => {
+    const worktreePath = createTempDir('takt-gitignore-worktree-');
+    const taktPath = join(worktreePath, '.takt');
+    writeFileSync(taktPath, 'not a directory\n', 'utf-8');
+
+    expect(() => ensureWorktreeTaktGitignore(worktreePath)).toThrow(
+      `Worktree .takt must be a directory or missing: ${taktPath}`,
+    );
+
+    expect(readFileSync(taktPath, 'utf-8')).toBe('not a directory\n');
+  });
+
+  it('Given .takt is a symlink, When ensuring takt gitignore, Then it fails without replacing it', () => {
+    const worktreePath = createTempDir('takt-gitignore-worktree-');
+    const outsideDir = createTempDir('takt-gitignore-outside-');
+    const taktPath = join(worktreePath, '.takt');
+    symlinkSync(outsideDir, taktPath);
+
+    expect(() => ensureWorktreeTaktGitignore(worktreePath)).toThrow(
+      `Worktree .takt must be a directory or missing: ${taktPath}`,
+    );
+
+    expect(lstatSync(taktPath).isSymbolicLink()).toBe(true);
+  });
+
+  it('Given a broken .takt/.gitignore symlink, When ensuring takt gitignore, Then it does not write outside the worktree', () => {
+    const worktreePath = createTempDir('takt-gitignore-worktree-');
+    const outsideDir = createTempDir('takt-gitignore-outside-');
+    const taktDir = join(worktreePath, '.takt');
+    const gitignorePath = join(taktDir, '.gitignore');
+    const externalTarget = join(outsideDir, 'created-through-symlink');
+    mkdirSync(taktDir, { recursive: true });
+    symlinkSync(externalTarget, gitignorePath);
+
+    expect(() => ensureWorktreeTaktGitignore(worktreePath)).toThrow(
+      `Worktree .takt/.gitignore must be a regular file or missing: ${gitignorePath}`,
+    );
+
+    expect(existsSync(externalTarget)).toBe(false);
+    expect(lstatSync(gitignorePath).isSymbolicLink()).toBe(true);
+  });
+
+  it('Given .takt/.gitignore is a directory, When ensuring takt gitignore, Then it fails without replacing it', () => {
+    const worktreePath = createTempDir('takt-gitignore-worktree-');
+    const taktDir = join(worktreePath, '.takt');
+    const gitignorePath = join(taktDir, '.gitignore');
+    mkdirSync(gitignorePath, { recursive: true });
+
+    expect(() => ensureWorktreeTaktGitignore(worktreePath)).toThrow(
+      `Worktree .takt/.gitignore must be a regular file or missing: ${gitignorePath}`,
+    );
+
+    expect(lstatSync(gitignorePath).isDirectory()).toBe(true);
+  });
+
+  it('Given .takt/.gitignore cannot be inspected, When ensuring takt gitignore, Then it fails without creating a partial file', () => {
+    const worktreePath = createTempDir('takt-gitignore-worktree-');
+    const taktDir = join(worktreePath, '.takt');
+    const gitignorePath = join(taktDir, '.gitignore');
+    mkdirSync(taktDir, { recursive: true });
+    chmodSync(taktDir, 0o000);
+
+    let thrown: unknown;
+    try {
+      ensureWorktreeTaktGitignore(worktreePath);
+    } catch (error: unknown) {
+      thrown = error;
+    } finally {
+      chmodSync(taktDir, 0o700);
+    }
+
+    expect((thrown as NodeJS.ErrnoException).code).toMatch(/^(EACCES|EPERM)$/);
+    expect(existsSync(gitignorePath)).toBe(false);
   });
 });

--- a/src/__tests__/repertoire/add.test.ts
+++ b/src/__tests__/repertoire/add.test.ts
@@ -160,6 +160,25 @@ describe('repertoireAddCommand temporary directory handling', () => {
     expect(mockResolveRepertoireConfigPath).toHaveBeenCalledWith(join(secureTempDir, 'extract'));
   });
 
+  it('should create a missing TMPDIR before creating import artifacts', async () => {
+    const originalTmpDir = process.env.TMPDIR;
+    const missingTmpDir = join(tmpdir(), 'takt-repertoire-missing-tmp');
+    process.env.TMPDIR = missingTmpDir;
+
+    try {
+      await repertoireAddCommand('github:owner/repo@main');
+
+      expect(mockMkdirSync).toHaveBeenCalledWith(missingTmpDir, { recursive: true });
+      expect(mockMkdtempSync).toHaveBeenCalledWith(join(missingTmpDir, 'takt-import-'));
+    } finally {
+      if (originalTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = originalTmpDir;
+      }
+    }
+  });
+
   it('should clean up the mkdtemp-created directory once', async () => {
     await repertoireAddCommand('github:owner/repo@main');
 

--- a/src/__tests__/tmpdir.test.ts
+++ b/src/__tests__/tmpdir.test.ts
@@ -1,0 +1,42 @@
+import { existsSync, mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ensureCurrentTmpDirExists } from '../shared/utils/tmpdir.js';
+
+const temporaryDirs: string[] = [];
+
+function createTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirs.push(dir);
+  return dir;
+}
+
+describe('ensureCurrentTmpDirExists', () => {
+  afterEach(() => {
+    for (const dir of temporaryDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('Given TMPDIR points to a missing directory, When ensuring current tmpdir, Then the directory is created and returned', () => {
+    const originalTmpDir = process.env.TMPDIR;
+    const parentDir = createTempDir('takt-tmpdir-parent-');
+    const missingTmpDir = join(parentDir, 'missing', 'tmp');
+    process.env.TMPDIR = missingTmpDir;
+
+    try {
+      const ensuredTmpDir = ensureCurrentTmpDirExists();
+
+      expect(ensuredTmpDir).toBe(missingTmpDir);
+      expect(existsSync(missingTmpDir)).toBe(true);
+      expect(statSync(missingTmpDir).isDirectory()).toBe(true);
+    } finally {
+      if (originalTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = originalTmpDir;
+      }
+    }
+  });
+});

--- a/src/__tests__/traced-config-boundary.test.ts
+++ b/src/__tests__/traced-config-boundary.test.ts
@@ -223,4 +223,33 @@ describe('traced config boundaries', () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('Given TMPDIR points to a missing directory, When runtime bridge loads trace entries, Then mkdtemp succeeds', () => {
+    const originalTmpDir = process.env.TMPDIR;
+    const tempDir = join(tmpdir(), `takt-traced-missing-tmpdir-${randomUUID()}`);
+    const missingTmpDir = join(tempDir, 'missing-tmp');
+    mkdirSync(tempDir, { recursive: true });
+    process.env.TMPDIR = missingTmpDir;
+
+    try {
+      const traceEntries = loadTraceEntriesViaRuntime({
+        provider: {
+          doc: 'provider',
+          format: String,
+          env: 'TAKT_PROVIDER',
+          sources: { global: false, local: true, env: true, cli: false },
+        },
+      }, 'local', { provider: 'codex' });
+
+      expect(traceEntries.get('provider')?.origin).toBe('local');
+      expect(traceEntries.get('provider')?.value).toBe('codex');
+    } finally {
+      if (originalTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = originalTmpDir;
+      }
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/__tests__/workflowExecution-session-loading.test.ts
+++ b/src/__tests__/workflowExecution-session-loading.test.ts
@@ -5,6 +5,9 @@
  * retry runs (startStep / retryNote) load persisted sessions.
  */
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { USAGE_MISSING_REASONS } from '../core/logging/contracts.js';
 import type { WorkflowConfig } from '../core/models/index.js';
@@ -200,7 +203,8 @@ vi.mock('../infra/fs/index.js', () => ({
   appendNdjsonLine: vi.fn(),
 }));
 
-vi.mock('../shared/utils/index.js', () => ({
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   createLogger: vi.fn().mockReturnValue({
     debug: vi.fn(),
     info: vi.fn(),
@@ -290,6 +294,7 @@ function makeConfigWithStep(overrides: Record<string, unknown>): WorkflowConfig 
 }
 
 describe('executeWorkflow session loading', () => {
+  const temporaryDirs: string[] = [];
   const restoredEnvKeys = [
     'TAKT_OBSERVABILITY',
     'OTEL_EXPORTER_OTLP_ENDPOINT',
@@ -333,6 +338,12 @@ describe('executeWorkflow session loading', () => {
     }
   }
 
+  function createTempDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    temporaryDirs.push(dir);
+    return dir;
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     restoreEnv();
@@ -356,6 +367,9 @@ describe('executeWorkflow session loading', () => {
 
   afterEach(() => {
     restoreEnv();
+    for (const dir of temporaryDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('should pass empty initialSessions on normal run', async () => {
@@ -429,20 +443,26 @@ describe('executeWorkflow session loading', () => {
 
   it('should load worktree sessions on retry when cwd differs from projectCwd', async () => {
     // Given: retry execution in a worktree (cwd !== projectCwd)
-    await executeWorkflow(makeConfig(), 'task', '/tmp/worktree', {
-      projectCwd: '/tmp/project',
+    const projectDir = createTempDir('takt-session-project-');
+    const worktreeDir = createTempDir('takt-session-worktree-');
+
+    await executeWorkflow(makeConfig(), 'task', worktreeDir, {
+      projectCwd: projectDir,
       startStep: 'implement',
     });
 
     // Then: loadWorktreeSessions is called instead of loadPersonaSessions
-    expect(mockLoadWorktreeSessions).toHaveBeenCalledWith('/tmp/project', '/tmp/worktree', 'claude');
+    expect(mockLoadWorktreeSessions).toHaveBeenCalledWith(projectDir, worktreeDir, 'claude');
     expect(mockLoadPersonaSessions).not.toHaveBeenCalled();
   });
 
   it('should not load sessions for worktree normal run', async () => {
     // Given: normal execution in a worktree (no retry)
-    await executeWorkflow(makeConfig(), 'task', '/tmp/worktree', {
-      projectCwd: '/tmp/project',
+    const projectDir = createTempDir('takt-session-project-');
+    const worktreeDir = createTempDir('takt-session-worktree-');
+
+    await executeWorkflow(makeConfig(), 'task', worktreeDir, {
+      projectCwd: projectDir,
     });
 
     // Then: neither session loader is called

--- a/src/__tests__/workflowExecution-structured-caller.test.ts
+++ b/src/__tests__/workflowExecution-structured-caller.test.ts
@@ -13,11 +13,14 @@ import { getWorkflowSourcePath } from '../infra/config/loaders/workflowSourceMet
 const {
   MockWorkflowEngine,
   disabledObservability,
+  mockEnsureCurrentTmpDirExists,
   mockGetProvider,
   mockRunAgent,
 } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { EventEmitter: EE } = require('node:events') as typeof import('node:events');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { tmpdir: getTmpdir } = require('node:os') as typeof import('node:os');
 
   class MockWorkflowEngine extends EE {
     static lastInstance: MockWorkflowEngine;
@@ -69,6 +72,7 @@ const {
       sessionLogExporter: false,
       usageEventsPhase: false,
     },
+    mockEnsureCurrentTmpDirExists: vi.fn(() => getTmpdir()),
     mockGetProvider: vi.fn(),
     mockRunAgent: vi.fn(),
   };
@@ -163,6 +167,7 @@ vi.mock('../shared/utils/index.js', () => ({
   writePromptLog: vi.fn(),
   getDebugPromptsLogFile: vi.fn().mockReturnValue(null),
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
+  ensureCurrentTmpDirExists: mockEnsureCurrentTmpDirExists,
   isValidReportDirName: vi.fn().mockReturnValue(true),
   playWarningSound: vi.fn(),
 }));

--- a/src/__tests__/workflowExecutionBootstrapWorktreeGitignore.test.ts
+++ b/src/__tests__/workflowExecutionBootstrapWorktreeGitignore.test.ts
@@ -1,21 +1,17 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkflowConfig } from '../core/models/index.js';
 
 const {
-  mockWriteFileAtomic,
   mockResolveWorkflowConfigValues,
   mockCreateOutputFns,
   mockInitializeOtelFoundation,
-  mockEnsureWorktreeTaktGitignore,
 } = vi.hoisted(() => ({
-  mockWriteFileAtomic: vi.fn(),
   mockResolveWorkflowConfigValues: vi.fn(),
   mockCreateOutputFns: vi.fn(),
   mockInitializeOtelFoundation: vi.fn(),
-  mockEnsureWorktreeTaktGitignore: vi.fn(),
 }));
 
 vi.mock('../infra/config/index.js', () => ({
@@ -25,7 +21,7 @@ vi.mock('../infra/config/index.js', () => ({
   resolveWorkflowConfigValues: mockResolveWorkflowConfigValues,
   updatePersonaSession: vi.fn(),
   updateWorktreeSession: vi.fn(),
-  writeFileAtomic: mockWriteFileAtomic,
+  writeFileAtomic: vi.fn(),
 }));
 
 vi.mock('../infra/config/resolveConfigValue.js', () => ({
@@ -44,7 +40,7 @@ vi.mock('../infra/config/paths.js', () => ({
 vi.mock('../infra/fs/index.js', () => ({
   createSessionLog: vi.fn(() => ({ history: [] })),
   generateSessionId: vi.fn(() => 'session-1'),
-  initNdjsonLog: vi.fn(() => '/project/.takt/runs/direct-resume/logs/session.ndjson'),
+  initNdjsonLog: vi.fn(() => '/project/.takt/runs/worktree-run/logs/session.ndjson'),
 }));
 
 vi.mock('../shared/context.js', () => ({
@@ -64,18 +60,6 @@ vi.mock('../shared/ui/TaskPrefixWriter.js', () => ({
   })),
 }));
 
-vi.mock('../shared/utils/index.js', () => ({
-  createLogger: vi.fn(() => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    error: vi.fn(),
-  })),
-  generateReportDir: vi.fn(() => 'generated-run'),
-  getDebugPromptsLogFile: vi.fn(() => undefined),
-  isValidReportDirName: vi.fn(() => true),
-  preventSleep: vi.fn(),
-}));
-
 vi.mock('../shared/utils/providerEventLogger.js', () => ({
   createProviderEventLogger: vi.fn(() => ({
     wrapCallback: (handler: unknown) => handler,
@@ -90,10 +74,6 @@ vi.mock('../shared/utils/usageEventLogger.js', () => ({
 
 vi.mock('../infra/observability/otelFoundation.js', () => ({
   initializeOtelFoundation: mockInitializeOtelFoundation,
-}));
-
-vi.mock('../infra/task/projectLocalTaktSync.js', () => ({
-  ensureWorktreeTaktGitignore: mockEnsureWorktreeTaktGitignore,
 }));
 
 vi.mock('../features/analytics/index.js', () => ({
@@ -140,17 +120,17 @@ const workflowConfig: WorkflowConfig = {
 
 const temporaryDirs: string[] = [];
 
-function createTempProject(): string {
-  const projectDir = mkdtempSync(join(tmpdir(), 'takt-direct-resume-'));
-  temporaryDirs.push(projectDir);
-  return projectDir;
+function createTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirs.push(dir);
+  return dir;
 }
 
-function hasTasksYamlWrite(): boolean {
-  return mockWriteFileAtomic.mock.calls.some((call) => String(call[0]).endsWith('/.takt/tasks.yaml'));
+function readBuiltinProjectDotgitignore(): string {
+  return readFileSync(join(__dirname, '..', '..', 'builtins', 'project', 'dotgitignore'), 'utf-8');
 }
 
-describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
+describe('createWorkflowExecutionBootstrap worktree gitignore integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateOutputFns.mockReturnValue({
@@ -185,71 +165,9 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     }
   });
 
-  it('Given directResume is passed, When bootstrap creates run meta, Then source metadata is persisted in meta.json', async () => {
-    await createWorkflowExecutionBootstrap(workflowConfig, 'Resume direct run', '/project', {
-      projectCwd: '/project',
-      provider: 'mock',
-      reportDirName: 'direct-resume',
-      directResume: {
-        sourceRunSlug: '20260524-source-run',
-        resumeMode: 'retry',
-      },
-    });
-
-    const metaWrite = mockWriteFileAtomic.mock.calls.find((call) =>
-      call[0] === '/project/.takt/runs/direct-resume/meta.json'
-    );
-    expect(metaWrite).toBeDefined();
-    const meta = JSON.parse(String(metaWrite![1])) as {
-      source_run_slug?: string;
-      resume_mode?: string;
-    };
-    expect(meta.source_run_slug).toBe('20260524-source-run');
-    expect(meta.resume_mode).toBe('retry');
-  });
-
-  it('Given no tasks.yaml exists, When direct resume bootstrap runs, Then tasks.yaml is not created', async () => {
-    const projectDir = createTempProject();
-
-    await createWorkflowExecutionBootstrap(workflowConfig, 'Resume direct run', projectDir, {
-      projectCwd: projectDir,
-      provider: 'mock',
-      reportDirName: 'direct-resume',
-      directResume: {
-        sourceRunSlug: '20260524-source-run',
-        resumeMode: 'requeue',
-      },
-    });
-
-    expect(existsSync(join(projectDir, '.takt', 'tasks.yaml'))).toBe(false);
-    expect(hasTasksYamlWrite()).toBe(false);
-  });
-
-  it('Given tasks.yaml already exists, When direct resume bootstrap runs, Then tasks.yaml remains unchanged', async () => {
-    const projectDir = createTempProject();
-    const tasksDir = join(projectDir, '.takt');
-    const tasksPath = join(tasksDir, 'tasks.yaml');
-    const initialTasks = 'tasks:\n  - name: keep-existing\n    status: pending\n';
-    mkdirSync(tasksDir, { recursive: true });
-    writeFileSync(tasksPath, initialTasks, 'utf-8');
-
-    await createWorkflowExecutionBootstrap(workflowConfig, 'Resume direct run', projectDir, {
-      projectCwd: projectDir,
-      provider: 'mock',
-      reportDirName: 'direct-resume',
-      directResume: {
-        sourceRunSlug: '20260524-source-run',
-        resumeMode: 'instruct',
-      },
-    });
-
-    expect(readFileSync(tasksPath, 'utf-8')).toBe(initialTasks);
-    expect(hasTasksYamlWrite()).toBe(false);
-  });
-
-  it('Given cwd differs from projectCwd, When bootstrap runs, Then worktree .takt/.gitignore is ensured', async () => {
-    const projectDir = createTempProject();
-    const worktreeDir = createTempProject();
+  it('Given cwd differs from projectCwd, When bootstrap runs, Then worktree .takt/.gitignore is created from built-in template', async () => {
+    const projectDir = createTempDir('takt-bootstrap-project-');
+    const worktreeDir = createTempDir('takt-bootstrap-worktree-');
 
     await createWorkflowExecutionBootstrap(workflowConfig, 'Run in worktree', worktreeDir, {
       projectCwd: projectDir,
@@ -257,19 +175,19 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
       reportDirName: 'worktree-run',
     });
 
-    expect(mockEnsureWorktreeTaktGitignore).toHaveBeenCalledTimes(1);
-    expect(mockEnsureWorktreeTaktGitignore).toHaveBeenCalledWith(worktreeDir);
+    expect(readFileSync(join(worktreeDir, '.takt', '.gitignore'), 'utf-8')).toBe(readBuiltinProjectDotgitignore());
   });
 
-  it('Given cwd equals projectCwd, When bootstrap runs, Then worktree .takt/.gitignore is not ensured', async () => {
-    const projectDir = createTempProject();
+  it('Given worktree cwd and invalid reportDirName, When bootstrap rejects, Then worktree .takt is not created', async () => {
+    const projectDir = createTempDir('takt-bootstrap-project-');
+    const worktreeDir = createTempDir('takt-bootstrap-worktree-');
 
-    await createWorkflowExecutionBootstrap(workflowConfig, 'Run in project', projectDir, {
+    await expect(createWorkflowExecutionBootstrap(workflowConfig, 'Run in worktree', worktreeDir, {
       projectCwd: projectDir,
       provider: 'mock',
-      reportDirName: 'project-run',
-    });
+      reportDirName: '../invalid',
+    })).rejects.toThrow('Invalid reportDirName: ../invalid');
 
-    expect(mockEnsureWorktreeTaktGitignore).not.toHaveBeenCalled();
+    expect(existsSync(join(worktreeDir, '.takt'))).toBe(false);
   });
 });

--- a/src/commands/repertoire/add.ts
+++ b/src/commands/repertoire/add.ts
@@ -8,7 +8,6 @@
 
 import { mkdirSync, mkdtempSync, copyFileSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { stringify as stringifyYaml } from 'yaml';
@@ -45,7 +44,7 @@ import {
 import { getScopedProviderOptionsCandidateKey } from '../../infra/config/loaders/providerOptionsLookupDirectories.js';
 import { confirm } from '../../shared/prompt/index.js';
 import { info, success } from '../../shared/ui/index.js';
-import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
+import { createLogger, ensureCurrentTmpDirExists, getErrorMessage } from '../../shared/utils/index.js';
 
 const require = createRequire(import.meta.url);
 const { version: TAKT_VERSION } = require('../../../package.json') as { version: string };
@@ -81,7 +80,7 @@ export async function repertoireAddCommand(spec: string): Promise<void> {
 
   const ref = resolveRef(specRef, owner, repo, execGh);
 
-  const tmpBase = mkdtempSync(join(tmpdir(), 'takt-import-'));
+  const tmpBase = mkdtempSync(join(ensureCurrentTmpDirExists(), 'takt-import-'));
   const tmpTarPath = join(tmpBase, 'archive.tar.gz');
   const tmpExtractDir = join(tmpBase, 'extract');
   const tmpIncludeFile = join(tmpBase, 'include.txt');

--- a/src/features/interactive/clipboardImage.ts
+++ b/src/features/interactive/clipboardImage.ts
@@ -1,8 +1,8 @@
 import * as childProcess from 'node:child_process';
 import { promisify } from 'node:util';
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
+import { ensureCurrentTmpDirExists } from '../../shared/utils/index.js';
 import { MAX_INLINE_IMAGE_BYTES, type PastedImage } from './inlineImagePaste.js';
 
 const CLIPBOARD_COMMAND_TIMEOUT_MS = 10_000;
@@ -61,7 +61,7 @@ async function execClipboardCommand(file: string, args: string[]): Promise<{ std
 }
 
 async function readMacOSClipboardImage(): Promise<PastedImage> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'takt-clipboard-image-'));
+  const tempDir = await mkdtemp(path.join(ensureCurrentTmpDirExists(), 'takt-clipboard-image-'));
   const pngPath = path.join(tempDir, 'clipboard.png');
   const tiffPath = path.join(tempDir, 'clipboard.tiff');
 

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -32,6 +32,7 @@ import { createUsageEventLogger, isUsageEventsEnabled } from '../../../shared/ut
 import { initializeOtelFoundation, type OtelFoundationHandle } from '../../../infra/observability/otelFoundation.js';
 import { PHASE_USAGE_EVENTS_LOG_FILE_SUFFIX } from '../../../core/logging/contracts.js';
 import { initAnalyticsWriter } from '../../analytics/index.js';
+import { ensureWorktreeTaktGitignore } from '../../../infra/task/projectLocalTaktSync.js';
 import { AnalyticsEmitter } from './analyticsEmitter.js';
 import { createOutputFns, createPrefixedStreamHandler } from './outputFns.js';
 import { RunMetaManager } from './runMeta.js';
@@ -124,6 +125,9 @@ export async function createWorkflowExecutionBootstrap(
   const runSlug = options.reportDirName ?? generateReportDir(task);
   if (!isValidReportDirName(runSlug)) {
     throw new Error(`Invalid reportDirName: ${runSlug}`);
+  }
+  if (isWorktree) {
+    ensureWorktreeTaktGitignore(cwd);
   }
 
   const runPaths = buildRunPaths(cwd, runSlug);

--- a/src/infra/claude/mcp-config.ts
+++ b/src/infra/claude/mcp-config.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { McpServerConfig } from '../../core/models/index.js';
+import { ensureCurrentTmpDirExists } from '../../shared/utils/index.js';
 
 export interface PreparedClaudeMcpConfig {
   path?: string;
@@ -17,7 +17,7 @@ export async function prepareClaudeMcpConfig(
     return { cleanup: emptyCleanup };
   }
 
-  const tempDir = await mkdtemp(join(tmpdir(), 'takt-claude-mcp-'));
+  const tempDir = await mkdtemp(join(ensureCurrentTmpDirExists(), 'takt-claude-mcp-'));
   const configPath = join(tempDir, 'mcp-config.json');
 
   try {

--- a/src/infra/config/traced/tracedConfigRuntimeBridge.ts
+++ b/src/infra/config/traced/tracedConfigRuntimeBridge.ts
@@ -2,9 +2,9 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { tmpdir } from 'node:os';
 import { stringify as stringifyYaml } from 'yaml';
 import type { SchemaShape, TracedValue } from 'traced-config';
+import { ensureCurrentTmpDirExists } from '../../../shared/utils/index.js';
 
 type SerializedSchemaFormat = 'string' | 'number' | 'boolean' | 'json' | undefined;
 
@@ -154,7 +154,7 @@ export function loadTraceEntriesViaRuntime(
   fileOrigin: 'global' | 'local',
   parsedConfig: Record<string, unknown>,
 ): Map<string, TracedValue<unknown>> {
-  const tempDir = mkdtempSync(join(tmpdir(), 'takt-traced-config-'));
+  const tempDir = mkdtempSync(join(ensureCurrentTmpDirExists(), 'takt-traced-config-'));
 
   try {
     const tempConfigPath = Object.keys(parsedConfig).length > 0

--- a/src/infra/copilot/client.ts
+++ b/src/infra/copilot/client.ts
@@ -6,11 +6,10 @@
  */
 
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgentResponse } from '../../core/models/index.js';
 import { buildEnvWithNestedObservabilitySnapshot } from '../../shared/telemetry/index.js';
-import { createLogger, crossSpawn, getErrorMessage } from '../../shared/utils/index.js';
+import { createLogger, crossSpawn, ensureCurrentTmpDirExists, getErrorMessage } from '../../shared/utils/index.js';
 import type { CopilotCallOptions } from './types.js';
 
 const log = createLogger('copilot-client');
@@ -397,7 +396,8 @@ export class CopilotClient {
     let shareTmpDir: string | undefined;
     let shareFilePath: string | undefined;
     try {
-      shareTmpDir = await mkdtemp(join(tmpdir(), 'takt-copilot-'));
+      const shareTmpParentDir = ensureCurrentTmpDirExists();
+      shareTmpDir = await mkdtemp(join(shareTmpParentDir, 'takt-copilot-'));
       shareFilePath = join(shareTmpDir, 'session.md');
     } catch (err) {
       log.debug('mkdtemp failed, skipping session extraction', { err });

--- a/src/infra/task/projectLocalTaktSync.ts
+++ b/src/infra/task/projectLocalTaktSync.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { getProjectResourcesDir } from '../resources/index.js';
 import { isRealPathInside } from '../../shared/utils/index.js';
 
 const SYNCED_TAKT_RESOURCES = ['config.yaml', 'workflows', 'facets', 'quality-gates'] as const;
@@ -48,6 +49,22 @@ function ensureSafeDirectory(targetRoot: string, directoryPath: string): void {
   }
   fs.mkdirSync(directoryPath, { recursive: true });
   assertTargetPathInside(targetRoot, directoryPath);
+}
+
+function ensureWorktreeTaktDirectory(worktreePath: string): string {
+  const targetTaktDir = path.join(worktreePath, '.takt');
+  const pathKind = getPathKind(targetTaktDir);
+  if (pathKind === 'missing') {
+    fs.mkdirSync(targetTaktDir, { recursive: true });
+    assertTargetPathInside(worktreePath, targetTaktDir);
+    return targetTaktDir;
+  }
+  if (pathKind !== 'directory') {
+    throw new Error(`Worktree .takt must be a directory or missing: ${targetTaktDir}`);
+  }
+
+  assertTargetPathInside(worktreePath, targetTaktDir);
+  return targetTaktDir;
 }
 
 function ensureSourcePathKind(sourcePath: string): Exclude<PathKind, 'symlink'> {
@@ -108,6 +125,35 @@ function shouldSkipTaktSyncEntry(sourceDir: string, entry: string): boolean {
   return path.basename(sourceDir) === 'quality-gates' && QUALITY_GATES_GENERATED_DIRS.has(entry);
 }
 
+function ensureWorktreeTaktGitignoreFile(targetTaktDir: string): void {
+  const targetPath = path.join(targetTaktDir, '.gitignore');
+  const targetKind = getPathKind(targetPath);
+  if (targetKind === 'file') {
+    return;
+  }
+  if (targetKind !== 'missing') {
+    throw new Error(`Worktree .takt/.gitignore must be a regular file or missing: ${targetPath}`);
+  }
+
+  const sourcePath = path.join(getProjectResourcesDir(), 'dotgitignore');
+  const sourceKind = ensureSourcePathKind(sourcePath);
+  if (sourceKind !== 'file') {
+    throw new Error(`Expected built-in project .gitignore template: ${sourcePath}`);
+  }
+
+  fs.copyFileSync(sourcePath, targetPath);
+  assertTargetPathInside(targetTaktDir, targetPath);
+}
+
+export function ensureWorktreeTaktGitignore(worktreePath: string): void {
+  if (getPathKind(worktreePath) !== 'directory') {
+    throw new Error(`Worktree path must be an existing directory: ${worktreePath}`);
+  }
+
+  const targetTaktDir = ensureWorktreeTaktDirectory(worktreePath);
+  ensureWorktreeTaktGitignoreFile(targetTaktDir);
+}
+
 export function syncProjectLocalTaktForRetry(projectDir: string, worktreePath: string): void {
   if (getPathKind(worktreePath) !== 'directory') {
     throw new Error(`Worktree path must be an existing directory: ${worktreePath}`);
@@ -121,6 +167,8 @@ export function syncProjectLocalTaktForRetry(projectDir: string, worktreePath: s
 
   const targetTaktDir = path.join(worktreePath, '.takt');
   ensureSafeDirectory(worktreePath, targetTaktDir);
+  ensureWorktreeTaktGitignoreFile(targetTaktDir);
+
   for (const resource of SYNCED_TAKT_RESOURCES) {
     const sourcePath = path.join(sourceTaktDir, resource);
     const targetPath = path.join(targetTaktDir, resource);

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -18,5 +18,6 @@ export * from './streamDiagnostics.js';
 export * from './structuredOutput.js';
 export * from './taskPaths.js';
 export * from './text.js';
+export * from './tmpdir.js';
 export * from './types.js';
 export * from './updateNotifier.js';

--- a/src/shared/utils/tmpdir.ts
+++ b/src/shared/utils/tmpdir.ts
@@ -1,0 +1,8 @@
+import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+export function ensureCurrentTmpDirExists(): string {
+  const currentTmpDir = tmpdir();
+  mkdirSync(currentTmpDir, { recursive: true });
+  return currentTmpDir;
+}


### PR DESCRIPTION
## Summary

## 背景

タスク用 worktree では、親プロジェクトに未コミットの `.takt/.gitignore` があっても新しい worktree には引き継がれない。
その状態で workflow runtime prepare が `.takt/.runtime/tmp` を `TMPDIR` として設定すると、`.takt/.runtime` や `.takt/runs` が git 未追跡として見える。

実際に、エージェントが `git status` に出た `.takt/.runtime` を実行キャッシュと判断して削除し、その後の report phase で以下のように失敗した。

```text
ENOENT: no such file or directory, mkdtemp .../.takt/.runtime/tmp/takt-traced-config-XXXXXX
```

テスト自体は成功していたが、TAKT 自身の report phase が `TMPDIR` 欠落で落ちた。

## 問題

- ルート `.gitignore` は `.takt/` 全体を ignore せず、`.takt/.gitignore` に委譲している。
- しかし `.takt/.gitignore` が未コミットだと、task worktree には存在しない。
- `saveProjectConfig` では `.takt/.gitignore` を作るが、task worktree 実行開始時に常に保証されるわけではない。
- `projectLocalTaktSync` は `config.yaml` / `workflows` / `facets` / `quality-gates` の同期が主目的で、`.gitignore` 欠落の補完にはなっていない。

## 提案

task/worktree 実行開始時に、`cwd/.takt/.gitignore` が存在しなければ `builtins/project/dotgitignore` をコピーして補完する。

このファイルは消さない。生成された `.takt/.gitignore` が auto-commit に含まれてもよい。むしろプロジェクト側へ入ることで、以後の worktree でも `.takt/runs` や `.takt/.runtime` が安定して ignore される。

既存の `.takt/.gitignore` がある場合は上書きしない。

## 追加の防御

`loadTraceEntriesViaRuntime` などで `mkdtemp(join(tmpdir(), ...))` する前に、現在の `TMPDIR` が存在することを `mkdirSync(tmpdir(), { recursive: true })` で保証する。

これにより、実行中に `.takt/.runtime/tmp` が誤って削除されても、report phase が即 ENOENT で落ちにくくなる。

## 受け入れ条件

- task worktree に `.takt/.gitignore` がない場合でも、workflow 実行開始時に作成される。
- 生成された `.takt/.gitignore` は削除されない。
- auto-commit が有効な場合、`.takt/.gitignore` が必要に応じてコミットされることを許容する。
- `.takt/.runtime/` と `.takt/runs/` は未追跡成果物として `git status` に出ない。
- 既存の `.takt/.gitignore` は上書きされない。
- `TMPDIR` が欠落していても traced-config runtime bridge の `mkdtemp` が ENOENT で失敗しない。

## 回帰テスト案

- `.takt/.gitignore` がない worktree を作り、実行準備後に `.takt/.gitignore` が作られることを確認する。
- `.takt/.runtime/tmp` と `.takt/runs/...` を作っても `git status --porcelain` に出ないことを確認する。
- `stageAndCommit` で `.takt/.gitignore` はコミット対象になり得る一方、`.takt/.runtime` と `.takt/runs` はコミットされないことを確認する。
- 既存 `.takt/.gitignore` の内容は保持されることを確認する。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 一時ディレクトリが未存在/不正な環境などのエッジケースを追加し、クリップボード画像取得・Copilot共有・traced設定・repertoire追加・ワークツリー処理の挙動を幅広く検証しました。

* **Bug Fixes**
  * ワークツリー用の `.takt/.gitignore` を適切に作成・反映し、無視対象が正しく反映されるよう堅牢化しました。
  * 一時ディレクトリ基点の共通化により、各機能での一時領域作成がより安定しました。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->