### PR TITLE
fix: Instruct →「タスクにつむ」(requeue) で選択したワークフローを永続化する

### DIFF
--- a/src/__tests__/requeueHelpers.test.ts
+++ b/src/__tests__/requeueHelpers.test.ts
@@ -57,6 +57,7 @@ vi.mock('../infra/config/index.js', async (importOriginal) => ({
 import {
   buildAutoRequeueNote,
   hasDeprecatedProviderConfig,
+  resolveSelectedWorkflowOverride,
   selectWorkflowWithOptionalReuse,
 } from '../features/tasks/list/requeueHelpers.js';
 import type { TaskFailure } from '../infra/task/index.js';
@@ -214,6 +215,20 @@ describe('hasDeprecatedProviderConfig', () => {
     ].join('\n');
 
     expect(hasDeprecatedProviderConfig(orderContent)).toBe(false);
+  });
+});
+
+describe('resolveSelectedWorkflowOverride', () => {
+  it('should return selected workflow when previous workflow differs', () => {
+    expect(resolveSelectedWorkflowOverride('default', 'selected-workflow')).toBe('selected-workflow');
+  });
+
+  it('should return undefined when previous workflow matches selected workflow', () => {
+    expect(resolveSelectedWorkflowOverride('default', 'default')).toBeUndefined();
+  });
+
+  it('should return selected workflow when previous workflow is undefined', () => {
+    expect(resolveSelectedWorkflowOverride(undefined, 'default')).toBe('default');
   });
 });
 

--- a/src/__tests__/taskInstructionActions.test.ts
+++ b/src/__tests__/taskInstructionActions.test.ts
@@ -296,7 +296,7 @@ describe('instructBranch direct execution flow', () => {
       undefined,
       'Use [Image #1].',
       undefined,
-      undefined,
+      'default',
       '.takt/tasks/done-task',
     );
     expect(mockPrepareTaskSpecDirectory).toHaveBeenCalledWith(
@@ -772,11 +772,69 @@ describe('instructBranch direct execution flow', () => {
       undefined,
       '追加指示A',
       undefined,
-      undefined,
+      'default',
       undefined,
     );
     expect(mockStartReExecution).not.toHaveBeenCalled();
     expect(mockExecuteAndCompleteTask).not.toHaveBeenCalled();
+  });
+
+  it('should pass selected workflow when save_task uses a different workflow', async () => {
+    mockConfirm.mockResolvedValue(false);
+    mockSelectWorkflow.mockResolvedValue('selected-workflow');
+    mockDispatchConversationAction.mockImplementation(async (_result, handlers) =>
+      handlers.save_task({ task: '追加指示A' }));
+
+    const result = await instructBranch('/project', {
+      kind: 'completed',
+      name: 'done-task',
+      createdAt: '2026-02-14T00:00:00.000Z',
+      filePath: '/project/.takt/tasks.yaml',
+      content: 'done',
+      branch: 'takt/done-task',
+      worktreePath: '/project/.takt/worktrees/done-task',
+      data: { task: 'done', workflow: 'default' },
+    });
+
+    expect(result).toBe(true);
+    expect(mockRequeueTask).toHaveBeenCalledWith(
+      'done-task',
+      ['completed', 'failed'],
+      undefined,
+      '追加指示A',
+      undefined,
+      'selected-workflow',
+      undefined,
+    );
+  });
+
+  it('should pass undefined workflow override when save_task keeps the same workflow', async () => {
+    mockConfirm.mockResolvedValue(true);
+    mockSelectWorkflow.mockResolvedValue('default');
+    mockDispatchConversationAction.mockImplementation(async (_result, handlers) =>
+      handlers.save_task({ task: '追加指示A' }));
+
+    const result = await instructBranch('/project', {
+      kind: 'completed',
+      name: 'done-task',
+      createdAt: '2026-02-14T00:00:00.000Z',
+      filePath: '/project/.takt/tasks.yaml',
+      content: 'done',
+      branch: 'takt/done-task',
+      worktreePath: '/project/.takt/worktrees/done-task',
+      data: { task: 'done', workflow: 'default' },
+    });
+
+    expect(result).toBe(true);
+    expect(mockRequeueTask).toHaveBeenCalledWith(
+      'done-task',
+      ['completed', 'failed'],
+      undefined,
+      '追加指示A',
+      undefined,
+      undefined,
+      undefined,
+    );
   });
 
   it('should requeue task with existing retry note appended when save_task', async () => {
@@ -800,7 +858,7 @@ describe('instructBranch direct execution flow', () => {
       undefined,
       '既存ノート\n\n追加指示A',
       undefined,
-      undefined,
+      'default',
       undefined,
     );
   });

--- a/src/features/tasks/list/requeueHelpers.ts
+++ b/src/features/tasks/list/requeueHelpers.ts
@@ -17,6 +17,13 @@ const log = createLogger('list-tasks');
 export const DEPRECATED_PROVIDER_CONFIG_WARNING =
   'Detected deprecated provider config in selected run order.md. Please migrate legacy fields to the provider block.';
 
+export function resolveSelectedWorkflowOverride(
+  previousWorkflow: string | undefined,
+  selectedWorkflow: string,
+): string | undefined {
+  return previousWorkflow === selectedWorkflow ? undefined : selectedWorkflow;
+}
+
 export function appendRetryNote(existing: string | undefined, additional: string): string {
   const trimmedAdditional = additional.trim();
   if (trimmedAdditional === '') {

--- a/src/features/tasks/list/taskInstructionActions.ts
+++ b/src/features/tasks/list/taskInstructionActions.ts
@@ -23,6 +23,7 @@ import {
   appendRetryNote,
   DEPRECATED_PROVIDER_CONFIG_WARNING,
   hasDeprecatedProviderConfig,
+  resolveSelectedWorkflowOverride,
   selectWorkflowWithOptionalReuse,
   selectRunSessionContext,
 } from './requeueHelpers.js';
@@ -172,7 +173,15 @@ export async function instructBranch(
       const taskDir = preparedSpec?.taskDirRelative;
       const runner = new TaskRunner(projectDir);
       try {
-        runner.requeueTask(target.name, ['completed', 'failed'], undefined, retryNote, undefined, undefined, taskDir);
+        runner.requeueTask(
+          target.name,
+          ['completed', 'failed'],
+          undefined,
+          retryNote,
+          undefined,
+          resolveSelectedWorkflowOverride(target.data?.workflow, selectedWorkflow),
+          taskDir,
+        );
       } catch (error) {
         cleanupPreparedRetryTaskSpec(preparedSpec);
         throw error;

--- a/src/features/tasks/list/taskRetryActions.ts
+++ b/src/features/tasks/list/taskRetryActions.ts
@@ -31,6 +31,7 @@ import {
   buildAutoRequeueNote,
   DEPRECATED_PROVIDER_CONFIG_WARNING,
   hasDeprecatedProviderConfig,
+  resolveSelectedWorkflowOverride,
   selectWorkflowWithOptionalReuse,
 } from './requeueHelpers.js';
 import { prepareTaskForExecution } from './prepareTaskForExecution.js';
@@ -218,13 +219,6 @@ function resolveWorktreePath(task: TaskListItem): string {
     throw new Error(`Worktree directory does not exist: ${task.worktreePath}`);
   }
   return task.worktreePath;
-}
-
-function resolveSelectedWorkflowOverride(
-  previousWorkflow: string | undefined,
-  selectedWorkflow: string,
-): string | undefined {
-  return previousWorkflow === selectedWorkflow ? undefined : selectedWorkflow;
 }
 
 function requireFailedTaskFailure(task: TaskListItem): TaskFailure {


### PR DESCRIPTION
## Summary

Issue #912 の修正です。

`takt list` → **Instruct** で「前回のワークフローを使用しますか？」に **n** と答えて別のワークフローを選択したあと、**「タスクにつむ」(requeue → pending)** を選ぶと、選択したワークフローが永続化されず、その後の `takt run` がタスクに保存済みの `workflow` フィールド（例: `default`）を実行してしまう問題を修正します。

選択が反映されるのは即時 **Execute** 経路と失敗タスクの **Retry** 経路のみで、Instruct の requeue 経路だけが選択を破棄していました。

## 原因

`src/features/tasks/list/taskInstructionActions.ts` の `save_task` 分岐が、`requeueTask` の workflow override 引数に `undefined` を渡しており、取得済みの `selectedWorkflow` を使っていませんでした。`requeueTask` → `buildRetryTaskRecord` は workflow が truthy のときだけ書き込むため、`undefined` では元の `task.workflow` が維持されます。

## 修正内容

- `taskRetryActions.ts` 内のプライベート関数だった `resolveSelectedWorkflowOverride` を `requeueHelpers.ts` へ移動して共有化
- Instruct の `save_task` 分岐で、Retry 経路と同様に `resolveSelectedWorkflowOverride(target.data?.workflow, selectedWorkflow)` を `requeueTask` に渡すように修正
- `requeueHelpers.test.ts` / `taskInstructionActions.test.ts` にテストを追加

Closes #912
