### PR TITLE
[codex] Add final gate routing tags

### DIFF
--- a/builtins/en/config.yaml
+++ b/builtins/en/config.yaml
@@ -80,6 +80,12 @@ language: en        # UI language: en | ja
 #     review:
 #       provider: opencode
 #       model: opencode/qwen3-coder-next
+#     final-gate:
+#       provider: codex
+#       model: gpt-5
+#       provider_options:
+#         codex:
+#           reasoning_effort: high
 #     edit:
 #       provider_options:
 #         codex:

--- a/builtins/en/workflows/audit-architecture-backend.yaml
+++ b/builtins/en/workflows/audit-architecture-backend.yaml
@@ -66,6 +66,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     policy: review
     knowledge:

--- a/builtins/en/workflows/audit-architecture-dual.yaml
+++ b/builtins/en/workflows/audit-architecture-dual.yaml
@@ -68,6 +68,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     policy: review
     knowledge:

--- a/builtins/en/workflows/audit-architecture-frontend.yaml
+++ b/builtins/en/workflows/audit-architecture-frontend.yaml
@@ -68,6 +68,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     policy: review
     knowledge:

--- a/builtins/en/workflows/audit-architecture.yaml
+++ b/builtins/en/workflows/audit-architecture.yaml
@@ -62,6 +62,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     policy: review
     knowledge: architecture

--- a/builtins/en/workflows/audit-e2e.yaml
+++ b/builtins/en/workflows/audit-e2e.yaml
@@ -75,6 +75,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/audit-security.yaml
+++ b/builtins/en/workflows/audit-security.yaml
@@ -58,6 +58,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     knowledge: security
     instruction: audit-security-supervise

--- a/builtins/en/workflows/audit-unit.yaml
+++ b/builtins/en/workflows/audit-unit.yaml
@@ -77,6 +77,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/backend-cqrs-mini.yaml
+++ b/builtins/en/workflows/backend-cqrs-mini.yaml
@@ -125,6 +125,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: supervisor
         policy: review

--- a/builtins/en/workflows/backend-mini.yaml
+++ b/builtins/en/workflows/backend-mini.yaml
@@ -123,6 +123,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: supervisor
         policy: review

--- a/builtins/en/workflows/cli.yaml
+++ b/builtins/en/workflows/cli.yaml
@@ -98,6 +98,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/deep-research.yaml
+++ b/builtins/en/workflows/deep-research.yaml
@@ -89,6 +89,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: research-supervisor
     policy: research
     knowledge: research

--- a/builtins/en/workflows/dual-cqrs-mini.yaml
+++ b/builtins/en/workflows/dual-cqrs-mini.yaml
@@ -131,6 +131,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: dual-supervisor
         policy: review

--- a/builtins/en/workflows/dual-mini.yaml
+++ b/builtins/en/workflows/dual-mini.yaml
@@ -129,6 +129,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: dual-supervisor
         policy: review

--- a/builtins/en/workflows/frontend-mini.yaml
+++ b/builtins/en/workflows/frontend-mini.yaml
@@ -126,6 +126,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: supervisor
         policy: review

--- a/builtins/en/workflows/merge-readiness-dual-final-gate.yaml
+++ b/builtins/en/workflows/merge-readiness-dual-final-gate.yaml
@@ -34,10 +34,13 @@ steps:
   - name: final_gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy:
@@ -58,6 +61,8 @@ steps:
       - name: supervise
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: dual-supervisor
         policy: review

--- a/builtins/en/workflows/merge-readiness-final-gate.yaml
+++ b/builtins/en/workflows/merge-readiness-final-gate.yaml
@@ -24,10 +24,13 @@ steps:
   - name: final_gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -45,6 +48,8 @@ steps:
       - name: supervise
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review

--- a/builtins/en/workflows/peer-review-with-fc.yaml
+++ b/builtins/en/workflows/peer-review-with-fc.yaml
@@ -171,6 +171,8 @@ steps:
   - name: merge-readiness-review
     tags:
       - review
+      - final-gate
+      - merge-readiness
     edit: false
     persona: merge-readiness-reviewer
     policy: review

--- a/builtins/en/workflows/research.yaml
+++ b/builtins/en/workflows/research.yaml
@@ -43,6 +43,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: research-supervisor
     policy: research
     knowledge: research

--- a/builtins/en/workflows/review-backend-cqrs.yaml
+++ b/builtins/en/workflows/review-backend-cqrs.yaml
@@ -175,10 +175,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -202,6 +205,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -233,6 +238,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-backend.yaml
+++ b/builtins/en/workflows/review-backend.yaml
@@ -149,10 +149,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -176,6 +179,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -207,6 +212,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-default.yaml
+++ b/builtins/en/workflows/review-default.yaml
@@ -183,10 +183,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -210,6 +213,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -320,6 +325,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-dual-cqrs.yaml
+++ b/builtins/en/workflows/review-dual-cqrs.yaml
@@ -202,10 +202,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -229,6 +232,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -260,6 +265,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-dual.yaml
+++ b/builtins/en/workflows/review-dual.yaml
@@ -176,10 +176,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -203,6 +206,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -234,6 +239,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-frontend.yaml
+++ b/builtins/en/workflows/review-frontend.yaml
@@ -175,10 +175,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -202,6 +205,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -233,6 +238,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/review-takt-default.yaml
+++ b/builtins/en/workflows/review-takt-default.yaml
@@ -211,10 +211,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -238,6 +241,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -351,6 +356,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/takt-default-with-fc.yaml
+++ b/builtins/en/workflows/takt-default-with-fc.yaml
@@ -88,6 +88,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/en/workflows/terraform.yaml
+++ b/builtins/en/workflows/terraform.yaml
@@ -162,10 +162,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -232,6 +235,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: *terraform_supervise_edit
     persona: *terraform_supervise_persona
     policy: *terraform_supervise_policy

--- a/builtins/ja/config.yaml
+++ b/builtins/ja/config.yaml
@@ -80,6 +80,12 @@ language: ja         # 表示言語: ja | en
 #     review:
 #       provider: opencode
 #       model: opencode/qwen3-coder-next
+#     final-gate:
+#       provider: codex
+#       model: gpt-5
+#       provider_options:
+#         codex:
+#           reasoning_effort: high
 #     edit:
 #       provider_options:
 #         codex:

--- a/builtins/ja/workflows/audit-architecture-backend.yaml
+++ b/builtins/ja/workflows/audit-architecture-backend.yaml
@@ -66,6 +66,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     policy: review
     knowledge:

--- a/builtins/ja/workflows/audit-architecture-dual.yaml
+++ b/builtins/ja/workflows/audit-architecture-dual.yaml
@@ -68,6 +68,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     policy: review
     knowledge:

--- a/builtins/ja/workflows/audit-architecture-frontend.yaml
+++ b/builtins/ja/workflows/audit-architecture-frontend.yaml
@@ -68,6 +68,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     policy: review
     knowledge:

--- a/builtins/ja/workflows/audit-architecture.yaml
+++ b/builtins/ja/workflows/audit-architecture.yaml
@@ -62,6 +62,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     policy: review
     knowledge: architecture

--- a/builtins/ja/workflows/audit-e2e.yaml
+++ b/builtins/ja/workflows/audit-e2e.yaml
@@ -75,6 +75,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/audit-security.yaml
+++ b/builtins/ja/workflows/audit-security.yaml
@@ -58,6 +58,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: supervisor
     knowledge: security
     instruction: audit-security-supervise

--- a/builtins/ja/workflows/audit-unit.yaml
+++ b/builtins/ja/workflows/audit-unit.yaml
@@ -77,6 +77,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/backend-cqrs-mini.yaml
+++ b/builtins/ja/workflows/backend-cqrs-mini.yaml
@@ -125,6 +125,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: supervisor
         policy: review

--- a/builtins/ja/workflows/backend-mini.yaml
+++ b/builtins/ja/workflows/backend-mini.yaml
@@ -123,6 +123,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: supervisor
         policy: review

--- a/builtins/ja/workflows/cli.yaml
+++ b/builtins/ja/workflows/cli.yaml
@@ -98,6 +98,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/deep-research.yaml
+++ b/builtins/ja/workflows/deep-research.yaml
@@ -89,6 +89,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: research-supervisor
     policy: research
     knowledge: research

--- a/builtins/ja/workflows/dual-cqrs-mini.yaml
+++ b/builtins/ja/workflows/dual-cqrs-mini.yaml
@@ -131,6 +131,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: dual-supervisor
         policy: review

--- a/builtins/ja/workflows/dual-mini.yaml
+++ b/builtins/ja/workflows/dual-mini.yaml
@@ -129,6 +129,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: dual-supervisor
         policy: review

--- a/builtins/ja/workflows/frontend-mini.yaml
+++ b/builtins/ja/workflows/frontend-mini.yaml
@@ -126,6 +126,7 @@ steps:
       - name: supervise
         tags:
           - review
+          - supervise
         edit: false
         persona: supervisor
         policy: review

--- a/builtins/ja/workflows/merge-readiness-dual-final-gate.yaml
+++ b/builtins/ja/workflows/merge-readiness-dual-final-gate.yaml
@@ -34,10 +34,13 @@ steps:
   - name: final_gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy:
@@ -58,6 +61,8 @@ steps:
       - name: supervise
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: dual-supervisor
         policy: review

--- a/builtins/ja/workflows/merge-readiness-final-gate.yaml
+++ b/builtins/ja/workflows/merge-readiness-final-gate.yaml
@@ -24,10 +24,13 @@ steps:
   - name: final_gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -45,6 +48,8 @@ steps:
       - name: supervise
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review

--- a/builtins/ja/workflows/peer-review-with-fc.yaml
+++ b/builtins/ja/workflows/peer-review-with-fc.yaml
@@ -171,6 +171,8 @@ steps:
   - name: merge-readiness-review
     tags:
       - review
+      - final-gate
+      - merge-readiness
     edit: false
     persona: merge-readiness-reviewer
     policy: review

--- a/builtins/ja/workflows/research.yaml
+++ b/builtins/ja/workflows/research.yaml
@@ -43,6 +43,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     persona: research-supervisor
     policy: research
     knowledge: research

--- a/builtins/ja/workflows/review-backend-cqrs.yaml
+++ b/builtins/ja/workflows/review-backend-cqrs.yaml
@@ -175,10 +175,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -202,6 +205,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -233,6 +238,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-backend.yaml
+++ b/builtins/ja/workflows/review-backend.yaml
@@ -149,10 +149,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -176,6 +179,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -207,6 +212,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-default.yaml
+++ b/builtins/ja/workflows/review-default.yaml
@@ -183,10 +183,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -210,6 +213,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -293,6 +298,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-dual-cqrs.yaml
+++ b/builtins/ja/workflows/review-dual-cqrs.yaml
@@ -202,10 +202,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -229,6 +232,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -260,6 +265,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-dual.yaml
+++ b/builtins/ja/workflows/review-dual.yaml
@@ -176,10 +176,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -203,6 +206,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -234,6 +239,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-frontend.yaml
+++ b/builtins/ja/workflows/review-frontend.yaml
@@ -175,10 +175,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -202,6 +205,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -233,6 +238,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/review-takt-default.yaml
+++ b/builtins/ja/workflows/review-takt-default.yaml
@@ -211,10 +211,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -238,6 +241,8 @@ steps:
       - name: review-synthesis
         tags:
           - review
+          - final-gate
+          - supervise
         edit: false
         persona: supervisor
         policy: review
@@ -323,6 +328,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/takt-default-with-fc.yaml
+++ b/builtins/ja/workflows/takt-default-with-fc.yaml
@@ -88,6 +88,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: false
     persona: supervisor
     policy: review

--- a/builtins/ja/workflows/terraform.yaml
+++ b/builtins/ja/workflows/terraform.yaml
@@ -162,10 +162,13 @@ steps:
   - name: final-gate
     tags:
       - review
+      - final-gate
     parallel:
       - name: merge-readiness-review
         tags:
           - review
+          - final-gate
+          - merge-readiness
         edit: false
         persona: merge-readiness-reviewer
         policy: review
@@ -232,6 +235,7 @@ steps:
   - name: supervise
     tags:
       - review
+      - supervise
     edit: *terraform_supervise_edit
     persona: *terraform_supervise_persona
     policy: *terraform_supervise_policy

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -54,6 +54,12 @@ interactive_preview_steps: 3  # インタラクティブモードでの step プ
 #     review:
 #       provider: opencode
 #       model: opencode/qwen3-coder-next
+#     final-gate:
+#       provider: codex
+#       model: gpt-5
+#       provider_options:
+#         codex:
+#           reasoning_effort: high
 #     edit:
 #       provider_options:
 #         codex:
@@ -462,6 +468,12 @@ provider_routing:
     review:
       provider: opencode
       model: opencode/qwen3-coder-next
+    final-gate:
+      provider: codex
+      model: gpt-5
+      provider_options:
+        codex:
+          reasoning_effort: high
     edit:
       provider_options:
         codex:
@@ -481,7 +493,7 @@ steps:
     tags: [implementation, edit]
 ```
 
-`provider_routing.personas` は workflow step の raw `persona` キーを使います。`persona_name` は表示専用で、routing には影響しません。`provider_routing.tags` は step の `tags` に一致する entry を適用します。複数 tag が一致した場合は step に書かれた順に適用され、後ろの tag が同じ provider / model / provider_options leaf を上書きします。`provider_routing.steps` は workflow step の `name` を使います。
+`provider_routing.personas` は workflow step の raw `persona` キーを使います。`persona_name` は表示専用で、routing には影響しません。`provider_routing.tags` は step の `tags` に一致する entry を適用します。複数 tag が一致した場合は step に書かれた順に適用され、後ろの tag が同じ provider / model / provider_options leaf を上書きします。たとえば builtin の最終ゲートは `review` の後に `final-gate` を持つため、通常レビューを OpenCode にしつつ merge-readiness / supervisor だけ Codex の高推論モデルへ上書きできます。より細かく分ける場合は `merge-readiness` と `supervise` タグを個別に指定できます。`provider_routing.steps` は workflow step の `name` を使います。
 
 各 routing entry では `provider`、`model`、`provider_options` を指定できます。これらは個別に省略できますが、各 entry には少なくとも 1 つ必要です。空の `provider_options` オブジェクトは受理されません。
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,12 @@ interactive_preview_steps: 3  # Step previews in interactive mode (0-10, default
 #     review:
 #       provider: opencode
 #       model: opencode/qwen3-coder-next
+#     final-gate:
+#       provider: codex
+#       model: gpt-5
+#       provider_options:
+#         codex:
+#           reasoning_effort: high
 #     edit:
 #       provider_options:
 #         codex:
@@ -462,6 +468,12 @@ provider_routing:
     review:
       provider: opencode
       model: opencode/qwen3-coder-next
+    final-gate:
+      provider: codex
+      model: gpt-5
+      provider_options:
+        codex:
+          reasoning_effort: high
     edit:
       provider_options:
         codex:
@@ -481,7 +493,7 @@ steps:
     tags: [implementation, edit]
 ```
 
-`provider_routing.personas` uses the raw `persona` key from the workflow step, so `persona_name` is display-only and does not affect routing. `provider_routing.tags` applies entries matching the step's `tags`; when multiple tags match, TAKT applies them in the order written on the step, and later tags override the same provider/model/provider_options leaf. `provider_routing.steps` uses the workflow step `name`.
+`provider_routing.personas` uses the raw `persona` key from the workflow step, so `persona_name` is display-only and does not affect routing. `provider_routing.tags` applies entries matching the step's `tags`; when multiple tags match, TAKT applies them in the order written on the step, and later tags override the same provider/model/provider_options leaf. For example, builtin final-gate steps put `final-gate` after `review`, so you can route ordinary reviewers to OpenCode while overriding only merge-readiness / supervisor to a high-reasoning Codex model. For finer routing, target `merge-readiness` and `supervise` separately. `provider_routing.steps` uses the workflow step `name`.
 
 Each routing entry can include `provider`, `model`, and/or `provider_options`. Those fields are individually optional, but each entry must include at least one of them. Empty `provider_options` objects are rejected.
 


### PR DESCRIPTION
## Summary
- Add dedicated provider routing tags for final gate, merge-readiness, and supervise steps while preserving existing review tags.
- Update builtin config examples and configuration docs to show routing ordinary review steps separately from final-gate Codex checks.
- Keep workflow_call steps schema-compliant by tagging callable workflow internals and concrete supervise steps only.

## Execution Report
- npm run build
- npm test
- workflow YAML parse/tag validation
- git diff --check

## Notes
- No issue is linked because this change was requested directly in chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ワークフローのタグ付けが拡張され、`supervise` や `final-gate` などの識別がより明確になりました。
  * 一部の設定例に、`final-gate` 向けのルーティング例が追加されました。

* **ドキュメント**
  * 設定ドキュメントに、タグやステップごとのルーティングの適用例が追加されました。
  * 複数タグの優先順や上書きの考え方が、よりわかりやすく説明されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->