### PR TITLE
fix: expose in-flight team leader parts

### DIFF
--- a/src/__tests__/agent-usecases.test.ts
+++ b/src/__tests__/agent-usecases.test.ts
@@ -557,6 +557,40 @@ describe('agent-usecases', () => {
     }));
   });
 
+  it('requestMoreParts は running/queued 中の予定済み作業をプロンプトに含める', async () => {
+    vi.mocked(runAgent).mockResolvedValue(doneResponse('x', {
+      done: true,
+      reasoning: 'Enough after running parts finish',
+      parts: [],
+    }));
+
+    await requestMoreParts(
+      'original instruction',
+      [{ id: 'verify-gates', title: 'Verify gates', status: 'done', content: 'lint passed' }],
+      ['verify-gates', 'verify', 'docs'],
+      2,
+      {
+        cwd: '/repo',
+        persona: 'team-leader',
+        language: 'en',
+        unfinishedScheduledPartCount: 2,
+        runningPartCount: 1,
+        queuedPartCount: 1,
+      },
+    );
+
+    expect(runAgent).toHaveBeenCalledWith(
+      'team-leader',
+      expect.stringContaining('Running parts: 1'),
+      expect.any(Object),
+    );
+    expect(runAgent).toHaveBeenCalledWith(
+      'team-leader',
+      expect.stringContaining('Queued parts: 1'),
+      expect.any(Object),
+    );
+  });
+
   it('requestMoreParts は inspect tools を feedback planning call に渡さない', async () => {
     vi.mocked(runAgent).mockResolvedValue(doneResponse('x', {
       done: true,

--- a/src/__tests__/team-leader-execution.test.ts
+++ b/src/__tests__/team-leader-execution.test.ts
@@ -22,6 +22,14 @@ function makeResult(part: PartDefinition): PartResult {
   };
 }
 
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
 describe('runTeamLeaderExecution', () => {
   it('初回5パートを最大2並列で順次実行する', async () => {
     const parts = ['p1', 'p2', 'p3', 'p4', 'p5'].map(makePart);
@@ -108,6 +116,63 @@ describe('runTeamLeaderExecution', () => {
     expect(result.partResults.some((r) => r.part.id === part3.id)).toBe(true);
   });
 
+  it('done 判定時に running 中パート数を伝え、完了まで planning done を保留する', async () => {
+    const fastPart = makePart('verify-gates');
+    const slowPart = makePart('verify');
+    const slowResult = createDeferred<PartResult>();
+    const feedbackRequested = createDeferred<void>();
+    const onPlanningDone = vi.fn();
+
+    const runPart = vi.fn(async (part: PartDefinition) => {
+      if (part.id === slowPart.id) {
+        return slowResult.promise;
+      }
+      return makeResult(part);
+    });
+    const requestMoreParts = vi.fn(async () => {
+      feedbackRequested.resolve();
+      return {
+        done: true,
+        reasoning: 'finished after verification',
+        parts: [],
+      };
+    });
+
+    const execution = runTeamLeaderExecution({
+      initialParts: [fastPart, slowPart],
+      maxConcurrency: 2,
+      refillThreshold: 1,
+      maxTotalParts: 3,
+      runPart,
+      requestMoreParts,
+      onPlanningDone,
+    });
+
+    await feedbackRequested.promise;
+
+    expect(requestMoreParts).toHaveBeenCalledWith({
+      partResults: [expect.objectContaining({ part: fastPart })],
+      scheduledIds: ['verify-gates', 'verify'],
+      remainingPartBudget: 1,
+      unfinishedScheduledPartCount: 1,
+      runningPartCount: 1,
+      queuedPartCount: 0,
+    });
+    expect(onPlanningDone).not.toHaveBeenCalled();
+
+    slowResult.resolve(makeResult(slowPart));
+
+    const result = await execution;
+
+    expect(result.partResults.map((r) => r.part.id).sort()).toEqual(['verify', 'verify-gates']);
+    expect(onPlanningDone).toHaveBeenCalledTimes(1);
+    expect(onPlanningDone).toHaveBeenCalledWith({
+      reason: 'finished after verification',
+      plannedParts: 2,
+      completedParts: 2,
+    });
+  });
+
   it('追加パートが残り maxTotalParts 予算を超える場合はエラーにする', async () => {
     const parts = ['p1', 'p2'].map(makePart);
     const runPart = vi.fn(async (part: PartDefinition) => makeResult(part));
@@ -131,6 +196,8 @@ describe('runTeamLeaderExecution', () => {
       scheduledIds: ['p1', 'p2'],
       remainingPartBudget: 1,
       unfinishedScheduledPartCount: 1,
+      runningPartCount: 0,
+      queuedPartCount: 1,
     });
   });
 

--- a/src/__tests__/team-leader-prompt-guidance.test.ts
+++ b/src/__tests__/team-leader-prompt-guidance.test.ts
@@ -161,6 +161,43 @@ describe('team leader decomposition guidance', () => {
     expect(promptBasedPrompt).not.toContain('少なくとも1つの part');
   });
 
+  it('Given feedback planning with in-flight scheduled work, When building more-parts prompts, Then the leader sees running and queued counts', () => {
+    const results = [
+      { id: 'verify-gates', title: 'Verify gates', status: 'done', content: 'lint passed' },
+    ];
+    const context = {
+      unfinishedScheduledPartCount: 2,
+      runningPartCount: 1,
+      queuedPartCount: 1,
+    };
+
+    const structuredPrompt = buildMorePartsPrompt(
+      'implement feature',
+      results,
+      ['verify-gates', 'verify', 'docs'],
+      2,
+      'en',
+      context,
+    );
+    const promptBasedPrompt = buildPromptBasedMorePartsPrompt(
+      '実装タスク',
+      results,
+      ['verify-gates', 'verify', 'docs'],
+      2,
+      'ja',
+      context,
+    );
+
+    expect(structuredPrompt).toContain('Scheduled Work Still In Flight');
+    expect(structuredPrompt).toContain('Unfinished scheduled parts: 2');
+    expect(structuredPrompt).toContain('Running parts: 1');
+    expect(structuredPrompt).toContain('Queued parts: 1');
+    expect(promptBasedPrompt).toContain('未完了の予定済み作業');
+    expect(promptBasedPrompt).toContain('未完了の予定済み parts: 2');
+    expect(promptBasedPrompt).toContain('実行中 parts: 1');
+    expect(promptBasedPrompt).toContain('待機中 parts: 1');
+  });
+
   it('Given builtin team-leader facets, When reading runtime instructions, Then both languages reject single oversized parts before execution', () => {
     const japanese = readBuiltinInstruction('builtins/ja/facets/instructions/team-leader-implement.md');
     const english = readBuiltinInstruction('builtins/en/facets/instructions/team-leader-implement.md');

--- a/src/agents/decompose-task-usecase.ts
+++ b/src/agents/decompose-task-usecase.ts
@@ -9,6 +9,7 @@ import {
   buildMorePartsPrompt,
   toMorePartsResponse,
   toPartDefinitions,
+  type MorePartsPlanningContext,
 } from './team-leader-structured-output.js';
 
 export interface DecomposeTaskOptions {
@@ -30,7 +31,7 @@ export interface DecomposeTaskOptions {
   }) => void;
 }
 
-export type MorePartsOptions = Omit<DecomposeTaskOptions, 'inspectTools' | 'onPromptResolved'>;
+export type MorePartsOptions = Omit<DecomposeTaskOptions, 'inspectTools' | 'onPromptResolved'> & MorePartsPlanningContext;
 
 export interface MorePartsResponse {
   done: boolean;
@@ -94,6 +95,7 @@ export async function requestMoreParts(
     existingIds,
     maxAdditionalParts,
     options.language,
+    options,
   );
 
   const response = await runAgent(options.persona, prompt, {

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -212,6 +212,7 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
       existingIds,
       maxAdditionalParts,
       options.language,
+      options,
     );
 
     return withRetry(async () => {

--- a/src/agents/team-leader-structured-output.ts
+++ b/src/agents/team-leader-structured-output.ts
@@ -2,6 +2,12 @@ import type { Language, PartDefinition } from '../core/models/types.js';
 import { ensureUniquePartIds, parsePartDefinitionEntry } from '../core/workflow/part-definition-validator.js';
 import type { MorePartsResponse } from './decompose-task-usecase.js';
 
+export interface MorePartsPlanningContext {
+  unfinishedScheduledPartCount?: number;
+  runningPartCount?: number;
+  queuedPartCount?: number;
+}
+
 function summarizePartContent(content: string): string {
   const maxLength = 2000;
   if (content.length <= maxLength) {
@@ -145,12 +151,52 @@ function buildDecomposeBasePrompt(
   ].join('\n');
 }
 
+function hasMorePartsPlanningContext(context?: MorePartsPlanningContext): boolean {
+  return context?.unfinishedScheduledPartCount !== undefined
+    || context?.runningPartCount !== undefined
+    || context?.queuedPartCount !== undefined;
+}
+
+function buildMorePartsPlanningContextSection(
+  language: Language | undefined,
+  context?: MorePartsPlanningContext,
+): string[] {
+  if (!hasMorePartsPlanningContext(context)) {
+    return [];
+  }
+
+  const unfinishedScheduledPartCount = context?.unfinishedScheduledPartCount ?? 0;
+  const runningPartCount = context?.runningPartCount ?? 0;
+  const queuedPartCount = context?.queuedPartCount ?? 0;
+
+  if (language === 'ja') {
+    return [
+      '',
+      '## 未完了の予定済み作業',
+      `- 未完了の予定済み parts: ${unfinishedScheduledPartCount}`,
+      `- 実行中 parts: ${runningPartCount}`,
+      `- 待機中 parts: ${queuedPartCount}`,
+      '- done=true は、完了済み結果だけでなく上記の未完了作業も踏まえて判断する',
+    ];
+  }
+
+  return [
+    '',
+    '## Scheduled Work Still In Flight',
+    `- Unfinished scheduled parts: ${unfinishedScheduledPartCount}`,
+    `- Running parts: ${runningPartCount}`,
+    `- Queued parts: ${queuedPartCount}`,
+    '- Treat done=true as a decision over completed results plus the in-flight scheduled work above',
+  ];
+}
+
 function buildMorePartsBasePrompt(
   originalInstruction: string,
   allResults: Array<{ id: string; title: string; status: string; content: string }>,
   existingIds: string[],
   maxAdditionalParts: number,
   language?: Language,
+  planningContext?: MorePartsPlanningContext,
 ): string {
   const resultBlock = allResults.map((result) => [
     `### ${result.id}: ${result.title} (${result.status})`,
@@ -167,6 +213,7 @@ function buildMorePartsBasePrompt(
       '',
       '## 完了済みパート',
       resultBlock || '(なし)',
+      ...buildMorePartsPlanningContextSection(language, planningContext),
       '',
       '## 判断ルール',
       '- 追加作業が不要なら done=true にする',
@@ -189,6 +236,7 @@ function buildMorePartsBasePrompt(
     '',
     '## Completed Parts',
     resultBlock || '(none)',
+    ...buildMorePartsPlanningContextSection(language, planningContext),
     '',
     '## Decision Rules',
     '- Set done=true when no additional work is required',
@@ -248,6 +296,7 @@ export function buildMorePartsPrompt(
   existingIds: string[],
   maxAdditionalParts: number,
   language?: Language,
+  planningContext?: MorePartsPlanningContext,
 ): string {
   return buildMorePartsBasePrompt(
     originalInstruction,
@@ -255,6 +304,7 @@ export function buildMorePartsPrompt(
     existingIds,
     maxAdditionalParts,
     language,
+    planningContext,
   );
 }
 
@@ -264,6 +314,7 @@ export function buildPromptBasedMorePartsPrompt(
   existingIds: string[],
   maxAdditionalParts: number,
   language?: Language,
+  planningContext?: MorePartsPlanningContext,
 ): string {
   const outputInstruction = language === 'ja'
     ? [
@@ -285,5 +336,6 @@ export function buildPromptBasedMorePartsPrompt(
     existingIds,
     maxAdditionalParts,
     language,
+    planningContext,
   )}\n${outputInstruction.join('\n')}`;
 }

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -235,6 +235,8 @@ export class TeamLeaderRunner {
         scheduledIds,
         remainingPartBudget,
         unfinishedScheduledPartCount,
+        runningPartCount,
+        queuedPartCount,
       }) => {
         emitTeamLeaderProgressHint(this.deps.engineOptions, 'feedback');
         try {
@@ -262,6 +264,9 @@ export class TeamLeaderRunner {
               workflowMeta: leaderWorkflowMeta,
               childProcessEnv: this.deps.engineOptions.childProcessEnv,
               onStream: this.deps.engineOptions.onStream,
+              unfinishedScheduledPartCount,
+              runningPartCount,
+              queuedPartCount,
             },
           );
         } catch (error) {

--- a/src/core/workflow/engine/team-leader-execution.ts
+++ b/src/core/workflow/engine/team-leader-execution.ts
@@ -15,6 +15,8 @@ export interface TeamLeaderExecutionOptions {
       scheduledIds: string[];
       remainingPartBudget: number;
       unfinishedScheduledPartCount: number;
+      runningPartCount: number;
+      queuedPartCount: number;
     }
   ) => Promise<MorePartsResponse>;
   onPartQueued?: (part: PartDefinition, partIndex: number) => void;
@@ -53,6 +55,12 @@ export async function runTeamLeaderExecution(
   let leaderDone = false;
   let deferredDoneReason: string | undefined;
 
+  const hasUnfinishedScheduledWork = (): boolean => {
+    // Use the live queue/running state here so a done response cannot finish planning while
+    // already-scheduled parts are still producing useful results.
+    return queue.length > 0 || running.size > 0 || plannedParts.length > partResults.length;
+  };
+
   const tryPlanMoreParts = async (): Promise<void> => {
     if (leaderDone) {
       return;
@@ -80,10 +88,12 @@ export async function runTeamLeaderExecution(
         scheduledIds: [...scheduledIds],
         remainingPartBudget,
         unfinishedScheduledPartCount: plannedParts.length - partResults.length,
+        runningPartCount: running.size,
+        queuedPartCount: queue.length,
       });
 
       if (feedback.done) {
-        if (plannedParts.length > partResults.length) {
+        if (hasUnfinishedScheduledWork()) {
           deferredDoneReason = feedback.reasoning;
           return;
         }
@@ -106,7 +116,7 @@ export async function runTeamLeaderExecution(
       }
 
       if (newParts.length === 0) {
-        if (plannedParts.length > partResults.length) {
+        if (hasUnfinishedScheduledWork()) {
           return;
         }
         options.onPlanningNoNewParts?.({


### PR DESCRIPTION
## Summary
- Pass unfinished/running/queued scheduled-work counts from team-leader execution into feedback planning
- Add in-flight scheduled-work context to structured and prompt-based more-parts prompts
- Defer done/no-new-parts decisions using live queue/running state so scheduled work can finish before planning closes

Fixes #885

## Tests
- npm test -- src/__tests__/team-leader-execution.test.ts src/__tests__/team-leader-prompt-guidance.test.ts src/__tests__/agent-usecases.test.ts
- npm run build
- npm run lint
- npm test
- npm run test:e2e:mock
- npm audit --audit-level=moderate

## TAKT Review
- Not run locally; CONTRIBUTING marks it optional. Local build, lint, unit, mock E2E, and audit all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 追加の作業を依頼する際に、進行中・待機中・未完了の予定済み作業数を考慮した案内が表示されるようになりました。
  * 追加作業の判断に必要な情報が増え、より状況に沿った計画を立てやすくなりました。

* **バグ修正**
  * 追加作業の完了判定が、実行中や待機中の作業も含めて正しく行われるようになりました。
  * 進行状況に応じて、完了通知のタイミングがより適切になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->