### PR TITLE
fix: remove TEAM_LEADER_MAX_TURNS limit from decompose/moreParts calls

### DIFF
--- a/src/__tests__/agent-usecases.test.ts
+++ b/src/__tests__/agent-usecases.test.ts
@@ -405,9 +405,10 @@ describe('agent-usecases', () => {
     expect(runAgent).toHaveBeenCalledWith('team-leader', expect.any(String), expect.objectContaining({
       allowedTools: [],
       permissionMode: 'readonly',
-      maxTurns: 15,
       outputSchema: { type: 'decomposition', maxTotalParts: 3 },
     }));
+    const [, , callOptions] = vi.mocked(runAgent).mock.calls[0] ?? [];
+    expect(callOptions).not.toHaveProperty('maxTurns');
   });
 
   it('Given inspectTools, When decomposeTask runs, Then it passes them to the parent decomposition call only', async () => {
@@ -553,8 +554,9 @@ describe('agent-usecases', () => {
       allowedTools: [],
       outputSchema: { type: 'more-parts', maxAdditionalParts: 2 },
       permissionMode: 'readonly',
-      maxTurns: 15,
     }));
+    const [, , callOptions] = vi.mocked(runAgent).mock.calls[0] ?? [];
+    expect(callOptions).not.toHaveProperty('maxTurns');
   });
 
   it('requestMoreParts は inspect tools を feedback planning call に渡さない', async () => {

--- a/src/__tests__/structured-caller-prompt-based.test.ts
+++ b/src/__tests__/structured-caller-prompt-based.test.ts
@@ -189,9 +189,10 @@ describe('PromptBasedStructuredCaller', () => {
         provider: 'cursor',
         model: 'cursor-fast',
         personaPath: '/tmp/personas/team-leader.md',
-        maxTurns: 15,
       }),
     );
+    const [, , callOptions] = mockRunAgent.mock.calls[0] ?? [];
+    expect(callOptions).not.toHaveProperty('maxTurns');
     const [, , runOptions] = mockRunAgent.mock.calls[0] ?? [];
     expect(runOptions).not.toHaveProperty('outputSchema');
   });

--- a/src/agents/decompose-task-usecase.ts
+++ b/src/agents/decompose-task-usecase.ts
@@ -3,7 +3,6 @@ import type { ProviderType } from '../core/workflow/types.js';
 import { runAgent, type RunAgentOptions, type StreamCallback } from './runner.js';
 import { parseParts } from '../core/workflow/engine/task-decomposer.js';
 import { loadDecompositionSchema, loadMorePartsSchema } from '../infra/resources/schema-loader.js';
-import { buildMaxTurnsOption } from './provider-call-options.js';
 import {
   buildDecomposePrompt,
   buildMorePartsPrompt,
@@ -38,8 +37,6 @@ export interface MorePartsResponse {
   parts: PartDefinition[];
 }
 
-export const TEAM_LEADER_MAX_TURNS = 15;
-
 export async function decomposeTask(
   instruction: string,
   maxTotalParts: number,
@@ -60,7 +57,6 @@ export async function decomposeTask(
     resolvedProvider: options.resolvedProvider,
     allowedTools: options.inspectTools ?? [],
     permissionMode: 'readonly',
-    ...buildMaxTurnsOption(options.provider, options.resolvedProvider, TEAM_LEADER_MAX_TURNS),
     outputSchema: loadDecompositionSchema(maxTotalParts),
     onStream: options.onStream,
     workflowMeta: options.workflowMeta,
@@ -106,7 +102,6 @@ export async function requestMoreParts(
     resolvedProvider: options.resolvedProvider,
     allowedTools: [],
     permissionMode: 'readonly',
-    ...buildMaxTurnsOption(options.provider, options.resolvedProvider, TEAM_LEADER_MAX_TURNS),
     outputSchema: loadMorePartsSchema(maxAdditionalParts),
     onStream: options.onStream,
     workflowMeta: options.workflowMeta,

--- a/src/agents/structured-caller/prompt-based-structured-caller.ts
+++ b/src/agents/structured-caller/prompt-based-structured-caller.ts
@@ -14,7 +14,6 @@ import {
   type JudgeStatusResult,
 } from '../judge-status-usecase.js';
 import type { DecomposeTaskOptions, MorePartsOptions, MorePartsResponse } from '../decompose-task-usecase.js';
-import { TEAM_LEADER_MAX_TURNS } from '../decompose-task-usecase.js';
 import type { StructuredCaller } from './contracts.js';
 import {
   buildPromptBasedStructuredInstruction,
@@ -183,7 +182,6 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
         resolvedProvider: options.resolvedProvider,
         allowedTools: options.inspectTools ?? [],
         permissionMode: 'readonly',
-        ...buildMaxTurnsOption(options.provider, options.resolvedProvider, TEAM_LEADER_MAX_TURNS),
         onStream: options.onStream,
         workflowMeta: options.workflowMeta,
         childProcessEnv: options.childProcessEnv,
@@ -225,7 +223,6 @@ export class PromptBasedStructuredCaller implements StructuredCaller {
         resolvedProvider: options.resolvedProvider,
         allowedTools: [],
         permissionMode: 'readonly',
-        ...buildMaxTurnsOption(options.provider, options.resolvedProvider, TEAM_LEADER_MAX_TURNS),
         onStream: options.onStream,
         workflowMeta: options.workflowMeta,
         childProcessEnv: options.childProcessEnv,


### PR DESCRIPTION
## Summary
- team leader のタスク分解呼び出し（`decomposeTask` / `requestMoreParts`）から `maxTurns: 15` の制限を撤廃
- inspect tools（Read, Grep 等）でプロジェクトを調査してからタスク分解 JSON を返す処理で、ファイルが多いと 15 ターンでは足りず `Reached maximum number of turns (15)` エラーでワークフローが abort していた
- これらの呼び出しは `permissionMode: 'readonly'` なので、制限撤廃のリスクはコストのみ
- Phase 2/3 の制限（`REPORT_PHASE_MAX_TURNS=3`、judge `maxTurns=1/3`）はツールなしの短い処理なので維持

## Test plan
- [x] `npm run build` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 通過
- [x] `npm run test:e2e:mock` 通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更点**
  * 一部のエージェント処理で、会話ターンの固定上限（maxTurns）の明示的な適用をやめました。
  * 読み取り専用の権限指定をより明確にし、ツール利用の許可範囲も明示することで挙動の一貫性を高めました。
* **テスト**
  * 上限や呼び出しオプションに関する期待値を更新し、maxTurns 非付与を検証するよう調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->