### PR TITLE
fix: treat empty raw-finding location and suggestion as unset

### DIFF
--- a/src/__tests__/finding-manager-output-validation.test.ts
+++ b/src/__tests__/finding-manager-output-validation.test.ts
@@ -414,6 +414,25 @@ describe('finding-schemas backward compatibility', () => {
     expect(parsed[0]?.targetFindingId).toBeUndefined();
   });
 
+  it('should treat empty location and suggestion from structured output as unset', () => {
+    const parsed = parseReviewerRawFindings([
+      {
+        rawFindingId: 'raw-confirm',
+        familyTag: 'bug',
+        severity: 'low',
+        title: 'Confirmed fixed',
+        description: 'Verified at src/index.ts:42.',
+        kind: 'resolution_confirmation',
+        targetFindingId: 'F-0001',
+        location: '',
+        suggestion: '',
+      },
+    ]);
+
+    expect(parsed[0]?.location).toBeUndefined();
+    expect(parsed[0]?.suggestion).toBeUndefined();
+  });
+
   it('should treat an empty targetFindingId from structured output as unset', () => {
     const parsed = parseReviewerRawFindings([
       {

--- a/src/core/models/finding-schemas.ts
+++ b/src/core/models/finding-schemas.ts
@@ -61,9 +61,11 @@ export const RawFindingSchema = z.object({
   familyTag: nonEmptyString,
   severity: FindingSeveritySchema,
   title: nonEmptyString,
-  location: nonEmptyString.optional(),
+  // 構造化出力の strict 様式では全プロパティが required になるため、
+  // 該当なしの欄は空文字で埋められる。空文字は未指定として扱う。
+  location: z.string().optional().transform((value) => (value ? value : undefined)),
   description: nonEmptyString,
-  suggestion: nonEmptyString.optional(),
+  suggestion: z.string().optional().transform((value) => (value ? value : undefined)),
   kind: z.enum(RAW_FINDING_KINDS).optional(),
   targetFindingId: nonEmptyString.optional(),
 }).strict();
@@ -73,9 +75,11 @@ export const ReviewerRawFindingSchema = z.object({
   familyTag: nonEmptyString,
   severity: FindingSeveritySchema,
   title: nonEmptyString,
-  location: nonEmptyString.optional(),
+  // 構造化出力の strict 様式では全プロパティが required になるため、
+  // 該当なしの欄は空文字で埋められる。空文字は未指定として扱う。
+  location: z.string().optional().transform((value) => (value ? value : undefined)),
   description: nonEmptyString,
-  suggestion: nonEmptyString.optional(),
+  suggestion: z.string().optional().transform((value) => (value ? value : undefined)),
   kind: z.enum(RAW_FINDING_KINDS).optional(),
   // 構造化出力の strict 様式では全プロパティが required になるため、
   // issue 行は空文字で埋める。空文字は未指定として扱う。
@@ -249,9 +253,15 @@ export const RawFindingsOutputJsonSchema = {
           },
           severity: { enum: FINDING_SEVERITIES },
           title: { type: 'string', minLength: 1 },
-          location: { type: 'string', minLength: 1 },
+          location: {
+            type: 'string',
+            description: 'file:line evidence. Empty string when not applicable.',
+          },
           description: { type: 'string', minLength: 1 },
-          suggestion: { type: 'string', minLength: 1 },
+          suggestion: {
+            type: 'string',
+            description: 'Fix direction. Empty string when not applicable (e.g. resolution confirmations).',
+          },
         },
       },
     },


### PR DESCRIPTION
## 問題

解消確認（#961）の初の実戦投入で、bench の2周目が必ず死ぬことが判明した。

- strict な構造化出力様式は全プロパティ必須のため、修正案が存在しない解消確認エントリは `suggestion: ""` を出すしかない
- ところが JSON スキーマは location / suggestion に minLength 1 を要求しており、「空 = 該当なし」を表現する手段がなかった
- スキーマ違反 → サブステップ error → 並列ステップごと死亡（確認が初めて出る2周目で必ず発生）

## 変更

targetFindingId で導入済みの「空文字 = 未指定」の規約を location / suggestion にも適用。

- JSON スキーマ: minLength を外し、空文字が該当なしを意味することを description に明記
- レビュアー側 Zod: 空文字を undefined に変換（台帳側の非空不変条件は維持）

## 検証

- 空文字 → 未指定の変換テスト追加、finding 系スイート 71 件パス
- 全シャード green（既知の worktree 環境固有 ACP 1件のみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 空文字の入力を未設定として扱うようになり、出力データの扱いがより一貫しました。
  * 一部の項目で、空欄のままでも正しく保存・検証されるようになりました。
* **Tests**
  * 空文字の値が未設定として扱われるケースのテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->