### PR TITLE
[#905] add-exec-preset-export

### DIFF
--- a/src/__tests__/exec-command.test.ts
+++ b/src/__tests__/exec-command.test.ts
@@ -415,6 +415,7 @@ describe('exec command setup', () => {
       'プリセットを読み込む',
       '現在のプリセットを保存',
       'プリセットを削除',
+      'プリセットをワークフローとしてエクスポート',
       '戻る',
     ]);
     const sourceOptions = mockSelectOption.mock.calls.find((call) => call[0] === 'プリセット読み込み元')?.[1] ?? [];

--- a/src/__tests__/exec-presetExport.test.ts
+++ b/src/__tests__/exec-presetExport.test.ts
@@ -1,0 +1,377 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExecConfig } from '../features/exec/types.js';
+import type { ExecProviderModelDefaults } from '../features/exec/runtimeConfig.js';
+
+vi.mock('../features/exec/promptUtils.js', () => ({
+  selectExecOption: vi.fn(),
+  promptTextOrCancel: vi.fn(),
+  promptText: vi.fn(),
+  promptInteger: vi.fn(),
+}));
+
+vi.mock('../shared/ui/index.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return { ...actual, info: vi.fn() };
+});
+
+import { selectExecOption, promptTextOrCancel } from '../features/exec/promptUtils.js';
+import { info } from '../shared/ui/index.js';
+import { editPresetSetup, exportPresetAsWorkflow } from '../features/exec/presetSetup.js';
+
+const mockSelectExecOption = vi.mocked(selectExecOption);
+const mockPromptTextOrCancel = vi.mocked(promptTextOrCancel);
+const mockInfo = vi.mocked(info);
+
+const PROVIDER_MODEL_DEFAULTS: ExecProviderModelDefaults = {
+  provider: 'claude',
+  model: 'opus',
+};
+
+function createExecConfig(): ExecConfig {
+  return {
+    session: { provider: 'claude', model: 'opus', effort: 'high' },
+    replan: { instruction: 'exec-replan', knowledge: ['architecture'], policy: [] },
+    workers: [{
+      name: 'worker-1',
+      provider: 'claude',
+      model: 'sonnet',
+      effort: 'high',
+      instruction: 'exec-worker',
+      knowledge: ['architecture'],
+      policy: ['coding', 'testing'],
+    }],
+    judges: [{
+      name: 'judge-1',
+      provider: 'claude',
+      model: 'opus',
+      effort: 'high',
+      instruction: 'exec-judge',
+      knowledge: ['architecture'],
+      policy: ['review'],
+    }],
+    loop: { smallThreshold: 3, largeThreshold: 2, maxSteps: 20 },
+  };
+}
+
+function writeProjectPreset(
+  projectDir: string,
+  name: string,
+  config: ExecConfig,
+  description: string,
+): void {
+  const presetDir = join(projectDir, '.takt', 'exec', 'presets');
+  mkdirSync(presetDir, { recursive: true });
+  writeFileSync(join(presetDir, `${name}.yaml`), [
+    `name: ${name}`,
+    `description: ${description}`,
+    'session:',
+    `  provider: ${config.session.provider}`,
+    `  model: ${config.session.model}`,
+    ...(config.session.effort !== undefined ? [`  effort: ${config.session.effort}`] : []),
+    'replan:',
+    `  instruction: ${config.replan.instruction}`,
+    '  knowledge:',
+    ...config.replan.knowledge.map((k) => `    - ${k}`),
+    '  policy: []',
+    'workers:',
+    `  - name: ${config.workers[0]!.name}`,
+    `    provider: ${config.workers[0]!.provider}`,
+    `    model: ${config.workers[0]!.model}`,
+    ...(config.workers[0]!.effort !== undefined ? [`    effort: ${config.workers[0]!.effort}`] : []),
+    `    instruction: ${config.workers[0]!.instruction}`,
+    '    knowledge:',
+    ...config.workers[0]!.knowledge.map((k) => `      - ${k}`),
+    '    policy:',
+    ...config.workers[0]!.policy.map((p) => `      - ${p}`),
+    'judges:',
+    `  - name: ${config.judges[0]!.name}`,
+    `    provider: ${config.judges[0]!.provider}`,
+    `    model: ${config.judges[0]!.model}`,
+    ...(config.judges[0]!.effort !== undefined ? [`    effort: ${config.judges[0]!.effort}`] : []),
+    `    instruction: ${config.judges[0]!.instruction}`,
+    '    knowledge:',
+    ...config.judges[0]!.knowledge.map((k) => `      - ${k}`),
+    '    policy:',
+    ...config.judges[0]!.policy.map((p) => `      - ${p}`),
+    'loop:',
+    `  threshold: ${config.loop.smallThreshold}`,
+    `  large_threshold: ${config.loop.largeThreshold}`,
+    `  max_steps: ${config.loop.maxSteps}`,
+  ].join('\n'));
+}
+
+type RawWorkflowStep = {
+  name: string;
+  parallel?: Array<Record<string, unknown>>;
+  provider?: string;
+  model?: string;
+  [key: string]: unknown;
+};
+
+type RawWorkflow = {
+  name: string;
+  description: string;
+  initial_step: string;
+  max_steps: number;
+  steps: RawWorkflowStep[];
+  loop_monitors?: Array<{
+    cycle: string[];
+    threshold: number;
+    judge: Record<string, unknown>;
+  }>;
+};
+
+function readExportedWorkflow(projectDir: string, name: string): RawWorkflow {
+  const workflowPath = join(projectDir, '.takt', 'workflows', `${name}.yaml`);
+  return parseYaml(readFileSync(workflowPath, 'utf-8')) as RawWorkflow;
+}
+
+describe('exec preset export', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'takt-exec-preset-export-'));
+    mockSelectExecOption.mockReset();
+    mockPromptTextOrCancel.mockReset();
+    mockInfo.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  describe('exportPresetAsWorkflow', () => {
+    it('should write a valid workflow YAML to .takt/workflows/ when default preset is exported', async () => {
+      // Given: user selects default scope and enters a workflow name
+      mockSelectExecOption.mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce('my-workflow');
+
+      // When
+      await exportPresetAsWorkflow(projectDir, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then: YAML is written to the correct path with expected structure
+      const workflowPath = join(projectDir, '.takt', 'workflows', 'my-workflow.yaml');
+      expect(existsSync(workflowPath)).toBe(true);
+
+      const parsed = readExportedWorkflow(projectDir, 'my-workflow');
+      expect(parsed.name).toBe('my-workflow');
+      expect(parsed.description).toBe('my-workflow');
+      expect(parsed.initial_step).toBe('execute');
+      expect(parsed.max_steps).toBe(20);
+      expect(parsed.steps.map((s) => s.name)).toEqual(['execute', 'judge', 'replan']);
+    });
+
+    it('should resolve provider and model from defaults into all workflow actors', async () => {
+      // Given: default preset (no explicit provider/model) with specific defaults
+      const defaults: ExecProviderModelDefaults = { provider: 'claude', model: 'sonnet' };
+      mockSelectExecOption.mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce('resolved-test');
+
+      // When
+      await exportPresetAsWorkflow(projectDir, 'en', defaults);
+
+      // Then: all actors have the resolved provider and model
+      const parsed = readExportedWorkflow(projectDir, 'resolved-test');
+      const executeStep = parsed.steps.find((s) => s.name === 'execute');
+      const judgeStep = parsed.steps.find((s) => s.name === 'judge');
+      const replanStep = parsed.steps.find((s) => s.name === 'replan');
+
+      expect(executeStep?.parallel?.[0]).toMatchObject({ provider: 'claude', model: 'sonnet' });
+      expect(judgeStep?.parallel?.[0]).toMatchObject({ provider: 'claude', model: 'sonnet' });
+      expect(replanStep?.provider).toBe('claude');
+      expect(replanStep?.model).toBe('sonnet');
+    });
+
+    it('should include loop monitors matching the preset loop config', async () => {
+      // Given
+      mockSelectExecOption.mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce('loop-test');
+
+      // When
+      await exportPresetAsWorkflow(projectDir, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then: loop monitors reflect the default config thresholds
+      const parsed = readExportedWorkflow(projectDir, 'loop-test');
+      expect(parsed.loop_monitors).toHaveLength(2);
+      expect(parsed.loop_monitors?.[0]).toMatchObject({
+        cycle: ['execute', 'judge'],
+        threshold: 3,
+      });
+      expect(parsed.loop_monitors?.[1]).toMatchObject({
+        cycle: ['replan', 'execute', 'judge'],
+        threshold: 2,
+      });
+    });
+
+    it('should not write any file when preset selection is cancelled', async () => {
+      // Given: user cancels at scope selection
+      mockSelectExecOption.mockResolvedValueOnce(null);
+
+      // When
+      await exportPresetAsWorkflow(projectDir, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then: no file or directory created
+      expect(existsSync(join(projectDir, '.takt', 'workflows'))).toBe(false);
+      expect(mockInfo).not.toHaveBeenCalled();
+    });
+
+    it('should not write any file when workflow name input is cancelled', async () => {
+      // Given: default preset selected, then name input cancelled
+      mockSelectExecOption.mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce(null);
+
+      // When
+      await exportPresetAsWorkflow(projectDir, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then
+      expect(existsSync(join(projectDir, '.takt', 'workflows'))).toBe(false);
+      expect(mockInfo).not.toHaveBeenCalled();
+    });
+
+    it('should display a success message containing the workflow name after export', async () => {
+      // Given
+      mockSelectExecOption.mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce('msg-check');
+
+      // When
+      await exportPresetAsWorkflow(projectDir, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then
+      expect(mockInfo).toHaveBeenCalledTimes(1);
+      expect(mockInfo.mock.calls[0]?.[0]).toContain('msg-check');
+    });
+
+    it('should pass default value "exported-exec" to the workflow name prompt', async () => {
+      // Given
+      mockSelectExecOption.mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce('any');
+
+      // When
+      await exportPresetAsWorkflow(projectDir, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then: the prompt default is 'exported-exec' per the plan
+      expect(mockPromptTextOrCancel).toHaveBeenCalledWith(
+        expect.any(String),
+        'exported-exec',
+        'en',
+      );
+    });
+
+    it('should throw when workflow name contains path traversal characters', async () => {
+      // Given: user selects default preset and enters a path-traversal name
+      mockSelectExecOption.mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce('../evil');
+
+      // When / Then
+      await expect(exportPresetAsWorkflow(projectDir, 'en', PROVIDER_MODEL_DEFAULTS))
+        .rejects.toThrow('Invalid exec preset name');
+      expect(existsSync(join(projectDir, '.takt', 'workflows'))).toBe(false);
+    });
+
+    it('should throw when workflow name contains special characters', async () => {
+      // Given: user enters a name with spaces and special chars
+      mockSelectExecOption.mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce('my workflow!');
+
+      // When / Then
+      await expect(exportPresetAsWorkflow(projectDir, 'en', PROVIDER_MODEL_DEFAULTS))
+        .rejects.toThrow('Invalid exec preset name');
+      expect(existsSync(join(projectDir, '.takt', 'workflows'))).toBe(false);
+    });
+
+    it('should export a project preset with the preset provider and model resolved', async () => {
+      // Given: a project preset with explicit provider/model on actors
+      const presetConfig = createExecConfig();
+      writeProjectPreset(projectDir, 'custom-team', presetConfig, 'Custom team');
+
+      mockSelectExecOption
+        .mockResolvedValueOnce('project')
+        .mockResolvedValueOnce('custom-team');
+      mockPromptTextOrCancel.mockResolvedValueOnce('custom-workflow');
+
+      // When
+      await exportPresetAsWorkflow(projectDir, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then: exported YAML reflects the preset's actor config
+      const workflowPath = join(projectDir, '.takt', 'workflows', 'custom-workflow.yaml');
+      expect(existsSync(workflowPath)).toBe(true);
+
+      const parsed = readExportedWorkflow(projectDir, 'custom-workflow');
+      expect(parsed.name).toBe('custom-workflow');
+      expect(parsed.steps.map((s) => s.name)).toEqual(['execute', 'judge', 'replan']);
+
+      const executeStep = parsed.steps.find((s) => s.name === 'execute');
+      expect(executeStep?.parallel?.[0]).toMatchObject({
+        name: 'worker-1',
+        provider: 'claude',
+        model: 'sonnet',
+      });
+    });
+  });
+
+  describe('editPresetSetup with export action', () => {
+    it('should return the original config unchanged when export completes', async () => {
+      // Given: user selects 'export' action, then completes the export flow
+      const originalConfig = createExecConfig();
+      mockSelectExecOption
+        .mockResolvedValueOnce('export')
+        .mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce('edit-export-test');
+
+      // When
+      const result = await editPresetSetup(projectDir, originalConfig, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then: original config is returned without modification
+      expect(result).toEqual(originalConfig);
+    });
+
+    it('should write workflow YAML when export action is selected from the preset menu', async () => {
+      // Given
+      mockSelectExecOption
+        .mockResolvedValueOnce('export')
+        .mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce('menu-export');
+
+      // When
+      await editPresetSetup(projectDir, createExecConfig(), 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then
+      expect(existsSync(join(projectDir, '.takt', 'workflows', 'menu-export.yaml'))).toBe(true);
+    });
+
+    it('should return the original config when export is cancelled at preset selection', async () => {
+      // Given
+      const originalConfig = createExecConfig();
+      mockSelectExecOption
+        .mockResolvedValueOnce('export')
+        .mockResolvedValueOnce(null);
+
+      // When
+      const result = await editPresetSetup(projectDir, originalConfig, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then
+      expect(result).toEqual(originalConfig);
+      expect(existsSync(join(projectDir, '.takt', 'workflows'))).toBe(false);
+    });
+
+    it('should return the original config when export is cancelled at workflow name input', async () => {
+      // Given
+      const originalConfig = createExecConfig();
+      mockSelectExecOption
+        .mockResolvedValueOnce('export')
+        .mockResolvedValueOnce('default');
+      mockPromptTextOrCancel.mockResolvedValueOnce(null);
+
+      // When
+      const result = await editPresetSetup(projectDir, originalConfig, 'en', PROVIDER_MODEL_DEFAULTS);
+
+      // Then
+      expect(result).toEqual(originalConfig);
+      expect(existsSync(join(projectDir, '.takt', 'workflows'))).toBe(false);
+    });
+  });
+});

--- a/src/features/exec/presetSetup.ts
+++ b/src/features/exec/presetSetup.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import { info } from '../../shared/ui/index.js';
 import { sanitizeTerminalText } from '../../shared/utils/index.js';
 import type { SessionContext } from '../interactive/aiCaller.js';
@@ -6,13 +7,17 @@ import {
   loadExecPresetFromSource,
   listExecPresetsBySource,
   saveExecPreset,
+  validateExecPresetName,
 } from './presetStore.js';
 import { DEFAULT_EXEC_CONFIG } from './defaults.js';
 import { execLabel, execScopeLabel, type ExecLanguage } from './labels.js';
+import { writeProjectLocalTextFile } from './projectLocalFiles.js';
 import { promptTextOrCancel, selectExecOption } from './promptUtils.js';
+import { resolveExecConfigProviderModel, type ExecProviderModelDefaults } from './runtimeConfig.js';
 import type { ExecConfig, ExecPresetScope } from './types.js';
+import { buildExecWorkflowYaml } from './workflowTemplate.js';
 
-type PresetSetupAction = 'load' | 'save' | 'delete' | 'back';
+type PresetSetupAction = 'load' | 'save' | 'delete' | 'export' | 'back';
 type WritablePresetScope = 'project' | 'global';
 type LoadablePresetScope = ExecPresetScope | 'default';
 
@@ -90,11 +95,32 @@ async function deleteWritablePreset(cwd: string, lang: ExecLanguage): Promise<vo
   }));
 }
 
-export async function editPresetSetup(cwd: string, config: ExecConfig, lang: SessionContext['lang']): Promise<ExecConfig> {
+export async function exportPresetAsWorkflow(
+  cwd: string,
+  lang: ExecLanguage,
+  providerModelDefaults: ExecProviderModelDefaults,
+): Promise<void> {
+  const config = await selectPresetConfig(cwd, lang);
+  if (config === null) {
+    return;
+  }
+  const name = await promptTextOrCancel(execLabel(lang, 'preset.exportNamePrompt'), 'exported-exec', lang);
+  if (name === null) {
+    return;
+  }
+  validateExecPresetName(name);
+  const resolvedConfig = resolveExecConfigProviderModel(config, providerModelDefaults);
+  const yaml = buildExecWorkflowYaml(resolvedConfig, { workflowName: name, taskDescription: name });
+  writeProjectLocalTextFile(cwd, join(cwd, '.takt', 'workflows', `${name}.yaml`), yaml, 'exec workflow');
+  info(execLabel(lang, 'preset.exported', { name: sanitizeTerminalText(name) }));
+}
+
+export async function editPresetSetup(cwd: string, config: ExecConfig, lang: SessionContext['lang'], providerModelDefaults: ExecProviderModelDefaults): Promise<ExecConfig> {
   const action = await selectExecOption<PresetSetupAction>(lang, execLabel(lang, 'preset.menu'), [
     { label: execLabel(lang, 'preset.load'), value: 'load' },
     { label: execLabel(lang, 'preset.saveCurrent'), value: 'save' },
     { label: execLabel(lang, 'preset.delete'), value: 'delete' },
+    { label: execLabel(lang, 'preset.exportAsWorkflow'), value: 'export' },
     { label: execLabel(lang, 'common.back'), value: 'back' },
   ]);
   if (action === 'load') {
@@ -106,6 +132,11 @@ export async function editPresetSetup(cwd: string, config: ExecConfig, lang: Ses
   }
   if (action === 'delete') {
     await deleteWritablePreset(cwd, lang);
+    return config;
+  }
+  if (action === 'export') {
+    await exportPresetAsWorkflow(cwd, lang, providerModelDefaults);
+    return config;
   }
   return config;
 }

--- a/src/features/exec/setupMenu.ts
+++ b/src/features/exec/setupMenu.ts
@@ -550,7 +550,7 @@ async function resolveSetupSection(
     return editLoopConfig(config, ctx.lang);
   }
   if (section === 'preset') {
-    return editPresetSetup(cwd, config, ctx.lang);
+    return editPresetSetup(cwd, config, ctx.lang, providerModelDefaults);
   }
   return config;
 }

--- a/src/shared/i18n/labels_en.yaml
+++ b/src/shared/i18n/labels_en.yaml
@@ -161,6 +161,9 @@ exec:
     descriptionDefault: "Custom exec preset"
     saved: "Saved {scope} exec preset: {name}"
     deleted: "Deleted {scope} exec preset: {name}"
+    exportAsWorkflow: "Export preset as workflow"
+    exportNamePrompt: "Workflow name"
+    exported: "Exported workflow: {name}"
   facets:
     instructions: "instructions"
     knowledge: "knowledge"

--- a/src/shared/i18n/labels_ja.yaml
+++ b/src/shared/i18n/labels_ja.yaml
@@ -161,6 +161,9 @@ exec:
     descriptionDefault: "カスタム exec プリセット"
     saved: "{scope} exec プリセットを保存しました: {name}"
     deleted: "{scope} exec プリセットを削除しました: {name}"
+    exportAsWorkflow: "プリセットをワークフローとしてエクスポート"
+    exportNamePrompt: "ワークフロー名"
+    exported: "ワークフローをエクスポートしました: {name}"
   facets:
     instructions: "指示"
     knowledge: "知識"


### PR DESCRIPTION
## Summary

## Summary

Add a menu action in `takt exec` that exports an exec preset as a normal TAKT workflow YAML.

This should be exposed from the existing exec preset menu, not as a new CLI option.

## Background

`takt exec` already converts an `ExecConfig` into a normal workflow YAML internally when `/go` runs. The generated workflow is currently written to `.takt/exec/workflow.yaml` as an execution artifact.

Users should be able to take an exec preset created through `takt exec` and save/export it as a reusable normal workflow without running a task just to copy the generated artifact.

## Desired UX

In the `takt exec` setup preset menu, add an action such as:

- Load preset
- Save current preset
- Delete preset
- Export preset as workflow
- Back

The export flow should let the user choose the preset source/preset, then choose or enter the workflow output name/path.

## Requirements

- Do not add a new CLI flag or top-level option for this.
- Implement it as an action in the existing exec preset menu.
- Export a normal TAKT workflow YAML that can be used with normal workflow selection/execution.
- Reuse the existing exec preset loading and exec workflow generation logic where possible.
- Resolve provider/model the same way `takt exec` does at exec mode start, so the exported workflow is explicit and runnable.
- Write project-local workflows under `.takt/workflows/` by default.
- Use project-local path safety checks for the workflow output file.
- Avoid requiring a `/go` run just to produce the workflow.

## Acceptance Criteria

- From `takt exec` setup, a user can open the preset menu and export an exec preset as a workflow YAML.
- The exported workflow includes execute, judge, replan, and loop monitor structure equivalent to the current generated exec workflow.
- The exported workflow can be selected/executed as a normal TAKT workflow.
- Existing preset load/save/delete behavior remains unchanged.

## Execution Report

Workflow `takt-default` completed successfully.

Closes #905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 実行プリセットをワークフローとして書き出せるようになりました。
  * 書き出し先の名前入力、保存成功メッセージ、英語/日本語の表示文言が追加されました。

* **バグ修正**
  * 不正な名前やキャンセル時に、ワークフローが作成されないようになりました。
  * 書き出し後も元のプリセット設定が変更されないようになりました。

* **テスト**
  * ワークフロー出力の生成内容、入力キャンセル、エラー処理を確認するテストを追加・拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->