### PR TITLE
fix: rescan eval suite fixture mismatch and broken assertions

### DIFF
--- a/eval/promptfooconfig.rescan.yaml
+++ b/eval/promptfooconfig.rescan.yaml
@@ -77,5 +77,9 @@ tests:
       - type: javascript
         metric: verdict/reject
         value: |
-          const ok = /(結果|判定|Verdict).{0,12}REJECT/.test(output) || /^#+ *REJECT/m.test(output);
-          return ok;
+          // src/features/analytics/report-parser.ts の extractDecisionFromReport と
+          // 同様に、verdict 値を語（\w+）として抽出し REJECT と厳密比較する。
+          // 部分一致（REJECTED 等）を verdict と誤認しないため。
+          const labeled = [...output.matchAll(/(?:結果|判定|Verdict)[^\w\n]{0,12}(\w+)/g)].map((m) => m[1]);
+          const headings = [...output.matchAll(/^#+ *(\w+)/gm)].map((m) => m[1]);
+          return [...labeled, ...headings].some((v) => v.toUpperCase() === 'REJECT');

--- a/eval/promptfooconfig.rescan.yaml
+++ b/eval/promptfooconfig.rescan.yaml
@@ -23,6 +23,8 @@ providers:
     label: gemma4-31b
   - id: 'exec: bash providers/opencode-review.sh ollama-cloud/qwen3.5:397b fixtures/inventory-es'
     label: qwen3.5-397b
+  - id: 'exec: bash providers/opencode-review.sh ollama-cloud/qwen3-coder-next fixtures/inventory-es'
+    label: qwen3-coder-next
 
 tests:
   - description: 'round-2: resolved previous findings must not suppress a full re-scan'

--- a/eval/promptfooconfig.rescan.yaml
+++ b/eval/promptfooconfig.rescan.yaml
@@ -8,7 +8,7 @@
 description: 'TAKT facet eval: peer-review / arch-review round-2 re-scan'
 
 prompts:
-  - file://prompts/arch-review.phase1.md
+  - file://prompts/rescan.phase1.md
 
 providers:
   - id: openai:codex-sdk
@@ -33,7 +33,8 @@ tests:
       - type: javascript
         metric: rescan/evidence-table-present
         value: |
-          return /再走査証跡|Re-scan Evidence/i.test(output);
+          const ok = /再走査証跡|Re-scan Evidence/i.test(output);
+          return ok;
       - type: javascript
         metric: recall/ship-projection-contract
         value: |
@@ -47,7 +48,8 @@ tests:
       - type: javascript
         metric: recall/monolith
         value: |
-          return /(分割|単一ファイル|モノリ|複数の責務|1ファイル|一つのファイル)/.test(output);
+          const ok = /(分割|単一ファイル|モノリ|複数の責務|1ファイル|一つのファイル)/.test(output);
+          return ok;
       - type: javascript
         metric: recall/mutable-initial-state
         value: |
@@ -73,4 +75,5 @@ tests:
       - type: javascript
         metric: verdict/reject
         value: |
-          return /## 結果: *(REJECT|IMPROVE)/.test(output);
+          const ok = /(結果|判定|Verdict).{0,12}(REJECT|IMPROVE)/.test(output) || /^#+ *REJECT/m.test(output);
+          return ok;

--- a/eval/promptfooconfig.rescan.yaml
+++ b/eval/promptfooconfig.rescan.yaml
@@ -77,5 +77,5 @@ tests:
       - type: javascript
         metric: verdict/reject
         value: |
-          const ok = /(結果|判定|Verdict).{0,12}(REJECT|IMPROVE)/.test(output) || /^#+ *REJECT/m.test(output);
+          const ok = /(結果|判定|Verdict).{0,12}REJECT/.test(output) || /^#+ *REJECT/m.test(output);
           return ok;

--- a/eval/scripts/prepare.mjs
+++ b/eval/scripts/prepare.mjs
@@ -41,6 +41,9 @@ const TARGETS = [
   { id: 'antipattern-review', workflow: 'peer-review', step: 'ai-antipattern-review-2nd', fixture: 'eval/fixtures/sample-project' },
   { id: 'frontend-review', workflow: 'review-frontend', step: 'frontend-review', fixture: 'eval/fixtures/frontend-app' },
   { id: 'cqrs-review', workflow: 'review-backend-cqrs', step: 'cqrs-es-review', fixture: 'eval/fixtures/backend-cqrs' },
+  // rescan は arch-review と同じ facet 構成だが fixture が異なるため、
+  // スナップショット（Source Path）を inventory-es 側に生成する専用エントリが必要
+  { id: 'rescan', workflow: 'peer-review', step: 'arch-review', fixture: 'eval/fixtures/inventory-es' },
   { id: 'frontend-implement', workflow: 'frontend', step: 'implement', fixture: 'eval/fixtures/frontend-app', mutable: true },
   { id: 'cqrs-implement', workflow: 'backend-cqrs', step: 'implement', fixture: 'eval/fixtures/backend-cqrs', mutable: true },
 ];


### PR DESCRIPTION
## 問題

rescan スイート（#951）は arch-review 用に prepare されたプロンプトを流用しており、Source Path が `fixtures/sample-project/.takt/eval-snapshots/` を指したままだった。inventory-es fixture で実行すると、

- codex は隣の fixture（sample-project）を読んでレビュー対象を誤認する
- opencode 系プロバイダは作業ディレクトリ外 Read が external_directory 自動拒否となり、空出力で全滅する

さらにアサート3件（証跡表・モノリス・判定）が「1行の return 本体」で書かれており、promptfoo が式として解釈して SyntaxError → 恒久的に不合格として採点されていた。

## 変更

- `prepare.mjs` に rescan ターゲットを追加（スナップショットを inventory-es 内に生成し、専用の `prompts/rescan.phase1.md` を出力）
- `promptfooconfig.rescan.yaml` の参照プロンプトを差し替え
- 壊れていたアサート3件を2行の関数本体に修正。判定アサートは見出しの表記揺れ（結果/判定/### REJECT）も許容

## 検証

- 生成プロンプトに sample-project 参照ゼロを確認
- gemma 実走: 空出力が解消し、アサート実行エラー 0 件で 5/7 メトリクス合格（T3/T6 は本物の見逃し = 測定として正常）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * rescan 評価で参照するフェーズ1プロンプトを更新し、実行プロバイダ構成も切り替えました。
  * 証拠表・判定の検出を整理し、`REJECT` の近接一致や `#+ *REJECT` 見出し形式など多様な表記にも対応しました（`IMPROVE` は対象外）。
* **Chores**
  * `rescan` 用ターゲットを追加し、対象 fixture を切り替えて専用スナップショット（Source Path）を生成するよう調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->