### PR TITLE
fix(ci): pr-comment-commands.yml の YAML 構文エラーを修正

### DIFF
--- a/.github/workflows/pr-comment-commands.yml
+++ b/.github/workflows/pr-comment-commands.yml
@@ -20,8 +20,7 @@ jobs:
       (
         github.event.comment.body == '/review' ||
         startsWith(github.event.comment.body, '/review ') ||
-        startsWith(github.event.comment.body, '/review
-')
+        startsWith(github.event.comment.body, format('/review{0}', fromJSON('"\n"')))
       ) &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     concurrency:


### PR DESCRIPTION
## 概要

`pr-comment-commands.yml` が導入コミット #736（2026-05-17）以来ずっと不正 YAML で、全ブランチの push で `startup_failure` になっていた。結果として、このワークフローが提供する PRコメントのスラッシュコマンド（`/review` など）は #736 以降まったく発火していなかった。

## 原因

`review` job の `if: |` ブロックスカラー内で、単一引用符の文字列 `'/review\n'` を **実際の改行** で書いていたため、閉じの `')` がインデント0で始まり、ブロックスカラーがそこで終端して YAML 構造が壊れていた。

```yaml
startsWith(github.event.comment.body, '/review
')
```

## 修正

改行文字を `fromJSON('"\n"')` で生成し `format()` で組み立てることで、意図（`/review` + 改行始まりのコメントにマッチ）を保ったまま YAML を1行に収める。

```yaml
startsWith(github.event.comment.body, format('/review{0}', fromJSON('"\n"')))
```

## 検証

- `js-yaml` でパース OK（jobs: review, resolve, ci, takt）。
- 同種の行分割された単一引用符コマンドは他に存在しないことを確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * コメントコマンドの判定を改善し、改行を含む入力でも正しく認識されるようになりました。
  * 一部のレビュー指示が意図どおり処理されないケースを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->