### PR TITLE
chore: increase team leader max turns

### DIFF
--- a/src/__tests__/agent-usecases.test.ts
+++ b/src/__tests__/agent-usecases.test.ts
@@ -405,7 +405,7 @@ describe('agent-usecases', () => {
     expect(runAgent).toHaveBeenCalledWith('team-leader', expect.any(String), expect.objectContaining({
       allowedTools: [],
       permissionMode: 'readonly',
-      maxTurns: 5,
+      maxTurns: 15,
       outputSchema: { type: 'decomposition', maxTotalParts: 3 },
     }));
   });
@@ -553,7 +553,7 @@ describe('agent-usecases', () => {
       allowedTools: [],
       outputSchema: { type: 'more-parts', maxAdditionalParts: 2 },
       permissionMode: 'readonly',
-      maxTurns: 5,
+      maxTurns: 15,
     }));
   });
 

--- a/src/__tests__/structured-caller-prompt-based.test.ts
+++ b/src/__tests__/structured-caller-prompt-based.test.ts
@@ -189,7 +189,7 @@ describe('PromptBasedStructuredCaller', () => {
         provider: 'cursor',
         model: 'cursor-fast',
         personaPath: '/tmp/personas/team-leader.md',
-        maxTurns: 5,
+        maxTurns: 15,
       }),
     );
     const [, , runOptions] = mockRunAgent.mock.calls[0] ?? [];

--- a/src/agents/decompose-task-usecase.ts
+++ b/src/agents/decompose-task-usecase.ts
@@ -38,7 +38,7 @@ export interface MorePartsResponse {
   parts: PartDefinition[];
 }
 
-export const TEAM_LEADER_MAX_TURNS = 5;
+export const TEAM_LEADER_MAX_TURNS = 15;
 
 export async function decomposeTask(
   instruction: string,


### PR DESCRIPTION
## Summary
- Increase team_leader decompose/requestMoreParts maxTurns from 5 to 15
- Update related structured caller expectations

## Verification
- npm test -- agent-usecases structured-caller-prompt-based
- npm run build
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * タスク分解や追加分割の処理で、より多くの試行回数を使えるようになりました。
  * これにより、複雑な内容でも処理の安定性や精度が向上する可能性があります。

* **テスト**
  * 関連テストの期待値を新しい試行回数に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->