### PR TITLE
fix: normalize Codex structured output schemas

### DIFF
--- a/src/__tests__/codex-structured-output.test.ts
+++ b/src/__tests__/codex-structured-output.test.ts
@@ -16,6 +16,7 @@ import type { CodexCallOptions } from '../infra/codex/types.js';
 
 let mockEvents: Array<Record<string, unknown>> = [];
 let lastThreadOptions: Record<string, unknown> | undefined;
+let lastRunOptions: Record<string, unknown> | undefined;
 let lastCodexConstructorOptions: Record<string, unknown> | undefined;
 
 vi.mock('@openai/codex-sdk', () => {
@@ -28,13 +29,16 @@ vi.mock('@openai/codex-sdk', () => {
         lastThreadOptions = options;
         return {
           id: 'thread-mock',
-          runStreamed: async () => ({
-            events: (async function* () {
-              for (const event of mockEvents) {
-                yield event;
-              }
-            })(),
-          }),
+          runStreamed: async (_input: unknown, options?: Record<string, unknown>) => {
+            lastRunOptions = options;
+            return {
+              events: (async function* () {
+                for (const event of mockEvents) {
+                  yield event;
+                }
+              })(),
+            };
+          },
         };
       }
       async resumeThread() {
@@ -52,6 +56,7 @@ describe('CodexClient — structuredOutput 抽出', () => {
     vi.clearAllMocks();
     mockEvents = [];
     lastThreadOptions = undefined;
+    lastRunOptions = undefined;
     lastCodexConstructorOptions = undefined;
     delete process.env.TAKT_OBSERVABILITY;
     delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
@@ -270,6 +275,126 @@ describe('CodexClient — structuredOutput 抽出', () => {
     });
 
     expect(result.structuredOutput).toEqual({ step: 1 });
+  });
+
+  it('should normalize the schema sent to Codex while keeping literal values unchanged when outputSchema is provided', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        allOf: { type: 'string' },
+        action: { type: 'string' },
+        goals: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        labels: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        meta: {
+          type: 'object',
+          properties: {
+            owner: { type: 'string' },
+          },
+          default: { properties: { owner: 'nrs' } },
+          enum: [{ properties: { owner: 'nrs' } }],
+          allOf: [
+            {
+              properties: {
+                owner: { minLength: 1 },
+              },
+            },
+          ],
+        },
+      },
+      $defs: {
+        taskRef: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+          allOf: [
+            {
+              properties: {
+                id: { minLength: 1 },
+              },
+            },
+          ],
+        },
+      },
+      allOf: [
+        {
+          if: {
+            properties: { action: { const: 'enqueue_new_task' } },
+            required: ['action'],
+          },
+          then: {
+            properties: {
+              goals: { minItems: 1 },
+            },
+          },
+        },
+      ],
+      required: ['action', 'goals'],
+      additionalProperties: false,
+    };
+    const originalSchema = structuredClone(schema);
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      {
+        type: 'item.completed',
+        item: {
+          id: 'msg-1',
+          type: 'agent_message',
+          text: '{"allOf": "field", "action": "wait_before_next_scan", "goals": [], "labels": [], "meta": {"owner": "nrs"}}',
+        },
+      },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    await client.call('coder', 'prompt', {
+      cwd: '/tmp',
+      outputSchema: schema,
+    });
+
+    expect(lastRunOptions?.outputSchema).toEqual({
+      type: 'object',
+      properties: {
+        allOf: { type: 'string' },
+        action: { type: 'string' },
+        goals: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        labels: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        meta: {
+          type: 'object',
+          properties: {
+            owner: { type: 'string' },
+          },
+          default: { properties: { owner: 'nrs' } },
+          enum: [{ properties: { owner: 'nrs' } }],
+          required: ['owner'],
+        },
+      },
+      $defs: {
+        taskRef: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+          required: ['id'],
+        },
+      },
+      required: ['action', 'goals', 'allOf', 'labels', 'meta'],
+      additionalProperties: false,
+    });
+    expect(lastRunOptions?.outputSchema).not.toHaveProperty('allOf');
+    expect(schema).toEqual(originalSchema);
   });
 
   it('provider_options.codex.network_access が ThreadOptions に反映される', async () => {

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -34,6 +34,7 @@ import {
   emitCodexItemUpdate,
 } from './CodexStreamHandler.js';
 import { buildRateLimitedResponseFields, containsRateLimitError } from '../rate-limit/detection.js';
+import { normalizeCodexOutputSchema } from './structured-output-schema.js';
 
 export type { CodexCallOptions } from './types.js';
 
@@ -359,7 +360,7 @@ export class CodexClient {
 
         const turnOptions: TurnOptions = {
           signal: streamAbortController.signal,
-          ...(options.outputSchema ? { outputSchema: options.outputSchema } : {}),
+          ...(options.outputSchema ? { outputSchema: normalizeCodexOutputSchema(options.outputSchema) } : {}),
         };
         const { events } = await thread.runStreamed(input, turnOptions);
         resetIdleTimeout();

--- a/src/infra/codex/structured-output-schema.ts
+++ b/src/infra/codex/structured-output-schema.ts
@@ -1,0 +1,92 @@
+const CODEX_UNSUPPORTED_SCHEMA_KEYS = new Set([
+  'allOf',
+]);
+
+const SCHEMA_MAP_KEYS = new Set([
+  '$defs',
+  'definitions',
+  'properties',
+]);
+
+const SCHEMA_VALUE_KEYS = new Set([
+  'additionalProperties',
+  'contains',
+  'if',
+  'items',
+  'not',
+  'propertyNames',
+  'then',
+  'else',
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeSchemaKeywordValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => (isPlainObject(item) ? normalizeCodexOutputSchema(item) : item));
+  }
+  if (isPlainObject(value)) {
+    return normalizeCodexOutputSchema(value);
+  }
+  return value;
+}
+
+function normalizeSchemaMap(value: unknown): unknown {
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, nestedSchema] of Object.entries(value)) {
+    normalized[key] = normalizeSchemaKeywordValue(nestedSchema);
+  }
+  return normalized;
+}
+
+function collectRequiredProperties(
+  properties: Record<string, unknown>,
+  currentRequired: unknown,
+): string[] {
+  const required = Array.isArray(currentRequired)
+    ? currentRequired.filter((value): value is string => typeof value === 'string')
+    : [];
+  const seen = new Set(required);
+
+  for (const propertyName of Object.keys(properties)) {
+    if (!seen.has(propertyName)) {
+      required.push(propertyName);
+      seen.add(propertyName);
+    }
+  }
+
+  return required;
+}
+
+export function normalizeCodexOutputSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (CODEX_UNSUPPORTED_SCHEMA_KEYS.has(key)) {
+      // Codex forwards this schema to OpenAI response_format, which rejects allOf before the model call.
+      continue;
+    }
+    if (SCHEMA_MAP_KEYS.has(key)) {
+      normalized[key] = normalizeSchemaMap(value);
+      continue;
+    }
+    if (SCHEMA_VALUE_KEYS.has(key)) {
+      normalized[key] = normalizeSchemaKeywordValue(value);
+      continue;
+    }
+    normalized[key] = value;
+  }
+
+  if (isPlainObject(normalized.properties)) {
+    // OpenAI Structured Outputs requires every object property to be listed as required.
+    normalized.required = collectRequiredProperties(normalized.properties, normalized.required);
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
## Summary
- Normalize Codex structured output schemas before passing them to the Codex SDK
- Strip unsupported `allOf` schema keywords so Codex/OpenAI response_format does not reject auto-improvement-loop schemas before execution
- Preserve schema-map property names such as a response field literally named `allOf`, and keep the caller's original schema immutable

Fixes #871

## Tests
- npm test -- src/__tests__/codex-structured-output.test.ts
- npm test -- src/__tests__/provider-structured-output.test.ts src/__tests__/codex-structured-output.test.ts
- npm run build
- npm run lint
- npm test
- npm run test:e2e:mock
- npm audit --audit-level=moderate

## TAKT Review
- Not run locally; CONTRIBUTING marks it optional. Local build, lint, unit, mock E2E, and audit all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Codex の構造化出力 用 スキーマを 送信 前 に正規化して反映するようになりました。  
* **バグ修正**
  * 未対応 要素（例: `allOf`）を除外し、再帰的に整形します。  
  * `object` の `required` を `properties` に基づき補完します。  
  * 元のスキーマ内容は変更されません。  
* **テスト**
  * 正規化結果 と 渡されるオプション内容 の検証を追加しました。  
  * テスト間の観測値の持ち越しを防ぎます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->