### PR TITLE
fix(release): prepublishOnly からフルテスト再実行を外す

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:e2e:cursor": "npm run test:e2e:provider:cursor",
     "lint": "eslint src/",
     "check:release": "npm run build && npm run lint && npm run test && npm run test:it && npm run test:e2e:all; code=$?; if [ \"$code\" -eq 0 ]; then msg='check:release passed'; else msg=\"check:release failed (exit=$code)\"; fi; if command -v osascript >/dev/null 2>&1; then osascript -e \"display notification \\\"$msg\\\" with title \\\"takt\\\" subtitle \\\"Release Check\\\"\" >/dev/null 2>&1 || true; fi; echo \"[takt] $msg\"; exit $code",
-    "prepublishOnly": "npm run lint && npm run build && npm run test",
+    "prepublishOnly": "npm run lint && npm run build",
     "canary:coder": "node scripts/canary-coder.mjs"
   },
   "keywords": [


### PR DESCRIPTION
## 背景

v0.50.0 の publish（`auto-tag.yml` の publish ジョブ）が失敗した。`tag` ジョブは成功して `v0.50.0` タグは push 済みだが、`npm publish --tag latest` が **npm レジストリ到達前**、`prepublishOnly` の `npm run test` 段階で exit 1 になっていた。

## 原因

`prepublishOnly`（`npm run lint && npm run build && npm run test`）自体は不変だが、参照先の `scripts.test` が今回の差分で変わった。

| | v0.49.0（成功） | v0.50.0（失敗） |
|---|---|---|
| `scripts.test` | `vitest run` | `node scripts/run-npm-test.mjs`（4シャード×`--maxWorkers=1`、#916/#920 で追加） |

PR CI はシャードを**別々のランナーで並列**に流すので緑。一方 `auto-tag.yml` の publish ジョブは**単一ランナー**で、そこで複数シャードが競合し、builtin workflow ディレクトリ走査系テスト（`workflowLoader.test.ts` / `config.test.ts` / `workflow-categories.test.ts`）が **15s `testTimeout` を超過**して失敗していた（builtin workflow が 51→58 に増えた分も影響）。

## 修正

`prepublishOnly` から `&& npm run test` を外し、`npm run lint && npm run build` のみにする。テストは PR CI が担保済みで、publish 時のフルテスト再実行は冗長。これで publish が単一ランナーのテスト競合で落ちなくなる。

```diff
-    "prepublishOnly": "npm run lint && npm run build && npm run test",
+    "prepublishOnly": "npm run lint && npm run build",
```

## 補足

- これは**次回以降の自動 publish** を直すもの。既存タグ `v0.50.0` の publish は、publish ジョブがタグを checkout してそのタグの（旧）`prepublishOnly` を実行するため、この PR では復旧しない。v0.50.0 は別途手動 publish で対応する。
- 代替案として `prepublishOnly` の末尾を `vitest run` に固定する案もあるが、テストゲートは PR CI に一本化する方針で本 PR は再実行を除去する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 公開前の実行手順が見直され、実行内容が「lint」と「build」に整理されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->