### PR TITLE
Release v0.50.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:e2e:cursor": "npm run test:e2e:provider:cursor",
     "lint": "eslint src/",
     "check:release": "npm run build && npm run lint && npm run test && npm run test:it && npm run test:e2e:all; code=$?; if [ \"$code\" -eq 0 ]; then msg='check:release passed'; else msg=\"check:release failed (exit=$code)\"; fi; if command -v osascript >/dev/null 2>&1; then osascript -e \"display notification \\\"$msg\\\" with title \\\"takt\\\" subtitle \\\"Release Check\\\"\" >/dev/null 2>&1 || true; fi; echo \"[takt] $msg\"; exit $code",
-    "prepublishOnly": "npm run lint && npm run build && npm run test",
+    "prepublishOnly": "npm run lint && npm run build",
     "canary:coder": "node scripts/canary-coder.mjs"
   },
   "keywords": [


### PR DESCRIPTION
## 目的：v0.50.0 の再 publish

v0.50.0 の初回 publish（PR #989 マージ時の `auto-tag.yml`）は **npm レジストリ到達前**に失敗した。`tag` ジョブは成功し `v0.50.0` タグは push されたが、`publish` ジョブの `npm publish` が `prepublishOnly` の `npm run test` 段階で exit 1 になり、**npm は 0.49.0 のまま**。

### 原因

`prepublishOnly`（`npm run lint && npm run build && npm run test`）は不変だが、参照先 `scripts.test` が今回の差分で `vitest run` → `node scripts/run-npm-test.mjs`（4シャード×`--maxWorkers=1`、#916/#920）に変わった。PR CI はシャードを別ランナーで並列実行するので緑だが、`auto-tag` の publish ジョブは**単一ランナー**で、シャード競合により builtin workflow 走査系テスト（`workflowLoader` / `config` / `workflow-categories`）が **15s `testTimeout`** を超過していた。

### 本PRの内容

`prepublishOnly` から `&& npm run test` を除去（`npm run lint && npm run build` のみ）。テストは PR CI が担保済みで publish 時の再実行は冗長。

```diff
-    "prepublishOnly": "npm run lint && npm run build && npm run test",
+    "prepublishOnly": "npm run lint && npm run build",
```

### リリース手順（メンテナ手動）

既存タグ `v0.50.0`（`01e5737`）は初回失敗時のもの。マージ前に削除し、auto-tag に本PR head の修正入りコミットへ貼り直させる。

1. CI 緑を確認
2. `git push origin :refs/tags/v0.50.0`（既存タグ削除）
3. 本PRをマージ → `auto-tag.yml` が修正入りコミットに `v0.50.0` を作成 → publish 成功

版・CHANGELOG・README 等は #989 で main に反映済みのため、本PRの差分は prepublishOnly 修正のみ。#991 は本PRに統合するためクローズ。