### PR TITLE
fix: restore bash in allowed_tools when permission mode is readonly

### DIFF
--- a/src/__tests__/opencode-provider-addendum.test.ts
+++ b/src/__tests__/opencode-provider-addendum.test.ts
@@ -178,7 +178,7 @@ describe('OpenCodeProvider tool naming addendum', () => {
     expect(listed).toEqual(['read', 'todowrite', 'edit', 'bash']);
   });
 
-  it('should exclude edit when permissionMode is readonly', () => {
+  it('should exclude edit but allow bash when permissionMode is readonly', () => {
     const provider = new OpenCodeProvider() as {
       getRuntimeInstructions(allowedTools?: string[], permissionMode?: PermissionMode, networkAccess?: boolean): string | null;
     };
@@ -186,7 +186,7 @@ describe('OpenCodeProvider tool naming addendum', () => {
     const runtimeInstructions = provider.getRuntimeInstructions(['read', 'edit', 'write', 'bash'], 'readonly', undefined);
 
     const listed = extractToolNames(runtimeInstructions);
-    expect(listed).toEqual(['read']);
+    expect(listed).toEqual(['read', 'bash']);
   });
 
   it('should exclude web tools when networkAccess is false', () => {

--- a/src/__tests__/opencode-types.test.ts
+++ b/src/__tests__/opencode-types.test.ts
@@ -168,7 +168,7 @@ describe('OpenCode permissions', () => {
     ]);
   });
 
-  it('should keep readonly mode from widening to explicitly whitelisted write or command tools', () => {
+  it('should keep readonly mode from widening to explicitly whitelisted edit tools but allow bash', () => {
     const ruleset = buildOpenCodePermissionRuleset('readonly', undefined, [
       'Read',
       'Bash',
@@ -178,6 +178,7 @@ describe('OpenCode permissions', () => {
     expect(ruleset).toEqual([
       { permission: '*', pattern: '*', action: 'deny' },
       { permission: 'read', pattern: '*', action: 'allow' },
+      { permission: 'bash', pattern: '*', action: 'allow' },
     ]);
   });
 

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -226,7 +226,7 @@ export function resolveOpenCodeAllowedPermissions(
     .filter((permission): permission is string => (
       permission !== null
       && isOpenCodePermissionKey(permission)
-      && isAllowedByPermissionMode(permission, mode)
+      && (permission !== 'edit' || isAllowedByPermissionMode(permission, mode))
       && (networkAccess !== false || !isOpenCodeWebPermission(permission))
     ));
   return Array.from(new Set(allowed));


### PR DESCRIPTION
## Summary

PR #886 で追加した `allowed_tools` の `bash` が `readonly` mode でフィルタされない修正が、PR #893 のマージで上書きされて消えていた。再適用する。

## Problem

`review-readonly.yaml` に `bash` が明示的に含まれているが、`resolveOpenCodeAllowedPermissions` の `isAllowedByPermissionMode` が `readonly` mode で `bash` を deny するため、OpenCode に渡されるツールが `glob, grep, read` の3つだけになる。

`bash` がないと `qwen3-coder-next` が `run` を呼んでループする。

## Fix

`isAllowedByPermissionMode` のガードを `edit` permission のみに限定。`bash` 等は `allowed_tools` に明示指定されていれば `readonly` mode でも通す。

## Related

- #886 (元の修正)
- #893 (上書きした PR)
- #892 (TAKT agent for OpenCode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `readonly` モードでの権限判定を調整し、`edit` は引き続き許可されない一方で、`bash` は明示的に許可されるようになりました。
  * これにより、`readonly` 時のツール利用可否がより実際の挙動に合うようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->