### PR TITLE
feat: add tags and persona fields to phase usage events

### DIFF
--- a/src/__tests__/analyze-usage-command.test.ts
+++ b/src/__tests__/analyze-usage-command.test.ts
@@ -87,6 +87,60 @@ describe('analyze usage command', () => {
     ]);
   });
 
+  it('includes tags and persona in aggregation', () => {
+    const root = createTempDir();
+    const file = join(root, 'session-usage-events.phase.jsonl');
+    writeFileSync(file, [
+      record({
+        run_id: 'run-a',
+        total_tokens: 10,
+        input_tokens: 6,
+        output_tokens: 4,
+        tags: ['coding', 'review'],
+        persona: 'coder',
+      }),
+      record({
+        run_id: 'run-a',
+        total_tokens: 15,
+        input_tokens: 10,
+        output_tokens: 5,
+        tags: ['review'],
+        persona: 'reviewer',
+      }),
+      record({
+        run_id: 'run-a',
+        total_tokens: 5,
+        input_tokens: 3,
+        output_tokens: 2,
+        tags: ['review'],
+        persona: 'reviewer',
+      }),
+    ].join('\n') + '\n', 'utf-8');
+
+    const rows = analyzeUsage([file]);
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        step: 'implement',
+        phase: 'phase1_execute',
+        tags: ['coding', 'review'],
+        persona: 'coder',
+        runs: 1,
+        calls: 1,
+        totalTokens: 10,
+      }),
+      expect.objectContaining({
+        step: 'implement',
+        phase: 'phase1_execute',
+        tags: ['review'],
+        persona: 'reviewer',
+        runs: 1,
+        calls: 2,
+        totalTokens: 20,
+      }),
+    ]);
+  });
+
   it('formats markdown and csv output', () => {
     const rows = [{
       step: 'implement',

--- a/src/__tests__/phaseUsageEvent.test.ts
+++ b/src/__tests__/phaseUsageEvent.test.ts
@@ -162,4 +162,217 @@ describe('phase usage event mapper', () => {
       usage: {},
     });
   });
+
+  it('maps tags and persona from span attributes to event record', () => {
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'codex',
+        'takt.model.name': 'gpt-5',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.tags': ['coding', 'review'],
+        'takt.step.persona': 'coder',
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.execution_id': 'implement:1:1:1',
+        'takt.phase.status': 'done',
+        'takt.usage.missing': false,
+        'gen_ai.usage.input_tokens': 11,
+        'gen_ai.usage.output_tokens': 7,
+        'gen_ai.usage.total_tokens': 18,
+        'gen_ai.usage.cached_input_tokens': 3,
+        'gen_ai.usage.cache_creation_input_tokens': 2,
+        'gen_ai.usage.cache_read_input_tokens': 1,
+      },
+    };
+
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+    expect(record).toMatchObject({
+      tags: ['coding', 'review'],
+      persona: 'coder',
+    });
+  });
+
+  it('handles step with no tags (agent step that does not have tags)', () => {
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'codex',
+        'takt.model.name': 'gpt-5',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.persona': 'coder',
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.execution_id': 'implement:1:1:1',
+        'takt.phase.status': 'done',
+        'takt.usage.missing': false,
+        'gen_ai.usage.input_tokens': 11,
+        'gen_ai.usage.output_tokens': 7,
+        'gen_ai.usage.total_tokens': 18,
+      },
+    };
+
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+    expect(record).not.toBeUndefined();
+    expect(record?.tags).toBeUndefined();
+    expect(record?.persona).toBe('coder');
+  });
+
+  it('maps tags and persona for judge stage spans', () => {
+    const span: SpanSnapshot = {
+      name: 'judge_stage.implement.3.ai_judge',
+      endTime: [1_778_777_215, 0],
+      attributes: {
+        'takt.provider.name': 'claude-sdk',
+        'takt.model.name': 'claude-sonnet-4',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.tags': ['review', 'validation'],
+        'takt.step.persona': 'conductor',
+        'takt.phase.execution_id': 'implement:3:1:1',
+        'takt.judge.stage': 3,
+        'takt.judge.method': 'ai_judge',
+        'takt.judge.status': 'done',
+        'gen_ai.usage.input_tokens': 5,
+        'gen_ai.usage.output_tokens': 4,
+      },
+    };
+
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+    expect(record).toMatchObject({
+      tags: ['review', 'validation'],
+      persona: 'conductor',
+      phase: 'phase3_fallback',
+      judge_stage: 3,
+    });
+  });
+
+  it('includes tags and persona in the generated event when both are present', () => {
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'claude',
+        'takt.model.name': 'claude-3-7',
+        'takt.step.name': 'review',
+        'takt.step.type': 'agent',
+        'takt.step.tags': ['review'],
+        'takt.step.persona': 'conductor',
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.execution_id': 'review:1:1:1',
+        'takt.phase.status': 'done',
+        'takt.usage.missing': false,
+        'gen_ai.usage.input_tokens': 20,
+        'gen_ai.usage.output_tokens': 15,
+        'gen_ai.usage.total_tokens': 35,
+      },
+    };
+
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+    expect(record).toEqual({
+      run_id: 'run-1',
+      session_id: 'session-1',
+      provider: 'claude',
+      provider_model: 'claude-3-7',
+      step: 'review',
+      step_type: 'agent',
+      tags: ['review'],
+      persona: 'conductor',
+      phase: 'phase1_execute',
+      phase_name: 'execute',
+      phase_execution_id: 'review:1:1:1',
+      timestamp: '2026-05-14T16:46:45.000Z',
+      success: true,
+      usage_missing: false,
+      usage: {
+        input_tokens: 20,
+        output_tokens: 15,
+        total_tokens: 35,
+      },
+    });
+  });
+
+  it('maps tags and persona from phase span when tags is empty array', () => {
+    const span: SpanSnapshot = {
+      name: 'phase.implement.execute',
+      endTime: [1_778_777_205, 0],
+      attributes: {
+        'takt.provider.name': 'codex',
+        'takt.model.name': 'gpt-5',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.tags': [],
+        'takt.step.persona': 'coder',
+        'takt.phase.number': 1,
+        'takt.phase.name': 'execute',
+        'takt.phase.execution_id': 'implement:1:1:1',
+        'takt.phase.status': 'done',
+        'takt.usage.missing': false,
+        'gen_ai.usage.input_tokens': 11,
+        'gen_ai.usage.output_tokens': 7,
+        'gen_ai.usage.total_tokens': 18,
+      },
+    };
+
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+    expect(record).not.toBeUndefined();
+    expect(record?.tags).toBeUndefined();
+    expect(record?.persona).toBe('coder');
+  });
+
+  it('maps tags and persona for judge stage spans with empty tags array', () => {
+    const span: SpanSnapshot = {
+      name: 'judge_stage.implement.3.ai_judge',
+      endTime: [1_778_777_215, 0],
+      attributes: {
+        'takt.provider.name': 'claude-sdk',
+        'takt.model.name': 'claude-sonnet-4',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.tags': [],
+        'takt.step.persona': 'coder',
+        'takt.phase.execution_id': 'implement:3:1:1',
+        'takt.judge.stage': 3,
+        'takt.judge.method': 'ai_judge',
+        'takt.judge.status': 'done',
+        'gen_ai.usage.input_tokens': 5,
+        'gen_ai.usage.output_tokens': 4,
+      },
+    };
+
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+    expect(record).not.toBeUndefined();
+    expect(record?.tags).toBeUndefined();
+    expect(record?.persona).toBe('coder');
+  });
+
+  it('skips judge stage span when tags is empty array and persona is missing', () => {
+    const span: SpanSnapshot = {
+      name: 'judge_stage.implement.3.ai_judge',
+      endTime: [1_778_777_215, 0],
+      attributes: {
+        'takt.provider.name': 'claude-sdk',
+        'takt.model.name': 'claude-sonnet-4',
+        'takt.step.name': 'implement',
+        'takt.step.type': 'agent',
+        'takt.step.tags': [],
+        'takt.phase.execution_id': 'implement:3:1:1',
+        'takt.judge.stage': 3,
+        'takt.judge.method': 'ai_judge',
+        'takt.judge.status': 'done',
+        'gen_ai.usage.input_tokens': 5,
+        'gen_ai.usage.output_tokens': 4,
+      },
+    };
+
+    const record = mapSpanEndToPhaseUsageEvent(span, context);
+    expect(record).not.toBeUndefined();
+    expect(record?.tags).toBeUndefined();
+    expect(record?.persona).toBeUndefined();
+  });
 });

--- a/src/__tests__/usageEventsSpanProcessor.test.ts
+++ b/src/__tests__/usageEventsSpanProcessor.test.ts
@@ -161,7 +161,114 @@ describe('UsageEventsSpanProcessor', () => {
       runId: 'run-1',
     }));
   });
+
+  it('includes tags and persona in the recorded event', () => {
+    const phaseUsageLogPath = createTempLogPath('tags-persona-usage.phase.jsonl');
+    const processor = new UsageEventsSpanProcessor({
+      runId: 'run-1',
+      sessionId: 'session-1',
+      phaseUsageLogPath,
+    });
+
+    processor.onEnd(makePhaseSpanWithTagsAndPersona('run-1') as unknown as ReadableSpan);
+    processor.shutdown();
+
+    const records = readRecords(phaseUsageLogPath);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      run_id: 'run-1',
+      session_id: 'session-1',
+      step: 'implement',
+      tags: ['coding', 'validation'],
+      persona: 'coder',
+      phase: 'phase1_execute',
+    });
+  });
+
+  it('includes persona when tags is missing', () => {
+    const phaseUsageLogPath = createTempLogPath('persona-only-usage.phase.jsonl');
+    const processor = new UsageEventsSpanProcessor({
+      runId: 'run-2',
+      sessionId: 'session-2',
+      phaseUsageLogPath,
+    });
+
+    processor.onEnd(makePhaseSpanWithPersonaOnly('run-2') as unknown as ReadableSpan);
+    processor.shutdown();
+
+    const records = readRecords(phaseUsageLogPath);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      run_id: 'run-2',
+      session_id: 'session-2',
+      step: 'review',
+      persona: 'conductor',
+      phase: 'phase1_execute',
+    });
+  });
+
+  it('excludes tags field when step.tags is missing', () => {
+    const phaseUsageLogPath = createTempLogPath('no-tags-usage.phase.jsonl');
+    const processor = new UsageEventsSpanProcessor({
+      runId: 'run-3',
+      sessionId: 'session-3',
+      phaseUsageLogPath,
+    });
+
+    processor.onEnd(makePhaseSpan('run-3') as unknown as ReadableSpan);
+    processor.shutdown();
+
+    const records = readRecords(phaseUsageLogPath);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      step: 'implement',
+    });
+    expect(records[0].tags).toBeUndefined();
+  });
 });
+
+function makePhaseSpanWithTagsAndPersona(runId: string): Record<string, unknown> {
+  return {
+    name: 'phase.implement.execute',
+    endTime: [1_778_777_205, 0],
+    attributes: {
+      'takt.run.id': runId,
+      'takt.provider.name': 'mock',
+      'takt.model.name': 'mock-model',
+      'takt.step.name': 'implement',
+      'takt.step.type': 'agent',
+      'takt.step.tags': ['coding', 'validation'],
+      'takt.step.persona': 'coder',
+      'takt.phase.number': 1,
+      'takt.phase.name': 'execute',
+      'takt.phase.status': 'done',
+      'gen_ai.usage.input_tokens': 3,
+      'gen_ai.usage.output_tokens': 2,
+      'gen_ai.usage.total_tokens': 5,
+    },
+  };
+}
+
+function makePhaseSpanWithPersonaOnly(runId: string): Record<string, unknown> {
+  return {
+    name: 'phase.review.execute',
+    endTime: [1_778_777_205, 0],
+    attributes: {
+      'takt.run.id': runId,
+      'takt.provider.name': 'claude',
+      'takt.model.name': 'claude-3-7',
+      'takt.step.name': 'review',
+      'takt.step.type': 'agent',
+      'takt.step.persona': 'conductor',
+      'takt.phase.number': 1,
+      'takt.phase.name': 'execute',
+      'takt.phase.status': 'done',
+      'gen_ai.usage.input_tokens': 10,
+      'gen_ai.usage.output_tokens': 8,
+      'gen_ai.usage.total_tokens': 18,
+    },
+  };
+}
 
 function makePhaseSpan(runId: string): Record<string, unknown> {
   return {

--- a/src/__tests__/workflowSpans.test.ts
+++ b/src/__tests__/workflowSpans.test.ts
@@ -1152,4 +1152,282 @@ describe('workflow OpenTelemetry spans', () => {
     expect(spans[0]?.exceptions).toEqual([error]);
     expect(spans[0]?.ended).toBe(true);
   });
+
+  it('records takt.step.tags and takt.step.persona on step spans for agent steps', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step = makeStep({
+      personaDisplayName: 'coder',
+      tags: ['coding', 'review'],
+    });
+
+    await module.runWithStepSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      step,
+      iteration: 1,
+    }, async () => makeDoneResult());
+
+    const stepSpan = findSpan(spans, 'step.implement');
+    expect(stepSpan.attributes).toMatchObject({
+      'takt.step.tags': ['coding', 'review'],
+      'takt.step.persona': 'coder',
+    });
+  });
+
+  it('does not record takt.step.tags on system step spans (tags is undefined for system steps)', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step: WorkflowStep = {
+      name: 'system-check',
+      kind: 'system',
+      personaDisplayName: 'system',
+      instruction: 'System check',
+      tags: undefined,
+    };
+
+    await module.runWithStepSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      step,
+      iteration: 1,
+    }, async () => makeDoneResult());
+
+    const stepSpan = findSpan(spans, 'step.system-check');
+    expect(stepSpan.attributes['takt.step.tags']).toBeUndefined();
+    expect(stepSpan.attributes['takt.step.persona']).toBe('system');
+  });
+
+  it('records takt.step.tags and takt.step.persona on phase spans', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step = makeStep({
+      name: 'review',
+      personaDisplayName: 'conductor',
+      tags: ['review', 'validation'],
+    });
+
+    await module.runWithStepSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      step,
+      iteration: 2,
+    }, async () => {
+      await module.runWithPhaseSpan({
+        enabled: true,
+        workflowName: 'test-workflow',
+        step,
+        iteration: 2,
+        phase: 1,
+        phaseName: 'execute',
+        instruction: 'execute',
+        phaseExecutionId: 'review:2:1:1',
+        providerInfo: {
+          provider: 'claude',
+          model: 'claude-sonnet-4',
+          providerSource: 'project',
+          modelSource: 'global',
+        },
+        getPromptParts: () => ({
+          systemPrompt: 'system',
+          userInstruction: 'user',
+        }),
+      }, async () => ({ status: 'done', content: 'ok' }), (result: { status: string; content: string }) => ({
+        status: result.status,
+        content: result.content,
+        providerUsage: {
+          usageMissing: false,
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        },
+      }));
+      return makeDoneResult();
+    });
+
+    const phaseSpan = spans.find((span) => span.name === 'phase.review.execute');
+    expect(phaseSpan).not.toBeUndefined();
+    expect(phaseSpan?.attributes).toMatchObject({
+      'takt.step.tags': ['review', 'validation'],
+      'takt.step.persona': 'conductor',
+    });
+  });
+
+  it('records takt.step.tags and takt.step.persona on judge stage spans', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step = makeStep({
+      name: 'review',
+      personaDisplayName: 'conductor',
+      tags: ['validation', 'review'],
+    });
+
+    await module.runWithStepSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      step,
+      iteration: 3,
+    }, async () => {
+      await module.runWithPhaseSpan({
+        enabled: true,
+        workflowName: 'test-workflow',
+        step,
+        iteration: 3,
+        phase: 3,
+        phaseName: 'judge',
+        phaseExecutionId: 'review:3:1:1',
+      }, async () => {
+        module.recordJudgeStageSpan({
+          enabled: true,
+          workflowName: 'test-workflow',
+          step,
+          iteration: 3,
+          phaseExecutionId: 'review:3:1:1',
+          entry: {
+            stage: 1,
+            method: 'structured_output',
+            status: 'done',
+            instruction: 'judge instruction',
+            response: 'judge response',
+            providerUsage: {
+              usageMissing: false,
+              inputTokens: 5,
+              outputTokens: 3,
+              totalTokens: 8,
+            },
+          },
+          providerInfo: {
+            provider: 'claude-sdk',
+            model: 'claude-sonnet-4',
+          },
+        });
+        return { ruleIndex: 0, method: 'structured_output' };
+      }, (result: { ruleIndex: number; method: string }) => ({
+        status: 'done',
+        matchedRuleIndex: result.ruleIndex,
+        matchedRuleMethod: result.method,
+      }));
+      return makeDoneResult();
+    });
+
+    const judgeSpan = spans.find((span) => span.name === 'judge_stage.review.1.structured_output');
+    expect(judgeSpan).not.toBeUndefined();
+    expect(judgeSpan?.attributes).toMatchObject({
+      'takt.step.tags': ['validation', 'review'],
+      'takt.step.persona': 'conductor',
+    });
+  });
+
+  it('does not record takt.step.tags on system step phase spans (tags is undefined for system steps)', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step: WorkflowStep = {
+      name: 'system-check',
+      kind: 'system',
+      personaDisplayName: 'system',
+      instruction: 'System check',
+      tags: undefined,
+    };
+
+    await module.runWithStepSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      step,
+      iteration: 1,
+    }, async () => {
+      await module.runWithPhaseSpan({
+        enabled: true,
+        workflowName: 'test-workflow',
+        step,
+        iteration: 1,
+        phase: 1,
+        phaseName: 'execute',
+        phaseExecutionId: 'system-check:1:1:1',
+        providerInfo: {
+          provider: 'codex',
+          model: 'gpt-5',
+          providerSource: 'project',
+          modelSource: 'global',
+        },
+        getPromptParts: () => ({
+          systemPrompt: 'system',
+          userInstruction: 'user',
+        }),
+      }, async () => ({ status: 'done', content: 'ok' }), (result: { status: string; content: string }) => ({
+        status: result.status,
+        content: result.content,
+        providerUsage: {
+          usageMissing: false,
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        },
+      }));
+      return makeDoneResult();
+    });
+
+    const phaseSpan = spans.find((span) => span.name === 'phase.system-check.execute');
+    expect(phaseSpan).not.toBeUndefined();
+    expect(phaseSpan?.attributes['takt.step.tags']).toBeUndefined();
+    expect(phaseSpan?.attributes['takt.step.persona']).toBe('system');
+  });
+
+  it('does not record takt.step.tags on system step judge stage spans', async () => {
+    const { module, spans } = await loadWorkflowSpansWithMockedApi();
+    const step: WorkflowStep = {
+      name: 'system-check',
+      kind: 'system',
+      personaDisplayName: 'system',
+      instruction: 'System check',
+      tags: undefined,
+    };
+
+    await module.runWithStepSpan({
+      enabled: true,
+      workflowName: 'test-workflow',
+      step,
+      iteration: 1,
+    }, async () => {
+      await module.runWithPhaseSpan({
+        enabled: true,
+        workflowName: 'test-workflow',
+        step,
+        iteration: 1,
+        phase: 3,
+        phaseName: 'judge',
+        phaseExecutionId: 'system-check:3:1:1',
+      }, async () => {
+        module.recordJudgeStageSpan({
+          enabled: true,
+          workflowName: 'test-workflow',
+          step,
+          iteration: 1,
+          phaseExecutionId: 'system-check:3:1:1',
+          entry: {
+            stage: 1,
+            method: 'structured_output',
+            status: 'done',
+            instruction: 'judge instruction',
+            response: 'judge response',
+            providerUsage: {
+              usageMissing: false,
+              inputTokens: 5,
+              outputTokens: 3,
+              totalTokens: 8,
+            },
+          },
+          providerInfo: {
+            provider: 'claude-sdk',
+            model: 'claude-sonnet-4',
+          },
+        });
+        return { ruleIndex: 0, method: 'structured_output' };
+      }, (result: { ruleIndex: number; method: string }) => ({
+        status: 'done',
+        matchedRuleIndex: result.ruleIndex,
+        matchedRuleMethod: result.method,
+      }));
+      return makeDoneResult();
+    });
+
+    const judgeSpan = spans.find((span) => span.name === 'judge_stage.system-check.1.structured_output');
+    expect(judgeSpan).not.toBeUndefined();
+    expect(judgeSpan?.attributes['takt.step.tags']).toBeUndefined();
+    expect(judgeSpan?.attributes['takt.step.persona']).toBe('system');
+  });
 });

--- a/src/commands/analyze-usage.ts
+++ b/src/commands/analyze-usage.ts
@@ -15,6 +15,8 @@ export interface UsageAnalysisRow {
   phase: string;
   provider: string;
   model: string;
+  tags?: string[];
+  persona?: string;
   runs: number;
   calls: number;
   missing: number;
@@ -35,6 +37,8 @@ interface UsageGroup {
   phase: string;
   provider: string;
   model: string;
+  tags?: string[];
+  persona?: string;
   runs: Set<string>;
   calls: number;
   missing: number;
@@ -52,6 +56,8 @@ const MARKDOWN_COLUMNS: Array<[string, keyof UsageAnalysisRow]> = [
   ['phase', 'phase'],
   ['provider', 'provider'],
   ['model', 'model'],
+  ['tags', 'tags'],
+  ['persona', 'persona'],
   ['runs', 'runs'],
   ['calls', 'calls'],
   ['missing', 'missing'],
@@ -81,6 +87,8 @@ export function analyzeUsage(inputs: string[]): UsageAnalysisRow[] {
           phase: record.phase,
           provider: record.provider,
           model: record.provider_model,
+          tags: record.tags,
+          persona: record.persona,
           runs: new Set<string>(),
           calls: 0,
           missing: 0,
@@ -178,14 +186,23 @@ function isPhaseUsageRecord(value: unknown): value is PhaseUsageEventLogRecord {
     return false;
   }
   const candidate = value as Partial<PhaseUsageEventLogRecord>;
-  return typeof candidate.run_id === 'string'
+  if (!(typeof candidate.run_id === 'string'
     && typeof candidate.provider === 'string'
     && typeof candidate.provider_model === 'string'
     && typeof candidate.step === 'string'
     && typeof candidate.phase === 'string'
     && typeof candidate.usage_missing === 'boolean'
     && candidate.usage !== null
-    && typeof candidate.usage === 'object';
+    && typeof candidate.usage === 'object')) {
+    return false;
+  }
+  if (candidate.tags !== undefined && !Array.isArray(candidate.tags)) {
+    return false;
+  }
+  if (candidate.persona !== undefined && typeof candidate.persona !== 'string') {
+    return false;
+  }
+  return true;
 }
 
 function groupKey(record: PhaseUsageEventLogRecord): string {
@@ -194,6 +211,8 @@ function groupKey(record: PhaseUsageEventLogRecord): string {
     record.phase,
     record.provider,
     record.provider_model,
+    record.persona ?? '',
+    record.tags?.join(';') ?? '',
   ].join('\u0000');
 }
 
@@ -228,6 +247,8 @@ function groupToRow(group: UsageGroup): UsageAnalysisRow {
     phase: group.phase,
     provider: group.provider,
     model: group.model,
+    tags: group.tags,
+    persona: group.persona,
     runs: group.runs.size,
     calls: group.calls,
     missing: group.missing,
@@ -299,7 +320,10 @@ function formatValue(value: UsageAnalysisRow[keyof UsageAnalysisRow]): string {
   if (typeof value === 'number') {
     return Number.isInteger(value) ? String(value) : value.toFixed(2);
   }
-  return value;
+  if (Array.isArray(value)) {
+    return value.join(';');
+  }
+  return value ?? '';
 }
 
 function csvCell(value: string): string {

--- a/src/core/logging/phaseUsageEvent.ts
+++ b/src/core/logging/phaseUsageEvent.ts
@@ -31,6 +31,8 @@ export interface PhaseUsageEventLogRecord {
   phase_execution_id?: string;
   judge_stage?: JudgeStage;
   judge_method?: JudgeMethod;
+  persona?: string;
+  tags?: string[];
   timestamp: string;
   success: boolean;
   usage_missing: boolean;
@@ -60,6 +62,8 @@ interface PhaseUsageMeta {
   phaseExecutionId?: string;
   judgeStage?: JudgeStage;
   judgeMethod?: JudgeMethod;
+  persona?: string;
+  tags?: string[];
   success: boolean;
 }
 
@@ -128,7 +132,7 @@ function mapJudgeStageSpan(
   });
 }
 
-function buildCommonMeta(span: SpanSnapshot): Pick<PhaseUsageMeta, 'provider' | 'providerModel' | 'step' | 'stepType'> | undefined {
+function buildCommonMeta(span: SpanSnapshot): Pick<PhaseUsageMeta, 'provider' | 'providerModel' | 'step' | 'stepType' | 'persona' | 'tags'> | undefined {
   const provider = getProvider(span.attributes, 'takt.provider.name');
   const step = getString(span.attributes, 'takt.step.name');
   const stepType = getStepType(span.attributes, 'takt.step.type');
@@ -141,6 +145,8 @@ function buildCommonMeta(span: SpanSnapshot): Pick<PhaseUsageMeta, 'provider' | 
     providerModel: getString(span.attributes, 'takt.model.name') ?? '(default)',
     step,
     stepType,
+    persona: getString(span.attributes, 'takt.step.persona'),
+    tags: getTags(span.attributes, 'takt.step.tags'),
   };
 }
 
@@ -162,6 +168,8 @@ function buildRecord(
     ...(meta.phaseExecutionId ? { phase_execution_id: meta.phaseExecutionId } : {}),
     ...(meta.judgeStage ? { judge_stage: meta.judgeStage } : {}),
     ...(meta.judgeMethod ? { judge_method: meta.judgeMethod } : {}),
+    ...(meta.persona ? { persona: meta.persona } : {}),
+    ...(meta.tags ? { tags: meta.tags } : {}),
     timestamp: hrTimeToIso(span.endTime),
     success: meta.success,
     usage_missing: usage.missing,
@@ -281,6 +289,19 @@ function getJudgeStage(attributes: Record<string, unknown>, key: string): JudgeS
 function getJudgeMethod(attributes: Record<string, unknown>, key: string): JudgeMethod | undefined {
   const value = getString(attributes, key);
   return value === 'structured_output' || value === 'phase3_tag' || value === 'ai_judge' ? value : undefined;
+}
+
+function getTags(attributes: Record<string, unknown>, key: string): string[] | undefined {
+  const value = attributes[key];
+  if (!Array.isArray(value) || value.length === 0) {
+    return undefined;
+  }
+  for (const item of value) {
+    if (typeof item !== 'string') {
+      return undefined;
+    }
+  }
+  return value as string[];
 }
 
 function getUsageMissingReason(value: unknown): UsageMissingReason {

--- a/src/core/workflow/observability/workflowSpans.ts
+++ b/src/core/workflow/observability/workflowSpans.ts
@@ -45,7 +45,7 @@ const JUDGE_STAGE_COUNTER_OPTIONS = {
   description: 'Workflow judge stage executions by status',
 };
 
-type AttributeInput = Record<string, string | number | boolean | undefined>;
+type AttributeInput = Record<string, string | number | boolean | string[] | undefined>;
 
 export interface WorkflowSpanParams {
   enabled: boolean;
@@ -274,6 +274,7 @@ function buildStepAttributes(params: StepSpanParams): Attributes {
     ...workflowStackAttributes(params.workflowStack),
     'takt.step.name': params.step.name,
     'takt.step.persona': params.step.personaDisplayName,
+    'takt.step.tags': params.step.tags,
     'takt.step.type': getWorkflowStepKind(params.step),
     'takt.step.iteration': params.iteration,
     'takt.step.local_iteration': params.stepIteration,
@@ -312,6 +313,7 @@ function buildPhaseAttributes(params: PhaseSpanParams): Attributes {
     ...workflowStackAttributes(params.workflowStack),
     'takt.step.name': params.step.name,
     'takt.step.persona': params.step.personaDisplayName,
+    'takt.step.tags': params.step.tags,
     'takt.step.type': getWorkflowStepKind(params.step),
     'takt.step.iteration': params.iteration,
     'takt.phase.number': params.phase,
@@ -329,6 +331,7 @@ function buildJudgeStageAttributes(params: JudgeStageSpanParams): Attributes {
     ...workflowStackAttributes(params.workflowStack),
     'takt.step.name': params.step.name,
     'takt.step.persona': params.step.personaDisplayName,
+    'takt.step.tags': params.step.tags,
     'takt.step.type': getWorkflowStepKind(params.step),
     'takt.step.iteration': params.iteration,
     'takt.phase.number': 3,

--- a/tools/token-usage.sh
+++ b/tools/token-usage.sh
@@ -154,15 +154,18 @@ const grandCached = runs.reduce((s, r) => s + r.total.cached, 0);
 const grandInput = runs.reduce((s, r) => s + r.total.input, 0);
 const grandOutput = runs.reduce((s, r) => s + r.total.output, 0);
 
-if (csv) {
-  console.log("task,run_id,provider,model,step,input_tokens,output_tokens,total_tokens,cached_tokens,calls");
-  for (const run of runs.slice(0, top)) {
-    for (const [step, s] of [...run.steps.entries()].sort((a, b) => b[1].total - a[1].total)) {
-      console.log([run.task || "-", run.run_id, run.provider, run.model, step, s.input, s.output, s.total, s.cached, s.count].join(","));
+  if (csv) {
+    console.log("task,run_id,provider,model,step,tags,persona,input_tokens,output_tokens,total_tokens,cached_tokens,calls");
+    for (const run of runs.slice(0, top)) {
+      for (const [step, s] of [...run.steps.entries()].sort((a, b) => b[1].total - a[1].total)) {
+        const stepRecords = records.filter(r => r.step === step && r.run_id === run.run_id);
+        const persona = stepRecords.find(r => r.persona)?.persona || "-";
+        const tags = stepRecords.find(r => r.tags)?.tags?.join(";") || "-";
+        console.log([run.task || "-", run.run_id, run.provider, run.model, step, tags, persona, s.input, s.output, s.total, s.cached, s.count].join(","));
+      }
     }
+    process.exit(0);
   }
-  process.exit(0);
-}
 
 const W = 76;
 const bar = "=".repeat(W);


### PR DESCRIPTION
## Summary

phase usage event (`.phase.jsonl`) に `tags` と `persona` フィールドを追加し、ステップ種別やペルソナ別の集計・分析を可能にする。

## Changes

### Core
- `src/core/logging/phaseUsageEvent.ts`: `PhaseUsageEventLogRecord` に `persona` と `tags` を追加。`buildCommonMeta` でスパン属性 `takt.step.persona` / `takt.step.tags` から取得
- `src/core/workflow/observability/workflowSpans.ts`: step / phase / judge stage スパンに `takt.step.tags` 属性を設定（`takt.step.persona` は既存）

### CLI
- `src/commands/analyze-usage.ts`: `tags` / `persona` の型検証を追加、`groupKey` に含める
- `tools/token-usage.sh`: CSV ヘッダーに `tags` / `persona` カラムを追加

### Tests
- `src/__tests__/phaseUsageEvent.test.ts`: tags/persona フィールドの出力テスト
- `src/__tests__/usageEventsSpanProcessor.test.ts`: スパン属性からの取得テスト
- `src/__tests__/workflowSpans.test.ts`: スパン属性設定テスト
- `src/__tests__/analyze-usage-command.test.ts`: 型検証・groupKey テスト

## Output Format

```jsonl
{
  ...existing fields,
  "tags": ["coding", "review"],
  "persona": "coder"
}
```

Closes #870