### PR TITLE
fix: inject dispute guidance only when open findings exist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,3 +74,14 @@ If CodeRabbit reviews your PR, go through each comment, decide whether it should
 ## License
 
 By contributing, you agree that your contributions will be licensed under the MIT License.
+
+## Instruction / facet 変更時の canary
+
+`InstructionBuilder` や `builtins/{lang}/facets/instructions` などプロンプト組み立てに影響する変更は、ユニットテストでは捕まらない「弱いモデルのツール呼び出し不安定化」を引き起こすことがある（実例: 台帳が空の段階への異議申告ガイド注入で implement が連続失敗）。変更時は実プロバイダでの canary 実行を推奨する。
+
+```bash
+npm run build
+npm run canary:coder -- --provider opencode --model ollama-cloud/qwen3-coder-next
+```
+
+小さな implement 1走を現行の指示組み立てで実行し、完走とツールエラー数を確認する。PR の必須ゲートではない（実プロバイダのコストがかかるため）。

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test:e2e:cursor": "npm run test:e2e:provider:cursor",
     "lint": "eslint src/",
     "check:release": "npm run build && npm run lint && npm run test && npm run test:it && npm run test:e2e:all; code=$?; if [ \"$code\" -eq 0 ]; then msg='check:release passed'; else msg=\"check:release failed (exit=$code)\"; fi; if command -v osascript >/dev/null 2>&1; then osascript -e \"display notification \\\"$msg\\\" with title \\\"takt\\\" subtitle \\\"Release Check\\\"\" >/dev/null 2>&1 || true; fi; echo \"[takt] $msg\"; exit $code",
-    "prepublishOnly": "npm run lint && npm run build && npm run test"
+    "prepublishOnly": "npm run lint && npm run build && npm run test",
+    "canary:coder": "node scripts/canary-coder.mjs"
   },
   "keywords": [
     "ai",

--- a/scripts/canary-coder.mjs
+++ b/scripts/canary-coder.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * coder canary: facet / instruction 変更が弱いモデルのツール呼び出しを
+ * 不安定化させていないかを、実プロバイダでの小さな implement 1走で確認する。
+ *
+ * 使い方:
+ *   npm run build && node scripts/canary-coder.mjs --provider opencode --model ollama-cloud/qwen3-coder-next
+ *
+ * PR ゲートではない（実プロバイダのコストがかかる）。InstructionBuilder や
+ * builtins/{lang}/facets/instructions を変更したときの推奨手順。
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+function argOf(flag) {
+  const index = args.indexOf(flag);
+  return index !== -1 ? args[index + 1] : undefined;
+}
+const provider = argOf('--provider');
+const model = argOf('--model');
+if (!provider || !model) {
+  console.error('usage: node scripts/canary-coder.mjs --provider <provider> --model <model>');
+  process.exit(2);
+}
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const workDir = mkdtempSync(join(tmpdir(), 'takt-canary-'));
+const workflowDir = join(workDir, '.takt', 'workflows');
+mkdirSync(workflowDir, { recursive: true });
+
+// 単一 implement ステップの最小ワークフロー。現行の InstructionBuilder /
+// builtins の組み立てをそのまま通す。
+writeFileSync(join(workflowDir, 'canary.yaml'), [
+  'name: canary',
+  'max_steps: 1',
+  'initial_step: implement',
+  'steps:',
+  '  - name: implement',
+  '    persona: coder',
+  `    provider: ${provider}`,
+  `    model: ${model}`,
+  '    instruction: |',
+  '      タスクの内容を実装してください。実装が完了したら [STEP:1] を出力してください。',
+  '    edit: true',
+  '    rules:',
+  '      - condition: 実装が完了した',
+  '        next: COMPLETE',
+  '      - condition: 実装を進められない',
+  '        next: ABORT',
+].join('\n'));
+
+const task = 'greet.ts を作成し、greet(name: string): string 関数（"Hello, <name>!" を返す）を export してください。既存ファイルの変更は不要です。';
+
+console.log(`canary: ${provider}/${model} @ ${workDir}`);
+const result = spawnSync('node', [join(repoRoot, 'bin', 'takt'), '-t', task, '-w', 'canary', '--pipeline', '--skip-git', '-q'], {
+  cwd: workDir,
+  encoding: 'utf-8',
+  timeout: 10 * 60 * 1000,
+});
+
+const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+const toolErrors = (output.match(/✗ Tool/g) ?? []).length;
+const completed = result.status === 0 && !/aborted/i.test(output);
+
+console.log(output.split('\n').slice(-15).join('\n'));
+console.log(`---\ncanary result: completed=${completed} toolErrors=${toolErrors}`);
+
+rmSync(workDir, { recursive: true, force: true });
+
+const TOOL_ERROR_BUDGET = 5;
+if (!completed || toolErrors > TOOL_ERROR_BUDGET) {
+  console.error(`canary FAILED (completed=${completed}, toolErrors=${toolErrors} > budget ${TOOL_ERROR_BUDGET})`);
+  process.exit(1);
+}
+console.log('canary OK');

--- a/scripts/canary-coder.mjs
+++ b/scripts/canary-coder.mjs
@@ -77,9 +77,11 @@ try {
   const TOOL_ERROR_BUDGET = 5;
   if (!runCompleted || !artifactOk || toolErrors > TOOL_ERROR_BUDGET) {
     console.error(`canary FAILED (completed=${runCompleted}, artifact=${artifactOk}, toolErrors=${toolErrors} > budget ${TOOL_ERROR_BUDGET})`);
-    process.exit(1);
+    // process.exit は finally を飛ばすため、exitCode で自然終了させる
+    process.exitCode = 1;
+  } else {
+    console.log('canary OK');
   }
-  console.log('canary OK');
 } finally {
   rmSync(workDir, { recursive: true, force: true });
 }

--- a/scripts/canary-coder.mjs
+++ b/scripts/canary-coder.mjs
@@ -63,8 +63,14 @@ try {
     timeout: 10 * 60 * 1000,
   });
 
+  if (result.error) {
+    console.error(`spawn failed: ${result.error.message}`);
+  }
   const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
-  const toolErrors = (output.match(/✗ Tool/g) ?? []).length;
+  // ツール失敗行（✗ <ツール名>:）を数える。ストリーム表示の文言に結合して
+  // いるのは既知の制約: セッションログは現状 step/phase イベントのみで
+  // ツール粒度を持たないため、構造化カウントには takt 側の拡張が要る。
+  const toolErrors = (output.match(/^\s*✗ \S+:/gm) ?? []).length;
   const runCompleted = result.status === 0 && !/aborted/i.test(output);
   // 完了宣言だけの空振りを弾く: 成果物の実在と内容まで確認する
   const artifactPath = join(workDir, 'greet.ts');

--- a/scripts/canary-coder.mjs
+++ b/scripts/canary-coder.mjs
@@ -10,7 +10,7 @@
  * builtins/{lang}/facets/instructions を変更したときの推奨手順。
  */
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -56,24 +56,30 @@ writeFileSync(join(workflowDir, 'canary.yaml'), [
 const task = 'greet.ts を作成し、greet(name: string): string 関数（"Hello, <name>!" を返す）を export してください。既存ファイルの変更は不要です。';
 
 console.log(`canary: ${provider}/${model} @ ${workDir}`);
-const result = spawnSync('node', [join(repoRoot, 'bin', 'takt'), '-t', task, '-w', 'canary', '--pipeline', '--skip-git', '-q'], {
-  cwd: workDir,
-  encoding: 'utf-8',
-  timeout: 10 * 60 * 1000,
-});
+try {
+  const result = spawnSync('node', [join(repoRoot, 'bin', 'takt'), '-t', task, '-w', 'canary', '--pipeline', '--skip-git', '-q'], {
+    cwd: workDir,
+    encoding: 'utf-8',
+    timeout: 10 * 60 * 1000,
+  });
 
-const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
-const toolErrors = (output.match(/✗ Tool/g) ?? []).length;
-const completed = result.status === 0 && !/aborted/i.test(output);
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  const toolErrors = (output.match(/✗ Tool/g) ?? []).length;
+  const runCompleted = result.status === 0 && !/aborted/i.test(output);
+  // 完了宣言だけの空振りを弾く: 成果物の実在と内容まで確認する
+  const artifactPath = join(workDir, 'greet.ts');
+  const artifactOk = existsSync(artifactPath)
+    && /export\s+(function\s+greet|const\s+greet)/.test(readFileSync(artifactPath, 'utf-8'));
 
-console.log(output.split('\n').slice(-15).join('\n'));
-console.log(`---\ncanary result: completed=${completed} toolErrors=${toolErrors}`);
+  console.log(output.split('\n').slice(-15).join('\n'));
+  console.log(`---\ncanary result: completed=${runCompleted} artifact=${artifactOk} toolErrors=${toolErrors}`);
 
-rmSync(workDir, { recursive: true, force: true });
-
-const TOOL_ERROR_BUDGET = 5;
-if (!completed || toolErrors > TOOL_ERROR_BUDGET) {
-  console.error(`canary FAILED (completed=${completed}, toolErrors=${toolErrors} > budget ${TOOL_ERROR_BUDGET})`);
-  process.exit(1);
+  const TOOL_ERROR_BUDGET = 5;
+  if (!runCompleted || !artifactOk || toolErrors > TOOL_ERROR_BUDGET) {
+    console.error(`canary FAILED (completed=${runCompleted}, artifact=${artifactOk}, toolErrors=${toolErrors} > budget ${TOOL_ERROR_BUDGET})`);
+    process.exit(1);
+  }
+  console.log('canary OK');
+} finally {
+  rmSync(workDir, { recursive: true, force: true });
 }
-console.log('canary OK');

--- a/src/__tests__/instruction-builder-dispute-guidance.test.ts
+++ b/src/__tests__/instruction-builder-dispute-guidance.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { InstructionBuilder } from '../core/workflow/instruction/InstructionBuilder.js';
+import { ledgerHasOpenFindings } from '../core/workflow/findings/context.js';
+import type { FindingLedger } from '../core/models/finding-types.js';
 import type { InstructionContext } from '../core/workflow/instruction/instruction-context.js';
 import type { WorkflowStep } from '../core/models/types.js';
 
@@ -69,5 +71,41 @@ describe('dispute guidance injection', () => {
     expect(section).toContain('raw findings schema');
     expect(section).not.toContain('Disputed Findings');
     expect(section).not.toContain('dispute claim');
+  });
+});
+
+describe('ledgerHasOpenFindings', () => {
+  function makeLedger(statuses: Array<'open' | 'resolved' | 'waived'>): FindingLedger {
+    return {
+      version: 1,
+      workflowName: 'w',
+      nextId: statuses.length + 1,
+      updatedAt: '2026-07-05T00:00:00.000Z',
+      rawFindings: [],
+      conflicts: [],
+      findings: statuses.map((status, index) => ({
+        id: `F-000${index + 1}`,
+        status,
+        lifecycle: status === 'open' ? 'new' : status,
+        severity: 'high',
+        title: `Finding ${index + 1}`,
+        reviewers: ['reviewer'],
+        rawFindingIds: [],
+        firstSeen: { runId: 'r', stepName: 's', timestamp: '2026-07-05T00:00:00.000Z' },
+        lastSeen: { runId: 'r', stepName: 's', timestamp: '2026-07-05T00:00:00.000Z' },
+      })),
+    };
+  }
+
+  it('should be false for an empty ledger', () => {
+    expect(ledgerHasOpenFindings(makeLedger([]))).toBe(false);
+  });
+
+  it('should be false when all findings are resolved or waived', () => {
+    expect(ledgerHasOpenFindings(makeLedger(['resolved', 'waived']))).toBe(false);
+  });
+
+  it('should be true when any finding is open', () => {
+    expect(ledgerHasOpenFindings(makeLedger(['resolved', 'open', 'waived']))).toBe(true);
   });
 });

--- a/src/__tests__/instruction-builder-dispute-guidance.test.ts
+++ b/src/__tests__/instruction-builder-dispute-guidance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { InstructionBuilder } from '../core/workflow/instruction/InstructionBuilder.js';
-import { ledgerHasOpenFindings } from '../core/workflow/findings/context.js';
+import { ledgerHasOpenFindings, ledgerHasWaivedFindings } from '../core/workflow/findings/context.js';
 import type { FindingLedger } from '../core/models/finding-types.js';
 import type { InstructionContext } from '../core/workflow/instruction/instruction-context.js';
 import type { WorkflowStep } from '../core/models/types.js';
@@ -15,7 +15,7 @@ function makeStep(): WorkflowStep {
   } as WorkflowStep;
 }
 
-function makeContext(options: { hasOpenFindings: boolean; rawFindingsJsonSchema?: Record<string, unknown> }): InstructionContext {
+function makeContext(options: { hasOpenFindings: boolean; hasWaivedFindings?: boolean; rawFindingsJsonSchema?: Record<string, unknown> }): InstructionContext {
   return {
     task: 'task',
     iteration: 1,
@@ -30,6 +30,7 @@ function makeContext(options: { hasOpenFindings: boolean; rawFindingsJsonSchema?
       ledgerSummary: '{}',
       reportLedgerSummary: '{}',
       hasOpenFindings: options.hasOpenFindings,
+      hasWaivedFindings: options.hasWaivedFindings ?? false,
       ...(options.rawFindingsJsonSchema !== undefined ? { rawFindingsJsonSchema: options.rawFindingsJsonSchema } : {}),
     },
   } as unknown as InstructionContext;
@@ -74,6 +75,35 @@ describe('dispute guidance injection', () => {
   });
 });
 
+describe('reviewer duty gating', () => {
+  it('should omit confirmation and waived duties for reviewers when the ledger is empty', () => {
+    const instruction = new InstructionBuilder(
+      makeStep(),
+      makeContext({ hasOpenFindings: false, rawFindingsJsonSchema: { type: 'object' } }),
+    ).build();
+
+    const section = extractFindingContractSection(instruction);
+    expect(section).toContain('kind "issue"');
+    expect(section).not.toContain('resolution_confirmation');
+    expect(section).not.toContain('waived');
+  });
+
+  it('should inject confirmation duties when open findings exist and waived duty only with waived findings', () => {
+    const withOpen = extractFindingContractSection(new InstructionBuilder(
+      makeStep(),
+      makeContext({ hasOpenFindings: true, rawFindingsJsonSchema: { type: 'object' } }),
+    ).build());
+    expect(withOpen).toContain('resolution_confirmation');
+    expect(withOpen).not.toContain('listed as waived');
+
+    const withWaived = extractFindingContractSection(new InstructionBuilder(
+      makeStep(),
+      makeContext({ hasOpenFindings: true, hasWaivedFindings: true, rawFindingsJsonSchema: { type: 'object' } }),
+    ).build());
+    expect(withWaived).toContain('listed as waived');
+  });
+});
+
 describe('ledgerHasOpenFindings', () => {
   function makeLedger(statuses: Array<'open' | 'resolved' | 'waived'>): FindingLedger {
     return {
@@ -107,5 +137,10 @@ describe('ledgerHasOpenFindings', () => {
 
   it('should be true when any finding is open', () => {
     expect(ledgerHasOpenFindings(makeLedger(['resolved', 'open', 'waived']))).toBe(true);
+  });
+
+  it('should detect waived findings independently', () => {
+    expect(ledgerHasWaivedFindings(makeLedger(['resolved', 'open']))).toBe(false);
+    expect(ledgerHasWaivedFindings(makeLedger(['waived']))).toBe(true);
   });
 });

--- a/src/__tests__/instruction-builder-dispute-guidance.test.ts
+++ b/src/__tests__/instruction-builder-dispute-guidance.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { InstructionBuilder } from '../core/workflow/instruction/InstructionBuilder.js';
+import type { InstructionContext } from '../core/workflow/instruction/instruction-context.js';
+import type { WorkflowStep } from '../core/models/types.js';
+
+function makeStep(): WorkflowStep {
+  return {
+    kind: 'agent',
+    name: 'fix',
+    persona: 'bench-coder',
+    instruction: 'Fix the findings.',
+    edit: true,
+  } as WorkflowStep;
+}
+
+function makeContext(ledgerSummary: string): InstructionContext {
+  return {
+    task: 'task',
+    iteration: 1,
+    maxSteps: 10,
+    stepIteration: 1,
+    cwd: '/tmp',
+    projectCwd: '/tmp',
+    userInputs: [],
+    language: 'en',
+    findingContract: {
+      ledgerCopyPath: '/tmp/.takt/findings/ledger.json',
+      ledgerSummary,
+      reportLedgerSummary: '{}',
+    },
+  } as unknown as InstructionContext;
+}
+
+describe('dispute guidance injection', () => {
+  it('should omit the dispute guidance when the ledger has no open findings', () => {
+    const instruction = new InstructionBuilder(makeStep(), makeContext(JSON.stringify({ open: [], resolved: [], waived: [] }))).build();
+
+    expect(instruction).not.toContain('Disputed Findings');
+  });
+
+  it('should inject the dispute guidance when open findings exist', () => {
+    const summary = JSON.stringify({
+      open: [{ id: 'F-0001', severity: 'high', title: 'Issue' }],
+      resolved: [],
+      waived: [],
+    });
+    const instruction = new InstructionBuilder(makeStep(), makeContext(summary)).build();
+
+    expect(instruction).toContain('Disputed Findings');
+  });
+
+  it('should not inject coder guidance into reviewer instructions even with open findings', () => {
+    const summary = JSON.stringify({ open: [{ id: 'F-0001', severity: 'high', title: 'Issue' }], resolved: [] });
+    const context = makeContext(summary);
+    (context.findingContract as { rawFindingsJsonSchema?: object }).rawFindingsJsonSchema = { type: 'object' };
+    const instruction = new InstructionBuilder(makeStep(), context).build();
+
+    expect(instruction).not.toContain('## Disputed Findings');
+  });
+});

--- a/src/__tests__/instruction-builder-dispute-guidance.test.ts
+++ b/src/__tests__/instruction-builder-dispute-guidance.test.ts
@@ -13,7 +13,7 @@ function makeStep(): WorkflowStep {
   } as WorkflowStep;
 }
 
-function makeContext(ledgerSummary: string): InstructionContext {
+function makeContext(options: { hasOpenFindings: boolean; rawFindingsJsonSchema?: Record<string, unknown> }): InstructionContext {
   return {
     task: 'task',
     iteration: 1,
@@ -25,36 +25,49 @@ function makeContext(ledgerSummary: string): InstructionContext {
     language: 'en',
     findingContract: {
       ledgerCopyPath: '/tmp/.takt/findings/ledger.json',
-      ledgerSummary,
+      ledgerSummary: '{}',
       reportLedgerSummary: '{}',
+      hasOpenFindings: options.hasOpenFindings,
+      ...(options.rawFindingsJsonSchema !== undefined ? { rawFindingsJsonSchema: options.rawFindingsJsonSchema } : {}),
     },
   } as unknown as InstructionContext;
 }
 
+/** Finding Contract セクション（appendFindingContractInstruction の出力範囲）を切り出す */
+function extractFindingContractSection(instruction: string): string {
+  const start = instruction.indexOf('## Finding Contract');
+  expect(start).toBeGreaterThanOrEqual(0);
+  return instruction.slice(start);
+}
+
 describe('dispute guidance injection', () => {
   it('should omit the dispute guidance when the ledger has no open findings', () => {
-    const instruction = new InstructionBuilder(makeStep(), makeContext(JSON.stringify({ open: [], resolved: [], waived: [] }))).build();
+    const instruction = new InstructionBuilder(makeStep(), makeContext({ hasOpenFindings: false })).build();
 
-    expect(instruction).not.toContain('Disputed Findings');
+    const section = extractFindingContractSection(instruction);
+    expect(section).toContain('Consolidated ledger copy');
+    expect(section).not.toContain('Disputed Findings');
+    expect(section).not.toContain('dispute claim');
   });
 
   it('should inject the dispute guidance when open findings exist', () => {
-    const summary = JSON.stringify({
-      open: [{ id: 'F-0001', severity: 'high', title: 'Issue' }],
-      resolved: [],
-      waived: [],
-    });
-    const instruction = new InstructionBuilder(makeStep(), makeContext(summary)).build();
+    const instruction = new InstructionBuilder(makeStep(), makeContext({ hasOpenFindings: true })).build();
 
-    expect(instruction).toContain('Disputed Findings');
+    const section = extractFindingContractSection(instruction);
+    expect(section).toContain('"## Disputed Findings" heading');
+    expect(section).toContain('findingId: the ledger finding id');
+    expect(section).toContain('evidence: file:line references backing the reason');
   });
 
-  it('should not inject coder guidance into reviewer instructions even with open findings', () => {
-    const summary = JSON.stringify({ open: [{ id: 'F-0001', severity: 'high', title: 'Issue' }], resolved: [] });
-    const context = makeContext(summary);
-    (context.findingContract as { rawFindingsJsonSchema?: object }).rawFindingsJsonSchema = { type: 'object' };
-    const instruction = new InstructionBuilder(makeStep(), context).build();
+  it('should not inject dispute guidance when rawFindingsJsonSchema is present (reviewer branch wins)', () => {
+    const instruction = new InstructionBuilder(
+      makeStep(),
+      makeContext({ hasOpenFindings: true, rawFindingsJsonSchema: { type: 'object' } }),
+    ).build();
 
-    expect(instruction).not.toContain('## Disputed Findings');
+    const section = extractFindingContractSection(instruction);
+    expect(section).toContain('raw findings schema');
+    expect(section).not.toContain('Disputed Findings');
+    expect(section).not.toContain('dispute claim');
   });
 });

--- a/src/__tests__/instruction-builder-dispute-guidance.test.ts
+++ b/src/__tests__/instruction-builder-dispute-guidance.test.ts
@@ -88,6 +88,16 @@ describe('reviewer duty gating', () => {
     expect(section).not.toContain('waived');
   });
 
+  it('should inject the waived duty independently of open findings', () => {
+    const section = extractFindingContractSection(new InstructionBuilder(
+      makeStep(),
+      makeContext({ hasOpenFindings: false, hasWaivedFindings: true, rawFindingsJsonSchema: { type: 'object' } }),
+    ).build());
+
+    expect(section).toContain('listed as waived');
+    expect(section).not.toContain('resolution_confirmation');
+  });
+
   it('should inject confirmation duties when open findings exist and waived duty only with waived findings', () => {
     const withOpen = extractFindingContractSection(new InstructionBuilder(
       makeStep(),

--- a/src/__tests__/invalid-tool-argument-loop.test.ts
+++ b/src/__tests__/invalid-tool-argument-loop.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { InvalidToolArgumentLoopDetector } from '../infra/opencode/unavailable-tool-loop.js';
+
+const SCHEMA_ERROR = 'The read tool was called with invalid arguments: SchemaError(Expected string)';
+
+describe('InvalidToolArgumentLoopDetector', () => {
+  it('should trip after four consecutive argument errors on the same tool', () => {
+    const detector = new InvalidToolArgumentLoopDetector();
+
+    expect(detector.observe('c1', 'read', SCHEMA_ERROR)).toBeUndefined();
+    expect(detector.observe('c2', 'read', SCHEMA_ERROR)).toBeUndefined();
+    expect(detector.observe('c3', 'read', SCHEMA_ERROR)).toBeUndefined();
+    expect(detector.observe('c4', 'read', SCHEMA_ERROR)).toContain('invalid tool argument loop');
+  });
+
+  it('should restart the count when the failing tool changes', () => {
+    const detector = new InvalidToolArgumentLoopDetector();
+
+    detector.observe('c1', 'read', SCHEMA_ERROR);
+    detector.observe('c2', 'read', SCHEMA_ERROR);
+    detector.observe('c3', 'read', SCHEMA_ERROR);
+    expect(detector.observe('c4', 'edit', SCHEMA_ERROR)).toBeUndefined();
+    expect(detector.observe('c5', 'edit', SCHEMA_ERROR)).toBeUndefined();
+  });
+
+  it('should reset on a non-argument error and on reset()', () => {
+    const detector = new InvalidToolArgumentLoopDetector();
+
+    detector.observe('c1', 'read', SCHEMA_ERROR);
+    detector.observe('c2', 'read', SCHEMA_ERROR);
+    detector.observe('c3', 'read', 'file not found');
+    expect(detector.observe('c4', 'read', SCHEMA_ERROR)).toBeUndefined();
+
+    detector.observe('c5', 'read', SCHEMA_ERROR);
+    detector.observe('c6', 'read', SCHEMA_ERROR);
+    detector.reset();
+    expect(detector.observe('c7', 'read', SCHEMA_ERROR)).toBeUndefined();
+  });
+
+  it('should ignore duplicate observations for the same call id', () => {
+    const detector = new InvalidToolArgumentLoopDetector();
+
+    detector.observe('c1', 'read', SCHEMA_ERROR);
+    detector.observe('c1', 'read', SCHEMA_ERROR);
+    detector.observe('c1', 'read', SCHEMA_ERROR);
+    detector.observe('c2', 'read', SCHEMA_ERROR);
+    detector.observe('c3', 'read', SCHEMA_ERROR);
+    expect(detector.observe('c4', 'read', SCHEMA_ERROR)).toContain('invalid tool argument loop');
+  });
+});

--- a/src/__tests__/invalid-tool-argument-loop.test.ts
+++ b/src/__tests__/invalid-tool-argument-loop.test.ts
@@ -23,18 +23,24 @@ describe('InvalidToolArgumentLoopDetector', () => {
     expect(detector.observe('c5', 'edit', SCHEMA_ERROR)).toBeUndefined();
   });
 
-  it('should reset on a non-argument error and on reset()', () => {
+  it('should reset the count on a non-argument error', () => {
     const detector = new InvalidToolArgumentLoopDetector();
 
     detector.observe('c1', 'read', SCHEMA_ERROR);
     detector.observe('c2', 'read', SCHEMA_ERROR);
     detector.observe('c3', 'read', 'file not found');
-    expect(detector.observe('c4', 'read', SCHEMA_ERROR)).toBeUndefined();
 
-    detector.observe('c5', 'read', SCHEMA_ERROR);
-    detector.observe('c6', 'read', SCHEMA_ERROR);
+    expect(detector.observe('c4', 'read', SCHEMA_ERROR)).toBeUndefined();
+  });
+
+  it('should reset the count when reset() is called', () => {
+    const detector = new InvalidToolArgumentLoopDetector();
+
+    detector.observe('c1', 'read', SCHEMA_ERROR);
+    detector.observe('c2', 'read', SCHEMA_ERROR);
     detector.reset();
-    expect(detector.observe('c7', 'read', SCHEMA_ERROR)).toBeUndefined();
+
+    expect(detector.observe('c3', 'read', SCHEMA_ERROR)).toBeUndefined();
   });
 
   it('should ignore duplicate observations for the same call id', () => {

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -221,6 +221,7 @@ export class ParallelRunner {
                   ledgerCopyPath: findingLedgerCopyPath,
                   ledgerSummary: this.renderFindingLedgerSummary(),
                   reportLedgerSummary: this.renderFindingLedgerReportSummary(),
+                  hasOpenFindings: this.ledgerHasOpenFindings(),
                   rawFindingsJsonSchema: RawFindingsStructuredOutput.schema,
                 }
               : undefined,
@@ -652,6 +653,13 @@ export class ParallelRunner {
       throw new Error('Finding contract is configured but finding ledger store is not available');
     }
     return this.deps.findingLedgerStore.createRunCopy();
+  }
+
+  private ledgerHasOpenFindings(): boolean {
+    if (!this.deps.findingLedgerStore) {
+      return false;
+    }
+    return this.deps.findingLedgerStore.loadLedger().findings.some((finding) => finding.status === 'open');
   }
 
   private renderFindingLedgerSummary(): string {

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -39,7 +39,7 @@ import {
   type FindingManagerRunResult,
   runFindingManagerForParallelStep,
 } from '../findings/manager-runner.js';
-import { renderFindingLedgerInstructionSummary, renderFindingLedgerReportSummary } from '../findings/context.js';
+import { ledgerHasOpenFindings, renderFindingLedgerInstructionSummary, renderFindingLedgerReportSummary } from '../findings/context.js';
 import { isNonAiReturnValueRule } from '../evaluation/rule-utils.js';
 
 const log = createLogger('parallel-runner');
@@ -659,7 +659,7 @@ export class ParallelRunner {
     if (!this.deps.findingLedgerStore) {
       return false;
     }
-    return this.deps.findingLedgerStore.loadLedger().findings.some((finding) => finding.status === 'open');
+    return ledgerHasOpenFindings(this.deps.findingLedgerStore.loadLedger());
   }
 
   private renderFindingLedgerSummary(): string {

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -39,7 +39,7 @@ import {
   type FindingManagerRunResult,
   runFindingManagerForParallelStep,
 } from '../findings/manager-runner.js';
-import { ledgerHasOpenFindings, renderFindingLedgerInstructionSummary, renderFindingLedgerReportSummary } from '../findings/context.js';
+import { ledgerHasOpenFindings, ledgerHasWaivedFindings, renderFindingLedgerInstructionSummary, renderFindingLedgerReportSummary } from '../findings/context.js';
 import { isNonAiReturnValueRule } from '../evaluation/rule-utils.js';
 
 const log = createLogger('parallel-runner');
@@ -222,6 +222,7 @@ export class ParallelRunner {
                   ledgerSummary: this.renderFindingLedgerSummary(),
                   reportLedgerSummary: this.renderFindingLedgerReportSummary(),
                   hasOpenFindings: this.ledgerHasOpenFindings(),
+                  hasWaivedFindings: this.ledgerHasWaivedFindings(),
                   rawFindingsJsonSchema: RawFindingsStructuredOutput.schema,
                 }
               : undefined,
@@ -660,6 +661,13 @@ export class ParallelRunner {
       return false;
     }
     return ledgerHasOpenFindings(this.deps.findingLedgerStore.loadLedger());
+  }
+
+  private ledgerHasWaivedFindings(): boolean {
+    if (!this.deps.findingLedgerStore) {
+      return false;
+    }
+    return ledgerHasWaivedFindings(this.deps.findingLedgerStore.loadLedger());
   }
 
   private renderFindingLedgerSummary(): string {

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -25,7 +25,7 @@ import type { StructuredOutputNormalizerRegistry } from './structured-output-nor
 import { runQualityGates } from '../quality-gates/qualityGateRunner.js';
 import type { FindingLedgerStore } from '../findings/store.js';
 import { RawFindingsStructuredOutput } from '../findings/manager-runner.js';
-import { renderFindingLedgerInstructionSummary, renderFindingLedgerReportSummary } from '../findings/context.js';
+import { ledgerHasOpenFindings, renderFindingLedgerInstructionSummary, renderFindingLedgerReportSummary } from '../findings/context.js';
 import type { FindingContractInstructionContext } from '../instruction/instruction-context.js';
 
 const log = createLogger('workflow-engine');
@@ -149,7 +149,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
       ledgerCopyPath: params.findingLedgerStore.createRunCopy(),
       ledgerSummary: renderFindingLedgerInstructionSummary(ledger),
       reportLedgerSummary: renderFindingLedgerReportSummary(ledger),
-      hasOpenFindings: ledger.findings.some((finding) => finding.status === 'open'),
+      hasOpenFindings: ledgerHasOpenFindings(ledger),
       ...(includeRawFindingsSchema
         ? {
             rawFindingsJsonSchema: RawFindingsStructuredOutput.schema,

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -149,6 +149,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
       ledgerCopyPath: params.findingLedgerStore.createRunCopy(),
       ledgerSummary: renderFindingLedgerInstructionSummary(ledger),
       reportLedgerSummary: renderFindingLedgerReportSummary(ledger),
+      hasOpenFindings: ledger.findings.some((finding) => finding.status === 'open'),
       ...(includeRawFindingsSchema
         ? {
             rawFindingsJsonSchema: RawFindingsStructuredOutput.schema,

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -25,7 +25,7 @@ import type { StructuredOutputNormalizerRegistry } from './structured-output-nor
 import { runQualityGates } from '../quality-gates/qualityGateRunner.js';
 import type { FindingLedgerStore } from '../findings/store.js';
 import { RawFindingsStructuredOutput } from '../findings/manager-runner.js';
-import { ledgerHasOpenFindings, renderFindingLedgerInstructionSummary, renderFindingLedgerReportSummary } from '../findings/context.js';
+import { ledgerHasOpenFindings, ledgerHasWaivedFindings, renderFindingLedgerInstructionSummary, renderFindingLedgerReportSummary } from '../findings/context.js';
 import type { FindingContractInstructionContext } from '../instruction/instruction-context.js';
 
 const log = createLogger('workflow-engine');
@@ -150,6 +150,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
       ledgerSummary: renderFindingLedgerInstructionSummary(ledger),
       reportLedgerSummary: renderFindingLedgerReportSummary(ledger),
       hasOpenFindings: ledgerHasOpenFindings(ledger),
+      hasWaivedFindings: ledgerHasWaivedFindings(ledger),
       ...(includeRawFindingsSchema
         ? {
             rawFindingsJsonSchema: RawFindingsStructuredOutput.schema,

--- a/src/core/workflow/findings/context.ts
+++ b/src/core/workflow/findings/context.ts
@@ -67,6 +67,11 @@ export function ledgerHasOpenFindings(ledger: FindingLedger): boolean {
   return ledger.findings.some((finding) => finding.status === 'open');
 }
 
+/** 台帳に waived な指摘が存在するか（waived 除外指示の注入判定に使う）。 */
+export function ledgerHasWaivedFindings(ledger: FindingLedger): boolean {
+  return ledger.findings.some((finding) => finding.status === 'waived');
+}
+
 export function buildFindingsRuleContext(ledger: FindingLedger): FindingsRuleContext {
   const openItems = ledger.findings.filter((finding) => finding.status === 'open');
   const activeConflicts = ledger.conflicts.filter((conflict) => conflict.status === 'active');

--- a/src/core/workflow/findings/context.ts
+++ b/src/core/workflow/findings/context.ts
@@ -62,6 +62,11 @@ export function renderFindingLedgerReportSummary(ledger: FindingLedger): string 
   }, null, 2);
 }
 
+/** 台帳に open な指摘が存在するか（異議申告ガイドの注入判定に使う）。 */
+export function ledgerHasOpenFindings(ledger: FindingLedger): boolean {
+  return ledger.findings.some((finding) => finding.status === 'open');
+}
+
 export function buildFindingsRuleContext(ledger: FindingLedger): FindingsRuleContext {
   const openItems = ledger.findings.filter((finding) => finding.status === 'open');
   const activeConflicts = ledger.conflicts.filter((conflict) => conflict.status === 'active');

--- a/src/core/workflow/instruction/InstructionBuilder.ts
+++ b/src/core/workflow/instruction/InstructionBuilder.ts
@@ -227,6 +227,19 @@ export class InstructionBuilder {
     return [structureHeader, ...stepLines].join('\n');
   }
 
+  private hasOpenLedgerFindings(): boolean {
+    const summary = this.context.findingContract?.ledgerSummary;
+    if (summary === undefined) {
+      return false;
+    }
+    try {
+      const parsed = JSON.parse(summary) as { open?: unknown[] };
+      return Array.isArray(parsed.open) && parsed.open.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
   private appendFindingContractInstruction(instructions: string): string {
     if (!this.context.findingContract) {
       return instructions;
@@ -257,7 +270,10 @@ export class InstructionBuilder {
         '- Return structured output matching this raw findings schema:',
         renderFencedJsonBlock(this.context.findingContract.rawFindingsJsonSchema),
       );
-    } else {
+    } else if (this.hasOpenLedgerFindings()) {
+      // 異議申告のガイドは open な指摘が存在するときだけ注入する。台帳が空の
+      // 段階（初回 implement 等）では無意味であり、無関係なプロトコル文が
+      // 弱いモデルのツール呼び出しを不安定化させることを実走で確認済み。
       lines.push(
         '',
         '- If an open finding is valid but cannot be fixed (frozen public contract, external constraint, deliberate trade-off), do NOT loop on it. State a dispute claim in your response under a "## Disputed Findings" heading, one entry per finding:',

--- a/src/core/workflow/instruction/InstructionBuilder.ts
+++ b/src/core/workflow/instruction/InstructionBuilder.ts
@@ -245,13 +245,21 @@ export class InstructionBuilder {
     ];
 
     if (this.context.findingContract.rawFindingsJsonSchema) {
+      // 状態に該当しない指示は注入しない: 確認・再指摘系は open がある
+      // ラウンドだけ、waived 除外は waived が実在するときだけ。
       lines.push(
         '',
         '- Report every issue you observe as structured raw findings with kind "issue" (empty targetFindingId).',
-        '- Each round, verify the open ledger findings that fall within your review scope.',
-        '- When you have confirmed an open finding is fixed, report it as a raw finding with kind "resolution_confirmation", the ledger finding id in targetFindingId, and file:line evidence in description. Findings are only marked resolved through such confirmations.',
-        '- Do not re-report an open finding that is still unfixed; report a new issue only if it regressed or changed.',
-        '- Do not re-report findings listed as waived in the ledger summary. If you observe that a waiver premise no longer holds, report that observation as a new issue citing the waived finding id.',
+        ...(this.context.findingContract.hasOpenFindings
+          ? [
+              '- Each round, verify the open ledger findings that fall within your review scope.',
+              '- When you have confirmed an open finding is fixed, report it as a raw finding with kind "resolution_confirmation", the ledger finding id in targetFindingId, and file:line evidence in description. Findings are only marked resolved through such confirmations.',
+              '- Do not re-report an open finding that is still unfixed; report a new issue only if it regressed or changed.',
+            ]
+          : []),
+        ...(this.context.findingContract.hasWaivedFindings
+          ? ['- Do not re-report findings listed as waived in the ledger summary. If you observe that a waiver premise no longer holds, report that observation as a new issue citing the waived finding id.']
+          : []),
         '- Use rawFindingId values that are unique within this response.',
         '- Copy each Observed Findings family_tag value into the structured familyTag field.',
         '- Return structured output matching this raw findings schema:',

--- a/src/core/workflow/instruction/InstructionBuilder.ts
+++ b/src/core/workflow/instruction/InstructionBuilder.ts
@@ -227,19 +227,6 @@ export class InstructionBuilder {
     return [structureHeader, ...stepLines].join('\n');
   }
 
-  private hasOpenLedgerFindings(): boolean {
-    const summary = this.context.findingContract?.ledgerSummary;
-    if (summary === undefined) {
-      return false;
-    }
-    try {
-      const parsed = JSON.parse(summary) as { open?: unknown[] };
-      return Array.isArray(parsed.open) && parsed.open.length > 0;
-    } catch {
-      return false;
-    }
-  }
-
   private appendFindingContractInstruction(instructions: string): string {
     if (!this.context.findingContract) {
       return instructions;
@@ -270,7 +257,7 @@ export class InstructionBuilder {
         '- Return structured output matching this raw findings schema:',
         renderFencedJsonBlock(this.context.findingContract.rawFindingsJsonSchema),
       );
-    } else if (this.hasOpenLedgerFindings()) {
+    } else if (this.context.findingContract.hasOpenFindings) {
       // 異議申告のガイドは open な指摘が存在するときだけ注入する。台帳が空の
       // 段階（初回 implement 等）では無意味であり、無関係なプロトコル文が
       // 弱いモデルのツール呼び出しを不安定化させることを実走で確認済み。

--- a/src/core/workflow/instruction/instruction-context.ts
+++ b/src/core/workflow/instruction/instruction-context.ts
@@ -10,6 +10,8 @@ export interface FindingContractInstructionContext {
   ledgerCopyPath: string;
   ledgerSummary: string;
   reportLedgerSummary: string;
+  /** Whether the ledger currently has open findings (computed from the ledger, not re-parsed from the summary). */
+  hasOpenFindings: boolean;
   rawFindingsJsonSchema?: Record<string, unknown>;
 }
 

--- a/src/core/workflow/instruction/instruction-context.ts
+++ b/src/core/workflow/instruction/instruction-context.ts
@@ -12,6 +12,8 @@ export interface FindingContractInstructionContext {
   reportLedgerSummary: string;
   /** Whether the ledger currently has open findings (computed from the ledger, not re-parsed from the summary). */
   hasOpenFindings: boolean;
+  /** Whether the ledger currently has waived findings. */
+  hasWaivedFindings: boolean;
   rawFindingsJsonSchema?: Record<string, unknown>;
 }
 

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -38,7 +38,7 @@ import {
   emitResult,
   handlePartUpdated,
 } from './OpenCodeStreamHandler.js';
-import { UnavailableToolLoopDetector } from './unavailable-tool-loop.js';
+import { InvalidToolArgumentLoopDetector, UnavailableToolLoopDetector } from './unavailable-tool-loop.js';
 import { buildRateLimitedResponseFields, containsRateLimitError } from '../rate-limit/detection.js';
 
 export type { OpenCodeCallOptions } from './types.js';
@@ -766,6 +766,7 @@ export class OpenCodeClient {
         let failureMessage = '';
         const state = createStreamTrackingState();
         const unavailableToolLoopDetector = new UnavailableToolLoopDetector();
+        const invalidArgumentLoopDetector = new InvalidToolArgumentLoopDetector();
         const echoState = { remainingPrompts: buildPromptEchoCandidates(prompt, options.systemPrompt) };
         const textOffsets = new Map<string, number>();
         const textContentParts = new Map<string, string>();
@@ -816,10 +817,15 @@ export class OpenCodeClient {
                   toolPart.callID || toolPart.id,
                   toolPart.tool,
                   toolPart.state.error,
+                ) ?? invalidArgumentLoopDetector.observe(
+                  toolPart.callID || toolPart.id,
+                  toolPart.tool,
+                  toolPart.state.error,
                 )
                 : undefined;
               if (toolPart.state.status === 'completed') {
                 unavailableToolLoopDetector.reset();
+                invalidArgumentLoopDetector.reset();
               }
               handlePartUpdated(part, delta, options.onStream, state);
               if (loopError !== undefined) {

--- a/src/infra/opencode/unavailable-tool-loop.ts
+++ b/src/infra/opencode/unavailable-tool-loop.ts
@@ -39,3 +39,60 @@ export class UnavailableToolLoopDetector {
     this.lastUnavailableToolCallId = undefined;
   }
 }
+
+const INVALID_ARGUMENT_ERROR_PATTERNS = [
+  'invalid arguments',
+  'schemaerror',
+];
+
+// 引数エラーは正常な試行錯誤でも起きるため、unavailable より閾値を緩くする。
+const REPEATED_INVALID_ARGUMENT_THRESHOLD = 4;
+
+function isInvalidArgumentErrorMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return INVALID_ARGUMENT_ERROR_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+/**
+ * 実在するツールを壊れた引数で呼び続けるループの検出器。
+ * UnavailableToolLoopDetector の兄弟: あちらは「存在しないツール」、
+ * こちらは「同一ツールへの引数バリデーションエラーの連発」を打ち切る。
+ * 実測では弱いモデルがこの状態で10分以上もがき続けた。
+ */
+export class InvalidToolArgumentLoopDetector {
+  private consecutiveInvalidArgumentErrors = 0;
+  private lastToolName: string | undefined;
+  private lastCallId: string | undefined;
+
+  observe(toolCallId: string, tool: string, message: string): string | undefined {
+    if (!isInvalidArgumentErrorMessage(message)) {
+      this.reset();
+      return undefined;
+    }
+
+    if (toolCallId === this.lastCallId) {
+      return undefined;
+    }
+    this.lastCallId = toolCallId;
+
+    if (tool !== this.lastToolName) {
+      this.lastToolName = tool;
+      this.consecutiveInvalidArgumentErrors = 1;
+      return undefined;
+    }
+
+    this.consecutiveInvalidArgumentErrors += 1;
+    if (this.consecutiveInvalidArgumentErrors < REPEATED_INVALID_ARGUMENT_THRESHOLD) {
+      return undefined;
+    }
+
+    return `OpenCode invalid tool argument loop detected for tool "${tool}": ${message}`;
+  }
+
+  reset(): void {
+    this.consecutiveInvalidArgumentErrors = 0;
+    this.lastToolName = undefined;
+    this.lastCallId = undefined;
+  }
+}
+


### PR DESCRIPTION
## 問題

#969 導入後、FC ベンチが**初回 implement で2連続死**（coder が壊れたツール呼び出し — Read 引数の SchemaError や Edit の oldString 不一致 — を11〜12分続けて「実装を進められない」と自己申告 → ABORT）。

## 因果の確定（隔離実験）

| 条件 | implement 結果 |
|------|---------------|
| FC + 異議ガイドあり | 死亡 2/2 |
| FC + 異議ガイドのみ除去（dist 直パッチ） | **成功** |
| 非 FC（同 coder・同タスク・数分差） | 成功 |

台帳が空の段階で無関係な異議申告プロトコルを注入すると、弱い coder のツール呼び出しが不安定化する。「注意予算は有限」の実例。

## 変更（同一事件からの包括対処、点修正ではなく原則で）

**1. 状態条件付き注入の一般化** — 「台帳の状態に該当しない指示は注入しない」を全ブロックに適用:

| ブロック | 注入条件 |
|---|---|
| 異議申告ガイド（coder） | open 実在 |
| 解消確認・再指摘禁止の義務（レビュアー） | open 実在 |
| waived 除外指示（レビュアー） | waived 実在 |
| issue 報告・スキーマ・familyTag・台帳パス | 常に該当のため無条件のまま |

判定は台帳から純関数（`ledgerHasOpenFindings` / `ledgerHasWaivedFindings`）で構築側にて計算（CodeRabbit 指摘反映: summary 文字列の再パースなし）。

**2. InvalidToolArgumentLoopDetector** — 既存の unavailable-tool 検出器の兄弟。同一ツールへの引数バリデーションエラー連続4回でコールを打ち切り、再発時に10分超の空転を防ぐ（成功・ツール切替・別種エラーでリセット）。

**3. coder canary（`npm run canary:coder`）** — instruction 変更時に実プロバイダで最小 implement 1走し、完走・成果物実在・ツールエラー数を確認する推奨手順（PR ゲートではない、CONTRIBUTING 記載）。

## 検証

- ユニット: 注入条件6件 + 純関数境界4件 + 検出器4件、全シャード green（既知の worktree 環境固有のみ）
- codex レビュー: 本体 APPROVE ×2 + ガード追加分も反例2ラウンド（成果物検証・finally スキップ）を経て APPROVE
- CodeRabbit: 5件全消化（うち設計指摘の hasOpenFindings 構築側移動を採用）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 指摘の状態に応じて、実行時の案内文がより適切に出し分けられるようになりました。
  * 無効な引数によるツール失敗の連続発生を検知し、ループを早期に止めやすくなりました。
  * canary 実行用のコマンドが追加され、実環境での確認を行いやすくなりました。

* **Bug Fixes**
  * 指摘がない場合に不要な「Disputed Findings」案内が出ないよう改善しました。

* **Documentation**
  * 変更時の canary 実行手順と注意点を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->