### PR TITLE
fix: preserve OpenCode session across step phases via per-prompt tools restriction

### DIFF
--- a/e2e/specs/opencode-conversation.e2e.ts
+++ b/e2e/specs/opencode-conversation.e2e.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterAll } from 'vitest';
-import { getOpenCodeSessionSnapshot, resetSharedServer } from '../../src/infra/opencode/client.js';
+import { getOpenCodeSessionMessages, getOpenCodeSessionSnapshot, resetSharedServer } from '../../src/infra/opencode/client.js';
 import { OpenCodeProvider } from '../../src/infra/providers/opencode.js';
 
 const MODEL = process.env.TAKT_E2E_MODEL ?? process.env.OPENCODE_E2E_MODEL ?? 'opencode/big-pickle';
@@ -130,8 +130,18 @@ describe('OpenCode real E2E conversation', () => {
     // 再開ターンでは permission_summary は再発行されない（セッション権限は不変）
     const secondTurnEvents = streamEvents.slice(secondTurnStartIndex);
     expect(secondTurnEvents.some((event) => event.type === 'permission_summary')).toBe(false);
-    // tools マップにより read が不可視になっている
+    // tools マップにより read が不可視になっている。文字列不在ではなく、
+    // 記録されたメッセージ（観測単位）でターン2にツールパートが一切ないことを検証する
     expect(result2.content).toContain('NO-READ-TOOL');
+    const messages = await getOpenCodeSessionMessages(MODEL, sessionId, process.cwd());
+    const lastUserIndex = messages.reduce(
+      (last, message, index) => (message.info.role === 'user' ? index : last),
+      -1,
+    );
+    expect(lastUserIndex).toBeGreaterThan(0);
+    const secondTurnParts = messages.slice(lastUserIndex + 1).flatMap((message) => message.parts);
+    expect(secondTurnParts.length).toBeGreaterThan(0);
+    expect(secondTurnParts.filter((part) => part.type === 'tool')).toEqual([]);
     // セッション権限は 1 ターン目の緩和済みルールセットのまま
     const session = await getOpenCodeSessionSnapshot(MODEL, sessionId, process.cwd());
     if (!session.permission) {

--- a/e2e/specs/opencode-conversation.e2e.ts
+++ b/e2e/specs/opencode-conversation.e2e.ts
@@ -3,49 +3,6 @@ import { getOpenCodeSessionSnapshot, resetSharedServer } from '../../src/infra/o
 import { OpenCodeProvider } from '../../src/infra/providers/opencode.js';
 
 const MODEL = process.env.TAKT_E2E_MODEL ?? process.env.OPENCODE_E2E_MODEL ?? 'opencode/big-pickle';
-const DENY_OR_FAILURE_PATTERN = /denied|deny|permission|not allowed|forbidden|reject|failed/i;
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  if (value && typeof value === 'object') {
-    return value as Record<string, unknown>;
-  }
-  return undefined;
-}
-
-function hasRuntimeDenyOrFailureEvent(
-  events: Array<{ type: string; data?: unknown }>,
-  sessionId: string,
-): boolean {
-  return events.some((event) => {
-    const data = asRecord(event.data);
-    if (!data) {
-      return false;
-    }
-
-    if (event.type === 'permission_asked') {
-      return (
-        data.sessionId === sessionId
-        && (data.reply === 'reject' || data.reply === 'deny')
-      );
-    }
-
-    if (event.type === 'tool_result') {
-      const content = String(data.content ?? '');
-      return data.isError === true && DENY_OR_FAILURE_PATTERN.test(content);
-    }
-
-    return false;
-  });
-}
-
-function expectDenyOnlyRuleset(ruleset: unknown): void {
-  expect(Array.isArray(ruleset)).toBe(true);
-  const permissions = ruleset as Array<{ permission?: unknown; action?: unknown }>;
-  expect(permissions.length).toBeGreaterThan(0);
-  expect(permissions.every((rule) => rule.action === 'deny')).toBe(true);
-  expect(permissions.some((rule) => rule.permission === 'read')).toBe(true);
-}
-
 describe('OpenCode real E2E conversation', () => {
   afterAll(() => {
     resetSharedServer();
@@ -118,7 +75,7 @@ describe('OpenCode real E2E conversation', () => {
     expect(results[2].content).toMatch(/84/);
   }, 180_000);
 
-  it('should use a deny-only permission session when allowedTools is empty', async () => {
+  it('should reuse the session and hide tools per prompt when allowedTools is empty', async () => {
     const provider = new OpenCodeProvider();
     const agent = provider.setup({
       name: 'coder',
@@ -139,6 +96,8 @@ describe('OpenCode real E2E conversation', () => {
     if (!sessionId) {
       throw new Error('OpenCode session ID is required for permission verification');
     }
+    // セッション permission は edit/write を許可し external_directory を deny する
+    // 緩和済みルールセット（フェーズ制限は per-prompt tools マップが担う）
     expect(streamEvents).toContainEqual({
       type: 'permission_summary',
       data: expect.objectContaining({
@@ -146,42 +105,44 @@ describe('OpenCode real E2E conversation', () => {
         resolvedPermissions: [
           { permission: '*', pattern: '*', action: 'deny' },
           { permission: 'read', pattern: '*', action: 'allow' },
+          { permission: 'edit', pattern: '*', action: 'allow' },
+          { permission: 'write', pattern: '*', action: 'allow' },
+          { permission: 'external_directory', pattern: '*', action: 'deny' },
         ],
       }),
     });
 
     const secondTurnStartIndex = streamEvents.length;
-    const result2 = await agent.call('Use the OpenCode read tool to inspect package.json before answering with only the package name.', {
-      cwd: process.cwd(),
-      model: MODEL,
-      sessionId,
-      allowedTools: [],
-      onStream: (event) => streamEvents.push(event),
-    });
+    const result2 = await agent.call(
+      'Use the OpenCode read tool to inspect package.json. If you have no read tool available, reply exactly NO-READ-TOOL.',
+      {
+        cwd: process.cwd(),
+        model: MODEL,
+        sessionId,
+        allowedTools: [],
+        onStream: (event) => streamEvents.push(event),
+      },
+    );
 
-    expect(result2.sessionId).toBeDefined();
-    const permissionSessionId = result2.sessionId;
-    if (!permissionSessionId) {
-      throw new Error('OpenCode permission session ID is required for deny-all verification');
-    }
+    expect(result2.status).toBe('done');
+    // セッションは再作成されず、同一 ID のまま継続する
+    expect(result2.sessionId).toBe(sessionId);
+    // 再開ターンでは permission_summary は再発行されない（セッション権限は不変）
     const secondTurnEvents = streamEvents.slice(secondTurnStartIndex);
-    const hasRuntimeDenyEvent = hasRuntimeDenyOrFailureEvent(secondTurnEvents, permissionSessionId);
-    expect(hasRuntimeDenyEvent).toBe(true);
-    const permissionSummary = secondTurnEvents.find((event) => (
-      event.type === 'permission_summary'
-      && asRecord(event.data)?.sessionId === permissionSessionId
-    ));
-    expect(permissionSummary).toBeDefined();
-    const permissionSummaryData = asRecord(permissionSummary?.data);
-    expect(permissionSummaryData).toEqual(expect.objectContaining({
-      sessionId: permissionSessionId,
-      allowedTools: [],
-    }));
-    expectDenyOnlyRuleset(permissionSummaryData?.resolvedPermissions);
-    const session = await getOpenCodeSessionSnapshot(MODEL, permissionSessionId, process.cwd());
+    expect(secondTurnEvents.some((event) => event.type === 'permission_summary')).toBe(false);
+    // tools マップにより read が不可視になっている
+    expect(result2.content).toContain('NO-READ-TOOL');
+    // セッション権限は 1 ターン目の緩和済みルールセットのまま
+    const session = await getOpenCodeSessionSnapshot(MODEL, sessionId, process.cwd());
     if (!session.permission) {
-      throw new Error('OpenCode session permission is required for deny-all verification');
+      throw new Error('OpenCode session permission is required for verification');
     }
-    expectDenyOnlyRuleset(session.permission);
+    const permissions = session.permission as Array<{ permission?: unknown; action?: unknown }>;
+    expect(permissions).toContainEqual(
+      expect.objectContaining({ permission: 'external_directory', action: 'deny' }),
+    );
+    expect(permissions).toContainEqual(
+      expect.objectContaining({ permission: 'edit', action: 'allow' }),
+    );
   }, 180_000);
 });

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -163,8 +163,13 @@ const { createOpencodeMock } = vi.hoisted(() => ({
   createOpencodeMock: vi.fn(),
 }));
 
-const DENY_ONLY_OPEN_CODE_PERMISSION_RULESET = [
+// セッションの deny は後から昇格できないため、edit/write はセッションスコープで
+// 常に許可される（フェーズごとの制限は per-prompt tools マップが担う）
+const EMPTY_TOOLS_SESSION_PERMISSION_RULESET = [
   { permission: '*', pattern: '*', action: 'deny' },
+  { permission: 'edit', pattern: '*', action: 'allow' },
+  { permission: 'write', pattern: '*', action: 'allow' },
+  { permission: 'external_directory', pattern: '*', action: 'deny' },
 ];
 
 function deferred<T = void>(): {
@@ -803,10 +808,27 @@ describe('OpenCodeClient stream cleanup', () => {
         { permission: 'bash', pattern: '*', action: 'allow' },
         { permission: 'websearch', pattern: '*', action: 'allow' },
         { permission: 'webfetch', pattern: '*', action: 'allow' },
+        { permission: 'write', pattern: '*', action: 'allow' },
+        { permission: 'external_directory', pattern: '*', action: 'deny' },
       ],
     });
     expect(promptAsync).toHaveBeenCalledWith(
-      expect.not.objectContaining({ tools: expect.anything() }),
+      expect.objectContaining({
+        tools: expect.objectContaining({
+          read: true,
+          edit: true,
+          write: true,
+          patch: true,
+          bash: true,
+          todowrite: true,
+          websearch: true,
+          webfetch: true,
+          glob: false,
+          grep: false,
+          question: false,
+          task: false,
+        }),
+      }),
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
@@ -855,10 +877,22 @@ describe('OpenCodeClient stream cleanup', () => {
         { permission: '*', pattern: '*', action: 'deny' },
         { permission: 'read', pattern: '*', action: 'allow' },
         { permission: 'bash', pattern: '*', action: 'allow' },
+        { permission: 'edit', pattern: '*', action: 'allow' },
+        { permission: 'write', pattern: '*', action: 'allow' },
+        { permission: 'external_directory', pattern: '*', action: 'deny' },
       ],
     });
     expect(promptAsync).toHaveBeenCalledWith(
-      expect.not.objectContaining({ tools: expect.anything() }),
+      expect.objectContaining({
+        tools: expect.objectContaining({
+          read: true,
+          bash: true,
+          edit: false,
+          write: false,
+          patch: false,
+          task: false,
+        }),
+      }),
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
@@ -1475,6 +1509,9 @@ describe('OpenCodeClient stream cleanup', () => {
       directory: '/tmp',
       permission: [
         { permission: '*', pattern: '*', action: 'allow' },
+        { permission: 'edit', pattern: '*', action: 'allow' },
+        { permission: 'write', pattern: '*', action: 'allow' },
+        { permission: 'external_directory', pattern: '*', action: 'deny' },
       ],
     });
   });
@@ -1519,10 +1556,25 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(result.status).toBe('done');
     expect(sessionCreate).toHaveBeenCalledWith({
       directory: '/tmp',
-      permission: DENY_ONLY_OPEN_CODE_PERMISSION_RULESET,
+      permission: EMPTY_TOOLS_SESSION_PERMISSION_RULESET,
     });
     expect(promptAsync).toHaveBeenCalledWith(
-      expect.not.objectContaining({ tools: expect.anything() }),
+      expect.objectContaining({
+        tools: expect.objectContaining({
+          read: false,
+          glob: false,
+          grep: false,
+          edit: false,
+          write: false,
+          patch: false,
+          bash: false,
+          todowrite: false,
+          websearch: false,
+          webfetch: false,
+          question: false,
+          task: false,
+        }),
+      }),
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
@@ -1581,14 +1633,14 @@ describe('OpenCodeClient stream cleanup', () => {
     });
   });
 
-  it('should create a permission-scoped child session when resuming with allowed tools', async () => {
+  it('should reuse the session and restrict tools per prompt when resuming with allowed tools', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([
       {
         type: 'message.updated',
         properties: {
           info: {
-            sessionID: 'session-existing-tools-deny',
+            sessionID: 'session-existing-tools',
             role: 'assistant',
             time: { created: Date.now(), completed: Date.now() + 1 },
           },
@@ -1597,15 +1649,14 @@ describe('OpenCodeClient stream cleanup', () => {
     ]);
 
     const promptAsync = vi.fn().mockResolvedValue(undefined);
-    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-existing-tools-deny' } });
-    const sessionUpdate = vi.fn().mockResolvedValue({ data: { id: 'unused-session' } });
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'unused-session' } });
     const disposeInstance = vi.fn().mockResolvedValue({ data: {} });
     const subscribe = vi.fn().mockResolvedValue({ stream });
 
     createOpencodeMock.mockResolvedValue({
       client: {
         instance: { dispose: disposeInstance },
-        session: { create: sessionCreate, update: sessionUpdate, promptAsync },
+        session: { create: sessionCreate, promptAsync },
         event: { subscribe },
         permission: { reply: vi.fn() },
       },
@@ -1621,15 +1672,13 @@ describe('OpenCodeClient stream cleanup', () => {
     });
 
     expect(result.status).toBe('done');
-    expect(result.sessionId).toBe('session-existing-tools-deny');
-    expect(sessionUpdate).not.toHaveBeenCalled();
-    expect(sessionCreate).toHaveBeenCalledWith({
-      directory: '/tmp',
-      parentID: 'session-existing-tools',
-      permission: DENY_ONLY_OPEN_CODE_PERMISSION_RULESET,
-    });
+    expect(result.sessionId).toBe('session-existing-tools');
+    expect(sessionCreate).not.toHaveBeenCalled();
     expect(promptAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionID: 'session-existing-tools-deny' }),
+      expect.objectContaining({
+        sessionID: 'session-existing-tools',
+        tools: expect.objectContaining({ edit: false, write: false, bash: false, read: false }),
+      }),
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
@@ -1700,47 +1749,6 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(sessionCreate).toHaveBeenCalledTimes(3);
     expect(promptAsync).toHaveBeenCalledTimes(2);
     expect(subscribe).toHaveBeenCalledTimes(2);
-  });
-
-  it('should stop before prompting when permission-scoped child session creation fails', async () => {
-    const { OpenCodeClient } = await import('../infra/opencode/client.js');
-    const promptAsync = vi.fn().mockResolvedValue(undefined);
-    const sessionCreate = vi.fn().mockRejectedValue(new Error('permission session create failed'));
-    const sessionUpdate = vi.fn().mockResolvedValue({ data: { id: 'unused-session' } });
-    const subscribe = vi.fn().mockResolvedValue({
-      stream: new MockEventStream([
-        { type: 'session.idle', properties: { sessionID: 'session-update-failure' } },
-      ]),
-    });
-
-    createOpencodeMock.mockResolvedValue({
-      client: {
-        instance: { dispose: vi.fn() },
-        session: { create: sessionCreate, update: sessionUpdate, promptAsync },
-        event: { subscribe },
-        permission: { reply: vi.fn() },
-      },
-      server: { close: vi.fn() },
-    });
-
-    const client = new OpenCodeClient();
-    const result = await client.call('coder', 'hello', {
-      cwd: '/tmp',
-      model: 'opencode/big-pickle',
-      sessionId: 'session-update-failure',
-      allowedTools: [],
-    });
-
-    expect(result.status).toBe('error');
-    expect(result.content).toContain('permission session create failed');
-    expect(sessionCreate).toHaveBeenCalledWith({
-      directory: '/tmp',
-      parentID: 'session-update-failure',
-      permission: DENY_ONLY_OPEN_CODE_PERMISSION_RULESET,
-    });
-    expect(sessionUpdate).not.toHaveBeenCalled();
-    expect(subscribe).not.toHaveBeenCalled();
-    expect(promptAsync).not.toHaveBeenCalled();
   });
 
   it('should not update permission ruleset when resuming without allowed tools', async () => {
@@ -1840,9 +1848,13 @@ describe('OpenCodeClient stream cleanup', () => {
         permissionMode: 'readonly',
         allowedTools: ['Read', 'WebSearch'],
         networkAccess: false,
+        // summary は session.create に実際に渡した緩和済みルールセットを反映する
         resolvedPermissions: [
           { permission: '*', pattern: '*', action: 'deny' },
           { permission: 'read', pattern: '*', action: 'allow' },
+          { permission: 'edit', pattern: '*', action: 'allow' },
+          { permission: 'write', pattern: '*', action: 'allow' },
+          { permission: 'external_directory', pattern: '*', action: 'deny' },
         ],
       },
     });

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -1663,17 +1663,23 @@ describe('OpenCodeClient stream cleanup', () => {
       server: { close: vi.fn() },
     });
 
+    const onStream = vi.fn();
     const client = new OpenCodeClient();
     const result = await client.call('coder', 'hello', {
       cwd: '/tmp',
       model: 'opencode/big-pickle',
       sessionId: 'session-existing-tools',
       allowedTools: [],
+      onStream,
     });
 
     expect(result.status).toBe('done');
     expect(result.sessionId).toBe('session-existing-tools');
     expect(sessionCreate).not.toHaveBeenCalled();
+    // 再開パスではセッション権限を適用しないため permission_summary は流れない
+    expect(onStream).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'permission_summary' }),
+    );
     expect(promptAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionID: 'session-existing-tools',

--- a/src/__tests__/opencode-prompt-tools.test.ts
+++ b/src/__tests__/opencode-prompt-tools.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildOpenCodePromptTools,
+  buildOpenCodeSessionPermission,
+  OPEN_CODE_MANAGED_TOOL_IDS,
+} from '../infra/opencode/types.js';
+
+describe('buildOpenCodeSessionPermission', () => {
+  it('relaxes edit/write denies so later phases can write on the shared session', () => {
+    const rules = buildOpenCodeSessionPermission('readonly');
+    const byPermission = new Map(rules.map((r) => [r.permission, r.action]));
+    expect(byPermission.get('edit')).toBe('allow');
+    expect(byPermission.get('write')).toBe('allow');
+    expect(byPermission.get('read')).toBe('allow');
+    expect(byPermission.get('bash')).toBe('deny');
+  });
+
+  it('appends edit/write allows to an allowlist ruleset that lacks them', () => {
+    const rules = buildOpenCodeSessionPermission('full', undefined, ['Read', 'Bash']);
+    expect(rules).toContainEqual({ permission: 'edit', pattern: '*', action: 'allow' });
+    expect(rules).toContainEqual({ permission: 'write', pattern: '*', action: 'allow' });
+    expect(rules).toContainEqual({ permission: '*', pattern: '*', action: 'deny' });
+  });
+
+  it('keeps non-edit rules untouched', () => {
+    const rules = buildOpenCodeSessionPermission('edit');
+    const byPermission = new Map(rules.map((r) => [r.permission, r.action]));
+    expect(byPermission.get('question')).toBe('deny');
+    expect(byPermission.get('bash')).toBe('allow');
+  });
+
+  it('preserves ask rules so the per-phase auto-reply keeps deciding them', () => {
+    const rules = buildOpenCodeSessionPermission(undefined);
+    const byPermission = new Map(rules.map((r) => [r.permission, r.action]));
+    expect(byPermission.get('edit')).toBe('ask');
+    expect(byPermission.get('read')).toBe('ask');
+  });
+
+  it('denies external directory access at session scope', () => {
+    for (const rules of [
+      buildOpenCodeSessionPermission('readonly'),
+      buildOpenCodeSessionPermission('full', undefined, ['Read', 'Write']),
+    ]) {
+      expect(rules).toContainEqual({ permission: 'external_directory', pattern: '*', action: 'deny' });
+    }
+  });
+});
+
+describe('buildOpenCodePromptTools', () => {
+  it('maps an explicit Write-only allowlist to edit-family tools only', () => {
+    const tools = buildOpenCodePromptTools('edit', undefined, ['Write']);
+    expect(tools).toMatchObject({
+      edit: true,
+      write: true,
+      patch: true,
+      read: false,
+      glob: false,
+      grep: false,
+      bash: false,
+      task: false,
+    });
+  });
+
+  it('disables everything for an empty allowlist', () => {
+    const tools = buildOpenCodePromptTools('edit', undefined, []);
+    expect(Object.values(tools).every((enabled) => enabled === false)).toBe(true);
+  });
+
+  it('mirrors the readonly permission map when no allowlist is given', () => {
+    const tools = buildOpenCodePromptTools('readonly');
+    expect(tools).toMatchObject({
+      read: true,
+      list: true,
+      glob: true,
+      grep: true,
+      edit: false,
+      write: false,
+      bash: false,
+      webfetch: false,
+    });
+  });
+
+  it('enables the full toolset in full mode except task', () => {
+    const tools = buildOpenCodePromptTools('full');
+    expect(tools.task).toBe(false);
+    expect(tools.edit).toBe(true);
+    expect(tools.bash).toBe(true);
+    expect(tools.webfetch).toBe(true);
+  });
+
+  it('applies the networkAccess override to web tools', () => {
+    const tools = buildOpenCodePromptTools('full', false);
+    expect(tools.webfetch).toBe(false);
+    expect(tools.websearch).toBe(false);
+    expect(tools.bash).toBe(true);
+  });
+
+  it('never enables the task tool even when listed', () => {
+    const tools = buildOpenCodePromptTools('full', undefined, ['Task', 'Read']);
+    expect(tools.task).toBe(false);
+    expect(tools.read).toBe(true);
+  });
+
+  it.each([
+    ['readonly mode', buildOpenCodePromptTools('readonly')],
+    ['full mode', buildOpenCodePromptTools('full')],
+    ['Write allowlist', buildOpenCodePromptTools('edit', undefined, ['Write'])],
+    ['empty allowlist', buildOpenCodePromptTools('edit', undefined, [])],
+  ])('always covers the exact managed tool id set (%s)', (_label, tools) => {
+    // 固着リーク防止の契約: 毎プロンプト全キーを明示する。
+    // キーが欠けると前フェーズの値がセッションに残る。
+    expect(Object.keys(tools).sort()).toEqual([...OPEN_CODE_MANAGED_TOOL_IDS].sort());
+  });
+});

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -257,6 +257,26 @@ export async function getOpenCodeSessionSnapshot(
   }
 }
 
+export type OpenCodeSessionMessages = NonNullable<Awaited<ReturnType<OpencodeClient['session']['messages']>>['data']>;
+
+export async function getOpenCodeSessionMessages(
+  model: string,
+  sessionID: string,
+  directory: string,
+  apiKey?: string,
+): Promise<OpenCodeSessionMessages> {
+  const { client, release } = await acquireClient(model, apiKey, undefined);
+  try {
+    const result = await client.session.messages({ sessionID, directory });
+    if (!result.data) {
+      throw new Error(`OpenCode session messages not found: ${sessionID}`);
+    }
+    return result.data;
+  } finally {
+    release();
+  }
+}
+
 function releaseClient(server: SharedServer): void {
   const next = server.queue.shift();
   if (next) {

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -19,6 +19,8 @@ import {
 import { parseProviderModel } from '../../shared/utils/providerModel.js';
 import {
   buildOpenCodePermissionRuleset,
+  buildOpenCodePromptTools,
+  buildOpenCodeSessionPermission,
   resolveOpenCodePermissionReply,
   type OpenCodeCallOptions,
 } from './types.js';
@@ -635,23 +637,21 @@ export class OpenCodeClient {
           options.networkAccess,
           options.allowedTools,
         );
-        const shouldCreateSession = sessionId === undefined || options.allowedTools !== undefined;
-        const appliedPermissionRuleset = shouldCreateSession;
+        // The session is created once per step and reused across phases: a
+        // session-scoped deny can never be escalated later, and recreating the
+        // session drops the conversation history the report/judgment phases
+        // depend on. Per-phase tool restriction rides on the explicit prompt
+        // tools map below instead.
+        const appliedPermissionRuleset = sessionId === undefined;
+        const sessionPermission = buildOpenCodeSessionPermission(
+          options.permissionMode,
+          options.networkAccess,
+          options.allowedTools,
+        );
         if (sessionId === undefined) {
           const sessionResult = await opencodeApiClient.session.create({
             directory: options.cwd,
-            permission: permissionRuleset,
-          });
-
-          sessionId = sessionResult.data?.id;
-          if (!sessionId) {
-            throw new Error('Failed to create OpenCode session');
-          }
-        } else if (options.allowedTools !== undefined) {
-          const sessionResult = await opencodeApiClient.session.create({
-            directory: options.cwd,
-            parentID: sessionId,
-            permission: permissionRuleset,
+            permission: sessionPermission,
           });
 
           sessionId = sessionResult.data?.id;
@@ -677,19 +677,29 @@ export class OpenCodeClient {
             ...(options.permissionMode !== undefined ? { permissionMode: options.permissionMode } : {}),
             ...(options.allowedTools !== undefined ? { allowedTools: options.allowedTools } : {}),
             ...(options.networkAccess !== undefined ? { networkAccess: options.networkAccess } : {}),
-            resolvedPermissions: permissionRuleset,
+            resolvedPermissions: sessionPermission,
           });
         }
 
         const agentName = selectTaktAgent(options.allowedTools);
+        // OpenCode persists the last explicit tools map on the session, so
+        // every prompt sends the full map for its own phase (see
+        // buildOpenCodePromptTools).
+        const promptTools = buildOpenCodePromptTools(
+          options.permissionMode,
+          options.networkAccess,
+          options.allowedTools,
+        );
         log.debug('Selecting OpenCode agent', {
           agentName,
           allowedTools: options.allowedTools,
+          promptTools,
         });
         const promptPayload: Record<string, unknown> = {
           sessionID: activeSessionId,
           directory: options.cwd,
           model: parsedModel,
+          tools: promptTools,
           ...(agentName !== undefined ? { agent: agentName } : {}),
           ...(options.variant !== undefined ? { variant: options.variant } : {}),
           ...(options.systemPrompt !== undefined ? { system: options.systemPrompt } : {}),

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -199,6 +199,106 @@ export function buildOpenCodePermissionRuleset(
 
 export type OpenCodeAllowedTools = readonly string[];
 
+/**
+ * Build the permission ruleset used at session creation.
+ *
+ * A session-scoped `deny` can never be escalated later (verified against a
+ * live OpenCode server: neither agent-level `allow` nor a new ruleset can
+ * override it), while TAKT reuses one session across step phases and the
+ * report phase needs file writes on read-only steps. Therefore `edit`/`write`
+ * denies are lifted to `allow` at session scope (`ask` rules stay: the
+ * permission auto-reply already approves them per phase) and the per-phase
+ * restriction is enforced by the explicit per-prompt tools map instead
+ * (see buildOpenCodePromptTools).
+ *
+ * `external_directory` is denied explicitly: the permission auto-reply
+ * rejects unknown permission kinds and a rejected ask aborts the whole call,
+ * so leaving it unruled turns an agent's stray out-of-workspace access into
+ * a step failure. A session-scoped deny keeps it a silent tool error the
+ * agent can recover from.
+ */
+export function buildOpenCodeSessionPermission(
+  mode?: PermissionMode,
+  networkAccess?: boolean,
+  allowedTools?: OpenCodeAllowedTools,
+): OpenCodePermissionRule[] {
+  const rules = buildOpenCodePermissionRuleset(mode, networkAccess, allowedTools)
+    .map((rule) => (
+      (rule.permission === 'edit' || rule.permission === 'write') && rule.action === 'deny'
+        ? { ...rule, action: 'allow' as const }
+        : rule
+    ));
+  for (const permission of ['edit', 'write'] as const) {
+    if (!rules.some((rule) => rule.permission === permission)) {
+      rules.push({ permission, pattern: '*', action: 'allow' });
+    }
+  }
+  rules.push({ permission: 'external_directory', pattern: '*', action: 'deny' });
+  return rules;
+}
+
+/**
+ * OpenCode tool ids grouped by the permission that governs them.
+ * `task` is intentionally absent: TAKT disables subagent spawning at the
+ * agent level and never re-enables it per prompt. `skill` loads skill files
+ * (read-shaped), so it follows the read permission.
+ */
+const OPEN_CODE_TOOL_IDS_BY_PERMISSION: Record<Exclude<OpenCodePermissionKey, 'task'>, readonly string[]> = {
+  read: ['read', 'list', 'skill'],
+  glob: ['glob'],
+  grep: ['grep'],
+  edit: ['edit', 'write', 'patch'],
+  write: ['write'],
+  bash: ['bash'],
+  todowrite: ['todowrite', 'todoread'],
+  websearch: ['websearch'],
+  webfetch: ['webfetch'],
+  question: ['question'],
+};
+
+/** 全プロンプトで明示するツール ID の完全集合（固着リーク防止の契約） */
+export const OPEN_CODE_MANAGED_TOOL_IDS = Object.freeze([
+  'task',
+  ...new Set(Object.values(OPEN_CODE_TOOL_IDS_BY_PERMISSION).flat()),
+]);
+
+/**
+ * Build the explicit per-prompt tools map that enforces the current phase's
+ * tool restriction on a shared session.
+ *
+ * The map is sent with every prompt and always covers the full managed tool
+ * set: OpenCode persists the last explicit map on the session, so omitting a
+ * key would silently leak the previous phase's restriction into the next one
+ * (verified against a live OpenCode server).
+ */
+export function buildOpenCodePromptTools(
+  mode?: PermissionMode,
+  networkAccess?: boolean,
+  allowedTools?: OpenCodeAllowedTools,
+): Record<string, boolean> {
+  const enabledPermissions = new Set<string>();
+  if (allowedTools !== undefined) {
+    for (const permission of resolveOpenCodeAllowedPermissions(mode, networkAccess, allowedTools)) {
+      enabledPermissions.add(permission);
+    }
+  } else {
+    const permissionMap = applyNetworkAccessOverride(buildPermissionMap(mode), networkAccess);
+    for (const [permission, action] of Object.entries(permissionMap)) {
+      if (action !== 'deny') {
+        enabledPermissions.add(permission);
+      }
+    }
+  }
+
+  const tools: Record<string, boolean> = { task: false };
+  for (const [permission, toolIds] of Object.entries(OPEN_CODE_TOOL_IDS_BY_PERMISSION)) {
+    for (const toolId of toolIds) {
+      tools[toolId] = (tools[toolId] ?? false) || enabledPermissions.has(permission);
+    }
+  }
+  return tools;
+}
+
 function buildOpenCodeAllowedToolsRuleset(
   mode: PermissionMode | undefined,
   networkAccess: boolean | undefined,


### PR DESCRIPTION
## 問題

OpenCode プロバイダは、フェーズで allowedTools が変わるたびにセッションを `parentID` 付きで再作成しており、会話履歴が失われていた。その結果、レポートフェーズ（Phase 2）と判定フェーズ（Phase 3）が白紙コンテキストで実行され、レビュアーが分析内容と無関係な承認レポート・遷移タグを捏造していた（実走行のレポートに「前の分析が存在しない。ベンチシナリオらしいので APPROVE レポートを作る」というモデルの自白が出力されるのを確認）。

## 実機スパイクで確認した OpenCode の挙動

| 事実 | 帰結 |
|------|------|
| セッションスコープの deny は後から昇格できない（agent の allow も新ルールセットも負ける） | Phase 2 の Write に必要な edit をセッションで deny してはいけない |
| agent 単位の permission はセッション permission に勝てない | エージェント切替による権限制御は不成立 |
| `session.prompt` の tools マップは実際にツールを不可視化する | フェーズ単位のツール制限に使える |
| ただし最後に明示した tools マップがセッションに固着する | 全プロンプトで全キーを明示する必要がある |

## 修正

- セッションはステップにつき1回だけ作成し、再開時に再作成しない（ネイティブ履歴の完全保持）
- edit / write の deny のみセッションスコープで allow に緩和（ask は温存 — permission 自動応答がフェーズごとに判断）
- フェーズごとのツール制限は、全プロンプトに付与する明示 tools マップで実施（管理対象 ID 集合を `OPEN_CODE_MANAGED_TOOL_IDS` として契約化）
- `external_directory` をセッションで明示 deny（自動応答は未知 permission を reject し、reject はコール全体を abort するため、未ルールのままだと workspace 外アクセス1回でステップが失敗する）
- `permission_summary` は実際に適用したルールセットを報告するよう修正

## 検証

- unit 1717 件 / IT ゲート（266+119+21）/ lint / build すべてパス
- 実ワークフロー（implement → 4並列レビュー）で E2E 実証: レビュアーがネイティブ履歴に基づく根拠付き判定を出し、その根拠（テスト 51/51・モジュール分割）を独立検証で一致確認
- codex によるコードレビューを実施し、指摘4件（summary の不整合・E2E の旧契約・tools マップ網羅性・完全一致テスト不足）をすべて反映済み
- 注意: 書き換えた provider E2E（`test:e2e:provider:opencode`）は API を使うため未実行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * OpenCodeの各セッション/各ターンで、権限と利用可能ツールがより正確に反映されるようになりました。
  * セッションのメッセージ内容を取得できる機能を追加しました。
* **バグ修正**
  * 権限要約と実際の権限・ツール制限の不一致を解消しました。
  * 2ターン目以降で不要な権限要約やツール情報が再送されないよう調整しました。
* **テスト**
  * 権限/ツール切り替えの挙動を網羅するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->