### PR TITLE
fix: use positive tool list in OpenCode runtime instructions

### DIFF
--- a/src/__tests__/opencode-provider-addendum.test.ts
+++ b/src/__tests__/opencode-provider-addendum.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+function extractToolNames(instruction: string | null): string[] {
+  const match = instruction?.match(/You have ONLY these tools:\s*(.*?)\./);
+  return match?.[1]?.split(',').map((n) => n.trim()).filter(Boolean) ?? [];
+}
+
 const openCodeMocks = vi.hoisted(() => ({
   callOpenCode: vi.fn(),
   callOpenCodeCustom: vi.fn(),
@@ -157,9 +162,8 @@ describe('OpenCodeProvider tool naming addendum', () => {
 
     const runtimeInstructions = provider.getRuntimeInstructions(['read', 'edit', 'write']);
 
-    expect(runtimeInstructions).toContain('You have ONLY these tools: read, edit.');
-    expect(runtimeInstructions).toContain('No other tools exist.');
-    expect(runtimeInstructions).not.toContain('write');
+    const listed = extractToolNames(runtimeInstructions);
+    expect(listed).toEqual(['read', 'edit']);
   });
 
   it('should canonicalize and deduplicate tool names', () => {
@@ -169,9 +173,8 @@ describe('OpenCodeProvider tool naming addendum', () => {
 
     const runtimeInstructions = provider.getRuntimeInstructions([' Read ', 'TODO_WRITE', 'apply_patch', 'read', 'Bash']);
 
-    expect(runtimeInstructions).toContain('You have ONLY these tools: read, todowrite, edit, bash.');
-    expect(runtimeInstructions).not.toContain('apply_patch');
-    expect(runtimeInstructions).not.toContain('TODO_WRITE');
+    const listed = extractToolNames(runtimeInstructions);
+    expect(listed).toEqual(['read', 'todowrite', 'edit', 'bash']);
   });
 
   it('should pass custom system prompt without appending OpenCode runtime instructions', async () => {

--- a/src/__tests__/opencode-provider-addendum.test.ts
+++ b/src/__tests__/opencode-provider-addendum.test.ts
@@ -93,10 +93,13 @@ describe('OpenCodeProvider tool naming addendum', () => {
     agentRunnerMocks.getRuntimeInstructionsMock.mockReset();
     agentRunnerMocks.getRuntimeInstructionsMock.mockImplementation(
       (allowedTools?: string[]) => {
-        if (allowedTools !== undefined && allowedTools.length === 0) {
+        if (allowedTools === undefined) {
+          return 'OpenCode tool names are lowercase. Do not call run, list, todo, or todo_write.';
+        }
+        if (allowedTools.length === 0) {
           return null;
         }
-        return 'OpenCode tool names are lowercase. Do not call run, list, todo, or todo_write.';
+        return `You have ONLY these tools: ${allowedTools.join(', ')}. No other tools exist.`;
       },
     );
     agentRunnerMocks.loadTemplateMock.mockReset().mockReturnValue('template');
@@ -147,15 +150,28 @@ describe('OpenCodeProvider tool naming addendum', () => {
     expect(runtimeInstructions).toContain('Do not call run, list, todo, or todo_write.');
   });
 
-  it('should include addendum when allowedTools contains tools', () => {
+  it('should list only allowed tools when allowedTools is specified', () => {
     const provider = new OpenCodeProvider() as {
       getRuntimeInstructions(allowedTools?: string[]): string | null;
     };
 
     const runtimeInstructions = provider.getRuntimeInstructions(['read', 'edit', 'write']);
 
-    expect(runtimeInstructions).toContain('OpenCode tool names are lowercase.');
-    expect(runtimeInstructions).toContain('Do not call run, list, todo, or todo_write.');
+    expect(runtimeInstructions).toContain('You have ONLY these tools: read, edit.');
+    expect(runtimeInstructions).toContain('No other tools exist.');
+    expect(runtimeInstructions).not.toContain('write');
+  });
+
+  it('should canonicalize and deduplicate tool names', () => {
+    const provider = new OpenCodeProvider() as {
+      getRuntimeInstructions(allowedTools?: string[]): string | null;
+    };
+
+    const runtimeInstructions = provider.getRuntimeInstructions([' Read ', 'TODO_WRITE', 'apply_patch', 'read', 'Bash']);
+
+    expect(runtimeInstructions).toContain('You have ONLY these tools: read, todowrite, edit, bash.');
+    expect(runtimeInstructions).not.toContain('apply_patch');
+    expect(runtimeInstructions).not.toContain('TODO_WRITE');
   });
 
   it('should pass custom system prompt without appending OpenCode runtime instructions', async () => {
@@ -205,10 +221,13 @@ describe('OpenCodeProvider tool naming addendum', () => {
       agentRunnerMocks.getRuntimeInstructionsMock.mockReset();
       agentRunnerMocks.getRuntimeInstructionsMock.mockImplementation(
         (allowedTools?: string[]) => {
-          if (allowedTools !== undefined && allowedTools.length === 0) {
+          if (allowedTools === undefined) {
+            return 'OpenCode tool names are lowercase. Do not call run, list, todo, or todo_write.';
+          }
+          if (allowedTools.length === 0) {
             return null;
           }
-          return 'OpenCode tool names are lowercase. Do not call run, list, todo, or todo_write.';
+          return `You have ONLY these tools: ${allowedTools.join(', ')}. No other tools exist.`;
         },
       );
       agentRunnerMocks.loadTemplateMock.mockReset().mockReturnValue('template');
@@ -294,7 +313,7 @@ describe('OpenCodeProvider tool naming addendum', () => {
         'provider_runtime_system_prompt',
         'en',
         expect.objectContaining({
-          providerRuntimeInstructions: expect.stringContaining('OpenCode tool names are lowercase.'),
+          providerRuntimeInstructions: expect.stringContaining('You have ONLY these tools:'),
         }),
       );
       expect(call.systemPrompt).toBe('template');

--- a/src/__tests__/opencode-provider-addendum.test.ts
+++ b/src/__tests__/opencode-provider-addendum.test.ts
@@ -269,7 +269,7 @@ describe('OpenCodeProvider tool naming addendum', () => {
       expect(call.systemPrompt).toBe('');
       expect(call.systemPrompt).not.toContain('OpenCode tool names are lowercase.');
       expect(call.systemPrompt).not.toContain('glob for file discovery');
-      expect(agentRunnerMocks.getRuntimeInstructionsMock).toHaveBeenCalledWith([]);
+      expect(agentRunnerMocks.getRuntimeInstructionsMock).toHaveBeenCalledWith([], undefined, undefined);
     });
 
     it('should include addendum in resolved system prompt when allowedTools is undefined', async () => {
@@ -294,7 +294,7 @@ describe('OpenCodeProvider tool naming addendum', () => {
         }),
       );
       expect(call.systemPrompt).toBe('template');
-      expect(agentRunnerMocks.getRuntimeInstructionsMock).toHaveBeenCalledWith(undefined);
+      expect(agentRunnerMocks.getRuntimeInstructionsMock).toHaveBeenCalledWith(undefined, undefined, undefined);
     });
 
     it('should include addendum in resolved system prompt when allowedTools is non-empty', async () => {
@@ -320,6 +320,6 @@ describe('OpenCodeProvider tool naming addendum', () => {
         }),
       );
       expect(call.systemPrompt).toBe('template');
-      expect(agentRunnerMocks.getRuntimeInstructionsMock).toHaveBeenCalledWith(['read', 'edit', 'write']);
+      expect(agentRunnerMocks.getRuntimeInstructionsMock).toHaveBeenCalledWith(['read', 'edit', 'write'], undefined, undefined);
     });
   });

--- a/src/__tests__/opencode-provider-addendum.test.ts
+++ b/src/__tests__/opencode-provider-addendum.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PermissionMode } from '../core/models/index.js';
 
 function extractToolNames(instruction: string | null): string[] {
   const match = instruction?.match(/You have ONLY these tools:\s*(.*?)\./);
@@ -179,7 +180,7 @@ describe('OpenCodeProvider tool naming addendum', () => {
 
   it('should exclude edit when permissionMode is readonly', () => {
     const provider = new OpenCodeProvider() as {
-      getRuntimeInstructions(allowedTools?: string[], permissionMode?: string, networkAccess?: boolean): string | null;
+      getRuntimeInstructions(allowedTools?: string[], permissionMode?: PermissionMode, networkAccess?: boolean): string | null;
     };
 
     const runtimeInstructions = provider.getRuntimeInstructions(['read', 'edit', 'write', 'bash'], 'readonly', undefined);
@@ -190,7 +191,7 @@ describe('OpenCodeProvider tool naming addendum', () => {
 
   it('should exclude web tools when networkAccess is false', () => {
     const provider = new OpenCodeProvider() as {
-      getRuntimeInstructions(allowedTools?: string[], permissionMode?: string, networkAccess?: boolean): string | null;
+      getRuntimeInstructions(allowedTools?: string[], permissionMode?: PermissionMode, networkAccess?: boolean): string | null;
     };
 
     const runtimeInstructions = provider.getRuntimeInstructions(['read', 'bash', 'websearch', 'webfetch'], 'full', false);
@@ -201,7 +202,7 @@ describe('OpenCodeProvider tool naming addendum', () => {
 
   it('should include edit when permissionMode is full', () => {
     const provider = new OpenCodeProvider() as {
-      getRuntimeInstructions(allowedTools?: string[], permissionMode?: string, networkAccess?: boolean): string | null;
+      getRuntimeInstructions(allowedTools?: string[], permissionMode?: PermissionMode, networkAccess?: boolean): string | null;
     };
 
     const runtimeInstructions = provider.getRuntimeInstructions(['read', 'edit', 'bash'], 'full', undefined);

--- a/src/__tests__/opencode-provider-addendum.test.ts
+++ b/src/__tests__/opencode-provider-addendum.test.ts
@@ -177,6 +177,39 @@ describe('OpenCodeProvider tool naming addendum', () => {
     expect(listed).toEqual(['read', 'todowrite', 'edit', 'bash']);
   });
 
+  it('should exclude edit when permissionMode is readonly', () => {
+    const provider = new OpenCodeProvider() as {
+      getRuntimeInstructions(allowedTools?: string[], permissionMode?: string, networkAccess?: boolean): string | null;
+    };
+
+    const runtimeInstructions = provider.getRuntimeInstructions(['read', 'edit', 'write', 'bash'], 'readonly', undefined);
+
+    const listed = extractToolNames(runtimeInstructions);
+    expect(listed).toEqual(['read', 'bash']);
+  });
+
+  it('should exclude web tools when networkAccess is false', () => {
+    const provider = new OpenCodeProvider() as {
+      getRuntimeInstructions(allowedTools?: string[], permissionMode?: string, networkAccess?: boolean): string | null;
+    };
+
+    const runtimeInstructions = provider.getRuntimeInstructions(['read', 'bash', 'websearch', 'webfetch'], 'full', false);
+
+    const listed = extractToolNames(runtimeInstructions);
+    expect(listed).toEqual(['read', 'bash']);
+  });
+
+  it('should include edit when permissionMode is full', () => {
+    const provider = new OpenCodeProvider() as {
+      getRuntimeInstructions(allowedTools?: string[], permissionMode?: string, networkAccess?: boolean): string | null;
+    };
+
+    const runtimeInstructions = provider.getRuntimeInstructions(['read', 'edit', 'bash'], 'full', undefined);
+
+    const listed = extractToolNames(runtimeInstructions);
+    expect(listed).toEqual(['read', 'edit', 'bash']);
+  });
+
   it('should pass custom system prompt without appending OpenCode runtime instructions', async () => {
     const provider = new OpenCodeProvider();
     const agent = provider.setup({

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -178,7 +178,7 @@ export class AgentRunner {
       ...options,
       allowedTools: options.allowedTools ?? agentConfig.allowedTools,
     };
-    const providerRuntimeInstructions = provider.getRuntimeInstructions(customOptions.allowedTools);
+    const providerRuntimeInstructions = provider.getRuntimeInstructions(customOptions.allowedTools, options.permissionMode, options.providerOptions?.opencode?.networkAccess);
     const systemPrompt = buildWrappedSystemPrompt(resolvedSystemPrompt, {
       ...customOptions,
       providerRuntimeInstructions,
@@ -253,7 +253,7 @@ export class AgentRunner {
       );
       const systemPrompt = buildWrappedSystemPrompt(agentDefinition, {
         ...options,
-        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools),
+        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools, options.permissionMode, options.providerOptions?.opencode?.networkAccess),
       });
       options.onPromptResolved?.({
         systemPrompt,
@@ -272,7 +272,7 @@ export class AgentRunner {
 
       const systemPrompt = buildWrappedSystemPrompt(personaSpec, {
         ...options,
-        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools),
+        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools, options.permissionMode, options.providerOptions?.opencode?.networkAccess),
       });
 
       options.onPromptResolved?.({
@@ -285,7 +285,7 @@ export class AgentRunner {
 
     const systemPrompt = buildWrappedSystemPrompt('', {
       ...options,
-      providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools),
+      providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools, options.permissionMode, options.providerOptions?.opencode?.networkAccess),
     });
     options.onPromptResolved?.({
       systemPrompt,

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -178,17 +178,25 @@ export class AgentRunner {
       ...options,
       allowedTools: options.allowedTools ?? agentConfig.allowedTools,
     };
-    const providerRuntimeInstructions = provider.getRuntimeInstructions(customOptions.allowedTools, options.permissionMode, options.providerOptions?.opencode?.networkAccess);
-    const systemPrompt = buildWrappedSystemPrompt(resolvedSystemPrompt, {
-      ...customOptions,
-      providerRuntimeInstructions,
-    });
     const resolvedProviderOptions = AgentRunner.resolveProviderOptions(
       options.cwd,
       agentConfig.name,
       customOptions,
       resolved.personaProviders,
     );
+    const callOptions = AgentRunner.buildCallOptions(
+      resolved.model,
+      providerType,
+      resolvedProviderOptions,
+      customOptions,
+      resolved.localConfig,
+      resolved.globalConfig,
+    );
+    const providerRuntimeInstructions = provider.getRuntimeInstructions(customOptions.allowedTools, callOptions.permissionMode, callOptions.providerOptions?.opencode?.networkAccess);
+    const systemPrompt = buildWrappedSystemPrompt(resolvedSystemPrompt, {
+      ...customOptions,
+      providerRuntimeInstructions,
+    });
 
     options.onPromptResolved?.({
       systemPrompt,
@@ -200,14 +208,7 @@ export class AgentRunner {
       systemPrompt,
     });
 
-    return agent.call(task, AgentRunner.buildCallOptions(
-      resolved.model,
-      providerType,
-      resolvedProviderOptions,
-      customOptions,
-      resolved.localConfig,
-      resolved.globalConfig,
-    ));
+    return agent.call(task, callOptions);
   }
 
   async run(
@@ -253,7 +254,7 @@ export class AgentRunner {
       );
       const systemPrompt = buildWrappedSystemPrompt(agentDefinition, {
         ...options,
-        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools, options.permissionMode, options.providerOptions?.opencode?.networkAccess),
+        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools, callOptions.permissionMode, callOptions.providerOptions?.opencode?.networkAccess),
       });
       options.onPromptResolved?.({
         systemPrompt,
@@ -272,7 +273,7 @@ export class AgentRunner {
 
       const systemPrompt = buildWrappedSystemPrompt(personaSpec, {
         ...options,
-        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools, options.permissionMode, options.providerOptions?.opencode?.networkAccess),
+        providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools, callOptions.permissionMode, callOptions.providerOptions?.opencode?.networkAccess),
       });
 
       options.onPromptResolved?.({
@@ -285,7 +286,7 @@ export class AgentRunner {
 
     const systemPrompt = buildWrappedSystemPrompt('', {
       ...options,
-      providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools, options.permissionMode, options.providerOptions?.opencode?.networkAccess),
+      providerRuntimeInstructions: provider.getRuntimeInstructions(options.allowedTools, callOptions.permissionMode, callOptions.providerOptions?.opencode?.networkAccess),
     });
     options.onPromptResolved?.({
       systemPrompt,

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -208,6 +208,19 @@ function buildOpenCodeAllowedToolsRuleset(
     return [{ permission: '*', pattern: '*', action: 'deny' }];
   }
 
+  const uniqueAllowed = resolveOpenCodeAllowedPermissions(mode, networkAccess, allowedTools);
+
+  return [
+    { permission: '*', pattern: '*', action: 'deny' },
+    ...uniqueAllowed.map((permission) => ({ permission, pattern: '*', action: 'allow' as const })),
+  ];
+}
+
+export function resolveOpenCodeAllowedPermissions(
+  mode: PermissionMode | undefined,
+  networkAccess: boolean | undefined,
+  allowedTools: OpenCodeAllowedTools,
+): string[] {
   const allowed = allowedTools
     .map(toOpenCodeAllowedPermission)
     .filter((permission): permission is string => (
@@ -216,12 +229,7 @@ function buildOpenCodeAllowedToolsRuleset(
       && (permission !== 'edit' || isAllowedByPermissionMode(permission, mode))
       && (networkAccess !== false || !isOpenCodeWebPermission(permission))
     ));
-  const uniqueAllowed = Array.from(new Set(allowed));
-
-  return [
-    { permission: '*', pattern: '*', action: 'deny' },
-    ...uniqueAllowed.map((permission) => ({ permission, pattern: '*', action: 'allow' as const })),
-  ];
+  return Array.from(new Set(allowed));
 }
 
 function isOpenCodeWebPermission(permission: string): boolean {

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -245,6 +245,8 @@ function isOpenCodePermissionKey(permission: string): permission is OpenCodePerm
   return (OPEN_CODE_PERMISSION_KEYS as readonly string[]).includes(permission);
 }
 
+export { toOpenCodeAllowedPermission as canonicalizeOpenCodeToolName };
+
 function toOpenCodeAllowedPermission(tool: string): string | null {
   const trimmed = tool.trim();
   if (!trimmed) {

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -253,8 +253,6 @@ function isOpenCodePermissionKey(permission: string): permission is OpenCodePerm
   return (OPEN_CODE_PERMISSION_KEYS as readonly string[]).includes(permission);
 }
 
-export { toOpenCodeAllowedPermission as canonicalizeOpenCodeToolName };
-
 function toOpenCodeAllowedPermission(tool: string): string | null {
   const trimmed = tool.trim();
   if (!trimmed) {

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -15,13 +15,16 @@ const OPENCODE_TOOL_NAMING_FALLBACK = [
   'Do not call run, list, todo, or todo_write.',
 ].join(' ');
 
-function buildToolNamingInstruction(allowedTools: string[]): string {
+function buildToolNamingInstruction(allowedTools: string[]): string | null {
   const seen = new Set<string>();
   for (const tool of allowedTools) {
     const canonical = canonicalizeOpenCodeToolName(tool);
     if (canonical !== null) {
       seen.add(canonical);
     }
+  }
+  if (seen.size === 0) {
+    return null;
   }
   const names = Array.from(seen);
   return `You have ONLY these tools: ${names.join(', ')}. No other tools exist. Do not attempt to call any tool not in this list.`;

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -4,15 +4,28 @@
 
 import { callOpenCode, callOpenCodeCustom, type OpenCodeCallOptions } from '../opencode/index.js';
 import { mapsToOpenCodeEditPermission } from '../opencode/allowedTools.js';
+import { canonicalizeOpenCodeToolName } from '../opencode/types.js';
 import { resolveOpencodeApiKey } from '../config/index.js';
 import type { AgentResponse } from '../../core/models/index.js';
 import type { AgentSetup, Provider, ProviderAgent, ProviderCallOptions } from './types.js';
 
-const OPENCODE_TOOL_NAMING_ADDENDUM = [
+const OPENCODE_TOOL_NAMING_FALLBACK = [
   'OpenCode tool names are lowercase.',
   'Use bash for shell commands, glob for file discovery, grep for search, read for file reads, edit/write for changes, and todowrite for todos.',
   'Do not call run, list, todo, or todo_write.',
 ].join(' ');
+
+function buildToolNamingInstruction(allowedTools: string[]): string {
+  const seen = new Set<string>();
+  for (const tool of allowedTools) {
+    const canonical = canonicalizeOpenCodeToolName(tool);
+    if (canonical !== null) {
+      seen.add(canonical);
+    }
+  }
+  const names = Array.from(seen);
+  return `You have ONLY these tools: ${names.join(', ')}. No other tools exist. Do not attempt to call any tool not in this list.`;
+}
 
 function toOpenCodeOptions(options: ProviderCallOptions): OpenCodeCallOptions {
   if (!options.model) {
@@ -43,10 +56,13 @@ export class OpenCodeProvider implements Provider {
   readonly supportsNativeImageInput = false;
 
   getRuntimeInstructions(allowedTools?: string[]): string | null {
-    if (allowedTools !== undefined && allowedTools.length === 0) {
+    if (allowedTools === undefined) {
+      return OPENCODE_TOOL_NAMING_FALLBACK;
+    }
+    if (allowedTools.length === 0) {
       return null;
     }
-    return OPENCODE_TOOL_NAMING_ADDENDUM;
+    return buildToolNamingInstruction(allowedTools);
   }
 
   keepsAllowedToolWithoutEdit(tool: string): boolean {

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -4,9 +4,10 @@
 
 import { callOpenCode, callOpenCodeCustom, type OpenCodeCallOptions } from '../opencode/index.js';
 import { mapsToOpenCodeEditPermission } from '../opencode/allowedTools.js';
-import { canonicalizeOpenCodeToolName } from '../opencode/types.js';
+import { resolveOpenCodeAllowedPermissions } from '../opencode/types.js';
 import { resolveOpencodeApiKey } from '../config/index.js';
 import type { AgentResponse } from '../../core/models/index.js';
+import type { PermissionMode } from '../../core/models/index.js';
 import type { AgentSetup, Provider, ProviderAgent, ProviderCallOptions } from './types.js';
 
 const OPENCODE_TOOL_NAMING_FALLBACK = [
@@ -15,18 +16,15 @@ const OPENCODE_TOOL_NAMING_FALLBACK = [
   'Do not call run, list, todo, or todo_write.',
 ].join(' ');
 
-function buildToolNamingInstruction(allowedTools: string[]): string | null {
-  const seen = new Set<string>();
-  for (const tool of allowedTools) {
-    const canonical = canonicalizeOpenCodeToolName(tool);
-    if (canonical !== null) {
-      seen.add(canonical);
-    }
-  }
-  if (seen.size === 0) {
+function buildToolNamingInstruction(
+  allowedTools: string[],
+  mode: PermissionMode | undefined,
+  networkAccess: boolean | undefined,
+): string | null {
+  const names = resolveOpenCodeAllowedPermissions(mode, networkAccess, allowedTools);
+  if (names.length === 0) {
     return null;
   }
-  const names = Array.from(seen);
   return `You have ONLY these tools: ${names.join(', ')}. No other tools exist. Do not attempt to call any tool not in this list.`;
 }
 
@@ -58,14 +56,14 @@ export class OpenCodeProvider implements Provider {
   readonly supportsStructuredOutput = false;
   readonly supportsNativeImageInput = false;
 
-  getRuntimeInstructions(allowedTools?: string[]): string | null {
+  getRuntimeInstructions(allowedTools?: string[], permissionMode?: PermissionMode, networkAccess?: boolean): string | null {
     if (allowedTools === undefined) {
       return OPENCODE_TOOL_NAMING_FALLBACK;
     }
     if (allowedTools.length === 0) {
       return null;
     }
-    return buildToolNamingInstruction(allowedTools);
+    return buildToolNamingInstruction(allowedTools, permissionMode, networkAccess);
   }
 
   keepsAllowedToolWithoutEdit(tool: string): boolean {

--- a/src/infra/providers/types.ts
+++ b/src/infra/providers/types.ts
@@ -45,7 +45,7 @@ export interface ProviderAgent {
 export interface Provider {
   supportsStructuredOutput: boolean;
   supportsNativeImageInput: boolean;
-  getRuntimeInstructions(allowedTools?: string[]): string | null;
+  getRuntimeInstructions(allowedTools?: string[], permissionMode?: import('../../core/models/index.js').PermissionMode, networkAccess?: boolean): string | null;
   keepsAllowedToolWithoutEdit(tool: string): boolean;
   setup(config: AgentSetup): ProviderAgent;
 }


### PR DESCRIPTION
## Summary

- OpenCode の `allowed_tools` 指定時、禁止リスト（`Do not call run, list, todo`）ではなく許可リスト（`You have ONLY these tools: read, glob, grep, bash`）を使うように変更
- ツール名は permission system と同じ正規化ロジック（`toOpenCodeAllowedPermission`）で canonical 化・重複排除

## Root cause

OpenCode の `default.txt` システムプロンプトに `ls tool to list the files` という few-shot 例があり、`qwen3-coder-next` 等のモデルが存在しない `list`/`ls` ツールを呼び続ける。`list` は OpenCode の登録ツールではなく、permission system でスキーマからも除外されているが、モデルがシステムプロンプトの例示から推論して呼んでしまう。

禁止リスト（「使うな」）は弱いモデルには効かないため、許可リスト（「使えるのはこれだけ」）に変更。

## Changes

- `src/infra/providers/opencode.ts`: `getRuntimeInstructions` を3分岐に変更（未指定→従来fallback、空→null、非空→正の許可リスト）
- `src/infra/opencode/types.ts`: `toOpenCodeAllowedPermission` を `canonicalizeOpenCodeToolName` として export
- テスト: canonical 化・重複排除のケースを追加、結合経路テストの mock を更新

## Test plan

- [x] `opencode-provider-addendum.test.ts` — 10 tests passed
- [x] `provider-tool-addendum-boundary.test.ts` — 10 tests passed
- [x] build, lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * OpenCodeプロバイダーのランタイム指示文を改善し、許可ツール一覧のみを反映して動的に生成します（空指定時は出力しません／未指定時はフォールバック）。
  * 指示文生成に権限モードおよびネットワーク許可設定も反映されるようになりました。
* **Bug Fixes**
  * ツール名の大文字/小文字、前後空白、重複を整理し、意図した許可のみが有効になります。
* **Tests**
  * 新しい指示文仕様に合わせて検証内容を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->