### PR TITLE
feat: add rescan-semantics eval suite for the implementation-semantics reviewer

### DIFF
--- a/eval/promptfooconfig.rescan-semantics.yaml
+++ b/eval/promptfooconfig.rescan-semantics.yaml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+#
+# Prompt quality eval for TAKT facets: 2周目レビューの再走査（rescan evidence）の
+# coding-review 断面。前回指摘が解消済みの文脈で、残存する既知欠陥を
+# coding-review 視点の再走査で検出できるかを測る。
+# ローカルモデルは opencode CLI 経由（実プロバイダ認証が必要）。
+# 実行: npm run eval:prompts -- rescan-coding
+
+description: 'TAKT facet eval: deep-peer-review / implementation-semantics-review round-2 re-scan'
+
+prompts:
+  - file://prompts/rescan-semantics.phase1.md
+
+providers:
+  - id: 'exec: bash providers/opencode-review.sh ollama-cloud/gemma4:31b fixtures/inventory-es'
+    label: gemma4-31b
+
+tests:
+  - description: 'round-2: resolved previous findings must not suppress a full re-scan'
+    vars:
+      task: file://cases/inventory-review-task.md
+      previous_response: file://cases/prev-review-inventory-round2.md
+    assert:
+      - type: javascript
+        metric: rescan/evidence-table-present
+        value: |
+          const ok = /再走査証跡|Re-scan Evidence/i.test(output);
+          return ok;
+      - type: javascript
+        metric: recall/prototype-pollution-dict
+        value: |
+          const ok = /toString|hasOwn|プロトタイプ|in 演算子|継承プロパティ/.test(output);
+          return ok;
+      - type: javascript
+        metric: recall/derived-value-dual-bookkeeping
+        value: |
+          return /(導出|重複管理|二重|別々に管理|単一情報源)/.test(output) &&
+            /(reserved|version|合計)/i.test(output);
+      - type: javascript
+        metric: recall/silent-ignore
+        value: |
+          const ok = /(サイレント|黙って|無視|握りつぶ|検知できず|fail-?fast)/i.test(output);
+          return ok;
+      - type: javascript
+        metric: recall/naming-meaning-mismatch
+        value: |
+          return /(命名|名前)/.test(output) &&
+            /(乖離|不一致|ずれ|一致しない)/.test(output);
+      - type: javascript
+        metric: precision/no-fabricated-citations
+        value: |
+          // 行番号付き引用（事実主張）のみ検査する。
+          const cited = [...output.matchAll(/((?:src|tests)\/[\w./-]+\.ts):\d+/g)].map((m) => m[1]);
+          const allowed = new Set([
+            'src/index.ts', 'src/types.ts',
+            'tests/domain.test.ts', 'tests/event-store.test.ts',
+            'tests/command-handler.test.ts', 'tests/projection.test.ts',
+          ]);
+          const bad = [...new Set(cited.filter((c) => !allowed.has(c)))];
+          return {
+            pass: bad.length === 0,
+            score: bad.length === 0 ? 1 : 0,
+            reason: bad.length === 0 ? 'all line-cited files exist' : `fabricated citations: ${bad.join(', ')}`,
+          };
+      - type: javascript
+        metric: verdict/reject
+        value: |
+          // verdict 値を語として抽出し REJECT と厳密比較する（REJECTED 等の誤マッチ防止）
+          const labeled = [...output.matchAll(/(?:結果|判定|Verdict)[^\w\n]{0,12}(\w+)/g)].map((m) => m[1]);
+          const headings = [...output.matchAll(/^#+ *(\w+)/gm)].map((m) => m[1]);
+          const inline = /\(REJECT\)|\*\*REJECT\*\*/.test(output);
+          return inline || [...labeled, ...headings].some((v) => v.toUpperCase() === 'REJECT');

--- a/eval/scripts/prepare.mjs
+++ b/eval/scripts/prepare.mjs
@@ -45,6 +45,7 @@ const TARGETS = [
   // スナップショット（Source Path）を inventory-es 側に生成する専用エントリが必要
   { id: 'rescan', workflow: 'peer-review', step: 'arch-review', fixture: 'eval/fixtures/inventory-es' },
   { id: 'rescan-coding', workflow: 'peer-review', step: 'coding-review', fixture: 'eval/fixtures/inventory-es' },
+  { id: 'rescan-semantics', workflow: 'deep-peer-review', step: 'implementation-semantics-review', fixture: 'eval/fixtures/inventory-es' },
   { id: 'frontend-implement', workflow: 'frontend', step: 'implement', fixture: 'eval/fixtures/frontend-app', mutable: true },
   { id: 'cqrs-implement', workflow: 'backend-cqrs', step: 'implement', fixture: 'eval/fixtures/backend-cqrs', mutable: true },
 ];

--- a/eval/scripts/run-evals.mjs
+++ b/eval/scripts/run-evals.mjs
@@ -21,6 +21,7 @@ const SUITES = {
   cqrs: 'promptfooconfig.cqrs.yaml',
   rescan: 'promptfooconfig.rescan.yaml',
   'rescan-coding': 'promptfooconfig.rescan-coding.yaml',
+  'rescan-semantics': 'promptfooconfig.rescan-semantics.yaml',
   'frontend-coder': 'promptfooconfig.frontend-coder.yaml',
   'cqrs-coder': 'promptfooconfig.cqrs-coder.yaml',
 };
@@ -40,7 +41,7 @@ for (const name of names) {
 }
 // rescan / rescan-coding はローカルモデル（要 opencode 認証）を含む測定用スイートで、
 // 弱いモデルの行は常に部分失敗するため、デフォルトのゲート実行からは除外する。
-const DEFAULT_EXCLUDED = new Set(['rescan', 'rescan-coding']);
+const DEFAULT_EXCLUDED = new Set(['rescan', 'rescan-coding', 'rescan-semantics']);
 const selected = names.length > 0 ? names : Object.keys(SUITES).filter((s) => !DEFAULT_EXCLUDED.has(s));
 
 const summary = [];


### PR DESCRIPTION
## 内容

#958 で新設した実装意味論レビュアーの断面測定スイート。prepare に rescan-semantics ターゲット（deep-peer-review / implementation-semantics-review、fixture: inventory-es）を追加し、カテゴリ単位のアサート（プロトタイプ汚染辞書・導出値の二重管理・サイレント無視・命名乖離 + 共通の捏造引用/判定チェック）で測定する。デフォルト実行からは除外（要 opencode 認証の測定用スイート）。

## 初回測定（gemma4:31b、repeat 3）

| カテゴリ | 検出 |
|---------|------|
| プロトタイプ汚染（Record 辞書 + in 演算子） | **3/3** |
| 導出値の二重管理 | **3/3** |
| サイレント無視（fail-fast 違反） | **3/3** |
| 命名と意味の乖離 | 1/3 |
| 捏造引用 | 0（3/3 クリーン） |

上位3カテゴリは**これまでどのレビュアー断面も一度も検出できなかった欠陥クラス**で、judge が実走コードを減点した筆頭項目と一致する。役割境界も機能しており、モノリス等の他レビュアー担当領域への越境指摘なし。