### PR TITLE
docs: clarify exception translation boundaries

### DIFF
--- a/builtins/en/facets/knowledge/architecture.md
+++ b/builtins/en/facets/knowledge/architecture.md
@@ -106,6 +106,17 @@ Prohibited patterns:
 - Error handling centralized (no try-catch scattered everywhere)
 - Business logic not leaking into Controller/View
 
+**Exception Translation at Protocol Boundaries:**
+
+Adapters such as HTTP, CLI, GraphQL, and message consumers are boundaries that translate internal exceptions into external protocol representations. Scattering the same try-catch / response translation across endpoints or handlers easily makes status codes, error shapes, logs, and authorization failures inconsistent. Centralize exception translation in a dedicated layer at the adapter boundary, and keep only truly cross-cutting translations in a global handler.
+
+| Criteria | Judgment |
+|----------|----------|
+| Each endpoint / handler implements the same translation from the same exception to the same protocol representation | REJECT |
+| Translation to protocol representation lives in the application or domain layer | REJECT |
+| API-specific exception translation is placed in a global handler shared by all APIs | REJECT |
+| Translation to external representation is centralized in an exception translation layer at the adapter boundary | OK |
+
 ## Resolve at the Boundary
 
 Values such as config, options, providers, permissions, and paths should be resolved at the boundary before entering the core flow. Main processing should assume values are already resolved and should not keep asking config sources.

--- a/builtins/en/facets/policies/coding.md
+++ b/builtins/en/facets/policies/coding.md
@@ -459,8 +459,7 @@ async function createUser(data) {
 }
 
 // ✅ Centralized handling at the upper layer
-// Catch collectively at the Controller/Handler layer
-// Or handle via @ControllerAdvice / ErrorBoundary
+// Handle collectively at the boundary exception translation layer
 async function createUser(data) {
   return await userService.create(data)  // Let exceptions propagate up
 }
@@ -471,8 +470,20 @@ async function createUser(data) {
 | Layer | Responsibility |
 |-------|---------------|
 | Domain/Service layer | Throw exceptions on business rule violations |
-| Controller/Handler layer | Catch exceptions and convert to responses |
-| Global handler | Handle common exceptions (NotFound, auth errors, etc.) |
+| Application layer | Do not swallow exceptions; only handle explicit compensation or retry |
+| Adapter boundary | Translate exceptions to protocol-specific responses or presentation |
+| Global handler | Handle only cross-cutting exceptions such as authentication, validation, and common error shapes |
+
+### HTTP Exception Translation
+
+HTTP adapters / controllers / handlers must not translate exceptions into HTTP representation endpoint by endpoint. Translate exceptions into HTTP status codes, response bodies, and headers at an exception translation layer on the HTTP adapter boundary.
+
+| Criteria | Judgment |
+|----------|----------|
+| Each endpoint maps exceptions to HTTP representation through the same try-catch or wrapper | REJECT. Move it to an exception translation layer at the HTTP adapter boundary |
+| API-specific exception mapping is added to a global handler shared by all APIs | REJECT. Keep it inside the target API boundary |
+| Only truly cross-cutting mappings such as authentication, validation, and common error shapes are handled by a global handler | OK |
+| HTTP representation mapping lives in the application or domain layer | REJECT. Keep it at the HTTP adapter boundary |
 
 ## Conversion Placement
 

--- a/builtins/ja/facets/knowledge/architecture.md
+++ b/builtins/ja/facets/knowledge/architecture.md
@@ -106,6 +106,17 @@ Vertical Slice の判定基準:
 - エラーハンドリングが一元化されているか（各所でtry-catch禁止）
 - ビジネスロジックがController/Viewに漏れていないか
 
+**プロトコル境界の例外変換**
+
+HTTP、CLI、GraphQL、message consumer などの adapter は、内部例外を外部プロトコルの表現へ変換する境界である。endpoint や handler ごとに同じ try-catch / response 変換を散在させると、ステータス、エラー形状、ログ、認可失敗の扱いが不整合になりやすい。例外変換は adapter 境界の専用レイヤに集約し、真に横断的な変換だけを global handler に置く。
+
+| 基準 | 判定 |
+|------|------|
+| endpoint / handler ごとに同じ例外から同じプロトコル表現への変換を実装している | REJECT |
+| プロトコル表現への変換が application/domain 層に入っている | REJECT |
+| 特定 API 固有の例外変換を全 API 共通の global handler に置いている | REJECT |
+| adapter 境界の例外変換レイヤで、外部表現への変換を一元化している | OK |
+
 ## 境界での解決
 
 設定、Option、provider、権限、パスのような値は、境界で解決してから内部へ渡す。メイン処理は「何が解決済みか」を前提に組み立て、各所で設定ソースを問い合わせない。

--- a/builtins/ja/facets/policies/coding.md
+++ b/builtins/ja/facets/policies/coding.md
@@ -459,8 +459,7 @@ async function createUser(data) {
 }
 
 // ✅ 上位層で一元処理
-// Controller/Handler層でまとめてキャッチ
-// または @ControllerAdvice / ErrorBoundary で処理
+// 境界の例外変換レイヤでまとめて処理
 async function createUser(data) {
   return await userService.create(data)  // 例外はそのまま上に投げる
 }
@@ -471,8 +470,20 @@ async function createUser(data) {
 | 層 | 責務 |
 |----|------|
 | ドメイン/サービス層 | ビジネスルール違反時に例外をスロー |
-| Controller/Handler層 | 例外をキャッチしてレスポンスに変換 |
-| グローバルハンドラ | 共通例外（NotFound, 認証エラー等）を処理 |
+| Application層 | 例外を握りつぶさず、必要な補償や再試行だけを明示的に扱う |
+| Adapter境界 | 例外をプロトコル固有のレスポンスや表示に変換 |
+| グローバルハンドラ | 認証、入力検証、共通エラー形状など横断的な例外だけを処理 |
+
+### HTTP 例外変換
+
+HTTP adapter / controller / handler は、endpoint ごとに例外を HTTP 表現へ変換しない。例外から HTTP ステータス、レスポンス本文、ヘッダへの変換は HTTP adapter 境界の例外変換レイヤへ集約する。
+
+| 基準 | 判定 |
+|------|------|
+| 各 endpoint が同じ try-catch や wrapper で例外を HTTP 表現に変換している | REJECT。HTTP adapter 境界の例外変換レイヤに分離 |
+| 特定 API 固有の例外変換を全 API 共通の global handler に追加する | REJECT。対象 API の境界に閉じる |
+| 認証、入力検証、共通エラー形状など真に横断的な変換だけを global handler で扱う | OK |
+| 例外型から HTTP 表現への変換が application/domain 層にある | REJECT。HTTP adapter 境界で扱う |
 
 ## 変換処理の配置
 


### PR DESCRIPTION
## 概要
- adapter 境界で例外変換を集約する方針を architecture knowledge に追加
- HTTP 例外変換の配置基準を coding policy に追加
- 英語版と日本語版の facet 文面を同期

## テスト
- 未実行（ドキュメント/ポリシー文面のみの変更）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 例外の扱いを、各エンドポイントで個別対応するのではなく、境界側で一元的に変換する方針として明確化しました。
  * HTTP、CLI、GraphQL、メッセージ処理などでのエラー表現の整理基準を追加しました。
  * グローバルなハンドリングでは、認証・入力検証などの共通的な変換のみを扱うよう整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->