### PR TITLE
feat: allow enqueue_task branch overrides

### DIFF
--- a/src/__tests__/it-system-workflow-execution.test.ts
+++ b/src/__tests__/it-system-workflow-execution.test.ts
@@ -476,6 +476,58 @@ describe('system workflow execution integration', () => {
     });
   });
 
+  it('enqueue_task.branch を新規 task の保存オプションへ伝搬できる', async () => {
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'enqueue-task-explicit-branch',
+        initial_step: 'enqueue_part',
+        max_steps: 2,
+        steps: [
+          {
+            name: 'enqueue_part',
+            mode: 'system',
+            effects: [
+              {
+                type: 'enqueue_task',
+                mode: 'new',
+                workflow: 'takt-default',
+                branch: 'feat/my-feature-part1',
+                base_branch: 'main',
+                task: 'Implement part 1',
+                worktree: {
+                  enabled: true,
+                  auto_pr: true,
+                  draft_pr: true,
+                },
+              },
+            ],
+            rules: [
+              { when: 'effect.enqueue_part.enqueue_task.success == true', next: 'COMPLETE' },
+            ],
+          },
+        ],
+      },
+      projectDir,
+    );
+
+    const state = await new WorkflowEngine(
+      config,
+      projectDir,
+      'Current task body',
+      createSystemEngineOptions(projectDir),
+    ).run();
+
+    expect(state.status).toBe('completed');
+    expect(mockSaveTaskFile).toHaveBeenCalledWith(projectDir, 'Implement part 1', {
+      workflow: 'takt-default',
+      worktree: true,
+      branch: 'feat/my-feature-part1',
+      baseBranch: 'main',
+      autoPr: true,
+      draftPr: true,
+    });
+  });
+
   it('context と structured のテンプレートを effect に展開し effect.when で COMPLETE できる', async () => {
     setMockScenario([
       {

--- a/src/__tests__/system-step-services.test.ts
+++ b/src/__tests__/system-step-services.test.ts
@@ -2110,7 +2110,7 @@ describe('DefaultSystemStepServices', () => {
     );
   });
 
-  it('rejects from_pr enqueue_task payloads that include issue or worktree at the effect boundary', async () => {
+  it('rejects from_pr enqueue_task payloads that include new-task-only fields at the effect boundary', async () => {
     const services = new DefaultSystemStepServices({
       cwd: '/repo/worktree',
       projectCwd: '/repo',
@@ -2124,6 +2124,7 @@ describe('DefaultSystemStepServices', () => {
       task: '{structured:plan.dummy_field}',
       pr: '{context:route.pr.number}',
       issue: '{structured:plan.issue}',
+      branch: 'feat/stacked-part',
     }, {
       mode: 'from_pr',
       workflow: 'takt-default',
@@ -2131,6 +2132,21 @@ describe('DefaultSystemStepServices', () => {
       pr: 42,
       issue: { create: true },
     }, {} as never)).rejects.toThrow('System effect mode "from_pr" does not allow field "issue"');
+
+    await expect(services.executeEffect({
+      type: 'enqueue_task',
+      mode: 'from_pr',
+      workflow: 'takt-default',
+      task: '{structured:plan.dummy_field}',
+      pr: '{context:route.pr.number}',
+      branch: 'feat/stacked-part',
+    }, {
+      mode: 'from_pr',
+      workflow: 'takt-default',
+      task: 'Address review comments',
+      pr: 42,
+      branch: 'feat/stacked-part',
+    }, {} as never)).rejects.toThrow('System effect mode "from_pr" does not allow field "branch"');
   });
 
   it('treats non-conflict merge failures as failed sync_with_root effects', async () => {

--- a/src/__tests__/system-workflow-schema.test.ts
+++ b/src/__tests__/system-workflow-schema.test.ts
@@ -661,6 +661,7 @@ describe('system workflow schema', () => {
           workflow: 'takt-default',
           task: '{structured:plan.dummy_field}',
           pr: 42,
+          branch: 'feat/stacked-part',
           issue: { create: true },
           worktree: { enabled: true },
         },
@@ -683,6 +684,10 @@ describe('system workflow schema', () => {
         expect.objectContaining({
           path: ['effects', 0, 'issue'],
           message: 'enqueue_task mode "from_pr" does not allow "issue"',
+        }),
+        expect.objectContaining({
+          path: ['effects', 0, 'branch'],
+          message: 'enqueue_task mode "from_pr" does not allow "branch"',
         }),
         expect.objectContaining({
           path: ['effects', 0, 'worktree'],

--- a/src/core/models/workflow-system-input-types.ts
+++ b/src/core/models/workflow-system-input-types.ts
@@ -147,6 +147,7 @@ export type WorkflowEffect =
     mode: 'new' | 'from_pr';
     workflow: string;
     task: string;
+    branch?: string;
     pr?: WorkflowEffectScalarReference;
     issue?: WorkflowEnqueueIssueConfig | WorkflowTemplateReference;
     base_branch?: string | WorkflowEnqueueBaseBranchConfig;

--- a/src/core/models/workflow-system-schemas.ts
+++ b/src/core/models/workflow-system-schemas.ts
@@ -126,6 +126,7 @@ const EnqueueTaskEffectBaseSchema = z.object({
   mode: z.enum(['new', 'from_pr']),
   workflow: z.string().min(1),
   task: z.string().min(1),
+  branch: z.string().min(1).optional(),
   pr: EffectReferenceScalarSchema.optional(),
   issue: z.union([EnqueueIssueRawSchema, TemplateReferenceSchema]).optional(),
   base_branch: EnqueueBaseBranchRawSchema.optional(),
@@ -153,6 +154,13 @@ export const WorkflowEffectRawSchema = z.discriminatedUnion('type', [
         code: z.ZodIssueCode.custom,
         path: ['issue'],
         message: 'enqueue_task mode "from_pr" does not allow "issue"',
+      });
+    }
+    if (data.mode === 'from_pr' && data.branch !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['branch'],
+        message: 'enqueue_task mode "from_pr" does not allow "branch"',
       });
     }
     if (data.mode === 'from_pr' && data.worktree !== undefined) {

--- a/src/core/workflow/system/system-step-effect-runner.ts
+++ b/src/core/workflow/system/system-step-effect-runner.ts
@@ -97,6 +97,7 @@ export function validateSystemEffectPayload(
     if (payload.mode !== undefined) requireString(payload.mode, 'mode');
     if (payload.workflow !== undefined) requireString(payload.workflow, 'workflow');
     if (payload.task !== undefined) requireString(payload.task, 'task');
+    if (payload.branch !== undefined) requireString(payload.branch, 'branch');
     if (payload.pr !== undefined) requireNumber(payload.pr, 'pr');
     if (payload.base_branch !== undefined) validateBaseBranchPayload(payload.base_branch);
     if (payload.issue !== undefined) validateIssuePayload(payload.issue);
@@ -110,6 +111,9 @@ export function validateSystemEffectPayload(
       }
       if (payload.issue !== undefined) {
         throw new Error('System effect mode "from_pr" does not allow field "issue"');
+      }
+      if (payload.branch !== undefined) {
+        throw new Error('System effect mode "from_pr" does not allow field "branch"');
       }
       if (payload.worktree !== undefined) {
         throw new Error('System effect mode "from_pr" does not allow field "worktree"');

--- a/src/infra/config/loaders/workflowSystemStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowSystemStepNormalizer.ts
@@ -51,6 +51,7 @@ function normalizeWorkflowEffect(effect: RawWorkflowEffect): WorkflowEffect {
       mode: effect.mode,
       workflow: effect.workflow,
       task: effect.task,
+      ...(effect.branch !== undefined ? { branch: effect.branch } : {}),
       ...(effect.base_branch !== undefined ? { base_branch: effect.base_branch } : {}),
       ...(effect.worktree !== undefined ? { worktree: effect.worktree } : {}),
       ...(effect.pr !== undefined ? { pr: normalizeEffectScalarReference(effect.pr, 'effects.pr') } : {}),

--- a/src/infra/workflow/system/system-enqueue-effect.ts
+++ b/src/infra/workflow/system/system-enqueue-effect.ts
@@ -32,6 +32,7 @@ export async function enqueueTaskEffect(
     mode: 'new' | 'from_pr';
     workflow: string;
     task: string;
+    branch?: string;
     pr?: number;
     issue?: WorkflowEnqueueIssueConfig;
     base_branch?: string | WorkflowEnqueueBaseBranchConfig;
@@ -53,10 +54,12 @@ export async function enqueueTaskEffect(
   }
 
   if (payload.mode === 'new') {
+    // from_pr tasks inherit their target from the source PR, so explicit branch is only saved for new tasks.
     const created = await saveTaskFile(options.projectCwd, payload.task, {
       workflow: payload.workflow,
       ...(issueNumber !== undefined ? { issue: issueNumber } : {}),
       ...(payload.worktree?.enabled === true ? { worktree: true } : {}),
+      ...(payload.branch ? { branch: payload.branch } : {}),
       ...(baseBranch ? { baseBranch } : {}),
       ...(payload.worktree?.auto_pr === true ? { autoPr: true } : {}),
       ...(payload.worktree?.draft_pr === true ? { draftPr: true } : {}),


### PR DESCRIPTION
## Summary
- Add `branch` to `enqueue_task` effects for `mode: new`
- Thread the branch through schema parsing, workflow normalization, effect validation, and `saveTaskFile`
- Reject `branch` on `mode: from_pr`, because `from_pr` follow-up tasks derive their target from the source PR

Closes #697.

## TDD
- Red: `npm test -- src/__tests__/it-system-workflow-execution.test.ts -t "enqueue_task.branch"` failed because the schema rejected the new `branch` key
- Green: added schema/runtime propagation and boundary tests for `branch`

## Verification
- `npm test -- src/__tests__/it-system-workflow-execution.test.ts src/__tests__/system-workflow-schema.test.ts src/__tests__/system-step-services.test.ts`
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm test` (497 files, 7075 tests)
- `npm run test:e2e:mock` (38 files passed, 1 skipped; 115 passed, 14 skipped, 30 todo)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 新しいタスク作成時に、ブランチ指定を保存設定へ反映できるようになりました。
  * ワークフローの入力でブランチ情報を扱えるようになりました。

* **バグ修正**
  * `from_pr` 形式では、許可されないブランチ指定が正しくエラーになるようになりました。
  * タスク保存時の各種設定が、指定内容どおりにワークフローへ反映されることを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->