### PR TITLE
docs: clarify CQRS notification waiting guidance

### DIFF
--- a/builtins/en/facets/knowledge/cqrs-es.md
+++ b/builtins/en/facets/knowledge/cqrs-es.md
@@ -226,7 +226,8 @@ Cases where UseCase is unnecessary:
 | Controller directly references Repository for validation | Separate into UseCase layer |
 | UseCase depends on HTTP requests/responses | REJECT. UseCase must be protocol-independent |
 | UseCase directly modifies Aggregate internal state | REJECT. Use CommandGateway |
-| UseCase waits for results via Subscription Query | REJECT. Does not work in distributed environments. Use reactive polling |
+| UseCase waits for results via Subscription Query with guaranteed notification delivery, such as Axon Server | OK |
+| UseCase waits for results via Subscription Query with unverified delivery guarantees | REJECT. Use reactive polling |
 | UseCase only delegates to a query boundary or command dispatch | Consider deleting |
 
 ## Projection Design
@@ -260,14 +261,15 @@ External workers and asynchronous work should start from domain events confirmed
 
 Query side operates on an event-driven PubSub model. Projections update Read Models via EventHandler, and queries read from Read Models.
 
-Event distribution uses PubSub (via message broker) to deliver events to all instances. Do not use mechanisms that assume delivery to the same instance.
+Event distribution uses PubSub (via message broker) to deliver events to all instances. Do not use mechanisms that assume delivery to the same instance unless their delivery guarantees are verified.
 
-- **Subscription Query** (e.g., Axon's `subscriptionQuery()`): delivers change notifications back to the subscribing instance, but in distributed environments or when using third-party event store plugins, the subscribing instance and the notified instance may differ, making it impossible to return the response on the same machine. When synchronous response is needed, use reactive polling to wait for Read Model updates.
+- **Subscription Query** (e.g., Axon's `subscriptionQuery()`): delivers change notifications back to the subscriber. It is allowed when Axon Server or another verified setup guarantees delivery to the subscriber. If delivery is not guaranteed in a distributed deployment or with a third-party event store plugin, use reactive polling to wait for Read Model updates when synchronous response is needed.
 - **Subscribing event processor** (e.g., Axon's `SubscribingEventProcessor`): relies on local event bus subscription, so only the instance that emitted the event receives it. In distributed environments, other instances' Projections are not updated. Use PubSub to distribute events to all instances.
 
 | Criteria | Judgment |
 |----------|----------|
-| Using Subscription Query (e.g., Axon's `subscriptionQuery()`) | REJECT. Does not work in distributed environments. Use reactive polling |
+| Using Subscription Query (e.g., Axon's `subscriptionQuery()`) with verified delivery guarantees such as Axon Server | OK |
+| Using Subscription Query (e.g., Axon's `subscriptionQuery()`) without verified delivery guarantees | REJECT. Use reactive polling |
 | Using Subscribing event processor (e.g., Axon's `SubscribingEventProcessor`) | REJECT. Local delivery only. Other instances not updated in distributed environments |
 | Controller directly referencing Repository | REJECT. Must go through UseCase layer |
 | Query side referencing Command Model | REJECT |
@@ -353,11 +355,14 @@ Completion notifications for asynchronous work must assume duplicates, delays, a
 
 ## Eventual Consistency
 
-When synchronous response is needed after command dispatch, use reactive polling to wait for Projection updates.
+When synchronous response is needed after command dispatch and no reliable event notification can reach the waiting process, use reactive polling to wait for Projection updates.
 
 | Criteria | Judgment |
 |----------|----------|
-| Using Subscription Query to wait for Projection updates | REJECT. Does not work in distributed environments. Use reactive polling |
+| A notification mechanism reliably delivers Projection-update notifications to the waiting process | OK. Notification-driven waiting is allowed |
+| Subscription Query is backed by Axon Server or another verified setup that delivers update notifications to the subscriber | OK |
+| Kafka or a similar system is used and routing, redelivery, and missing-notification behavior are operationally guaranteed | OK |
+| Subscription Query or event notification delivery is single-process, single-instance, or unverified | REJECT. Use reactive polling |
 | Blocking the request thread with `Thread.sleep` or equivalent while waiting for Projection updates | REJECT. It can exhaust request threads under concurrency |
 | Updated state must be returned in the same HTTP response | Wait non-blockingly on a reactive HTTP stack |
 | The same HTTP response does not need to wait | `202 Accepted` + frontend long polling, regular polling, SSE, or WebSocket |
@@ -368,6 +373,8 @@ When synchronous response is needed after command dispatch, use reactive polling
 ### Reactive Polling
 
 Pattern: dispatch command → wait for Projection update completion with non-blocking polling. Reactive polling means waiting without occupying a request thread; it is not a synchronous `while` loop with `Thread.sleep`.
+
+The polling condition is evaluated by re-reading the Read Model, not by relying on an event notification. Re-read at intervals until the expected predicate is satisfied, and stop when timeout or maxAttempts is reached.
 
 ```kotlin
 // UseCase: send command → poll for completion

--- a/builtins/ja/facets/knowledge/cqrs-es.md
+++ b/builtins/ja/facets/knowledge/cqrs-es.md
@@ -402,7 +402,8 @@ UseCaseが不要なケース:
 | ControllerがRepository直接参照してバリデーション | UseCase層に分離 |
 | UseCaseがHTTPリクエスト/レスポンスに依存 | REJECT。UseCaseはプロトコル非依存 |
 | UseCaseがAggregate内部状態を直接変更 | REJECT。CommandGateway経由 |
-| UseCaseがSubscription Queryで結果を待機 | REJECT。分散環境で動作しない。リアクティブポーリングを使う |
+| UseCaseがAxon Serverなど通知配送が保証されたSubscription Queryで結果を待機 | OK |
+| UseCaseが配送保証不明なSubscription Queryで結果を待機 | REJECT。リアクティブポーリングを使う |
 | UseCaseが別の問い合わせ層やコマンド送信への薄い委譲だけで終わる | 削除を検討 |
 
 ## プロジェクション設計
@@ -488,14 +489,15 @@ class InventoryReleaseHandler(private val commandGateway: CommandGateway) {
 
 Query側はイベント駆動のPubSubモデルで動作する。Projection が EventHandler でRead Modelを更新し、Query側はRead Modelを参照する。
 
-イベント配信はPubSub（メッセージブローカー経由）で全インスタンスに配信する。同一インスタンスへの配信を前提とする仕組みは使わない。
+イベント配信はPubSub（メッセージブローカー経由）で全インスタンスに配信する。同一インスタンスへの配信を前提とする仕組みは、配送保証が確認できない限り使わない。
 
-- **Subscription Query**（たとえばAxonの `subscriptionQuery()`）: クエリ結果の変更通知を購読元インスタンスに返す仕組みだが、分散配置やサードパーティのイベントストアプラグイン使用時に、購読を発行したインスタンスと通知を受け取るインスタンスが異なり、同一筐体でレスポンスを返せない。同期的な応答が必要な場合はリアクティブポーリングで Read Model の更新を待機する。
+- **Subscription Query**（たとえばAxonの `subscriptionQuery()`）: クエリ結果の変更通知を購読元へ返す仕組み。Axon Server などで購読元への通知配送が保証される構成なら使用できる。分散配置やサードパーティのイベントストアプラグイン使用時に配送先が保証されない場合、同期的な応答が必要ならリアクティブポーリングで Read Model の更新を待機する。
 - **Subscribing イベントプロセッサ**（たとえばAxonの `SubscribingEventProcessor`）: ローカルのイベントバスからの直接購読に依存し、イベントを発行したインスタンスのみがイベントを受け取る。分散環境では他インスタンスの Projection が更新されない。PubSubで全インスタンスにイベントが配信される構成にする。
 
 | 基準 | 判定 |
 |------|------|
-| Subscription Query（たとえばAxonの `subscriptionQuery()`）の使用 | REJECT。分散環境で動作しない。リアクティブポーリングを使う |
+| Axon Server など配送保証が確認できる Subscription Query（たとえばAxonの `subscriptionQuery()`）の使用 | OK |
+| 配送保証が確認できない Subscription Query（たとえばAxonの `subscriptionQuery()`）の使用 | REJECT。リアクティブポーリングを使う |
 | Subscribing イベントプロセッサ（たとえばAxonの `SubscribingEventProcessor`）の使用 | REJECT。ローカル配信のみ。分散環境で他インスタンスが更新されない |
 | Controller から Repository を直接参照 | REJECT。UseCase層を経由 |
 | Query側が Command Model を参照 | REJECT |
@@ -581,11 +583,14 @@ Aggregate → Event Bus → Projection(@EventHandler) → Repository(Read Model)
 
 ## 結果整合性
 
-コマンド発行後に同期的なレスポンスが必要な場合、リアクティブポーリングで Projection の更新を待機する。
+コマンド発行後に同期的なレスポンスが必要で、待機中の処理へ確実に届くイベント通知を利用できない場合、リアクティブポーリングで Projection の更新を待機する。
 
 | 基準 | 判定 |
 |------|------|
-| Subscription Query で Projection 更新を待機 | REJECT。分散環境で動作しない。リアクティブポーリングを使う |
+| 待機中の処理へ Projection 更新通知が確実に配送される基盤がある | OK。通知駆動で待機してよい |
+| Axon Server を利用した Subscription Query など、購読元へ更新通知が届く構成が確認できている | OK |
+| Kafka などを使い、通知の配送先と再配送・欠落時の扱いが運用上保証されている | OK |
+| Subscription Query やイベント通知の配送先が単一プロセス・単一インスタンス前提、または保証不明 | REJECT。リアクティブポーリングを使う |
 | `Thread.sleep` や同等の待機でリクエストスレッドをブロックして Projection 更新を待つ | REJECT。高並行時にスレッド枯渇を起こす |
 | 同一HTTPレスポンスで更新後状態を返す必要がある | リアクティブHTTPスタックで非ブロッキングに待機 |
 | 同一HTTPレスポンスで待つ必要がない | `202 Accepted` + フロントエンドのロングポーリング、通常ポーリング、SSE、WebSocket |
@@ -596,6 +601,8 @@ Aggregate → Event Bus → Projection(@EventHandler) → Repository(Read Model)
 ### リアクティブポーリング
 
 コマンド発行 → Projection更新完了を非ブロッキングなポーリングで待機するパターン。リアクティブポーリングはリクエストスレッドを占有しない待機であり、`while` ループと `Thread.sleep` で同期的に待つ実装ではない。
+
+ポーリングの判定はイベント通知ではなく、Read Model を再取得して期待する状態になったかを predicate で確認する。条件を満たすまで一定間隔で再取得し、timeout または maxAttempts に達したら待機を打ち切る。
 
 ```kotlin
 // UseCase: コマンド送信 → ポーリングで完了待機


### PR DESCRIPTION
Summary: Clarifies that Subscription Query is acceptable when backed by Axon Server or another verified notification-delivery setup, while unverified single-process/single-instance delivery should use reactive polling. Also states that reactive polling re-reads the Read Model until a predicate is satisfied or timeout/maxAttempts is reached. Updates both Japanese and English builtin CQRS/ES knowledge. Verification: Not run (documentation-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * CQRS/ES の知識ドキュメントを更新し、結果待機の判断基準をより明確にしました。
  * Subscription Query は、確実な通知配信が保証される場合のみ利用可とし、不明な場合はリアクティブポーリングを推奨するよう整理しました。
  * イベント通知に依存せず、Read Model を再取得して期待状態を確認する待機方式と、タイムアウト／試行回数の考え方を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->