### PR TITLE
feat: retry invalid reviewer structured output once with a corrective prompt

### DIFF
--- a/src/__tests__/workflow-engine-structured-caller.test.ts
+++ b/src/__tests__/workflow-engine-structured-caller.test.ts
@@ -680,6 +680,113 @@ describe('WorkflowEngine structured caller defaults', () => {
     expect(result.stepOutputs.has('fix')).toBe(true);
   });
 
+  it('parallel sub-step の構造化出力が壊れていたら同一セッションで1回是正して続行する', async () => {
+    const initialLedger = {
+      version: 1,
+      workflowName: 'structured-retry-test',
+      nextId: 1,
+      updatedAt: '2026-06-13T00:00:00.000Z',
+      findings: [],
+      rawFindings: [],
+      conflicts: [],
+    };
+
+    let reviewerCalls = 0;
+    vi.mocked(runAgent).mockImplementation(async (_persona, instruction, options) => {
+      options?.onPromptResolved?.({ systemPrompt: 'system', userInstruction: instruction });
+      const schemaText = options?.outputSchema ? JSON.stringify(options.outputSchema) : '';
+      if (schemaText.includes('"matches"')) {
+        return {
+          persona: 'findings-manager',
+          status: 'done',
+          content: '{}',
+          structuredOutput: {
+            matches: [], newFindings: [], resolvedFindings: [], reopenedFindings: [], conflicts: [], resolvedConflicts: [],
+          },
+          timestamp: new Date('2026-06-13T00:00:03.000Z'),
+        };
+      }
+      if (schemaText.includes('"rawFindings"')) {
+        reviewerCalls += 1;
+        if (reviewerCalls === 1) {
+          // 1回目: スキーマ違反（タイポキー）の構造化出力
+          return {
+            persona: 'reviewer',
+            status: 'done',
+            content: 'Review report body.',
+            structuredOutput: { rawFindings: [{ rawFindingId: 'raw-1', efamilyTag: 'bug' }] },
+            timestamp: new Date('2026-06-13T00:00:01.000Z'),
+          };
+        }
+        // 2回目（是正コール）: 正しい出力
+        expect(instruction).toContain('failed schema validation');
+        return {
+          persona: 'reviewer',
+          status: 'done',
+          content: '{"rawFindings": []}',
+          structuredOutput: { rawFindings: [] },
+          timestamp: new Date('2026-06-13T00:00:02.000Z'),
+        };
+      }
+      return {
+        persona: 'agent',
+        status: 'done',
+        content: 'ok',
+        timestamp: new Date('2026-06-13T00:00:04.000Z'),
+      };
+    });
+
+    const config: WorkflowConfig = {
+      name: 'structured-retry-test',
+      maxSteps: 2,
+      initialStep: 'reviewers',
+      findingContract: {
+        ledgerPath: '.takt/findings/peer-review.json',
+        rawFindingsPath: '.takt/findings/raw',
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          outputContract: 'findings-manager',
+        },
+      },
+      steps: [
+        makeStep({
+          name: 'reviewers',
+          persona: 'reviewer',
+          instruction: 'Run reviewers.',
+          parallel: [
+            makeStep({
+              name: 'solo-review',
+              persona: 'solo-reviewer',
+              instruction: 'Review.',
+              rules: [makeRule('true', 'COMPLETE')],
+            }),
+          ],
+          rules: [
+            makeRule('findings.open.count == 0', 'COMPLETE'),
+            makeRule('invalid manager output', 'ABORT', { returnValue: 'needs_fix' }),
+          ],
+        }),
+      ],
+    };
+
+    const ledgerPath = getAuthoritativeLedgerPath(cwd);
+    mkdirSync(dirname(ledgerPath), { recursive: true });
+    writeFileSync(ledgerPath, JSON.stringify(initialLedger, null, 2), 'utf-8');
+
+    const result = await new WorkflowEngine(config, cwd, 'task', {
+      projectCwd: cwd,
+      provider: 'claude',
+      reportDirName: 'test-report-dir',
+      detectRuleIndex: () => -1,
+    }).run();
+
+    expect(result.status).toBe('completed');
+    expect(reviewerCalls).toBe(2);
+    // レポート本文は元の Phase 1 出力が維持される
+    expect(result.stepOutputs.get('solo-review')?.content).toBe('Review report body.');
+  });
+
   it('parallel sub-step の phase 3 判定でも findings ガードが不成立なら採用せずフォールバックする', async () => {
     const initialLedger = {
       version: 1,
@@ -2068,14 +2175,18 @@ describe('WorkflowEngine structured caller defaults', () => {
   });
 
   it('finding_contract の parallel reviewer は旧 findings キーを raw findings として扱わない', async () => {
-    vi.mocked(runAgent).mockResolvedValueOnce({
-      persona: 'architecture-reviewer',
-      status: 'done',
-      content: 'Architecture issue found.',
-      structuredOutput: {
-        findings: [],
-      },
-      timestamp: new Date('2026-06-13T00:00:01.000Z'),
+    // Phase 1 と是正コールの両方で、旧 findings キーの不正出力を返す
+    vi.mocked(runAgent).mockImplementation(async (_persona, instruction, options) => {
+      options?.onPromptResolved?.({ systemPrompt: 'system', userInstruction: instruction });
+      return {
+        persona: 'architecture-reviewer',
+        status: 'done',
+        content: 'Architecture issue found.',
+        structuredOutput: {
+          findings: [],
+        },
+        timestamp: new Date('2026-06-13T00:00:01.000Z'),
+      };
     });
 
     const config: WorkflowConfig = {
@@ -2123,11 +2234,14 @@ describe('WorkflowEngine structured caller defaults', () => {
     }).run();
 
     expect(result.status).toBe('aborted');
+    // 是正リトライを1回挟んだうえで、なお不正なら失敗する
     expect(result.lastOutput?.error).toContain(
-      'Step "architecture-review" requires structured_output for provider "claude": $.findings is not allowed by the schema',
+      'structured output remained invalid after one correction',
     );
+    expect(result.lastOutput?.error).toContain('$.findings is not allowed by the schema');
     expect(existsSync(join(resolveFindingLedgerRoot(cwd), '.takt', 'findings', 'raw', 'test-report-dir.reviewers.json'))).toBe(false);
-    expect(vi.mocked(runAgent)).toHaveBeenCalledTimes(1);
+    // Phase 1 + 是正コールの2回
+    expect(vi.mocked(runAgent)).toHaveBeenCalledTimes(2);
   });
 
   it('finding_contract の通常 reviewer step には raw findings schema を注入しない', async () => {

--- a/src/__tests__/workflow-engine-structured-caller.test.ts
+++ b/src/__tests__/workflow-engine-structured-caller.test.ts
@@ -718,8 +718,12 @@ describe('WorkflowEngine structured caller defaults', () => {
             timestamp: new Date('2026-06-13T00:00:01.000Z'),
           };
         }
-        // 2回目（是正コール）: 正しい出力
+        // 2回目（是正コール）: 正しい出力。是正では tools を絞り、
+        // Phase 1 のイベントコールバックを引き継がないことも検証する
         expect(instruction).toContain('failed schema validation');
+        expect(options?.permissionMode).toBe('readonly');
+        expect(options?.allowedTools).toEqual([]);
+        expect(options?.onPromptResolved).toBeUndefined();
         return {
           persona: 'reviewer',
           status: 'done',

--- a/src/__tests__/workflow-engine-structured-caller.test.ts
+++ b/src/__tests__/workflow-engine-structured-caller.test.ts
@@ -822,6 +822,12 @@ describe('WorkflowEngine structured caller defaults', () => {
           status: 'rate_limited',
           content: '',
           error: 'Rate limited by provider',
+          errorKind: 'rate_limit',
+          rateLimitInfo: {
+            provider: 'claude',
+            detectedAt: new Date('2026-06-13T00:00:02.000Z'),
+            source: 'sdk_error',
+          },
           timestamp: new Date('2026-06-13T00:00:02.000Z'),
         };
       }
@@ -878,8 +884,11 @@ describe('WorkflowEngine structured caller defaults', () => {
       detectRuleIndex: () => -1,
     }).run();
 
-    // rate_limited が error に化けず、サブステップの応答として保持される
-    expect(result.stepOutputs.get('solo-review')?.status).toBe('rate_limited');
+    // rate_limited が error に化けず、メタデータごと保持される
+    const soloOutput = result.stepOutputs.get('solo-review');
+    expect(soloOutput?.status).toBe('rate_limited');
+    expect(soloOutput?.errorKind).toBe('rate_limit');
+    expect(soloOutput?.rateLimitInfo).toMatchObject({ provider: 'claude', source: 'sdk_error' });
   });
 
   it('parallel sub-step の phase 3 判定でも findings ガードが不成立なら採用せずフォールバックする', async () => {

--- a/src/__tests__/workflow-engine-structured-caller.test.ts
+++ b/src/__tests__/workflow-engine-structured-caller.test.ts
@@ -791,6 +791,97 @@ describe('WorkflowEngine structured caller defaults', () => {
     expect(result.stepOutputs.get('solo-review')?.content).toBe('Review report body.');
   });
 
+  it('是正コールが rate_limited を返したら error に潰さずそのまま伝播する', async () => {
+    const initialLedger = {
+      version: 1,
+      workflowName: 'structured-retry-ratelimit-test',
+      nextId: 1,
+      updatedAt: '2026-06-13T00:00:00.000Z',
+      findings: [],
+      rawFindings: [],
+      conflicts: [],
+    };
+
+    let reviewerCalls = 0;
+    vi.mocked(runAgent).mockImplementation(async (_persona, instruction, options) => {
+      options?.onPromptResolved?.({ systemPrompt: 'system', userInstruction: instruction });
+      const schemaText = options?.outputSchema ? JSON.stringify(options.outputSchema) : '';
+      if (schemaText.includes('"rawFindings"')) {
+        reviewerCalls += 1;
+        if (reviewerCalls === 1) {
+          return {
+            persona: 'reviewer',
+            status: 'done',
+            content: 'Review report body.',
+            structuredOutput: { rawFindings: [{ rawFindingId: 'raw-1', efamilyTag: 'bug' }] },
+            timestamp: new Date('2026-06-13T00:00:01.000Z'),
+          };
+        }
+        return {
+          persona: 'reviewer',
+          status: 'rate_limited',
+          content: '',
+          error: 'Rate limited by provider',
+          timestamp: new Date('2026-06-13T00:00:02.000Z'),
+        };
+      }
+      return {
+        persona: 'agent',
+        status: 'done',
+        content: 'ok',
+        timestamp: new Date('2026-06-13T00:00:04.000Z'),
+      };
+    });
+
+    const config: WorkflowConfig = {
+      name: 'structured-retry-ratelimit-test',
+      maxSteps: 2,
+      initialStep: 'reviewers',
+      findingContract: {
+        ledgerPath: '.takt/findings/peer-review.json',
+        rawFindingsPath: '.takt/findings/raw',
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          outputContract: 'findings-manager',
+        },
+      },
+      steps: [
+        makeStep({
+          name: 'reviewers',
+          persona: 'reviewer',
+          instruction: 'Run reviewers.',
+          parallel: [
+            makeStep({
+              name: 'solo-review',
+              persona: 'solo-reviewer',
+              instruction: 'Review.',
+              rules: [makeRule('true', 'COMPLETE')],
+            }),
+          ],
+          rules: [
+            makeRule('findings.open.count == 0', 'COMPLETE'),
+            makeRule('invalid manager output', 'ABORT', { returnValue: 'needs_fix' }),
+          ],
+        }),
+      ],
+    };
+
+    const ledgerPath = getAuthoritativeLedgerPath(cwd);
+    mkdirSync(dirname(ledgerPath), { recursive: true });
+    writeFileSync(ledgerPath, JSON.stringify(initialLedger, null, 2), 'utf-8');
+
+    const result = await new WorkflowEngine(config, cwd, 'task', {
+      projectCwd: cwd,
+      provider: 'claude',
+      reportDirName: 'test-report-dir',
+      detectRuleIndex: () => -1,
+    }).run();
+
+    // rate_limited が error に化けず、サブステップの応答として保持される
+    expect(result.stepOutputs.get('solo-review')?.status).toBe('rate_limited');
+  });
+
   it('parallel sub-step の phase 3 判定でも findings ガードが不成立なら採用せずフォールバックする', async () => {
     const initialLedger = {
       version: 1,

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -298,13 +298,20 @@ export class ParallelRunner {
               'Re-emit ONLY the corrected structured output matching the schema.',
               'Do not repeat the report text. Do not add commentary.',
             ].join('\n');
+            // 是正は JSON 再出力のみ: ツール・編集権限は不要なので絞り、
+            // Phase 1 のイベントコールバックも引き継がない。
             const correctiveResponse = await executeAgent(executableSubStep.persona, correctionInstruction, {
               ...agentOptions,
+              permissionMode: 'readonly',
+              allowedTools: [],
+              onPromptResolved: undefined,
               ...(subResponse.sessionId !== undefined ? { sessionId: subResponse.sessionId } : {}),
             });
+            // 非ネイティブ構造化出力プロバイダでは是正 JSON が content に入る
+            // ため、是正応答をそのまま正規化する（本文の差し替えはマージ時）。
             const renormalized = this.deps.stepExecutor.normalizeStructuredOutputWithDiagnostics(
               executableSubStep,
-              { ...correctiveResponse, content: subResponse.content },
+              correctiveResponse,
               runtime,
             );
             if (renormalized.invalidDetail !== undefined || renormalized.response.status !== 'done') {

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -305,6 +305,7 @@ export class ParallelRunner {
               permissionMode: 'readonly',
               allowedTools: [],
               onPromptResolved: undefined,
+              onStream: undefined,
               ...(subResponse.sessionId !== undefined ? { sessionId: subResponse.sessionId } : {}),
             });
             // 非ネイティブ構造化出力プロバイダでは是正 JSON が content に入る
@@ -314,7 +315,11 @@ export class ParallelRunner {
               correctiveResponse,
               runtime,
             );
-            if (renormalized.invalidDetail !== undefined || renormalized.response.status !== 'done') {
+            if (correctiveResponse.status === 'rate_limited' || correctiveResponse.status === 'blocked') {
+              // レート制限・ブロックは専用フロー（メタデータ伝播・バックオフ）
+              // が上位にあるため、error に潰さずそのまま伝える。
+              subResponse = correctiveResponse;
+            } else if (renormalized.invalidDetail !== undefined || renormalized.response.status !== 'done') {
               subResponse = {
                 ...subResponse,
                 status: 'error',

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -281,7 +281,46 @@ export class ParallelRunner {
           providerUsage: result.providerUsage,
         }));
         if (findingLedgerCopyPath) {
-          subResponse = this.deps.stepExecutor.normalizeStructuredOutput(executableSubStep, subResponse, runtime);
+          const normalized = this.deps.stepExecutor.normalizeStructuredOutputWithDiagnostics(executableSubStep, subResponse, runtime);
+          subResponse = normalized.response;
+          if (normalized.invalidDetail !== undefined) {
+            // 弱いモデルは大きな構造化出力で JSON を壊しやすい。1回だけ
+            // 同一セッションで是正を求め、直れば元の応答（レポート本文）に
+            // 構造化出力だけをマージして続行する。
+            log.info('Structured output invalid for parallel sub-step, requesting one correction', {
+              step: subStep.name,
+              detail: normalized.invalidDetail,
+            });
+            const correctionInstruction = [
+              'Your structured output failed schema validation:',
+              normalized.invalidDetail,
+              '',
+              'Re-emit ONLY the corrected structured output matching the schema.',
+              'Do not repeat the report text. Do not add commentary.',
+            ].join('\n');
+            const correctiveResponse = await executeAgent(executableSubStep.persona, correctionInstruction, {
+              ...agentOptions,
+              ...(subResponse.sessionId !== undefined ? { sessionId: subResponse.sessionId } : {}),
+            });
+            const renormalized = this.deps.stepExecutor.normalizeStructuredOutputWithDiagnostics(
+              executableSubStep,
+              { ...correctiveResponse, content: subResponse.content },
+              runtime,
+            );
+            if (renormalized.invalidDetail !== undefined || renormalized.response.status !== 'done') {
+              subResponse = {
+                ...subResponse,
+                status: 'error',
+                error: `Step "${subStep.name}" structured output remained invalid after one correction: ${renormalized.invalidDetail ?? renormalized.response.error ?? 'correction failed'}`,
+              };
+            } else {
+              subResponse = {
+                ...subResponse,
+                structuredOutput: renormalized.response.structuredOutput,
+                ...(correctiveResponse.sessionId !== undefined ? { sessionId: correctiveResponse.sessionId } : {}),
+              };
+            }
+          }
         }
         if (!didEmitPhaseStart) {
           throw new Error(`Missing prompt parts for phase start: ${subStep.name}:1`);

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -226,8 +226,29 @@ export class StepExecutor {
     response: AgentResponse,
     runtime?: RuntimeStepResolution,
   ): AgentResponse {
+    const result = this.normalizeStructuredOutputWithDiagnostics(step, response, runtime);
+    if (result.invalidDetail !== undefined) {
+      const provider = this.deps.optionsBuilder.resolveStepProviderModel(step, runtime).provider;
+      throw new Error(
+        `Step "${step.name}" requires structured_output for provider "${provider}": ${result.invalidDetail}`,
+      );
+    }
+    return result.response;
+  }
+
+  /**
+   * Like normalizeStructuredOutput, but returns the validation failure as a
+   * diagnostic instead of throwing, so callers can attempt a corrective
+   * retry with the agent (weak models frequently emit malformed JSON on
+   * large structured outputs).
+   */
+  normalizeStructuredOutputWithDiagnostics(
+    step: WorkflowStep,
+    response: AgentResponse,
+    runtime?: RuntimeStepResolution,
+  ): { response: AgentResponse; invalidDetail?: string } {
     if (!step.structuredOutput) {
-      return response;
+      return { response };
     }
 
     const provider = this.deps.optionsBuilder.resolveStepProviderModel(step, runtime).provider;
@@ -247,10 +268,10 @@ export class StepExecutor {
         detail,
       );
       if (fallback) {
-        return fallback;
+        return { response: fallback };
       }
       this.logStructuredOutputFailure(step, failureReason, detail);
-      return response;
+      return { response };
     }
 
     try {
@@ -274,12 +295,14 @@ export class StepExecutor {
         language: this.deps.getLanguage(),
       });
       if (structuredOutput === response.structuredOutput) {
-        return response;
+        return { response };
       }
 
       return {
-        ...response,
-        structuredOutput,
+        response: {
+          ...response,
+          structuredOutput,
+        },
       };
     } catch (error) {
       const detail = getErrorMessage(error);
@@ -290,16 +313,14 @@ export class StepExecutor {
         detail,
       );
       if (fallback) {
-        return fallback;
+        return { response: fallback };
       }
       this.logStructuredOutputFailure(
         step,
         supportsStructuredOutput !== false && response.structuredOutput === undefined ? 'missing' : 'schema_error',
         detail,
       );
-      throw new Error(
-        `Step "${step.name}" requires structured_output for provider "${provider}": ${detail}`,
-      );
+      return { response, invalidDetail: detail };
     }
   }
 


### PR DESCRIPTION
## 問題

FC ベンチの実走で、ローカルレビュアー（gemma）の2周目が構造化出力のスキーマ違反で必ず死ぬことが判明した。台帳文脈と解消確認義務（#961）でプロンプトと出力 JSON が肥大化すると、手書き JSON の品質が保てず（構文エラー、`efamilyTag` のようなタイポキー）、**1回の不正出力で並列ステップごと50分の走行が全損**する。findings-manager にはセマンティックリトライがあるのに、レビュアー側には無かった。

## 変更

- `normalizeStructuredOutput` に診断版（throw せず invalidDetail を返す）を追加し、既存メソッドはそのラッパに（throw 契約は不変）
- ParallelRunner: 検証失敗時、**同一セッションに1回だけ**「検証エラー: 〜。スキーマに合致する JSON のみ再出力せよ」と是正を要求。成功したら構造化出力だけを元応答にマージ（レポート本文は Phase 1 の原文を維持）。2回目も不正なら従来どおり致命（メッセージ改善）
- 是正コールは readonly・ツールなし・Phase 1 のイベントコールバック引き継ぎなし（codex レビュー反映: 是正 JSON を content で返す非ネイティブプロバイダでも成功するよう、是正応答をそのまま正規化）

## 検証

- 回帰テスト: タイポ出力 → 是正1回で復帰（是正コールのオプション制限もアサート）、旧キー拒否はリトライ経路込みで fail-closed 維持
- 全シャード green（既知の worktree 環境固有 ACP 1件のみ）
- codex レビュー2ラウンド（High×2/Medium×1 → 反映 → **APPROVE**）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 並列サブステップの構造化出力がスキーマ不一致の場合、同一セッション内で1回だけ是正して続行できるようになりました。
  * 是正時はレポート本文を再生成せず、修正された構造化出力のみを反映します。
  * 是正が `rate_limited` / `blocked` の場合も状態と理由情報を保持して反映します。
* **Tests**
  * 是正（correction）と旧 `findings` 形式の不正出力に関する検証を追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->