### PR TITLE
fix: omit OpenCode tool guidance for no-tools phases

### DIFF
--- a/src/__tests__/opencode-provider-addendum.test.ts
+++ b/src/__tests__/opencode-provider-addendum.test.ts
@@ -10,7 +10,68 @@ vi.mock('../infra/opencode/index.js', () => ({
   callOpenCodeCustom: openCodeMocks.callOpenCodeCustom,
 }));
 
+const agentRunnerMocks = vi.hoisted(() => {
+  const getRuntimeInstructions = vi.fn(
+    (allowedTools?: string[]) => {
+      if (allowedTools !== undefined && allowedTools.length === 0) {
+        return null;
+      }
+      return 'OpenCode tool names are lowercase. Do not call run, list, todo, or todo_write.';
+    },
+  );
+  const providerCall = vi.fn().mockResolvedValue({
+    status: 'done',
+    content: '',
+    persona: 'coder',
+    timestamp: new Date(),
+  });
+  const providerSetup = vi.fn(() => ({ call: providerCall }));
+
+  return {
+    getProviderMock: vi.fn(() => ({
+      supportsStructuredOutput: false,
+      supportsNativeImageInput: false,
+      getRuntimeInstructions,
+      keepsAllowedToolWithoutEdit: vi.fn(() => true),
+      setup: providerSetup,
+    })),
+    getRuntimeInstructionsMock: getRuntimeInstructions,
+    providerCallMock: providerCall,
+    providerSetupMock: providerSetup,
+    loadProjectConfigMock: vi.fn(),
+    loadGlobalConfigMock: vi.fn(),
+    loadCustomAgentsMock: vi.fn(),
+    loadAgentPromptMock: vi.fn(),
+    loadPersonaPromptFromPathMock: vi.fn(),
+    resolveConfigValueMock: vi.fn(),
+    resolveProviderOptionsWithTraceMock: vi.fn(),
+    loadTemplateMock: vi.fn(),
+  };
+});
+
+vi.mock('../infra/providers/index.js', () => ({
+  getProvider: agentRunnerMocks.getProviderMock,
+}));
+
+vi.mock('../infra/config/index.js', () => ({
+  loadProjectConfig: agentRunnerMocks.loadProjectConfigMock,
+  loadGlobalConfig: agentRunnerMocks.loadGlobalConfigMock,
+  loadCustomAgents: agentRunnerMocks.loadCustomAgentsMock,
+  loadAgentPrompt: agentRunnerMocks.loadAgentPromptMock,
+  loadPersonaPromptFromPath: agentRunnerMocks.loadPersonaPromptFromPathMock,
+}));
+
+vi.mock('../infra/config/resolveConfigValue.js', () => ({
+  resolveConfigValue: agentRunnerMocks.resolveConfigValueMock,
+  resolveProviderOptionsWithTrace: agentRunnerMocks.resolveProviderOptionsWithTraceMock,
+}));
+
+vi.mock('../shared/prompts/index.js', () => ({
+  loadTemplate: agentRunnerMocks.loadTemplateMock,
+}));
+
 import { OpenCodeProvider } from '../infra/providers/opencode.js';
+import { runAgent } from '../agents/runner.js';
 
 describe('OpenCodeProvider tool naming addendum', () => {
   beforeEach(() => {
@@ -28,14 +89,70 @@ describe('OpenCodeProvider tool naming addendum', () => {
       persona: 'coder',
       timestamp: new Date(),
     });
+
+    agentRunnerMocks.getRuntimeInstructionsMock.mockReset();
+    agentRunnerMocks.getRuntimeInstructionsMock.mockImplementation(
+      (allowedTools?: string[]) => {
+        if (allowedTools !== undefined && allowedTools.length === 0) {
+          return null;
+        }
+        return 'OpenCode tool names are lowercase. Do not call run, list, todo, or todo_write.';
+      },
+    );
+    agentRunnerMocks.loadTemplateMock.mockReset().mockReturnValue('template');
+    agentRunnerMocks.loadProjectConfigMock.mockReset().mockReturnValue({ provider: 'opencode' });
+    agentRunnerMocks.loadGlobalConfigMock.mockReset().mockReturnValue({
+      language: 'en',
+      concurrency: 1,
+      taskPollIntervalMs: 500,
+    });
+    agentRunnerMocks.resolveConfigValueMock.mockReset().mockReturnValue(undefined);
+    agentRunnerMocks.resolveProviderOptionsWithTraceMock.mockReset().mockReturnValue({
+      value: undefined,
+      source: 'default',
+      originResolver: () => 'default',
+    });
+    agentRunnerMocks.loadCustomAgentsMock.mockReset().mockReturnValue(new Map());
+    agentRunnerMocks.loadAgentPromptMock.mockReset().mockReturnValue('prompt');
+    agentRunnerMocks.loadPersonaPromptFromPathMock.mockReset();
   });
 
   it('should expose OpenCode tool naming text as provider runtime instructions', () => {
     const provider = new OpenCodeProvider() as {
-      getRuntimeInstructions(): string | null;
+      getRuntimeInstructions(allowedTools?: string[]): string | null;
     };
 
     const runtimeInstructions = provider.getRuntimeInstructions();
+
+    expect(runtimeInstructions).toContain('OpenCode tool names are lowercase.');
+    expect(runtimeInstructions).toContain('Do not call run, list, todo, or todo_write.');
+  });
+
+  it('should return null when allowedTools is empty array (no-tools execution)', () => {
+    const provider = new OpenCodeProvider() as {
+      getRuntimeInstructions(allowedTools?: string[]): string | null;
+    };
+
+    expect(provider.getRuntimeInstructions([])).toBeNull();
+  });
+
+  it('should include addendum when allowedTools is undefined (normal execution)', () => {
+    const provider = new OpenCodeProvider() as {
+      getRuntimeInstructions(allowedTools?: string[]): string | null;
+    };
+
+    const runtimeInstructions = provider.getRuntimeInstructions();
+
+    expect(runtimeInstructions).toContain('OpenCode tool names are lowercase.');
+    expect(runtimeInstructions).toContain('Do not call run, list, todo, or todo_write.');
+  });
+
+  it('should include addendum when allowedTools contains tools', () => {
+    const provider = new OpenCodeProvider() as {
+      getRuntimeInstructions(allowedTools?: string[]): string | null;
+    };
+
+    const runtimeInstructions = provider.getRuntimeInstructions(['read', 'edit', 'write']);
 
     expect(runtimeInstructions).toContain('OpenCode tool names are lowercase.');
     expect(runtimeInstructions).toContain('Do not call run, list, todo, or todo_write.');
@@ -82,3 +199,105 @@ describe('OpenCodeProvider tool naming addendum', () => {
     );
   });
 });
+
+  describe('AgentRunner path — allowedTools propagation', () => {
+    beforeEach(() => {
+      agentRunnerMocks.getRuntimeInstructionsMock.mockReset();
+      agentRunnerMocks.getRuntimeInstructionsMock.mockImplementation(
+        (allowedTools?: string[]) => {
+          if (allowedTools !== undefined && allowedTools.length === 0) {
+            return null;
+          }
+          return 'OpenCode tool names are lowercase. Do not call run, list, todo, or todo_write.';
+        },
+      );
+      agentRunnerMocks.loadTemplateMock.mockReset().mockReturnValue('template');
+      agentRunnerMocks.loadProjectConfigMock.mockReset().mockReturnValue({ provider: 'opencode' });
+      agentRunnerMocks.loadGlobalConfigMock.mockReset().mockReturnValue({
+        language: 'en',
+        concurrency: 1,
+        taskPollIntervalMs: 500,
+      });
+      agentRunnerMocks.resolveConfigValueMock.mockReset().mockReturnValue(undefined);
+      agentRunnerMocks.resolveProviderOptionsWithTraceMock.mockReset().mockReturnValue({
+        value: undefined,
+        source: 'default',
+        originResolver: () => 'default',
+      });
+      agentRunnerMocks.loadCustomAgentsMock.mockReset().mockReturnValue(new Map());
+      agentRunnerMocks.loadAgentPromptMock.mockReset().mockReturnValue('prompt');
+      agentRunnerMocks.loadPersonaPromptFromPathMock.mockReset();
+    });
+
+    it('should exclude addendum from resolved system prompt when allowedTools is []', async () => {
+      const onPromptResolved = vi.fn();
+      const task = 'test task';
+
+      await runAgent(undefined, task, {
+        cwd: '/repo',
+        resolvedProvider: 'opencode',
+        allowedTools: [],
+        onPromptResolved,
+      });
+
+      expect(onPromptResolved).toHaveBeenCalledTimes(1);
+      const call = onPromptResolved.mock.calls[0]?.[0];
+      expect(call).toBeDefined();
+      expect(agentRunnerMocks.loadTemplateMock).not.toHaveBeenCalled();
+      expect(call.systemPrompt).toBe('');
+      expect(call.systemPrompt).not.toContain('OpenCode tool names are lowercase.');
+      expect(call.systemPrompt).not.toContain('glob for file discovery');
+      expect(agentRunnerMocks.getRuntimeInstructionsMock).toHaveBeenCalledWith([]);
+    });
+
+    it('should include addendum in resolved system prompt when allowedTools is undefined', async () => {
+      const onPromptResolved = vi.fn();
+      const task = 'test task';
+
+      await runAgent(undefined, task, {
+        cwd: '/repo',
+        resolvedProvider: 'opencode',
+        onPromptResolved,
+      });
+
+      expect(onPromptResolved).toHaveBeenCalledTimes(1);
+      const call = onPromptResolved.mock.calls[0]?.[0];
+      expect(call).toBeDefined();
+      expect(agentRunnerMocks.loadTemplateMock).toHaveBeenCalledTimes(1);
+      expect(agentRunnerMocks.loadTemplateMock).toHaveBeenCalledWith(
+        'provider_runtime_system_prompt',
+        'en',
+        expect.objectContaining({
+          providerRuntimeInstructions: expect.stringContaining('OpenCode tool names are lowercase.'),
+        }),
+      );
+      expect(call.systemPrompt).toBe('template');
+      expect(agentRunnerMocks.getRuntimeInstructionsMock).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should include addendum in resolved system prompt when allowedTools is non-empty', async () => {
+      const onPromptResolved = vi.fn();
+      const task = 'test task';
+
+      await runAgent(undefined, task, {
+        cwd: '/repo',
+        resolvedProvider: 'opencode',
+        allowedTools: ['read', 'edit', 'write'],
+        onPromptResolved,
+      });
+
+      expect(onPromptResolved).toHaveBeenCalledTimes(1);
+      const call = onPromptResolved.mock.calls[0]?.[0];
+      expect(call).toBeDefined();
+      expect(agentRunnerMocks.loadTemplateMock).toHaveBeenCalledTimes(1);
+      expect(agentRunnerMocks.loadTemplateMock).toHaveBeenCalledWith(
+        'provider_runtime_system_prompt',
+        'en',
+        expect.objectContaining({
+          providerRuntimeInstructions: expect.stringContaining('OpenCode tool names are lowercase.'),
+        }),
+      );
+      expect(call.systemPrompt).toBe('template');
+      expect(agentRunnerMocks.getRuntimeInstructionsMock).toHaveBeenCalledWith(['read', 'edit', 'write']);
+    });
+  });

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -178,7 +178,7 @@ export class AgentRunner {
       ...options,
       allowedTools: options.allowedTools ?? agentConfig.allowedTools,
     };
-    const providerRuntimeInstructions = provider.getRuntimeInstructions();
+    const providerRuntimeInstructions = provider.getRuntimeInstructions(customOptions.allowedTools);
     const systemPrompt = buildWrappedSystemPrompt(resolvedSystemPrompt, {
       ...customOptions,
       providerRuntimeInstructions,
@@ -253,7 +253,7 @@ export class AgentRunner {
       );
       const systemPrompt = buildWrappedSystemPrompt(agentDefinition, {
         ...options,
-        providerRuntimeInstructions: provider.getRuntimeInstructions(),
+        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools),
       });
       options.onPromptResolved?.({
         systemPrompt,
@@ -272,7 +272,7 @@ export class AgentRunner {
 
       const systemPrompt = buildWrappedSystemPrompt(personaSpec, {
         ...options,
-        providerRuntimeInstructions: provider.getRuntimeInstructions(),
+        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools),
       });
 
       options.onPromptResolved?.({
@@ -285,7 +285,7 @@ export class AgentRunner {
 
     const systemPrompt = buildWrappedSystemPrompt('', {
       ...options,
-      providerRuntimeInstructions: provider.getRuntimeInstructions(),
+      providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools),
     });
     options.onPromptResolved?.({
       systemPrompt,

--- a/src/infra/providers/claude-headless.ts
+++ b/src/infra/providers/claude-headless.ts
@@ -32,7 +32,7 @@ export class ClaudeHeadlessProvider implements Provider {
   readonly supportsStructuredOutput = true;
   readonly supportsNativeImageInput = false;
 
-  getRuntimeInstructions(): string | null {
+  getRuntimeInstructions(_allowedTools?: string[]): string | null {
     return null;
   }
 

--- a/src/infra/providers/claude-terminal.ts
+++ b/src/infra/providers/claude-terminal.ts
@@ -73,7 +73,7 @@ export class ClaudeTerminalProvider implements Provider {
   readonly supportsStructuredOutput = true;
   readonly supportsNativeImageInput = false;
 
-  getRuntimeInstructions(): string | null {
+  getRuntimeInstructions(_allowedTools?: string[]): string | null {
     return null;
   }
 

--- a/src/infra/providers/claude.ts
+++ b/src/infra/providers/claude.ts
@@ -40,7 +40,7 @@ export class ClaudeProvider implements Provider {
   readonly supportsStructuredOutput = true;
   readonly supportsNativeImageInput = true;
 
-  getRuntimeInstructions(): string | null {
+  getRuntimeInstructions(_allowedTools?: string[]): string | null {
     return null;
   }
 

--- a/src/infra/providers/codex.ts
+++ b/src/infra/providers/codex.ts
@@ -30,7 +30,7 @@ export class CodexProvider implements Provider {
   readonly supportsStructuredOutput = true;
   readonly supportsNativeImageInput = true;
 
-  getRuntimeInstructions(): string | null {
+  getRuntimeInstructions(_allowedTools?: string[]): string | null {
     return null;
   }
 

--- a/src/infra/providers/copilot.ts
+++ b/src/infra/providers/copilot.ts
@@ -40,7 +40,7 @@ export class CopilotProvider implements Provider {
   readonly supportsStructuredOutput = false;
   readonly supportsNativeImageInput = false;
 
-  getRuntimeInstructions(): string | null {
+  getRuntimeInstructions(_allowedTools?: string[]): string | null {
     return null;
   }
 

--- a/src/infra/providers/cursor.ts
+++ b/src/infra/providers/cursor.ts
@@ -39,7 +39,7 @@ export class CursorProvider implements Provider {
   readonly supportsStructuredOutput = false;
   readonly supportsNativeImageInput = false;
 
-  getRuntimeInstructions(): string | null {
+  getRuntimeInstructions(_allowedTools?: string[]): string | null {
     return null;
   }
 

--- a/src/infra/providers/kiro.ts
+++ b/src/infra/providers/kiro.ts
@@ -44,7 +44,7 @@ export class KiroProvider implements Provider {
   readonly supportsStructuredOutput = false;
   readonly supportsNativeImageInput = false;
 
-  getRuntimeInstructions(): string | null {
+  getRuntimeInstructions(_allowedTools?: string[]): string | null {
     return null;
   }
 

--- a/src/infra/providers/mock.ts
+++ b/src/infra/providers/mock.ts
@@ -22,7 +22,7 @@ export class MockProvider implements Provider {
   readonly supportsStructuredOutput = true;
   readonly supportsNativeImageInput = false;
 
-  getRuntimeInstructions(): string | null {
+  getRuntimeInstructions(_allowedTools?: string[]): string | null {
     return null;
   }
 

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -42,7 +42,10 @@ export class OpenCodeProvider implements Provider {
   readonly supportsStructuredOutput = false;
   readonly supportsNativeImageInput = false;
 
-  getRuntimeInstructions(): string | null {
+  getRuntimeInstructions(allowedTools?: string[]): string | null {
+    if (allowedTools !== undefined && allowedTools.length === 0) {
+      return null;
+    }
     return OPENCODE_TOOL_NAMING_ADDENDUM;
   }
 

--- a/src/infra/providers/types.ts
+++ b/src/infra/providers/types.ts
@@ -45,7 +45,7 @@ export interface ProviderAgent {
 export interface Provider {
   supportsStructuredOutput: boolean;
   supportsNativeImageInput: boolean;
-  getRuntimeInstructions(): string | null;
+  getRuntimeInstructions(allowedTools?: string[]): string | null;
   keepsAllowedToolWithoutEdit(tool: string): boolean;
   setup(config: AgentSetup): ProviderAgent;
 }


### PR DESCRIPTION
## Summary

Fixes #872.

OpenCode の no-tools execution、特に report phase で `allowedTools: []` が指定される場合に、OpenCode 固有の tool naming guidance を system prompt へ注入しないようにします。

これにより、ツールが実行不能な report phase で `glob`、`read`、`grep` などの利用を促す矛盾した指示を避けます。

## Changes

- `Provider.getRuntimeInstructions` に `allowedTools` を渡せるよう変更
- OpenCode provider は `allowedTools: []` の場合に tool naming addendum を返さない
- `AgentRunner` の各 system prompt 構築経路で `allowedTools` を provider runtime instructions へ渡す
- OpenCode provider 単体テストと AgentRunner 経由の prompt-resolution テストを追加

## Validation

- `npm run build`
- `npm run lint -- --quiet`
- `npm test -- src/__tests__/opencode-provider-addendum.test.ts`

## Notes

実行権限の設定は変更していません。
通常の execute phase や、ツールが許可されている execution では既存の OpenCode tool naming guidance を維持します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロバイダーのランタイム指示が、許可されたツール設定に応じて動的に調整されるようになりました。

* **改善**
  * ツールが許可されない場合、OpenCodeプロバイダーのツール命名ガイドラインの適用が制御されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->