### PR TITLE
fix: use wildcard deny for OpenCode no-tools phases

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -164,17 +164,7 @@ const { createOpencodeMock } = vi.hoisted(() => ({
 }));
 
 const DENY_ONLY_OPEN_CODE_PERMISSION_RULESET = [
-  { permission: 'read', pattern: '**', action: 'deny' },
-  { permission: 'glob', pattern: '**', action: 'deny' },
-  { permission: 'grep', pattern: '**', action: 'deny' },
-  { permission: 'edit', pattern: '**', action: 'deny' },
-  { permission: 'write', pattern: '**', action: 'deny' },
-  { permission: 'bash', pattern: '**', action: 'deny' },
-  { permission: 'task', pattern: '**', action: 'deny' },
-  { permission: 'todowrite', pattern: '**', action: 'deny' },
-  { permission: 'websearch', pattern: '**', action: 'deny' },
-  { permission: 'webfetch', pattern: '**', action: 'deny' },
-  { permission: 'question', pattern: '**', action: 'deny' },
+  { permission: '*', pattern: '*', action: 'deny' },
 ];
 
 function deferred<T = void>(): {

--- a/src/__tests__/opencode-types.test.ts
+++ b/src/__tests__/opencode-types.test.ts
@@ -211,13 +211,12 @@ describe('OpenCode permissions', () => {
     ]);
   });
 
-  it('should treat an explicit empty allowed tools list as deny all', () => {
+  it('should treat an explicit empty allowed tools list as wildcard deny', () => {
     const ruleset = buildOpenCodePermissionRuleset('edit', undefined, []);
 
-    expect(ruleset.length).toBeGreaterThan(1);
-    expect(ruleset.every((rule) => rule.action === 'deny')).toBe(true);
-    expect(ruleset).toContainEqual({ permission: 'read', pattern: '**', action: 'deny' });
-    expect(ruleset).toContainEqual({ permission: 'bash', pattern: '**', action: 'deny' });
+    expect(ruleset).toEqual([
+      { permission: '*', pattern: '*', action: 'deny' },
+    ]);
   });
 
   it('should not widen a whitelist when network access is enabled', () => {

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -205,11 +205,7 @@ function buildOpenCodeAllowedToolsRuleset(
   allowedTools: OpenCodeAllowedTools,
 ): OpenCodePermissionRule[] {
   if (allowedTools.length === 0) {
-    return OPEN_CODE_PERMISSION_KEYS.map((permission) => ({
-      permission,
-      pattern: '**',
-      action: 'deny',
-    }));
+    return [{ permission: '*', pattern: '*', action: 'deny' }];
   }
 
   const allowed = allowedTools


### PR DESCRIPTION
## Summary

OpenCode の `allowedTools: []` を使用する report phase で、モデルに tool schema が露出し続ける問題を修正します。

空の許可リストでは、個別 tool の `deny` ルールではなく、以下の wildcard deny を生成するよう変更しました。

```ts
[{ permission: '*', pattern: '*', action: 'deny' }]
```

これにより、OpenCode 側の tool filtering が built-in tool と MCP tool を含めて no-tools として扱えるようにします。

allowedTools 未指定時、および非空配列による既存の whitelist 動作は変更していません。

## Changes

- 空の allowedTools に対する OpenCode permission ruleset を wildcard deny 1件へ変更
- OpenCode client の deny-only ruleset テストを更新
- OpenCode permission ruleset の unit test を更新
- 先行して試した tools: {} による変更は採用せず、permission ruleset に統一

## Validation

- npm test -- src/__tests__/opencode-client-cleanup.test.ts src/__tests__/opencode-types.test.ts
   - 85 tests passed

- npm run build
- npm run lint -- --quiet
- OpenCode を使用する workflow で実プロバイダ smoke test を実施
  - 従来発生することがあった report phase の read / glob tool call による ABORT は再現しなくなっている

## Related

Closes #882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * OpenCode権限ルール設定の処理を最適化しました。複数の個別拒否ルール定義をワイルドカード単一ルールに統合し、コードの効率性を改善しました。

* **Tests**
  * 権限ルール生成のテストケースを更新し、最適化された処理を検証するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->