### PR TITLE
[codex] clarify MCP worktree autoPr descriptions

### DIFF
--- a/src/__tests__/mcp-entrypoint.test.ts
+++ b/src/__tests__/mcp-entrypoint.test.ts
@@ -86,8 +86,8 @@ describe('MCP package entrypoint', () => {
       const runNextTaskContext = objectProperties(runNextProperties.taskContext);
 
       expect(enqueueProperties.workflow?.description).toBe('Workflow identifier to store on the queued task. Ask the user which workflow to use before enqueueing.');
-      expect(enqueueProperties.worktree?.description).toBe('Whether the queued task should run in a TAKT-managed worktree.');
-      expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should automatically open a pull request. Ask the user before enqueueing.');
+      expect(enqueueProperties.worktree?.description).toBe('Whether the queued task should run in a TAKT-managed worktree. When true, successful execution attempts to auto-commit resulting changes locally; autoPr false does not disable that.');
+      expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should push the branch and automatically open a pull request. Ask the user before enqueueing; do not infer this from branch or PR context. When false, worktree execution may still auto-commit local changes.');
       expect(issueProperties.labels?.description).toBe('Issue labels to request from the configured issue provider.');
       expect(runNextProperties.provider?.description).toBe('Agent provider override for this task execution.');
       expect(runNextProperties.model?.description).toBe('Model override for this task execution.');

--- a/src/__tests__/mcpSchemas.test.ts
+++ b/src/__tests__/mcpSchemas.test.ts
@@ -223,8 +223,8 @@ describe('MCP tool input schemas', () => {
     const taskContextProperties = schemaProperties(requireSchema(enqueueProperties.taskContext, 'taskContext'));
 
     expect(enqueueProperties.workflow?.description).toBe('Workflow identifier to store on the queued task. Ask the user which workflow to use before enqueueing.');
-    expect(enqueueProperties.worktree?.description).toBe('Whether the queued task should run in a TAKT-managed worktree.');
-    expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should automatically open a pull request. Ask the user before enqueueing.');
+    expect(enqueueProperties.worktree?.description).toBe('Whether the queued task should run in a TAKT-managed worktree. When true, successful execution attempts to auto-commit resulting changes locally; autoPr false does not disable that.');
+    expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should push the branch and automatically open a pull request. Ask the user before enqueueing; do not infer this from branch or PR context. When false, worktree execution may still auto-commit local changes.');
     expect(issueProperties.labels?.description).toBe('Issue labels to request from the configured issue provider.');
     expect(runNextProperties.provider?.description).toBe('Agent provider override for this task execution.');
     expect(runNextProperties.model?.description).toBe('Model override for this task execution.');

--- a/src/features/mcp/schemas.ts
+++ b/src/features/mcp/schemas.ts
@@ -23,7 +23,7 @@ const workflowSchema = z.string().trim().min(1).max(MCP_WORKFLOW_MAX_LENGTH)
   .describe('Workflow identifier to store on the queued task. Ask the user which workflow to use before enqueueing.');
 const worktreeSchema = z.boolean()
   .optional()
-  .describe('Whether the queued task should run in a TAKT-managed worktree.');
+  .describe('Whether the queued task should run in a TAKT-managed worktree. When true, successful execution attempts to auto-commit resulting changes locally; autoPr false does not disable that.');
 const branchSchema = z.string().refine(isValidTaskContextBranchName, {
   message: 'branch must be a valid local branch name',
 }).describe('Plain local Git branch name for task execution context.');
@@ -45,7 +45,7 @@ const taskSaveOptionsSchema = z.object({
   workflow: workflowSchema,
   worktree: worktreeSchema,
   autoPr: z.boolean()
-    .describe('Whether successful worktree execution should automatically open a pull request. Ask the user before enqueueing.'),
+    .describe('Whether successful worktree execution should push the branch and automatically open a pull request. Ask the user before enqueueing; do not infer this from branch or PR context. When false, worktree execution may still auto-commit local changes.'),
   taskContext: taskContextSchema,
 }).strict();
 


### PR DESCRIPTION
## Summary

- Clarify the MCP worktree description so callers know successful worktree execution attempts to auto-commit resulting changes locally.
- Clarify the MCP autoPr description so callers know it controls branch publishing and PR creation, and should not be inferred from branch or PR context.
- Update schema description tests to match the new MCP wording.

## Validation

- Not run locally; wording-only change, CI will run the test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 入力オプションの説明を更新し、実行時の動作がより明確になりました。
  * 自動保存やプルリクエスト作成の条件、無効時の挙動、確認が必要なケースがわかりやすくなりました。

* **Tests**
  * スキーマ説明の内容に関するテストを更新し、新しい説明文が維持されるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->