### PR TITLE
Release v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.50.0] - 2026-07-06
+
+### Added
+
+- MCP server entrypoint `takt-mcp` (#938, #943). TAKT can now run as a stdio Model Context Protocol server, letting an MCP client (Codex, Claude Code, …) drive TAKT without shelling out to `takt add` / `takt run`. Three tools are exposed: `takt_enqueue_task` (save a pending task to `.takt/tasks.yaml`), `takt_create_issue_and_enqueue_task` (create an issue through the configured issue provider, then enqueue the task with the new issue number), and `takt_run_next_task` (claim and execute the next pending task). Every tool `cwd` is resolved with `realpath` and must stay inside the server's allowed project root. Register it in Codex with `codex mcp add takt -- takt-mcp` or a `[mcp_servers.takt]` block. See the CLI Reference for the full tool schemas.
+- ACP agent entrypoint `takt-acp` (#913, #916). TAKT can now run as an Agent Client Protocol agent over stdio JSON-RPC, launched from an ACP-compatible client. `session/prompt` is enqueue-first by default: prompts such as "enqueue this task" add a pending task (with `worktree: true`) to `.takt/tasks.yaml` for later `takt run`, while explicit "run it now" / "execute now" prompts execute directly. TAKT supports `initialize`, `session/new`, `session/prompt`, `session/cancel`, and `session/update`; stdio MCP servers passed on `session/new` are forwarded to workflow execution.
+- `for-local-llm` workflow family (#958, #974, #982). Five workflows tuned for local or weaker models — `takt-default-for-local-llm`, `frontend-for-local-llm`, `backend-for-local-llm`, `backend-cqrs-for-local-llm`, and `dual-for-local-llm` — each running four (five for dual) parallel deep reviewers backed by the Finding Contract (ledger, resolution confirmations, dispute adjudication) plus a flat merge-readiness final gate. A new `implementation-semantics` reviewer (persona, knowledge, instruction, and finding-contract output contract) catches behavioral defects that survive compilation. A review-only `peer-review-for-local-llm` workflow ships alongside them.
+- `cli` workflow (#947). A CLI-development workflow: plan → write_tests → draft (implement + AI self-review) → peer-review (parallel reviewers + fix) → supervise → COMPLETE.
+- Finding Contract dispute/waiver lifecycle (#969). A coder that cannot fix a valid finding can now state a dispute under a fixed `## Disputed Findings` heading (finding id / reason / file:line); the findings manager either waives the finding (removing it from the blocking set with a recorded reason and evidence) or rejects the dispute (it stays open and blocking). Gates keep their existing `findings.open.count == 0` condition, so this unblocks runs that previously deadlocked on a valid-but-unfixable finding.
+- `when()` syntax for engine-evaluated conditions (#977). Deterministic state expressions in rule conditions are now declared explicitly with `when(...)`, matching the existing `ai()` / `all()` / `any()` family — e.g. `condition: when(findings.conflicts.count > 0)` or `approved && when(findings.open.count == 0)`. The rule-level `when:` key is sugar that wraps its expression automatically. See the BREAKING note below for custom workflows.
+- Final-gate provider routing tag (#954). Builtin final-gate steps now carry a `final-gate` tag, so `provider_routing.tags.final-gate` can route the merge-readiness gate to a stronger provider/model independently of other review steps.
+- Merge-readiness review gate (#949). Builtin development and maintenance workflows gained a parallel final merge-readiness gate (`merge-readiness-final-gate` / `merge-readiness-dual-final-gate`) that judges only whether the change is ready to merge.
+- OpenCode native `json_schema` structured output (#965), with a one-shot corrective retry when a reviewer emits invalid structured output (#963). OpenCode reviewer steps now request structured output via OpenCode's native `format: json_schema`, which enforces key structure at the source instead of relying on hand-written JSON; when a reviewer still emits invalid JSON, TAKT asks the same session once to re-emit the corrected payload before failing.
+
+### Changed
+
+- **BREAKING:** deterministic rule conditions now require the explicit `when()` wrapper (#977). Bare comparison expressions (e.g. `findings.open.count == 0`) in a rule `condition` are treated as plain prose tag conditions, not engine-evaluated facts, and aggregate guards containing a bare expression fail configuration with a migration hint. This replaces a fragile comparison-operator heuristic that could silently turn prose like `coverage >= 80%` into an unmatchable dead rule. Custom workflows that relied on the old heuristic must wrap deterministic clauses in `when(...)` (or use the `when:` rule key); builtin workflows were migrated.
+- **BREAKING:** the `-with-fc` workflow lineage was removed (#974). `takt-default-with-fc` and `peer-review-with-fc` (added in 0.47.0) are superseded by the new `for-local-llm` family, which is now the Finding Contract lineup. Update any references to the old workflow names.
+- The fixer no longer aborts a run on "cannot proceed" (#986). When the fixer gives up on a blocker, the workflow now routes back to the planner to re-decompose it (the planner seat can be routed to a stronger model) instead of throwing away the whole run. A new replan-cycle loop monitor aborts only when consecutive replans repeat the same dead end, with a handoff summary for the human. Applies to the five development workflows.
+- Codex `approval_policy` is pinned to `never`. Because TAKT runs Codex non-interactively there is no human to approve escalations, so the sandbox mode is now the sole write boundary: `readonly` hard-blocks writes and `edit`/`full` behave as before, instead of Codex's default approval policy auto-approving an escalation past a read-only sandbox.
+- Codex model-capability checks are delegated to the provider (#983).
+
+### Fixed
+
+- OpenCode idle watchdog now fires on stalled sessions (#984). The 10-minute idle watchdog could sleep through a stall because its timer reset on any server-wide event (LSP, file watcher, sibling sessions); the reset is now scoped to the session's own events.
+- OpenCode session is preserved across step phases via per-prompt tool restriction (#948), and out-of-workspace denial is kept effective but non-fatal (#957).
+- OpenCode structured-output recovery: fall back to a formatless retry when native structured output is not produced (#967), recover when the gateway rejects `json_schema`, and treat empty or typo'd raw-finding location/suggestion fields as unset (#962).
+- Finding-contract resolution is reachable and guarded tag rules are supported (#961); dispute guidance is injected only when open findings exist (#973).
+- Cursor CLI config directory is preserved across runs (#960).
+- Symlinked stdio entrypoints are resolved to their real path (#955), so `takt-mcp` / `takt-acp` work when launched via a symlink.
+- Report-phase failures and empty Phase 1 output are now soft errors (#907, #911, #927). A report-generation failure continues to Phase 3 (status judgment) instead of aborting, empty Phase 1 output is detected as an error so later phases do not run on no content, and a report fallback path was added.
+- Isolated clone fetch no longer fails when the parent repo HEAD is on the target branch (#924) — TAKT detaches HEAD before fetching.
+- `bash` tool handling in OpenCode readonly and no-tools phases corrected (#918, #919).
+- `takt list` instruct + requeue flow fixed (#942).
+- Judgment, findings, and OpenCode handling hardened per a full-area audit (#981).
+
+### Internal
+
+- CQRS+ES knowledge and guidance strengthened (#925, #940, #941, #979, #988).
+- Prompt-quality tooling: a promptfoo-based facet quality eval (#946) and a rescan-semantics eval suite for the implementation-semantics reviewer (#951, #952, #959).
+- Reviewers must cite re-scan evidence in review reports (#951), were taught published-state immutability and family-level finding aggregation (#953), and no longer flag guarded Records (#968).
+- Review / write-tests / test-policy facet contracts tightened (#915, #917, #932, #944, #966, #987).
+- Codex: parallelized test gates (#920), MCP task workflow and auto-PR decisions (#972).
+- `when()` helpers tightened per coding standards (#978).
+
 ## [0.49.0] - 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ See the [Builtin Catalog](./docs/builtin-catalog.md) for all workflows and perso
 
 See the [CLI Reference](./docs/cli-reference.md) for all commands and options.
 
+TAKT also ships two client-integration entrypoints: `takt-acp` runs TAKT as an [Agent Client Protocol](./docs/cli-reference.md#acp-agent) agent over stdio JSON-RPC, and `takt-mcp` runs it as a stdio [MCP server](./docs/cli-reference.md#mcp-server) so an MCP client (Codex, Claude Code, …) can enqueue tasks, create an issue and enqueue, or run the next pending task.
+
 ### Instant exec mode
 
 `takt exec` starts TAKT's interactive task-entry mode. The Assistant agent clarifies the request, `/go` turns the conversation into a generated workflow, Worker agent(s) implement the task, Review agent(s) review the result, the Replanning agent asks the user for direction when needed, and loop detection prevents repeated unproductive cycles.

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,51 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.50.0] - 2026-07-06
+
+### Added
+
+- MCP サーバーエントリポイント `takt-mcp` (#938, #943)。TAKT を stdio Model Context Protocol サーバーとして起動できるようになりました。MCP クライアント（Codex、Claude Code など）から `takt add` / `takt run` を経由せずに TAKT を操作できます。公開ツールは 3 つです。`takt_enqueue_task`（`.takt/tasks.yaml` に pending タスクを保存）、`takt_create_issue_and_enqueue_task`（設定済み issue プロバイダで issue を作成し、その番号でタスクを積む）、`takt_run_next_task`（次の pending タスクを取得して実行）。各ツールの `cwd` は `realpath` で解決され、サーバーの許可プロジェクトルート内に収まる必要があります。Codex には `codex mcp add takt -- takt-mcp` または `[mcp_servers.takt]` ブロックで登録します。ツールスキーマの詳細は CLI Reference を参照してください。
+- ACP エージェントエントリポイント `takt-acp` (#913, #916)。TAKT を stdio JSON-RPC 上の Agent Client Protocol エージェントとして起動できるようになりました。ACP 互換クライアントから起動します。`session/prompt` は既定で enqueue-first です。「タスクを積んで」のようなプロンプトは `.takt/tasks.yaml` に pending タスク（`worktree: true`）を追加し、後で `takt run` で実行できます。「今すぐ実行」のような明示的なプロンプトのみ直接実行します。`initialize`、`session/new`、`session/prompt`、`session/cancel`、`session/update` をサポートし、`session/new` で渡された stdio MCP サーバーはワークフロー実行へ引き継がれます。
+- `for-local-llm` ワークフローファミリー (#958, #974, #982)。ローカルまたは非力なモデル向けに調整した 5 つのワークフロー（`takt-default-for-local-llm`、`frontend-for-local-llm`、`backend-for-local-llm`、`backend-cqrs-for-local-llm`、`dual-for-local-llm`）を追加。それぞれ 4 つ（dual は 5 つ）の並列ディープレビュアーが Finding Contract（レジャー、解決確認、ディスピュート裁定）を背景に走り、フラットなマージレディネス最終ゲートを備えます。コンパイルを通過する挙動上の欠陥を捉える新しい `implementation-semantics` レビュアー（ペルソナ、ナレッジ、インストラクション、finding-contract 出力契約）を追加。レビュー専用の `peer-review-for-local-llm` ワークフローも同梱します。
+- `cli` ワークフロー (#947)。CLI 開発向けワークフローです（plan → write_tests → draft（実装 + AI セルフレビュー）→ peer-review（並列レビュアー + fix）→ supervise → COMPLETE）。
+- Finding Contract のディスピュート/waiver ライフサイクル (#969)。妥当だが修正できない finding に対し、コーダーが固定見出し `## Disputed Findings` の下でディスピュート（finding id / 理由 / file:line）を宣言できるようになりました。findings マネージャは finding を waive（理由と根拠を記録してブロッキング集合から除外）するか、ディスピュートを却下（open のままブロッキング継続）します。ゲートは従来通り `findings.open.count == 0` 条件を保つため、妥当だが修正不能な finding でデッドロックしていた実行が解けます。
+- エンジン評価条件のための `when()` 構文 (#977)。ルール条件内の決定的な状態式を、既存の `ai()` / `all()` / `any()` ファミリーと同様に `when(...)` で明示的に宣言するようになりました（例: `condition: when(findings.conflicts.count > 0)` や `approved && when(findings.open.count == 0)`）。ルールレベルの `when:` キーは式を自動的にラップするシュガーです。カスタムワークフローについては後述の BREAKING を参照してください。
+- 最終ゲート用のプロバイダルーティングタグ (#954)。ビルトインの最終ゲートステップに `final-gate` タグが付与され、`provider_routing.tags.final-gate` でマージレディネスゲートだけを他のレビューステップと独立して強いプロバイダ/モデルへルーティングできます。
+- マージレディネスレビューゲート (#949)。ビルトインの開発・メンテナンスワークフローに、マージ可能かどうかだけを判定する並列の最終マージレディネスゲート（`merge-readiness-final-gate` / `merge-readiness-dual-final-gate`）を追加しました。
+- OpenCode ネイティブ `json_schema` 構造化出力 (#965) と、レビュアーが不正な構造化出力を出した際の 1 回限りの是正リトライ (#963)。OpenCode レビュアーステップは、手書き JSON に頼らずキー構造をソースで強制する OpenCode ネイティブの `format: json_schema` で構造化出力を要求するようになりました。それでも不正な JSON が出た場合、失敗させる前に同一セッションへ一度だけ修正済みペイロードの再出力を求めます。
+
+### Changed
+
+- **BREAKING:** 決定的なルール条件に `when()` ラッパーが必須になりました (#977)。ルール `condition` 内の裸の比較式（例: `findings.open.count == 0`）はエンジン評価される事実ではなく、単なる散文タグ条件として扱われます。裸の式を含む集約ガードは移行ヒント付きで設定エラーになります。これは、`coverage >= 80%` のような散文を暗黙にマッチ不能なデッドルール化していた脆い比較演算子ヒューリスティックを置き換えるものです。旧ヒューリスティックに依存していたカスタムワークフローは、決定的な句を `when(...)`（またはルールの `when:` キー）でラップする必要があります。ビルトインは移行済みです。
+- **BREAKING:** `-with-fc` ワークフロー系統を削除 (#974)。`takt-default-with-fc` と `peer-review-with-fc`（0.47.0 で追加）は、新しい `for-local-llm` ファミリーに置き換えられました。これが Finding Contract のラインナップになります。旧ワークフロー名への参照は更新してください。
+- fixer が「続行不能」で実行を中断しなくなりました (#986)。fixer がブロッカーを諦めた場合、実行全体を捨てる代わりに planner へ戻して再分解します（planner の席は強いモデルにルーティング可能）。新しい再計画サイクルのループモニターは、連続する再計画が同じ行き詰まりを繰り返したときだけ、人間向けの引き継ぎサマリーとともに中断します。5 つの開発ワークフローに適用されます。
+- Codex の `approval_policy` を `never` に固定。TAKT は Codex を非対話で実行するためエスカレーションを承認する人間がいません。そのためサンドボックスモードが唯一の書き込み境界となり、`readonly` は書き込みを完全にブロック、`edit`/`full` は従来通りに動作します（Codex の既定承認ポリシーが読み取り専用サンドボックスを越えてエスカレーションを自動承認する挙動を防止）。
+- Codex のモデル能力チェックをプロバイダへ委譲 (#983)。
+
+### Fixed
+
+- OpenCode のアイドルウォッチドッグがストールしたセッションで発火するようになりました (#984)。10 分のアイドルウォッチドッグは、サーバー全体のイベント（LSP、ファイルウォッチャー、兄弟セッション）でタイマーがリセットされるためストールを見逃すことがありました。リセットをそのセッション自身のイベントに限定しました。
+- OpenCode セッションがステップフェーズ間でプロンプト単位のツール制限により保持されるようになり (#948)、ワークスペース外拒否は有効かつ非致命的に保たれます (#957)。
+- OpenCode 構造化出力のリカバリ: ネイティブ構造化出力が生成されないときはフォーマットなしのリトライにフォールバックし (#967)、ゲートウェイが `json_schema` を拒否したときも復帰、空または誤字の raw-finding の location/suggestion フィールドは未設定として扱います (#962)。
+- finding-contract の解決が到達可能になり、ガード付きタグルールをサポート (#961)。ディスピュートガイダンスは open な finding が存在するときだけ注入されます (#973)。
+- Cursor CLI の設定ディレクトリが実行間で保持されるようになりました (#960)。
+- シンボリックリンクされた stdio エントリポイントを実パスへ解決 (#955)。`takt-mcp` / `takt-acp` をシンボリックリンク経由で起動しても動作します。
+- レポートフェーズの失敗と空の Phase 1 出力がソフトエラーになりました (#907, #911, #927)。レポート生成の失敗は中断せず Phase 3（ステータス判定）へ継続し、空の Phase 1 出力はエラーとして検出され後続フェーズが無内容で走らないようにし、レポートのフォールバック経路を追加しました。
+- 分離クローンの fetch が、親リポジトリの HEAD が対象ブランチにある場合に失敗しなくなりました (#924)。fetch 前に HEAD をデタッチします。
+- OpenCode の readonly・ツールなしフェーズでの `bash` ツール処理を修正 (#918, #919)。
+- `takt list` の追加指示 + リキューフローを修正 (#942)。
+- フルエリア監査に基づき判定・findings・OpenCode 処理を堅牢化 (#981)。
+
+### Internal
+
+- CQRS+ES のナレッジとガイダンスを強化 (#925, #940, #941, #979, #988)。
+- プロンプト品質ツール: promptfoo ベースのファセット品質 eval (#946) と、implementation-semantics レビュアー向けの rescan-semantics eval スイート (#951, #952, #959)。
+- レビュアーはレビューレポートに再スキャンの証跡を記載する必要があり (#951)、published-state の不変性とファミリーレベルの finding 集約を学習し (#953)、ガード付き Record を指摘しなくなりました (#968)。
+- review / write-tests / test-policy のファセット契約を厳格化 (#915, #917, #932, #944, #966, #987)。
+- Codex: テストゲートの並列化 (#920)、MCP タスクワークフローと auto-PR の判断 (#972)。
+- `when()` ヘルパーをコーディング規約に沿って整理 (#978)。
+
 ## [0.49.0] - 2026-06-28
 
 ### Added

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -248,6 +248,8 @@ workflow ファイルの正式ディレクトリ名は `workflows/` です。
 
 全コマンド・オプションは [CLI Reference](./cli-reference.ja.md) を参照してください。
 
+クライアント連携用のエントリポイントも 2 つ同梱しています。`takt-acp` は TAKT を stdio JSON-RPC 上の [Agent Client Protocol](./cli-reference.ja.md#acp-agent) エージェントとして起動し、`takt-mcp` は stdio の [MCP サーバー](./cli-reference.ja.md#mcp-server) として起動して、MCP クライアント（Codex、Claude Code など）からタスクを積んだり、issue を作成して積んだり、次の pending タスクを実行したりできます。
+
 ### インスタント exec モード
 
 `takt exec` は TAKT の対話型タスク入力モードを開始します。Assistant エージェントがリクエストを明確化し、`/go` で会話をワークフローに変換、Worker エージェントがタスクを実装、Review エージェントがレビュー、Replanning エージェントが必要に応じてユーザーに方針確認を行い、ループ検出が非生産的な繰り返しを防止します。

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-zX2WyeyC+zgLTRhR8xLA74eQYVPxw4MPS0m7WRnOW4E=";
+            npmDepsHash = "sha256-bETaKbQO+WKDlyEy9uuDzMSnowvOWa988d+1p3a3zc4=";
             nodejs = nodejs;
             ONNXRUNTIME_NODE_INSTALL = "skip";
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Workflow control for AI coding agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- MCP server entrypoint `takt-mcp` (#938, #943) — run TAKT as a stdio MCP server exposing `takt_enqueue_task`, `takt_create_issue_and_enqueue_task`, and `takt_run_next_task`.
- ACP agent entrypoint `takt-acp` (#913, #916) — run TAKT as an Agent Client Protocol agent over stdio JSON-RPC, enqueue-first by default.
- `for-local-llm` workflow family (#958, #974, #982) — five workflows with parallel deep reviewers, the Finding Contract, a new `implementation-semantics` reviewer, and a merge-readiness final gate. Replaces the `-with-fc` lineage.
- `cli` workflow (#947).
- Finding Contract dispute/waiver lifecycle (#969).
- `when()` syntax for engine-evaluated deterministic conditions (#977).
- Final-gate provider routing tag (#954) and merge-readiness review gate (#949).
- OpenCode native `json_schema` structured output (#965) with a one-shot corrective retry (#963).

### Changed

- **BREAKING:** deterministic rule conditions now require the explicit `when()` wrapper (#977).
- **BREAKING:** the `-with-fc` workflow lineage (`takt-default-with-fc`, `peer-review-with-fc`) was removed (#974).
- The fixer replans instead of aborting on "cannot proceed" (#986).
- Codex `approval_policy` pinned to `never`; model-capability checks delegated to the provider (#983).

### Fixed

- OpenCode idle watchdog fires on stalled sessions (#984); session preserved across phases (#948); out-of-workspace denial non-fatal (#957); structured-output recovery + formatless fallback (#962, #967).
- Finding-contract resolution reachable + guarded tag rules (#961); dispute guidance only when open findings exist (#973).
- Cursor CLI config dir preserved (#960); symlinked stdio entrypoints resolved (#955).
- Report-phase failures / empty Phase 1 output are soft errors (#907, #911, #927); isolated-clone fetch detaches HEAD (#924); OpenCode `bash` tool handling (#918, #919); `takt list` instruct+requeue (#942); full-area audit hardening (#981).

### Internal

- CQRS+ES guidance (#925, #940, #941, #979, #988); prompt-quality eval tooling (#946, #951, #952, #959); review/test facet contracts (#915, #917, #932, #944, #966, #987); Codex test-gate parallelization (#920) and MCP task workflow (#972); `when()` helper cleanup (#978).

See CHANGELOG.md for the full, detailed entry.

## Commits

- 76e54672 feat: replan instead of aborting when the fixer gives up (#986)
- eac072c5 docs: strengthen cqrs-es guidance (#988)
- e19e3205 chore: tag first test-writing workflow steps (#987)
- 6068e532 takt: preserve-cursor-config-dir (#960)
- b40ff7bd fix: make the opencode idle watchdog actually fire on stalled sessions (#984)
- 2fd744fb [codex] Delegate model capability checks to providers (#983)
- e77b5153 refactor: rename deep-peer-review to peer-review-for-local-llm (#982)
- 37dc01d2 fix: recover opencode structured output when the gateway rejects json_schema
- fe2a2e3d fix: force codex approval_policy=never so the sandbox mode is authoritative
- 2e803a19 fix: harden judgment, findings, and opencode per the full-area $coding audit (#981)
- 0936aed5 Strengthen CQRS aggregate metadata guidance (#979)
- f2ebe15f refactor: tighten the when() helpers per coding standards (#978)
- e1ea5ea1 feat: require the explicit when() syntax for deterministic conditions (#977)
- a35fa190 feat: add the for-local-llm workflow family (#974)
- 5a8e0891 fix: inject dispute guidance only when open findings exist (#973)
- f19f339d [codex] require MCP task workflow and auto PR decisions (#972)
- 15a3771f feat: add dispute/waiver lifecycle to the finding contract (#969)
- 0e407491 fix: stop flagging guarded Records in implementation-semantics knowledge (#968)
- 56cb585c feat: add rescan-semantics eval suite for the implementation-semantics reviewer (#959)
- ecf03886 fix: fall back to formatless retry when native structured output is not produced (#967)
- 848ddd70 chore: strengthen write-tests contract (#966)
- 93759a7b feat: use OpenCode native json_schema structured output (#965)
- 738c8493 feat: retry invalid reviewer structured output once with a corrective prompt (#963)
- 105e5f47 fix: treat empty raw-finding location and suggestion as unset (#962)
- 21fa0baa fix: make finding-contract resolution reachable and support guarded tag rules (#961)
- 0c66e44e fix: handle symlinked stdio entrypoints (#955)
- 59e04060 feat: add takt-default-deep-review workflow with an implementation-semantics reviewer (#958)
- 2bc84cdf fix: keep out-of-workspace denial effective and non-fatal for opencode (#957)
- 0a7f3cfa feat: add final gate routing tags (#954)
- b64b7493 feat: teach reviewers published-state immutability and family-level finding aggregation (#953)
- 924cd2cd fix: rescan eval suite fixture mismatch and broken assertions (#952)
- 4d1fc70b feat: require re-scan evidence in review reports and add rescan eval suite (#951)
- b8da2401 feat: add promptfoo-based prompt quality eval for facets (#946)
- fefb1901 [codex] Add merge readiness review gate (#949)
- 6e937685 [#938] add-takt-mcp (#943)
- 126e1c2f feat: add cli workflow (#947)
- faebc528 fix: preserve OpenCode session across step phases via per-prompt tools restriction (#948)
- ca0c7352 takt: fix-instruct-requeue-workflow (#942)
- b74b0a4c chore: tighten review facet contract checks (#944)
- d085490a docs: clarify cqrs notification waiting guidance (#941)
- 75766639 docs: clarify cqrs reactive polling guidance (#940)
- 71ebd1e1 [#913] implement-acp-agent (#916)
- 08973768 fix: improve review-fix takt facet checks (#932)
- 9514c026 fix: soft error for Report phase failure and empty Phase 1 output detection (#927)
- 556cb3c1 fix: detach HEAD before fetching into checked-out branch in isolated clone (#924)
- 31aed80f docs: add CQRS+ES adoption criteria to knowledge facet (#925)
- d48fab67 [codex] Parallelize test gates (#920)
- 23e68950 fix: remove bash from OPENCODE_UNSAFE_WITHOUT_EDIT_TOOL_NAMES (#919)
- 77856536 fix: restore bash in allowed_tools when permission mode is readonly (#918)
- 37236c42 docs: harden facet review contracts (#917)
- 15defbff [#907] add-report-fallback (#911)
- 3896868b fix: テストポリシーにレイヤー間の重複テスト禁止ルールを追加 (#915)
- 55c31be7 Merge pull request #910 from nrslib/release/v0.49.0
