### PR TITLE
fix: make task publish pushes noninteractive

### DIFF
--- a/src/__tests__/autoCommit.test.ts
+++ b/src/__tests__/autoCommit.test.ts
@@ -101,6 +101,32 @@ describe('autoCommitAndPush', () => {
     );
   });
 
+  it('runs fallback direct push without terminal credential prompts', () => {
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (includesCommand(argsArr, 'status')) {
+        return 'M src/index.ts\n';
+      }
+      if (includesCommand(argsArr, 'rev-parse')) {
+        return 'abc1234\n';
+      }
+      if (includesCommand(argsArr, 'config')) {
+        return '';
+      }
+      return Buffer.from('');
+    });
+
+    autoCommitAndPush('/tmp/clone', 'my-task', '/project');
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['push', '/project', 'HEAD'],
+      expect.objectContaining({
+        env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }),
+      }),
+    );
+  });
+
   it('should return success with no commit when there are no changes', () => {
     mockExecFileSync.mockImplementation((_cmd, args) => {
       const argsArr = args as string[];

--- a/src/__tests__/postExecution.test.ts
+++ b/src/__tests__/postExecution.test.ts
@@ -532,6 +532,34 @@ describe('postExecutionFlow', () => {
     expect(result.taskFailed).toBeUndefined();
   });
 
+  it('origin push の認証プロンプト失敗は workflow 失敗にせず retryable publish failure として返す', async () => {
+    mockAutoCommitAndPush.mockReturnValue({
+      success: true,
+      commitHash: 'abc123',
+      message: 'Committed: abc123 - takt: Fix the bug',
+    });
+    mockPushBranch.mockImplementation(() => {
+      throw new Error("fatal: could not read Username for 'https://github.com': terminal prompts disabled");
+    });
+
+    const result = await postExecutionFlow({
+      ...baseOptions,
+      shouldCreatePr: true,
+      shouldPublishBranchToOrigin: true,
+    });
+
+    expect(mockPushBranch).toHaveBeenCalledWith('/project', 'task/fix-the-bug');
+    expect(mockFindExistingPr).not.toHaveBeenCalled();
+    expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    expect(result.taskFailed).toBeUndefined();
+    expect(result.prFailed).toBe(true);
+    expect(result.prError).toContain('Workflow completed, but publishing failed.');
+    expect(result.prError).toContain('branch: task/fix-the-bug');
+    expect(result.prError).toContain('commit: abc123');
+    expect(result.prError).toContain('TAKT does not prompt for credentials during task execution.');
+    expect(result.prError).toContain('retry publishing from takt list');
+  });
+
   it('root からの origin push が git 整形済み non-fast-forward エラーのとき prError に診断ヒントまで伝播する', async () => {
     const stderr =
       '! [rejected] task/fix-the-bug -> task/fix-the-bug (non-fast-forward)\n' +

--- a/src/__tests__/relay-push.test.ts
+++ b/src/__tests__/relay-push.test.ts
@@ -50,7 +50,11 @@ describe('relayPushCloneToOrigin', () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'git',
       ['push', 'origin', 'refs/takt-relay/feat/my-branch:refs/heads/feat/my-branch'],
-      { cwd: '/project', stdio: 'pipe' },
+      expect.objectContaining({
+        cwd: '/project',
+        stdio: 'pipe',
+        env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }),
+      }),
     );
   });
 

--- a/src/__tests__/taskGit.test.ts
+++ b/src/__tests__/taskGit.test.ts
@@ -42,8 +42,45 @@ describe('pushBranch', () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'git',
       ['push', 'origin', 'feature/my-branch'],
-      { cwd: '/project', stdio: 'pipe' },
+      expect.objectContaining({
+        cwd: '/project',
+        stdio: 'pipe',
+        env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }),
+      }),
     );
+  });
+
+  it('disables askpass and SSH prompts for origin pushes', () => {
+    const previousSshCommand = process.env.GIT_SSH_COMMAND;
+    process.env.GIT_SSH_COMMAND = 'ssh -i ~/.ssh/takt-test-key -o BatchMode=no';
+    mockExecFileSync.mockReturnValue(Buffer.from(''));
+
+    try {
+      pushBranch('/project', 'feature/my-branch');
+    } finally {
+      if (previousSshCommand === undefined) {
+        delete process.env.GIT_SSH_COMMAND;
+      } else {
+        process.env.GIT_SSH_COMMAND = previousSshCommand;
+      }
+    }
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['push', 'origin', 'feature/my-branch'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          GIT_ASKPASS: '',
+          SSH_ASKPASS: '',
+          GCM_INTERACTIVE: 'never',
+          GIT_SSH_COMMAND: 'ssh -i ~/.ssh/takt-test-key -o BatchMode=yes',
+        }),
+      }),
+    );
+    const env = (mockExecFileSync.mock.calls[0]?.[2] as { env: NodeJS.ProcessEnv }).env;
+    const askPassConfigIndex = Number(env.GIT_CONFIG_COUNT) - 1;
+    expect(env[`GIT_CONFIG_KEY_${askPassConfigIndex}`]).toBe('core.askPass');
+    expect(env[`GIT_CONFIG_VALUE_${askPassConfigIndex}`]).toBe('');
   });
 
   it('should throw when git push fails', () => {
@@ -103,7 +140,11 @@ describe('pushHeadToOriginBranch', () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'git',
       ['push', 'origin', 'HEAD:refs/heads/feature/my-branch'],
-      { cwd: '/clone', stdio: 'pipe' },
+      expect.objectContaining({
+        cwd: '/clone',
+        stdio: 'pipe',
+        env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }),
+      }),
     );
   });
 

--- a/src/features/tasks/execute/postExecution.ts
+++ b/src/features/tasks/execute/postExecution.ts
@@ -26,6 +26,30 @@ const ORIGIN_PUSH_FAILURE_MESSAGE = 'Failed to push branch to origin.';
 const PR_COMMENT_FAILURE_MESSAGE = 'Failed to update pull request comment.';
 const PR_CREATION_FAILURE_MESSAGE = 'Failed to create pull request.';
 
+function isCredentialPromptFailure(message: string): boolean {
+  return /could not read (Username|Password)|terminal prompts disabled|authentication failed|GIT_TERMINAL_PROMPT/i.test(message);
+}
+
+function formatOriginPushFailure(detail: string, branch: string, commitHash: string): string {
+  const base = `${ORIGIN_PUSH_FAILURE_MESSAGE} ${detail}`.trim();
+  if (!isCredentialPromptFailure(detail)) {
+    return base;
+  }
+
+  return [
+    base,
+    '',
+    'Workflow completed, but publishing failed.',
+    '',
+    'Local result is preserved:',
+    `  branch: ${branch}`,
+    `  commit: ${commitHash}`,
+    '',
+    'Git credentials are unavailable for non-interactive push.',
+    'TAKT does not prompt for credentials during task execution.',
+    'Fix authentication, then retry publishing from takt list.',
+  ].join('\n');
+}
 
 export interface PostExecutionOptions {
   execCwd: string;
@@ -100,7 +124,7 @@ export async function postExecutionFlow(options: PostExecutionOptions): Promise<
         outcome: ORIGIN_PUSH_FAILURE_MESSAGE,
         error: pushDetail,
       });
-      const pushFailureMessage = `${ORIGIN_PUSH_FAILURE_MESSAGE} ${pushDetail}`.trim();
+      const pushFailureMessage = formatOriginPushFailure(pushDetail, branch, commitResult.commitHash);
       error(pushFailureMessage);
       return { prFailed: true, prError: pushFailureMessage };
     }

--- a/src/infra/task/autoCommit.ts
+++ b/src/infra/task/autoCommit.ts
@@ -10,7 +10,7 @@
 import { execFileSync } from 'node:child_process';
 import { resolveConfigValue } from '../config/index.js';
 import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
-import { materializeCloneHeadToRootBranch, stageAndCommit } from './git.js';
+import { getNonInteractiveGitEnv, materializeCloneHeadToRootBranch, stageAndCommit } from './git.js';
 
 const log = createLogger('autoCommit');
 const AUTO_COMMIT_PUSH_FAILURE_MESSAGE = 'Push to main repo failed after commit creation.';
@@ -65,6 +65,7 @@ export class AutoCommitter {
           execFileSync('git', ['push', projectDir, 'HEAD'], {
             cwd: cloneCwd,
             stdio: 'pipe',
+            env: getNonInteractiveGitEnv(),
           });
           log.info('Pushed to main repo', { projectDir });
         }

--- a/src/infra/task/git.ts
+++ b/src/infra/task/git.ts
@@ -126,6 +126,39 @@ function throwPushFailureWithStderr(err: unknown, extraHint: string): never {
   throw err;
 }
 
+function appendGitConfigEnv(env: NodeJS.ProcessEnv, key: string, value: string): void {
+  const parsedCount = Number.parseInt(env.GIT_CONFIG_COUNT ?? '0', 10);
+  const index = Number.isFinite(parsedCount) && parsedCount >= 0 ? parsedCount : 0;
+  env[`GIT_CONFIG_KEY_${index}`] = key;
+  env[`GIT_CONFIG_VALUE_${index}`] = value;
+  env.GIT_CONFIG_COUNT = String(index + 1);
+}
+
+function withSshBatchMode(command: string | undefined): string {
+  const base = command?.trim() || 'ssh';
+  if (/\bBatchMode\s*=\s*yes\b/i.test(base)) {
+    return base;
+  }
+  if (/\bBatchMode\s*=\s*\S+\b/i.test(base)) {
+    return base.replace(/\bBatchMode\s*=\s*\S+\b/i, 'BatchMode=yes');
+  }
+  return `${base} -o BatchMode=yes`;
+}
+
+export function getNonInteractiveGitEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    // Credential prompts can hang workflow execution, so TAKT-managed pushes must fail fast instead.
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_ASKPASS: '',
+    SSH_ASKPASS: '',
+    GCM_INTERACTIVE: 'never',
+    GIT_SSH_COMMAND: withSshBatchMode(process.env.GIT_SSH_COMMAND),
+  };
+  appendGitConfigEnv(env, 'core.askPass', '');
+  return env;
+}
+
 /**
  * Throws on failure.
  */
@@ -135,6 +168,7 @@ export function pushBranch(cwd: string, branch: string): void {
     execFileSync('git', ['push', 'origin', branch], {
       cwd,
       stdio: 'pipe',
+      env: getNonInteractiveGitEnv(),
     });
   } catch (err) {
     throwPushFailureWithStderr(err, NON_FAST_FORWARD_PUSH_HINT);
@@ -162,6 +196,7 @@ export function pushHeadToOriginBranch(cwd: string, branch: string): void {
     execFileSync('git', ['push', 'origin', `HEAD:refs/heads/${branch}`], {
       cwd,
       stdio: 'pipe',
+      env: getNonInteractiveGitEnv(),
     });
   } catch (err) {
     throwPushFailureWithStderr(err, NON_FAST_FORWARD_PUSH_HINT);
@@ -174,7 +209,11 @@ export function relayPushCloneToOrigin(cloneCwd: string, rootCwd: string, branch
   try {
     execFileSync('git', ['fetch', cloneCwd, `HEAD:${tempRef}`], { cwd: rootCwd, stdio: 'pipe' });
     log.info('Relay push: pushing to origin', { rootCwd, branch });
-    execFileSync('git', ['push', 'origin', `${tempRef}:refs/heads/${branch}`], { cwd: rootCwd, stdio: 'pipe' });
+    execFileSync('git', ['push', 'origin', `${tempRef}:refs/heads/${branch}`], {
+      cwd: rootCwd,
+      stdio: 'pipe',
+      env: getNonInteractiveGitEnv(),
+    });
     log.info('Relay push: succeeded', { rootCwd, branch });
   } finally {
     try {


### PR DESCRIPTION
## Summary
- Run TAKT-managed `git push` operations with `GIT_TERMINAL_PROMPT=0` so workflow execution cannot hang on Git credential prompts
- Preserve successful workflow/local commit state when origin publishing fails, and report auth prompt failures as retryable publish failures
- Skip PR creation when branch publishing fails and include the preserved branch/commit plus retry guidance in the publish error

Closes #866.

## TDD
- Red: `npm test -- src/__tests__/taskGit.test.ts src/__tests__/relay-push.test.ts src/__tests__/autoCommit.test.ts` failed because push helpers did not pass `GIT_TERMINAL_PROMPT=0`
- Green: added non-interactive push env and retryable credential-prompt reporting

## Verification
- `npm test -- src/__tests__/postExecution.test.ts src/__tests__/taskGit.test.ts src/__tests__/relay-push.test.ts src/__tests__/autoCommit.test.ts src/__tests__/taskExecution.test.ts src/__tests__/pipelineExecution.test.ts src/__tests__/it-pipeline-modes.test.ts src/__tests__/taskPullAction.test.ts src/__tests__/taskSyncAction.test.ts`
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm test` (497 files, 7076 tests)
- `npm run test:e2e:mock` (38 files passed, 1 skipped; 115 passed, 14 skipped, 30 todo)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git への push 時に、 資格情報 / SSH の対話プロンプトを抑止する 非対話 環境設定 を適用しました。
  * origin への push 失敗時の案内を強化し、 非対話 環境向けの再試行手順や ブランチ / コミット情報 を含めるようにしました。
* **Tests**
  * 資格情報プロンプト抑止 や origin push 失敗（認証プロンプト失敗）ケースの テストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->