### PR TITLE
docs: clarify CQRS reactive polling guidance

### DIFF
--- a/builtins/en/facets/knowledge/cqrs-es.md
+++ b/builtins/en/facets/knowledge/cqrs-es.md
@@ -358,13 +358,16 @@ When synchronous response is needed after command dispatch, use reactive polling
 | Criteria | Judgment |
 |----------|----------|
 | Using Subscription Query to wait for Projection updates | REJECT. Does not work in distributed environments. Use reactive polling |
-| UI expects immediate updates | Polling or WebSocket |
+| Blocking the request thread with `Thread.sleep` or equivalent while waiting for Projection updates | REJECT. It can exhaust request threads under concurrency |
+| Updated state must be returned in the same HTTP response | Wait non-blockingly on a reactive HTTP stack |
+| The same HTTP response does not need to wait | `202 Accepted` + frontend long polling, regular polling, SSE, or WebSocket |
+| UI expects immediate updates | Frontend polling, SSE, WebSocket, or server-side reactive waiting |
 | Consistency delay exceeds tolerance | Reconsider architecture |
 | Compensating transactions undefined | Request failure scenario review |
 
 ### Reactive Polling
 
-Pattern: dispatch command → poll for Projection update completion.
+Pattern: dispatch command → wait for Projection update completion with non-blocking polling. Reactive polling means waiting without occupying a request thread; it is not a synchronous `while` loop with `Thread.sleep`.
 
 ```kotlin
 // UseCase: send command → poll for completion
@@ -392,6 +395,20 @@ private fun pollForCompletion(orderId: String): Mono<Void> {
 }
 ```
 
+Avoid blocking waits:
+
+```kotlin
+// NG - Occupies the request thread and can exhaust the pool under load
+while (Instant.now().isBefore(deadline)) {
+    val order = orderRepository.findById(orderId).orElse(null)
+    if (order?.status == OrderStatus.CONFIRMED) return PlaceOrderOutput(orderId)
+    Thread.sleep(100)
+}
+
+// OK - If the same response must wait, move the wait onto a reactive path
+return pollForCompletion(orderId).thenReturn(PlaceOrderOutput(orderId))
+```
+
 When polling is appropriate:
 - Need to wait for Saga completion before returning response
 - Need to return created resource ID after command dispatch
@@ -399,6 +416,8 @@ When polling is appropriate:
 When polling is not needed:
 - Simple operations that complete with just command dispatch (no result waiting)
 - UI does not require real-time updates
+
+When the server does not wait, return `202 Accepted` with a tracking ID after accepting the command, then let the frontend long-poll or regularly poll a read API. If the user experience requires immediate updates, SSE or WebSocket are also options.
 
 ## Saga vs EventHandler
 

--- a/builtins/ja/facets/knowledge/cqrs-es.md
+++ b/builtins/ja/facets/knowledge/cqrs-es.md
@@ -586,13 +586,16 @@ Aggregate → Event Bus → Projection(@EventHandler) → Repository(Read Model)
 | 基準 | 判定 |
 |------|------|
 | Subscription Query で Projection 更新を待機 | REJECT。分散環境で動作しない。リアクティブポーリングを使う |
-| UIが即座に更新を期待している | ポーリング or WebSocket |
+| `Thread.sleep` や同等の待機でリクエストスレッドをブロックして Projection 更新を待つ | REJECT。高並行時にスレッド枯渇を起こす |
+| 同一HTTPレスポンスで更新後状態を返す必要がある | リアクティブHTTPスタックで非ブロッキングに待機 |
+| 同一HTTPレスポンスで待つ必要がない | `202 Accepted` + フロントエンドのロングポーリング、通常ポーリング、SSE、WebSocket |
+| UIが即座に更新を期待している | フロントエンドポーリング、SSE、WebSocket、またはサーバー側のリアクティブ待機 |
 | 整合性遅延が許容範囲を超える | アーキテクチャ再検討 |
 | 補償トランザクションが未定義 | 障害シナリオの検討を要求 |
 
 ### リアクティブポーリング
 
-コマンド発行 → Projection更新完了をポーリングで待機するパターン。
+コマンド発行 → Projection更新完了を非ブロッキングなポーリングで待機するパターン。リアクティブポーリングはリクエストスレッドを占有しない待機であり、`while` ループと `Thread.sleep` で同期的に待つ実装ではない。
 
 ```kotlin
 // UseCase: コマンド送信 → ポーリングで完了待機
@@ -620,6 +623,20 @@ private fun pollForCompletion(orderId: String): Mono<Void> {
 }
 ```
 
+ブロッキング待機は避ける:
+
+```kotlin
+// NG - リクエストスレッドを占有し、負荷時にスレッド枯渇を起こす
+while (Instant.now().isBefore(deadline)) {
+    val order = orderRepository.findById(orderId).orElse(null)
+    if (order?.status == OrderStatus.CONFIRMED) return PlaceOrderOutput(orderId)
+    Thread.sleep(100)
+}
+
+// OK - 同一レスポンスで待つならリアクティブな待機へ載せる
+return pollForCompletion(orderId).thenReturn(PlaceOrderOutput(orderId))
+```
+
 ポーリングが適切なケース:
 - Saga が完了するまでレスポンスを返したくない場合
 - コマンド発行後に作成されたリソースのIDを返す場合
@@ -627,6 +644,8 @@ private fun pollForCompletion(orderId: String): Mono<Void> {
 ポーリングが不要なケース:
 - コマンド発行だけで完了する単純な操作（結果を待たない）
 - UIがリアルタイム更新を必要としない場合
+
+サーバー側で待たない場合は、コマンド受付後に `202 Accepted` と追跡IDを返し、フロントエンドが読み取りAPIをロングポーリングまたは通常ポーリングする。ユーザー体験上の即時性が必要なら SSE や WebSocket も選択肢に含める。
 
 ## Saga vs EventHandler
 


### PR DESCRIPTION
Summary: Clarifies CQRS/ES guidance so Projection waiting uses non-blocking reactive polling when the same HTTP response must wait, and recommends 202 Accepted plus frontend polling/SSE/WebSocket when the server does not need to wait. Updates both Japanese and English builtin knowledge. Verification: npm run build passed. npm test was not run per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 「Eventual Consistency / Reactive Polling」に関するガイドを拡充し、非同期での待ち方や運用指針をより具体的に説明しました。
  * 同期的な待機の代わりに、非ブロッキングな待機や追跡ID付きの応答、ポーリング方式の選択肢を明確化しました。
  * 具体例を見直し、待機しない場合のレスポンス設計も追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->