### PR TITLE
fix: make the opencode idle watchdog actually fire on stalled sessions

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2443,6 +2443,42 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(promptAsync.mock.calls[3]?.[0]).not.toHaveProperty('format');
   });
 
+  it('should not leak sibling-session text into the active session content', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const stream = new MockEventStream([
+      {
+        type: 'message.part.updated',
+        properties: { part: { id: 'p-sibling', type: 'text', text: 'sibling text', sessionID: 'other-session' } },
+      },
+      {
+        type: 'message.part.updated',
+        properties: { part: { id: 'p-own', type: 'text', text: 'own text', sessionID: 'session-own' } },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-own' } },
+    ]);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-own' } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('coder', 'do it', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toContain('own text');
+    expect(result.content).not.toContain('sibling text');
+  });
+
   it('should time out a stalled session even while unrelated bus events keep flowing', async () => {
     process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
     try {

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -13,6 +13,30 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AskUserQuestionDeniedError } from '../core/workflow/ask-user-question-error.js';
 import { resetDebugLogger, setVerboseConsole } from '../shared/utils/index.js';
 
+/**
+ * 自セッションの進捗が止まったまま、サーバ全体のバスに無関係イベントが
+ * 流れ続ける状況を再現するストリーム。旧実装はこれで永遠に延命していた。
+ */
+class ChatterOnlyEventStream implements AsyncIterable<unknown> {
+  constructor(private readonly chatterIntervalMs: number) {}
+
+  [Symbol.asyncIterator](): AsyncIterator<unknown> {
+    const interval = this.chatterIntervalMs;
+    return {
+      async next(): Promise<IteratorResult<unknown, void>> {
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, interval));
+        return {
+          done: false,
+          value: {
+            type: 'message.part.updated',
+            properties: { part: { id: 'p-x', type: 'text', text: 'sibling', sessionID: 'other-session' } },
+          },
+        };
+      },
+    };
+  }
+}
+
 class MockEventStream implements AsyncGenerator<unknown, void, unknown> {
   private index = 0;
   private readonly events: unknown[];
@@ -2418,6 +2442,38 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(promptAsync).toHaveBeenCalledTimes(4);
     expect(promptAsync.mock.calls[3]?.[0]).not.toHaveProperty('format');
   });
+
+  it('should time out a stalled session even while unrelated bus events keep flowing', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      const { OpenCodeClient } = await import('../infra/opencode/client.js');
+      createOpencodeMock.mockResolvedValue({
+        client: {
+          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+          session: {
+            create: vi.fn().mockResolvedValue({ data: { id: 'session-stalled' } }),
+            promptAsync: vi.fn().mockReturnValue(new Promise(() => { /* 完了しない */ })),
+          },
+          event: { subscribe: vi.fn().mockResolvedValue({ stream: new ChatterOnlyEventStream(100) }) },
+          permission: { reply: vi.fn() },
+        },
+        server: { close: vi.fn() },
+      });
+
+      const result = await new OpenCodeClient().call('coder', 'do it', {
+        cwd: '/tmp',
+        model: 'opencode/big-pickle',
+        interactionTimeoutMs: 500,
+      });
+
+      // 兄弟セッションのイベントでは延命せず、無音タイムアウトが発火して
+      // エラーとして表面化する（永久ハングしない）
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('timed out');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 20_000);
 
   it('should not trip the invalid-argument loop across interleaved unavailable errors', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -18,13 +18,22 @@ import { resetDebugLogger, setVerboseConsole } from '../shared/utils/index.js';
  * 流れ続ける状況を再現するストリーム。旧実装はこれで永遠に延命していた。
  */
 class ChatterOnlyEventStream implements AsyncIterable<unknown> {
+  private pendingTimer: ReturnType<typeof setTimeout> | undefined;
+  readonly returnSpy = vi.fn(async (): Promise<IteratorResult<unknown, void>> => {
+    if (this.pendingTimer !== undefined) {
+      clearTimeout(this.pendingTimer);
+    }
+    return { done: true, value: undefined };
+  });
+
   constructor(private readonly chatterIntervalMs: number) {}
 
   [Symbol.asyncIterator](): AsyncIterator<unknown> {
-    const interval = this.chatterIntervalMs;
     return {
-      async next(): Promise<IteratorResult<unknown, void>> {
-        await new Promise((resolvePromise) => setTimeout(resolvePromise, interval));
+      next: async (): Promise<IteratorResult<unknown, void>> => {
+        await new Promise((resolvePromise) => {
+          this.pendingTimer = setTimeout(resolvePromise, this.chatterIntervalMs);
+        });
         return {
           done: false,
           value: {
@@ -33,6 +42,7 @@ class ChatterOnlyEventStream implements AsyncIterable<unknown> {
           },
         };
       },
+      return: this.returnSpy,
     };
   }
 }
@@ -2483,6 +2493,7 @@ describe('OpenCodeClient stream cleanup', () => {
     process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
     try {
       const { OpenCodeClient } = await import('../infra/opencode/client.js');
+      const chatterStream = new ChatterOnlyEventStream(100);
       createOpencodeMock.mockResolvedValue({
         client: {
           instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
@@ -2490,7 +2501,7 @@ describe('OpenCodeClient stream cleanup', () => {
             create: vi.fn().mockResolvedValue({ data: { id: 'session-stalled' } }),
             promptAsync: vi.fn().mockReturnValue(new Promise(() => { /* 完了しない */ })),
           },
-          event: { subscribe: vi.fn().mockResolvedValue({ stream: new ChatterOnlyEventStream(100) }) },
+          event: { subscribe: vi.fn().mockResolvedValue({ stream: chatterStream }) },
           permission: { reply: vi.fn() },
         },
         server: { close: vi.fn() },
@@ -2506,6 +2517,8 @@ describe('OpenCodeClient stream cleanup', () => {
       // エラーとして表面化する（永久ハングしない）
       expect(result.status).toBe('error');
       expect(result.error).toContain('timed out');
+      // 中断経路でもイテレータの後始末（SSE クローズ）が呼ばれること
+      expect(chatterStream.returnSpy).toHaveBeenCalled();
     } finally {
       delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
     }

--- a/src/infra/opencode/OpenCodeStreamHandler.ts
+++ b/src/infra/opencode/OpenCodeStreamHandler.ts
@@ -10,18 +10,21 @@ import type { StreamCallback } from '../../shared/types/provider.js';
 /** Subset of OpenCode Part types relevant for stream handling */
 export interface OpenCodeTextPart {
   id: string;
+  sessionID: string;
   type: 'text';
   text: string;
 }
 
 export interface OpenCodeReasoningPart {
   id: string;
+  sessionID: string;
   type: 'reasoning';
   text: string;
 }
 
 export interface OpenCodeToolPart {
   id: string;
+  sessionID: string;
   type: 'tool';
   callID: string;
   tool: string;
@@ -34,7 +37,7 @@ export type OpenCodeToolState =
   | { status: 'completed'; input: Record<string, unknown>; output: string; title: string }
   | { status: 'error'; input: Record<string, unknown>; error: string };
 
-export type OpenCodePart = OpenCodeTextPart | OpenCodeReasoningPart | OpenCodeToolPart | { id: string; type: string };
+export type OpenCodePart = OpenCodeTextPart | OpenCodeReasoningPart | OpenCodeToolPart | { id: string; type: string; sessionID?: string };
 
 /** OpenCode SSE event types relevant for stream handling */
 export interface OpenCodeMessagePartUpdatedEvent {

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -47,6 +47,23 @@ const TAKT_AGENT = 'takt';
 const TAKT_AGENT_REVIEW = 'takt-review';
 const TAKT_AGENT_REPORT = 'takt-report';
 
+/**
+ * イベントが属するセッション ID を取り出す。イベントバスはサーバ全体で
+ * 共有されるため、無音検出のリセットは「自セッションの進捗」だけに
+ * 反応させる必要がある（LSP・ファイルウォッチャ・兄弟セッションの
+ * イベントでリセットすると、生成が死んでいても永遠にハングする）。
+ */
+function extractEventSessionId(event: OpenCodeStreamEvent): string | undefined {
+  const props = event.properties as Record<string, unknown> | undefined;
+  if (!props) return undefined;
+  if (typeof props.sessionID === 'string') return props.sessionID;
+  const part = props.part as { sessionID?: unknown } | undefined;
+  if (part !== undefined && typeof part.sessionID === 'string') return part.sessionID;
+  const info = props.info as { sessionID?: unknown } | undefined;
+  if (info !== undefined && typeof info.sessionID === 'string') return info.sessionID;
+  return undefined;
+}
+
 function selectTaktAgent(allowedTools: readonly string[] | undefined): string {
   if (allowedTools !== undefined && allowedTools.length === 0) {
     return TAKT_AGENT_REPORT;
@@ -62,7 +79,11 @@ function selectTaktAgent(allowedTools: readonly string[] | undefined): string {
 }
 
 const log = createLogger('opencode-sdk');
-const OPENCODE_STREAM_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+/** 呼び出し時に評価する（テストや実験で env から上書きできるようにする） */
+function resolveStreamIdleTimeoutMs(): number {
+  const fromEnv = Number(process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS);
+  return fromEnv > 0 ? fromEnv : 10 * 60 * 1000;
+}
 const OPENCODE_STREAM_ABORTED_MESSAGE = 'OpenCode execution aborted';
 const OPENCODE_RETRY_MAX_ATTEMPTS = 3;
 const OPENCODE_RETRY_BASE_DELAY_MS = 250;
@@ -578,7 +599,8 @@ export class OpenCodeClient {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
       const streamAbortController = new AbortController();
-      const timeoutMessage = `OpenCode stream timed out after ${Math.floor(OPENCODE_STREAM_IDLE_TIMEOUT_MS / 60000)} minutes of inactivity`;
+      const streamIdleTimeoutMs = resolveStreamIdleTimeoutMs();
+      const timeoutMessage = `OpenCode stream timed out after ${Math.round(streamIdleTimeoutMs / 60000)} minutes of inactivity`;
       let abortCause: OpenCodeAbortCause | undefined;
       let diagRef: StreamDiagnostics | undefined;
       let release: (() => void) | undefined;
@@ -623,9 +645,10 @@ export class OpenCodeClient {
         }
         idleTimeoutId = setTimeout(() => {
           diagRef?.onIdleTimeoutFired();
+          log.warn(timeoutMessage, { sessionId, model: options.model });
           abortCause = 'timeout';
           streamAbortController.abort();
-        }, OPENCODE_STREAM_IDLE_TIMEOUT_MS);
+        }, streamIdleTimeoutMs);
       };
 
       const onExternalAbort = (): void => {
@@ -788,11 +811,36 @@ export class OpenCodeClient {
           textOffsets.set(partId, prevOffset + rawDelta.length);
         };
 
-        for await (const event of stream) {
+        // for-await 単体だと、タイマーが abort してもイベントが来るまで
+        // 待ちから戻らない（SDK が signal を尊重しない場合は永久待機）。
+        // イテレータと abort をレースさせ、タイマー発火で必ず脱出する。
+        const streamIterator = (stream as AsyncIterable<unknown>)[Symbol.asyncIterator]();
+        const streamAborted = new Promise<never>((_, reject) => {
+          streamAbortController.signal.addEventListener('abort', () => {
+            reject(new Error(timeoutMessage));
+          }, { once: true });
+        });
+        streamAborted.catch(() => { /* race の敗者側での未処理拒否を防ぐ */ });
+
+        try {
+        while (true) {
           if (streamAbortController.signal.aborted) break;
-          resetIdleTimeout();
+          let iteration: IteratorResult<unknown>;
+          try {
+            iteration = await Promise.race([streamIterator.next(), streamAborted]);
+          } catch (raceError) {
+            if (streamAbortController.signal.aborted) break;
+            throw raceError;
+          }
+          if (iteration.done) break;
+          const event = iteration.value;
 
           const sseEvent = event as OpenCodeStreamEvent;
+          // 無音検出のリセットは自セッションのイベントだけ。サーバ全体の
+          // バスに流れる無関係イベントでは延命しない。
+          if (extractEventSessionId(sseEvent) === activeSessionId) {
+            resetIdleTimeout();
+          }
           diag.onFirstEvent(sseEvent.type);
           diag.onEvent(sseEvent.type);
           if (sseEvent.type === 'message.part.updated') {
@@ -1071,6 +1119,12 @@ export class OpenCodeClient {
             continue;
           }
         }
+        } finally {
+          // for-await が break 時に行っていた後始末（SSE クローズ）を再現する
+          try {
+            await streamIterator.return?.(undefined);
+          } catch { /* クローズ失敗は結果に影響させない */ }
+        }
 
         // The idle watchdog and external aborts cancel the stream. If the
         // iterator ends without throwing, the loop falls through with
@@ -1141,6 +1195,7 @@ export class OpenCodeClient {
             persona: agentType,
             status: 'error',
             content: message,
+            error: message,
             timestamp: new Date(),
             sessionId: activeSessionId,
           };
@@ -1215,6 +1270,7 @@ export class OpenCodeClient {
           persona: agentType,
           status: 'error',
           content: errorMessage,
+          error: errorMessage,
           timestamp: new Date(),
           sessionId,
         };

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -836,9 +836,16 @@ export class OpenCodeClient {
           const event = iteration.value;
 
           const sseEvent = event as OpenCodeStreamEvent;
-          // 無音検出のリセットは自セッションのイベントだけ。サーバ全体の
-          // バスに流れる無関係イベントでは延命しない。
-          if (extractEventSessionId(sseEvent) === activeSessionId) {
+          // セッション帰属が判明していて自分でないイベントは処理しない。
+          // サーバプールは同一モデルで共有されるため（並列レビュー等）、
+          // 兄弟セッションの text/tool 更新を通すと content と検出器が
+          // 汚染される。帰属不明のイベントは種別ごとの処理に委ねるが、
+          // 無音検出のリセット（延命）は自セッションのイベントに限る。
+          const eventSessionId = extractEventSessionId(sseEvent);
+          if (eventSessionId !== undefined && eventSessionId !== activeSessionId) {
+            continue;
+          }
+          if (eventSessionId === activeSessionId) {
             resetIdleTimeout();
           }
           diag.onFirstEvent(sseEvent.type);


### PR DESCRIPTION
ベンチ実走が2.5時間ハングした実障害の恒久修正です（10分の無音ウォッチドッグが実装済みなのに不発だった）。

## 不発の原因（2つの欠陥）

1. **idle リセットがサーバ全体バスの全イベントで発火** — LSP・ファイルウォッチャ・兄弟セッションが何かを流し続ける限り、生成が死んでいてもタイマーが延命され続ける
2. **for-await は次のイベントが来るまで abort を観測しない** — SDK が signal を無視するとタイマーが発火しても永久待機

## 変更

- 無音検出のリセットを**自セッション帰属イベントに限定**（`extractEventSessionId`）
- **帰属が判明していて自分でないイベントは処理前に skip** — サーバプールは同一モデルで共有されるため（並列レビュー4席）、兄弟セッションの text/tool 更新が本文・ループ検出器を汚染し得た（codex レビューで検出）
- イテレーションを **abort とレース** + finally で `iterator.return`（for-await の SSE クローズ後始末を維持）
- タイムアウトの env 上書き（`TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS`、テスト用）、発火を log.warn に可視化
- error 返却2箇所に `AgentResponse.error` を設定（content のみだった既存のプロバイダエラー鉄則違反）

## テスト

- 回帰: 兄弟セッションのイベントだけが流れ続けるストールが**タイムアウトとして表面化**する（旧実装は永久ハング）
- 回帰: 兄弟セッションの text が本文に混入しない
- opencode cleanup/retry 73 tests green、全シャード green

codex `$coding` レビュー: 1st MEDIUM（兄弟イベント汚染）→ 反映 → **APPROVE**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ほかのセッション由来のイベントが混ざっても、現在の処理結果に影響しないよう改善しました。
  * 停滞状態でも無音タイムアウトで適切に失敗し、ハングしにくくなりました。
  * ストリーミングの終了判定とキャンセルがより確実になり、タイムアウト時の挙動が安定しました。
  * エラー時の返却内容を分かりやすく調整しました。
* **Tests**
  * 停滞中でも無関係イベントが継続するケースなどを再現し、クリーンアップまで含めて検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->