### PR TITLE
[#888] filter-tool-schemas

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -754,7 +754,7 @@ describe('OpenCodeClient stream cleanup', () => {
     );
   });
 
-  it('should pass allowed tools as a permission whitelist to session.create', async () => {
+  it('Given allowed tools are configured, When calling OpenCode, Then it passes the same whitelist to session.create and promptAsync', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([
       {
@@ -806,7 +806,16 @@ describe('OpenCodeClient stream cleanup', () => {
       ],
     });
     expect(promptAsync).toHaveBeenCalledWith(
-      expect.not.objectContaining({ tools: expect.anything() }),
+      expect.objectContaining({
+        tools: {
+          read: true,
+          edit: true,
+          todowrite: true,
+          bash: true,
+          websearch: true,
+          webfetch: true,
+        },
+      }),
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
@@ -858,7 +867,12 @@ describe('OpenCodeClient stream cleanup', () => {
       ],
     });
     expect(promptAsync).toHaveBeenCalledWith(
-      expect.not.objectContaining({ tools: expect.anything() }),
+      expect.objectContaining({
+        tools: {
+          read: true,
+          bash: true,
+        },
+      }),
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
@@ -1477,9 +1491,13 @@ describe('OpenCodeClient stream cleanup', () => {
         { permission: '*', pattern: '*', action: 'allow' },
       ],
     });
+    expect(promptAsync).toHaveBeenCalledWith(
+      expect.not.objectContaining({ tools: expect.anything() }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
-  it('should pass deny-all permission ruleset when allowedTools is an explicit empty array', async () => {
+  it('Given allowedTools is an explicit empty array, When calling OpenCode, Then it denies permissions and hides all prompt tools', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([
       {
@@ -1522,7 +1540,7 @@ describe('OpenCodeClient stream cleanup', () => {
       permission: DENY_ONLY_OPEN_CODE_PERMISSION_RULESET,
     });
     expect(promptAsync).toHaveBeenCalledWith(
-      expect.not.objectContaining({ tools: expect.anything() }),
+      expect.objectContaining({ tools: {} }),
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });

--- a/src/__tests__/opencode-types.test.ts
+++ b/src/__tests__/opencode-types.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildOpenCodePermissionRuleset,
+  buildOpenCodePromptTools,
   mapToOpenCodePermissionReply,
   resolveOpenCodePermissionReply,
 } from '../infra/opencode/types.js';
@@ -240,5 +241,52 @@ describe('OpenCode permissions', () => {
       { permission: '*', pattern: '*', action: 'deny' },
       { permission: 'read', pattern: '*', action: 'allow' },
     ]);
+  });
+});
+
+describe('buildOpenCodePromptTools', () => {
+  it('Given allowedTools is unset, When building prompt tools, Then it preserves the existing unfiltered payload', () => {
+    expect(buildOpenCodePromptTools('edit', undefined, undefined)).toBeUndefined();
+  });
+
+  it('Given allowedTools is empty, When building prompt tools, Then it sends an explicit empty tool map', () => {
+    expect(buildOpenCodePromptTools('edit', undefined, [])).toEqual({});
+  });
+
+  it('Given allowedTools uses TAKT casing, When building prompt tools, Then it maps to OpenCode tool names', () => {
+    expect(buildOpenCodePromptTools('full', undefined, ['Read', 'Bash'])).toEqual({
+      read: true,
+      bash: true,
+    });
+  });
+
+  it('Given edit aliases are allowed, When building prompt tools, Then it exposes OpenCode edit only once', () => {
+    expect(buildOpenCodePromptTools('full', undefined, ['Edit', 'Write', 'apply_patch'])).toEqual({
+      edit: true,
+    });
+  });
+
+  it('Given network access is disabled, When building prompt tools, Then it removes web tools from the schema map', () => {
+    expect(buildOpenCodePromptTools('full', false, ['Read', 'WebSearch', 'WebFetch'])).toEqual({
+      read: true,
+    });
+  });
+
+  it('Given unknown custom tools are allowed, When building prompt tools, Then it omits them from the schema map', () => {
+    expect(buildOpenCodePromptTools('edit', undefined, ['Read', 'mcp__github__search'])).toEqual({
+      read: true,
+    });
+  });
+
+  it('Given a wildcard tool is allowed, When building prompt tools, Then it rejects the wildcard contract', () => {
+    expect(() => buildOpenCodePromptTools('full', false, ['*']))
+      .toThrow('OpenCode allowedTools does not accept wildcard permission: *');
+  });
+
+  it('Given readonly mode filters edit aliases, When building prompt tools, Then it matches the permission ruleset whitelist', () => {
+    expect(buildOpenCodePromptTools('readonly', undefined, ['Read', 'Bash', 'Edit'])).toEqual({
+      read: true,
+      bash: true,
+    });
   });
 });

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -17,6 +17,7 @@ import {
 import { parseProviderModel } from '../../shared/utils/providerModel.js';
 import {
   buildOpenCodePermissionRuleset,
+  buildOpenCodePromptTools,
   resolveOpenCodePermissionReply,
   type OpenCodeCallOptions,
 } from './types.js';
@@ -639,12 +640,18 @@ export class OpenCodeClient {
           });
         }
 
+        const promptTools = buildOpenCodePromptTools(
+          options.permissionMode,
+          options.networkAccess,
+          options.allowedTools,
+        );
         const promptPayload: Record<string, unknown> = {
           sessionID: activeSessionId,
           directory: options.cwd,
           model: parsedModel,
           ...(options.variant !== undefined ? { variant: options.variant } : {}),
           ...(options.systemPrompt !== undefined ? { system: options.systemPrompt } : {}),
+          ...(promptTools !== undefined ? { tools: promptTools } : {}),
           parts: [{ type: 'text' as const, text: prompt }],
         };
         const promptPayloadForSdk = promptPayload as unknown as Parameters<typeof opencodeApiClient.session.promptAsync>[0];

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -198,6 +198,20 @@ export function buildOpenCodePermissionRuleset(
 }
 
 export type OpenCodeAllowedTools = readonly string[];
+export type OpenCodePromptTools = Record<string, boolean>;
+
+export function buildOpenCodePromptTools(
+  mode: PermissionMode | undefined,
+  networkAccess: boolean | undefined,
+  allowedTools: OpenCodeAllowedTools | undefined,
+): OpenCodePromptTools | undefined {
+  if (allowedTools === undefined) {
+    return undefined;
+  }
+
+  const allowedPermissions = resolveOpenCodeAllowedPermissions(mode, networkAccess, allowedTools);
+  return Object.fromEntries(allowedPermissions.map((permission) => [permission, true]));
+}
 
 function buildOpenCodeAllowedToolsRuleset(
   mode: PermissionMode | undefined,
@@ -208,20 +222,28 @@ function buildOpenCodeAllowedToolsRuleset(
     return [{ permission: '*', pattern: '*', action: 'deny' }];
   }
 
-  const allowed = allowedTools
-    .map(toOpenCodeAllowedPermission)
-    .filter((permission): permission is string => (
-      permission !== null
-      && isOpenCodePermissionKey(permission)
-      && (permission !== 'edit' || isAllowedByPermissionMode(permission, mode))
-      && (networkAccess !== false || !isOpenCodeWebPermission(permission))
-    ));
-  const uniqueAllowed = Array.from(new Set(allowed));
+  const uniqueAllowed = resolveOpenCodeAllowedPermissions(mode, networkAccess, allowedTools);
 
   return [
     { permission: '*', pattern: '*', action: 'deny' },
     ...uniqueAllowed.map((permission) => ({ permission, pattern: '*', action: 'allow' as const })),
   ];
+}
+
+function resolveOpenCodeAllowedPermissions(
+  mode: PermissionMode | undefined,
+  networkAccess: boolean | undefined,
+  allowedTools: OpenCodeAllowedTools,
+): OpenCodePermissionKey[] {
+  const allowed = allowedTools
+    .map(toOpenCodeAllowedPermission)
+    .filter((permission): permission is OpenCodePermissionKey => (
+      permission !== null
+      && isOpenCodePermissionKey(permission)
+      && (permission !== 'edit' || isAllowedByPermissionMode(permission, mode))
+      && (networkAccess !== false || !isOpenCodeWebPermission(permission))
+    ));
+  return Array.from(new Set(allowed));
 }
 
 function isOpenCodeWebPermission(permission: string): boolean {


### PR DESCRIPTION
## Summary

## Background

OpenCode の `promptAsync` API には `tools: { [toolName: string]: boolean }` パラメータがあるが、TAKT は現在これを使用していない。

ツールの制御は permission ruleset（`permission.asked` → allow/reject）でのみ行われており、**モデルには全ツールのスキーマが見える**状態。モデルが利用不可のツール（`list`, `run` 等）を呼び続けるループの根本原因はここにある。

## Problem

`qwen3-coder-next` のようなモデルが、permission で拒否されるツール（`list`, `run`）を繰り返し呼ぶ。
- プロンプトで `Do not call run, list, todo, or todo_write.` と指示しているが無視される
- OpenCode の `doom_loop` 検出は `tool-error` 経路では発火しない（#886 の調査で確認）
- TAKT の `UnavailableToolLoopDetector` で検出・停止はできるが、ツールスキーマが見える以上、モデルが不要なツールを呼ぶ試行自体は防げない

## Proposal

`promptAsync` 呼び出し時に `tools` パラメータを渡して、`allowed_tools` に含まれるツールだけを `true` にする。

```typescript
// 例: allowed_tools = ['read', 'glob', 'grep', 'bash']
const promptPayload = {
  sessionID: activeSessionId,
  directory: options.cwd,
  model: parsedModel,
  parts: [{ type: 'text', text: prompt }],
  tools: {
    read: true,
    glob: true,
    grep: true,
    bash: true,
  },
};
```

これにより、`list`, `run` 等のスキーマがモデルに渡らなくなり、呼ぼうとすること自体を防げる。

## SDK Reference

```typescript
// node_modules/@opencode-ai/sdk/dist/v2/gen/types.gen.d.ts
export type SessionPromptAsyncData = {
  body?: {
    tools?: {
      [key: string]: boolean;
    };
    // ...
  };
};
```

## Related

- #886 (UnavailableToolLoopDetector の修正 + allowed_tools の readonly フィルタ修正)
- #882 / #887 (OpenCode no-tools phases の wildcard deny)

## Execution Report

Workflow `takt-default` completed successfully.

Closes #888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * OpenCode ツール権限の制御機能を強化。許可設定に基づいてプロンプトに適切なツール定義を自動的に含めるようになりました。

* **Tests**
  * ツール権限フィルタリングのテストケースを追加。権限モード、ネットワークアクセス設定、許可ツール一覧に応じたツール定義の検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->