### PR TITLE
fix: keep workflow-call step progress local

### DIFF
--- a/src/__tests__/engine-workflow-call.test.ts
+++ b/src/__tests__/engine-workflow-call.test.ts
@@ -200,6 +200,117 @@ steps:
     expect(finalPrompt).toContain('Child review complete');
   });
 
+  it('should relay child workflow progress info when workflow_call emits child step starts', async () => {
+    writeWorkflow(tmpDir, 'child.yaml', `name: child
+subworkflow:
+  callable: true
+initial_step: draft
+max_steps: 5
+steps:
+  - name: draft
+    persona: draft
+    instruction: "Draft child workflow"
+    rules:
+      - condition: done
+        next: review
+  - name: review
+    persona: reviewer
+    instruction: "Review child workflow"
+    rules:
+      - condition: done
+        next: COMPLETE
+`);
+
+    const config = createParentWorkflow(tmpDir, {
+      name: 'parent',
+      initial_step: 'delegate',
+      max_steps: 5,
+      steps: [
+        {
+          name: 'plan',
+          persona: 'planner',
+          instruction: 'Plan parent workflow',
+          rules: [
+            {
+              condition: 'done',
+              next: 'delegate',
+            },
+          ],
+        },
+        {
+          name: 'delegate',
+          kind: 'workflow_call',
+          call: 'child',
+          rules: [
+            {
+              condition: 'COMPLETE',
+              next: 'COMPLETE',
+            },
+            {
+              condition: 'ABORT',
+              next: 'ABORT',
+            },
+          ],
+        },
+        {
+          name: 'summarize',
+          persona: 'summarizer',
+          instruction: 'Summarize child output',
+          rules: [
+            {
+              condition: 'done',
+              next: 'COMPLETE',
+            },
+          ],
+        },
+      ],
+    });
+    const stepStarts: Array<{ stepName: string; progressInfo: unknown }> = [];
+    mockPersonaResponses({
+      draft: 'draft done',
+      reviewer: 'review done',
+    });
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' },
+      { index: 0, method: 'phase1_tag' },
+    ]);
+
+    engine = new WorkflowEngine(config, tmpDir, 'Verify workflow progress', createWorkflowCallOptions(tmpDir));
+    engine.on('step:start', (step, _iteration, _instruction, _providerInfo, progressInfo) => {
+      stepStarts.push({ stepName: step.name, progressInfo });
+    });
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+    expect(stepStarts).toEqual([
+      {
+        stepName: 'delegate',
+        progressInfo: {
+          workflowName: 'parent',
+          stepIndex: 1,
+          totalSteps: 3,
+        },
+      },
+      {
+        stepName: 'draft',
+        progressInfo: {
+          workflowName: 'child',
+          stepIndex: 0,
+          totalSteps: 2,
+        },
+      },
+      {
+        stepName: 'review',
+        progressInfo: {
+          workflowName: 'child',
+          stepIndex: 1,
+          totalSteps: 2,
+        },
+      },
+    ]);
+  });
+
   it('子 workflow の step:rate_limited イベントを親 engine に中継する', async () => {
     writeWorkflow(tmpDir, 'child.yaml', `name: child
 subworkflow:

--- a/src/__tests__/workflow-run-loop-step-progress.test.ts
+++ b/src/__tests__/workflow-run-loop-step-progress.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkflowConfig, WorkflowStep } from '../core/models/index.js';
+import { createInitialState } from '../core/workflow/engine/state-manager.js';
+import { runWorkflowToCompletion } from '../core/workflow/engine/WorkflowRunLoop.js';
+import { makeResponse, makeRule, makeStep } from './engine-test-helpers.js';
+
+function makeConfig(steps: WorkflowStep[], initialStep: string): WorkflowConfig {
+  return {
+    name: 'progress-workflow',
+    description: 'Progress workflow',
+    maxSteps: 5,
+    initialStep,
+    steps,
+  };
+}
+
+describe('WorkflowRunLoop step progress events', () => {
+  it('should emit workflow-local progress info when step starts', async () => {
+    const planStep = makeStep('plan');
+    const reviewStep = makeStep('review', {
+      rules: [makeRule('Review complete', 'COMPLETE')],
+    });
+    const summarizeStep = makeStep('summarize');
+    const config = makeConfig([planStep, reviewStep, summarizeStep], reviewStep.name);
+    const state = createInitialState(config, { projectCwd: '/worktree' });
+    const response = makeResponse({
+      persona: 'review',
+      status: 'done',
+      content: 'done',
+    });
+    const providerInfo = { provider: undefined, model: undefined };
+    const progressInfo = {
+      workflowName: 'forwarded-progress-workflow',
+      stepIndex: 7,
+      totalSteps: 9,
+    };
+    const getStepProgress = vi.fn(() => progressInfo);
+    const deps = {
+      state,
+      options: {},
+      getWorkflowName: () => config.name,
+      getCurrentWorkflowStack: () => undefined,
+      getCwd: () => '/worktree',
+      getMaxSteps: () => 5,
+      getReportDir: () => '/worktree/.takt/runs/test/reports',
+      abortRequested: () => false,
+      getStep: (name: string) => {
+        const step = config.steps.find((candidate) => candidate.name === name);
+        if (!step) {
+          throw new Error(`Unknown step: ${name}`);
+        }
+        return step;
+      },
+      getStepProgress,
+      applyRuntimeEnvironment: vi.fn(),
+      loopDetectorCheck: () => ({ count: 1, isLoop: false }),
+      cycleDetectorRecordAndCheck: () => ({ triggered: false, cycleCount: 0 }),
+      resolveDoneTransition: vi.fn(() => ({ nextStep: 'COMPLETE' })),
+      runLoopMonitorJudge: vi.fn(),
+      runStep: vi.fn(async (_step: WorkflowStep, instruction: string) => ({ response, instruction })),
+      runQualityGates: vi.fn(async () => ({ ok: true as const })),
+      persistPreviousResponseSnapshot: vi.fn(),
+      buildInstruction: vi.fn((_step: WorkflowStep, stepIteration: number) => `instruction ${stepIteration}`),
+      buildPhase1Instruction: vi.fn((_step: WorkflowStep, instruction: string) => instruction),
+      resolveStepProviderModel: vi.fn(() => providerInfo),
+      resolveRuntimeForStep: vi.fn(),
+      setActiveStep: vi.fn(),
+      addUserInput: vi.fn(),
+      emit: vi.fn(),
+      updateMaxSteps: vi.fn(),
+    };
+
+    await runWorkflowToCompletion(deps);
+
+    expect(getStepProgress).toHaveBeenCalledWith(reviewStep);
+    expect(deps.emit).toHaveBeenCalledWith(
+      'step:start',
+      reviewStep,
+      1,
+      'instruction 1',
+      providerInfo,
+      progressInfo,
+    );
+  });
+});

--- a/src/__tests__/workflowExecutionEvents.test.ts
+++ b/src/__tests__/workflowExecutionEvents.test.ts
@@ -39,6 +39,8 @@ function createBridgeHarness(options?: {
   resumePoint?: WorkflowResumePoint;
   findingIds?: string[];
   traceDiscovery?: { queries: string[] };
+  usePrefixWriter?: boolean;
+  workflowSteps?: Array<{ name: string }>;
 }) {
   const resumePoint = options?.resumePoint ?? {
     version: 1,
@@ -72,20 +74,21 @@ function createBridgeHarness(options?: {
     onFindingLedgerUpdated: vi.fn(),
     seedFindingContractFindingIds: vi.fn(),
   };
+  const displayRef = { current: null };
   const bridge = bindWorkflowExecutionEvents({
     engine: engine as never,
     workflowConfig: {
       name: 'parent',
       maxSteps: 5,
-      steps: [{ name: 'review' }],
+      steps: options?.workflowSteps ?? [{ name: 'review' }],
     },
     task: 'task',
     projectCwd: '/tmp/project',
     currentProvider: options?.currentProvider ?? 'mock',
     configuredModel: options?.configuredModel ?? 'gpt-test',
     out: out as never,
-    prefixWriter: prefixWriter as never,
-    displayRef: { current: null },
+    prefixWriter: options?.usePrefixWriter === false ? undefined : prefixWriter as never,
+    displayRef,
     handlerRef: { current: null },
     providerEventLogger: {
       setStep: vi.fn(),
@@ -126,7 +129,7 @@ function createBridgeHarness(options?: {
     },
   });
 
-  return { bridge, engine, out, runMetaManager, resumePoint, analyticsEmitter };
+  return { bridge, engine, out, runMetaManager, resumePoint, analyticsEmitter, displayRef };
 }
 
 describe('bindWorkflowExecutionEvents', () => {
@@ -277,6 +280,35 @@ describe('bindWorkflowExecutionEvents', () => {
     });
 
     expect(out.info).toHaveBeenCalledWith('Variant: high');
+  });
+
+  it('should use child workflow progress when relaying workflow_call child step starts', () => {
+    const { engine, displayRef } = createBridgeHarness({
+      usePrefixWriter: false,
+      workflowSteps: [{ name: 'plan' }, { name: 'delegate' }, { name: 'summarize' }],
+    });
+    const childStep = {
+      name: 'child-review',
+      personaDisplayName: 'Child Reviewer',
+      instruction: '',
+    } as WorkflowStep;
+
+    engine.emit('step:start', childStep, 2, 'instruction', {
+      provider: 'mock',
+      model: 'gpt-test',
+    }, {
+      workflowName: 'child',
+      stepIndex: 0,
+      totalSteps: 2,
+    });
+
+    expect(displayRef.current).not.toBeNull();
+    expect((displayRef.current as never as { progressInfo?: unknown }).progressInfo).toMatchObject({
+      iteration: 2,
+      maxSteps: 5,
+      stepIndex: 0,
+      totalSteps: 2,
+    });
   });
 
   it('Codex reasoning effort を step start の provider option 表示に含める', () => {

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -17,6 +17,7 @@ import type {
   WorkflowEngineOptions,
   WorkflowRunResult,
   WorkflowSharedRuntimeState,
+  WorkflowStepProgressInfo,
 } from '../types.js';
 import { LoopDetector } from './loop-detector.js';
 import { createInitialState, addUserInput as addUserInputToState } from './state-manager.js';
@@ -237,6 +238,7 @@ export class WorkflowEngine extends EventEmitter {
           buildInstruction: this.stepCoordinator.buildInstruction.bind(this.stepCoordinator),
           buildPhase1Instruction: this.stepCoordinator.buildPhase1Instruction.bind(this.stepCoordinator),
           resolveStepProviderModel: (step, runtime) => this.optionsBuilder.resolveStepProviderModel(step, runtime),
+          getStepProgress: this.getStepProgressInfo.bind(this),
           resolveRuntimeForStep: this.stepCoordinator.resolveRuntimeForStep.bind(this.stepCoordinator),
           setActiveStep: this.setActiveResumePoint.bind(this),
           addUserInput: this.addUserInput.bind(this),
@@ -284,6 +286,15 @@ export class WorkflowEngine extends EventEmitter {
       stack: [...this.resumeStackPrefix, buildWorkflowResumePointEntry(this.config, step.name, getWorkflowStepKind(step))],
       iteration,
       elapsed_ms: Date.now() - this.sharedRuntime.startedAtMs,
+    };
+  }
+
+  private getStepProgressInfo(step: WorkflowStep): WorkflowStepProgressInfo {
+    const stepIndex = this.config.steps.findIndex((candidate) => candidate.name === step.name);
+    return {
+      workflowName: this.config.name,
+      stepIndex: stepIndex >= 0 ? stepIndex : 0,
+      totalSteps: this.config.steps.length,
     };
   }
 

--- a/src/core/workflow/engine/WorkflowRunLoop.ts
+++ b/src/core/workflow/engine/WorkflowRunLoop.ts
@@ -4,6 +4,7 @@ import { ABORT_STEP, COMPLETE_STEP, ERROR_MESSAGES } from '../constants.js';
 import type {
   RuntimeStepResolution,
   StepProviderInfo,
+  WorkflowStepProgressInfo,
   StepRunResult,
   WorkflowAbortKind,
   WorkflowAbortResult,
@@ -69,6 +70,7 @@ interface WorkflowRunLoopDeps {
   buildInstruction: (step: WorkflowStep, stepIteration: number) => string;
   buildPhase1Instruction: (step: WorkflowStep, instruction: string, runtime?: RuntimeStepResolution) => string;
   resolveStepProviderModel: (step: WorkflowStep, runtime?: RuntimeStepResolution) => StepProviderInfo;
+  getStepProgress?: (step: WorkflowStep) => WorkflowStepProgressInfo;
   resolveRuntimeForStep: (step: WorkflowStep) => RuntimeStepResolution | undefined;
   setActiveStep: (step: WorkflowStep, iteration: number) => void;
   addUserInput: (input: string) => void;
@@ -358,7 +360,12 @@ export async function runWorkflowToCompletion(deps: WorkflowRunLoopDeps): Promis
       : '';
     deps.setActiveStep(step, activeIteration);
     const providerInfo = deps.resolveStepProviderModel(step, stepRuntime);
-    deps.emit('step:start', step, activeIteration, stepInstruction, providerInfo);
+    const progressInfo = deps.getStepProgress?.(step);
+    if (progressInfo) {
+      deps.emit('step:start', step, activeIteration, stepInstruction, providerInfo, progressInfo);
+    } else {
+      deps.emit('step:start', step, activeIteration, stepInstruction, providerInfo);
+    }
 
     try {
       const result = await runWithStepSpan({

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -149,6 +149,12 @@ export interface WorkflowRunResult {
   returnValue?: string;
 }
 
+export interface WorkflowStepProgressInfo {
+  workflowName: string;
+  stepIndex: number;
+  totalSteps: number;
+}
+
 export interface WorkflowCallChildEngine {
   on: (event: string, listener: (...args: unknown[]) => void) => void;
   runWithResult: () => Promise<WorkflowRunResult>;
@@ -166,7 +172,13 @@ export type WorkflowCallResolver = (request: WorkflowCallResolutionRequest) => W
 
 /** Events emitted by workflow engine */
 export interface WorkflowEvents {
-  'step:start': (step: WorkflowStep, iteration: number, instruction: string, providerInfo: StepProviderInfo) => void;
+  'step:start': (
+    step: WorkflowStep,
+    iteration: number,
+    instruction: string,
+    providerInfo: StepProviderInfo,
+    progressInfo?: WorkflowStepProgressInfo,
+  ) => void;
   'step:complete': (step: WorkflowStep, response: AgentResponse, instruction: string) => void;
   'step:report': (step: WorkflowStep, filePath: string, fileName: string) => void;
   'findings:ledger': (ledger: FindingLedger) => void;

--- a/src/features/tasks/execute/workflowExecutionEvents.ts
+++ b/src/features/tasks/execute/workflowExecutionEvents.ts
@@ -3,7 +3,7 @@ import type { WorkflowResumePointEntry } from '../../../core/models/index.js';
 import type { WorkflowEngine } from '../../../core/workflow/index.js';
 import type { WorkflowTraceDiscovery } from '../../../core/workflow/observability/traceDiscovery.js';
 import type { SessionLog } from '../../../infra/fs/index.js';
-import type { StepProviderInfo } from '../../../core/workflow/types.js';
+import type { StepProviderInfo, WorkflowStepProgressInfo } from '../../../core/workflow/types.js';
 import { CONFIGURED_PROVIDER_OPTION_VALUE } from '../../../core/workflow/providerOptionsRedaction.js';
 import type { ProviderType } from '../../../shared/types/provider.js';
 import { StreamDisplay } from '../../../shared/ui/index.js';
@@ -124,6 +124,34 @@ function emitProviderOptionLines(
   }
 }
 
+function resolveDisplayProgress(
+  workflowConfig: WorkflowExecutionEventBridgeDeps['workflowConfig'],
+  step: { name: string },
+  progressInfo: WorkflowStepProgressInfo | undefined,
+): Pick<WorkflowStepProgressInfo, 'stepIndex' | 'totalSteps'> {
+  // workflow_call relays child step events through the parent bridge, so the
+  // emitting engine must be allowed to provide its own workflow-local progress.
+  if (
+    progressInfo
+    && Number.isInteger(progressInfo.stepIndex)
+    && progressInfo.stepIndex >= 0
+    && Number.isInteger(progressInfo.totalSteps)
+    && progressInfo.totalSteps > 0
+    && progressInfo.stepIndex < progressInfo.totalSteps
+  ) {
+    return {
+      stepIndex: progressInfo.stepIndex,
+      totalSteps: progressInfo.totalSteps,
+    };
+  }
+
+  const stepIndex = workflowConfig.steps.findIndex((workflowStep) => workflowStep.name === step.name);
+  return {
+    stepIndex: stepIndex >= 0 ? stepIndex : 0,
+    totalSteps: workflowConfig.steps.length,
+  };
+}
+
 export function bindWorkflowExecutionEvents(
   deps: WorkflowExecutionEventBridgeDeps,
 ): WorkflowExecutionEventBridge {
@@ -197,7 +225,7 @@ export function bindWorkflowExecutionEvents(
     );
   });
 
-  deps.engine.on('step:start', (step, iteration, instruction, providerInfo) => {
+  deps.engine.on('step:start', (step, iteration, instruction, providerInfo, progressInfo) => {
     state.currentIteration = iteration;
     state.lastResumePoint = getResumePoint();
     deps.runMetaManager.updateStep(step.name, iteration, state.lastResumePoint);
@@ -234,12 +262,12 @@ export function bindWorkflowExecutionEvents(
     deps.analyticsEmitter.updateProviderInfo(iteration, stepProvider, stepModel);
 
     if (!deps.prefixWriter) {
-      const stepIndex = deps.workflowConfig.steps.findIndex((workflowStep) => workflowStep.name === step.name);
+      const displayProgress = resolveDisplayProgress(deps.workflowConfig, step, progressInfo);
       deps.displayRef.current = new StreamDisplay(safePersonaDisplayName, isQuietMode(), {
         iteration,
         maxSteps: deps.workflowConfig.maxSteps,
-        stepIndex: stepIndex >= 0 ? stepIndex : 0,
-        totalSteps: deps.workflowConfig.steps.length,
+        stepIndex: displayProgress.stepIndex,
+        totalSteps: displayProgress.totalSteps,
       });
       deps.handlerRef.current = null;
     }


### PR DESCRIPTION
## Summary
- Emit workflow-local step progress metadata with `step:start` events.
- Prefer emitted child workflow progress in the execution event bridge so `workflow_call` child steps display their own step count.
- Add regression coverage for run-loop progress emission and bridge display behavior.

Fixes #883

## Verification
- npm test -- src/__tests__/workflowExecutionEvents.test.ts
- npm test -- src/__tests__/workflow-run-loop-step-progress.test.ts
- npm test -- src/__tests__/workflowExecutionEvents.test.ts src/__tests__/workflow-run-loop-step-progress.test.ts src/__tests__/engine-workflow-call.test.ts src/__tests__/workflowExecution-structured-caller.test.ts src/__tests__/StreamDisplay.test.ts
- npm run build
- npm run lint
- git diff --check
- npm audit --audit-level=moderate
- npm test
- npm run test:e2e:mock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 「ステップ開始」イベントに、進捗メタデータ（ワークフロー名、ステップ位置、総ステップ数）を追加しました（任意）。
  * 表示用の進捗が、親子ワークフロー間でも適切なステップ数に基づいて更新されます。
* **テスト**
  * 親子ワークフローの進捗中継と、イベント発火内容（進捗情報含む）を検証するテストを追加・拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->