### PR TITLE
fix: fall back to formatless retry when native structured output is not produced

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2301,6 +2301,64 @@ describe('OpenCodeClient stream cleanup', () => {
     }
   });
 
+  it('should fall back to formatless retry when the model does not produce structured output', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const schema = { type: 'object', required: ['rawFindings'], properties: { rawFindings: { type: 'array' } } };
+    const subscribe = vi.fn()
+      .mockResolvedValueOnce({
+        stream: new MockEventStream([
+          {
+            type: 'message.updated',
+            properties: {
+              info: {
+                sessionID: 'session-fmt',
+                role: 'assistant',
+                error: { name: 'StructuredOutputError', data: { message: 'Model did not produce structured output' } },
+              },
+            },
+          },
+        ]),
+      })
+      .mockResolvedValueOnce({
+        stream: new MockEventStream([
+          {
+            type: 'message.part.updated',
+            properties: {
+              part: { id: 'p-1', type: 'text', text: 'report\n```json\n{"rawFindings": []}\n```' },
+              delta: 'report\n```json\n{"rawFindings": []}\n```'
+            },
+          },
+          { type: 'session.idle', properties: { sessionID: 'session-fmt' } },
+        ]),
+      });
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-fmt' } }),
+          promptAsync,
+        },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const result = await client.call('reviewer', 'review it', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      outputSchema: schema,
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.structuredOutput).toEqual({ rawFindings: [] });
+    // 1回目は format 付き、2回目（フォールバック）は format なし
+    expect(promptAsync.mock.calls[0]?.[0]).toHaveProperty('format');
+    expect(promptAsync.mock.calls[1]?.[0]).not.toHaveProperty('format');
+  });
+
   it('should pass the external_directory deny in the server config', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2354,9 +2354,69 @@ describe('OpenCodeClient stream cleanup', () => {
 
     expect(result.status).toBe('done');
     expect(result.structuredOutput).toEqual({ rawFindings: [] });
-    // 1回目は format 付き、2回目（フォールバック）は format なし
+    // 1回目は format 付き、2回目（フォールバック）は format なし。追加の再試行はしない
+    expect(promptAsync).toHaveBeenCalledTimes(2);
     expect(promptAsync.mock.calls[0]?.[0]).toHaveProperty('format');
     expect(promptAsync.mock.calls[1]?.[0]).not.toHaveProperty('format');
+  });
+
+  it('should still fall back when the format failure lands on the last transient-budget attempt', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const schema = { type: 'object', required: ['rawFindings'], properties: { rawFindings: { type: 'array' } } };
+    // transient は promptAsync 例外経路（abortCause: prompt）でのみリトライされる
+    const emptyStream = () => new MockEventStream([]);
+    const formatFailureStream = new MockEventStream([
+      {
+        type: 'message.updated',
+        properties: {
+          info: { sessionID: 'session-budget', role: 'assistant', error: { name: 'StructuredOutputError', data: { message: 'Model did not produce structured output' } } },
+        },
+      },
+    ]);
+    const successStream = new MockEventStream([
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: { id: 'p-1', type: 'text', text: 'report\n```json\n{"rawFindings": []}\n```' },
+          delta: 'report\n```json\n{"rawFindings": []}\n```',
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-budget' } },
+    ]);
+    const subscribe = vi.fn()
+      .mockResolvedValueOnce({ stream: emptyStream() })
+      .mockResolvedValueOnce({ stream: emptyStream() })
+      .mockResolvedValueOnce({ stream: formatFailureStream })
+      .mockResolvedValueOnce({ stream: successStream });
+    const promptAsync = vi.fn()
+      .mockRejectedValueOnce(new Error('transport error'))
+      .mockRejectedValueOnce(new Error('transport error'))
+      .mockResolvedValue(undefined);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-budget' } }),
+          promptAsync,
+        },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const result = await client.call('reviewer', 'review it', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      outputSchema: schema,
+    });
+
+    // transient 2回で基礎予算(3)の最終試行に format 失敗が来ても、別枠でフォールバックできる
+    expect(result.status).toBe('done');
+    expect(result.structuredOutput).toEqual({ rawFindings: [] });
+    expect(promptAsync).toHaveBeenCalledTimes(4);
+    expect(promptAsync.mock.calls[3]?.[0]).not.toHaveProperty('format');
   });
 
   it('should pass the external_directory deny in the server config', async () => {

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -571,7 +571,11 @@ export class OpenCodeClient {
     // あるため、その失敗を検出したら format なし（手書き JSON + 下流の
     // 是正リトライ）へフォールバックする。
     let disableNativeStructuredOutput = false;
-    for (let attempt = 1; attempt <= OPENCODE_RETRY_MAX_ATTEMPTS; attempt++) {
+    // フォールバック（format なし再試行）は transient 再試行の予算とは別枠で
+    // 1回だけ確保する: 先行の transient エラーで予算を使い切っていても、
+    // 最終試行の format 失敗から救済できるようにする。
+    let maxAttempts = OPENCODE_RETRY_MAX_ATTEMPTS;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
       const streamAbortController = new AbortController();
       const timeoutMessage = `OpenCode stream timed out after ${Math.floor(OPENCODE_STREAM_IDLE_TIMEOUT_MS / 60000)} minutes of inactivity`;
@@ -1093,9 +1097,9 @@ export class OpenCodeClient {
             options.outputSchema !== undefined
             && !disableNativeStructuredOutput
             && message.toLowerCase().includes('did not produce structured output')
-            && attempt < OPENCODE_RETRY_MAX_ATTEMPTS
           ) {
             disableNativeStructuredOutput = true;
+            maxAttempts = Math.max(maxAttempts, attempt + 1);
             log.info('Native structured output failed; retrying without format', { agentType, attempt });
             await this.waitForRetryDelay(attempt, options.abortSignal);
             continue;

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -567,6 +567,10 @@ export class OpenCodeClient {
     prompt: string,
     options: OpenCodeCallOptions,
   ): Promise<AgentResponse> {
+    // native format（StructuredOutput ツール）をモデルが呼ばない個体が
+    // あるため、その失敗を検出したら format なし（手書き JSON + 下流の
+    // 是正リトライ）へフォールバックする。
+    let disableNativeStructuredOutput = false;
     for (let attempt = 1; attempt <= OPENCODE_RETRY_MAX_ATTEMPTS; attempt++) {
       let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
       const streamAbortController = new AbortController();
@@ -734,7 +738,7 @@ export class OpenCodeClient {
           ...(options.systemPrompt !== undefined ? { system: options.systemPrompt } : {}),
           // ネイティブ構造化出力: OpenCode がスキーマのキー構造を強制する
           // （enum 等の値制約までは保証されないため、下流のスキーマ検証は維持）。
-          ...(options.outputSchema !== undefined
+          ...(options.outputSchema !== undefined && !disableNativeStructuredOutput
             ? { format: { type: 'json_schema' as const, schema: options.outputSchema, retryCount: 2 } }
             : {}),
           parts: [{ type: 'text' as const, text: prompt }],
@@ -1085,6 +1089,18 @@ export class OpenCodeClient {
             emitResult(options.onStream, false, rateLimitedResponse.error ?? rateLimitedResponse.content, activeSessionId);
             return rateLimitedResponse;
           }
+          if (
+            options.outputSchema !== undefined
+            && !disableNativeStructuredOutput
+            && message.toLowerCase().includes('did not produce structured output')
+            && attempt < OPENCODE_RETRY_MAX_ATTEMPTS
+          ) {
+            disableNativeStructuredOutput = true;
+            log.info('Native structured output failed; retrying without format', { agentType, attempt });
+            await this.waitForRetryDelay(attempt, options.abortSignal);
+            continue;
+          }
+
           const retriable = this.isRetriableError(message, streamAbortController.signal.aborted, abortCause);
           if (retriable && attempt < OPENCODE_RETRY_MAX_ATTEMPTS) {
             log.info('Retrying OpenCode call after transient failure', { agentType, attempt, message });


### PR DESCRIPTION
## 問題

#965 の native structured output を FC ベンチ実走に投入したところ、新たな挙動を発見した。opencode の json_schema format は **StructuredOutput という合成ツールをモデルに呼ばせる方式**で実装されており（セッション DB の実物で確認）、gemma はツール多用のレビュー後にこのツールを呼ばずに終わることがある。その場合 opencode の内部リトライ（retryCount 2）でも救えず、「Model did not produce structured output」でコールが失敗し、並列ステップごと走行が死ぬ。

## 変更

この失敗を検出したら **format なしで1回だけ再試行**する（既存の attempt 予算内）。フォールバック後は従来の手書き JSON 経路 + 下流のスキーマ検証 + 是正リトライ（#963）が受ける。

- native 強制が効く場合: タイポキー根絶（第一選択のまま）
- モデルが StructuredOutput ツールを呼ばない場合: 走行を殺さずに旧経路へ委譲

## 検証

- ユニット: 1回目 format 付き失敗 → 2回目 format なしで成功し、payload から format が外れることをアサート（64/64）
- 全シャード green（既知の worktree 環境固有 ACP 1件のみ）
- codex レビュー: **指摘なし APPROVE**（誤検出時の影響が再試行に限定されること・attempt 予算整合・フォールバック一回性を確認済み）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * SDKのネイティブ構造化出力が失敗した場合、出力形式を切り替えて再試行するフォールバックを追加しました。
  * 再試行の際に追加試行回数を動的に拡張し、回復経路を強化しました。
* **バグ修正**
  * `outputSchema` 設定時でも、必要に応じて `format` 付与を抑制する挙動を調整し、安定した結果取得を支援します。
* **テスト**
  * フォールバック時の回復パターン（トランジェント失敗やストリーム再購読含む）を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->