### PR TITLE
feat: use OpenCode native json_schema structured output

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2243,6 +2243,64 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(result.structuredOutput).toEqual({ rawFindings: [] });
   });
 
+  it.each([
+    {
+      name: 'broken JSON inside the fence',
+      text: 'report\n```json\n{"rawFindings": [}\n```',
+      expected: undefined,
+    },
+    {
+      name: 'array-rooted fenced JSON',
+      text: 'report\n```json\n[1, 2]\n```',
+      expected: undefined,
+    },
+    {
+      name: 'multiple fenced blocks (last one wins)',
+      text: '```json\n{"first": true}\n```\nmore text\n```json\n{"rawFindings": []}\n```',
+      expected: { rawFindings: [] },
+    },
+  ])('structured fallback edge case: $name', async ({ text, expected }) => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const schema = { type: 'object', required: ['rawFindings'], properties: { rawFindings: { type: 'array' } } };
+    const stream = new MockEventStream([
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: { id: 'part-1', type: 'text', text },
+          delta: text,
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-edge' } },
+    ]);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-edge' } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const result = await client.call('reviewer', 'review it', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      outputSchema: schema,
+    });
+
+    // 抽出に失敗しても done のまま返し、判定は下流（検証 + 是正リトライ）に委ねる
+    expect(result.status).toBe('done');
+    if (expected === undefined) {
+      expect(result.structuredOutput).toBeUndefined();
+    } else {
+      expect(result.structuredOutput).toEqual(expected);
+    }
+  });
+
   it('should pass the external_directory deny in the server config', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2155,6 +2155,94 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(result.content).toContain('abort');
   });
 
+  it('should request native structured output and capture info.structured', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const schema = { type: 'object', required: ['rawFindings'], properties: { rawFindings: { type: 'array' } } };
+    const stream = new MockEventStream([
+      {
+        type: 'message.updated',
+        properties: {
+          info: {
+            sessionID: 'session-structured',
+            role: 'assistant',
+            structured: { rawFindings: [] },
+          },
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-structured' } },
+    ]);
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-structured' } }),
+          promptAsync,
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const result = await client.call('reviewer', 'review it', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      outputSchema: schema,
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.structuredOutput).toEqual({ rawFindings: [] });
+    expect(promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: { type: 'json_schema', schema, retryCount: 2 },
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('should fall back to the trailing JSON block when structured is not emitted', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const schema = { type: 'object', required: ['rawFindings'], properties: { rawFindings: { type: 'array' } } };
+    const stream = new MockEventStream([
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: 'part-1',
+            type: 'text',
+            text: 'report text\n```json\n{"rawFindings": []}\n```',
+          },
+          delta: 'report text\n```json\n{"rawFindings": []}\n```',
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-fallback' } },
+    ]);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-fallback' } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const result = await client.call('reviewer', 'review it', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      outputSchema: schema,
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.structuredOutput).toEqual({ rawFindings: [] });
+  });
+
   it('should pass the external_directory deny in the server config', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([

--- a/src/__tests__/provider-structured-output.test.ts
+++ b/src/__tests__/provider-structured-output.test.ts
@@ -321,24 +321,23 @@ describe('OpenCodeProvider — structured output', () => {
     vi.clearAllMocks();
   });
 
-  it('supportsStructuredOutput is false', () => {
+  it('supportsStructuredOutput is true', () => {
     const provider = new OpenCodeProvider() as { supportsStructuredOutput?: boolean };
-    expect(provider.supportsStructuredOutput).toBe(false);
+    expect(provider.supportsStructuredOutput).toBe(true);
   });
 
-  it('outputSchema を callOpenCode に渡さない', async () => {
+  it('outputSchema を callOpenCode に渡す', async () => {
     mockCallOpenCode.mockResolvedValue(doneResponse('coder'));
 
     const agent = new OpenCodeProvider().setup({ name: 'coder' });
-    const result = await agent.call('prompt', {
+    await agent.call('prompt', {
       cwd: '/tmp',
       model: 'openai/gpt-4',
       outputSchema: SCHEMA,
     });
 
     const opts = mockCallOpenCode.mock.calls[0]?.[2];
-    expect(opts).not.toHaveProperty('outputSchema');
-    expect(result.structuredOutput).toBeUndefined();
+    expect(opts).toHaveProperty('outputSchema', SCHEMA);
   });
 
   it('provider_options.opencode.variant を callOpenCode に渡す', async () => {
@@ -363,19 +362,18 @@ describe('OpenCodeProvider — structured output', () => {
     });
   });
 
-  it('systemPrompt 指定時も outputSchema を callOpenCodeCustom に渡さない', async () => {
+  it('systemPrompt 指定時も outputSchema を callOpenCodeCustom に渡す', async () => {
     mockCallOpenCodeCustom.mockResolvedValue(doneResponse('judge'));
 
     const agent = new OpenCodeProvider().setup({ name: 'judge', systemPrompt: 'sys' });
-    const result = await agent.call('prompt', {
+    await agent.call('prompt', {
       cwd: '/tmp',
       model: 'openai/gpt-4',
       outputSchema: SCHEMA,
     });
 
     const opts = mockCallOpenCodeCustom.mock.calls[0]?.[3];
-    expect(opts).not.toHaveProperty('outputSchema');
-    expect(result.structuredOutput).toBeUndefined();
+    expect(opts).toHaveProperty('outputSchema', SCHEMA);
   });
 
   it('structuredOutput がない場合は undefined', async () => {

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -11,6 +11,7 @@ import type { AgentResponse } from '../../core/models/index.js';
 import { loadTemplate } from '../../shared/prompts/index.js';
 import { mapsToOpenCodeEditPermission } from './allowedTools.js';
 import { AskUserQuestionDeniedError } from '../../core/workflow/ask-user-question-error.js';
+import { parseLastJsonBlock } from '../../agents/structured-caller/shared.js';
 import { createLogger, getErrorMessage, createStreamDiagnostics, type StreamDiagnostics } from '../../shared/utils/index.js';
 import {
   getNestedObservabilityEnvFingerprint,
@@ -731,6 +732,11 @@ export class OpenCodeClient {
           ...(agentName !== undefined ? { agent: agentName } : {}),
           ...(options.variant !== undefined ? { variant: options.variant } : {}),
           ...(options.systemPrompt !== undefined ? { system: options.systemPrompt } : {}),
+          // ネイティブ構造化出力: OpenCode がスキーマのキー構造を強制する
+          // （enum 等の値制約までは保証されないため、下流のスキーマ検証は維持）。
+          ...(options.outputSchema !== undefined
+            ? { format: { type: 'json_schema' as const, schema: options.outputSchema, retryCount: 2 } }
+            : {}),
           parts: [{ type: 'text' as const, text: prompt }],
         };
         const promptPayloadForSdk = promptPayload as unknown as Parameters<typeof opencodeApiClient.session.promptAsync>[0];
@@ -748,6 +754,7 @@ export class OpenCodeClient {
 
         let content = '';
         let success = true;
+        let capturedStructuredOutput: Record<string, unknown> | undefined;
         let failureMessage = '';
         const state = createStreamTrackingState();
         const unavailableToolLoopDetector = new UnavailableToolLoopDetector();
@@ -947,11 +954,15 @@ export class OpenCodeClient {
                 role?: 'assistant' | 'user';
                 time?: { completed?: number };
                 error?: unknown;
+                structured?: unknown;
               };
             };
             const info = messageProps.info;
             const isCurrentAssistantMessage = info?.sessionID === activeSessionId && info?.role === 'assistant';
             if (isCurrentAssistantMessage) {
+              if (info?.structured !== undefined && info.structured !== null && typeof info.structured === 'object' && !Array.isArray(info.structured)) {
+                capturedStructuredOutput = info.structured as Record<string, unknown>;
+              }
               const streamError = extractOpenCodeErrorMessage(info?.error);
               if (streamError) {
                 success = false;
@@ -969,11 +980,15 @@ export class OpenCodeClient {
                 sessionID?: string;
                 role?: 'assistant' | 'user';
                 error?: unknown;
+                structured?: unknown;
               };
             };
             const info = completedProps.info;
             const isCurrentAssistantMessage = info?.sessionID === activeSessionId && info?.role === 'assistant';
             if (isCurrentAssistantMessage) {
+              if (info?.structured !== undefined && info.structured !== null && typeof info.structured === 'object' && !Array.isArray(info.structured)) {
+                capturedStructuredOutput = info.structured as Record<string, unknown>;
+              }
               const streamError = extractOpenCodeErrorMessage(info?.error);
               if (streamError) {
                 success = false;
@@ -1090,12 +1105,26 @@ export class OpenCodeClient {
         const trimmed = content.trim();
         emitResult(options.onStream, true, trimmed, activeSessionId);
 
+        // format 要求時に structured がイベントで捕捉できなかった場合は、
+        // 本文の末尾 JSON をフォールバックとして採取する（検証は下流で行う）。
+        if (capturedStructuredOutput === undefined && options.outputSchema !== undefined) {
+          try {
+            const parsed = parseLastJsonBlock(trimmed);
+            if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+              capturedStructuredOutput = parsed as Record<string, unknown>;
+            }
+          } catch {
+            // フォールバック採取の失敗は無視する（下流の検証と是正リトライに委ねる）
+          }
+        }
+
         return {
           persona: agentType,
           status: 'done',
           content: trimmed,
           timestamp: new Date(),
           sessionId: activeSessionId,
+          ...(capturedStructuredOutput !== undefined ? { structuredOutput: capturedStructuredOutput } : {}),
         };
       } catch (error) {
         const message = getErrorMessage(error);

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -1112,9 +1112,16 @@ export class OpenCodeClient {
             const parsed = parseLastJsonBlock(trimmed);
             if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
               capturedStructuredOutput = parsed as Record<string, unknown>;
+            } else {
+              log.debug('Structured output fallback found non-object JSON', { agentType });
             }
-          } catch {
-            // フォールバック採取の失敗は無視する（下流の検証と是正リトライに委ねる）
+          } catch (fallbackError) {
+            // フォールバック採取の失敗は握りつぶすが、調査用に痕跡は残す
+            // （下流の検証と是正リトライに委ねる）。
+            log.debug('Structured output fallback extraction failed', {
+              agentType,
+              error: getErrorMessage(fallbackError),
+            });
           }
         }
 

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -408,4 +408,6 @@ export interface OpenCodeCallOptions {
   opencodeApiKey?: string;
   interactionTimeoutMs?: number;
   childProcessEnv?: Readonly<Record<string, string>>;
+  /** JSON schema for native structured output (OpenCode format: json_schema). */
+  outputSchema?: Record<string, unknown>;
 }

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -47,12 +47,13 @@ function toOpenCodeOptions(options: ProviderCallOptions): OpenCodeCallOptions {
     onAskUserQuestion: options.onAskUserQuestion,
     opencodeApiKey: options.opencodeApiKey ?? resolveOpencodeApiKey(),
     childProcessEnv: options.childProcessEnv,
+    outputSchema: options.outputSchema,
   };
 }
 
 /** OpenCode provider — delegates to OpenCode SDK */
 export class OpenCodeProvider implements Provider {
-  readonly supportsStructuredOutput = false;
+  readonly supportsStructuredOutput = true;
   readonly supportsNativeImageInput = false;
 
   getRuntimeInstructions(allowedTools?: string[], permissionMode?: PermissionMode, networkAccess?: boolean): string | null {


### PR DESCRIPTION
## 問題

FC ベンチの実走で、ローカルレビュアー（gemma）に大きな rawFindings JSON を手書きさせる方式の限界が確定した。是正リトライ1回（#963）を入れても、同型のタイポキー（efamilyTag → 是正後に eFamilyTag）を再生産して走行が死ぬ。

## 根治

ライブスパイクで確認: opencode の prompt は `format: { type: 'json_schema', schema, retryCount }` を受け付け、**キー構造をネイティブに強制する**（タイポキーが構造的に不可能になる）。ただし enum 値までは強制されない（実測: severity 列挙に CRITICAL が通った）ため、既存のスキーマ検証 + #963 の是正リトライを値レベルの防波堤として維持する3段構えとする。

## 変更

- `OpenCodeCallOptions` に `outputSchema` を追加し、prompt payload に `format: json_schema`（retryCount 2）を付与（outputSchema 未指定時は従来どおり format なし）
- `message.updated` / `message.completed` の `info.structured` を捕捉して `AgentResponse.structuredOutput` に設定。未捕捉時は本文末尾のフェンス付き JSON を throw なしでフォールバック採取（検証は下流の責務）
- `OpenCodeProvider.supportsStructuredOutput = true`
- プロバイダ契約テストを新仕様に更新

## 検証

- ユニット: payload の format 付与、info.structured 捕捉、フォールバック採取、契約テスト（計 87 件のスイート群パス）
- 全シャード green（既知の worktree 環境固有 ACP 1件のみ）
- codex レビュー: 設計は承認（「実装本体にブロッカーなし」）、指摘は契約テストの旧仕様残り2件 → 反映済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenCodeで構造化出力に対応し、`outputSchema` 付きのスキーマ指定で structured output を受け取れるようになりました。
  * ネイティブなstructuredが取得できない場合でも、応答末尾のJSONから復元できるようになりました。
* **Tests**
  * structured output の取得・復元、フォールバックのエッジケース、返却有無を検証するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->