### PR TITLE
fix: harden judgment, findings, and opencode per the full-area $coding audit

### DIFF
--- a/scripts/canary-coder.mjs
+++ b/scripts/canary-coder.mjs
@@ -78,8 +78,11 @@ try {
   if (existsSync(artifactPath)) {
     const source = readFileSync(artifactPath, 'utf-8');
     // 形だけの export では通さない: 要求仕様（"Hello, <name>!" の生成）まで確認する
+    // テンプレートリテラル形（`Hello, ${name}!`）または連結形（"Hello, " + name + "!"）
+    // のどちらでも、末尾の "!" まで含めて挙動を確認する
     artifactOk = /export\s+(function\s+greet|const\s+greet)/.test(source)
-      && /Hello,\s*\$\{[^}]*\}!|Hello,\s*['"] ?\+/.test(source);
+      && (/Hello,\s*\$\{[^}]*\}!/.test(source)
+        || (source.includes('Hello,') && /['"\`]!['"\`]|!['"\`]\s*;/.test(source)));
   }
 
   console.log(output.split('\n').slice(-15).join('\n'));

--- a/scripts/canary-coder.mjs
+++ b/scripts/canary-coder.mjs
@@ -10,7 +10,7 @@
  * builtins/{lang}/facets/instructions を変更したときの推奨手順。
  */
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -74,20 +74,24 @@ try {
   const toolErrors = (output.match(/^\s*✗ \S+:/gm) ?? []).length;
   const runCompleted = result.status === 0 && !/aborted/i.test(output);
   // 完了宣言だけの空振りを弾く: 成果物は形ではなく挙動で検証する。
-  // 生成された TS を Node の型ストリップで import 実行し、要求仕様どおりの
-  // 戻り値かを直接確認する（正規表現による形の検査はバイパス可能だった）。
+  // リポジトリの typescript devDep でトランスパイルして import 実行し、
+  // 要求仕様どおりの戻り値かを直接確認する（正規表現による形の検査は
+  // バイパス可能だった。Node の型ストリップは engines 下限の Node 20 に
+  // 存在しないため使わない）。
   const artifactPath = join(workDir, 'greet.ts');
   let artifactOk = false;
   if (existsSync(artifactPath)) {
-    const probe = spawnSync('node', [
-      '--experimental-strip-types',
-      '--input-type=module',
-      '-e',
-      `import { greet } from '${pathToFileURL(artifactPath).href}'; process.exit(greet('Takt') === 'Hello, Takt!' ? 0 : 1);`,
-    ], { encoding: 'utf-8', timeout: 30_000 });
-    artifactOk = probe.status === 0;
-    if (!artifactOk && probe.stderr) {
-      console.error(`artifact probe failed: ${probe.stderr.split('\n')[0]}`);
+    const { default: ts } = await import('typescript');
+    const transpiled = ts.transpileModule(readFileSync(artifactPath, 'utf-8'), {
+      compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2022 },
+    }).outputText;
+    const probePath = join(workDir, 'greet.probe.mjs');
+    writeFileSync(probePath, transpiled);
+    try {
+      const { greet } = await import(pathToFileURL(probePath).href);
+      artifactOk = typeof greet === 'function' && greet('Takt') === 'Hello, Takt!';
+    } catch (error) {
+      console.error(`artifact probe failed: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 

--- a/scripts/canary-coder.mjs
+++ b/scripts/canary-coder.mjs
@@ -10,9 +10,10 @@
  * builtins/{lang}/facets/instructions を変更したときの推奨手順。
  */
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { fileURLToPath } from 'node:url';
 
 const args = process.argv.slice(2);
@@ -72,17 +73,22 @@ try {
   // ツール粒度を持たないため、構造化カウントには takt 側の拡張が要る。
   const toolErrors = (output.match(/^\s*✗ \S+:/gm) ?? []).length;
   const runCompleted = result.status === 0 && !/aborted/i.test(output);
-  // 完了宣言だけの空振りを弾く: 成果物の実在と内容まで確認する
+  // 完了宣言だけの空振りを弾く: 成果物は形ではなく挙動で検証する。
+  // 生成された TS を Node の型ストリップで import 実行し、要求仕様どおりの
+  // 戻り値かを直接確認する（正規表現による形の検査はバイパス可能だった）。
   const artifactPath = join(workDir, 'greet.ts');
   let artifactOk = false;
   if (existsSync(artifactPath)) {
-    const source = readFileSync(artifactPath, 'utf-8');
-    // 形だけの export では通さない: 要求仕様（"Hello, <name>!" の生成）まで確認する
-    // テンプレートリテラル形（`Hello, ${name}!`）または連結形（"Hello, " + name + "!"）
-    // のどちらでも、末尾の "!" まで含めて挙動を確認する
-    artifactOk = /export\s+(function\s+greet|const\s+greet)/.test(source)
-      && (/Hello,\s*\$\{[^}]*\}!/.test(source)
-        || (source.includes('Hello,') && /['"\`]!['"\`]|!['"\`]\s*;/.test(source)));
+    const probe = spawnSync('node', [
+      '--experimental-strip-types',
+      '--input-type=module',
+      '-e',
+      `import { greet } from '${pathToFileURL(artifactPath).href}'; process.exit(greet('Takt') === 'Hello, Takt!' ? 0 : 1);`,
+    ], { encoding: 'utf-8', timeout: 30_000 });
+    artifactOk = probe.status === 0;
+    if (!artifactOk && probe.stderr) {
+      console.error(`artifact probe failed: ${probe.stderr.split('\n')[0]}`);
+    }
   }
 
   console.log(output.split('\n').slice(-15).join('\n'));

--- a/scripts/canary-coder.mjs
+++ b/scripts/canary-coder.mjs
@@ -74,8 +74,13 @@ try {
   const runCompleted = result.status === 0 && !/aborted/i.test(output);
   // 完了宣言だけの空振りを弾く: 成果物の実在と内容まで確認する
   const artifactPath = join(workDir, 'greet.ts');
-  const artifactOk = existsSync(artifactPath)
-    && /export\s+(function\s+greet|const\s+greet)/.test(readFileSync(artifactPath, 'utf-8'));
+  let artifactOk = false;
+  if (existsSync(artifactPath)) {
+    const source = readFileSync(artifactPath, 'utf-8');
+    // 形だけの export では通さない: 要求仕様（"Hello, <name>!" の生成）まで確認する
+    artifactOk = /export\s+(function\s+greet|const\s+greet)/.test(source)
+      && /Hello,\s*\$\{[^}]*\}!|Hello,\s*['"] ?\+/.test(source);
+  }
 
   console.log(output.split('\n').slice(-15).join('\n'));
   console.log(`---\ncanary result: completed=${runCompleted} artifact=${artifactOk} toolErrors=${toolErrors}`);

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2419,6 +2419,50 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(promptAsync.mock.calls[3]?.[0]).not.toHaveProperty('format');
   });
 
+  it('should not trip the invalid-argument loop across interleaved unavailable errors', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const INVALID = 'The read tool was called with invalid arguments: SchemaError(Expected string)';
+    const UNAVAILABLE = 'unavailable tool: fetch';
+    const toolError = (id, tool, error) => ({
+      type: 'message.part.updated',
+      properties: { part: { id, type: 'tool', tool, callID: id, state: { status: 'error', error } } },
+    });
+    // invalid ×3 → unavailable ×1 → invalid ×1: 修正前は invalid 側が
+    // unavailable を観測できず「連続4回」と誤認して打ち切っていた並び
+    const stream = new MockEventStream([
+      toolError('c1', 'read', INVALID),
+      toolError('c2', 'read', INVALID),
+      toolError('c3', 'read', INVALID),
+      toolError('c4', 'fetch', UNAVAILABLE),
+      toolError('c5', 'read', INVALID),
+      {
+        type: 'message.part.updated',
+        properties: { part: { id: 'p-text', type: 'text', text: 'done' }, delta: 'done' },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-mixed' } },
+    ]);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-mixed' } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('coder', 'do it', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+    });
+
+    // 偽の連続判定で error にならず完走する（unavailable も1回では閾値未満）
+    expect(result.status).toBe('done');
+  });
+
   it('should pass the external_directory deny in the server config', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const stream = new MockEventStream([

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2423,7 +2423,7 @@ describe('OpenCodeClient stream cleanup', () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const INVALID = 'The read tool was called with invalid arguments: SchemaError(Expected string)';
     const UNAVAILABLE = 'unavailable tool: fetch';
-    const toolError = (id, tool, error) => ({
+    const toolError = (id: string, tool: string, error: string) => ({
       type: 'message.part.updated',
       properties: { part: { id, type: 'tool', tool, callID: id, state: { status: 'error', error } } },
     });

--- a/src/__tests__/rule-evaluator-when.test.ts
+++ b/src/__tests__/rule-evaluator-when.test.ts
@@ -303,3 +303,12 @@ describe('RuleEvaluator with when conditions', () => {
     );
   });
 });
+
+describe('operators inside string literals', () => {
+  it('should not split on operators that appear inside quoted strings', () => {
+    const state = makeState() as WorkflowState & { structuredOutputs: Map<string, unknown> };
+    state.structuredOutputs.set('plan', { note: 'a == b' });
+
+    expect(evaluateWhenExpression('structured.plan.note == "a == b"', state)).toBe(true);
+  });
+});

--- a/src/__tests__/rule-evaluator-when.test.ts
+++ b/src/__tests__/rule-evaluator-when.test.ts
@@ -305,6 +305,14 @@ describe('RuleEvaluator with when conditions', () => {
 });
 
 describe('operators inside string literals', () => {
+  it('should not split exists() predicates on operators inside quoted strings', () => {
+    const state = makeState() as WorkflowState & { structuredOutputs: Map<string, unknown> };
+    state.structuredOutputs.set('scan', { items: [{ note: 'a == b' }] });
+
+    expect(evaluateWhenExpression('exists(structured.scan.items, "a == b" == item.note)', state)).toBe(true);
+  });
+
+
   it('should not split on operators that appear inside quoted strings', () => {
     const state = makeState() as WorkflowState & { structuredOutputs: Map<string, unknown> };
     state.structuredOutputs.set('plan', { note: 'a == b' });

--- a/src/__tests__/rule-utils.test.ts
+++ b/src/__tests__/rule-utils.test.ts
@@ -14,7 +14,7 @@ import { unwrapWhenCondition,
   hasUnquotedFindingsReference,
   isDeterministicCondition,
 } from '../core/workflow/evaluation/rule-utils.js';
-import type { OutputContractEntry } from '../core/models/types.js';
+import type { WorkflowRule, OutputContractEntry } from '../core/models/types.js';
 import { makeStep } from './test-helpers.js';
 
 describe('hasTagBasedRules', () => {
@@ -191,5 +191,21 @@ describe('getReportFiles', () => {
       { name: 'review.md', format: 'review', useJudge: true },
     ];
     expect(getReportFiles(contracts)).toEqual(['00-plan.md', 'review.md']);
+  });
+});
+
+describe('generateStatusRulesComponents interactive default', () => {
+  it('should exclude interactive-only rules when interactive is unspecified', async () => {
+    const { generateStatusRulesComponents } = await import('../core/workflow/instruction/status-rules.js');
+    const rules = [
+      { condition: 'approved', next: 'COMPLETE' },
+      { condition: 'ユーザー入力が必要', next: 'ask', interactiveOnly: true },
+    ] as WorkflowRule[];
+
+    const withoutOption = generateStatusRulesComponents('gate', rules, 'ja');
+    expect(JSON.stringify(withoutOption)).not.toContain('ユーザー入力が必要');
+
+    const interactive = generateStatusRulesComponents('gate', rules, 'ja', { interactive: true });
+    expect(JSON.stringify(interactive)).toContain('ユーザー入力が必要');
   });
 });

--- a/src/__tests__/rule-utils.test.ts
+++ b/src/__tests__/rule-utils.test.ts
@@ -195,17 +195,25 @@ describe('getReportFiles', () => {
 });
 
 describe('generateStatusRulesComponents interactive default', () => {
-  it('should exclude interactive-only rules when interactive is unspecified', async () => {
+  const rules = [
+    { condition: 'approved', next: 'COMPLETE' },
+    { condition: 'ユーザー入力が必要', next: 'ask', interactiveOnly: true },
+  ] as WorkflowRule[];
+
+  it('should exclude interactive-only rules from the criteria table when interactive is unspecified', async () => {
     const { generateStatusRulesComponents } = await import('../core/workflow/instruction/status-rules.js');
-    const rules = [
-      { condition: 'approved', next: 'COMPLETE' },
-      { condition: 'ユーザー入力が必要', next: 'ask', interactiveOnly: true },
-    ] as WorkflowRule[];
 
-    const withoutOption = generateStatusRulesComponents('gate', rules, 'ja');
-    expect(JSON.stringify(withoutOption)).not.toContain('ユーザー入力が必要');
+    const components = generateStatusRulesComponents('gate', rules, 'ja');
 
-    const interactive = generateStatusRulesComponents('gate', rules, 'ja', { interactive: true });
-    expect(JSON.stringify(interactive)).toContain('ユーザー入力が必要');
+    expect(components.criteriaTable).toContain('approved');
+    expect(components.criteriaTable).not.toContain('ユーザー入力が必要');
+  });
+
+  it('should include interactive-only rules in the criteria table when interactive is true', async () => {
+    const { generateStatusRulesComponents } = await import('../core/workflow/instruction/status-rules.js');
+
+    const components = generateStatusRulesComponents('gate', rules, 'ja', { interactive: true });
+
+    expect(components.criteriaTable).toContain('ユーザー入力が必要');
   });
 });

--- a/src/__tests__/workflow-step-normalizers.test.ts
+++ b/src/__tests__/workflow-step-normalizers.test.ts
@@ -273,3 +273,18 @@ describe('guarded compound rejection on unsupported paths', () => {
     )).toThrow('does not support findings guards');
   });
 });
+
+describe('reserved syntax fail-fast', () => {
+  it.each([
+    ['malformed ai', 'ai("unclosed'],
+    ['aggregate with trailing garbage', 'all("x") extra'],
+    ['chained when', 'when(findings.open.count == 0) && when(findings.conflicts.count == 0)'],
+  ])('should reject %s instead of degrading to a prose tag', (_label, condition) => {
+    expect(() => normalizeRule({ condition, next: 'COMPLETE' })).toThrow('reserved syntax');
+  });
+
+  it('should keep prose tags mentioning ai casually', () => {
+    const normalized = normalizeRule({ condition: 'aiレビューが完了した', next: 'COMPLETE' });
+    expect(normalized.isAiCondition).toBeUndefined();
+  });
+});

--- a/src/core/workflow/evaluation/RuleEvaluator.ts
+++ b/src/core/workflow/evaluation/RuleEvaluator.ts
@@ -177,9 +177,11 @@ export class RuleEvaluator {
     if (rule?.guardCondition !== undefined && !evaluateWhenExpression(rule.guardCondition, this.ctx.state)) {
       return -1;
     }
-    // 決定的条件のルールはタグ申告（[STEP:N]）でも成立させない。
-    // 実状態で偽なら不一致として扱い、決定的評価ステージに委ねる。
-    if (rule !== undefined && isDeterministicCondition(rule.condition) && !evaluateWhenExpression(unwrapWhenCondition(rule.condition), this.ctx.state)) {
+    // 決定的条件のルールはタグ申告（[STEP:N]）では常に成立させない。
+    // 真であっても採用は段階評価（位置準拠の決定的ステージ）に一任する。
+    // 真なら通す形にすると、モデルのタグ申告が when(true) 等を本来の段階
+    // より早く発火させ、位置意味論を迂回できてしまう。
+    if (rule !== undefined && isDeterministicCondition(rule.condition)) {
       return -1;
     }
 

--- a/src/core/workflow/evaluation/rule-utils.ts
+++ b/src/core/workflow/evaluation/rule-utils.ts
@@ -175,10 +175,13 @@ export function resolvePhase3Adoption<T extends Phase3AdoptionInput>(
     result = { ...result, ruleIndex: preemptIndex, method: 'auto_select' };
   }
   const rule = rules?.[result.ruleIndex];
+  // 判定が決定的ルールを指した場合は真偽を問わず採用しない（選択候補から
+  // 除外済みだが、返ってきても位置準拠の段階評価へフォールバックさせる）。
+  // 先行採用（preempt）だけがエンジン側の正規経路。
   const blocked = (rule?.guardCondition !== undefined && !evaluate(rule.guardCondition, state))
     || (rule !== undefined
-      && isDeterministicCondition(rule.condition)
-      && !evaluate(unwrapWhenCondition(rule.condition), state));
+      && result.ruleIndex !== preemptIndex
+      && isDeterministicCondition(rule.condition));
   return { result, blocked };
 }
 

--- a/src/core/workflow/evaluation/when-evaluator.ts
+++ b/src/core/workflow/evaluation/when-evaluator.ts
@@ -111,14 +111,12 @@ function parseLiteral(raw: string, state: WorkflowState, item?: unknown): unknow
 function evaluateExistsPredicate(predicate: string, item: unknown, state: WorkflowState): boolean {
   return splitTopLevel(predicate, '&&').every((clause) => {
     const operatorMatch = findOperator(clause);
-  const operator = operatorMatch?.operator;
-    if (operator !== '==') {
+    if (operatorMatch?.operator !== '==') {
       throw new Error(`exists() only supports "==" and "&&": "${predicate}"`);
     }
 
-    const operatorIndex = clause.indexOf(operator);
-    const leftRaw = clause.slice(0, operatorIndex);
-    const rightRaw = clause.slice(operatorIndex + operator.length);
+    const leftRaw = clause.slice(0, operatorMatch.index);
+    const rightRaw = clause.slice(operatorMatch.index + operatorMatch.operator.length);
     if (leftRaw.trim().length === 0 || rightRaw.trim().length === 0) {
       throw new Error(`Invalid exists() clause "${clause}"`);
     }

--- a/src/core/workflow/evaluation/when-evaluator.ts
+++ b/src/core/workflow/evaluation/when-evaluator.ts
@@ -1,6 +1,6 @@
 import type { WorkflowState } from '../../models/types.js';
 import { resolveWorkflowStateReference } from '../state/workflow-state-access.js';
-import { splitTopLevelClausesOrThrow } from '../../models/workflow-condition-expression.js';
+import { isEscapedQuote, splitTopLevelClausesOrThrow } from '../../models/workflow-condition-expression.js';
 
 export function splitTopLevel(expression: string, separator: '||' | '&&'): string[] {
   // トークナイズは models の唯一実装に委譲（parse/normalize と同一契約）。
@@ -9,12 +9,12 @@ export function splitTopLevel(expression: string, separator: '||' | '&&'): strin
   return splitTopLevelClausesOrThrow(expression, separator, 'when expression');
 }
 
-function findOperator(expression: string): string | undefined {
+function findOperator(expression: string): { operator: string; index: number } | undefined {
   const operators = ['>=', '<=', '!=', '==', '>', '<'] as const;
   let inString = false;
 
   for (let index = 0; index < expression.length; index++) {
-    if (expression[index] === '"') {
+    if (expression[index] === '"' && !isEscapedQuote(expression, index)) {
       inString = !inString;
       continue;
     }
@@ -23,7 +23,7 @@ function findOperator(expression: string): string | undefined {
     }
     for (const operator of operators) {
       if (expression.slice(index, index + operator.length) === operator) {
-        return operator;
+        return { operator, index };
       }
     }
   }
@@ -37,7 +37,7 @@ function splitFunctionArgs(argsText: string): [string, string] {
 
   for (let index = 0; index < argsText.length; index++) {
     const current = argsText[index];
-    if (current === '"') {
+    if (current === '"' && !isEscapedQuote(argsText, index)) {
       inString = !inString;
       continue;
     }
@@ -110,7 +110,8 @@ function parseLiteral(raw: string, state: WorkflowState, item?: unknown): unknow
 
 function evaluateExistsPredicate(predicate: string, item: unknown, state: WorkflowState): boolean {
   return splitTopLevel(predicate, '&&').every((clause) => {
-    const operator = findOperator(clause);
+    const operatorMatch = findOperator(clause);
+  const operator = operatorMatch?.operator;
     if (operator !== '==') {
       throw new Error(`exists() only supports "==" and "&&": "${predicate}"`);
     }
@@ -149,18 +150,18 @@ function evaluateClause(clause: string, state: WorkflowState): boolean {
     return evaluateExistsClause(normalized, state);
   }
 
-  const operator = findOperator(normalized);
-  if (!operator) {
+  const operatorMatch = findOperator(normalized);
+  if (!operatorMatch) {
     const value = parseLiteral(normalized, state);
     if (typeof value !== 'boolean') {
       throw new Error(`Bare when clause must resolve to boolean: "${normalized}"`);
     }
     return value;
   }
+  const { operator } = operatorMatch;
 
-  const operatorIndex = normalized.indexOf(operator);
-  const leftRaw = normalized.slice(0, operatorIndex);
-  const rightRaw = normalized.slice(operatorIndex + operator.length);
+  const leftRaw = normalized.slice(0, operatorMatch.index);
+  const rightRaw = normalized.slice(operatorMatch.index + operator.length);
   if (leftRaw.trim().length === 0 || rightRaw.trim().length === 0) {
     throw new Error(`Invalid when clause "${normalized}"`);
   }

--- a/src/core/workflow/findings/manager-runner.ts
+++ b/src/core/workflow/findings/manager-runner.ts
@@ -89,11 +89,18 @@ function extractStructuredRawFindings(input: {
 }): RawFinding[] {
   return input.subResults.flatMap((result) => {
     const structuredOutput = result.response.structuredOutput;
+    // raw findings は Finding Contract の契約入力。欠落や不正 shape を
+    // 空扱いすると台帳に指摘が残らず findings.open.count == 0 のゲートが
+    // 誤って通るため、黙って捨てず fail-fast する。
     if (structuredOutput === undefined) {
-      return [];
+      throw new Error(
+        `Finding contract reviewer "${result.subStep.name}" returned no structured output; raw findings are required`,
+      );
     }
     if (!Array.isArray(structuredOutput.rawFindings)) {
-      return [];
+      throw new Error(
+        `Finding contract reviewer "${result.subStep.name}" returned structured output without a rawFindings array`,
+      );
     }
     return parseReviewerRawFindings(structuredOutput.rawFindings).map((rawFinding) => ({
       ...rawFinding,

--- a/src/core/workflow/instruction/status-rules.ts
+++ b/src/core/workflow/instruction/status-rules.ts
@@ -33,12 +33,14 @@ export function generateStatusRulesComponents(
   options?: { interactive?: boolean },
 ): StatusRulesComponents {
   const tag = stepName.toUpperCase();
-  const interactiveEnabled = options?.interactive;
+  // 実行側（RuleEvaluator / judge-utils）と同じ既定: 未指定は非対話として
+  // 扱う。既定が逆だと「表示されるのに採用されない」ルールが生まれる。
+  const interactiveEnabled = options?.interactive === true;
   // 決定的条件はエンジンが実状態から評価する（モデルに選ばせない）。
   // 表示から除外しても原 index を保持するため番号はずれない。
   const visibleRules = rules
     .map((rule, index) => ({ rule, index }))
-    .filter(({ rule }) => isJudgeableRule(rule, interactiveEnabled !== false));
+    .filter(({ rule }) => isJudgeableRule(rule, interactiveEnabled));
 
   // Build criteria table rows
   const headerNum = '#';

--- a/src/infra/config/loaders/workflowRuleNormalizer.ts
+++ b/src/infra/config/loaders/workflowRuleNormalizer.ts
@@ -43,6 +43,28 @@ export function splitTagFindingsCondition(condition: string): { tagText: string;
   return { tagText, guard: guardClauses.map(unwrapWhenCondition).join(' && ') };
 }
 
+
+/**
+ * ai() / all() / any() / when() は予約構文。これらで始まるのにパースできない
+ * 条件は、散文タグへ落とさず設定エラーにする（黙殺すると malformed な
+ * "all(\"x\") extra" 等がモデル判定行きになり原因が見えなくなる）。
+ */
+function assertReservedSyntaxWellFormed(condition: string): void {
+  const trimmed = condition.trim();
+  const reserved = /^(ai|all|any|when)\(/.exec(trimmed)?.[1];
+  if (reserved === undefined) {
+    return;
+  }
+  const wellFormed = (reserved === 'ai' && parseAiConditionExpression(trimmed) !== undefined)
+    || ((reserved === 'all' || reserved === 'any') && parseAggregateConditionExpression(trimmed) !== undefined)
+    || (reserved === 'when' && (isDeterministicCondition(trimmed) || splitTagFindingsCondition(trimmed) !== undefined));
+  if (!wellFormed) {
+    throw new Error(
+      `Configuration error: rule condition "${condition}" starts with reserved syntax "${reserved}(" but cannot be parsed as it`,
+    );
+  }
+}
+
 export function normalizeRule(rule: {
   condition?: string;
   when?: string;
@@ -59,6 +81,7 @@ export function normalizeRule(rule: {
     throw new Error('Workflow rule requires condition or when');
   }
   const next = rule.next ?? '';
+  assertReservedSyntaxWellFormed(condition);
   const aiExpression = parseAiConditionExpression(condition);
   if (aiExpression) {
     return {

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -812,17 +812,22 @@ export class OpenCodeClient {
 
             if (part.type === 'tool') {
               const toolPart = part as OpenCodeToolPart;
-              const loopError = toolPart.state.status === 'error'
-                ? unavailableToolLoopDetector.observe(
+              let loopError: string | undefined;
+              if (toolPart.state.status === 'error') {
+                // 両検出器に必ず観測させる（?? 短絡だと invalid 側が
+                // unavailable エラーを見逃し、連続性の判定が狂う）
+                const unavailableError = unavailableToolLoopDetector.observe(
                   toolPart.callID || toolPart.id,
                   toolPart.tool,
                   toolPart.state.error,
-                ) ?? invalidArgumentLoopDetector.observe(
+                );
+                const invalidArgumentError = invalidArgumentLoopDetector.observe(
                   toolPart.callID || toolPart.id,
                   toolPart.tool,
                   toolPart.state.error,
-                )
-                : undefined;
+                );
+                loopError = unavailableError ?? invalidArgumentError;
+              }
               if (toolPart.state.status === 'completed') {
                 unavailableToolLoopDetector.reset();
                 invalidArgumentLoopDetector.reset();


### PR DESCRIPTION
#978 マージ後に実施した、キャンペーン関連全域の codex `$coding` スキル監査（3ドメイン・9指摘）の反映です。マージ済みブランチに誤って積んでいた分を独立 PR 化しました。

## 判定・条件系（4件）

- タグ申告・Phase 3 判定は決定的ルールを**真偽問わず**採用しない（真なら通す形だと when(true) 等をモデル申告で本来の段階より早く発火でき、位置意味論を迂回できた — #976/#977 の最後の抜け道）
- 予約構文（ai( / all( / any( / when( 始まり）のパース失敗は設定エラー（散文タグへの黙落ち禁止。`when(A) && when(B)` 連結も明示エラー）
- 演算子探索がエスケープ引用符対応 + 走査位置を使用（文字列リテラル内の `==` で誤分割しない。exists() 述語含む）
- status-rules の interactive 既定を実行側と統一（未指定 = 非対話）

## Finding Contract（1件 + 後送2件）

- レビュアー結果の structuredOutput / rawFindings 欠落を fail-fast（空扱いだと台帳に指摘が残らず `findings.open.count == 0` ゲートが誤って開く理論経路）
- 後送: 台帳スキーマの状態不変条件、waiver 証跡と claim 証跡の機械照合（TL 実験後の設計課題）

## opencode（2件）

- ループ検出器2種に全ツールエラーを必ず観測させる（?? 短絡による観測漏れで連続性判定が狂っていた）
- canary は生成物を **transpile → import → 実行**して `greet('Takt') === 'Hello, Takt!'` を検証（正規表現の形検査は反例が2回続いたため廃止。Node 20 互換のため typescript devDep でトランスパイル）

## 検証

- 回帰テスト: 予約構文 fail-fast×3 + 散文誤検知なし / 文字列内演算子（通常節・exists 節）/ 評価器経路の空節 throw / canary は正負両方向を実行実証
- 全シャード green（既知の worktree 環境固有1件のみ）
- codex `$coding` レビュー: 指摘9件 → 反映 → 追撃4ラウンド（exists 直し漏れ・canary 反例×2・Node 20 回帰）→ **APPROVE**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * クォートやエスケープを含む条件式の演算子解釈を改善し、誤判定を防止
  * 壊れた予約構文や不正条件は早期にエラーで中断、raw findings 不足も中断
  * 対話設定の既定値を反映し、表示・採用ルールを調整
* **Reliability**
  * ストリーミング時のエラー連鎖判定を見直し、誤った中断を抑制
* **Tests / Quality**
  * 条件分割・拒否・インタラクティブ判定・ループ検知のテストを追加/強化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->