### PR TITLE
fix: remove bash from OPENCODE_UNSAFE_WITHOUT_EDIT_TOOL_NAMES

### DIFF
--- a/src/__tests__/allowed-tool-edit-policy.test.ts
+++ b/src/__tests__/allowed-tool-edit-policy.test.ts
@@ -98,7 +98,7 @@ describe('allowed-tool-edit-policy', () => {
       false,
       false,
       'opencode',
-    )).toEqual(['read', 'grep']);
+    )).toEqual(['read', 'bash', ' Bash ', 'grep']);
   });
 
   it('should remove edit tools from Claude team leader part_allowed_tools when part_edit is false', () => {
@@ -122,6 +122,6 @@ describe('allowed-tool-edit-policy', () => {
       ['read', 'bash', ' Bash ', 'edit', 'write', 'grep'],
       false,
       'opencode',
-    )).toEqual(['read', 'grep']);
+    )).toEqual(['read', 'bash', ' Bash ', 'grep']);
   });
 });

--- a/src/__tests__/engine-provider-options.test.ts
+++ b/src/__tests__/engine-provider-options.test.ts
@@ -350,7 +350,7 @@ describe('WorkflowEngine provider_options resolution', () => {
     await engine.run();
 
     const options = vi.mocked(runAgent).mock.calls[0]?.[2];
-    expect(options?.allowedTools).toEqual(['read']);
+    expect(options?.allowedTools).toEqual(['read', 'bash']);
   });
 
   it('should keep claude allowedTools when the provider is mock', async () => {

--- a/src/__tests__/engine-team-leader.test.ts
+++ b/src/__tests__/engine-team-leader.test.ts
@@ -723,7 +723,7 @@ describe('WorkflowEngine Integration: TeamLeaderRunner', () => {
     expect(partCall?.[2]?.allowedTools).toEqual(['Read', 'Grep']);
   });
 
-  it('OpenCode part では part_edit false の part_allowed_tools から編集系ツールを除去する', async () => {
+  it('OpenCode part では part_edit false の part_allowed_tools から編集系ツールを除去するが bash は残す', async () => {
     const config = buildTeamLeaderConfig();
     const step = config.steps[0];
     if (!step?.teamLeader) {
@@ -768,7 +768,7 @@ describe('WorkflowEngine Integration: TeamLeaderRunner', () => {
     expect(state.status).toBe('completed');
     const partCall = vi.mocked(runAgent).mock.calls.find(([, , options]) => options?.resolvedProvider === 'opencode');
     expect(partCall).toBeDefined();
-    expect(partCall?.[2]?.allowedTools).toEqual(['read', 'grep']);
+    expect(partCall?.[2]?.allowedTools).toEqual(['read', 'bash', 'grep']);
   });
 
   it('config 層の claude.allowed_tools は opencode part 実行時に再注入されない', async () => {

--- a/src/__tests__/options-builder.test.ts
+++ b/src/__tests__/options-builder.test.ts
@@ -817,7 +817,7 @@ describe('OptionsBuilder.buildAgentOptions', () => {
 
     const options = builder.buildAgentOptions(step);
 
-    expect(options.allowedTools).toEqual(['read', 'grep']);
+    expect(options.allowedTools).toEqual(['read', 'bash', ' Bash ', 'grep']);
   });
 
   it('silently drops claude allowedTools when configured for a non-claude provider', () => {

--- a/src/__tests__/workflowResolver.test.ts
+++ b/src/__tests__/workflowResolver.test.ts
@@ -368,8 +368,8 @@ steps:
 
     const result = getWorkflowSummary(workflowPath, tempDir, 1);
 
-    expect(result.firstStep?.allowedTools).toEqual(['read', 'grep']);
-    expect(result.stepPreviews[0]?.allowedTools).toEqual(['read', 'grep']);
+    expect(result.firstStep?.allowedTools).toEqual(['read', 'bash', ' Bash ', 'grep']);
+    expect(result.stepPreviews[0]?.allowedTools).toEqual(['read', 'bash', ' Bash ', 'grep']);
   });
 
   it('should resolve preview tools from persona_providers provider_options', () => {

--- a/src/infra/opencode/allowedTools.ts
+++ b/src/infra/opencode/allowedTools.ts
@@ -7,7 +7,6 @@ const OPENCODE_EDIT_PERMISSION_TOOL_NAMES = new Set([
 
 const OPENCODE_UNSAFE_WITHOUT_EDIT_TOOL_NAMES = new Set([
   ...OPENCODE_EDIT_PERMISSION_TOOL_NAMES,
-  'bash',
 ]);
 
 export function mapsToOpenCodeEditPermission(tool: string): boolean {


### PR DESCRIPTION
## Summary

PR #893 で `bash` が `OPENCODE_UNSAFE_WITHOUT_EDIT_TOOL_NAMES` に追加され、`edit: false` のレビューステップで `bash` がエンジン層でフィルタされるようになった。これにより OpenCode + `qwen3-coder-next` でレビューステップに `bash` が渡らず、モデルが `run` を呼んでループする問題が再発していた。

## Fix

`OPENCODE_UNSAFE_WITHOUT_EDIT_TOOL_NAMES` から `bash` を削除。`edit/write/apply_patch/patch` のみが `edit: false` 時にフィルタされる。

`bash` はファイル編集ツールではなく、レビューでのテスト実行・ビルド確認に必要。

## Related

- #886, #918 (`types.ts` 側の readonly フィルタ修正)
- #892 (TAKT agent for OpenCode)
- #893 (bash を unsafe に追加した PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenCode の **edit 無効時**のツール許可判定を調整し、`bash`（`' Bash '` など表記ゆれを含む）が許可ツール一覧から外れなくなりました。
  * これにより、プレビューやフェーズごとの `allowedTools` の期待値が更新され、`bash` を含む集合で動作するようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->