### PR TITLE
Fix failed retries resuming past iteration budget

### DIFF
--- a/src/__tests__/resolveTask.test.ts
+++ b/src/__tests__/resolveTask.test.ts
@@ -475,6 +475,23 @@ describe('resolveTaskExecution', () => {
     expect(result.initialIterationOverride).toBeUndefined();
   });
 
+  it('should raise stored maxStepsOverride when resumed iteration reaches an unavailable workflow ceiling', async () => {
+    const root = createTempProjectDir();
+    const task = createTask({
+      data: ({
+        task: 'Run task',
+        workflow: 'missing-workflow',
+        exceeded_max_steps: 50,
+        exceeded_current_iteration: 50,
+      } as unknown) as NonNullable<TaskInfo['data']>,
+    });
+
+    const result = await resolveTaskExecutionStrict(task, root);
+
+    expect(result.initialIterationOverride).toBe(50);
+    expect(result.maxStepsOverride).toBe(51);
+  });
+
   it('should fail fast when an unknown workflow key is present', async () => {
     const root = createTempProjectDir();
     const task = createTask({

--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -192,7 +192,16 @@ describe('TaskRunner (tasks.yaml)', () => {
     });
   });
 
-  it('should fail interrupted running tasks with start_movement from run meta', () => {
+  it('should fail interrupted running tasks with retry metadata from run meta', () => {
+    const latestResumePoint = {
+      version: 1 as const,
+      stack: [
+        { workflow: 'default', step: 'delegate', kind: 'workflow_call' as const },
+        { workflow: 'takt/coding', step: 'review', kind: 'agent' as const },
+      ],
+      iteration: 7,
+      elapsed_ms: 183245,
+    };
     runner.addTask('Task A', {
       workflow: 'default',
       start_step: 'draft',
@@ -223,15 +232,7 @@ describe('TaskRunner (tasks.yaml)', () => {
       startTime: '2026-04-13T00:00:00.000Z',
       currentStep: 'delegate',
       currentIteration: 7,
-      resume_point: {
-        version: 1,
-        stack: [
-          { workflow: 'default', step: 'delegate', kind: 'workflow_call' },
-          { workflow: 'takt/coding', step: 'review', kind: 'agent' },
-        ],
-        iteration: 7,
-        elapsed_ms: 183245,
-      },
+      resume_point: latestResumePoint,
     });
 
     const current = loadTasksFile(testDir);
@@ -248,8 +249,9 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(file.tasks[0]?.run_slug).toBe('20260413-task-a');
     expect(file.tasks[0]?.start_movement).toBe('delegate');
     expect(file.tasks[0]?.start_step).toBeUndefined();
-    expect(file.tasks[0]?.resume_point).toBeUndefined();
-    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
+    expect(file.tasks[0]?.resume_point).toEqual(latestResumePoint);
+    expect(file.tasks[0]?.exceeded_current_iteration).toBe(7);
+    expect(file.tasks[0]?.exceeded_max_steps).toBe(30);
     expect(file.tasks[0]?.failure).toEqual({
       error: 'Task was interrupted before this TAKT run started. Requeue it explicitly to run again.',
     });
@@ -765,7 +767,7 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(file.tasks[0]?.resume_point).toEqual(resumePoint);
   });
 
-  it('should keep only start_movement when a re-executed task fails with run meta', () => {
+  it('should preserve latest retry metadata when a re-executed task fails with run meta', () => {
     const latestResumePoint = {
       version: 1 as const,
       stack: [
@@ -821,12 +823,12 @@ describe('TaskRunner (tasks.yaml)', () => {
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.start_movement).toBe('final-review');
     expect(file.tasks[0]?.start_step).toBeUndefined();
-    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
-    expect(file.tasks[0]?.resume_point).toBeUndefined();
-    expect(file.tasks[0]?.exceeded_max_steps).toBeUndefined();
+    expect(file.tasks[0]?.exceeded_current_iteration).toBe(9);
+    expect(file.tasks[0]?.resume_point).toEqual(latestResumePoint);
+    expect(file.tasks[0]?.exceeded_max_steps).toBe(30);
   });
 
-  it('should keep only start_movement when terminal failure happens after the child completes', () => {
+  it('should preserve terminal failure resume_point after the child completes', () => {
     const workflowCallResumePoint = {
       version: 1 as const,
       stack: [
@@ -881,8 +883,9 @@ describe('TaskRunner (tasks.yaml)', () => {
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.start_movement).toBe('delegate');
     expect(file.tasks[0]?.start_step).toBeUndefined();
-    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
-    expect(file.tasks[0]?.resume_point).toBeUndefined();
+    expect(file.tasks[0]?.exceeded_current_iteration).toBe(7);
+    expect(file.tasks[0]?.resume_point).toEqual(workflowCallResumePoint);
+    expect(file.tasks[0]?.exceeded_max_steps).toBeUndefined();
   });
 
   it('should clear stale retry metadata when a re-executed task completes without run meta', () => {

--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -625,6 +625,42 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(file.tasks[0]?.retry_note).toBe('retry note');
   });
 
+  it('should clear stale retry budget when requeueing onto a different workflow', () => {
+    const resumePoint = {
+      version: 1 as const,
+      stack: [
+        { workflow: 'default', step: 'delegate', kind: 'workflow_call' as const },
+      ],
+      iteration: 7,
+      elapsed_ms: 183245,
+    };
+    writeTasksFile(testDir, [TaskRecordSchema.parse({
+      name: 'task-a',
+      status: 'failed',
+      content: 'Task A',
+      workflow: 'default',
+      start_step: 'delegate',
+      exceeded_max_steps: 30,
+      exceeded_current_iteration: 7,
+      resume_point: resumePoint,
+      created_at: '2026-02-09T00:00:00.000Z',
+      started_at: '2026-02-09T00:01:00.000Z',
+      completed_at: '2026-02-09T00:05:00.000Z',
+      owner_pid: null,
+      failure: {
+        error: 'Boom',
+      },
+    }) as unknown as Record<string, unknown>]);
+
+    runner.requeueTask('task-a', ['failed'], undefined, 'retry note', undefined, 'selected-workflow');
+
+    const file = loadTasksFile(testDir);
+    expect(file.tasks[0]?.workflow).toBe('selected-workflow');
+    expect(file.tasks[0]?.resume_point).toBeUndefined();
+    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
+    expect(file.tasks[0]?.exceeded_max_steps).toBeUndefined();
+  });
+
   it('should persist task_dir as the only task spec source when requeueing task', () => {
     runner.addTask('Task A');
     const task = runner.claimNextTasks(1)[0]!;
@@ -883,7 +919,7 @@ describe('TaskRunner (tasks.yaml)', () => {
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.start_movement).toBe('delegate');
     expect(file.tasks[0]?.start_step).toBeUndefined();
-    expect(file.tasks[0]?.exceeded_current_iteration).toBe(7);
+    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
     expect(file.tasks[0]?.resume_point).toEqual(workflowCallResumePoint);
     expect(file.tasks[0]?.exceeded_max_steps).toBeUndefined();
   });

--- a/src/__tests__/worktree-exceeded-requeue.test.ts
+++ b/src/__tests__/worktree-exceeded-requeue.test.ts
@@ -348,7 +348,7 @@ describe('シナリオ3・4: requeue → re-execution passes exceeded metadata t
     const resumePoint = {
       version: 1 as const,
       stack: [
-        { workflow: 'test-workflow', step: 'implement', kind: 'agent' as const },
+        { workflow: 'test-workflow', step: 'plan', kind: 'agent' as const },
       ],
       iteration: 51,
       elapsed_ms: 183245,
@@ -356,11 +356,10 @@ describe('シナリオ3・4: requeue → re-execution passes exceeded metadata t
     writeFailedRecord(testDir, {
       worktree: true,
       worktree_path: cloneDir,
-      exceeded_current_iteration: 51,
       resume_point: resumePoint,
     });
 
-    runner.requeueTask('task-a', ['failed'], 'implement', undefined, resumePoint);
+    runner.requeueTask('task-a', ['failed'], 'plan', undefined, resumePoint);
 
     const [task] = runner.claimNextTasks(1);
     if (!task) throw new Error('No task claimed');

--- a/src/__tests__/worktree-exceeded-requeue.test.ts
+++ b/src/__tests__/worktree-exceeded-requeue.test.ts
@@ -107,6 +107,30 @@ function writeExceededRecord(testDir: string, overrides: Record<string, unknown>
   );
 }
 
+function writeFailedRecord(testDir: string, overrides: Record<string, unknown> = {}): void {
+  mkdirSync(join(testDir, '.takt'), { recursive: true });
+  const record = {
+    name: 'task-a',
+    status: 'failed',
+    content: 'Do work',
+    workflow: 'test-workflow',
+    created_at: '2026-02-09T00:00:00.000Z',
+    started_at: '2026-02-09T00:01:00.000Z',
+    completed_at: '2026-02-09T00:05:00.000Z',
+    owner_pid: null,
+    start_step: 'implement',
+    failure: {
+      error: 'Boom after retry',
+    },
+    ...overrides,
+  };
+  writeFileSync(
+    join(testDir, '.takt', 'tasks.yaml'),
+    stringifyYaml({ tasks: [record] }),
+    'utf-8',
+  );
+}
+
 function buildTestWorkflowConfig(): WorkflowConfig {
   return {
     name: 'test-workflow',
@@ -314,6 +338,41 @@ describe('シナリオ3・4: requeue → re-execution passes exceeded metadata t
     expect(vi.mocked(executeWorkflow)).toHaveBeenCalledOnce();
     const capturedOptions = vi.mocked(executeWorkflow).mock.calls[0]![3] as WorkflowExecutionOptions;
     expect(capturedOptions.startStep).toBe('implement');
+  });
+
+  it('scenario 7: failed requeue raises maxStepsOverride beyond the restored iteration', async () => {
+    vi.mocked(loadWorkflowByIdentifier).mockReturnValue({
+      ...buildTestWorkflowConfig(),
+      maxSteps: 50,
+    });
+    const resumePoint = {
+      version: 1 as const,
+      stack: [
+        { workflow: 'test-workflow', step: 'implement', kind: 'agent' as const },
+      ],
+      iteration: 51,
+      elapsed_ms: 183245,
+    };
+    writeFailedRecord(testDir, {
+      worktree: true,
+      worktree_path: cloneDir,
+      exceeded_current_iteration: 51,
+      resume_point: resumePoint,
+    });
+
+    runner.requeueTask('task-a', ['failed'], 'implement', undefined, resumePoint);
+
+    const [task] = runner.claimNextTasks(1);
+    if (!task) throw new Error('No task claimed');
+
+    vi.mocked(executeWorkflow).mockResolvedValueOnce({ success: true });
+
+    await executeAndCompleteTask(task, runner, testDir);
+
+    expect(vi.mocked(executeWorkflow)).toHaveBeenCalledOnce();
+    const capturedOptions = vi.mocked(executeWorkflow).mock.calls[0]![3] as WorkflowExecutionOptions;
+    expect(capturedOptions.initialIterationOverride).toBe(51);
+    expect(capturedOptions.maxStepsOverride).toBe(100);
   });
 
   it('scenario 6: re-execution trims workflow_call resume_point to the root step when the child no longer resolves', async () => {

--- a/src/features/tasks/execute/resolveTask.ts
+++ b/src/features/tasks/execute/resolveTask.ts
@@ -13,7 +13,7 @@ import {
   resolveTaskStartStepValue,
   TaskExecutionConfigSchema,
 } from '../../../infra/task/index.js';
-import type { WorkflowResumePoint } from '../../../core/models/index.js';
+import type { WorkflowConfig, WorkflowResumePoint } from '../../../core/models/index.js';
 import { trimResumePointStackForWorkflow } from '../../../core/workflow/run/resume-point.js';
 import { getGitProvider, type Issue } from '../../../infra/git/index.js';
 import { withProgress } from '../../../shared/ui/index.js';
@@ -58,7 +58,7 @@ export interface ResolvedTaskExecution {
 }
 
 function resolveRetryResume(
-  workflowIdentifier: string,
+  workflowConfig: WorkflowConfig | null | undefined,
   projectCwd: string,
   lookupCwd: string,
   configuredStartStep: string | undefined,
@@ -71,7 +71,6 @@ function resolveRetryResume(
     return configuredStartStep ? { startStep: configuredStartStep } : {};
   }
 
-  const workflowConfig = loadWorkflowByIdentifier(workflowIdentifier, projectCwd, { lookupCwd });
   if (!workflowConfig) {
     return {
       ...(configuredStartStep ? { startStep: configuredStartStep } : {}),
@@ -100,6 +99,36 @@ function resolveRetryResume(
   return {
     ...(configuredStartStep ? { startStep: configuredStartStep } : {}),
   };
+}
+
+function resolveWorkflowMaxSteps(workflowConfig: WorkflowConfig | null | undefined): number | undefined {
+  const maxSteps = workflowConfig?.maxSteps;
+  return typeof maxSteps === 'number' && Number.isFinite(maxSteps) && maxSteps > 0
+    ? maxSteps
+    : undefined;
+}
+
+function resolveRetryMaxStepsOverride(
+  storedMaxSteps: number | undefined,
+  initialIteration: number | undefined,
+  workflowMaxSteps: number | undefined,
+): number | undefined {
+  if (initialIteration === undefined) {
+    return storedMaxSteps;
+  }
+
+  const currentMaxSteps = storedMaxSteps ?? workflowMaxSteps;
+  if (currentMaxSteps === undefined || initialIteration < currentMaxSteps) {
+    return storedMaxSteps;
+  }
+  if (workflowMaxSteps === undefined) {
+    return storedMaxSteps;
+  }
+
+  // Iteration-limit checks run before the next step, so the restored ceiling
+  // must be strictly greater than the iteration count saved in retry metadata.
+  const retryWindowCount = Math.floor(initialIteration / workflowMaxSteps) + 1;
+  return Math.max(currentMaxSteps, retryWindowCount * workflowMaxSteps);
 }
 
 function throwIfAborted(signal?: AbortSignal): void {
@@ -224,16 +253,24 @@ export async function resolveTaskExecution(
   }
 
   const resolvedReportDirName = reportDirName ?? generateReportDir(task.content);
+  const needsWorkflowRetryContext = resumePoint !== undefined || data.exceeded_current_iteration !== undefined;
+  const workflowConfig = needsWorkflowRetryContext
+    ? loadWorkflowByIdentifier(workflowIdentifier, defaultCwd, { lookupCwd: execCwd })
+    : undefined;
   const retryResume = resolveRetryResume(
-    workflowIdentifier,
+    workflowConfig,
     defaultCwd,
     execCwd,
     configuredStartStep,
     resumePoint,
   );
   const resolvedRetryNote = data.retry_note;
-  const maxStepsOverride = data.exceeded_max_steps;
   const initialIterationOverride = data.exceeded_current_iteration ?? retryResume.resumePoint?.iteration;
+  const maxStepsOverride = resolveRetryMaxStepsOverride(
+    data.exceeded_max_steps,
+    initialIterationOverride,
+    resolveWorkflowMaxSteps(workflowConfig),
+  );
 
   const autoPr = data.auto_pr ?? resolveWorkflowConfigValue(defaultCwd, 'autoPr') ?? false;
   const draftPr = data.draft_pr ?? resolveWorkflowConfigValue(defaultCwd, 'draftPr') ?? false;

--- a/src/features/tasks/execute/resolveTask.ts
+++ b/src/features/tasks/execute/resolveTask.ts
@@ -122,7 +122,9 @@ function resolveRetryMaxStepsOverride(
     return storedMaxSteps;
   }
   if (workflowMaxSteps === undefined) {
-    return storedMaxSteps;
+    return storedMaxSteps !== undefined && initialIteration >= storedMaxSteps
+      ? initialIteration + 1
+      : storedMaxSteps;
   }
 
   // Iteration-limit checks run before the next step, so the restored ceiling

--- a/src/infra/task/taskLifecycleService.ts
+++ b/src/infra/task/taskLifecycleService.ts
@@ -117,9 +117,15 @@ export class TaskLifecycleService {
       return retryMetadata;
     }
 
-    return retryMetadata.startStep
-      ? { startStep: retryMetadata.startStep }
-      : {};
+    // Failed terminal states are requeueable, so keep the latest resume cursor.
+    // Otherwise a retry can restore a later iteration while falling back to the
+    // workflow's original maxSteps and immediately exceed again.
+    return {
+      ...retryMetadata,
+      ...(task.exceeded_max_steps !== undefined && retryMetadata.currentIteration !== undefined
+        ? { maxSteps: task.exceeded_max_steps }
+        : {}),
+    };
   }
 
   completeTask(result: TaskResult): string {

--- a/src/infra/task/taskRecordMutations.ts
+++ b/src/infra/task/taskRecordMutations.ts
@@ -7,6 +7,7 @@ export interface ResolvedTaskRetryMetadata {
   startStep?: string;
   resumePoint?: WorkflowResumePoint;
   currentIteration?: number;
+  maxSteps?: number;
   preserveExisting?: boolean;
 }
 
@@ -45,6 +46,9 @@ export function buildTerminalTaskRecord(
     ...(nextRetryMetadata?.resumePoint ? { resume_point: nextRetryMetadata.resumePoint } : {}),
     ...(nextRetryMetadata?.currentIteration !== undefined
       ? { exceeded_current_iteration: nextRetryMetadata.currentIteration }
+      : {}),
+    ...(nextRetryMetadata?.maxSteps !== undefined
+      ? { exceeded_max_steps: nextRetryMetadata.maxSteps }
       : {}),
   };
 }

--- a/src/infra/task/taskRecordMutations.ts
+++ b/src/infra/task/taskRecordMutations.ts
@@ -38,18 +38,20 @@ export function buildTerminalTaskRecord(
 ): TaskRecord {
   const nextTask = retryMetadata?.preserveExisting ? { ...task } : clearRetryMetadata(task);
   const nextRetryMetadata = retryMetadata?.preserveExisting ? undefined : retryMetadata;
+  const exceededMetadata =
+    nextRetryMetadata?.currentIteration !== undefined && nextRetryMetadata.maxSteps !== undefined
+      ? {
+          exceeded_current_iteration: nextRetryMetadata.currentIteration,
+          exceeded_max_steps: nextRetryMetadata.maxSteps,
+        }
+      : {};
 
   return {
     ...nextTask,
     ...updates,
     ...(nextRetryMetadata?.startStep ? { start_step: nextRetryMetadata.startStep } : {}),
     ...(nextRetryMetadata?.resumePoint ? { resume_point: nextRetryMetadata.resumePoint } : {}),
-    ...(nextRetryMetadata?.currentIteration !== undefined
-      ? { exceeded_current_iteration: nextRetryMetadata.currentIteration }
-      : {}),
-    ...(nextRetryMetadata?.maxSteps !== undefined
-      ? { exceeded_max_steps: nextRetryMetadata.maxSteps }
-      : {}),
+    ...exceededMetadata,
   };
 }
 
@@ -65,6 +67,8 @@ export function buildRetryTaskRecord(
   const taskSpecSource = taskDir
     ? { content: undefined, content_file: undefined, task_dir: taskDir }
     : {};
+  const preservesSameWorkflow = workflow === undefined || workflow === task.workflow;
+  const preservesResumeBudget = resumePoint !== undefined && preservesSameWorkflow;
 
   return {
     ...task,
@@ -79,6 +83,10 @@ export function buildRetryTaskRecord(
     start_step: startStep,
     retry_note: retryNote,
     resume_point: resumePoint,
+    // Retry budgets are tied to the saved resume cursor and workflow. Carrying
+    // them to a different workflow can start that workflow already over budget.
+    exceeded_current_iteration: preservesResumeBudget ? task.exceeded_current_iteration : undefined,
+    exceeded_max_steps: preservesResumeBudget ? task.exceeded_max_steps : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- Preserve the latest run metadata retry cursor when interrupted or re-executed tasks end as failed.
- Keep retry budget metadata paired and tied to the same resume cursor/workflow so stale budgets are not carried to a different workflow.
- Derive a retry maxStepsOverride from the workflow window, or a safe stored ceiling fallback, so failed retries resume above the restored iteration.

Fixes #787

## Verification
- npm run build
- npm run lint
- npm audit --audit-level=moderate
- npm test (497 files / 7077 tests)
- npm run test:e2e:mock (38 passed / 1 skipped; 115 passed / 14 skipped / 30 todo)