### PR TITLE
[codex] Fix symlinked stdio entrypoints

### DIFF
--- a/src/__tests__/entrypoint.test.ts
+++ b/src/__tests__/entrypoint.test.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { isDirectEntrypoint } from '../shared/utils/entrypoint.js';
+
+describe('isDirectEntrypoint', () => {
+  let tempDir: string | undefined;
+
+  afterEach(() => {
+    if (tempDir !== undefined) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  function createTempFile(name: string): string {
+    tempDir ??= mkdtempSync(join(tmpdir(), 'takt-entrypoint-'));
+    const filePath = join(tempDir, name);
+    writeFileSync(filePath, '', 'utf-8');
+    return filePath;
+  }
+
+  it('returns true for the direct entrypoint path', () => {
+    const entrypoint = createTempFile('entrypoint.js');
+
+    expect(isDirectEntrypoint(pathToFileURL(entrypoint).href, ['node', entrypoint])).toBe(true);
+  });
+
+  it('returns true for a symlink to the entrypoint path', () => {
+    const entrypoint = createTempFile('entrypoint.js');
+    const linkedEntrypoint = join(tempDir!, 'linked-entrypoint.js');
+    symlinkSync(entrypoint, linkedEntrypoint);
+
+    expect(isDirectEntrypoint(pathToFileURL(entrypoint).href, ['node', linkedEntrypoint])).toBe(true);
+  });
+
+  it('returns false for another path', () => {
+    const entrypoint = createTempFile('entrypoint.js');
+    const otherFile = createTempFile('other.js');
+
+    expect(isDirectEntrypoint(pathToFileURL(entrypoint).href, ['node', otherFile])).toBe(false);
+  });
+
+  it('returns false when argv does not include an entrypoint path', () => {
+    const entrypoint = createTempFile('entrypoint.js');
+
+    expect(isDirectEntrypoint(pathToFileURL(entrypoint).href, ['node'])).toBe(false);
+  });
+});

--- a/src/app/acp/index.ts
+++ b/src/app/acp/index.ts
@@ -2,7 +2,6 @@
 
 import { Readable, Writable } from 'node:stream';
 import type { ReadableStream, WritableStream } from 'node:stream/web';
-import { pathToFileURL } from 'node:url';
 import {
   agent,
   methods,
@@ -23,6 +22,7 @@ import {
 import { isValidAcpBranchName } from './taskContext.js';
 import { isValidTaskContextPrNumber } from '../../features/tasks/taskContextValidation.js';
 import { createLogger } from '../../shared/utils/debug.js';
+import { isDirectEntrypoint } from '../../shared/utils/entrypoint.js';
 
 const log = createLogger('acp');
 
@@ -160,6 +160,6 @@ export function connectTaktAcpAgentToStdio(): void {
   ));
 }
 
-if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+if (isDirectEntrypoint(import.meta.url)) {
   connectTaktAcpAgentToStdio();
 }

--- a/src/app/mcp/index.ts
+++ b/src/app/mcp/index.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-import { pathToFileURL } from 'node:url';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createTaktMcpServer } from './server.js';
+import { isDirectEntrypoint } from '../../shared/utils/entrypoint.js';
 
 export async function connectTaktMcpServerToStdio(): Promise<void> {
   const server = createTaktMcpServer();
   await server.connect(new StdioServerTransport());
 }
 
-if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+if (isDirectEntrypoint(import.meta.url)) {
   connectTaktMcpServerToStdio().catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`${message}\n`);

--- a/src/shared/utils/entrypoint.ts
+++ b/src/shared/utils/entrypoint.ts
@@ -1,0 +1,15 @@
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export function isDirectEntrypoint(metaUrl: string, argv = process.argv): boolean {
+  const entrypointArg = argv[1];
+  if (entrypointArg === undefined) {
+    return false;
+  }
+
+  try {
+    return realpathSync(entrypointArg) === realpathSync(fileURLToPath(metaUrl));
+  } catch {
+    return false;
+  }
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -4,6 +4,7 @@
 
 export * from './debug.js';
 export * from './delay.js';
+export * from './entrypoint.js';
 export * from './error.js';
 export * from './notification.js';
 export * from './pathBoundary.js';


### PR DESCRIPTION
## Summary

- Resolve stdio entrypoint direct-run checks through real paths so npm-linked or globally installed symlink binaries start correctly.
- Apply the shared check to both takt-mcp and takt-acp entrypoints.
- Add focused tests for direct, symlinked, missing, and mismatched entrypoint paths.

## Execution Report

- npm run build
- npx vitest run src/__tests__/entrypoint.test.ts --config vitest.config.unit.parallel.ts
- npx vitest run src/__tests__/mcp-entrypoint.integration.test.ts --config vitest.config.it.parallel.ts
- Verified takt-mcp returns an MCP initialize response when invoked through the npm-linked symlink.

No linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * エントリポイントの判定を共通化し、実行中のファイルが直接起動された場合のみ処理を開始するようになりました。
  * シンボリックリンク経由の起動にも対応しました。

* **テスト**
  * エントリポイント判定の主要ケースを追加検証しました。
  * 自身の起動、別ファイル、引数不一致などの判定を確認します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->