### PR TITLE
fix: never let judgment select deterministic rule conditions

### DIFF
--- a/src/__tests__/immediate-deterministic-match.test.ts
+++ b/src/__tests__/immediate-deterministic-match.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { findImmediateDeterministicMatch } from '../core/workflow/evaluation/rule-utils.js';
+import type { WorkflowRule, WorkflowState } from '../core/models/types.js';
+
+function rule(condition: string, overrides: Partial<WorkflowRule> = {}): WorkflowRule {
+  return { condition, next: 'COMPLETE', ...overrides } as WorkflowRule;
+}
+
+function stateWithFindings(open: number, conflicts: number): WorkflowState {
+  return {
+    findings: {
+      open: { count: open, bySeverity: { critical: 0, high: 0, medium: 0, low: 0 }, items: [] },
+      resolved: { count: 0 },
+      waived: { count: 0 },
+      conflicts: { count: conflicts, items: [] },
+    },
+  } as unknown as WorkflowState;
+}
+
+describe('findImmediateDeterministicMatch', () => {
+  const rules = [
+    rule('approved'),
+    rule('needs_fix', { next: 'fix' }),
+    rule('findings.conflicts.count > 0', { next: 'ABORT' }),
+  ];
+
+  it('should return the deterministic rule index when its condition holds', () => {
+    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 1), false)).toBe(2);
+  });
+
+  it('should return -1 when no deterministic condition holds', () => {
+    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 0), false)).toBe(-1);
+  });
+
+  it('should skip deferred true and non-deterministic rules', () => {
+    const mixed = [rule('approved'), rule('true', { next: 'fix' })];
+    expect(findImmediateDeterministicMatch(mixed, stateWithFindings(0, 0), false)).toBe(-1);
+  });
+});

--- a/src/__tests__/judge-deterministic-exclusion.test.ts
+++ b/src/__tests__/judge-deterministic-exclusion.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isValidRuleIndex, buildJudgeConditions } from '../agents/judge-utils.js';
+import type { WorkflowRule } from '../core/models/types.js';
+
+function rule(condition: string): WorkflowRule {
+  return { condition, next: 'COMPLETE' } as WorkflowRule;
+}
+
+describe('deterministic conditions are not model-selectable', () => {
+  const rules = [
+    rule('approved'),
+    rule('needs_fix'),
+    rule('findings.open.count > 0'),
+    rule('findings.conflicts.count > 0'),
+  ];
+
+  it('should reject a judged index that points at a deterministic rule', () => {
+    // 実走事例: final-gate の判定が findings.conflicts.count > 0 を「選択」し、
+    // 実際には conflict ゼロなのに ABORT した
+    expect(isValidRuleIndex(3, rules, false)).toBe(false);
+    expect(isValidRuleIndex(2, rules, false)).toBe(false);
+    expect(isValidRuleIndex(0, rules, false)).toBe(true);
+    expect(isValidRuleIndex(1, rules, false)).toBe(true);
+  });
+
+  it('should exclude deterministic rules from the judge condition list', () => {
+    const conditions = buildJudgeConditions(rules, false);
+
+    expect(conditions.map((c) => c.text)).toEqual(['approved', 'needs_fix']);
+    // 元のルール index を保持する（番号の付け替えで誤採用しない）
+    expect(conditions.map((c) => c.index)).toEqual([0, 1]);
+  });
+});

--- a/src/__tests__/workflow-engine-structured-caller.test.ts
+++ b/src/__tests__/workflow-engine-structured-caller.test.ts
@@ -680,6 +680,97 @@ describe('WorkflowEngine structured caller defaults', () => {
     expect(result.stepOutputs.has('fix')).toBe(true);
   });
 
+  it('真に成立している決定的ルールは phase 3 の approved 判定より先行して採用される', async () => {
+    const initialLedger = {
+      version: 1,
+      workflowName: 'phase3-preempt-test',
+      nextId: 1,
+      updatedAt: '2026-06-13T00:00:00.000Z',
+      findings: [],
+      rawFindings: [],
+      conflicts: [
+        {
+          id: 'C-TEST',
+          status: 'active',
+          findingIds: [],
+          rawFindingIds: [],
+          description: 'Reviewers disagree.',
+          firstSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+          lastSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+        },
+      ],
+    };
+
+    vi.mocked(runAgent).mockImplementation(async (_persona, instruction, options) => {
+      options?.onPromptResolved?.({ systemPrompt: 'system', userInstruction: instruction });
+      const schemaText = options?.outputSchema ? JSON.stringify(options.outputSchema) : '';
+      if (schemaText.includes('"step"')) {
+        // 判定は approved(=1) を主張する
+        return {
+          persona: 'judge',
+          status: 'done',
+          content: '{"step": 1}',
+          structuredOutput: { step: 1 },
+          timestamp: new Date('2026-06-13T00:00:03.000Z'),
+        };
+      }
+      return {
+        persona: 'agent',
+        status: 'done',
+        content: 'All good, approving.',
+        timestamp: new Date('2026-06-13T00:00:01.000Z'),
+      };
+    });
+
+    const config: WorkflowConfig = {
+      name: 'phase3-preempt-test',
+      maxSteps: 3,
+      initialStep: 'final-gate',
+      findingContract: {
+        ledgerPath: '.takt/findings/peer-review.json',
+        rawFindingsPath: '.takt/findings/raw',
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          outputContract: 'findings-manager',
+        },
+      },
+      steps: [
+        makeStep({
+          name: 'final-gate',
+          persona: 'merge-readiness-reviewer',
+          instruction: 'Judge merge readiness.',
+          outputContracts: [{ name: 'merge-readiness-review.md', format: '# Merge Readiness Review' }],
+          rules: [
+            makeRule('approved', 'COMPLETE'),
+            makeRule('needs_fix', 'fix'),
+            makeRule('findings.conflicts.count > 0', 'ABORT'),
+          ],
+        }),
+        makeStep({
+          name: 'fix',
+          persona: 'coder',
+          instruction: 'Fix.',
+          rules: [makeRule('true', 'COMPLETE')],
+        }),
+      ],
+    };
+
+    const ledgerPath = getAuthoritativeLedgerPath(cwd);
+    mkdirSync(dirname(ledgerPath), { recursive: true });
+    writeFileSync(ledgerPath, JSON.stringify(initialLedger, null, 2), 'utf-8');
+
+    const result = await new WorkflowEngine(config, cwd, 'task', {
+      projectCwd: cwd,
+      provider: 'claude',
+      reportDirName: 'test-report-dir',
+      detectRuleIndex: () => -1,
+    }).run();
+
+    // conflict が実在する以上、approved 判定でも ABORT が先行する
+    expect(result.status).toBe('aborted');
+  });
+
   it('parallel sub-step の構造化出力が壊れていたら同一セッションで1回是正して続行する', async () => {
     const initialLedger = {
       version: 1,

--- a/src/agents/judge-utils.ts
+++ b/src/agents/judge-utils.ts
@@ -1,10 +1,16 @@
 import type { WorkflowRule } from '../core/models/types.js';
+import { isDeterministicCondition } from '../core/workflow/evaluation/rule-utils.js';
 import { loadTemplate } from '../shared/prompts/index.js';
 
 export function isValidRuleIndex(index: number, rules: WorkflowRule[], interactive: boolean): boolean {
   if (index < 0 || index >= rules.length) return false;
   const rule = rules[index];
-  return !(rule?.interactiveOnly && !interactive);
+  if (rule === undefined) return false;
+  if (rule.interactiveOnly && !interactive) return false;
+  // 決定的条件（findings.* 等）はエンジンが実状態から評価するもので、
+  // モデルの申告で成立させてはならない（偽の conflict 宣言でゲートを
+  // 落とせてしまう）。判定の選択対象から機械的に除外する。
+  return !isDeterministicCondition(rule.condition);
 }
 
 export function buildJudgeConditions(
@@ -15,6 +21,7 @@ export function buildJudgeConditions(
   return rules
     .map((rule, index) => ({ rule, index }))
     .filter(({ rule }) => interactive || !rule.interactiveOnly)
+    .filter(({ rule }) => !isDeterministicCondition(rule.condition))
     .map(({ index, rule }) => ({ index: indexes?.[index] ?? index, text: rule.condition }));
 }
 

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -18,6 +18,7 @@ import { ParallelLogger } from './parallel-logger.js';
 import { needsStatusJudgmentPhase, runReportPhase, ReportPhaseGenerationError, runStatusJudgmentPhase } from '../phase-runner.js';
 import { detectMatchedRule } from '../evaluation/index.js';
 import { evaluateWhenExpression } from '../evaluation/when-evaluator.js';
+import { isDeterministicCondition } from '../evaluation/rule-utils.js';
 import type { StatusJudgmentPhaseResult } from '../phase-runner.js';
 import { incrementStepIteration } from './state-manager.js';
 import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
@@ -421,8 +422,12 @@ export class ParallelRunner {
         // ここで評価する。不成立なら採用せず、ガード対応済みの通常ルール
         // 評価へフォールバックする（StepExecutor 側と同じ扱い）。
         const subPhase3Rule = subPhase3 !== undefined ? subStep.rules?.[subPhase3.ruleIndex] : undefined;
-        const subPhase3GuardFailed = subPhase3Rule?.guardCondition !== undefined
-          && !evaluateWhenExpression(subPhase3Rule.guardCondition, state);
+        const subPhase3GuardFailed = (subPhase3Rule?.guardCondition !== undefined
+          && !evaluateWhenExpression(subPhase3Rule.guardCondition, state))
+          // 決定的条件は申告では成立させない（StepExecutor 側と同じ防御）
+          || (subPhase3Rule !== undefined
+            && isDeterministicCondition(subPhase3Rule.condition)
+            && !evaluateWhenExpression(subPhase3Rule.condition, state));
         if (subPhase3GuardFailed && subPhase3 !== undefined) {
           log.debug('Phase 3 rule guard failed for sub-step; falling back to rule evaluation', {
             step: subStep.name,

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -18,7 +18,7 @@ import { ParallelLogger } from './parallel-logger.js';
 import { needsStatusJudgmentPhase, runReportPhase, ReportPhaseGenerationError, runStatusJudgmentPhase } from '../phase-runner.js';
 import { detectMatchedRule } from '../evaluation/index.js';
 import { evaluateWhenExpression } from '../evaluation/when-evaluator.js';
-import { isDeterministicCondition } from '../evaluation/rule-utils.js';
+import { findImmediateDeterministicMatch, isDeterministicCondition } from '../evaluation/rule-utils.js';
 import type { StatusJudgmentPhaseResult } from '../phase-runner.js';
 import { incrementStepIteration } from './state-manager.js';
 import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
@@ -421,6 +421,13 @@ export class ParallelRunner {
         // Phase 3 はルール番号を直接採用するため、ガード（findings 条件）を
         // ここで評価する。不成立なら採用せず、ガード対応済みの通常ルール
         // 評価へフォールバックする（StepExecutor 側と同じ扱い）。
+        // StepExecutor 側と同じく、採用前にエンジン所有の決定的条件を先行評価
+        const subPreemptIndex = subPhase3 !== undefined
+          ? findImmediateDeterministicMatch(subStep.rules, state, this.deps.getInteractive())
+          : -1;
+        if (subPhase3 !== undefined && subPreemptIndex !== -1) {
+          subPhase3 = { ...subPhase3, ruleIndex: subPreemptIndex, method: 'auto_select' };
+        }
         const subPhase3Rule = subPhase3 !== undefined ? subStep.rules?.[subPhase3.ruleIndex] : undefined;
         const subPhase3GuardFailed = (subPhase3Rule?.guardCondition !== undefined
           && !evaluateWhenExpression(subPhase3Rule.guardCondition, state))

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -22,7 +22,7 @@ import { InstructionBuilder } from '../instruction/InstructionBuilder.js';
 import { needsStatusJudgmentPhase, runReportPhase, ReportPhaseGenerationError, runStatusJudgmentPhase } from '../phase-runner.js';
 import { detectMatchedRule } from '../evaluation/index.js';
 import { evaluateWhenExpression } from '../evaluation/when-evaluator.js';
-import { isDeterministicCondition } from '../evaluation/rule-utils.js';
+import { findImmediateDeterministicMatch, isDeterministicCondition } from '../evaluation/rule-utils.js';
 import type { StatusJudgmentPhaseResult } from '../phase-runner.js';
 import { buildSessionKey } from '../session-key.js';
 import { incrementStepIteration, getPreviousOutput } from './state-manager.js';
@@ -518,12 +518,25 @@ export class StepExecutor {
       // Phase 3 の判定はタグ/構造化出力からルール番号を直接採用するため、
       // ここでガード（findings 条件）を評価する。不成立なら採用せず、
       // ガード対応済みの通常ルール評価へフォールバックする。
+      // Phase 3 の採用前に、エンジン所有の決定的条件（findings.* 等）を
+      // 実状態で先行評価する。成立していれば判定結果より優先して採用する
+      // （判定は決定的ルールを選べないため、真に成立している ABORT 等が
+      // 判定成功時に素通りしないよう、ここで拾う）。
+      const preemptIndex = findImmediateDeterministicMatch(step.rules, state, this.deps.getInteractive());
+      if (preemptIndex !== -1) {
+        log.debug('Deterministic rule preempts phase 3 result', {
+          step: step.name,
+          preemptIndex,
+          judgedIndex: phase3Result.ruleIndex,
+        });
+        phase3Result = { ...phase3Result, ruleIndex: preemptIndex, method: 'auto_select' };
+      }
       const phase3Rule = step.rules?.[phase3Result.ruleIndex];
       if (
         (phase3Rule?.guardCondition !== undefined
           && !evaluateWhenExpression(phase3Rule.guardCondition, state))
-        // 決定的条件（findings.* 等）は選択候補から除外済みだが、万一
-        // 選ばれて返ってきても申告では成立させず、実状態で再評価する。
+        // 決定的条件は選択候補から除外済みだが、万一選ばれて返ってきても
+        // 申告では成立させず、実状態で再評価する。
         || (phase3Rule !== undefined
           && isDeterministicCondition(phase3Rule.condition)
           && !evaluateWhenExpression(phase3Rule.condition, state))

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -22,6 +22,7 @@ import { InstructionBuilder } from '../instruction/InstructionBuilder.js';
 import { needsStatusJudgmentPhase, runReportPhase, ReportPhaseGenerationError, runStatusJudgmentPhase } from '../phase-runner.js';
 import { detectMatchedRule } from '../evaluation/index.js';
 import { evaluateWhenExpression } from '../evaluation/when-evaluator.js';
+import { isDeterministicCondition } from '../evaluation/rule-utils.js';
 import type { StatusJudgmentPhaseResult } from '../phase-runner.js';
 import { buildSessionKey } from '../session-key.js';
 import { incrementStepIteration, getPreviousOutput } from './state-manager.js';
@@ -519,8 +520,13 @@ export class StepExecutor {
       // ガード対応済みの通常ルール評価へフォールバックする。
       const phase3Rule = step.rules?.[phase3Result.ruleIndex];
       if (
-        phase3Rule?.guardCondition !== undefined
-        && !evaluateWhenExpression(phase3Rule.guardCondition, state)
+        (phase3Rule?.guardCondition !== undefined
+          && !evaluateWhenExpression(phase3Rule.guardCondition, state))
+        // 決定的条件（findings.* 等）は選択候補から除外済みだが、万一
+        // 選ばれて返ってきても申告では成立させず、実状態で再評価する。
+        || (phase3Rule !== undefined
+          && isDeterministicCondition(phase3Rule.condition)
+          && !evaluateWhenExpression(phase3Rule.condition, state))
       ) {
         log.debug('Phase 3 rule guard failed; falling back to rule evaluation', {
           step: step.name,

--- a/src/core/workflow/evaluation/RuleEvaluator.ts
+++ b/src/core/workflow/evaluation/RuleEvaluator.ts
@@ -191,6 +191,11 @@ export class RuleEvaluator {
     if (rule?.guardCondition !== undefined && !evaluateWhenExpression(rule.guardCondition, this.ctx.state)) {
       return -1;
     }
+    // 決定的条件のルールはタグ申告（[STEP:N]）でも成立させない。
+    // 実状態で偽なら不一致として扱い、決定的評価ステージに委ねる。
+    if (rule !== undefined && isDeterministicCondition(rule.condition) && !evaluateWhenExpression(rule.condition, this.ctx.state)) {
+      return -1;
+    }
 
     return ruleIndex;
   }

--- a/src/core/workflow/evaluation/rule-utils.ts
+++ b/src/core/workflow/evaluation/rule-utils.ts
@@ -2,7 +2,8 @@
  * Shared rule utility functions used by both engine.ts and instruction-builder.ts.
  */
 
-import type { WorkflowStep, WorkflowRule, OutputContractEntry } from '../../models/types.js';
+import type { WorkflowState, WorkflowStep, WorkflowRule, OutputContractEntry } from '../../models/types.js';
+import { evaluateWhenExpression } from './when-evaluator.js';
 import { isEscapedQuote } from '../../models/workflow-condition-expression.js';
 
 const DETERMINISTIC_CONDITION_PATTERN = /^(true|false|exists\(.*\)|(?:context|structured|effect|findings)\..*|.*(?:==|!=|>=|<=|>|<).*)$/;
@@ -102,3 +103,30 @@ export function getJudgmentReportFiles(outputContracts: OutputContractEntry[] | 
     .filter((entry) => entry.useJudge !== false)
     .map((entry) => entry.name);
 }
+
+/**
+ * 即時決定的条件（findings.* 等、'true' の deferred を除く）を順に実状態で
+ * 評価し、最初に成立した rule index を返す。Phase 3 判定の採用前に
+ * エンジン所有の事実を先行させるための共有ヘルパ
+ * （RuleEvaluator.evaluateImmediateDeterministicConditions と同一規則）。
+ */
+export function findImmediateDeterministicMatch(
+  rules: readonly WorkflowRule[] | undefined,
+  state: WorkflowState,
+  interactive: boolean | undefined,
+): number {
+  if (!rules) return -1;
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    if (!rule) continue;
+    if (rule.interactiveOnly && interactive !== true) continue;
+    if (rule.isAiCondition || rule.isAggregateCondition) continue;
+    if (!isDeterministicCondition(rule.condition)) continue;
+    if (isDeferredDeterministicCondition(rule.condition)) continue;
+    if (evaluateWhenExpression(rule.condition, state)) {
+      return i;
+    }
+  }
+  return -1;
+}
+

--- a/src/core/workflow/instruction/status-rules.ts
+++ b/src/core/workflow/instruction/status-rules.ts
@@ -9,6 +9,7 @@
  */
 
 import type { WorkflowRule, Language } from '../../models/types.js';
+import { isDeterministicCondition } from '../evaluation/rule-utils.js';
 
 /** Components of the generated status rules */
 export interface StatusRulesComponents {
@@ -35,7 +36,10 @@ export function generateStatusRulesComponents(
   const interactiveEnabled = options?.interactive;
   const visibleRules = rules
     .map((rule, index) => ({ rule, index }))
-    .filter(({ rule }) => interactiveEnabled !== false || !rule.interactiveOnly);
+    .filter(({ rule }) => interactiveEnabled !== false || !rule.interactiveOnly)
+    // 決定的条件はエンジンが実状態から評価する（モデルに選ばせない）。
+    // 表示から除外しても原 index を保持するため番号はずれない。
+    .filter(({ rule }) => !isDeterministicCondition(rule.condition));
 
   // Build criteria table rows
   const headerNum = '#';


### PR DESCRIPTION
## 問題（TL 実走で発見）

team-leader 走行の final-gate が、台帳 conflict **0件**なのに `findings.conflicts.count > 0 (structured_output)` で ABORT した。Phase 3 判定が全ルール条件を選択肢として提示していたため、モデルが決定的条件を「申告」でき、エンジンは実状態を評価せずそれを採用していた — **モデルの嘘（または誤選択）だけでゲートを落とせる穴**。

## 修正（2層 + 先行評価）

- 選択層: 判定の候補一覧（buildJudgeConditions / status-rules の表示）と index 検証（isValidRuleIndex）から決定的条件ルールを除外。原 index は保持し番号ずれなし
- 先行評価: **Phase 3 の採用前に、エンジン所有の即時決定的条件を実状態で先行評価**（findImmediateDeterministicMatch — 評価器の即時決定的ステージと同一規則の共有ヘルパ）。真に成立している ABORT 等は approved 判定より優先される（codex レビューの反例を封じる要）
- 採用層防御: 万一決定的条件が選ばれて返っても実状態で再評価し、偽なら不採用でフォールスルー（StepExecutor / ParallelRunner / RuleEvaluator タグ経路の3箇所、#961 のガード防御と対称）

## 検証

- 反例2種を回帰テスト化: 「conflict 0 で conflicts>0 を申告 → 採用しない」「conflict 実在 + approved 判定 → ABORT が先行」
- 共有ヘルパのユニット + 全シャード green（既知の worktree 環境固有のみ）
- codex レビュー2ラウンド（High: 真decisive条件の素通り → 先行評価で反映 → **APPROVE**）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 決定的に確定できるルールを、後続の判定より優先して自動選択するようになりました。
  * ルール一覧や判定用の表示から、決定的条件のルールを除外するようになりました。

* **不具合修正**
  * ルール判定で、決定的条件が成立しているのに見落とされるケースを改善しました。
  * タグや構造化結果の判定より、実際の条件成立を優先するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->