### PR TITLE
[#870] add-tags-persona-to-phase-even

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "traced-config": "^0.3.0",
         "update-notifier": "^7.3.1",
         "wanakana": "^5.3.1",
-        "yaml": "^2.8.3",
+        "yaml": "^2.9.0",
         "zod": "^4.3.6"
       },
       "bin": {

--- a/src/__tests__/phaseUsageEvent.test.ts
+++ b/src/__tests__/phaseUsageEvent.test.ts
@@ -162,4 +162,202 @@ describe('phase usage event mapper', () => {
       usage: {},
     });
   });
+
+  it('includes step tags and persona from a phase span', () => {
+    // Given a phase span carrying step tags and persona attributes
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'codex',
+        'takt.model.name': 'gpt-5',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.persona': 'coder',
+        'takt.step.tags': ['coding', 'review'],
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.status': 'done',
+        'gen_ai.usage.input_tokens': 11,
+        'gen_ai.usage.output_tokens': 7,
+        'gen_ai.usage.total_tokens': 18,
+      },
+    };
+
+    // When the span is mapped to a phase usage event record
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+
+    // Then the record carries the tags array and persona
+    expect(record).toMatchObject({
+      tags: ['coding', 'review'],
+      persona: 'coder',
+    });
+  });
+
+  it('includes step tags and persona from a judge stage span', () => {
+    // Given a judge stage span carrying step tags and persona attributes
+    const span: SpanSnapshot = {
+      name: 'judge_stage.implement.3.ai_judge',
+      endTime: [1_778_777_215, 0],
+      attributes: {
+        'takt.provider.name': 'claude-sdk',
+        'takt.model.name': 'claude-sonnet-4',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.persona': 'conductor',
+        'takt.step.tags': ['review'],
+        'takt.judge.stage': 3,
+        'takt.judge.method': 'ai_judge',
+        'takt.judge.status': 'done',
+        'gen_ai.usage.input_tokens': 5,
+        'gen_ai.usage.output_tokens': 4,
+      },
+    };
+
+    // When the span is mapped to a phase usage event record
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+
+    // Then the record carries the tags array and persona
+    expect(record).toMatchObject({
+      tags: ['review'],
+      persona: 'conductor',
+    });
+  });
+
+  it('omits the tags and persona keys when the span has neither attribute', () => {
+    // Given a phase span without persona or tags (e.g. a system step)
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'mock',
+        'takt.step.name': 'init',
+        'takt.step.type': 'system',
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.status': 'done',
+        'gen_ai.usage.input_tokens': 1,
+        'gen_ai.usage.output_tokens': 1,
+        'gen_ai.usage.total_tokens': 2,
+      },
+    };
+
+    // When the span is mapped to a phase usage event record
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+
+    // Then neither key is present (no empty defaults are emitted)
+    expect(record).toBeDefined();
+    expect(record).not.toHaveProperty('tags');
+    expect(record).not.toHaveProperty('persona');
+  });
+
+  it('omits the tags key when the span carries an empty tags array', () => {
+    // Given a phase span whose tags attribute is an empty array
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'codex',
+        'takt.model.name': 'gpt-5',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.persona': 'coder',
+        'takt.step.tags': [],
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.status': 'done',
+        'gen_ai.usage.input_tokens': 11,
+        'gen_ai.usage.output_tokens': 7,
+        'gen_ai.usage.total_tokens': 18,
+      },
+    };
+
+    // When the span is mapped to a phase usage event record
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+
+    // Then the empty array is not emitted, while persona still is
+    expect(record).not.toHaveProperty('tags');
+    expect(record).toMatchObject({ persona: 'coder' });
+  });
+
+  it('ignores a non-array tags attribute', () => {
+    // Given a phase span whose tags attribute is malformed (not an array)
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'codex',
+        'takt.model.name': 'gpt-5',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.tags': 'coding',
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.status': 'done',
+        'gen_ai.usage.input_tokens': 11,
+        'gen_ai.usage.output_tokens': 7,
+        'gen_ai.usage.total_tokens': 18,
+      },
+    };
+
+    // When the span is mapped to a phase usage event record
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+
+    // Then the malformed value is rejected rather than passed through
+    expect(record).not.toHaveProperty('tags');
+  });
+
+  it('ignores a tags array containing a non-string element', () => {
+    // Given a phase span whose tags array carries a non-string element
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'codex',
+        'takt.model.name': 'gpt-5',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.tags': ['coding', 42],
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.status': 'done',
+        'gen_ai.usage.input_tokens': 11,
+        'gen_ai.usage.output_tokens': 7,
+        'gen_ai.usage.total_tokens': 18,
+      },
+    };
+
+    // When the span is mapped to a phase usage event record
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+
+    // Then the whole array is rejected rather than partially emitted
+    expect(record).not.toHaveProperty('tags');
+  });
+
+  it('ignores a tags array containing an empty string element', () => {
+    // Given a phase span whose tags array carries an empty string element
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'codex',
+        'takt.model.name': 'gpt-5',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.tags': ['coding', ''],
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.status': 'done',
+        'gen_ai.usage.input_tokens': 11,
+        'gen_ai.usage.output_tokens': 7,
+        'gen_ai.usage.total_tokens': 18,
+      },
+    };
+
+    // When the span is mapped to a phase usage event record
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+
+    // Then the whole array is rejected rather than partially emitted
+    expect(record).not.toHaveProperty('tags');
+  });
 });

--- a/src/__tests__/tokenUsageCsv.test.ts
+++ b/src/__tests__/tokenUsageCsv.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// These tests exercise the real aggregation logic embedded in tools/token-usage.sh
+// (persona/tags first-wins selection and `|` joined tags) by running the script
+// against fixture JSONL, so the CSV execution contract cannot silently regress.
+
+const scriptPath = join(process.cwd(), 'tools', 'token-usage.sh');
+
+function record(overrides: Record<string, unknown>): string {
+  return JSON.stringify({
+    run_id: 'fixture-run',
+    provider: 'mock',
+    provider_model: 'mock-model',
+    timestamp: '2026-06-21T00:00:00.000Z',
+    usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15, cached_input_tokens: 0 },
+    ...overrides,
+  });
+}
+
+function runCsv(scanDir: string): string {
+  const result = spawnSync('bash', [scriptPath, scanDir, '--csv', '--all'], {
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`token-usage.sh exited with ${result.status}: ${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+function dataRows(csv: string): string[][] {
+  return csv
+    .trim()
+    .split('\n')
+    .slice(1) // drop header
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(','));
+}
+
+describe('token-usage.sh CSV persona/tags columns', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'token-usage-csv-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeFixture(lines: string[]): void {
+    writeFileSync(join(tempDir, 'usage-events.phase.jsonl'), `${lines.join('\n')}\n`, 'utf-8');
+  }
+
+  it('emits the persona and tags columns in the CSV header', () => {
+    writeFixture([record({ step: 'review', persona: 'reviewer', tags: ['coding'] })]);
+
+    const header = runCsv(tempDir).trim().split('\n')[0];
+
+    expect(header).toBe(
+      'task,run_id,provider,model,step,persona,tags,input_tokens,output_tokens,total_tokens,cached_tokens,calls',
+    );
+  });
+
+  it('takes the first non-empty persona and tags across records (first-wins)', () => {
+    writeFixture([
+      record({ step: 'review' }), // no persona, no tags
+      record({ step: 'review', persona: 'reviewer', tags: ['coding', 'review'] }),
+      record({ step: 'review', persona: 'other', tags: ['ignored'] }),
+    ]);
+
+    const rows = dataRows(runCsv(tempDir));
+    const reviewRow = rows.find((cols) => cols[4] === 'review');
+
+    expect(reviewRow).toBeDefined();
+    expect(reviewRow?.[5]).toBe('reviewer');
+    // tags are pipe-joined so commas never leak into the CSV column structure
+    expect(reviewRow?.[6]).toBe('coding|review');
+    // all three records aggregate into a single step row
+    expect(reviewRow?.[11]).toBe('3');
+  });
+
+  it('leaves persona and tags columns empty when records carry neither', () => {
+    writeFixture([record({ step: 'build' })]);
+
+    const rows = dataRows(runCsv(tempDir));
+    const buildRow = rows.find((cols) => cols[4] === 'build');
+
+    expect(buildRow).toBeDefined();
+    expect(buildRow?.[5]).toBe('');
+    expect(buildRow?.[6]).toBe('');
+  });
+});

--- a/src/__tests__/usageEventsSpanProcessor.test.ts
+++ b/src/__tests__/usageEventsSpanProcessor.test.ts
@@ -67,6 +67,27 @@ describe('UsageEventsSpanProcessor', () => {
     ]);
   });
 
+  it('writes step tags and persona into the phase usage event record', () => {
+    const logPath = createTempLogPath();
+    const processor = new UsageEventsSpanProcessor({
+      runId: 'run-1',
+      sessionId: 'session-1',
+      phaseUsageLogPath: logPath,
+    });
+
+    processor.onEnd(makePhaseSpanWithTagsAndPersona('run-1') as unknown as ReadableSpan);
+
+    expect(readRecords(logPath)).toEqual([
+      expect.objectContaining({
+        run_id: 'run-1',
+        session_id: 'session-1',
+        phase: 'phase1_execute',
+        tags: ['coding', 'review'],
+        persona: 'coder',
+      }),
+    ]);
+  });
+
   it('ignores duplicate runId registrations without redirecting existing output', () => {
     const firstLogPath = createTempLogPath('first-usage-events.phase.jsonl');
     const secondLogPath = createTempLogPath('second-usage-events.phase.jsonl');
@@ -179,6 +200,18 @@ function makePhaseSpan(runId: string): Record<string, unknown> {
       'gen_ai.usage.input_tokens': 3,
       'gen_ai.usage.output_tokens': 2,
       'gen_ai.usage.total_tokens': 5,
+    },
+  };
+}
+
+function makePhaseSpanWithTagsAndPersona(runId: string): Record<string, unknown> {
+  const span = makePhaseSpan(runId) as { attributes: Record<string, unknown> };
+  return {
+    ...span,
+    attributes: {
+      ...span.attributes,
+      'takt.step.persona': 'coder',
+      'takt.step.tags': ['coding', 'review'],
     },
   };
 }

--- a/src/__tests__/workflowSpans.test.ts
+++ b/src/__tests__/workflowSpans.test.ts
@@ -996,6 +996,77 @@ describe('workflow OpenTelemetry spans', () => {
     }));
   });
 
+  it('sets step tags on phase spans for phase usage event filtering', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step = makeStep({ personaDisplayName: 'coder', tags: ['coding', 'review'] });
+
+    await module.runWithPhaseSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      step,
+      iteration: 1,
+      phase: 1,
+      phaseName: 'execute',
+      phaseExecutionId: 'implement:1:1:1',
+      getPromptParts: () => ({ systemPrompt: 's', userInstruction: 'u' }),
+    }, async () => ({ status: 'done', content: 'ok' }), (result: { status: string; content: string }) => ({
+      status: result.status,
+      content: result.content,
+    }));
+
+    expect(findSpan(spans, 'phase.implement.execute').attributes).toMatchObject({
+      'takt.step.persona': 'coder',
+      'takt.step.tags': ['coding', 'review'],
+    });
+  });
+
+  it('sets step tags on judge stage spans for phase usage event filtering', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step = makeStep({ personaDisplayName: 'conductor', tags: ['review'] });
+
+    module.recordJudgeStageSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      step,
+      iteration: 1,
+      phaseExecutionId: 'implement:3:1:1',
+      entry: {
+        stage: 1,
+        method: 'structured_output',
+        status: 'done',
+        instruction: 'judge instruction',
+        response: 'judge response',
+      },
+    });
+
+    const judgeSpan = findSpan(spans, 'judge_stage.implement.1.structured_output');
+    expect(judgeSpan.attributes).toMatchObject({
+      'takt.step.persona': 'conductor',
+      'takt.step.tags': ['review'],
+    });
+  });
+
+  it('omits the step tags attribute when the step has no tags', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step = makeStep({ personaDisplayName: 'coder' });
+
+    await module.runWithPhaseSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      step,
+      iteration: 1,
+      phase: 1,
+      phaseName: 'execute',
+      phaseExecutionId: 'implement:1:1:1',
+      getPromptParts: () => ({ systemPrompt: 's', userInstruction: 'u' }),
+    }, async () => ({ status: 'done', content: 'ok' }), (result: { status: string; content: string }) => ({
+      status: result.status,
+      content: result.content,
+    }));
+
+    expect(findSpan(spans, 'phase.implement.execute').attributes).not.toHaveProperty('takt.step.tags');
+  });
+
   it('attaches the workflow stack to phase and judge spans for parity', async () => {
     const { module, spans } = await loadWorkflowSpansWithMockedApi();
     const step = makeStep({ personaDisplayName: 'coder' });

--- a/src/core/logging/phaseUsageEvent.ts
+++ b/src/core/logging/phaseUsageEvent.ts
@@ -26,6 +26,8 @@ export interface PhaseUsageEventLogRecord {
   provider_model: string;
   step: string;
   step_type: PhaseUsageStepType;
+  tags?: string[];
+  persona?: string;
   phase: PhaseUsageType;
   phase_name: PhaseName;
   phase_execution_id?: string;
@@ -150,6 +152,8 @@ function buildRecord(
   meta: PhaseUsageMeta,
 ): PhaseUsageEventLogRecord {
   const usage = extractUsage(span.attributes);
+  const tags = getStringArray(span.attributes, 'takt.step.tags');
+  const persona = getString(span.attributes, 'takt.step.persona');
   return {
     run_id: context.runId,
     session_id: context.sessionId,
@@ -157,6 +161,8 @@ function buildRecord(
     provider_model: meta.providerModel,
     step: meta.step,
     step_type: meta.stepType,
+    ...(tags ? { tags } : {}),
+    ...(persona ? { persona } : {}),
     phase: meta.phase,
     phase_name: meta.phaseName,
     ...(meta.phaseExecutionId ? { phase_execution_id: meta.phaseExecutionId } : {}),
@@ -247,6 +253,17 @@ function phaseLabelForJudgeStage(stage: JudgeStage | undefined): PhaseUsageType 
 function getString(attributes: Record<string, unknown>, key: string): string | undefined {
   const value = attributes[key];
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getStringArray(attributes: Record<string, unknown>, key: string): string[] | undefined {
+  const value = attributes[key];
+  if (!Array.isArray(value) || value.length === 0) {
+    return undefined;
+  }
+  if (!value.every((item) => typeof item === 'string' && item.length > 0)) {
+    return undefined;
+  }
+  return value;
 }
 
 function getNumber(attributes: Record<string, unknown>, key: string): number | undefined {

--- a/src/core/workflow/observability/workflowSpans.ts
+++ b/src/core/workflow/observability/workflowSpans.ts
@@ -45,7 +45,7 @@ const JUDGE_STAGE_COUNTER_OPTIONS = {
   description: 'Workflow judge stage executions by status',
 };
 
-type AttributeInput = Record<string, string | number | boolean | undefined>;
+type AttributeInput = Record<string, string | number | boolean | string[] | undefined>;
 
 export interface WorkflowSpanParams {
   enabled: boolean;
@@ -312,6 +312,7 @@ function buildPhaseAttributes(params: PhaseSpanParams): Attributes {
     ...workflowStackAttributes(params.workflowStack),
     'takt.step.name': params.step.name,
     'takt.step.persona': params.step.personaDisplayName,
+    'takt.step.tags': params.step.tags,
     'takt.step.type': getWorkflowStepKind(params.step),
     'takt.step.iteration': params.iteration,
     'takt.phase.number': params.phase,
@@ -329,6 +330,7 @@ function buildJudgeStageAttributes(params: JudgeStageSpanParams): Attributes {
     ...workflowStackAttributes(params.workflowStack),
     'takt.step.name': params.step.name,
     'takt.step.persona': params.step.personaDisplayName,
+    'takt.step.tags': params.step.tags,
     'takt.step.type': getWorkflowStepKind(params.step),
     'takt.step.iteration': params.iteration,
     'takt.phase.number': 3,

--- a/tools/token-usage.sh
+++ b/tools/token-usage.sh
@@ -129,7 +129,7 @@ for (const r of records) {
 
   const stepKey = r.step || "unknown";
   if (!run.steps.has(stepKey)) {
-    run.steps.set(stepKey, { input: 0, output: 0, total: 0, cached: 0, count: 0 });
+    run.steps.set(stepKey, { input: 0, output: 0, total: 0, cached: 0, count: 0, persona: "", tags: [] });
   }
   const s = run.steps.get(stepKey);
   s.input += u.input_tokens || 0;
@@ -137,6 +137,8 @@ for (const r of records) {
   s.total += u.total_tokens || 0;
   s.cached += u.cached_input_tokens || 0;
   s.count++;
+  if (!s.persona && r.persona) s.persona = r.persona;
+  if (s.tags.length === 0 && Array.isArray(r.tags) && r.tags.length > 0) s.tags = r.tags;
 }
 
 let runs = [...byRun.values()].sort((a, b) => {
@@ -155,10 +157,10 @@ const grandInput = runs.reduce((s, r) => s + r.total.input, 0);
 const grandOutput = runs.reduce((s, r) => s + r.total.output, 0);
 
 if (csv) {
-  console.log("task,run_id,provider,model,step,input_tokens,output_tokens,total_tokens,cached_tokens,calls");
+  console.log("task,run_id,provider,model,step,persona,tags,input_tokens,output_tokens,total_tokens,cached_tokens,calls");
   for (const run of runs.slice(0, top)) {
     for (const [step, s] of [...run.steps.entries()].sort((a, b) => b[1].total - a[1].total)) {
-      console.log([run.task || "-", run.run_id, run.provider, run.model, step, s.input, s.output, s.total, s.cached, s.count].join(","));
+      console.log([run.task || "-", run.run_id, run.provider, run.model, step, s.persona || "", s.tags.join("|"), s.input, s.output, s.total, s.cached, s.count].join(","));
     }
   }
   process.exit(0);


### PR DESCRIPTION
## Summary

## 概要

現在の `.phase.jsonl`（phase usage event）には `step` と `step_type` しかなく、ステップの `tags` や `persona` が含まれていない。

集計・分析時に「review 系ステップだけ」「coder ペルソナのトークン消費」といったフィルタができるよう、これらのフィールドを追加する。

## やること

- `UsageEventsSpanProcessor` でスパン属性から `tags` と `persona` を取得し、phase usage event に書き出す
- ワークフローエンジン側でステップ実行時のスパンに `takt.step.tags` と `takt.step.persona` 属性を設定する
- `tools/token-usage.sh` の CSV 出力にも `tags` と `persona` カラムを追加する

## 追加フィールド

```jsonl
{
  ...既存フィールド,
  "tags": ["coding", "review"],
  "persona": "coder"
}
```

## 関連

- #869 Prometheus メトリクス（ラベルとしても活用できる）

## Execution Report

Workflow `takt-default` completed successfully.

Closes #870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ステップのタグとペルソナがフェーズ使用イベントに記録されるようになりました。
  * トークン使用量のCSV出力にペルソナとタグカラムが追加されました。メタデータがエクスポートデータに含まれます。

* **テスト**
  * タグとペルソナの記録・処理・出力に関する包括的なテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->