### PR TITLE
fix: cancel obsolete team leader parts

### DIFF
--- a/builtins/schemas/more-parts.json
+++ b/builtins/schemas/more-parts.json
@@ -30,6 +30,14 @@
         "required": ["id", "title", "instruction"],
         "additionalProperties": false
       }
+    },
+    "cancel_part_ids": {
+      "type": "array",
+      "description": "IDs of unfinished scheduled parts that became obsolete and should be canceled",
+      "items": {
+        "type": "string"
+      },
+      "default": []
     }
   },
   "required": ["done", "reasoning", "parts"],

--- a/src/__tests__/abort-signal.test.ts
+++ b/src/__tests__/abort-signal.test.ts
@@ -36,6 +36,20 @@ describe('buildAbortSignal', () => {
     dispose();
   });
 
+  it('複数の親シグナルのいずれかがabortされると子シグナルへ伝搬する', () => {
+    const workflowParent = new AbortController();
+    const partParent = new AbortController();
+    const { signal, dispose } = buildAbortSignal(1000, [workflowParent.signal, partParent.signal]);
+    const reason = new Error('part canceled');
+
+    partParent.abort(reason);
+
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBe(reason);
+
+    dispose();
+  });
+
   it('disposeでタイマーと親リスナーを解放する', () => {
     const parent = new AbortController();
     const addSpy = vi.spyOn(parent.signal, 'addEventListener');

--- a/src/__tests__/team-leader-execution.test.ts
+++ b/src/__tests__/team-leader-execution.test.ts
@@ -22,6 +22,19 @@ function makeResult(part: PartDefinition): PartResult {
   };
 }
 
+function makeErrorResult(part: PartDefinition, error: string): PartResult {
+  return {
+    part,
+    response: {
+      persona: `execute.${part.id}`,
+      status: 'error',
+      content: '',
+      error,
+      timestamp: new Date(),
+    },
+  };
+}
+
 describe('runTeamLeaderExecution', () => {
   it('初回5パートを最大2並列で順次実行する', async () => {
     const parts = ['p1', 'p2', 'p3', 'p4', 'p5'].map(makePart);
@@ -178,5 +191,71 @@ describe('runTeamLeaderExecution', () => {
     expect(result.plannedParts.map((p) => p.id)).toEqual(['p1']);
     expect(result.partResults).toHaveLength(1);
     expect(onPlanningNoNewParts).toHaveBeenCalledTimes(1);
+  });
+
+  it('feedback の cancelPartIds で未起動パートを planned から外して実行しない', async () => {
+    const part1 = makePart('impl');
+    const part2 = makePart('verify');
+    const onPartsCanceled = vi.fn();
+    const runPart = vi.fn(async (part: PartDefinition) => makeResult(part));
+    const requestMoreParts = vi.fn().mockResolvedValue({
+      done: true,
+      reasoning: 'replacement verification already passed',
+      parts: [],
+      cancelPartIds: ['verify'],
+    });
+
+    const result = await runTeamLeaderExecution({
+      initialParts: [part1, part2],
+      maxConcurrency: 1,
+      refillThreshold: 1,
+      runPart,
+      requestMoreParts,
+      onPartsCanceled,
+    });
+
+    expect(result.plannedParts.map((part) => part.id)).toEqual(['impl']);
+    expect(result.partResults.map((result) => result.part.id)).toEqual(['impl']);
+    expect(runPart).toHaveBeenCalledTimes(1);
+    expect(onPartsCanceled).toHaveBeenCalledWith({
+      partIds: ['verify'],
+      reason: 'replacement verification already passed',
+    });
+  });
+
+  it('feedback の cancelPartIds で実行中パートへ AbortSignal を発火し、集計から外す', async () => {
+    const part1 = makePart('impl');
+    const part2 = makePart('verify');
+    let verifySignal: AbortSignal | undefined;
+    const runPart = vi.fn(async (
+      part: PartDefinition,
+      _partIndex: number,
+      abortSignal?: AbortSignal,
+    ) => {
+      if (part.id === 'verify') {
+        verifySignal = abortSignal;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return makeErrorResult(part, 'should be ignored after cancellation');
+      }
+      return makeResult(part);
+    });
+    const requestMoreParts = vi.fn().mockResolvedValue({
+      done: true,
+      reasoning: 'new verification part made old one obsolete',
+      parts: [],
+      cancelPartIds: ['verify'],
+    });
+
+    const result = await runTeamLeaderExecution({
+      initialParts: [part1, part2],
+      maxConcurrency: 2,
+      refillThreshold: 1,
+      runPart,
+      requestMoreParts,
+    });
+
+    expect(verifySignal?.aborted).toBe(true);
+    expect(result.plannedParts.map((part) => part.id)).toEqual(['impl']);
+    expect(result.partResults.map((partResult) => partResult.part.id)).toEqual(['impl']);
   });
 });

--- a/src/__tests__/team-leader-structured-output.test.ts
+++ b/src/__tests__/team-leader-structured-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { toPartDefinitions } from '../agents/team-leader-structured-output.js';
+import { toMorePartsResponse, toPartDefinitions } from '../agents/team-leader-structured-output.js';
 
 function makeRawPart(id: string): Record<string, string> {
   return {
@@ -24,5 +24,27 @@ describe('toPartDefinitions', () => {
     expect(() => toPartDefinitions(rawParts, 5)).toThrow(
       'Structured output produced too many total parts: 6 > max_total_parts 5',
     );
+  });
+});
+
+describe('toMorePartsResponse', () => {
+  it('cancel_part_ids を cancelPartIds として正規化する', () => {
+    const result = toMorePartsResponse({
+      done: false,
+      reasoning: 'replace old verify',
+      parts: [],
+      cancel_part_ids: [' verify ', 'verify', 'legacy-check'],
+    }, 2);
+
+    expect(result.cancelPartIds).toEqual(['verify', 'legacy-check']);
+  });
+
+  it('cancel_part_ids が配列でない場合は明確なエラーにする', () => {
+    expect(() => toMorePartsResponse({
+      done: false,
+      reasoning: 'bad cancel ids',
+      parts: [],
+      cancel_part_ids: 'verify',
+    }, 2)).toThrow('Structured output "cancel_part_ids" must be an array');
   });
 });

--- a/src/agents/decompose-task-usecase.ts
+++ b/src/agents/decompose-task-usecase.ts
@@ -36,6 +36,7 @@ export interface MorePartsResponse {
   done: boolean;
   reasoning: string;
   parts: PartDefinition[];
+  cancelPartIds?: string[];
 }
 
 export const TEAM_LEADER_MAX_TURNS = 5;

--- a/src/agents/team-leader-structured-output.ts
+++ b/src/agents/team-leader-structured-output.ts
@@ -48,12 +48,32 @@ export function toMorePartsResponse(raw: unknown, maxAdditionalParts: number): M
 
   const parts = payload.parts.map((entry, index) => parsePartDefinitionEntry(entry, index));
   ensureUniquePartIds(parts);
+  const cancelPartIds = parseCancelPartIds(payload);
 
   return {
     done: payload.done,
     reasoning: payload.reasoning,
     parts,
+    ...(cancelPartIds ? { cancelPartIds } : {}),
   };
+}
+
+function parseCancelPartIds(payload: Record<string, unknown>): string[] | undefined {
+  const rawCancelPartIds = payload.cancel_part_ids ?? payload.cancelPartIds;
+  if (rawCancelPartIds === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(rawCancelPartIds)) {
+    throw new Error('Structured output "cancel_part_ids" must be an array');
+  }
+
+  const cancelPartIds = rawCancelPartIds.map((entry, index) => {
+    if (typeof entry !== 'string' || entry.trim().length === 0) {
+      throw new Error(`Structured output "cancel_part_ids[${index}]" must be a non-empty string`);
+    }
+    return entry.trim();
+  });
+  return [...new Set(cancelPartIds)];
 }
 
 function buildInspectToolGuidance(
@@ -171,6 +191,8 @@ function buildMorePartsBasePrompt(
       '## 判断ルール',
       '- 追加作業が不要なら done=true にする',
       '- 追加作業が必要なら parts に新しいパートを入れる',
+      '- 不要になった未完了パートがある場合は cancel_part_ids に対象IDを入れる',
+      '- 完了済みパートは cancel_part_ids に入れない',
       '- 不足が複数ある場合は、可能な限り一括で複数パートを返す',
       '- 既存差分を破壊しない',
       '- 未完了作業だけを追加 part に切り出す',
@@ -193,6 +215,8 @@ function buildMorePartsBasePrompt(
     '## Decision Rules',
     '- Set done=true when no additional work is required',
     '- If more work is needed, provide new parts in "parts"',
+    '- If unfinished scheduled parts became obsolete, put their IDs in "cancel_part_ids"',
+    '- Do not include completed parts in "cancel_part_ids"',
     '- If multiple missing tasks are known, return multiple new parts in one batch when possible',
     '- Preserve existing changes',
     '- Put only unfinished work into additional parts',
@@ -270,13 +294,13 @@ export function buildPromptBasedMorePartsPrompt(
         '',
         '出力形式:',
         '- ```json ... ``` ブロックのみを返す',
-        '- JSON は {"done": boolean, "reasoning": string, "parts": []} の形にする',
+        '- JSON は {"done": boolean, "reasoning": string, "parts": [], "cancel_part_ids": []} の形にする',
       ]
     : [
         '',
         'Output format:',
         '- Return only one ```json ... ``` block',
-        '- The JSON must be {"done": boolean, "reasoning": string, "parts": []}',
+        '- The JSON must be {"done": boolean, "reasoning": string, "parts": [], "cancel_part_ids": []}',
       ];
 
   return `${buildMorePartsBasePrompt(

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -224,6 +224,13 @@ export class TeamLeaderRunner {
           reasoning: reason,
         });
       },
+      onPartsCanceled: ({ partIds, reason }) => {
+        log.info('Team leader canceled obsolete parts', {
+          step: step.name,
+          partIds,
+          reasoning: reason,
+        });
+      },
       onPlanningError: (error) => {
         log.info('Team leader feedback failed; stop adding new parts', {
           step: step.name,
@@ -293,7 +300,7 @@ export class TeamLeaderRunner {
           throw error;
         }
       },
-      runPart: async (part, partIndex) => this.runSinglePart(
+      runPart: async (part, partIndex, partAbortSignal) => this.runSinglePart(
         step,
         leaderWorkflowMeta,
         part,
@@ -303,6 +310,7 @@ export class TeamLeaderRunner {
         updatePersonaSession,
         parallelLogger,
         runtime,
+        partAbortSignal,
       ).catch((error) => buildTeamLeaderErrorPartResult(step, part, error)),
     });
 
@@ -396,6 +404,7 @@ export class TeamLeaderRunner {
     updatePersonaSession: (persona: string, sessionId: string | undefined) => void,
     parallelLogger: ParallelLogger | undefined,
     runtime?: RuntimeStepResolution,
+    partAbortSignal?: AbortSignal,
   ): Promise<PartResult> {
     return runTeamLeaderPart(
       this.deps.optionsBuilder,
@@ -415,6 +424,7 @@ export class TeamLeaderRunner {
         sanitizeText: this.deps.sanitizeObservabilityText,
       },
       runtime,
+      partAbortSignal,
     );
   }
 }

--- a/src/core/workflow/engine/abort-signal.ts
+++ b/src/core/workflow/engine/abort-signal.ts
@@ -2,20 +2,24 @@ import { createPartTimeoutReason } from '../../../shared/types/agent-failure.js'
 
 export function buildAbortSignal(
   timeoutMs: number,
-  parentSignal: AbortSignal | undefined,
+  parentSignal: AbortSignal | readonly AbortSignal[] | undefined,
 ): { signal: AbortSignal; dispose: () => void } {
   const timeoutController = new AbortController();
   const timeoutId = setTimeout(() => {
     timeoutController.abort(new Error(createPartTimeoutReason(timeoutMs)));
   }, timeoutMs);
 
-  let abortListener: (() => void) | undefined;
-  if (parentSignal) {
-    abortListener = () => timeoutController.abort(parentSignal.reason);
-    if (parentSignal.aborted) {
-      abortListener();
+  const parentSignals = Array.isArray(parentSignal)
+    ? parentSignal
+    : parentSignal ? [parentSignal] : [];
+  const abortListeners: Array<{ signal: AbortSignal; listener: () => void }> = [];
+  for (const signal of parentSignals) {
+    const listener = () => timeoutController.abort(signal.reason);
+    if (signal.aborted) {
+      listener();
     } else {
-      parentSignal.addEventListener('abort', abortListener, { once: true });
+      signal.addEventListener('abort', listener, { once: true });
+      abortListeners.push({ signal, listener });
     }
   }
 
@@ -23,8 +27,8 @@ export function buildAbortSignal(
     signal: timeoutController.signal,
     dispose: () => {
       clearTimeout(timeoutId);
-      if (parentSignal && abortListener) {
-        parentSignal.removeEventListener('abort', abortListener);
+      for (const { signal, listener } of abortListeners) {
+        signal.removeEventListener('abort', listener);
       }
     },
   };

--- a/src/core/workflow/engine/team-leader-execution.ts
+++ b/src/core/workflow/engine/team-leader-execution.ts
@@ -8,7 +8,7 @@ export interface TeamLeaderExecutionOptions {
   maxConcurrency: number;
   refillThreshold: number;
   maxTotalParts?: number;
-  runPart: (part: PartDefinition, partIndex: number) => Promise<PartResult>;
+  runPart: (part: PartDefinition, partIndex: number, abortSignal: AbortSignal) => Promise<PartResult>;
   requestMoreParts: (
     args: {
       partResults: PartResult[];
@@ -22,12 +22,19 @@ export interface TeamLeaderExecutionOptions {
   onPlanningDone?: (feedback: { reason: string; plannedParts: number; completedParts: number }) => void;
   onPlanningNoNewParts?: (feedback: { reason: string; plannedParts: number; completedParts: number }) => void;
   onPartsAdded?: (feedback: { parts: PartDefinition[]; reason: string; totalPlanned: number }) => void;
+  onPartsCanceled?: (feedback: { partIds: string[]; reason: string }) => void;
   onPlanningError?: (error: unknown) => void;
 }
 
 interface RunningPart {
   partId: string;
   result: PartResult;
+}
+
+interface RunningPartExecution {
+  partId: string;
+  promise: Promise<RunningPart>;
+  abortController: AbortController;
 }
 
 export interface TeamLeaderExecutionResult {
@@ -46,12 +53,52 @@ export async function runTeamLeaderExecution(
   const queue: PartDefinition[] = [...options.initialParts];
   const plannedParts: PartDefinition[] = [...options.initialParts];
   const partResults: PartResult[] = [];
-  const running = new Map<string, Promise<RunningPart>>();
+  const running = new Map<string, RunningPartExecution>();
   const scheduledIds = new Set(options.initialParts.map((part) => part.id));
 
   let nextPartIndex = 0;
   let leaderDone = false;
   let deferredDoneReason: string | undefined;
+
+  const cancelScheduledParts = (partIds: string[] | undefined, reason: string): void => {
+    if (!partIds || partIds.length === 0) {
+      return;
+    }
+
+    const completedIds = new Set(partResults.map((result) => result.part.id));
+    const canceledPartIds: string[] = [];
+    for (const partId of new Set(partIds)) {
+      if (completedIds.has(partId)) {
+        continue;
+      }
+
+      const queueIndex = queue.findIndex((part) => part.id === partId);
+      const runningPart = running.get(partId);
+      const plannedIndex = plannedParts.findIndex((part) => part.id === partId);
+      if (queueIndex === -1 && !runningPart && plannedIndex === -1) {
+        continue;
+      }
+
+      if (queueIndex !== -1) {
+        queue.splice(queueIndex, 1);
+      }
+      if (runningPart) {
+        // Canceled running parts are intentionally ignored so obsolete aborts do not become false failures.
+        runningPart.abortController.abort(new Error(`Team leader canceled part: ${partId}`));
+        running.delete(partId);
+        void runningPart.promise.catch(() => undefined);
+      }
+      if (plannedIndex !== -1) {
+        plannedParts.splice(plannedIndex, 1);
+      }
+      canceledPartIds.push(partId);
+    }
+
+    if (canceledPartIds.length > 0) {
+      options.onPartsCanceled?.({ partIds: canceledPartIds, reason });
+      deferredDoneReason = undefined;
+    }
+  };
 
   const tryPlanMoreParts = async (): Promise<void> => {
     if (leaderDone) {
@@ -81,6 +128,8 @@ export async function runTeamLeaderExecution(
         remainingPartBudget,
         unfinishedScheduledPartCount: plannedParts.length - partResults.length,
       });
+
+      cancelScheduledParts(feedback.cancelPartIds, feedback.reasoning);
 
       if (feedback.done) {
         if (plannedParts.length > partResults.length) {
@@ -145,12 +194,15 @@ export async function runTeamLeaderExecution(
       const partIndex = nextPartIndex;
       nextPartIndex += 1;
       options.onPartQueued?.(part, partIndex);
-      const runningPart = options.runPart(part, partIndex).then((result) => ({ partId: part.id, result }));
-      running.set(part.id, runningPart);
+      const abortController = new AbortController();
+      const promise = options
+        .runPart(part, partIndex, abortController.signal)
+        .then((result) => ({ partId: part.id, result }));
+      running.set(part.id, { partId: part.id, promise, abortController });
     }
 
     if (running.size > 0) {
-      const completed = await Promise.race(running.values());
+      const completed = await Promise.race([...running.values()].map((runningPart) => runningPart.promise));
       running.delete(completed.partId);
       partResults.push(completed.result);
       options.onPartCompleted?.(completed.result);

--- a/src/core/workflow/engine/team-leader-part-runner.ts
+++ b/src/core/workflow/engine/team-leader-part-runner.ts
@@ -79,6 +79,7 @@ export async function runTeamLeaderPart(
   parallelLogger: ParallelLogger | undefined,
   observability: TeamLeaderPartObservability,
   runtime?: RuntimeStepResolution,
+  partAbortSignal?: AbortSignal,
 ): Promise<PartResult> {
   const partStep = createPartStep(step, part);
   const partProviderInfo = runtime
@@ -92,7 +93,12 @@ export async function runTeamLeaderPart(
       processSafety: leaderWorkflowMeta?.processSafety,
     },
   });
-  const { signal, dispose } = buildAbortSignal(defaultTimeoutMs, baseOptions.abortSignal);
+  const parentSignals = [baseOptions.abortSignal, partAbortSignal]
+    .filter((signal): signal is AbortSignal => signal !== undefined);
+  const { signal, dispose } = buildAbortSignal(
+    defaultTimeoutMs,
+    parentSignals.length > 0 ? parentSignals : undefined,
+  );
   const options = parallelLogger
     ? {
       ...baseOptions,


### PR DESCRIPTION
## Summary
- Add optional cancel_part_ids structured feedback for TeamLeader follow-up planning.
- Remove canceled unfinished parts from planned/queued state and abort running canceled parts with a part-scoped AbortSignal.
- Keep canceled obsolete part results out of aggregation so they do not appear as false failures.

## TDD
- Added failing coverage for queued part cancellation and running part abort in team-leader-execution.
- Added structured-output coverage for cancel_part_ids normalization and abort-signal coverage for multiple parent signals.

## Verification
- npm test -- src/__tests__/team-leader-execution.test.ts src/__tests__/team-leader-structured-output.test.ts
- npm test -- src/__tests__/abort-signal.test.ts src/__tests__/team-leader-execution.test.ts src/__tests__/team-leader-structured-output.test.ts src/__tests__/team-leader-runner-structured-caller.test.ts src/__tests__/engine-team-leader.test.ts
- npm test -- src/__tests__/team-leader-prompt-guidance.test.ts src/__tests__/schema-loader.test.ts src/__tests__/builtin-workflow-resources.test.ts
- npm run lint
- npm run build
- npm audit --audit-level=moderate
- npm test
- npm run test:e2e:mock

Closes #884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 追加パーツの返却内容に、不要になったパートをキャンセルする指定が含められるようになりました。
  * 実行中のパートを中断できるようになり、複数の中断条件に対応しました。

* **バグ修正**
  * 予定済み・実行中の不要なパートが、結果に残らないよう改善しました。
  * キャンセル時の通知や中断理由が正しく伝わるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->