### PR TITLE
[codex] require MCP task workflow and auto PR decisions

### DIFF
--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -162,14 +162,14 @@ codex mcp add takt -- takt-mcp
 |-----------|----|------|
 | `cwd` | 絶対パス文字列 | `.takt/tasks.yaml` を書き込む project root。 |
 | `task` | string | タスク指示書本文。 |
+| `workflow` | string | Workflow 名またはパス。MCP caller はタスク投入前に使用する workflow を確認する必要があります。 |
+| `autoPr` | boolean | 自動 PR を有効にしたタスクとして保存するかどうか。MCP caller はタスク投入前に確認する必要があります。 |
 
 任意入力:
 
 | フィールド | 型 | 説明 |
 |-----------|----|------|
-| `workflow` | string | Workflow 名またはパス。省略時は `default`。 |
 | `worktree` | boolean | `true` は自動の隔離 worktree を作成する。省略時は `true`。MCP 入力では任意の worktree パスを受け取りません。 |
-| `autoPr` | boolean | 自動 PR を有効にしたタスクとして保存する。省略時は `false`。 |
 | `taskContext.branch` | string | タスクに保存するローカルブランチ名。 |
 | `taskContext.baseBranch` | string | タスクに保存するベースブランチ名。 |
 | `taskContext.prNumber` | 正の safe integer | タスクに保存する Pull Request 番号。`Number.MAX_SAFE_INTEGER` を超える値は拒否されます。 |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -163,14 +163,14 @@ Required input:
 |-------|------|-------------|
 | `cwd` | absolute path string | Project root where `.takt/tasks.yaml` is written. |
 | `task` | string | Task instruction body. |
+| `workflow` | string | Workflow name or path. MCP callers must ask which workflow to use before enqueueing. |
+| `autoPr` | boolean | Save the task with auto-PR enabled. MCP callers must ask before enqueueing. |
 
 Optional input:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `workflow` | string | Workflow name or path. Defaults to `default`. |
 | `worktree` | boolean | `true` creates an automatic isolated worktree. Defaults to `true`. MCP input does not accept custom worktree paths. |
-| `autoPr` | boolean | Save the task with auto-PR enabled. Defaults to `false`. |
 | `taskContext.branch` | string | Local branch name to save with the task. |
 | `taskContext.baseBranch` | string | Base branch name to save with the task. |
 | `taskContext.prNumber` | positive safe integer | Pull request number to save with the task. Values greater than `Number.MAX_SAFE_INTEGER` are rejected. |

--- a/src/__tests__/mcp-entrypoint.test.ts
+++ b/src/__tests__/mcp-entrypoint.test.ts
@@ -69,7 +69,7 @@ describe('MCP package entrypoint', () => {
         title: 'Enqueue TAKT task',
         inputSchema: expect.objectContaining({
           type: 'object',
-          required: expect.arrayContaining(['cwd', 'task']),
+          required: expect.arrayContaining(['cwd', 'task', 'workflow', 'autoPr']),
         }),
       }));
       expect(toolsByName.get('takt_create_issue_and_enqueue_task')?.inputSchema.properties).toEqual(
@@ -85,9 +85,9 @@ describe('MCP package entrypoint', () => {
       const enqueueTaskContext = objectProperties(enqueueProperties.taskContext);
       const runNextTaskContext = objectProperties(runNextProperties.taskContext);
 
-      expect(enqueueProperties.workflow?.description).toBe('Workflow identifier to store on the queued task. Defaults to the TAKT default workflow.');
+      expect(enqueueProperties.workflow?.description).toBe('Workflow identifier to store on the queued task. Ask the user which workflow to use before enqueueing.');
       expect(enqueueProperties.worktree?.description).toBe('Whether the queued task should run in a TAKT-managed worktree.');
-      expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should automatically open a pull request.');
+      expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should automatically open a pull request. Ask the user before enqueueing.');
       expect(issueProperties.labels?.description).toBe('Issue labels to request from the configured issue provider.');
       expect(runNextProperties.provider?.description).toBe('Agent provider override for this task execution.');
       expect(runNextProperties.model?.description).toBe('Model override for this task execution.');
@@ -147,6 +147,7 @@ describe('MCP package entrypoint', () => {
           cwd,
           task: 'Implement MCP support',
           workflow: 'review',
+          autoPr: false,
         },
       });
       await client.callTool({
@@ -154,6 +155,8 @@ describe('MCP package entrypoint', () => {
         arguments: {
           cwd,
           task: 'Implement MCP support',
+          workflow: 'default',
+          autoPr: false,
           labels: ['enhancement'],
         },
       });
@@ -222,6 +225,8 @@ describe('MCP package entrypoint', () => {
         arguments: {
           cwd: outsideRoot,
           task: 'Implement MCP support',
+          workflow: 'default',
+          autoPr: false,
         },
       });
 

--- a/src/__tests__/mcpOperations.test.ts
+++ b/src/__tests__/mcpOperations.test.ts
@@ -4,11 +4,15 @@ import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  createIssueAndEnqueueTaktTask,
-  enqueueTaktTask,
+  createIssueAndEnqueueTaktTask as createIssueAndEnqueueTaktTaskOperation,
+  enqueueTaktTask as enqueueTaktTaskOperation,
   type McpOperationDependencies,
   runNextTaktTask,
 } from '../features/mcp/operations.js';
+import type {
+  CreateIssueAndEnqueueTaskInput,
+  EnqueueTaskInput,
+} from '../features/mcp/schemas.js';
 import { TaskRunner, type TaskInfo } from '../infra/task/index.js';
 
 vi.mock('../infra/task/summarize.js', async (importOriginal) => ({
@@ -79,6 +83,28 @@ function parseToolJson(result: unknown): Record<string, unknown> {
 
 const RAW_LOCAL_ERROR = "EACCES: permission denied, open '/Users/nrs/secret/.takt/tasks.yaml'";
 
+type EnqueueInputForTest = Omit<EnqueueTaskInput, 'workflow' | 'autoPr'> & Partial<Pick<EnqueueTaskInput, 'workflow' | 'autoPr'>>;
+type IssueEnqueueInputForTest = Omit<CreateIssueAndEnqueueTaskInput, 'workflow' | 'autoPr'> & Partial<Pick<CreateIssueAndEnqueueTaskInput, 'workflow' | 'autoPr'>>;
+
+function withRequiredTaskOptions<T extends EnqueueInputForTest | IssueEnqueueInputForTest>(input: T): T & {
+  workflow: string;
+  autoPr: boolean;
+} {
+  return {
+    workflow: 'default',
+    autoPr: false,
+    ...input,
+  };
+}
+
+function enqueueTaktTask(input: EnqueueInputForTest, deps?: McpOperationDependencies) {
+  return enqueueTaktTaskOperation(withRequiredTaskOptions(input), deps);
+}
+
+function createIssueAndEnqueueTaktTask(input: IssueEnqueueInputForTest, deps?: McpOperationDependencies) {
+  return createIssueAndEnqueueTaktTaskOperation(withRequiredTaskOptions(input), deps);
+}
+
 function expectNoRawLocalError(result: unknown): void {
   const text = getToolText(result);
   expect(text).not.toContain('/Users/nrs/secret');
@@ -113,7 +139,7 @@ describe('MCP task operations', () => {
     mockGetGitProvider.mockReturnValue(mockGitProvider);
   });
 
-  it('Given minimal enqueue input, When takt_enqueue_task runs, Then saveTaskFile receives MCP defaults', async () => {
+  it('Given required enqueue input, When takt_enqueue_task runs, Then saveTaskFile receives explicit MCP decisions', async () => {
     const saveTaskFile = vi.fn().mockResolvedValue({
       taskName: '20260702-add-mcp',
       tasksFile: '/repo/.takt/tasks.yaml',
@@ -122,6 +148,8 @@ describe('MCP task operations', () => {
     const result = await enqueueTaktTask({
       cwd: '/repo',
       task: 'Implement MCP support',
+      workflow: 'default',
+      autoPr: false,
     }, { saveTaskFile });
 
     expect(saveTaskFile).toHaveBeenCalledWith('/repo', 'Implement MCP support', {

--- a/src/__tests__/mcpSchemas.test.ts
+++ b/src/__tests__/mcpSchemas.test.ts
@@ -104,6 +104,22 @@ describe('MCP tool input schemas', () => {
   });
 
   it.each([
+    ['enqueue', enqueueTaskInputSchema],
+    ['issue enqueue', createIssueAndEnqueueTaskInputSchema],
+  ])('Given %s input missing one task decision, When parsing, Then each decision is required independently', (_name, schema) => {
+    expect(() => schema.parse({
+      cwd: '/repo',
+      task: 'Implement MCP support',
+      autoPr: false,
+    })).toThrow(/workflow/i);
+    expect(() => schema.parse({
+      cwd: '/repo',
+      task: 'Implement MCP support',
+      workflow: 'default',
+    })).toThrow(/autoPr/i);
+  });
+
+  it.each([
     '/tmp/takt/unsafe-worktree',
     '../outside-project',
     'feature/mcp',

--- a/src/__tests__/mcpSchemas.test.ts
+++ b/src/__tests__/mcpSchemas.test.ts
@@ -26,6 +26,11 @@ function requireSchema(schema: JsonSchemaObject | undefined, name: string): Json
 }
 
 describe('MCP tool input schemas', () => {
+  const requiredTaskOptions = {
+    workflow: 'default',
+    autoPr: false,
+  } as const;
+
   it('Given root tool arguments, When enqueue input is parsed, Then task settings are preserved', () => {
     const parsed = enqueueTaskInputSchema.parse({
       cwd: '/repo',
@@ -60,6 +65,7 @@ describe('MCP tool input schemas', () => {
     const parsed = enqueueTaskInputSchema.parse({
       cwd: '/repo',
       task,
+      ...requiredTaskOptions,
     });
 
     expect(parsed.task).toBe(task);
@@ -72,6 +78,7 @@ describe('MCP tool input schemas', () => {
         text: JSON.stringify({
           cwd: '/repo',
           task: 'Implement MCP support',
+          ...requiredTaskOptions,
         }),
       }],
     })).toThrow(/cwd|task/i);
@@ -81,7 +88,19 @@ describe('MCP tool input schemas', () => {
     expect(() => enqueueTaskInputSchema.parse({
       cwd: 'relative/repo',
       task: 'Implement MCP support',
+      ...requiredTaskOptions,
     })).toThrow(/absolute/i);
+  });
+
+  it('Given enqueue input without workflow or autoPr, When parsing, Then it asks callers to provide both decisions', () => {
+    expect(() => enqueueTaskInputSchema.parse({
+      cwd: '/repo',
+      task: 'Implement MCP support',
+    })).toThrow(/workflow|autoPr/i);
+    expect(() => createIssueAndEnqueueTaskInputSchema.parse({
+      cwd: '/repo',
+      task: 'Implement MCP support',
+    })).toThrow(/workflow|autoPr/i);
   });
 
   it.each([
@@ -92,6 +111,7 @@ describe('MCP tool input schemas', () => {
     expect(() => enqueueTaskInputSchema.parse({
       cwd: '/repo',
       task: 'Implement MCP support',
+      ...requiredTaskOptions,
       worktree,
     })).toThrow(/boolean|worktree/i);
   });
@@ -109,6 +129,7 @@ describe('MCP tool input schemas', () => {
     expect(() => enqueueTaskInputSchema.parse({
       cwd: '/repo',
       task: 'Implement MCP support',
+      ...requiredTaskOptions,
       taskContext: { branch },
     })).toThrow(/branch|Invalid/i);
   });
@@ -117,6 +138,7 @@ describe('MCP tool input schemas', () => {
     const parsed = createIssueAndEnqueueTaskInputSchema.parse({
       cwd: '/repo',
       task: 'Implement MCP support',
+      ...requiredTaskOptions,
       labels: ['enhancement', 'mcp'],
     });
 
@@ -128,15 +150,18 @@ describe('MCP tool input schemas', () => {
     expect(() => enqueueTaskInputSchema.parse({
       cwd: '/repo',
       task: 'x'.repeat((128 * 1024) + 1),
+      ...requiredTaskOptions,
     })).toThrow(/too big|maximum|at most/i);
     expect(() => enqueueTaskInputSchema.parse({
       cwd: '/repo',
       task: 'Implement MCP support',
+      autoPr: false,
       workflow: 'w'.repeat(129),
     })).toThrow(/too big|maximum|at most/i);
     expect(() => createIssueAndEnqueueTaskInputSchema.parse({
       cwd: '/repo',
       task: 'Implement MCP support',
+      ...requiredTaskOptions,
       labels: Array.from({ length: 21 }, (_, index) => `label-${index}`),
     })).toThrow(/too big|maximum|at most/i);
     expect(() => runNextTaskInputSchema.parse({
@@ -146,8 +171,8 @@ describe('MCP tool input schemas', () => {
   });
 
   it.each([
-    ['enqueue', enqueueTaskInputSchema, { cwd: '/repo', task: 'Implement MCP support' }],
-    ['issue enqueue', createIssueAndEnqueueTaskInputSchema, { cwd: '/repo', task: 'Implement MCP support' }],
+    ['enqueue', enqueueTaskInputSchema, { cwd: '/repo', task: 'Implement MCP support', ...requiredTaskOptions }],
+    ['issue enqueue', createIssueAndEnqueueTaskInputSchema, { cwd: '/repo', task: 'Implement MCP support', ...requiredTaskOptions }],
     ['run-next', runNextTaskInputSchema, { cwd: '/repo' }],
   ])('Given unsafe PR numbers, When %s input is parsed, Then they are rejected', (_name, schema, baseInput) => {
     for (const prNumber of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
@@ -181,9 +206,9 @@ describe('MCP tool input schemas', () => {
     const runNextProperties = schemaProperties(z.toJSONSchema(runNextTaskInputSchema, { io: 'input' }));
     const taskContextProperties = schemaProperties(requireSchema(enqueueProperties.taskContext, 'taskContext'));
 
-    expect(enqueueProperties.workflow?.description).toBe('Workflow identifier to store on the queued task. Defaults to the TAKT default workflow.');
+    expect(enqueueProperties.workflow?.description).toBe('Workflow identifier to store on the queued task. Ask the user which workflow to use before enqueueing.');
     expect(enqueueProperties.worktree?.description).toBe('Whether the queued task should run in a TAKT-managed worktree.');
-    expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should automatically open a pull request.');
+    expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should automatically open a pull request. Ask the user before enqueueing.');
     expect(issueProperties.labels?.description).toBe('Issue labels to request from the configured issue provider.');
     expect(runNextProperties.provider?.description).toBe('Agent provider override for this task execution.');
     expect(runNextProperties.model?.description).toBe('Model override for this task execution.');

--- a/src/features/mcp/operations.ts
+++ b/src/features/mcp/operations.ts
@@ -1,7 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { DEFAULT_WORKFLOW_NAME } from '../../shared/constants.js';
 import { safeExternalErrorMessage } from '../../shared/utils/safeExternalErrorMessage.js';
 import { TaskRunner, type TaskInfo } from '../../infra/task/index.js';
 import { getGitProvider, initGitProvider, type CloseIssueResult, type GitProvider } from '../../infra/git/index.js';
@@ -78,10 +77,6 @@ function assertCwdAllowedByMcpRoot(cwd: string, allowedProjectRoot: string | und
   throw new Error(`MCP cwd is outside the allowed project root: ${cwd}`);
 }
 
-function resolveWorkflow(workflow: string | undefined): string {
-  return workflow ?? DEFAULT_WORKFLOW_NAME;
-}
-
 function buildTaskExecutionOptions(input: RunNextTaskInput): TaskExecutionOptions | undefined {
   if (input.provider === undefined && input.model === undefined) {
     return undefined;
@@ -134,13 +129,12 @@ export async function enqueueTaktTask(
   try {
     assertCwdAllowedByMcpRoot(input.cwd, deps.allowedProjectRoot);
     const saveTaskFile = deps.saveTaskFile ?? defaultSaveTaskFile;
-    const workflow = resolveWorkflow(input.workflow);
     const created = await enqueueTask({
       cwd: input.cwd,
       task: input.task,
-      workflow,
+      workflow: input.workflow,
       worktree: input.worktree ?? true,
-      autoPr: input.autoPr ?? false,
+      autoPr: input.autoPr,
       taskContext: input.taskContext,
     }, saveTaskFile);
     return jsonResult(created);
@@ -157,13 +151,12 @@ export async function createIssueAndEnqueueTaktTask(
     assertCwdAllowedByMcpRoot(input.cwd, deps.allowedProjectRoot);
     initGitProvider(input.cwd);
     const gitProvider = getGitProvider();
-    const workflow = resolveWorkflow(input.workflow);
     const issueResult = await createIssueAndEnqueueTask({
       cwd: input.cwd,
       task: input.task,
-      workflow,
+      workflow: input.workflow,
       worktree: input.worktree ?? true,
-      autoPr: input.autoPr ?? false,
+      autoPr: input.autoPr,
       labels: input.labels,
       taskContext: input.taskContext,
       gitProvider,

--- a/src/features/mcp/schemas.ts
+++ b/src/features/mcp/schemas.ts
@@ -20,8 +20,7 @@ const taskContentSchema = z.string().max(MCP_TASK_MAX_LENGTH).refine((value) => 
   message: 'task is required',
 }).describe('Task body to save as a pending TAKT task. Boundary whitespace is preserved.');
 const workflowSchema = z.string().trim().min(1).max(MCP_WORKFLOW_MAX_LENGTH)
-  .optional()
-  .describe('Workflow identifier to store on the queued task. Defaults to the TAKT default workflow.');
+  .describe('Workflow identifier to store on the queued task. Ask the user which workflow to use before enqueueing.');
 const worktreeSchema = z.boolean()
   .optional()
   .describe('Whether the queued task should run in a TAKT-managed worktree.');
@@ -46,8 +45,7 @@ const taskSaveOptionsSchema = z.object({
   workflow: workflowSchema,
   worktree: worktreeSchema,
   autoPr: z.boolean()
-    .optional()
-    .describe('Whether successful worktree execution should automatically open a pull request.'),
+    .describe('Whether successful worktree execution should automatically open a pull request. Ask the user before enqueueing.'),
   taskContext: taskContextSchema,
 }).strict();
 


### PR DESCRIPTION
## Summary

- require MCP enqueue callers to provide both workflow and autoPr decisions
- remove MCP operation defaults for workflow and autoPr so parsed inputs are persisted explicitly
- update MCP schema, entrypoint, operation tests, and CLI reference docs

## Validation

- npm test -- --run src/__tests__/mcpSchemas.test.ts src/__tests__/mcpOperations.test.ts src/__tests__/mcp-entrypoint.test.ts
- npx tsc --noEmit --pretty false
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更点**
  * `takt_enqueue_task` の入力仕様を更新し、`workflow` と `autoPr` を事前確認が必要な必須項目として明確化しました。
  * `worktree` は引き続き任意項目として案内されています。
  * 関連するドキュメントを整理し、入力要件がより分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->