### PR TITLE
[codex] write_tests に test-planning タグを追加

### DIFF
--- a/builtins/en/workflows/backend-cqrs-for-local-llm.yaml
+++ b/builtins/en/workflows/backend-cqrs-for-local-llm.yaml
@@ -71,6 +71,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/backend-cqrs.yaml
+++ b/builtins/en/workflows/backend-cqrs.yaml
@@ -67,6 +67,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/backend-for-local-llm.yaml
+++ b/builtins/en/workflows/backend-for-local-llm.yaml
@@ -70,6 +70,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/backend.yaml
+++ b/builtins/en/workflows/backend.yaml
@@ -65,6 +65,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/cli.yaml
+++ b/builtins/en/workflows/cli.yaml
@@ -36,6 +36,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/default-high.yaml
+++ b/builtins/en/workflows/default-high.yaml
@@ -43,6 +43,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/default.yaml
+++ b/builtins/en/workflows/default.yaml
@@ -43,6 +43,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/dual-for-local-llm.yaml
+++ b/builtins/en/workflows/dual-for-local-llm.yaml
@@ -72,6 +72,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/dual.yaml
+++ b/builtins/en/workflows/dual.yaml
@@ -73,6 +73,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/frontend-for-local-llm.yaml
+++ b/builtins/en/workflows/frontend-for-local-llm.yaml
@@ -71,6 +71,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/frontend.yaml
+++ b/builtins/en/workflows/frontend.yaml
@@ -68,6 +68,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/review-fix-takt-default.yaml
+++ b/builtins/en/workflows/review-fix-takt-default.yaml
@@ -79,6 +79,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/takt-default-for-local-llm.yaml
+++ b/builtins/en/workflows/takt-default-for-local-llm.yaml
@@ -69,6 +69,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/en/workflows/takt-default-refresh-all.yaml
+++ b/builtins/en/workflows/takt-default-refresh-all.yaml
@@ -70,6 +70,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     session: refresh

--- a/builtins/en/workflows/takt-default-refresh-fast.yaml
+++ b/builtins/en/workflows/takt-default-refresh-fast.yaml
@@ -69,6 +69,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     session: refresh

--- a/builtins/en/workflows/takt-default.yaml
+++ b/builtins/en/workflows/takt-default.yaml
@@ -36,6 +36,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/backend-cqrs-for-local-llm.yaml
+++ b/builtins/ja/workflows/backend-cqrs-for-local-llm.yaml
@@ -71,6 +71,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/backend-cqrs.yaml
+++ b/builtins/ja/workflows/backend-cqrs.yaml
@@ -67,6 +67,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/backend-for-local-llm.yaml
+++ b/builtins/ja/workflows/backend-for-local-llm.yaml
@@ -70,6 +70,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/backend.yaml
+++ b/builtins/ja/workflows/backend.yaml
@@ -65,6 +65,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/cli.yaml
+++ b/builtins/ja/workflows/cli.yaml
@@ -36,6 +36,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/default-high.yaml
+++ b/builtins/ja/workflows/default-high.yaml
@@ -43,6 +43,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/default.yaml
+++ b/builtins/ja/workflows/default.yaml
@@ -43,6 +43,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/dual-for-local-llm.yaml
+++ b/builtins/ja/workflows/dual-for-local-llm.yaml
@@ -72,6 +72,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/dual.yaml
+++ b/builtins/ja/workflows/dual.yaml
@@ -73,6 +73,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/frontend-for-local-llm.yaml
+++ b/builtins/ja/workflows/frontend-for-local-llm.yaml
@@ -71,6 +71,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/frontend.yaml
+++ b/builtins/ja/workflows/frontend.yaml
@@ -68,6 +68,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -79,6 +79,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/takt-default-for-local-llm.yaml
+++ b/builtins/ja/workflows/takt-default-for-local-llm.yaml
@@ -69,6 +69,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:

--- a/builtins/ja/workflows/takt-default-refresh-all.yaml
+++ b/builtins/ja/workflows/takt-default-refresh-all.yaml
@@ -70,6 +70,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     session: refresh

--- a/builtins/ja/workflows/takt-default-refresh-fast.yaml
+++ b/builtins/ja/workflows/takt-default-refresh-fast.yaml
@@ -69,6 +69,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     session: refresh

--- a/builtins/ja/workflows/takt-default.yaml
+++ b/builtins/ja/workflows/takt-default.yaml
@@ -36,6 +36,7 @@ steps:
   - name: write_tests
     tags:
       - coding
+      - test-planning
     edit: true
     persona: coder
     policy:


### PR DESCRIPTION
## Summary

- `write-tests-first` を使う builtin workflow の `write_tests` step に `test-planning` tag を追加しました。
- 既存の `coding` tag の後ろに置き、`provider_routing.tags` でより具体的な上書きに使えるようにしました。
- `write-tests-maintenance` を使う maintenance workflow は対象外のままにしています。

## Execution Report

- `git diff --check`
- `npm test`

## Issue

- 関連 Issue なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * テスト作成ステップに新しいタグが追加され、テスト計画関連として識別しやすくなりました。
  * 複数のワークフローで同じ分類が反映され、タグベースの扱いが統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->