### PR TITLE
fix: overnight hardening from live bench operations

### DIFF
--- a/src/__tests__/engine-loop-monitors.test.ts
+++ b/src/__tests__/engine-loop-monitors.test.ts
@@ -1082,9 +1082,13 @@ describe('Judge failure falls back to the natural transition', () => {
       { index: 0, method: 'phase1_tag' },  // reviewers → COMPLETE
     ]);
 
+    const abortFn = vi.fn();
+    engine.on('workflow:abort', abortFn);
+
     const state = await engine.run();
 
     expect(state.status).toBe('completed');
+    expect(abortFn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/engine-loop-monitors.test.ts
+++ b/src/__tests__/engine-loop-monitors.test.ts
@@ -222,7 +222,7 @@ describe('WorkflowEngine Integration: Loop Monitors', () => {
       expect(state.iteration).toBe(8);
     });
 
-    it('should abort when judge returns non-done status', async () => {
+    it('should continue with the natural transition when judge returns non-done status', async () => {
       const config = buildConfigWithLoopMonitor(1);
       engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
 
@@ -236,11 +236,16 @@ describe('WorkflowEngine Integration: Loop Monitors', () => {
           content: 'judge failed',
           error: 'judge interrupted',
         }),
+        // 判定不能 → 自然遷移（ai_fix → ai_review）で続行
+        makeResponse({ persona: 'ai_review', content: 'No issues' }),
+        makeResponse({ persona: 'reviewers', content: 'All approved' }),
       ]);
 
       mockDetectMatchedRuleSequence([
         { index: 0, method: 'phase1_tag' },
         { index: 1, method: 'phase1_tag' },
+        { index: 0, method: 'phase1_tag' },
+        { index: 0, method: 'phase1_tag' },
         { index: 0, method: 'phase1_tag' },
       ]);
 
@@ -249,11 +254,9 @@ describe('WorkflowEngine Integration: Loop Monitors', () => {
 
       const state = await engine.run();
 
-      expect(state.status).toBe('aborted');
-      expect(abortFn).toHaveBeenCalledOnce();
-      const reason = abortFn.mock.calls[0]![1] as string;
-      expect(reason).toContain('Unhandled response status: error');
-      expect(runReportPhase).not.toHaveBeenCalled();
+      // 判定役の障害は走行を落とさない（自然遷移で続行して完走する）
+      expect(state.status).toBe('completed');
+      expect(abortFn).not.toHaveBeenCalled();
     });
 
     it('should inherit resolved provider and model from the step that triggered the judge', async () => {
@@ -1016,6 +1019,72 @@ describe('WorkflowEngine Integration: Loop Monitors', () => {
       expect(state.status).toBe('completed');
       expect(state.iteration).toBe(3);
     });
+  });
+});
+
+// =====================================================
+// 判定役の障害は走行を落とさない（自然遷移で続行）
+// =====================================================
+describe('Judge failure falls back to the natural transition', () => {
+  let tmpDir: string;
+  let engine: WorkflowEngine | null = null;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    applyDefaultMocks();
+    tmpDir = createTestTmpDir();
+  });
+
+  afterEach(() => {
+    if (engine) {
+      cleanupWorkflowEngine(engine);
+      engine = null;
+    }
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should continue with the natural next step when the judge agent errors', async () => {
+    const config = buildConfigWithLoopMonitor(2, {
+      judge: {
+        persona: 'supervisor',
+        instruction: 'The loop repeated {cycle_count} times.',
+        rules: [
+          { condition: 'Healthy', next: 'ai_review' },
+          { condition: 'Unproductive', next: 'reviewers' },
+        ],
+      },
+    });
+    engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+
+    mockRunAgentSequence([
+      makeResponse({ persona: 'implement', content: 'Implementation done' }),
+      makeResponse({ persona: 'ai_review', content: 'Issues found: X' }),
+      makeResponse({ persona: 'ai_fix', content: 'Fixed X' }),
+      makeResponse({ persona: 'ai_review', content: 'Issues found: Y' }),
+      makeResponse({ persona: 'ai_fix', content: 'Fixed Y' }),
+      // 判定役がプロバイダエラーで decision を返せない
+      makeResponse({ persona: 'supervisor', content: '', status: 'error', error: 'provider exploded' }),
+      // 自然遷移（ai_fix → ai_review）で続行し、承認 → reviewers → COMPLETE
+      makeResponse({ persona: 'ai_review', content: 'No issues' }),
+      makeResponse({ persona: 'reviewers', content: 'All approved' }),
+    ]);
+
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' },  // implement → ai_review
+      { index: 1, method: 'phase1_tag' },  // ai_review → ai_fix
+      { index: 0, method: 'phase1_tag' },  // ai_fix → ai_review
+      { index: 1, method: 'phase1_tag' },  // ai_review → ai_fix
+      { index: 0, method: 'phase1_tag' },  // ai_fix → ai_review（ここで cycle 検出）
+      // 判定役は error なのでルール照合なし
+      { index: 0, method: 'phase1_tag' },  // ai_review → reviewers（No issues）
+      { index: 0, method: 'phase1_tag' },  // reviewers → COMPLETE
+    ]);
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
   });
 });
 

--- a/src/__tests__/engine-parallel-failure.test.ts
+++ b/src/__tests__/engine-parallel-failure.test.ts
@@ -101,6 +101,46 @@ describe('WorkflowEngine Integration: Parallel Step Partial Failure', () => {
     }
   });
 
+  it('should retry a sub-step once with a fresh session when the provider errors', async () => {
+    const config = buildParallelOnlyConfig();
+    const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });
+
+    const mock = vi.mocked(runAgent);
+    const sessionIds: Array<string | undefined> = [];
+    let archCalls = 0;
+    mock.mockImplementation(async (persona, task, options) => {
+      options?.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      if (String(persona).includes('arch-review')) {
+        archCalls += 1;
+        sessionIds.push(options?.sessionId);
+        if (archCalls === 1) {
+          // 1回目はプロバイダ障害（劣化ループをガードがエラー化した形）
+          return makeResponse({ persona, status: 'error', content: '', error: 'assistant message cycle budget exceeded' });
+        }
+        return makeResponse({ persona, content: 'approved' });
+      }
+      return makeResponse({ persona: String(persona), content: 'approved' });
+    });
+
+    mockDetectMatchedRuleSequence([
+      { index: 0, method: 'phase1_tag' }, // arch-review（再試行後）→ approved
+      { index: 0, method: 'phase1_tag' }, // security-review → approved
+      { index: 0, method: 'aggregate' },  // 親 reviewers → done
+      { index: 0, method: 'phase1_tag' }, // done → COMPLETE
+    ]);
+
+    const state = await engine.run();
+
+    // 1席の一過性エラーで走行が落ちず、再試行で完走する
+    expect(state.status).toBe('completed');
+    expect(archCalls).toBe(2);
+    // 再試行は resume を切った新しいセッションで行われる
+    expect(sessionIds[1]).toBeUndefined();
+  });
+
   it('should abort with parent error when one sub-step rejects and another approves', async () => {
     const config = buildParallelOnlyConfig();
     const engine = new WorkflowEngine(config, tmpDir, 'test task', { projectCwd: tmpDir });

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2524,6 +2524,55 @@ describe('OpenCodeClient stream cleanup', () => {
     }
   }, 20_000);
 
+  it('should stop a degenerate loop that rotates tool names via the error budget', async () => {
+    process.env.TAKT_OPENCODE_TOOL_ERROR_BUDGET = '6';
+    try {
+      const { OpenCodeClient } = await import('../infra/opencode/client.js');
+      const tools = ['read', 'write', 'glob', 'grep', 'list', 'edit'];
+      const events = tools.map((tool, i) => ({
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: `c${i}`,
+            type: 'tool',
+            tool,
+            callID: `c${i}`,
+            sessionID: 'session-degenerate',
+            state: { status: 'error', error: `The ${tool} tool was called with invalid arguments: SchemaError(x)` },
+          },
+        },
+      }));
+      const stream = new MockEventStream([
+        ...events,
+        { type: 'session.idle', properties: { sessionID: 'session-degenerate' } },
+      ]);
+      createOpencodeMock.mockResolvedValue({
+        client: {
+          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+          session: {
+            create: vi.fn().mockResolvedValue({ data: { id: 'session-degenerate' } }),
+            promptAsync: vi.fn().mockResolvedValue(undefined),
+          },
+          event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+          permission: { reply: vi.fn() },
+        },
+        server: { close: vi.fn() },
+      });
+
+      const result = await new OpenCodeClient().call('coder', 'do it', {
+        cwd: '/tmp',
+        model: 'opencode/big-pickle',
+        interactionTimeoutMs: 500,
+      });
+
+      // ツール名が毎回違うため連続性の検出器は発火しないが、総量予算が止める
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('tool error budget exceeded');
+    } finally {
+      delete process.env.TAKT_OPENCODE_TOOL_ERROR_BUDGET;
+    }
+  });
+
   it('should not trip the invalid-argument loop across interleaved unavailable errors', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const INVALID = 'The read tool was called with invalid arguments: SchemaError(Expected string)';

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2524,6 +2524,46 @@ describe('OpenCodeClient stream cleanup', () => {
     }
   }, 20_000);
 
+  it('should stop a degenerate text-fragment loop via the message cycle budget', async () => {
+    process.env.TAKT_OPENCODE_MESSAGE_CYCLE_BUDGET = '5';
+    try {
+      const { OpenCodeClient } = await import('../infra/opencode/client.js');
+      const cycles = Array.from({ length: 6 }, (_, i) => ({
+        type: 'message.updated',
+        properties: {
+          info: { sessionID: 'session-spin', role: 'assistant', time: { completed: 1000 + i } },
+        },
+      }));
+      const stream = new MockEventStream([
+        ...cycles,
+        { type: 'session.idle', properties: { sessionID: 'session-spin' } },
+      ]);
+      createOpencodeMock.mockResolvedValue({
+        client: {
+          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+          session: {
+            create: vi.fn().mockResolvedValue({ data: { id: 'session-spin' } }),
+            promptAsync: vi.fn().mockResolvedValue(undefined),
+          },
+          event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+          permission: { reply: vi.fn() },
+        },
+        server: { close: vi.fn() },
+      });
+
+      const result = await new OpenCodeClient().call('coder', 'do it', {
+        cwd: '/tmp',
+        model: 'opencode/big-pickle',
+        interactionTimeoutMs: 500,
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('message cycle budget exceeded');
+    } finally {
+      delete process.env.TAKT_OPENCODE_MESSAGE_CYCLE_BUDGET;
+    }
+  });
+
   it('should stop a degenerate loop that rotates tool names via the error budget', async () => {
     process.env.TAKT_OPENCODE_TOOL_ERROR_BUDGET = '6';
     try {

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2524,41 +2524,42 @@ describe('OpenCodeClient stream cleanup', () => {
     }
   }, 20_000);
 
+  /** 予算系4テスト共通: イベント列を流して call の結果だけ返す */
+  async function runBudgetScenario(sessionId: string, events: unknown[]): Promise<import('../core/models/index.js').AgentResponse> {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const stream = new MockEventStream([
+      ...events,
+      { type: 'session.idle', properties: { sessionID: sessionId } },
+    ]);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: sessionId } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+    return new OpenCodeClient().call('coder', 'do it', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      interactionTimeoutMs: 500,
+    });
+  }
+
   it('should complete normally when message cycles stay under the budget', async () => {
     process.env.TAKT_OPENCODE_MESSAGE_CYCLE_BUDGET = '5';
     try {
-      const { OpenCodeClient } = await import('../infra/opencode/client.js');
-      const cycles = Array.from({ length: 4 }, (_, i) => ({
+      const result = await runBudgetScenario('session-under', Array.from({ length: 4 }, (_, i) => ({
         type: 'message.updated',
-        properties: {
-          info: { sessionID: 'session-under', role: 'assistant', time: { completed: 1000 + i } },
-        },
-      }));
-      const stream = new MockEventStream([
-        ...cycles,
-        {
-          type: 'message.part.updated',
-          properties: { part: { id: 'p-t', type: 'text', text: 'done', sessionID: 'session-under' } },
-        },
-        { type: 'session.idle', properties: { sessionID: 'session-under' } },
-      ]);
-      createOpencodeMock.mockResolvedValue({
-        client: {
-          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
-          session: {
-            create: vi.fn().mockResolvedValue({ data: { id: 'session-under' } }),
-            promptAsync: vi.fn().mockResolvedValue(undefined),
-          },
-          event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
-          permission: { reply: vi.fn() },
-        },
-        server: { close: vi.fn() },
-      });
-
-      const result = await new OpenCodeClient().call('coder', 'do it', {
-        cwd: '/tmp',
-        model: 'opencode/big-pickle',
-      });
+        properties: { info: { sessionID: 'session-under', role: 'assistant', time: { completed: 1000 + i } } },
+      })).concat([{
+        type: 'message.part.updated',
+        properties: { part: { id: 'p-t', type: 'text', text: 'done', sessionID: 'session-under' } },
+      }] as unknown[]));
 
       // 予算未満（4 < 5）なら通常どおり完了する
       expect(result.status).toBe('done');
@@ -2570,46 +2571,18 @@ describe('OpenCodeClient stream cleanup', () => {
   it('should complete normally when tool errors stay under the budget', async () => {
     process.env.TAKT_OPENCODE_TOOL_ERROR_BUDGET = '6';
     try {
-      const { OpenCodeClient } = await import('../infra/opencode/client.js');
-      const tools = ['read', 'write', 'glob', 'grep', 'list'];
-      const events = tools.map((tool, i) => ({
+      const result = await runBudgetScenario('session-under2', ['read', 'write', 'glob', 'grep', 'list'].map((tool, i) => ({
         type: 'message.part.updated',
         properties: {
           part: {
-            id: `u${i}`,
-            type: 'tool',
-            tool,
-            callID: `u${i}`,
-            sessionID: 'session-under2',
+            id: `u${i}`, type: 'tool', tool, callID: `u${i}`, sessionID: 'session-under2',
             state: { status: 'error', error: `The ${tool} tool was called with invalid arguments: SchemaError(x)` },
           },
         },
-      }));
-      const stream = new MockEventStream([
-        ...events,
-        {
-          type: 'message.part.updated',
-          properties: { part: { id: 'p-t2', type: 'text', text: 'done', sessionID: 'session-under2' } },
-        },
-        { type: 'session.idle', properties: { sessionID: 'session-under2' } },
-      ]);
-      createOpencodeMock.mockResolvedValue({
-        client: {
-          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
-          session: {
-            create: vi.fn().mockResolvedValue({ data: { id: 'session-under2' } }),
-            promptAsync: vi.fn().mockResolvedValue(undefined),
-          },
-          event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
-          permission: { reply: vi.fn() },
-        },
-        server: { close: vi.fn() },
-      });
-
-      const result = await new OpenCodeClient().call('coder', 'do it', {
-        cwd: '/tmp',
-        model: 'opencode/big-pickle',
-      });
+      })).concat([{
+        type: 'message.part.updated',
+        properties: { part: { id: 'p-t2', type: 'text', text: 'done', sessionID: 'session-under2' } },
+      }] as unknown[]));
 
       // 予算未満（5 < 6）なら通常どおり完了する（回転ツール名で連続性検出も発火しない）
       expect(result.status).toBe('done');
@@ -2621,35 +2594,10 @@ describe('OpenCodeClient stream cleanup', () => {
   it('should stop a degenerate text-fragment loop via the message cycle budget', async () => {
     process.env.TAKT_OPENCODE_MESSAGE_CYCLE_BUDGET = '5';
     try {
-      const { OpenCodeClient } = await import('../infra/opencode/client.js');
-      const cycles = Array.from({ length: 6 }, (_, i) => ({
+      const result = await runBudgetScenario('session-spin', Array.from({ length: 6 }, (_, i) => ({
         type: 'message.updated',
-        properties: {
-          info: { sessionID: 'session-spin', role: 'assistant', time: { completed: 1000 + i } },
-        },
-      }));
-      const stream = new MockEventStream([
-        ...cycles,
-        { type: 'session.idle', properties: { sessionID: 'session-spin' } },
-      ]);
-      createOpencodeMock.mockResolvedValue({
-        client: {
-          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
-          session: {
-            create: vi.fn().mockResolvedValue({ data: { id: 'session-spin' } }),
-            promptAsync: vi.fn().mockResolvedValue(undefined),
-          },
-          event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
-          permission: { reply: vi.fn() },
-        },
-        server: { close: vi.fn() },
-      });
-
-      const result = await new OpenCodeClient().call('coder', 'do it', {
-        cwd: '/tmp',
-        model: 'opencode/big-pickle',
-        interactionTimeoutMs: 500,
-      });
+        properties: { info: { sessionID: 'session-spin', role: 'assistant', time: { completed: 1000 + i } } },
+      })));
 
       expect(result.status).toBe('error');
       expect(result.error).toContain('message cycle budget exceeded');
@@ -2661,45 +2609,16 @@ describe('OpenCodeClient stream cleanup', () => {
   it('should stop a degenerate loop that rotates tool names via the error budget', async () => {
     process.env.TAKT_OPENCODE_TOOL_ERROR_BUDGET = '6';
     try {
-      const { OpenCodeClient } = await import('../infra/opencode/client.js');
-      const tools = ['read', 'write', 'glob', 'grep', 'list', 'edit'];
-      const events = tools.map((tool, i) => ({
+      const result = await runBudgetScenario('session-degenerate', ['read', 'write', 'glob', 'grep', 'list', 'edit'].map((tool, i) => ({
         type: 'message.part.updated',
         properties: {
           part: {
-            id: `c${i}`,
-            type: 'tool',
-            tool,
-            callID: `c${i}`,
-            sessionID: 'session-degenerate',
+            id: `c${i}`, type: 'tool', tool, callID: `c${i}`, sessionID: 'session-degenerate',
             state: { status: 'error', error: `The ${tool} tool was called with invalid arguments: SchemaError(x)` },
           },
         },
-      }));
-      const stream = new MockEventStream([
-        ...events,
-        { type: 'session.idle', properties: { sessionID: 'session-degenerate' } },
-      ]);
-      createOpencodeMock.mockResolvedValue({
-        client: {
-          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
-          session: {
-            create: vi.fn().mockResolvedValue({ data: { id: 'session-degenerate' } }),
-            promptAsync: vi.fn().mockResolvedValue(undefined),
-          },
-          event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
-          permission: { reply: vi.fn() },
-        },
-        server: { close: vi.fn() },
-      });
+      })));
 
-      const result = await new OpenCodeClient().call('coder', 'do it', {
-        cwd: '/tmp',
-        model: 'opencode/big-pickle',
-        interactionTimeoutMs: 500,
-      });
-
-      // ツール名が毎回違うため連続性の検出器は発火しないが、総量予算が止める
       expect(result.status).toBe('error');
       expect(result.error).toContain('tool error budget exceeded');
     } finally {

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2524,6 +2524,100 @@ describe('OpenCodeClient stream cleanup', () => {
     }
   }, 20_000);
 
+  it('should complete normally when message cycles stay under the budget', async () => {
+    process.env.TAKT_OPENCODE_MESSAGE_CYCLE_BUDGET = '5';
+    try {
+      const { OpenCodeClient } = await import('../infra/opencode/client.js');
+      const cycles = Array.from({ length: 4 }, (_, i) => ({
+        type: 'message.updated',
+        properties: {
+          info: { sessionID: 'session-under', role: 'assistant', time: { completed: 1000 + i } },
+        },
+      }));
+      const stream = new MockEventStream([
+        ...cycles,
+        {
+          type: 'message.part.updated',
+          properties: { part: { id: 'p-t', type: 'text', text: 'done', sessionID: 'session-under' } },
+        },
+        { type: 'session.idle', properties: { sessionID: 'session-under' } },
+      ]);
+      createOpencodeMock.mockResolvedValue({
+        client: {
+          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+          session: {
+            create: vi.fn().mockResolvedValue({ data: { id: 'session-under' } }),
+            promptAsync: vi.fn().mockResolvedValue(undefined),
+          },
+          event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+          permission: { reply: vi.fn() },
+        },
+        server: { close: vi.fn() },
+      });
+
+      const result = await new OpenCodeClient().call('coder', 'do it', {
+        cwd: '/tmp',
+        model: 'opencode/big-pickle',
+      });
+
+      // 予算未満（4 < 5）なら通常どおり完了する
+      expect(result.status).toBe('done');
+    } finally {
+      delete process.env.TAKT_OPENCODE_MESSAGE_CYCLE_BUDGET;
+    }
+  });
+
+  it('should complete normally when tool errors stay under the budget', async () => {
+    process.env.TAKT_OPENCODE_TOOL_ERROR_BUDGET = '6';
+    try {
+      const { OpenCodeClient } = await import('../infra/opencode/client.js');
+      const tools = ['read', 'write', 'glob', 'grep', 'list'];
+      const events = tools.map((tool, i) => ({
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: `u${i}`,
+            type: 'tool',
+            tool,
+            callID: `u${i}`,
+            sessionID: 'session-under2',
+            state: { status: 'error', error: `The ${tool} tool was called with invalid arguments: SchemaError(x)` },
+          },
+        },
+      }));
+      const stream = new MockEventStream([
+        ...events,
+        {
+          type: 'message.part.updated',
+          properties: { part: { id: 'p-t2', type: 'text', text: 'done', sessionID: 'session-under2' } },
+        },
+        { type: 'session.idle', properties: { sessionID: 'session-under2' } },
+      ]);
+      createOpencodeMock.mockResolvedValue({
+        client: {
+          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+          session: {
+            create: vi.fn().mockResolvedValue({ data: { id: 'session-under2' } }),
+            promptAsync: vi.fn().mockResolvedValue(undefined),
+          },
+          event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+          permission: { reply: vi.fn() },
+        },
+        server: { close: vi.fn() },
+      });
+
+      const result = await new OpenCodeClient().call('coder', 'do it', {
+        cwd: '/tmp',
+        model: 'opencode/big-pickle',
+      });
+
+      // 予算未満（5 < 6）なら通常どおり完了する（回転ツール名で連続性検出も発火しない）
+      expect(result.status).toBe('done');
+    } finally {
+      delete process.env.TAKT_OPENCODE_TOOL_ERROR_BUDGET;
+    }
+  });
+
   it('should stop a degenerate text-fragment loop via the message cycle budget', async () => {
     process.env.TAKT_OPENCODE_MESSAGE_CYCLE_BUDGET = '5';
     try {

--- a/src/__tests__/parallel-runner-terminal-status.test.ts
+++ b/src/__tests__/parallel-runner-terminal-status.test.ts
@@ -360,6 +360,29 @@ describe('ParallelRunner terminal sub-step statuses', () => {
     expect(result.response.content).toContain('Security reviewer failed after retry.');
   });
 
+  it('does not retry a sub-step whose error is a rate limit', async () => {
+    const { runner } = makeRunner();
+    const step = makeParallelStep();
+    const state = makeState();
+    queueAgentResponse(makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'error',
+      content: '',
+      error: '429 too many requests',
+      errorKind: 'rate_limit',
+    }));
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      content: '[SECURITY-REVIEW:1] approved',
+    }));
+
+    const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
+
+    // rate limit は新セッション再試行の対象外（既存の rate_limited 経路に委ねる）
+    expect(vi.mocked(executeAgent)).toHaveBeenCalledTimes(2);
+    expect(result.response.status).toBe('error');
+  });
+
   it('redacts sensitive sub-step error details from parent diagnostics', async () => {
     const { runner } = makeRunner();
     const step = makeParallelStep();

--- a/src/__tests__/parallel-runner-terminal-status.test.ts
+++ b/src/__tests__/parallel-runner-terminal-status.test.ts
@@ -386,7 +386,7 @@ describe('ParallelRunner terminal sub-step statuses', () => {
     const updateSession = vi.fn();
     const result = await runner.runParallelStep(step, state, 'test task', 5, updateSession);
 
-    expect(result.response.status).not.toBe('error');
+    expect(result.response.status).toBe('done');
     // 劣化していた旧セッションが resume 対象に残らない（undefined で削除）
     expect(updateSession).toHaveBeenCalledWith(expect.stringContaining('ai-antipattern-review-2nd'), undefined);
   });

--- a/src/__tests__/parallel-runner-terminal-status.test.ts
+++ b/src/__tests__/parallel-runner-terminal-status.test.ts
@@ -360,6 +360,37 @@ describe('ParallelRunner terminal sub-step statuses', () => {
     expect(result.response.content).toContain('Security reviewer failed after retry.');
   });
 
+  it('purges the stale persona session when the fresh retry returns no session id', async () => {
+    const { runner } = makeRunner();
+    const step = makeParallelStep();
+    const state = makeState();
+    queueAgentResponse(makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'error',
+      content: '',
+      error: 'assistant message cycle budget exceeded',
+    }));
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      content: '[SECURITY-REVIEW:1] approved',
+    }));
+    // 再試行は成功するが sessionId を返さない
+    queueAgentResponse({
+      ...makeAgentResponse({
+        persona: 'ai-antipattern-review-2nd',
+        content: '[AI-ANTIPATTERN-REVIEW-2ND:1] approved',
+      }),
+      sessionId: undefined,
+    });
+
+    const updateSession = vi.fn();
+    const result = await runner.runParallelStep(step, state, 'test task', 5, updateSession);
+
+    expect(result.response.status).not.toBe('error');
+    // 劣化していた旧セッションが resume 対象に残らない（undefined で削除）
+    expect(updateSession).toHaveBeenCalledWith(expect.stringContaining('ai-antipattern-review-2nd'), undefined);
+  });
+
   it('does not retry a sub-step whose error is a rate limit', async () => {
     const { runner } = makeRunner();
     const step = makeParallelStep();

--- a/src/__tests__/parallel-runner-terminal-status.test.ts
+++ b/src/__tests__/parallel-runner-terminal-status.test.ts
@@ -158,6 +158,15 @@ describe('ParallelRunner terminal sub-step statuses', () => {
       persona: 'security-review',
       content: '[SECURITY-REVIEW:1] approved',
     }));
+    // error 席は新セッションで1回再試行される。terminal のままにするため
+    // 再試行分も同じエラーを返す
+    queueAgentResponse(makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'error',
+      content: 'Reconnecting... 2/5',
+      error: 'timeout waiting for child process to exit',
+      failureCategory: 'provider_error',
+    }));
 
     const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
 
@@ -328,6 +337,15 @@ describe('ParallelRunner terminal sub-step statuses', () => {
       error: 'Security reviewer failed after retry.',
       failureCategory: 'provider_error',
     }));
+    // 再試行分も同じエラー（terminal 維持）
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      status: 'error',
+      content: '',
+      error: 'Security reviewer failed after retry.',
+      failureCategory: 'provider_error',
+    }));
+
 
     const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
 
@@ -355,6 +373,13 @@ describe('ParallelRunner terminal sub-step statuses', () => {
     queueAgentResponse(makeAgentResponse({
       persona: 'security-review',
       content: '[SECURITY-REVIEW:1] approved',
+    }));
+    // 再試行分も同じエラー（terminal 維持）
+    queueAgentResponse(makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'error',
+      content: '',
+      error: 'Provider failed with api_key=top-secret and Authorization: Bearer sk-secret123456',
     }));
 
     const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());

--- a/src/__tests__/permission-profile-partial.test.ts
+++ b/src/__tests__/permission-profile-partial.test.ts
@@ -8,16 +8,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_PROVIDER_PERMISSION_PROFILES,
+  mergeGlobalPermissionProfiles,
   resolveStepPermissionMode,
 } from '../core/workflow/permission-profile-resolution.js';
 
 describe('resolveStepPermissionMode with partial user profiles', () => {
   it('should keep the default mode for providers the user did not configure when profiles are merged', () => {
-    // runner と同じマージ（デフォルト表 + ユーザー定義の上書き）を通した場合
-    const merged = {
-      ...DEFAULT_PROVIDER_PERMISSION_PROFILES,
-      claude: { defaultPermissionMode: 'full' as const },
-    };
+    // runner が実際に使うマージ関数を通す（再現コードではなく実装をテストする）
+    const merged = mergeGlobalPermissionProfiles({
+      claude: { defaultPermissionMode: 'full' },
+    });
 
     const mode = resolveStepPermissionMode({
       stepName: 'implement',

--- a/src/__tests__/permission-profile-partial.test.ts
+++ b/src/__tests__/permission-profile-partial.test.ts
@@ -1,0 +1,57 @@
+/**
+ * 権限プロファイル解決の回帰テスト。
+ *
+ * 実障害: ユーザーが一部プロバイダだけ provider_profiles を書くと、
+ * デフォルト表が丸ごと置き換わり、未記載プロバイダ（opencode 等）が
+ * readonly に落ちて edit: true のステップが書き込みツールなしで走った。
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PROVIDER_PERMISSION_PROFILES,
+  resolveStepPermissionMode,
+} from '../core/workflow/permission-profile-resolution.js';
+
+describe('resolveStepPermissionMode with partial user profiles', () => {
+  it('should keep the default mode for providers the user did not configure when profiles are merged', () => {
+    // runner と同じマージ（デフォルト表 + ユーザー定義の上書き）を通した場合
+    const merged = {
+      ...DEFAULT_PROVIDER_PERMISSION_PROFILES,
+      claude: { defaultPermissionMode: 'full' as const },
+    };
+
+    const mode = resolveStepPermissionMode({
+      stepName: 'implement',
+      requiredPermissionMode: undefined,
+      provider: 'opencode',
+      projectProviderProfiles: undefined,
+      globalProviderProfiles: merged,
+    });
+
+    expect(mode).toBe(DEFAULT_PROVIDER_PERMISSION_PROFILES.opencode!.defaultPermissionMode);
+    expect(mode).not.toBe('readonly');
+  });
+
+  it('should fall back to readonly when a provider is missing from an unmerged map (the failure shape)', () => {
+    const mode = resolveStepPermissionMode({
+      stepName: 'implement',
+      requiredPermissionMode: undefined,
+      provider: 'opencode',
+      projectProviderProfiles: undefined,
+      globalProviderProfiles: { claude: { defaultPermissionMode: 'full' } },
+    });
+
+    expect(mode).toBe('readonly');
+  });
+
+  it('should honor the edit floor when the step requires edit', () => {
+    const mode = resolveStepPermissionMode({
+      stepName: 'implement',
+      requiredPermissionMode: 'edit',
+      provider: 'opencode',
+      projectProviderProfiles: undefined,
+      globalProviderProfiles: { claude: { defaultPermissionMode: 'full' } },
+    });
+
+    expect(mode).toBe('edit');
+  });
+});

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -16,7 +16,7 @@ import {
 import { getProvider, type ProviderType, type ProviderCallOptions } from '../infra/providers/index.js';
 import type { AgentResponse, CustomAgentConfig } from '../core/models/index.js';
 import { resolveAgentProviderModel } from '../core/workflow/provider-resolution.js';
-import { DEFAULT_PROVIDER_PERMISSION_PROFILES, resolveStepPermissionMode } from '../core/workflow/permission-profile-resolution.js';
+import { mergeGlobalPermissionProfiles, DEFAULT_PROVIDER_PERMISSION_PROFILES, resolveStepPermissionMode } from '../core/workflow/permission-profile-resolution.js';
 import { createLogger } from '../shared/utils/index.js';
 import type { RunAgentOptions } from './types.js';
 import { buildWrappedSystemPrompt } from './runner-prompt.js';
@@ -158,13 +158,7 @@ export class AgentRunner {
         provider: resolvedProvider,
         projectProviderProfiles: options.permissionResolution.providerProfiles
           ?? localConfig.providerProfiles,
-        // ユーザー定義はデフォルト表へのプロバイダ単位の上書き。?? で丸ごと
-        // 置き換えると、書かれていないプロバイダの既定権限が黙って消え、
-        // edit: true のステップが readonly ツールで走る（実障害）。
-        globalProviderProfiles: {
-          ...DEFAULT_PROVIDER_PERMISSION_PROFILES,
-          ...(globalConfig.providerProfiles ?? {}),
-        },
+        globalProviderProfiles: mergeGlobalPermissionProfiles(globalConfig.providerProfiles),
       });
     }
     return options.permissionMode;

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -158,8 +158,13 @@ export class AgentRunner {
         provider: resolvedProvider,
         projectProviderProfiles: options.permissionResolution.providerProfiles
           ?? localConfig.providerProfiles,
-        globalProviderProfiles: globalConfig.providerProfiles
-          ?? DEFAULT_PROVIDER_PERMISSION_PROFILES,
+        // ユーザー定義はデフォルト表へのプロバイダ単位の上書き。?? で丸ごと
+        // 置き換えると、書かれていないプロバイダの既定権限が黙って消え、
+        // edit: true のステップが readonly ツールで走る（実障害）。
+        globalProviderProfiles: {
+          ...DEFAULT_PROVIDER_PERMISSION_PROFILES,
+          ...(globalConfig.providerProfiles ?? {}),
+        },
       });
     }
     return options.permissionMode;

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -16,7 +16,7 @@ import {
 import { getProvider, type ProviderType, type ProviderCallOptions } from '../infra/providers/index.js';
 import type { AgentResponse, CustomAgentConfig } from '../core/models/index.js';
 import { resolveAgentProviderModel } from '../core/workflow/provider-resolution.js';
-import { mergeGlobalPermissionProfiles, DEFAULT_PROVIDER_PERMISSION_PROFILES, resolveStepPermissionMode } from '../core/workflow/permission-profile-resolution.js';
+import { mergeGlobalPermissionProfiles, resolveStepPermissionMode } from '../core/workflow/permission-profile-resolution.js';
 import { createLogger } from '../shared/utils/index.js';
 import type { RunAgentOptions } from './types.js';
 import { buildWrappedSystemPrompt } from './runner-prompt.js';

--- a/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
+++ b/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
@@ -73,12 +73,15 @@ export class LoopMonitorJudgeRunner {
     if (response.status !== 'done') {
       // 監視は衛生装置であり、判定役自身の障害（プロバイダエラー等）で
       // 走行本体を落とさない。介入しなかった場合の自然な遷移で続行する。
+      // リセットしないと次のサイクル末尾ステップ完了のたびに壊れた判定役を
+      // 呼び直すため、成功時と同様に検出状態をリセットする。
       log.warn('Loop monitor judge did not produce a decision; continuing with the natural transition', {
         cycle: monitor.cycle,
         status: response.status,
         error: response.error,
         fallbackNextStep,
       });
+      this.deps.resetCycleDetector();
       return fallbackNextStep;
     }
     const nextStep = this.deps.resolveNextStepFromDone(judgeStep, response);

--- a/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
+++ b/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
@@ -32,7 +32,8 @@ export class LoopMonitorJudgeRunner {
     monitor: LoopMonitorConfig,
     cycleCount: number,
     triggeringStep: WorkflowStep,
-    triggeringRuntime?: RuntimeStepResolution,
+    triggeringRuntime: RuntimeStepResolution | undefined,
+    fallbackNextStep: string,
   ): Promise<string> {
     const resolvedRuntime = this.resolveJudgeRuntime(monitor, triggeringStep, triggeringRuntime);
     const judgeStep = this.createJudgeStep(monitor, cycleCount, resolvedRuntime.providerInfo);
@@ -69,6 +70,17 @@ export class LoopMonitorJudgeRunner {
     this.deps.emitCollectedReports();
     this.deps.onStepComplete(judgeStep, response, instruction);
 
+    if (response.status !== 'done') {
+      // 監視は衛生装置であり、判定役自身の障害（プロバイダエラー等）で
+      // 走行本体を落とさない。介入しなかった場合の自然な遷移で続行する。
+      log.warn('Loop monitor judge did not produce a decision; continuing with the natural transition', {
+        cycle: monitor.cycle,
+        status: response.status,
+        error: response.error,
+        fallbackNextStep,
+      });
+      return fallbackNextStep;
+    }
     const nextStep = this.deps.resolveNextStepFromDone(judgeStep, response);
     log.info('Loop monitor judge decision', {
       cycle: monitor.cycle,

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -185,7 +185,11 @@ export class OptionsBuilder {
       resolvedModel,
       permissionResolution: {
         stepName: step.name,
-        requiredPermissionMode: step.requiredPermissionMode,
+        // edit: true はステップが編集する宣言。プロファイル解決の結果が
+        // readonly でも、下限として edit を要求する（書けないのに書けと
+        // 指示される構成矛盾を防ぐ）。
+        requiredPermissionMode: step.requiredPermissionMode
+          ?? (step.edit === true ? 'edit' : undefined),
         providerProfiles: this.engineOptions.providerProfiles,
       },
       providerOptions,

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -249,6 +249,7 @@ export class ParallelRunner {
         // Phase 1: main execution (Write excluded if sub-step has report)
         const baseOptions = this.deps.optionsBuilder.buildAgentOptions(executableSubStep, runtime);
         let didEmitPhaseStart = false;
+        let phase1CompletionExecutionId = phaseExecutionId;
         let resolvedPromptParts: PhasePromptParts | undefined;
         const phaseExecutionId = buildPhaseExecutionId({
           step: subStep.name,
@@ -301,7 +302,11 @@ export class ParallelRunner {
             phase: 1,
             sequence: 2,
           });
-          // onPromptResolved は引き継がない（同一 phase:start の二重発火を防ぐ）
+          // onPromptResolved は引き継がない（初回IDでの phase:start 二重発火を
+          // 防ぐ）。再試行は専用IDで phase:start を発火し、初回の prompt parts を
+          // 引き継いで紐付ける（指示は同一）。
+          this.deps.onPhaseStart?.(subStep, 1, 'execute', phase1Instruction, resolvedPromptParts, retryPhaseExecutionId, parentIteration);
+          phase1CompletionExecutionId = retryPhaseExecutionId;
           const retryOptions = { ...agentOptions, sessionId: undefined, onPromptResolved: undefined };
           subResponse = await runWithPhaseSpan({
             enabled: this.deps.observabilityEnabled,
@@ -383,7 +388,7 @@ export class ParallelRunner {
         if (subResponse.sessionId !== undefined) {
           updatePersonaSession(subSessionKey, subResponse.sessionId);
         }
-        this.deps.onPhaseComplete?.(subStep, 1, 'execute', subResponse.content, subResponse.status, subResponse.error, phaseExecutionId, parentIteration);
+        this.deps.onPhaseComplete?.(subStep, 1, 'execute', subResponse.content, subResponse.status, subResponse.error, phase1CompletionExecutionId, parentIteration);
         if (
           subResponse.status === 'done'
           && subResponse.structuredOutput === undefined

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -302,14 +302,20 @@ export class ParallelRunner {
             phase: 1,
             sequence: 2,
           });
-          // onPromptResolved は引き継がない（初回IDでの phase:start 二重発火を
-          // 防ぐ）。再試行は専用IDで phase:start を発火し、初回の prompt parts を
-          // 引き継いで紐付ける（指示は同一）。
-          if (resolvedPromptParts !== undefined) {
-            this.deps.onPhaseStart?.(subStep, 1, 'execute', phase1Instruction, resolvedPromptParts, retryPhaseExecutionId, parentIteration);
-            phase1CompletionExecutionId = retryPhaseExecutionId;
-          }
-          const retryOptions = { ...agentOptions, sessionId: undefined, onPromptResolved: undefined };
+          // 再試行は専用IDで phase:start を発火する（初回IDの二重発火はしない）。
+          // onPromptResolved を再試行自身のものに差し替えることで、初回試行が
+          // プロンプト解決前に死んだ場合でも、再試行の成功が phase:start を
+          // 発火させ、後段の Missing prompt parts 検査を正しく満たす。
+          const retryOptions = {
+            ...agentOptions,
+            sessionId: undefined,
+            onPromptResolved: (promptParts: PhasePromptParts) => {
+              resolvedPromptParts = promptParts;
+              this.deps.onPhaseStart?.(subStep, 1, 'execute', phase1Instruction, promptParts, retryPhaseExecutionId, parentIteration);
+              phase1CompletionExecutionId = retryPhaseExecutionId;
+              didEmitPhaseStart = true;
+            },
+          };
           subResponse = await runWithPhaseSpan({
             enabled: this.deps.observabilityEnabled,
             runId: this.deps.observabilityRunId,

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -286,16 +286,42 @@ export class ParallelRunner {
           error: result.error,
           providerUsage: result.providerUsage,
         }));
-        if (subResponse.status === 'error') {
+        if (subResponse.status === 'error' && subResponse.errorKind !== 'rate_limit') {
           // 並列レビューの1席のプロバイダ障害で走行全体を落とさない。
           // 空転はセッション文脈起因のことが多いため（長文脈での生成品質
           // 崩壊を実測）、再試行は resume を切った新しいセッションで行う。
+          // rate limit は再試行で叩かず既存の rate_limited 経路に委ねる。
           log.warn('Parallel sub-step provider error; retrying once with a fresh session', {
             step: subStep.name,
             error: subResponse.error,
           });
-          const retryOptions = { ...agentOptions, sessionId: undefined };
-          subResponse = await executeAgent(executableSubStep.persona, phase1Instruction, retryOptions);
+          const retryPhaseExecutionId = buildPhaseExecutionId({
+            step: subStep.name,
+            iteration: parentIteration,
+            phase: 1,
+            sequence: 2,
+          });
+          // onPromptResolved は引き継がない（同一 phase:start の二重発火を防ぐ）
+          const retryOptions = { ...agentOptions, sessionId: undefined, onPromptResolved: undefined };
+          subResponse = await runWithPhaseSpan({
+            enabled: this.deps.observabilityEnabled,
+            runId: this.deps.observabilityRunId,
+            workflowName: this.deps.getWorkflowName(),
+            step: executableSubStep,
+            iteration: parentIteration,
+            phase: 1,
+            phaseName: 'execute',
+            instruction: phase1Instruction,
+            phaseExecutionId: retryPhaseExecutionId,
+            workflowStack: this.deps.getCurrentWorkflowStack?.(),
+            sanitizeText: this.deps.sanitizeObservabilityText,
+            providerInfo: subPm,
+          }, () => executeAgent(executableSubStep.persona, phase1Instruction, retryOptions), (result) => ({
+            status: result.status,
+            content: result.content,
+            error: result.error,
+            providerUsage: result.providerUsage,
+          }));
         }
         if (findingLedgerCopyPath) {
           const normalized = this.deps.stepExecutor.normalizeStructuredOutputWithDiagnostics(executableSubStep, subResponse, runtime);

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -249,7 +249,6 @@ export class ParallelRunner {
         // Phase 1: main execution (Write excluded if sub-step has report)
         const baseOptions = this.deps.optionsBuilder.buildAgentOptions(executableSubStep, runtime);
         let didEmitPhaseStart = false;
-        let phase1CompletionExecutionId = phaseExecutionId;
         let resolvedPromptParts: PhasePromptParts | undefined;
         const phaseExecutionId = buildPhaseExecutionId({
           step: subStep.name,
@@ -257,6 +256,7 @@ export class ParallelRunner {
           phase: 1,
           sequence: 1,
         });
+        let phase1CompletionExecutionId = phaseExecutionId;
 
         // Override onStream with parallel logger's prefixed handler (immutable)
         const agentOptions = parallelLogger
@@ -305,8 +305,10 @@ export class ParallelRunner {
           // onPromptResolved は引き継がない（初回IDでの phase:start 二重発火を
           // 防ぐ）。再試行は専用IDで phase:start を発火し、初回の prompt parts を
           // 引き継いで紐付ける（指示は同一）。
-          this.deps.onPhaseStart?.(subStep, 1, 'execute', phase1Instruction, resolvedPromptParts, retryPhaseExecutionId, parentIteration);
-          phase1CompletionExecutionId = retryPhaseExecutionId;
+          if (resolvedPromptParts !== undefined) {
+            this.deps.onPhaseStart?.(subStep, 1, 'execute', phase1Instruction, resolvedPromptParts, retryPhaseExecutionId, parentIteration);
+            phase1CompletionExecutionId = retryPhaseExecutionId;
+          }
           const retryOptions = { ...agentOptions, sessionId: undefined, onPromptResolved: undefined };
           subResponse = await runWithPhaseSpan({
             enabled: this.deps.observabilityEnabled,

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -286,6 +286,17 @@ export class ParallelRunner {
           error: result.error,
           providerUsage: result.providerUsage,
         }));
+        if (subResponse.status === 'error') {
+          // 並列レビューの1席のプロバイダ障害で走行全体を落とさない。
+          // 空転はセッション文脈起因のことが多いため（長文脈での生成品質
+          // 崩壊を実測）、再試行は resume を切った新しいセッションで行う。
+          log.warn('Parallel sub-step provider error; retrying once with a fresh session', {
+            step: subStep.name,
+            error: subResponse.error,
+          });
+          const retryOptions = { ...agentOptions, sessionId: undefined };
+          subResponse = await executeAgent(executableSubStep.persona, phase1Instruction, retryOptions);
+        }
         if (findingLedgerCopyPath) {
           const normalized = this.deps.stepExecutor.normalizeStructuredOutputWithDiagnostics(executableSubStep, subResponse, runtime);
           subResponse = normalized.response;

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -329,6 +329,11 @@ export class ParallelRunner {
             error: result.error,
             providerUsage: result.providerUsage,
           }));
+          if (subResponse.sessionId === undefined) {
+            // 再試行がセッションIDを返さなかった場合、劣化していた旧セッションを
+            // resume 対象に残さない（残すと次の実行で文脈崩壊が再発する）
+            updatePersonaSession(subSessionKey, undefined);
+          }
         }
         if (findingLedgerCopyPath) {
           const normalized = this.deps.stepExecutor.normalizeStructuredOutputWithDiagnostics(executableSubStep, subResponse, runtime);

--- a/src/core/workflow/engine/WorkflowEngineStepCoordinator.ts
+++ b/src/core/workflow/engine/WorkflowEngineStepCoordinator.ts
@@ -66,7 +66,8 @@ interface WorkflowEngineStepCoordinatorDeps {
       monitor: LoopMonitorConfig,
       cycleCount: number,
       triggeringStep: WorkflowStep,
-      triggeringRuntime?: RuntimeStepResolution,
+      triggeringRuntime: RuntimeStepResolution | undefined,
+      fallbackNextStep: string,
     ) => Promise<string>;
   };
   workflowCallRunner: {
@@ -190,8 +191,9 @@ export class WorkflowEngineStepCoordinator {
     monitor: LoopMonitorConfig,
     cycleCount: number,
     triggeringStep: WorkflowStep,
-    triggeringRuntime?: RuntimeStepResolution,
+    triggeringRuntime: RuntimeStepResolution | undefined,
+    fallbackNextStep: string,
   ): Promise<string> {
-    return this.deps.loopMonitorJudgeRunner.run(monitor, cycleCount, triggeringStep, triggeringRuntime);
+    return this.deps.loopMonitorJudgeRunner.run(monitor, cycleCount, triggeringStep, triggeringRuntime, fallbackNextStep);
   }
 }

--- a/src/core/workflow/engine/WorkflowRunLoop.ts
+++ b/src/core/workflow/engine/WorkflowRunLoop.ts
@@ -47,7 +47,8 @@ interface WorkflowRunLoopDeps {
     monitor: LoopMonitorConfig,
     cycleCount: number,
     triggeringStep: WorkflowStep,
-    triggeringRuntime?: RuntimeStepResolution,
+    triggeringRuntime: RuntimeStepResolution | undefined,
+    fallbackNextStep: string,
   ) => Promise<string>;
   runStep: (
     step: WorkflowStep,
@@ -519,7 +520,7 @@ export async function runWorkflowToCompletion(deps: WorkflowRunLoopDeps): Promis
           threshold: cycleCheck.monitor.threshold,
         });
         deps.emit('step:cycle_detected', cycleCheck.monitor, cycleCheck.cycleCount);
-        nextStep = await deps.runLoopMonitorJudge(cycleCheck.monitor, cycleCheck.cycleCount, step, stepRuntime);
+        nextStep = await deps.runLoopMonitorJudge(cycleCheck.monitor, cycleCheck.cycleCount, step, stepRuntime, nextStep);
       }
 
       if (nextStep === COMPLETE_STEP) {

--- a/src/core/workflow/permission-profile-resolution.ts
+++ b/src/core/workflow/permission-profile-resolution.ts
@@ -25,6 +25,20 @@ export const DEFAULT_PROVIDER_PERMISSION_PROFILES: ProviderPermissionProfiles = 
   mock: { defaultPermissionMode: DEFAULT_PROVIDER_PROFILE_PERMISSION_MODE },
 };
 
+/**
+ * ユーザー定義のグローバルプロファイルを、デフォルト表へのプロバイダ単位の
+ * 上書きとして解決する。?? で丸ごと置き換えると、書かれていないプロバイダの
+ * 既定権限が黙って消える（edit: true のステップが readonly ツールで走る実障害）。
+ */
+export function mergeGlobalPermissionProfiles(
+  userProfiles: ProviderPermissionProfiles | undefined,
+): ProviderPermissionProfiles {
+  return {
+    ...DEFAULT_PROVIDER_PERMISSION_PROFILES,
+    ...(userProfiles ?? {}),
+  };
+}
+
 export function resolveStepPermissionMode(input: ResolvePermissionModeInput): PermissionMode {
   if (!input.provider) {
     return input.requiredPermissionMode ?? 'readonly';

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -38,7 +38,7 @@ import {
   emitResult,
   handlePartUpdated,
 } from './OpenCodeStreamHandler.js';
-import { InvalidToolArgumentLoopDetector, UnavailableToolLoopDetector } from './unavailable-tool-loop.js';
+import { InvalidToolArgumentLoopDetector, ToolErrorBudgetDetector, UnavailableToolLoopDetector } from './unavailable-tool-loop.js';
 import { buildRateLimitedResponseFields, containsRateLimitError } from '../rate-limit/detection.js';
 
 export type { OpenCodeCallOptions } from './types.js';
@@ -790,6 +790,7 @@ export class OpenCodeClient {
         const state = createStreamTrackingState();
         const unavailableToolLoopDetector = new UnavailableToolLoopDetector();
         const invalidArgumentLoopDetector = new InvalidToolArgumentLoopDetector();
+        const toolErrorBudgetDetector = new ToolErrorBudgetDetector();
         const echoState = { remainingPrompts: buildPromptEchoCandidates(prompt, options.systemPrompt) };
         const textOffsets = new Map<string, number>();
         const textContentParts = new Map<string, string>();
@@ -881,7 +882,12 @@ export class OpenCodeClient {
                   toolPart.tool,
                   toolPart.state.error,
                 );
-                loopError = unavailableError ?? invalidArgumentError;
+                const budgetError = toolErrorBudgetDetector.observe(
+                  toolPart.callID || toolPart.id,
+                  toolPart.tool,
+                  toolPart.state.error,
+                );
+                loopError = unavailableError ?? invalidArgumentError ?? budgetError;
               }
               if (toolPart.state.status === 'completed') {
                 unavailableToolLoopDetector.reset();

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -80,6 +80,12 @@ function selectTaktAgent(allowedTools: readonly string[] | undefined): string {
 
 const log = createLogger('opencode-sdk');
 /** 呼び出し時に評価する（テストや実験で env から上書きできるようにする） */
+function resolveMessageCycleBudget(): number {
+  const fromEnv = Number(process.env.TAKT_OPENCODE_MESSAGE_CYCLE_BUDGET);
+  return fromEnv > 0 ? fromEnv : 120;
+}
+
+/** 呼び出し時に評価する（テストや実験で env から上書きできるようにする） */
 function resolveStreamIdleTimeoutMs(): number {
   const fromEnv = Number(process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS);
   return fromEnv > 0 ? fromEnv : 10 * 60 * 1000;
@@ -823,6 +829,13 @@ export class OpenCodeClient {
         });
         streamAborted.catch(() => { /* race の敗者側での未処理拒否を防ぐ */ });
 
+        // 劣化した生成は「ごく短いアシスタント応答サイクル」を数百回繰り返す
+        // （実測: 524〜1211 ループ）。テキスト断片だけの空転はツールエラー
+        // 予算にも無音検出にも掛からないため、応答サイクル数で打ち切る。
+        // 健全なステップはツール往復込みでも数十サイクルに収まる。
+        let assistantMessageCycles = 0;
+        const messageCycleBudget = resolveMessageCycleBudget();
+
         try {
         while (true) {
           if (streamAbortController.signal.aborted) break;
@@ -1049,6 +1062,15 @@ export class OpenCodeClient {
                 failureMessage = streamError;
                 diag.onStreamError('message.updated', streamError);
                 break;
+              }
+              if (info?.time?.completed !== undefined) {
+                assistantMessageCycles += 1;
+                if (assistantMessageCycles >= messageCycleBudget) {
+                  success = false;
+                  failureMessage = `OpenCode assistant message cycle budget exceeded (${assistantMessageCycles} cycles in one call)`;
+                  diag.onStreamError('message.updated', failureMessage);
+                  break;
+                }
               }
             }
             continue;

--- a/src/infra/opencode/unavailable-tool-loop.ts
+++ b/src/infra/opencode/unavailable-tool-loop.ts
@@ -96,3 +96,35 @@ export class InvalidToolArgumentLoopDetector {
   }
 }
 
+/** 呼び出し時に評価する（テストで env から上書きできるようにする） */
+function resolveToolErrorBudget(): number {
+  const fromEnv = Number(process.env.TAKT_OPENCODE_TOOL_ERROR_BUDGET);
+  return fromEnv > 0 ? fromEnv : 25;
+}
+
+/**
+ * 1回の呼び出し内のツールエラー総量の予算。
+ * 連続性ベースの検出器（unavailable / invalid-argument）はツール名を変えながら
+ * 壊れた呼び出しを繰り返す劣化ループを検出できない（切り替えでリセットされる）。
+ * 実測: 夜間のプロバイダ劣化で、1ステップが559ループ・26分の空転を続けた。
+ * 正常な試行錯誤がこの予算に届くことはない（実測の健全走行は1桁）。
+ */
+export class ToolErrorBudgetDetector {
+  private totalToolErrors = 0;
+  private lastCallId: string | undefined;
+
+  observe(toolCallId: string, tool: string, message: string): string | undefined {
+    if (toolCallId === this.lastCallId) {
+      return undefined;
+    }
+    this.lastCallId = toolCallId;
+    this.totalToolErrors += 1;
+
+    const budget = resolveToolErrorBudget();
+    if (this.totalToolErrors < budget) {
+      return undefined;
+    }
+    return `OpenCode tool error budget exceeded (${this.totalToolErrors} tool errors in one call; last tool "${tool}"): ${message}`;
+  }
+}
+


### PR DESCRIPTION
夜間のベンチ実走（v2 n=6 キャンペーン）が炙り出した実障害の修正一式です。すべて実走で発生 → 原因特定 → 修正 → 回帰テストの順で作られています。

## 修正一覧

| # | 障害（実測） | 修正 |
|---|-------------|------|
| 1 | ユーザーが一部プロバイダだけ provider_profiles を書くとデフォルト表が丸ごと消え、未記載プロバイダが readonly に落ちる（edit: true のステップが書き込みツールなしで走り、coder が132ループ空転） | グローバルプロファイルはデフォルト表への**プロバイダ単位の上書きマージ**に |
| 2 | edit: true が allowed tools のフィルタにしか効かず、権限モードに影響しない | 明示指定がなければ**権限の下限 edit を供給** |
| 3 | ツール名を回しながら壊れた呼び出しを繰り返す劣化ループは連続性検出器で捕まらない | **ツールエラー総量予算**（25、env 上書き可） |
| 4 | テキスト断片だけの空転ループ（524〜1211 opencode loop steps を実測）はツールエラーも無音も出さない | **アシスタント応答サイクル予算**（120、env 上書き可） |
| 5 | ループ判定役自身のプロバイダエラーで「Unhandled response status: error」の走行全滅 | 判定不能時は**自然遷移で続行**（+ サイクル検出リセット） |
| 6 | 並列レビュー1席の一過性エラーで走行全体が中断（3走喪失） | **新セッションで1回だけ再試行**（rate limit は対象外。劣化は文脈起因のため同一セッション再試行は再発しやすい） |

## レビュー

codex `$coding` 4ラウンド（High: rate limit の再試行除外 / Medium: 判定不能後のサイクル検出リセット / Low→追撃: 再試行の phase イベント紐付け / TDZ）→ **APPROVE**。全シャード green（既知の環境依存1件を除く）。

この修正群の上で v2 ベンチは完走 5/6・judge 全 7〜8 を記録しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ループ監視の判定が失敗しても、自然な次ステップへ継続する挙動に改善。
  * 並列サブステップの条件付き再試行（最大1回）を追加。
  * OpenCodeのメッセージ/ツールエラー予算で、応答やツール失敗の繰り返しを上限で停止。
* **バグ修正**
  * 権限モードの決定ロジックと、グローバル権限プロファイルの合成を見直し（意図しないモード崩れを抑制）。
* **テスト**
  * ループ/並列/端末/予算/権限/秘匿のケースを追加検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->