### PR TITLE
refactor: tighten the when() helpers per coding standards

### DIFF
--- a/src/__tests__/immediate-deterministic-match.test.ts
+++ b/src/__tests__/immediate-deterministic-match.test.ts
@@ -25,11 +25,11 @@ describe('findImmediateDeterministicMatch', () => {
   ];
 
   it('should return the deterministic rule index when its condition holds', () => {
-    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 1), false)).toBe(2);
+    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 1), false, rules.length)).toBe(2);
   });
 
   it('should return -1 when no deterministic condition holds', () => {
-    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 0), false)).toBe(-1);
+    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 0), false, rules.length)).toBe(-1);
   });
 
   it('should not scan past endExclusive (positional first-match alignment)', () => {
@@ -41,6 +41,6 @@ describe('findImmediateDeterministicMatch', () => {
 
   it('should skip deferred true and non-deterministic rules', () => {
     const mixed = [rule('approved'), rule('when(true)', { next: 'fix' })];
-    expect(findImmediateDeterministicMatch(mixed, stateWithFindings(0, 0), false)).toBe(-1);
+    expect(findImmediateDeterministicMatch(mixed, stateWithFindings(0, 0), false, mixed.length)).toBe(-1);
   });
 });

--- a/src/__tests__/immediate-deterministic-match.test.ts
+++ b/src/__tests__/immediate-deterministic-match.test.ts
@@ -25,22 +25,22 @@ describe('findImmediateDeterministicMatch', () => {
   ];
 
   it('should return the deterministic rule index when its condition holds', () => {
-    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 1), false, rules.length)).toBe(2);
+    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 1), false, 0, rules.length)).toBe(2);
   });
 
   it('should return -1 when no deterministic condition holds', () => {
-    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 0), false, rules.length)).toBe(-1);
+    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 0), false, 0, rules.length)).toBe(-1);
   });
 
   it('should not scan past endExclusive (positional first-match alignment)', () => {
     // 判定が index 0 (approved) を選んだ場合、後方の決定的ルールは先行しない
-    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 1), false, 0)).toBe(-1);
+    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 1), false, 0, 0)).toBe(-1);
     // 判定 index が決定的ルールより後なら先行する
-    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 1), false, 3)).toBe(2);
+    expect(findImmediateDeterministicMatch(rules, stateWithFindings(0, 1), false, 0, 3)).toBe(2);
   });
 
   it('should skip deferred true and non-deterministic rules', () => {
     const mixed = [rule('approved'), rule('when(true)', { next: 'fix' })];
-    expect(findImmediateDeterministicMatch(mixed, stateWithFindings(0, 0), false, mixed.length)).toBe(-1);
+    expect(findImmediateDeterministicMatch(mixed, stateWithFindings(0, 0), false, 0, mixed.length)).toBe(-1);
   });
 });

--- a/src/__tests__/parallel-and-loader.test.ts
+++ b/src/__tests__/parallel-and-loader.test.ts
@@ -456,6 +456,8 @@ describe('all()/any() aggregate condition expression parsing', () => {
   it('should match aggregate condition with deterministic guard', () => {
     expect(() => parseAggregateConditionExpression('all("approved") && findings.open.count == 0'))
       .toThrow('must be wrapped in when(...)');
+    expect(() => parseAggregateConditionExpression('all("approved") && && when(findings.open.count == 0)'))
+      .toThrow('contains an empty clause');
     expect(parseAggregateConditionExpression('all("approved") && when(findings.open.count == 0)')).toEqual({
       type: 'all',
       argsText: '"approved"',

--- a/src/__tests__/rule-evaluator-when.test.ts
+++ b/src/__tests__/rule-evaluator-when.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { evaluateWhenExpression } from '../core/workflow/evaluation/when-evaluator.js';
 import { RuleEvaluator, type RuleEvaluatorContext } from '../core/workflow/evaluation/RuleEvaluator.js';
 import type { WorkflowState } from '../core/models/types.js';
 import { makeStep } from './test-helpers.js';
@@ -29,6 +30,30 @@ function makeContext(state: WorkflowState): RuleEvaluatorContext {
     } as RuleEvaluatorContext['structuredCaller'],
   };
 }
+
+
+describe('when expression empty clauses', () => {
+  it.each([
+    ['and', 'context.a.exists == true && && context.b.exists == true'],
+    ['or', 'context.a.exists == true || || context.b.exists == true'],
+    ['exists-inner', 'exists(findings.open.items, item.severity == "high" && && item.id == "F-1")'],
+  ])('should throw on empty clauses in %s expressions at evaluation time', (_label, expression) => {
+    const state = {
+      context: { a: { exists: true }, b: { exists: true } },
+      findings: {
+        open: {
+          count: 1,
+          bySeverity: { critical: 0, high: 1, medium: 0, low: 0 },
+          items: [{ id: 'F-1', severity: 'high', title: 't', reviewers: [] }],
+        },
+        resolved: { count: 0 },
+        waived: { count: 0 },
+        conflicts: { count: 0, items: [] },
+      },
+    } as never;
+    expect(() => evaluateWhenExpression(expression, state)).toThrow('contains an empty clause');
+  });
+});
 
 describe('RuleEvaluator with when conditions', () => {
   it('context 参照の真偽式を AI judge なしで評価できる', async () => {

--- a/src/__tests__/rule-utils.test.ts
+++ b/src/__tests__/rule-utils.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import {
+import { unwrapWhenCondition,
   hasTagBasedRules,
   hasOnlyOneBranch,
   getAutoSelectedTag,
@@ -75,6 +75,12 @@ describe('hasTagBasedRules', () => {
       ],
     });
     expect(hasTagBasedRules(step)).toBe(false);
+  });
+});
+
+describe('unwrapWhenCondition', () => {
+  it('should throw on non-when input (caller contract violation)', () => {
+    expect(() => unwrapWhenCondition('approved')).toThrow('requires a when(...) condition');
   });
 });
 

--- a/src/__tests__/workflow-step-normalizers.test.ts
+++ b/src/__tests__/workflow-step-normalizers.test.ts
@@ -197,11 +197,13 @@ describe('normalizeRule tag-and-findings compound conditions', () => {
     expect(normalized.guardCondition).toBeUndefined();
   });
 
-  it('should fail fast on malformed compounds with empty clauses', () => {
-    expect(() => normalizeRule({
-      condition: 'approved && && when(findings.open.count == 0)',
-      next: 'COMPLETE',
-    })).toThrow('contains an empty clause');
+  it.each([
+    ['middle', 'approved && && when(findings.open.count == 0)'],
+    ['leading', '&& when(findings.open.count == 0)'],
+    ['trailing', 'approved &&'],
+    ['consecutive', 'approved && && && when(findings.open.count == 0)'],
+  ])('should fail fast on malformed compounds with %s empty clauses', (_label, condition) => {
+    expect(() => normalizeRule({ condition, next: 'COMPLETE' })).toThrow('contains an empty clause');
   });
 
   it('should not split prose tags containing && when any clause is not a findings condition', () => {

--- a/src/__tests__/workflow-step-normalizers.test.ts
+++ b/src/__tests__/workflow-step-normalizers.test.ts
@@ -197,14 +197,11 @@ describe('normalizeRule tag-and-findings compound conditions', () => {
     expect(normalized.guardCondition).toBeUndefined();
   });
 
-  it('should not split malformed compounds with empty clauses', () => {
-    const normalized = normalizeRule({
-      condition: 'approved && && findings.open.count == 0',
+  it('should fail fast on malformed compounds with empty clauses', () => {
+    expect(() => normalizeRule({
+      condition: 'approved && && when(findings.open.count == 0)',
       next: 'COMPLETE',
-    });
-
-    expect(normalized.condition).toBe('approved && && findings.open.count == 0');
-    expect(normalized.guardCondition).toBeUndefined();
+    })).toThrow('contains an empty clause');
   });
 
   it('should not split prose tags containing && when any clause is not a findings condition', () => {

--- a/src/core/models/workflow-condition-expression.ts
+++ b/src/core/models/workflow-condition-expression.ts
@@ -322,7 +322,14 @@ export function splitTopLevelAndClauses(expression: string): string[] {
 }
 
 function splitGuardClauses(expression: string): string[] {
-  return splitTopLevelAndClauses(expression).filter((part) => part.length > 0);
+  // 空節（"a && && b" 等の壊れた設定）は黙って捨てず fail-fast する
+  const clauses = splitTopLevelAndClauses(expression);
+  for (const clause of clauses) {
+    if (clause.length === 0) {
+      throw new Error(`Configuration error: aggregate guard "${expression}" contains an empty clause`);
+    }
+  }
+  return clauses;
 }
 
 

--- a/src/core/models/workflow-condition-expression.ts
+++ b/src/core/models/workflow-condition-expression.ts
@@ -297,8 +297,12 @@ export function parseAggregateConditionExpression(value: string): AggregateCondi
  * 連結は単一の when 条件ではない）。
  */
 
-/** 括弧・引用符を尊重して && でトップレベル分割する（空節は保持、各節 trim）。 */
-export function splitTopLevelAndClauses(expression: string): string[] {
+/**
+ * 括弧・引用符（エスケープ含む）を尊重してトップレベルの論理区切りで分割する。
+ * 空節は保持する（壊れた設定の fail-fast 判定は呼び出し側の責務）。
+ * parse / normalize / evaluate が同一のトークナイズを共有するための唯一の実装。
+ */
+export function splitTopLevelClauses(expression: string, separator: '||' | '&&'): string[] {
   const parts: string[] = [];
   let inString = false;
   let depth = 0;
@@ -311,7 +315,7 @@ export function splitTopLevelAndClauses(expression: string): string[] {
     }
     if (!inString && current === '(') { depth++; continue; }
     if (!inString && current === ')') { depth--; continue; }
-    if (!inString && depth === 0 && expression.slice(index, index + 2) === '&&') {
+    if (!inString && depth === 0 && expression.slice(index, index + 2) === separator) {
       parts.push(expression.slice(start, index).trim());
       start = index + 2;
       index++;
@@ -319,6 +323,11 @@ export function splitTopLevelAndClauses(expression: string): string[] {
   }
   parts.push(expression.slice(start).trim());
   return parts;
+}
+
+/** 後方の呼び出し向け: && 専用の別名。 */
+export function splitTopLevelAndClauses(expression: string): string[] {
+  return splitTopLevelClauses(expression, '&&');
 }
 
 function splitGuardClauses(expression: string): string[] {

--- a/src/core/models/workflow-condition-expression.ts
+++ b/src/core/models/workflow-condition-expression.ts
@@ -297,7 +297,8 @@ export function parseAggregateConditionExpression(value: string): AggregateCondi
  * 連結は単一の when 条件ではない）。
  */
 
-function splitGuardClauses(expression: string): string[] {
+/** 括弧・引用符を尊重して && でトップレベル分割する（空節は保持、各節 trim）。 */
+export function splitTopLevelAndClauses(expression: string): string[] {
   const parts: string[] = [];
   let inString = false;
   let depth = 0;
@@ -317,8 +318,13 @@ function splitGuardClauses(expression: string): string[] {
     }
   }
   parts.push(expression.slice(start).trim());
-  return parts.filter((part) => part.length > 0);
+  return parts;
 }
+
+function splitGuardClauses(expression: string): string[] {
+  return splitTopLevelAndClauses(expression).filter((part) => part.length > 0);
+}
+
 
 export function isWhenConditionExpression(value: string): boolean {
   const trimmed = value.trim();
@@ -329,11 +335,11 @@ export function isWhenConditionExpression(value: string): boolean {
   return closing === trimmed.length - 1;
 }
 
-/** when(<式>) の内側を取り出す。when 形式でなければ trim のみ。 */
+/** when(<式>) の内側を取り出す。when 形式以外の入力は呼び出し側の契約違反として即座に失敗させる。 */
 export function unwrapWhenConditionExpression(value: string): string {
   const trimmed = value.trim();
   if (!isWhenConditionExpression(trimmed)) {
-    return trimmed;
+    throw new Error(`unwrapWhenConditionExpression requires a when(...) condition, got "${value}"`);
   }
   return trimmed.slice('when('.length, -1).trim();
 }

--- a/src/core/models/workflow-condition-expression.ts
+++ b/src/core/models/workflow-condition-expression.ts
@@ -330,15 +330,23 @@ export function splitTopLevelAndClauses(expression: string): string[] {
   return splitTopLevelClauses(expression, '&&');
 }
 
-function splitGuardClauses(expression: string): string[] {
-  // 空節（"a && && b" 等の壊れた設定）は黙って捨てず fail-fast する
-  const clauses = splitTopLevelAndClauses(expression);
+/** 分割して空節があれば fail-fast する（subject はエラー文の主語）。 */
+export function splitTopLevelClausesOrThrow(
+  expression: string,
+  separator: '||' | '&&',
+  subject: string,
+): string[] {
+  const clauses = splitTopLevelClauses(expression, separator);
   for (const clause of clauses) {
     if (clause.length === 0) {
-      throw new Error(`Configuration error: aggregate guard "${expression}" contains an empty clause`);
+      throw new Error(`Configuration error: ${subject} "${expression}" contains an empty clause`);
     }
   }
   return clauses;
+}
+
+function splitGuardClauses(expression: string): string[] {
+  return splitTopLevelClausesOrThrow(expression, '&&', 'aggregate guard');
 }
 
 

--- a/src/core/workflow/evaluation/RuleEvaluator.ts
+++ b/src/core/workflow/evaluation/RuleEvaluator.ts
@@ -18,7 +18,7 @@ import { createLogger } from '../../../shared/utils/index.js';
 import { buildJudgeConditions } from '../../../agents/judge-utils.js';
 import { AggregateEvaluator } from './AggregateEvaluator.js';
 import { evaluateWhenExpression } from './when-evaluator.js';
-import { hasUnquotedFindingsReference, isDeferredDeterministicCondition, isDeterministicCondition, isFindingsCondition, unwrapWhenCondition } from './rule-utils.js';
+import { findImmediateDeterministicMatch, hasUnquotedFindingsReference, isDeferredDeterministicCondition, isDeterministicCondition, isFindingsCondition, unwrapWhenCondition } from './rule-utils.js';
 
 const log = createLogger('rule-evaluator');
 
@@ -99,20 +99,14 @@ export class RuleEvaluator {
     }
 
     const firstNonDeterministicIndex = this.findFirstNonDeterministicRuleIndex();
-    const leadingDeterministicIndex = this.evaluateImmediateDeterministicConditions(
-      0,
-      firstNonDeterministicIndex >= 0 ? firstNonDeterministicIndex : undefined,
-    );
+    const leadingDeterministicIndex = findImmediateDeterministicMatch(this.step.rules, this.ctx.state, this.ctx.interactive, 0, firstNonDeterministicIndex >= 0 ? firstNonDeterministicIndex : (this.step.rules?.length ?? 0));
     if (leadingDeterministicIndex >= 0) {
       return { index: leadingDeterministicIndex, method: 'auto_select' };
     }
 
     const phase3TagIndex = this.resolveTaggedRuleIndex(tagContent, interactiveEnabled);
     if (phase3TagIndex >= 0) {
-      const immediateDeterministicIndex = this.evaluateImmediateDeterministicConditions(
-        firstNonDeterministicIndex + 1,
-        phase3TagIndex,
-      );
+      const immediateDeterministicIndex = findImmediateDeterministicMatch(this.step.rules, this.ctx.state, this.ctx.interactive, firstNonDeterministicIndex + 1, phase3TagIndex);
       if (immediateDeterministicIndex >= 0) {
         return { index: immediateDeterministicIndex, method: 'auto_select' };
       }
@@ -121,10 +115,7 @@ export class RuleEvaluator {
 
     const phase1TagIndex = this.resolveTaggedRuleIndex(agentContent, interactiveEnabled);
     if (phase1TagIndex >= 0) {
-      const immediateDeterministicIndex = this.evaluateImmediateDeterministicConditions(
-        firstNonDeterministicIndex + 1,
-        phase1TagIndex,
-      );
+      const immediateDeterministicIndex = findImmediateDeterministicMatch(this.step.rules, this.ctx.state, this.ctx.interactive, firstNonDeterministicIndex + 1, phase1TagIndex);
       if (immediateDeterministicIndex >= 0) {
         return { index: immediateDeterministicIndex, method: 'auto_select' };
       }
@@ -133,19 +124,14 @@ export class RuleEvaluator {
 
     const aiRuleIndex = await this.evaluateAiConditions(agentContent);
     if (aiRuleIndex >= 0) {
-      const immediateDeterministicIndex = this.evaluateImmediateDeterministicConditions(
-        firstNonDeterministicIndex + 1,
-        aiRuleIndex,
-      );
+      const immediateDeterministicIndex = findImmediateDeterministicMatch(this.step.rules, this.ctx.state, this.ctx.interactive, firstNonDeterministicIndex + 1, aiRuleIndex);
       if (immediateDeterministicIndex >= 0) {
         return { index: immediateDeterministicIndex, method: 'auto_select' };
       }
       return { index: aiRuleIndex, method: 'ai_judge' };
     }
 
-    const immediateDeterministicIndex = this.evaluateImmediateDeterministicConditions(
-      firstNonDeterministicIndex + 1,
-    );
+    const immediateDeterministicIndex = findImmediateDeterministicMatch(this.step.rules, this.ctx.state, this.ctx.interactive, firstNonDeterministicIndex + 1, this.step.rules?.length ?? 0);
     if (immediateDeterministicIndex >= 0) {
       return { index: immediateDeterministicIndex, method: 'auto_select' };
     }
@@ -220,32 +206,6 @@ export class RuleEvaluator {
     return -1;
   }
 
-  private evaluateImmediateDeterministicConditions(startIndex = 0, endExclusive?: number): number {
-    if (!this.step.rules) return -1;
-
-    const upperBound = endExclusive ?? this.step.rules.length;
-    for (let i = Math.max(startIndex, 0); i < upperBound; i++) {
-      const rule = this.step.rules[i];
-      if (!rule) continue;
-      if (rule.interactiveOnly && this.ctx.interactive !== true) {
-        continue;
-      }
-      if (rule.isAiCondition || rule.isAggregateCondition) {
-        continue;
-      }
-      if (!isDeterministicCondition(rule.condition)) {
-        continue;
-      }
-      if (isDeferredDeterministicCondition(rule.condition)) {
-        continue;
-      }
-      if (evaluateWhenExpression(unwrapWhenCondition(rule.condition), this.ctx.state)) {
-        return i;
-      }
-    }
-
-    return -1;
-  }
 
   private evaluateDeferredDeterministicConditions(): number {
     if (!this.step.rules) return -1;

--- a/src/core/workflow/evaluation/RuleEvaluator.ts
+++ b/src/core/workflow/evaluation/RuleEvaluator.ts
@@ -99,7 +99,7 @@ export class RuleEvaluator {
     }
 
     const firstNonDeterministicIndex = this.findFirstNonDeterministicRuleIndex();
-    const leadingDeterministicIndex = findImmediateDeterministicMatch(this.step.rules, this.ctx.state, this.ctx.interactive, 0, firstNonDeterministicIndex >= 0 ? firstNonDeterministicIndex : (this.step.rules?.length ?? 0));
+    const leadingDeterministicIndex = findImmediateDeterministicMatch(this.step.rules, this.ctx.state, this.ctx.interactive, 0, firstNonDeterministicIndex >= 0 ? firstNonDeterministicIndex : (this.step.rules.length));
     if (leadingDeterministicIndex >= 0) {
       return { index: leadingDeterministicIndex, method: 'auto_select' };
     }
@@ -131,7 +131,7 @@ export class RuleEvaluator {
       return { index: aiRuleIndex, method: 'ai_judge' };
     }
 
-    const immediateDeterministicIndex = findImmediateDeterministicMatch(this.step.rules, this.ctx.state, this.ctx.interactive, firstNonDeterministicIndex + 1, this.step.rules?.length ?? 0);
+    const immediateDeterministicIndex = findImmediateDeterministicMatch(this.step.rules, this.ctx.state, this.ctx.interactive, firstNonDeterministicIndex + 1, this.step.rules.length);
     if (immediateDeterministicIndex >= 0) {
       return { index: immediateDeterministicIndex, method: 'auto_select' };
     }

--- a/src/core/workflow/evaluation/rule-utils.ts
+++ b/src/core/workflow/evaluation/rule-utils.ts
@@ -15,7 +15,7 @@ export function isDeterministicCondition(condition: string): boolean {
   return isWhenConditionExpression(condition);
 }
 
-/** when(<式>) の内側の式を取り出す。when 形式でなければそのまま返す。 */
+/** when(<式>) の内側の式を取り出す。when 形式以外は契約違反として throw する。 */
 export function unwrapWhenCondition(condition: string): string {
   return unwrapWhenConditionExpression(condition);
 }
@@ -122,11 +122,12 @@ export function findImmediateDeterministicMatch(
   rules: readonly WorkflowRule[] | undefined,
   state: WorkflowState,
   interactive: boolean | undefined,
+  startIndex: number,
   endExclusive: number,
 ): number {
   if (!rules) return -1;
   const upperBound = Math.min(endExclusive, rules.length);
-  for (let i = 0; i < upperBound; i++) {
+  for (let i = Math.max(startIndex, 0); i < upperBound; i++) {
     const rule = rules[i];
     if (!rule) continue;
     if (rule.interactiveOnly && interactive !== true) continue;
@@ -169,7 +170,7 @@ export function resolvePhase3Adoption<T extends Phase3AdoptionInput>(
   // 先行採用は RuleEvaluator の位置準拠と同界: 判定が選んだルールより前に
   // ある決定的ルールだけが先行する（後ろのルールは first-match-wins に従い
   // 採用済みタグを覆さない。後段の防御はガード条件が担う）。
-  const preemptIndex = findImmediateDeterministicMatch(rules, state, interactive, phase3Result.ruleIndex);
+  const preemptIndex = findImmediateDeterministicMatch(rules, state, interactive, 0, phase3Result.ruleIndex);
   if (preemptIndex !== -1) {
     result = { ...result, ruleIndex: preemptIndex, method: 'auto_select' };
   }

--- a/src/core/workflow/evaluation/rule-utils.ts
+++ b/src/core/workflow/evaluation/rule-utils.ts
@@ -122,10 +122,10 @@ export function findImmediateDeterministicMatch(
   rules: readonly WorkflowRule[] | undefined,
   state: WorkflowState,
   interactive: boolean | undefined,
-  endExclusive?: number,
+  endExclusive: number,
 ): number {
   if (!rules) return -1;
-  const upperBound = endExclusive ?? rules.length;
+  const upperBound = Math.min(endExclusive, rules.length);
   for (let i = 0; i < upperBound; i++) {
     const rule = rules[i];
     if (!rule) continue;

--- a/src/core/workflow/evaluation/when-evaluator.ts
+++ b/src/core/workflow/evaluation/when-evaluator.ts
@@ -1,33 +1,11 @@
 import type { WorkflowState } from '../../models/types.js';
 import { resolveWorkflowStateReference } from '../state/workflow-state-access.js';
+import { splitTopLevelClauses } from '../../models/workflow-condition-expression.js';
 
 export function splitTopLevel(expression: string, separator: '||' | '&&'): string[] {
-  const parts: string[] = [];
-  let inString = false;
-  let depth = 0;
-  let start = 0;
-  for (let index = 0; index < expression.length - 1; index++) {
-    const current = expression[index];
-    if (current === '"') {
-      inString = !inString;
-      continue;
-    }
-    if (!inString && current === '(') {
-      depth++;
-      continue;
-    }
-    if (!inString && current === ')') {
-      depth--;
-      continue;
-    }
-    if (!inString && depth === 0 && expression.slice(index, index + 2) === separator) {
-      parts.push(expression.slice(start, index).trim());
-      start = index + 2;
-      index++;
-    }
-  }
-  parts.push(expression.slice(start).trim());
-  return parts.filter((part) => part.length > 0);
+  // トークナイズは models の唯一実装に委譲（parse/normalize と同一契約）。
+  // 評価側は従来どおり空節を除いて評価する。
+  return splitTopLevelClauses(expression, separator).filter((part) => part.length > 0);
 }
 
 function findOperator(expression: string): string | undefined {

--- a/src/core/workflow/evaluation/when-evaluator.ts
+++ b/src/core/workflow/evaluation/when-evaluator.ts
@@ -1,11 +1,12 @@
 import type { WorkflowState } from '../../models/types.js';
 import { resolveWorkflowStateReference } from '../state/workflow-state-access.js';
-import { splitTopLevelClauses } from '../../models/workflow-condition-expression.js';
+import { splitTopLevelClausesOrThrow } from '../../models/workflow-condition-expression.js';
 
 export function splitTopLevel(expression: string, separator: '||' | '&&'): string[] {
   // トークナイズは models の唯一実装に委譲（parse/normalize と同一契約）。
-  // 評価側は従来どおり空節を除いて評価する。
-  return splitTopLevelClauses(expression, separator).filter((part) => part.length > 0);
+  // 空節は黙殺しない: when(a && && b) は不正な式として即座に失敗させる
+  // （不正オペランドを throw する評価器の既存の厳格性と同じ扱い）。
+  return splitTopLevelClausesOrThrow(expression, separator, 'when expression');
 }
 
 function findOperator(expression: string): string | undefined {

--- a/src/infra/config/loaders/workflowRuleNormalizer.ts
+++ b/src/infra/config/loaders/workflowRuleNormalizer.ts
@@ -1,4 +1,5 @@
 import type { WorkflowRule } from '../../../core/models/index.js';
+import { splitTopLevelAndClauses } from '../../../core/models/workflow-condition-expression.js';
 import {
   parseAggregateConditionArgs,
   parseAggregateConditionExpression,
@@ -6,34 +7,6 @@ import {
 } from '../../../core/models/workflow-condition-expression.js';
 import { isDeterministicCondition, unwrapWhenCondition } from '../../../core/workflow/evaluation/rule-utils.js';
 
-function splitTopLevelPreservingEmpties(expression: string, separator: '&&'): string[] {
-  const parts: string[] = [];
-  let inString = false;
-  let depth = 0;
-  let start = 0;
-  for (let index = 0; index < expression.length - 1; index++) {
-    const current = expression[index];
-    if (current === '"') {
-      inString = !inString;
-      continue;
-    }
-    if (!inString && current === '(') {
-      depth++;
-      continue;
-    }
-    if (!inString && current === ')') {
-      depth--;
-      continue;
-    }
-    if (!inString && depth === 0 && expression.slice(index, index + 2) === separator) {
-      parts.push(expression.slice(start, index).trim());
-      start = index + 2;
-      index++;
-    }
-  }
-  parts.push(expression.slice(start).trim());
-  return parts;
-}
 
 /**
  * Split a plain compound condition "<tag text> && <findings guard>" into its
@@ -45,7 +18,7 @@ export function splitTagFindingsCondition(condition: string): { tagText: string;
   // 文字列リテラル・括弧内の && では分割しない（exists(...) 等を壊さない）。
   // splitTopLevel は空 clause を除去するため、壊れた設定（"a && && b" 等）の
   // fail-fast 用に空 clause を保持する分割をここで行う。
-  const clauses = splitTopLevelPreservingEmpties(condition, '&&');
+  const clauses = splitTopLevelAndClauses(condition);
   if (clauses.length < 2 || clauses.some((clause) => clause.length === 0)) {
     return undefined;
   }

--- a/src/infra/config/loaders/workflowRuleNormalizer.ts
+++ b/src/infra/config/loaders/workflowRuleNormalizer.ts
@@ -1,5 +1,5 @@
 import type { WorkflowRule } from '../../../core/models/index.js';
-import { splitTopLevelAndClauses } from '../../../core/models/workflow-condition-expression.js';
+import { splitTopLevelClausesOrThrow } from '../../../core/models/workflow-condition-expression.js';
 import {
   parseAggregateConditionArgs,
   parseAggregateConditionExpression,
@@ -18,12 +18,9 @@ export function splitTagFindingsCondition(condition: string): { tagText: string;
   // 文字列リテラル・括弧内の && では分割しない（exists(...) 等を壊さない）。
   // splitTopLevel は空 clause を除去するため、壊れた設定（"a && && b" 等）の
   // fail-fast 用に空 clause を保持する分割をここで行う。
-  const clauses = splitTopLevelAndClauses(condition);
-  if (clauses.length >= 2 && clauses.some((clause) => clause.length === 0)) {
-    // "a && && b" のような壊れた条件は、どの解釈でも設定ミス。散文タグに
-    // 流して黙殺せず fail-fast する（集約ガード側と同じ契約）。
-    throw new Error(`Configuration error: rule condition "${condition}" contains an empty clause`);
-  }
+  // "a && && b" のような壊れた条件は、どの解釈でも設定ミス。散文タグに
+  // 流して黙殺せず fail-fast する（集約ガード・評価器と同じ契約）。
+  const clauses = splitTopLevelClausesOrThrow(condition, '&&', 'rule condition');
   if (clauses.length < 2) {
     return undefined;
   }

--- a/src/infra/config/loaders/workflowRuleNormalizer.ts
+++ b/src/infra/config/loaders/workflowRuleNormalizer.ts
@@ -19,7 +19,12 @@ export function splitTagFindingsCondition(condition: string): { tagText: string;
   // splitTopLevel は空 clause を除去するため、壊れた設定（"a && && b" 等）の
   // fail-fast 用に空 clause を保持する分割をここで行う。
   const clauses = splitTopLevelAndClauses(condition);
-  if (clauses.length < 2 || clauses.some((clause) => clause.length === 0)) {
+  if (clauses.length >= 2 && clauses.some((clause) => clause.length === 0)) {
+    // "a && && b" のような壊れた条件は、どの解釈でも設定ミス。散文タグに
+    // 流して黙殺せず fail-fast する（集約ガード側と同じ契約）。
+    throw new Error(`Configuration error: rule condition "${condition}" contains an empty clause`);
+  }
+  if (clauses.length < 2) {
     return undefined;
   }
   const [tagText, ...guardClauses] = clauses;


### PR DESCRIPTION
#977 マージ後の自己監査（不要なデフォルト引数・死んだ互換分岐・重複の観点）で見つけた3件の締め直し。

- **unwrap の寛容フォールバック除去**: 非 when 入力は throw（全呼び出し元が when 形式を保証済み — 静かな許容は誤用を隠すだけ）
- **endExclusive を必須引数化**: 本番呼び出しは1箇所で常に指定しており、optional + デフォルトは使われない自由度だった
- **括弧対応 && スプリッタの一本化**: models の `splitTopLevelAndClauses` に集約し、normalizer の私製重複を削除

挙動変更なし（違反入力が静かに通る→即例外、のみ）。全シャード green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 複合条件（`||`/`&&`）の分割・検証を見直し、空節を含む不正入力を明確なエラーとして扱うよう改善しました。
  * `when(...)` 形式以外は例外として検知します。
  * 決定的な条件探索の探索範囲を厳密化し、指定範囲外のスキャンを抑制しました。
* **Tests**
  * 境界条件・不正入力・空節ケースのテストを追加／更新し、期待するエラーメッセージも調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->