### PR TITLE
[codex] add cli workflow

### DIFF
--- a/builtins/en/workflow-categories.yaml
+++ b/builtins/en/workflow-categories.yaml
@@ -4,6 +4,7 @@ workflow_categories:
       - default
       - default-mini
       - default-high
+      - cli
       - frontend
       - backend
       - dual

--- a/builtins/en/workflows/cli.yaml
+++ b/builtins/en/workflows/cli.yaml
@@ -1,0 +1,120 @@
+name: cli
+description: CLI development workflow (plan -> write_tests -> draft (implement + AI self-review) -> peer-review (parallel reviewers + fix) -> supervise -> COMPLETE).
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
+    opencode:
+      network_access: true
+max_steps: 50
+initial_step: plan
+steps:
+  - name: plan
+    tags:
+      - plan
+    edit: false
+    persona: planner
+    knowledge: architecture
+    provider_options:
+      extends: review-readonly
+    rules:
+      - condition: Requirements are clear and implementable
+        next: write_tests
+      - condition: User is asking a question (not an implementation task)
+        next: COMPLETE
+      - condition: Requirements unclear, insufficient info
+        next: ABORT
+        appendix: |
+          Items to confirm:
+          - {question 1}
+          - {question 2}
+    instruction: plan
+    output_contracts:
+      report:
+        - name: plan.md
+          format: plan
+  - name: write_tests
+    tags:
+      - coding
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+    knowledge:
+      - architecture
+      - unit-testing
+      - e2e-testing
+    provider_options:
+      extends: edit
+    required_permission_mode: edit
+    instruction: write-tests-first
+    rules:
+      - condition: Tests written
+        next: draft
+      - condition: Skip test writing because target is not yet implemented
+        next: draft
+      - condition: Cannot proceed with writing tests
+        next: plan
+      - condition: User input required for confirmation
+        next: write_tests
+        requires_user_input: true
+        interactive_only: true
+    output_contracts:
+      report:
+        - name: test-report.md
+          format: test-report
+  - name: draft
+    kind: workflow_call
+    call: draft
+    args:
+      impl_knowledge:
+        - architecture
+        - task-decomposition
+      fix_knowledge:
+        - architecture
+    rules:
+      - condition: COMPLETE
+        next: peer-review
+      - condition: need_replan
+        next: plan
+      - condition: ABORT
+        next: ABORT
+  - name: peer-review
+    kind: workflow_call
+    call: peer-review
+    args:
+      arch_knowledge:
+        - architecture
+      fix_knowledge:
+        - architecture
+    rules:
+      - condition: COMPLETE
+        next: supervise
+      - condition: need_replan
+        next: plan
+      - condition: ABORT
+        next: ABORT
+  - name: supervise
+    tags:
+      - review
+    edit: false
+    persona: supervisor
+    policy: review
+    knowledge: architecture
+    provider_options:
+      extends: review-readonly
+    pass_previous_response: false
+    rules:
+      - condition: All clear
+        next: COMPLETE
+      - condition: Requirements unmet, tests failing, build errors
+        next: plan
+    instruction: supervise
+    output_contracts:
+      report:
+        - name: supervisor-validation.md
+          format: supervisor-validation
+        - name: summary.md
+          format: summary
+          use_judge: false

--- a/builtins/en/workflows/peer-review.yaml
+++ b/builtins/en/workflows/peer-review.yaml
@@ -12,6 +12,12 @@ subworkflow:
       default:
         - architecture
         - takt
+    fix_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default:
+        - takt
+        - architecture
 workflow_config:
   provider_options:
     codex:
@@ -179,8 +185,7 @@ steps:
       - coding
       - testing
     knowledge:
-      - takt
-      - architecture
+      $param: fix_knowledge
     provider_options:
       extends: edit
     required_permission_mode: edit

--- a/builtins/ja/workflow-categories.yaml
+++ b/builtins/ja/workflow-categories.yaml
@@ -4,6 +4,7 @@ workflow_categories:
       - default
       - default-mini
       - default-high
+      - cli
       - frontend
       - backend
       - dual

--- a/builtins/ja/workflows/cli.yaml
+++ b/builtins/ja/workflows/cli.yaml
@@ -1,0 +1,120 @@
+name: cli
+description: CLI開発ワークフロー（計画 → テスト作成 → draft（実装+AI自己レビュー） → peer-review（並列レビュー+修正） → 監督 → 完了）
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
+    opencode:
+      network_access: true
+max_steps: 50
+initial_step: plan
+steps:
+  - name: plan
+    tags:
+      - plan
+    edit: false
+    persona: planner
+    knowledge: architecture
+    provider_options:
+      extends: review-readonly
+    rules:
+      - condition: 要件が明確で実装可能
+        next: write_tests
+      - condition: ユーザーが質問をしている（実装タスクではない）
+        next: COMPLETE
+      - condition: 要件が不明確、情報不足
+        next: ABORT
+        appendix: |
+          確認事項:
+          - {質問1}
+          - {質問2}
+    instruction: plan
+    output_contracts:
+      report:
+        - name: plan.md
+          format: plan
+  - name: write_tests
+    tags:
+      - coding
+    edit: true
+    persona: coder
+    policy:
+      - coding
+      - testing
+    knowledge:
+      - architecture
+      - unit-testing
+      - e2e-testing
+    provider_options:
+      extends: edit
+    required_permission_mode: edit
+    instruction: write-tests-first
+    rules:
+      - condition: テスト作成が完了した
+        next: draft
+      - condition: テスト対象が未実装のためテスト作成をスキップする
+        next: draft
+      - condition: テスト作成を進行できない
+        next: plan
+      - condition: ユーザーへの確認事項があるためユーザー入力が必要
+        next: write_tests
+        requires_user_input: true
+        interactive_only: true
+    output_contracts:
+      report:
+        - name: test-report.md
+          format: test-report
+  - name: draft
+    kind: workflow_call
+    call: draft
+    args:
+      impl_knowledge:
+        - architecture
+        - task-decomposition
+      fix_knowledge:
+        - architecture
+    rules:
+      - condition: COMPLETE
+        next: peer-review
+      - condition: need_replan
+        next: plan
+      - condition: ABORT
+        next: ABORT
+  - name: peer-review
+    kind: workflow_call
+    call: peer-review
+    args:
+      arch_knowledge:
+        - architecture
+      fix_knowledge:
+        - architecture
+    rules:
+      - condition: COMPLETE
+        next: supervise
+      - condition: need_replan
+        next: plan
+      - condition: ABORT
+        next: ABORT
+  - name: supervise
+    tags:
+      - review
+    edit: false
+    persona: supervisor
+    policy: review
+    knowledge: architecture
+    provider_options:
+      extends: review-readonly
+    pass_previous_response: false
+    rules:
+      - condition: すべて問題なし
+        next: COMPLETE
+      - condition: 要求未達成、テスト失敗、ビルドエラー
+        next: plan
+    instruction: supervise
+    output_contracts:
+      report:
+        - name: supervisor-validation.md
+          format: supervisor-validation
+        - name: summary.md
+          format: summary
+          use_judge: false

--- a/builtins/ja/workflows/peer-review.yaml
+++ b/builtins/ja/workflows/peer-review.yaml
@@ -12,6 +12,12 @@ subworkflow:
       default:
         - architecture
         - takt
+    fix_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default:
+        - takt
+        - architecture
 workflow_config:
   provider_options:
     codex:
@@ -179,8 +185,7 @@ steps:
       - coding
       - testing
     knowledge:
-      - takt
-      - architecture
+      $param: fix_knowledge
     provider_options:
       extends: edit
     required_permission_mode: edit


### PR DESCRIPTION
## Summary

- Add a new builtin `cli` workflow for Japanese and English resources.
- Keep the `takt-default` flow shape while removing TAKT-specific knowledge from the new workflow.
- Parameterize `peer-review` fix knowledge so `cli` can pass generic knowledge without changing existing defaults.
- Register `cli` in the Quick Start workflow category.

## Execution Report

- `npm run build`
- `npm test`
- `node dist/app/cli/index.js workflow doctor builtins/ja/workflows/cli.yaml builtins/en/workflows/cli.yaml builtins/ja/workflows/peer-review.yaml builtins/en/workflows/peer-review.yaml`

## Notes

No issue is linked because this change was requested directly in chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * CLI開発向けの新しいワークフローが追加され、段階的に作業を進められるようになりました。
  * レビュー時に使う知識セットを切り替えられるようになり、状況に応じた確認がしやすくなりました。
* **変更**
  * クイックスタート一覧にCLIワークフローが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->