### PR TITLE
fix: keep out-of-workspace denial effective and non-fatal for opencode

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2080,7 +2080,40 @@ describe('OpenCodeClient stream cleanup', () => {
     }, expect.any(Object));
   });
 
-  it('should reject OpenCode permission request when allowedTools is empty', async () => {
+  it('should pass the external_directory deny in the server config', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const stream = new MockEventStream([
+      { type: 'session.idle', properties: { sessionID: 'session-config-deny' } },
+    ]);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-config-deny' } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    await client.call('coder', 'hello', { cwd: '/tmp', model: 'opencode/big-pickle' });
+
+    // Prompt-level tools maps rewrite session.permission on the server, so
+    // the out-of-workspace deny must live in the server config, which that
+    // rewrite does not touch.
+    expect(createOpencodeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          permission: { external_directory: 'deny' },
+        }),
+      }),
+    );
+  });
+
+  it('should reject the permission but continue the call when allowedTools is empty', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([
       {
@@ -2125,8 +2158,10 @@ describe('OpenCodeClient stream cleanup', () => {
       onStream,
     });
 
-    expect(result.status).toBe('error');
-    expect(result.content).toContain('OpenCode permission rejected: read');
+    // A rejected permission is a per-tool failure: the call keeps consuming
+    // the stream and finishes normally on session.idle instead of aborting.
+    expect(result.status).not.toBe('error');
+    expect(result.error).toBeUndefined();
     expect(onStream).toHaveBeenCalledWith({
       type: 'permission_asked',
       data: {
@@ -2145,55 +2180,6 @@ describe('OpenCodeClient stream cleanup', () => {
     }, expect.any(Object));
   });
 
-  it('should fail fast after rejected permission when OpenCode does not emit idle', async () => {
-    const { OpenCodeClient } = await import('../infra/opencode/client.js');
-    const stream = new StallingEventStream({
-      type: 'permission.asked',
-      properties: {
-        id: 'perm-deny-no-idle',
-        sessionID: 'session-deny-no-idle',
-        permission: 'read',
-        patterns: ['**'],
-        always: [],
-      },
-    });
-
-    const promptAsync = vi.fn().mockResolvedValue(undefined);
-    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-deny-no-idle' } });
-    const subscribe = vi.fn().mockResolvedValue({ stream });
-    const permissionReply = vi.fn().mockResolvedValue({ data: {} });
-
-    createOpencodeMock.mockResolvedValue({
-      client: {
-        instance: { dispose: vi.fn() },
-        session: { create: sessionCreate, promptAsync },
-        event: { subscribe },
-        permission: { reply: permissionReply },
-      },
-      server: { close: vi.fn() },
-    });
-
-    const client = new OpenCodeClient();
-    const result = await Promise.race([
-      client.call('coder', 'hello', {
-        cwd: '/tmp',
-        model: 'opencode/big-pickle',
-        permissionMode: 'edit',
-        allowedTools: [],
-      }),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timed out')), 500)),
-    ]);
-
-    expect(result.status).toBe('error');
-    expect(result.content).toContain('OpenCode permission rejected: read');
-    expect(permissionReply).toHaveBeenCalledWith({
-      requestID: 'perm-deny-no-idle',
-      directory: '/tmp',
-      reply: 'reject',
-    }, expect.any(Object));
-    expect(stream.returnSpy).toHaveBeenCalled();
-  });
-
   it('should wait for rejected permission promptAsync settlement before releasing same config queue', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const firstPrompt = deferred();
@@ -2206,16 +2192,19 @@ describe('OpenCodeClient stream cleanup', () => {
     const permissionReply = vi.fn().mockResolvedValue({ data: {} });
     const subscribe = vi.fn()
       .mockResolvedValueOnce({
-        stream: new StallingEventStream({
-          type: 'permission.asked',
-          properties: {
-            id: 'perm-reject-before-queue',
-            sessionID: 'session-permission-reject',
-            permission: 'read',
-            patterns: ['**'],
-            always: [],
+        stream: new MockEventStream([
+          {
+            type: 'permission.asked',
+            properties: {
+              id: 'perm-reject-before-queue',
+              sessionID: 'session-permission-reject',
+              permission: 'read',
+              patterns: ['**'],
+              always: [],
+            },
           },
-        }),
+          { type: 'session.idle', properties: { sessionID: 'session-permission-reject' } },
+        ]),
       })
       .mockResolvedValueOnce({
         stream: new MockEventStream([
@@ -2256,8 +2245,8 @@ describe('OpenCodeClient stream cleanup', () => {
     firstPrompt.resolve();
 
     const [firstResult, secondResult] = await Promise.all([firstCall, secondCall]);
-    expect(firstResult.status).toBe('error');
-    expect(firstResult.content).toContain('OpenCode permission rejected: read');
+    expect(firstResult.status).not.toBe('error');
+    expect(firstResult.error).toBeUndefined();
     expect(secondResult.status).toBe('done');
     expect(sessionCreate).toHaveBeenCalledTimes(2);
     expect(promptAsync).toHaveBeenCalledTimes(2);

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2080,6 +2080,81 @@ describe('OpenCodeClient stream cleanup', () => {
     }, expect.any(Object));
   });
 
+  it('should fail instead of reporting success when the stream is aborted without throwing', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const abortController = new AbortController();
+    // Ends only when the stream abort signal fires (mirrors SSE behaviour):
+    // the loop then falls through without an exception and the post-loop
+    // guard must turn the aborted stream into an error, not a success.
+    const buildAbortEndingStream = (signal: AbortSignal) => {
+      let emitted = false;
+      return {
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+        next(): Promise<{ done: boolean; value?: unknown }> {
+          if (!emitted) {
+            emitted = true;
+            return Promise.resolve({
+              done: false,
+              value: {
+                type: 'permission.asked',
+                properties: {
+                  id: 'perm-stall',
+                  sessionID: 'session-stall',
+                  permission: 'read',
+                  patterns: ['**'],
+                  always: [],
+                },
+              },
+            });
+          }
+          return new Promise((resolve) => {
+            if (signal.aborted) {
+              resolve({ done: true });
+              return;
+            }
+            signal.addEventListener('abort', () => resolve({ done: true }), { once: true });
+          });
+        },
+        return: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+      };
+    };
+    const permissionReply = vi.fn().mockImplementation(() => {
+      // 最初の（そして唯一の）イベント処理後に外部 abort を発生させる
+      queueMicrotask(() => abortController.abort());
+      return Promise.resolve({ data: {} });
+    });
+    const subscribe = vi.fn().mockImplementation(
+      (_args: unknown, opts: { signal: AbortSignal }) =>
+        Promise.resolve({ stream: buildAbortEndingStream(opts.signal) }),
+    );
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-stall' } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+        },
+        event: { subscribe },
+        permission: { reply: permissionReply },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const result = await client.call('coder', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      permissionMode: 'edit',
+      allowedTools: [],
+      abortSignal: abortController.signal,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.content).toContain('abort');
+  });
+
   it('should pass the external_directory deny in the server config', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -1038,6 +1038,16 @@ export class OpenCodeClient {
           }
         }
 
+        // The idle watchdog and external aborts cancel the stream. If the
+        // iterator ends without throwing, the loop falls through with
+        // success still true - do not let a timed-out or aborted stream
+        // pass as a completed call (a stalled stream after a rejected
+        // permission would otherwise be reported as done).
+        if (success && streamAbortController.signal.aborted && (abortCause === 'timeout' || abortCause === 'external')) {
+          success = false;
+          failureMessage = abortCause === 'timeout' ? timeoutMessage : OPENCODE_STREAM_ABORTED_MESSAGE;
+        }
+
         content = [...textContentParts.values()].join('\n');
         if (!success && !streamAbortController.signal.aborted) {
           streamAbortController.abort();

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -176,6 +176,14 @@ async function createSharedServer(
       config: {
         model,
         small_model: model,
+        // Session-level permission rules are rewritten whenever a prompt
+        // carries a tools map (OpenCode materializes the map into
+        // session.permission), so session-scoped denies do not survive the
+        // first prompt. Server-config permission is outside that rewrite and
+        // is the only layer that reliably keeps out-of-workspace access a
+        // soft tool error instead of an ask (which would depend on the
+        // user's global OpenCode config).
+        permission: { external_directory: 'deny' },
         ...(apiKey ? { provider: { opencode: { options: { apiKey } } } } : {}),
         agent: {
           [TAKT_AGENT]: {
@@ -859,9 +867,15 @@ export class OpenCodeClient {
                   'OpenCode permission reply timed out',
                 );
                 if (reply === 'reject') {
-                  success = false;
-                  failureMessage = buildPermissionRejectedMessage(permProps.permission);
-                  break;
+                  // A rejected permission is a per-tool failure, not a fatal
+                  // one: OpenCode returns the rejection to the model as a tool
+                  // error and generation continues (verified against a live
+                  // server). Aborting here used to turn a single stray
+                  // out-of-workspace access into a whole-step failure.
+                  log.debug(buildPermissionRejectedMessage(permProps.permission), {
+                    permission: permProps.permission,
+                    patterns: permProps.patterns,
+                  });
                 }
               } catch (e) {
                 success = false;

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -872,7 +872,7 @@ export class OpenCodeClient {
                   // error and generation continues (verified against a live
                   // server). Aborting here used to turn a single stray
                   // out-of-workspace access into a whole-step failure.
-                  log.debug(buildPermissionRejectedMessage(permProps.permission), {
+                  log.info(buildPermissionRejectedMessage(permProps.permission), {
                     permission: permProps.permission,
                     patterns: permProps.patterns,
                   });

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -211,11 +211,12 @@ export type OpenCodeAllowedTools = readonly string[];
  * restriction is enforced by the explicit per-prompt tools map instead
  * (see buildOpenCodePromptTools).
  *
- * `external_directory` is denied explicitly: the permission auto-reply
- * rejects unknown permission kinds and a rejected ask aborts the whole call,
- * so leaving it unruled turns an agent's stray out-of-workspace access into
- * a step failure. A session-scoped deny keeps it a silent tool error the
- * agent can recover from.
+ * `external_directory` is denied explicitly. Note that this session-scoped
+ * rule only holds until the first prompt: a prompt-level tools map is
+ * materialized into `session.permission` by OpenCode and replaces this
+ * ruleset. The authoritative deny lives in the server config passed to
+ * `createOpencode` (see client.ts), which the rewrite does not touch; the
+ * rule here covers the window before the first prompt.
  */
 export function buildOpenCodeSessionPermission(
   mode?: PermissionMode,


### PR DESCRIPTION
## 問題

ベンチ実走で、モデルがワークスペース外のパスを探索した瞬間にステップごと死ぬ事象が多発した（当日の gemma combo 成功率 1/4）。モデルの探索先は訓練知識由来の `~/.claude/rules/*`、リポジトリ親ディレクトリ、自分の cwd のタイポ（qwen-**s-**coder…）の3類型。

## 根本原因（実サーバ・実データで検証済み）

1. TAKT が毎プロンプト送る tools マップ（#948 の固着対策）を、**opencode が session.permission に実体化してセッション作成時のルールセットを丸ごと置き換える**（セッション DB の実物で確認: external_directory deny と edit/write 緩和が消えツールID別ルールのみ残る）
2. ルール消失後の external_directory はユーザーのグローバル opencode config に落ち、`ask` が発動
3. TAKT の自動応答が reject を返した後、**クライアント自身が reject を致命扱いして break** → 並列サブステップ error → ワークフロー abort（50分の走行が迷いRead 1回で全損）

再現・対策はライブスパイク7本で確定: tools マップ送信で ask 再現（実走と同一パターン）、サーバ config 層の deny は書き換えの影響圏外で ask が発生せず、モデルはツール失敗を受けて正常続行する。

## 変更

- `createOpencode` のサーバ config に `permission: { external_directory: 'deny' }` を追加（権威はここ。セッションルールは初回プロンプトまでの窓のみ有効と型コメントに明記）
- permission reject を非致命化: reply 送信後も stream を消費し続ける（生成はサーバ側で継続。停滞時は既存の10分無応答ウォッチドッグが上限）
- codex レビュー反映: watchdog / 外部 abort でイテレータが例外なしに終了した場合に成功として素通りしないよう、ループ後に timeout/external abort を明示的に error 化
- テスト: 旧 fail-fast 契約の書き換え、サーバ config deny の固定テスト、abort 終了ストリームのガード テストを追加

## 検証

- ユニット 1690/1691 パス（1件は worktree 環境固有の ACP stdio テスト、main では通過確認済み・本変更と無関係）、lint / build クリーン、e2e smoke 20/20
- ライブスパイク: deny 有効時、モデルは外部 Read をツール失敗として受け「CANNOT_READ」を返し正常完走（ask ゼロ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 権限要求が拒否された場合でも、致命的な失敗扱いで処理を中断しないよう挙動を調整しました。
  * ストリームが例外なく終了しても、タイムアウト／外部中断時のみ正しくエラー情報が設定されるよう改善しました。
* **Tests**
  * ストリーム中断や権限拒否時の結果ステータスを確認するテストを追加・更新しました。
  * 権限拒否時の挙動を検証するケースのストリーム生成方法を見直しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->