### PR TITLE
[#950] preserve-cursor-config-dir

### DIFF
--- a/src/__tests__/runtime-environment.test.ts
+++ b/src/__tests__/runtime-environment.test.ts
@@ -18,6 +18,7 @@ describe('prepareRuntimeEnvironment', () => {
     'npm_config_cache',
     'GH_CONFIG_DIR',
     'GLAB_CONFIG_DIR',
+    'CURSOR_CONFIG_DIR',
     'HOME',
   ] as const;
   const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
@@ -247,6 +248,60 @@ describe('prepareRuntimeEnvironment', () => {
 
     expect(result).toBeDefined();
     expect(result?.injectedEnv.GLAB_CONFIG_DIR).toBe(explicitDir);
+  });
+
+  it('should preserve CURSOR_CONFIG_DIR when already set in environment', () => {
+    const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+    tempDirs.push(cwd);
+
+    const customCursorDir = '/custom/cursor/config';
+    process.env['CURSOR_CONFIG_DIR'] = customCursorDir;
+
+    const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+    expect(result).toBeDefined();
+    expect(result?.injectedEnv.CURSOR_CONFIG_DIR).toBe(customCursorDir);
+  });
+
+  it('should use XDG_CONFIG_HOME/cursor when CURSOR_CONFIG_DIR is unset', () => {
+    const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+    tempDirs.push(cwd);
+    const fakeHome = mkdtempSync(join(systemTmpDir, 'takt-fake-home-'));
+    tempDirs.push(fakeHome);
+    const fakeXdgConfig = mkdtempSync(join(systemTmpDir, 'takt-xdg-config-'));
+    tempDirs.push(fakeXdgConfig);
+
+    delete process.env['CURSOR_CONFIG_DIR'];
+    process.env['HOME'] = fakeHome;
+    process.env['XDG_CONFIG_HOME'] = fakeXdgConfig;
+
+    const runtimeConfigDir = join(cwd, '.takt', '.runtime', 'config');
+    const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+    expect(result).toBeDefined();
+    expect(result?.injectedEnv.XDG_CONFIG_HOME).toBe(runtimeConfigDir);
+    expect(result?.injectedEnv.CURSOR_CONFIG_DIR).toBe(join(fakeXdgConfig, 'cursor'));
+    expect(result?.injectedEnv.CURSOR_CONFIG_DIR).not.toBe(join(runtimeConfigDir, 'cursor'));
+  });
+
+  it('should fallback to ~/.cursor when CURSOR_CONFIG_DIR and XDG_CONFIG_HOME are unset', () => {
+    const cwd = mkdtempSync(join(systemTmpDir, 'takt-runtime-env-'));
+    tempDirs.push(cwd);
+    const fakeHome = mkdtempSync(join(systemTmpDir, 'takt-fake-home-'));
+    tempDirs.push(fakeHome);
+
+    delete process.env['CURSOR_CONFIG_DIR'];
+    delete process.env['XDG_CONFIG_HOME'];
+    process.env['HOME'] = fakeHome;
+
+    const runtimeConfigDir = join(cwd, '.takt', '.runtime', 'config');
+    const result = prepareRuntimeEnvironment(cwd, { prepare: ['node'] });
+
+    expect(result).toBeDefined();
+    expect(result?.injectedEnv.XDG_CONFIG_HOME).toBe(runtimeConfigDir);
+    expect(result?.injectedEnv.CURSOR_CONFIG_DIR).toBe(join(fakeHome, '.cursor'));
+    expect(result?.injectedEnv.CURSOR_CONFIG_DIR).not.toBe(join(fakeHome, '.config', 'cursor'));
+    expect(result?.injectedEnv.CURSOR_CONFIG_DIR).not.toBe(join(runtimeConfigDir, 'cursor'));
   });
 
 });

--- a/src/core/runtime/runtime-environment.ts
+++ b/src/core/runtime/runtime-environment.ts
@@ -44,9 +44,28 @@ function resolveGlabConfigDir(): string {
   return join(xdgBase, 'glab-cli');
 }
 
+/**
+ * Resolve the Cursor CLI config directory to preserve across runtime.prepare.
+ * Cursor honors CURSOR_CONFIG_DIR (highest precedence, points directly at the
+ * config dir) and otherwise XDG_CONFIG_HOME/cursor; its default is ~/.cursor
+ * (NOT ~/.config/cursor). Must be evaluated against the ORIGINAL process.env,
+ * i.e. before createBaseEnvironment's XDG_CONFIG_HOME override is applied to
+ * process.env (which happens later in prepareRuntimeEnvironment).
+ */
+function resolveCursorConfigDir(): string {
+  if (process.env['CURSOR_CONFIG_DIR']) {
+    return process.env['CURSOR_CONFIG_DIR'];
+  }
+  if (process.env['XDG_CONFIG_HOME']) {
+    return join(process.env['XDG_CONFIG_HOME'], 'cursor');
+  }
+  return join(process.env['HOME']!, '.cursor');
+}
+
 function createBaseEnvironment(runtimeRoot: string): Record<string, string> {
   const ghConfigDir = preserveToolConfigDir('GH_CONFIG_DIR', 'gh');
   const glabConfigDir = resolveGlabConfigDir();
+  const cursorConfigDir = resolveCursorConfigDir();
   return {
     TMPDIR: join(runtimeRoot, 'tmp'),
     XDG_CACHE_HOME: join(runtimeRoot, 'cache'),
@@ -55,6 +74,7 @@ function createBaseEnvironment(runtimeRoot: string): Record<string, string> {
     CI: 'true',
     GH_CONFIG_DIR: ghConfigDir,
     GLAB_CONFIG_DIR: glabConfigDir,
+    CURSOR_CONFIG_DIR: cursorConfigDir,
   };
 }
 


### PR DESCRIPTION
## Summary

`runtime.prepare` を使うと `XDG_CONFIG_HOME` が worktree 内（`<cwd>/.takt/.runtime/config`）へ差し替わります。このため `provider: cursor` が本来の設定ディレクトリ `~/.cursor` を参照できなくなっていました。すでに保護されている `gh`（`GH_CONFIG_DIR`）・`glab`（`GLAB_CONFIG_DIR`）と同じ扱いを cursor にも追加しています。

Closes #950

## 直したい問題

worktree 内には空の `cli-config.json` しか置かれず、`auth.json` も存在しません。そのため cursor がユーザーの整備した allowlist と認証を見失い、全 OS でサイレントに無効化されてしまいます（S1）。あわせて、並列 sub-step の reviewers が worktree 内 `.../cursor/cli-config.json.tmp` を open する際に `ENOENT` を起こし、workflow が abort することがあります（S2）。

`gh`・`glab` は元の設定ディレクトリを保持できていましたが、cursor だけ同じ保護が抜けておりました。今回 cursor にも同等の保護を入れて S1 を根本から解消いたします。S2 の残余は既存のリトライ（#819）で緩和される想定です。

## 変更点

`src/core/runtime/runtime-environment.ts` に `resolveCursorConfigDir()` を追加し、`createBaseEnvironment` で `CURSOR_CONFIG_DIR` を注入しております。解決の順序は次のとおりです。`XDG_CONFIG_HOME` が worktree 内へ上書きされる前の元の `process.env` を読む点は、gh・glab と同じ前提です。

1. `CURSOR_CONFIG_DIR` が設定済みであれば、その値をそのまま用いる
2. 未設定で `XDG_CONFIG_HOME` があれば `<XDG_CONFIG_HOME>/cursor`
3. どちらも未設定であれば `<HOME>/.cursor`

cursor の既定は `~/.config/cursor` ではなく `~/.cursor` のため、`preserveToolConfigDir` は流用せず、`resolveGlabConfigDir` にならって専用のリゾルバにしております。

## テスト

`src/__tests__/runtime-environment.test.ts` に 3 ケース追加しました。

1. `CURSOR_CONFIG_DIR` が設定済みのときは、その値を保持する
2. 未設定で `XDG_CONFIG_HOME` があるときは `<XDG_CONFIG_HOME>/cursor` を使う
3. どちらも未設定のときは `~/.cursor` へフォールバックする（`~/.config/cursor` や worktree 内を指さないことも確認）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cursor の設定ディレクトリが正しく解決されるようになりました。
  * `CURSOR_CONFIG_DIR` が設定済みの場合はその値を優先し、未設定時は `XDG_CONFIG_HOME/cursor`、さらに未設定なら `~/.cursor` を使います。
  * 環境変数の注入内容がより安定し、起動時の設定反映が一貫するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->