### PR TITLE
feat: FC manager の機械分類 — 決定可能な raw をコードで処理し LLM には判断だけ残す

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2162,6 +2162,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2179,6 +2182,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2196,6 +2202,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2213,6 +2222,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2230,6 +2242,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2247,6 +2262,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2264,6 +2282,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2281,6 +2302,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2298,6 +2322,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2321,6 +2348,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2344,6 +2374,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2367,6 +2400,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2390,6 +2426,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2413,6 +2452,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2436,6 +2478,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2459,6 +2504,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3239,6 +3287,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3256,6 +3307,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3273,6 +3327,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3290,6 +3347,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3307,6 +3367,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4961,6 +5024,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4978,6 +5044,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4995,6 +5064,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5012,6 +5084,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5029,6 +5104,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5046,6 +5124,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -12161,6 +12242,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -12175,6 +12259,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -12189,6 +12276,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -12203,6 +12293,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -15335,6 +15428,23 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2162,9 +2162,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2182,9 +2179,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2202,9 +2196,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2222,9 +2213,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2242,9 +2230,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2262,9 +2247,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2282,9 +2264,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2302,9 +2281,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2322,9 +2298,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2348,9 +2321,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2374,9 +2344,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2400,9 +2367,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2426,9 +2390,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2452,9 +2413,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2478,9 +2436,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2504,9 +2459,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3287,9 +3239,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3307,9 +3256,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3327,9 +3273,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3347,9 +3290,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3367,9 +3307,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5024,9 +4961,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5044,9 +4978,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5064,9 +4995,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5084,9 +5012,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5104,9 +5029,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5124,9 +5046,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -12242,9 +12161,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -12259,9 +12175,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -12276,9 +12189,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -12293,9 +12203,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -15428,23 +15335,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     }
   }

--- a/src/__tests__/finding-manager-mechanical-runner.test.ts
+++ b/src/__tests__/finding-manager-mechanical-runner.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentResponse, WorkflowStep } from '../core/models/types.js';
+import type { FindingLedger, FindingLedgerStore, RawFinding } from '../core/workflow/findings/types.js';
+import { runFindingManagerForParallelStep } from '../core/workflow/findings/manager-runner.js';
+
+vi.mock('../agents/agent-usecases.js', () => ({
+  executeAgent: vi.fn(),
+}));
+
+const { executeAgent } = await import('../agents/agent-usecases.js');
+const executeAgentMock = vi.mocked(executeAgent);
+
+function makeLedger(overrides: Partial<FindingLedger> = {}): FindingLedger {
+  return {
+    version: 1,
+    workflowName: 'peer-review',
+    nextId: 2,
+    updatedAt: '2026-06-13T00:00:00.000Z',
+    rawFindings: [
+      {
+        rawFindingId: 'raw-existing',
+        stepName: 'arch-review',
+        reviewer: 'arch-review',
+        familyTag: 'bug',
+        severity: 'high',
+        title: 'Existing issue',
+        location: 'src/a.ts:10',
+        description: 'Existing issue body.',
+      },
+    ],
+    conflicts: [],
+    findings: [
+      {
+        id: 'F-0001',
+        status: 'open',
+        lifecycle: 'new',
+        severity: 'high',
+        title: 'Existing issue',
+        location: 'src/a.ts:10',
+        reviewers: ['arch-review'],
+        rawFindingIds: ['raw-existing'],
+        firstSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+        lastSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+interface Harness {
+  savedLedgers: FindingLedger[];
+  savedRawFindings: RawFinding[][];
+  run: (input: {
+    reviewerRawFindings: Array<Record<string, unknown>>;
+    priorStepResponseText?: string;
+  }) => ReturnType<typeof runFindingManagerForParallelStep>;
+}
+
+function makeHarness(ledger: FindingLedger): Harness {
+  const savedLedgers: FindingLedger[] = [];
+  const savedRawFindings: RawFinding[][] = [];
+  const ledgerStore: FindingLedgerStore = {
+    loadLedger: () => ledger,
+    saveLedger: (next) => { savedLedgers.push(next); },
+    createRunCopy: () => '/tmp/ledger-copy.json',
+    saveRawFindings: (_runId, _stepName, rawFindings) => {
+      savedRawFindings.push(rawFindings);
+      return '/tmp/raw-findings.json';
+    },
+    saveManagerValidationReport: () => '/tmp/manager-report.json',
+  };
+  const optionsBuilder = {
+    buildAgentOptions: () => ({}),
+    resolveStepProviderModel: () => ({ provider: 'codex', model: 'gpt-test' }),
+  };
+  const stepExecutor = {
+    buildPhase1Instruction: (instruction: string) => instruction,
+    normalizeStructuredOutput: (_step: WorkflowStep, response: AgentResponse) => response,
+  };
+  const parentStep: WorkflowStep = { kind: 'agent', name: 'reviewers', persona: 'reviewer', edit: false } as WorkflowStep;
+  const contract = {
+    ledgerPath: '.takt/findings/ledger.json',
+    rawFindingsPath: '.takt/findings/raw',
+    manager: {
+      persona: 'findings-manager',
+      instruction: 'Reconcile findings.',
+      outputContract: 'Return JSON.',
+    },
+  };
+  return {
+    savedLedgers,
+    savedRawFindings,
+    run: (input) => runFindingManagerForParallelStep({
+      // テスト対象が使うメソッドだけを実装した最小 double。
+      contract: contract as never,
+      ledgerStore,
+      optionsBuilder: optionsBuilder as never,
+      stepExecutor: stepExecutor as never,
+      parentStep,
+      stepIteration: 2,
+      subResults: [
+        {
+          subStep: { kind: 'agent', name: 'arch-review', persona: 'arch', edit: false } as WorkflowStep,
+          response: {
+            status: 'done',
+            content: '',
+            structuredOutput: { rawFindings: input.reviewerRawFindings },
+          } as unknown as AgentResponse,
+        },
+      ],
+      workflowName: 'peer-review',
+      runId: 'run-2',
+      timestamp: '2026-06-14T00:00:00.000Z',
+      priorStepResponseText: input.priorStepResponseText,
+    }),
+  };
+}
+
+const CONFIRMATION_RAW = {
+  rawFindingId: 'c-1',
+  familyTag: 'bug',
+  severity: 'high',
+  title: 'Confirmed fixed',
+  location: 'src/a.ts:10',
+  description: 'Verified the fix at src/a.ts:10.',
+  suggestion: '',
+  kind: 'resolution_confirmation',
+  targetFindingId: 'F-0001',
+};
+
+const UNMATCHED_ISSUE_RAW = {
+  rawFindingId: 'i-1',
+  familyTag: 'security',
+  severity: 'medium',
+  title: 'New unmatched issue',
+  location: 'src/b.ts:5',
+  description: 'A different problem.',
+  suggestion: 'Fix it.',
+  kind: 'issue',
+  targetFindingId: '',
+};
+
+beforeEach(() => {
+  executeAgentMock.mockReset();
+});
+
+describe('runFindingManagerForParallelStep mechanical path', () => {
+  it('Given only mechanically classifiable confirmations and no prior response When run Then the manager agent is not called and the ledger is updated', async () => {
+    const harness = makeHarness(makeLedger());
+    const result = await harness.run({ reviewerRawFindings: [CONFIRMATION_RAW] });
+
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(result.status).toBe('updated');
+    expect(harness.savedLedgers).toHaveLength(1);
+    const finding = harness.savedLedgers[0]?.findings.find((entry) => entry.id === 'F-0001');
+    expect(finding?.status).toBe('resolved');
+  });
+
+  it('Given a residual raw finding When run Then the agent is called with only the residual raws and outputs are merged', async () => {
+    executeAgentMock.mockResolvedValue({
+      status: 'done',
+      content: '',
+      structuredOutput: {
+        matches: [],
+        newFindings: [
+          { rawFindingIds: ['run-2:reviewers:2:arch-review:i-1'], title: 'New unmatched issue', severity: 'medium' },
+        ],
+        resolvedFindings: [],
+        reopenedFindings: [],
+        conflicts: [],
+        resolvedConflicts: [],
+        waivedFindings: [],
+        disputeNotes: [],
+      },
+    } as unknown as AgentResponse);
+
+    const harness = makeHarness(makeLedger());
+    const result = await harness.run({ reviewerRawFindings: [CONFIRMATION_RAW, UNMATCHED_ISSUE_RAW] });
+
+    expect(executeAgentMock).toHaveBeenCalledTimes(1);
+    const instruction = executeAgentMock.mock.calls[0]?.[1] as string;
+    expect(instruction).toContain('classified mechanically');
+    expect(instruction).toContain('i-1');
+    expect(instruction).not.toContain('"run-2:reviewers:2:arch-review:c-1"');
+
+    expect(result.status).toBe('updated');
+    const ledger = harness.savedLedgers[0];
+    expect(ledger?.findings.find((entry) => entry.id === 'F-0001')?.status).toBe('resolved');
+    expect(ledger?.findings.some((entry) => entry.title === 'New unmatched issue' && entry.status === 'open')).toBe(true);
+  });
+
+  it('Given zero residual but a prior step response When run Then the agent is still called for waiver adjudication', async () => {
+    executeAgentMock.mockResolvedValue({
+      status: 'done',
+      content: '',
+      structuredOutput: {
+        matches: [],
+        newFindings: [],
+        resolvedFindings: [],
+        reopenedFindings: [],
+        conflicts: [],
+        resolvedConflicts: [],
+        waivedFindings: [],
+        disputeNotes: [],
+      },
+    } as unknown as AgentResponse);
+
+    const harness = makeHarness(makeLedger());
+    const result = await harness.run({
+      reviewerRawFindings: [CONFIRMATION_RAW],
+      priorStepResponseText: '## Disputed Findings\n- findingId: F-0001\n  reason: stale\n  evidence: src/a.ts:10',
+    });
+
+    expect(executeAgentMock).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('updated');
+  });
+});

--- a/src/__tests__/finding-manager-mechanical-runner.test.ts
+++ b/src/__tests__/finding-manager-mechanical-runner.test.ts
@@ -215,3 +215,94 @@ describe('runFindingManagerForParallelStep mechanical path', () => {
     expect(result.status).toBe('updated');
   });
 });
+
+describe('runFindingManagerForParallelStep conflict handling', () => {
+  it('Given an active conflict in the ledger When all raws are mechanical Then the agent is still called', async () => {
+    executeAgentMock.mockResolvedValue({
+      status: 'done',
+      content: '',
+      structuredOutput: {
+        matches: [],
+        newFindings: [],
+        resolvedFindings: [],
+        reopenedFindings: [],
+        conflicts: [],
+        resolvedConflicts: [],
+        waivedFindings: [],
+        disputeNotes: [],
+      },
+    } as unknown as AgentResponse);
+
+    const ledger = makeLedger({
+      conflicts: [
+        {
+          id: 'C-0001',
+          status: 'active',
+          findingIds: ['F-0001'],
+          rawFindingIds: ['raw-existing'],
+          description: 'Reviewers disagree about F-0001.',
+          firstSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+          lastSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+        },
+      ],
+    });
+    const harness = makeHarness(ledger);
+    const result = await harness.run({ reviewerRawFindings: [CONFIRMATION_RAW] });
+
+    expect(executeAgentMock).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('updated');
+  });
+
+  it('Given an active conflict referencing a resolved finding When the agent is called Then that finding keeps full detail in the instruction', async () => {
+    executeAgentMock.mockResolvedValue({
+      status: 'done',
+      content: '',
+      structuredOutput: {
+        matches: [],
+        newFindings: [
+          { rawFindingIds: ['run-2:reviewers:2:arch-review:i-1'], title: 'New unmatched issue', severity: 'medium' },
+        ],
+        resolvedFindings: [],
+        reopenedFindings: [],
+        conflicts: [],
+        resolvedConflicts: [],
+        waivedFindings: [],
+        disputeNotes: [],
+      },
+    } as unknown as AgentResponse);
+
+    const ledger = makeLedger({
+      findings: [
+        {
+          id: 'F-0001',
+          status: 'resolved',
+          lifecycle: 'resolved',
+          severity: 'high',
+          title: 'Existing issue',
+          location: 'src/a.ts:10',
+          description: 'Original detailed description of the conflicted finding.',
+          reviewers: ['arch-review'],
+          rawFindingIds: ['raw-existing'],
+          firstSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+          lastSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+        },
+      ],
+      conflicts: [
+        {
+          id: 'C-0001',
+          status: 'active',
+          findingIds: ['F-0001'],
+          rawFindingIds: ['raw-existing'],
+          description: 'Reviewers disagree about F-0001.',
+          firstSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+          lastSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+        },
+      ],
+    });
+    const harness = makeHarness(ledger);
+    await harness.run({ reviewerRawFindings: [UNMATCHED_ISSUE_RAW] });
+
+    const instruction = executeAgentMock.mock.calls[0]?.[1] as string;
+    expect(instruction).toContain('Original detailed description of the conflicted finding.');
+  });
+});

--- a/src/__tests__/finding-manager-mechanical-runner.test.ts
+++ b/src/__tests__/finding-manager-mechanical-runner.test.ts
@@ -189,6 +189,17 @@ describe('runFindingManagerForParallelStep mechanical path', () => {
     expect(ledger?.findings.some((entry) => entry.title === 'New unmatched issue' && entry.status === 'open')).toBe(true);
   });
 
+  it('Given zero residual and a prior response without a Disputed Findings heading When run Then the agent is skipped', async () => {
+    const harness = makeHarness(makeLedger());
+    const result = await harness.run({
+      reviewerRawFindings: [CONFIRMATION_RAW],
+      priorStepResponseText: 'F-0001 を修正しました。全テスト green です。',
+    });
+
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(result.status).toBe('updated');
+  });
+
   it('Given zero residual but a prior step response When run Then the agent is still called for waiver adjudication', async () => {
     executeAgentMock.mockResolvedValue({
       status: 'done',

--- a/src/__tests__/finding-manager-mechanical-runner.test.ts
+++ b/src/__tests__/finding-manager-mechanical-runner.test.ts
@@ -227,6 +227,33 @@ describe('runFindingManagerForParallelStep mechanical path', () => {
   });
 });
 
+describe('runFindingManagerForParallelStep invalid manager output', () => {
+  it('Given the agent returns semantically invalid output twice When run Then the result is invalid_manager_output and the ledger is not saved', async () => {
+    // 存在しない findingId への match は意味検証で invalid になる。
+    executeAgentMock.mockResolvedValue({
+      status: 'done',
+      content: '',
+      structuredOutput: {
+        matches: [{ findingId: 'F-9999', rawFindingIds: ['run-2:reviewers:2:arch-review:i-1'], evidence: null }],
+        newFindings: [],
+        resolvedFindings: [],
+        reopenedFindings: [],
+        conflicts: [],
+        resolvedConflicts: [],
+        waivedFindings: [],
+        disputeNotes: [],
+      },
+    } as unknown as AgentResponse);
+
+    const harness = makeHarness(makeLedger());
+    const result = await harness.run({ reviewerRawFindings: [UNMATCHED_ISSUE_RAW] });
+
+    expect(executeAgentMock).toHaveBeenCalledTimes(2);
+    expect(result.status).toBe('invalid_manager_output');
+    expect(harness.savedLedgers).toHaveLength(0);
+  });
+});
+
 describe('runFindingManagerForParallelStep conflict handling', () => {
   it('Given an active conflict in the ledger When all raws are mechanical Then the agent is still called', async () => {
     executeAgentMock.mockResolvedValue({

--- a/src/__tests__/finding-mechanical-classification.test.ts
+++ b/src/__tests__/finding-mechanical-classification.test.ts
@@ -191,3 +191,27 @@ describe('mergeFindingManagerOutputs', () => {
     expect(base.matches[0]?.rawFindingIds).toEqual(['raw-a']);
   });
 });
+
+describe('classifyRawFindingsMechanically conflicting signals', () => {
+  it('Given a confirmation and a re-reported issue for the same finding When classified Then all related raws fall to residual', () => {
+    const confirmation = makeRawFinding({
+      rawFindingId: 'raw-confirm',
+      kind: 'resolution_confirmation',
+      targetFindingId: 'F-0001',
+    });
+    const reReport = makeRawFinding({
+      rawFindingId: 'raw-issue',
+      kind: 'issue',
+      location: 'src/a.ts:10',
+      familyTag: 'bug',
+    });
+    const result = classifyRawFindingsMechanically({
+      previousLedger: makeLedger(),
+      rawFindings: [confirmation, reReport],
+    });
+    expect(result.output.resolvedFindings).toEqual([]);
+    expect(result.output.matches).toEqual([]);
+    expect(new Set(result.residualRawFindings.map((raw) => raw.rawFindingId)))
+      .toEqual(new Set(['raw-confirm', 'raw-issue']));
+  });
+});

--- a/src/__tests__/finding-mechanical-classification.test.ts
+++ b/src/__tests__/finding-mechanical-classification.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyRawFindingsMechanically,
+  mergeFindingManagerOutputs,
+} from '../core/workflow/findings/mechanical-classification.js';
+import { validateFindingManagerOutput } from '../core/workflow/findings/manager-output-validation.js';
+import type {
+  FindingLedger,
+  FindingLedgerEntry,
+  FindingManagerOutput,
+  RawFinding,
+} from '../core/workflow/findings/types.js';
+
+function makeRawFinding(overrides: Partial<RawFinding> = {}): RawFinding {
+  return {
+    rawFindingId: 'raw-current',
+    stepName: 'architecture-review',
+    reviewer: 'architecture-review',
+    familyTag: 'bug',
+    severity: 'high',
+    title: 'Current issue',
+    description: 'The issue is present in the current review.',
+    ...overrides,
+  };
+}
+
+function makeFinding(overrides: Partial<FindingLedgerEntry> = {}): FindingLedgerEntry {
+  return {
+    id: 'F-0001',
+    status: 'open',
+    lifecycle: 'new',
+    severity: 'high',
+    title: 'Existing issue',
+    location: 'src/a.ts:10',
+    reviewers: ['architecture-review'],
+    rawFindingIds: ['raw-existing'],
+    firstSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+    lastSeen: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' },
+    ...overrides,
+  };
+}
+
+function makeLedger(overrides: Partial<FindingLedger> = {}): FindingLedger {
+  return {
+    version: 1,
+    workflowName: 'peer-review',
+    nextId: 2,
+    updatedAt: '2026-06-13T00:00:00.000Z',
+    rawFindings: [makeRawFinding({ rawFindingId: 'raw-existing', location: 'src/a.ts:10' })],
+    conflicts: [],
+    findings: [makeFinding()],
+    ...overrides,
+  };
+}
+
+describe('classifyRawFindingsMechanically', () => {
+  it('Given a resolution confirmation targeting an open finding When classified Then it lands in resolvedFindings without residual', () => {
+    const raw = makeRawFinding({
+      rawFindingId: 'raw-confirm',
+      kind: 'resolution_confirmation',
+      targetFindingId: 'F-0001',
+      description: 'Verified fixed at src/a.ts:10.',
+    });
+    const result = classifyRawFindingsMechanically({ previousLedger: makeLedger(), rawFindings: [raw] });
+    expect(result.residualRawFindings).toEqual([]);
+    expect(result.output.resolvedFindings).toEqual([
+      { findingId: 'F-0001', rawFindingIds: ['raw-confirm'], evidence: 'Verified fixed at src/a.ts:10.' },
+    ]);
+  });
+
+  it('Given multiple confirmations for the same finding When classified Then rawFindingIds are merged into one entry', () => {
+    const raws = [
+      makeRawFinding({ rawFindingId: 'raw-c1', kind: 'resolution_confirmation', targetFindingId: 'F-0001' }),
+      makeRawFinding({ rawFindingId: 'raw-c2', kind: 'resolution_confirmation', targetFindingId: 'F-0001' }),
+    ];
+    const result = classifyRawFindingsMechanically({ previousLedger: makeLedger(), rawFindings: raws });
+    expect(result.output.resolvedFindings).toHaveLength(1);
+    expect(result.output.resolvedFindings[0]?.rawFindingIds).toEqual(['raw-c1', 'raw-c2']);
+  });
+
+  it('Given a confirmation targeting a missing finding When classified Then it goes to residual', () => {
+    const raw = makeRawFinding({ rawFindingId: 'raw-confirm', kind: 'resolution_confirmation', targetFindingId: 'F-9999' });
+    const result = classifyRawFindingsMechanically({ previousLedger: makeLedger(), rawFindings: [raw] });
+    expect(result.output.resolvedFindings).toEqual([]);
+    expect(result.residualRawFindings).toEqual([raw]);
+  });
+
+  it('Given a confirmation targeting an already resolved finding When classified Then it goes to residual', () => {
+    const ledger = makeLedger({ findings: [makeFinding({ status: 'resolved' })] });
+    const raw = makeRawFinding({ rawFindingId: 'raw-confirm', kind: 'resolution_confirmation', targetFindingId: 'F-0001' });
+    const result = classifyRawFindingsMechanically({ previousLedger: ledger, rawFindings: [raw] });
+    expect(result.residualRawFindings).toEqual([raw]);
+  });
+
+  it('Given an issue with exact location and familyTag match to one open finding When classified Then it lands in matches', () => {
+    const raw = makeRawFinding({ rawFindingId: 'raw-issue', kind: 'issue', location: 'src/a.ts:10', familyTag: 'bug' });
+    const result = classifyRawFindingsMechanically({ previousLedger: makeLedger(), rawFindings: [raw] });
+    expect(result.residualRawFindings).toEqual([]);
+    expect(result.output.matches).toEqual([{ findingId: 'F-0001', rawFindingIds: ['raw-issue'] }]);
+  });
+
+  it('Given an issue whose location matches but familyTag differs When classified Then it goes to residual', () => {
+    const raw = makeRawFinding({ rawFindingId: 'raw-issue', kind: 'issue', location: 'src/a.ts:10', familyTag: 'security' });
+    const result = classifyRawFindingsMechanically({ previousLedger: makeLedger(), rawFindings: [raw] });
+    expect(result.output.matches).toEqual([]);
+    expect(result.residualRawFindings).toEqual([raw]);
+  });
+
+  it('Given an issue matching a resolved finding location When classified Then it goes to residual as a reopen candidate', () => {
+    const ledger = makeLedger({ findings: [makeFinding({ status: 'resolved' })] });
+    const raw = makeRawFinding({ rawFindingId: 'raw-issue', kind: 'issue', location: 'src/a.ts:10' });
+    const result = classifyRawFindingsMechanically({ previousLedger: ledger, rawFindings: [raw] });
+    expect(result.output.matches).toEqual([]);
+    expect(result.residualRawFindings).toEqual([raw]);
+  });
+
+  it('Given an issue matching two open findings at the same location and tag When classified Then it goes to residual', () => {
+    const ledger = makeLedger({
+      rawFindings: [
+        makeRawFinding({ rawFindingId: 'raw-e1', location: 'src/a.ts:10' }),
+        makeRawFinding({ rawFindingId: 'raw-e2', location: 'src/a.ts:10' }),
+      ],
+      findings: [
+        makeFinding({ id: 'F-0001', rawFindingIds: ['raw-e1'] }),
+        makeFinding({ id: 'F-0002', rawFindingIds: ['raw-e2'] }),
+      ],
+    });
+    const raw = makeRawFinding({ rawFindingId: 'raw-issue', kind: 'issue', location: 'src/a.ts:10' });
+    const result = classifyRawFindingsMechanically({ previousLedger: ledger, rawFindings: [raw] });
+    expect(result.residualRawFindings).toEqual([raw]);
+  });
+
+  it('Given an issue without location When classified Then it goes to residual', () => {
+    const raw = makeRawFinding({ rawFindingId: 'raw-issue', kind: 'issue', location: undefined });
+    const result = classifyRawFindingsMechanically({ previousLedger: makeLedger(), rawFindings: [raw] });
+    expect(result.residualRawFindings).toEqual([raw]);
+  });
+
+  it('Given a fully mechanical round When validated with the real validator Then the output passes', () => {
+    const raws = [
+      makeRawFinding({ rawFindingId: 'raw-confirm', kind: 'resolution_confirmation', targetFindingId: 'F-0001', description: 'Verified.' }),
+    ];
+    const result = classifyRawFindingsMechanically({ previousLedger: makeLedger(), rawFindings: raws });
+    const validation = validateFindingManagerOutput({
+      previousLedger: makeLedger(),
+      rawFindings: raws,
+      managerOutput: result.output,
+    });
+    expect(validation.ok).toBe(true);
+  });
+});
+
+describe('mergeFindingManagerOutputs', () => {
+  function makeOutput(overrides: Partial<FindingManagerOutput> = {}): FindingManagerOutput {
+    return {
+      matches: [],
+      newFindings: [],
+      resolvedFindings: [],
+      reopenedFindings: [],
+      conflicts: [],
+      resolvedConflicts: [],
+      waivedFindings: [],
+      disputeNotes: [],
+      ...overrides,
+    };
+  }
+
+  it('Given both sides matched the same finding When merged Then rawFindingIds are unioned without duplicates', () => {
+    const base = makeOutput({ matches: [{ findingId: 'F-0001', rawFindingIds: ['raw-a', 'raw-b'] }] });
+    const extra = makeOutput({ matches: [{ findingId: 'F-0001', rawFindingIds: ['raw-b', 'raw-c'] }] });
+    const merged = mergeFindingManagerOutputs(base, extra);
+    expect(merged.matches).toEqual([{ findingId: 'F-0001', rawFindingIds: ['raw-a', 'raw-b', 'raw-c'] }]);
+  });
+
+  it('Given disjoint categories When merged Then all entries are preserved', () => {
+    const base = makeOutput({ resolvedFindings: [{ findingId: 'F-0001', rawFindingIds: ['raw-c1'], evidence: 'e1' }] });
+    const extra = makeOutput({
+      newFindings: [{ rawFindingIds: ['raw-n'], title: 'New issue', severity: 'low' }],
+      disputeNotes: [{ findingId: 'F-0002', reason: 'r', evidence: 'e' }],
+    });
+    const merged = mergeFindingManagerOutputs(base, extra);
+    expect(merged.resolvedFindings).toHaveLength(1);
+    expect(merged.newFindings).toHaveLength(1);
+    expect(merged.disputeNotes).toHaveLength(1);
+  });
+
+  it('Given the base output When merged Then the base arrays are not mutated', () => {
+    const base = makeOutput({ matches: [{ findingId: 'F-0001', rawFindingIds: ['raw-a'] }] });
+    const extra = makeOutput({ matches: [{ findingId: 'F-0001', rawFindingIds: ['raw-b'] }] });
+    mergeFindingManagerOutputs(base, extra);
+    expect(base.matches[0]?.rawFindingIds).toEqual(['raw-a']);
+  });
+});

--- a/src/core/workflow/findings/manager-output-validation.ts
+++ b/src/core/workflow/findings/manager-output-validation.ts
@@ -77,6 +77,20 @@ const FILE_LINE_EVIDENCE_PATTERN = /[^\s:]+\.[A-Za-z0-9_]+:\d+/;
  * する entry があり、その同一 entry 内に file:line 証跡がある」ことを判定する。
  * 別 finding の entry 内に対象 ID が付随的に現れただけでは claim と認めない。
  */
+/**
+ * 直前ステップ応答に「Disputed Findings」見出しがあるかを判定する。
+ * waiver はこの見出し配下の claim からしか成立しないため、見出しが無い応答は
+ * manager の判断材料を含まない（機械分類のみで完結できるかの判定に使う）。
+ */
+export function hasDisputeClaimsHeading(priorStepResponseText: string | undefined): boolean {
+  if (priorStepResponseText === undefined) {
+    return false;
+  }
+  return priorStepResponseText
+    .split('\n')
+    .some((line) => /^#{1,6}\s.*disputed findings/i.test(line.trim()));
+}
+
 function hasDisputeClaimFor(priorStepResponseText: string | undefined, findingId: string): boolean {
   if (priorStepResponseText === undefined) {
     return false;

--- a/src/core/workflow/findings/manager-runner.ts
+++ b/src/core/workflow/findings/manager-runner.ts
@@ -11,6 +11,7 @@ import { classifyRawFindingsMechanically, mergeFindingManagerOutputs } from './m
 import type { FindingLedgerStore, FindingManagerValidationAttemptReport } from './store.js';
 import type { FindingLedger, FindingManagerOutput, RawFinding } from './types.js';
 import {
+  hasDisputeClaimsHeading,
   validateFindingManagerOutput,
   type FindingManagerValidationResult,
 } from './manager-output-validation.js';
@@ -408,12 +409,13 @@ export async function runFindingManagerForParallelStep(
 
   // フィールド等価で確定する raw（解消確認・open 指摘への完全一致）はコードで
   // 分類し、判断が必要な残りだけを LLM manager に渡す。LLM を呼ばないのは
-  // 「残りゼロ・waiver 判断の材料になる prior step response なし・裁定待ちの
-  // active conflict なし」が全て揃う場合だけ。
+  // 「残りゼロ・prior step response に異議申告（Disputed Findings 見出し）なし・
+  // 裁定待ちの active conflict なし」が全て揃う場合だけ。waiver は見出し配下の
+  // claim からしか成立しないため、見出しの無い応答は判断材料を含まない。
   const mechanical = classifyRawFindingsMechanically({ previousLedger, rawFindings });
-  const hasPriorResponse = input.priorStepResponseText !== undefined && input.priorStepResponseText.trim() !== '';
+  const hasDisputeClaims = hasDisputeClaimsHeading(input.priorStepResponseText);
   const hasActiveConflict = previousLedger.conflicts.some((conflict) => conflict.status === 'active');
-  const needsAgent = mechanical.residualRawFindings.length > 0 || hasPriorResponse || hasActiveConflict;
+  const needsAgent = mechanical.residualRawFindings.length > 0 || hasDisputeClaims || hasActiveConflict;
 
   let managerOutput: FindingManagerOutput;
   let validation: FindingManagerValidationResult;

--- a/src/core/workflow/findings/manager-runner.ts
+++ b/src/core/workflow/findings/manager-runner.ts
@@ -202,10 +202,21 @@ function renderFencedTextBlock(content: string): string {
   return [`${fence}text`, content, fence].join('\n');
 }
 
-/** residual raws が参照する指摘（reopen・再確認の候補）は台帳スタブ化から除外して全文を渡す。 */
+/**
+ * residual raws が参照する指摘（reopen・再確認の候補）と、active conflict が
+ * 参照する指摘は台帳スタブ化から除外して全文を渡す。
+ */
 function collectFullDetailFindingIds(ledger: FindingLedger, residualRawFindings: readonly RawFinding[]): Set<string> {
   const rawFindingsById = new Map(ledger.rawFindings.map((rawFinding) => [rawFinding.rawFindingId, rawFinding]));
   const ids = new Set<string>();
+  for (const conflict of ledger.conflicts) {
+    if (conflict.status !== 'active') {
+      continue;
+    }
+    for (const findingId of conflict.findingIds) {
+      ids.add(findingId);
+    }
+  }
   for (const raw of residualRawFindings) {
     if (raw.targetFindingId !== undefined) {
       ids.add(raw.targetFindingId);
@@ -396,11 +407,13 @@ export async function runFindingManagerForParallelStep(
   const providerInfo = input.optionsBuilder.resolveStepProviderModel(managerStep);
 
   // フィールド等価で確定する raw（解消確認・open 指摘への完全一致）はコードで
-  // 分類し、判断が必要な残りだけを LLM manager に渡す。残りがゼロで、かつ
-  // waiver 判断の材料になる prior step response も無い場合は LLM を呼ばない。
+  // 分類し、判断が必要な残りだけを LLM manager に渡す。LLM を呼ばないのは
+  // 「残りゼロ・waiver 判断の材料になる prior step response なし・裁定待ちの
+  // active conflict なし」が全て揃う場合だけ。
   const mechanical = classifyRawFindingsMechanically({ previousLedger, rawFindings });
   const hasPriorResponse = input.priorStepResponseText !== undefined && input.priorStepResponseText.trim() !== '';
-  const needsAgent = mechanical.residualRawFindings.length > 0 || hasPriorResponse;
+  const hasActiveConflict = previousLedger.conflicts.some((conflict) => conflict.status === 'active');
+  const needsAgent = mechanical.residualRawFindings.length > 0 || hasPriorResponse || hasActiveConflict;
 
   let managerOutput: FindingManagerOutput;
   let validation: FindingManagerValidationResult;

--- a/src/core/workflow/findings/manager-runner.ts
+++ b/src/core/workflow/findings/manager-runner.ts
@@ -7,6 +7,7 @@ import {
   parseReviewerRawFindings,
 } from './schemas.js';
 import { reconcileFindingLedger } from './reconciler.js';
+import { classifyRawFindingsMechanically, mergeFindingManagerOutputs } from './mechanical-classification.js';
 import type { FindingLedgerStore, FindingManagerValidationAttemptReport } from './store.js';
 import type { FindingLedger, FindingManagerOutput, RawFinding } from './types.js';
 import {
@@ -134,32 +135,53 @@ function buildManagerStep(contract: FindingContractConfig): AgentWorkflowStep {
   };
 }
 
-function buildManagerInputLedger(ledger: FindingLedger): unknown {
+/**
+ * manager へ渡す台帳ビューを構築する。
+ * 解消済み・免除済みの指摘は照合キー（id / status / title / location）だけの
+ * スタブに落とし、本文と raw findings 全文は open な指摘と、residual raws が
+ * 参照する指摘（reopen 候補）だけに載せる。台帳肥大による manager の
+ * トークン消費を抑えるため。
+ */
+function buildManagerInputLedger(ledger: FindingLedger, fullDetailFindingIds?: ReadonlySet<string>): unknown {
   const rawFindingsById = new Map(ledger.rawFindings.map((rawFinding) => [rawFinding.rawFindingId, rawFinding]));
+  const needsFullDetail = (finding: FindingLedger['findings'][number]): boolean =>
+    finding.status === 'open'
+    || fullDetailFindingIds === undefined
+    || fullDetailFindingIds.has(finding.id);
   return {
     version: ledger.version,
     workflowName: ledger.workflowName,
     nextId: ledger.nextId,
     updatedAt: ledger.updatedAt,
-    findings: ledger.findings.map((finding) => ({
-      id: finding.id,
-      status: finding.status,
-      lifecycle: finding.lifecycle,
-      severity: finding.severity,
-      title: finding.title,
-      location: finding.location,
-      description: finding.description,
-      suggestion: finding.suggestion,
-      reviewers: finding.reviewers,
-      rawFindingIds: finding.rawFindingIds,
-      rawFindings: finding.rawFindingIds
-        .map((rawFindingId) => rawFindingsById.get(rawFindingId))
-        .filter((rawFinding): rawFinding is RawFinding => rawFinding !== undefined),
-      firstSeen: finding.firstSeen,
-      lastSeen: finding.lastSeen,
-      waivers: finding.waivers,
-      disputes: finding.disputes,
-    })),
+    findings: ledger.findings.map((finding) => (needsFullDetail(finding)
+      ? {
+        id: finding.id,
+        status: finding.status,
+        lifecycle: finding.lifecycle,
+        severity: finding.severity,
+        title: finding.title,
+        location: finding.location,
+        description: finding.description,
+        suggestion: finding.suggestion,
+        reviewers: finding.reviewers,
+        rawFindingIds: finding.rawFindingIds,
+        rawFindings: finding.rawFindingIds
+          .map((rawFindingId) => rawFindingsById.get(rawFindingId))
+          .filter((rawFinding): rawFinding is RawFinding => rawFinding !== undefined),
+        firstSeen: finding.firstSeen,
+        lastSeen: finding.lastSeen,
+        waivers: finding.waivers,
+        disputes: finding.disputes,
+      }
+      : {
+        id: finding.id,
+        status: finding.status,
+        lifecycle: finding.lifecycle,
+        severity: finding.severity,
+        title: finding.title,
+        location: finding.location,
+        lastSeen: finding.lastSeen,
+      })),
     conflicts: ledger.conflicts.map((conflict) => ({
       id: conflict.id,
       status: conflict.status,
@@ -180,22 +202,55 @@ function renderFencedTextBlock(content: string): string {
   return [`${fence}text`, content, fence].join('\n');
 }
 
+/** residual raws が参照する指摘（reopen・再確認の候補）は台帳スタブ化から除外して全文を渡す。 */
+function collectFullDetailFindingIds(ledger: FindingLedger, residualRawFindings: readonly RawFinding[]): Set<string> {
+  const rawFindingsById = new Map(ledger.rawFindings.map((rawFinding) => [rawFinding.rawFindingId, rawFinding]));
+  const ids = new Set<string>();
+  for (const raw of residualRawFindings) {
+    if (raw.targetFindingId !== undefined) {
+      ids.add(raw.targetFindingId);
+    }
+    for (const finding of ledger.findings) {
+      if (raw.location !== undefined && finding.location === raw.location) {
+        ids.add(finding.id);
+        continue;
+      }
+      const tagMatched = finding.rawFindingIds.some((id) => rawFindingsById.get(id)?.familyTag === raw.familyTag);
+      if (tagMatched) {
+        ids.add(finding.id);
+      }
+    }
+  }
+  return ids;
+}
+
 function buildManagerInstruction(input: {
   contract: FindingContractConfig;
   previousLedger: FindingLedger;
   ledgerCopyPath: string;
   rawFindingsPath: string;
-  rawFindings: RawFinding[];
+  residualRawFindings: RawFinding[];
+  mechanicallyClassifiedCount: number;
   priorStepResponseText?: string;
 }): string {
-  const managerInputLedger = buildManagerInputLedger(input.previousLedger);
+  const managerInputLedger = buildManagerInputLedger(
+    input.previousLedger,
+    collectFullDetailFindingIds(input.previousLedger, input.residualRawFindings),
+  );
+  const mechanicalNote = input.mechanicallyClassifiedCount > 0
+    ? [
+      input.contract.manager.instruction,
+      '',
+      `NOTE: ${input.mechanicallyClassifiedCount} raw findings (exact resolution confirmations and exact matches to open findings) were already classified mechanically by the engine and are NOT shown below. Classify only the raw findings listed below. Do not reference raw finding ids that are not listed.`,
+    ].join('\n')
+    : input.contract.manager.instruction;
   return loadTemplate('finding_manager_instruction', 'en', {
-    managerInstruction: input.contract.manager.instruction,
+    managerInstruction: mechanicalNote,
     outputContract: input.contract.manager.outputContract,
     ledgerCopyPath: input.ledgerCopyPath,
     managerInputLedger: renderFencedJsonBlock(managerInputLedger),
     rawFindingsPath: input.rawFindingsPath,
-    rawFindings: renderFencedJsonBlock(input.rawFindings),
+    rawFindings: renderFencedJsonBlock(input.residualRawFindings),
     coderResponse: renderFencedTextBlock(input.priorStepResponseText ?? '(no prior step response)'),
   });
 }
@@ -260,18 +315,22 @@ async function runManagerAttempt(input: {
 async function runManagerWithSemanticRetry(input: {
   previousLedger: FindingLedger;
   rawFindings: RawFinding[];
+  mechanicalOutput: FindingManagerOutput;
   managerStep: AgentWorkflowStep;
   instruction: string;
   optionsBuilder: OptionsBuilder;
   stepExecutor: Pick<StepExecutor, 'buildPhase1Instruction' | 'normalizeStructuredOutput'>;
   priorStepResponseText?: string;
 }): Promise<ValidatedManagerOutputRun> {
-  const firstManagerOutput = await runManagerAttempt({
+  // 検証は「機械分類 + LLM 分類」を統合した最終形に対して行う。
+  // 全 raw finding の網羅性は統合後でしか成立しないため。
+  const firstAgentOutput = await runManagerAttempt({
     managerStep: input.managerStep,
     instruction: input.instruction,
     optionsBuilder: input.optionsBuilder,
     stepExecutor: input.stepExecutor,
   });
+  const firstManagerOutput = mergeFindingManagerOutputs(input.mechanicalOutput, firstAgentOutput);
   const firstValidation = validateFindingManagerOutput({
     previousLedger: input.previousLedger,
     rawFindings: input.rawFindings,
@@ -287,16 +346,17 @@ async function runManagerWithSemanticRetry(input: {
     managerOutput: firstManagerOutput,
     validationErrors: firstValidation.errors,
   };
-  const retryManagerOutput = await runManagerAttempt({
+  const retryAgentOutput = await runManagerAttempt({
     managerStep: input.managerStep,
     instruction: buildManagerRetryInstruction({
       originalInstruction: input.instruction,
       validationErrors: firstValidation.errors,
-      managerOutput: firstManagerOutput,
+      managerOutput: firstAgentOutput,
     }),
     optionsBuilder: input.optionsBuilder,
     stepExecutor: input.stepExecutor,
   });
+  const retryManagerOutput = mergeFindingManagerOutputs(input.mechanicalOutput, retryAgentOutput);
   const retryValidation = validateFindingManagerOutput({
     previousLedger: input.previousLedger,
     rawFindings: input.rawFindings,
@@ -333,28 +393,50 @@ export async function runFindingManagerForParallelStep(
   });
   const rawFindingsPath = input.ledgerStore.saveRawFindings(input.runId, input.parentStep.name, rawFindings);
   const managerStep = buildManagerStep(input.contract);
-  const instruction = buildManagerInstruction({
-    contract: input.contract,
-    previousLedger,
-    ledgerCopyPath,
-    rawFindingsPath,
-    rawFindings,
-    priorStepResponseText: input.priorStepResponseText,
-  });
   const providerInfo = input.optionsBuilder.resolveStepProviderModel(managerStep);
-  const {
-    managerOutput,
-    validation,
-    invalidAttempts,
-  } = await runManagerWithSemanticRetry({
-    previousLedger,
-    rawFindings,
-    managerStep,
-    instruction,
-    optionsBuilder: input.optionsBuilder,
-    stepExecutor: input.stepExecutor,
-    priorStepResponseText: input.priorStepResponseText,
-  });
+
+  // フィールド等価で確定する raw（解消確認・open 指摘への完全一致）はコードで
+  // 分類し、判断が必要な残りだけを LLM manager に渡す。残りがゼロで、かつ
+  // waiver 判断の材料になる prior step response も無い場合は LLM を呼ばない。
+  const mechanical = classifyRawFindingsMechanically({ previousLedger, rawFindings });
+  const hasPriorResponse = input.priorStepResponseText !== undefined && input.priorStepResponseText.trim() !== '';
+  const needsAgent = mechanical.residualRawFindings.length > 0 || hasPriorResponse;
+
+  let managerOutput: FindingManagerOutput;
+  let validation: FindingManagerValidationResult;
+  let invalidAttempts: FindingManagerValidationAttemptReport[];
+  if (needsAgent) {
+    const instruction = buildManagerInstruction({
+      contract: input.contract,
+      previousLedger,
+      ledgerCopyPath,
+      rawFindingsPath,
+      residualRawFindings: mechanical.residualRawFindings,
+      mechanicallyClassifiedCount: rawFindings.length - mechanical.residualRawFindings.length,
+      priorStepResponseText: input.priorStepResponseText,
+    });
+    ({ managerOutput, validation, invalidAttempts } = await runManagerWithSemanticRetry({
+      previousLedger,
+      rawFindings,
+      mechanicalOutput: mechanical.output,
+      managerStep,
+      instruction,
+      optionsBuilder: input.optionsBuilder,
+      stepExecutor: input.stepExecutor,
+      priorStepResponseText: input.priorStepResponseText,
+    }));
+  } else {
+    managerOutput = mechanical.output;
+    validation = validateFindingManagerOutput({
+      previousLedger,
+      rawFindings,
+      managerOutput,
+      priorStepResponseText: input.priorStepResponseText,
+    });
+    invalidAttempts = validation.ok
+      ? []
+      : [{ attempt: 1, managerOutput, validationErrors: validation.errors }];
+  }
 
   if (!validation.ok) {
     const reportPath = input.ledgerStore.saveManagerValidationReport({

--- a/src/core/workflow/findings/mechanical-classification.ts
+++ b/src/core/workflow/findings/mechanical-classification.ts
@@ -1,0 +1,133 @@
+import type { FindingLedger, FindingLedgerEntry, FindingManagerOutput, RawFinding } from './types.js';
+
+/**
+ * raw findings のうち、構造化フィールドの等価比較だけで分類が確定するものを
+ * コードで処理し、判断が必要な残り（residual）だけを LLM manager に回すための
+ * 機械分類。
+ *
+ * 保守的な原則: フィールド等価で一意に決まらないものは全て residual に落とす。
+ * - resolution_confirmation は targetFindingId が open の指摘を指す場合のみ解消。
+ * - issue は「open の指摘と location + familyTag が完全一致し、候補が一意」の
+ *   場合のみ既存一致。解消済み指摘への一致（reopen 判断）や候補複数は residual。
+ * - 新規判定（どの既存指摘とも無関係）は重複グルーピングの判断を伴うため
+ *   機械では確定させず residual に落とす。
+ */
+export interface MechanicalClassificationResult {
+  output: FindingManagerOutput;
+  residualRawFindings: RawFinding[];
+}
+
+function emptyManagerOutput(): FindingManagerOutput {
+  return {
+    matches: [],
+    newFindings: [],
+    resolvedFindings: [],
+    reopenedFindings: [],
+    conflicts: [],
+    resolvedConflicts: [],
+    waivedFindings: [],
+    disputeNotes: [],
+  };
+}
+
+function buildFindingFamilyTags(ledger: FindingLedger): Map<string, Set<string>> {
+  const rawById = new Map(ledger.rawFindings.map((raw) => [raw.rawFindingId, raw]));
+  const tags = new Map<string, Set<string>>();
+  for (const finding of ledger.findings) {
+    const set = new Set<string>();
+    for (const rawFindingId of finding.rawFindingIds) {
+      const raw = rawById.get(rawFindingId);
+      if (raw) {
+        set.add(raw.familyTag);
+      }
+    }
+    tags.set(finding.id, set);
+  }
+  return tags;
+}
+
+export function classifyRawFindingsMechanically(input: {
+  previousLedger: FindingLedger;
+  rawFindings: RawFinding[];
+}): MechanicalClassificationResult {
+  const output = emptyManagerOutput();
+  const residualRawFindings: RawFinding[] = [];
+  const findingsById = new Map(input.previousLedger.findings.map((finding) => [finding.id, finding]));
+  const familyTags = buildFindingFamilyTags(input.previousLedger);
+  const openFindings = input.previousLedger.findings.filter((finding) => finding.status === 'open');
+
+  const resolvedByFindingId = new Map<string, { findingId: string; rawFindingIds: string[]; evidence: string }>();
+  const matchesByFindingId = new Map<string, { findingId: string; rawFindingIds: string[] }>();
+
+  for (const raw of input.rawFindings) {
+    if (raw.kind === 'resolution_confirmation') {
+      const target = raw.targetFindingId === undefined ? undefined : findingsById.get(raw.targetFindingId);
+      if (target !== undefined && target.status === 'open') {
+        const entry = resolvedByFindingId.get(target.id)
+          ?? { findingId: target.id, rawFindingIds: [], evidence: raw.description };
+        entry.rawFindingIds.push(raw.rawFindingId);
+        resolvedByFindingId.set(target.id, entry);
+        continue;
+      }
+      // 対象不明・既に解消済みへの確認は判断（reopen / conflict / no-op）が絡むため LLM へ。
+      residualRawFindings.push(raw);
+      continue;
+    }
+
+    // kind 未指定は issue として扱う（schema 上のデフォルト運用）。
+    const candidates = raw.location === undefined
+      ? []
+      : openFindings.filter((finding) =>
+        finding.location === raw.location && (familyTags.get(finding.id)?.has(raw.familyTag) ?? false));
+    if (candidates.length === 1) {
+      const target = candidates[0] as FindingLedgerEntry;
+      const entry = matchesByFindingId.get(target.id) ?? { findingId: target.id, rawFindingIds: [] };
+      entry.rawFindingIds.push(raw.rawFindingId);
+      matchesByFindingId.set(target.id, entry);
+      continue;
+    }
+    residualRawFindings.push(raw);
+  }
+
+  output.resolvedFindings = [...resolvedByFindingId.values()];
+  output.matches = [...matchesByFindingId.values()];
+  return { output, residualRawFindings };
+}
+
+function mergeByFindingId<T extends { findingId: string; rawFindingIds: string[] }>(
+  base: readonly T[],
+  extra: readonly T[],
+): T[] {
+  const merged = new Map<string, T>();
+  for (const entry of [...base, ...extra]) {
+    const existing = merged.get(entry.findingId);
+    if (existing === undefined) {
+      merged.set(entry.findingId, { ...entry, rawFindingIds: [...entry.rawFindingIds] });
+      continue;
+    }
+    const seen = new Set(existing.rawFindingIds);
+    for (const rawFindingId of entry.rawFindingIds) {
+      if (!seen.has(rawFindingId)) {
+        existing.rawFindingIds.push(rawFindingId);
+      }
+    }
+  }
+  return [...merged.values()];
+}
+
+/** 機械分類の結果と LLM manager の結果を統合する。findingId 重複は rawFindingIds を合併する。 */
+export function mergeFindingManagerOutputs(
+  base: FindingManagerOutput,
+  extra: FindingManagerOutput,
+): FindingManagerOutput {
+  return {
+    matches: mergeByFindingId(base.matches, extra.matches),
+    newFindings: [...base.newFindings, ...extra.newFindings],
+    resolvedFindings: mergeByFindingId(base.resolvedFindings, extra.resolvedFindings),
+    reopenedFindings: mergeByFindingId(base.reopenedFindings, extra.reopenedFindings),
+    conflicts: [...base.conflicts, ...extra.conflicts],
+    resolvedConflicts: [...base.resolvedConflicts, ...extra.resolvedConflicts],
+    waivedFindings: [...base.waivedFindings, ...extra.waivedFindings],
+    disputeNotes: [...base.disputeNotes, ...extra.disputeNotes],
+  };
+}

--- a/src/core/workflow/findings/mechanical-classification.ts
+++ b/src/core/workflow/findings/mechanical-classification.ts
@@ -58,6 +58,13 @@ export function classifyRawFindingsMechanically(input: {
 
   const resolvedByFindingId = new Map<string, { findingId: string; rawFindingIds: string[]; evidence: string }>();
   const matchesByFindingId = new Map<string, { findingId: string; rawFindingIds: string[] }>();
+  const rawsByFindingId = new Map<string, RawFinding[]>();
+
+  const trackRaw = (findingId: string, raw: RawFinding): void => {
+    const list = rawsByFindingId.get(findingId) ?? [];
+    list.push(raw);
+    rawsByFindingId.set(findingId, list);
+  };
 
   for (const raw of input.rawFindings) {
     if (raw.kind === 'resolution_confirmation') {
@@ -67,6 +74,7 @@ export function classifyRawFindingsMechanically(input: {
           ?? { findingId: target.id, rawFindingIds: [], evidence: raw.description };
         entry.rawFindingIds.push(raw.rawFindingId);
         resolvedByFindingId.set(target.id, entry);
+        trackRaw(target.id, raw);
         continue;
       }
       // 対象不明・既に解消済みへの確認は判断（reopen / conflict / no-op）が絡むため LLM へ。
@@ -84,9 +92,21 @@ export function classifyRawFindingsMechanically(input: {
       const entry = matchesByFindingId.get(target.id) ?? { findingId: target.id, rawFindingIds: [] };
       entry.rawFindingIds.push(raw.rawFindingId);
       matchesByFindingId.set(target.id, entry);
+      trackRaw(target.id, raw);
       continue;
     }
     residualRawFindings.push(raw);
+  }
+
+  // 同じ指摘に「解消確認」と「再報告（issue 一致）」が同時に来た場合は
+  // レビュワー間の食い違いであり、conflict 裁定は manager の判断領域。
+  // 両側の raw をすべて residual に落とし、機械分類からは取り下げる。
+  for (const findingId of [...resolvedByFindingId.keys()]) {
+    if (matchesByFindingId.has(findingId)) {
+      resolvedByFindingId.delete(findingId);
+      matchesByFindingId.delete(findingId);
+      residualRawFindings.push(...(rawsByFindingId.get(findingId) ?? []));
+    }
   }
 
   output.resolvedFindings = [...resolvedByFindingId.values()];


### PR DESCRIPTION
## 背景（実測）

findings-manager は毎レビューラウンド、全 raw findings 全文を埋め込んだ台帳（実測で 200KB 級）を持って LLM を呼んでおり、判定エージェント群の中で最大のトークン消費源だった。一方、実走の raw findings を調べると大半は `resolution_confirmation`（targetFindingId が構造化フィールドで入っている）か既存指摘への完全一致で、フィールドの照合だけで分類が確定する。

## 変更

1. **mechanical-classification.ts（新規）** — 次だけをコードで分類し、それ以外は residual として LLM に委譲する
   - `resolution_confirmation` で対象が open の指摘 → resolvedFindings
   - `issue` で open 指摘と location + familyTag が完全一致し候補が一意 → matches
   - 同一指摘に確認と再報告が同時に来た場合（レビュワー間の食い違い）は両方 residual へ
2. **manager-runner** — residual ゼロ・prior step response なし・active conflict なしが揃う場合は LLM を呼ばず機械分類のみで台帳更新（意味検証は従来どおり実施）。LLM を呼ぶ場合も residual raws + スリム台帳（解消済みはスタブ、ただし residual と active conflict が参照する指摘は全文）に縮小
3. 統合出力（機械 + LLM）に対して既存の意味検証・リトライ・invalid_manager_output 経路をそのまま適用

## 等価性の実証

アーカイブ済みの完走9走（takt-bench v3）で、機械分類の判定を manager（codex）の実判定と突き合わせた結果、**機械判定 746件が 100% 一致、LLM 委譲は 4件（0.5%）のみ**。曖昧4件の内訳は location を持たない工程指摘×2 と新規指摘×2 で、いずれも設計どおり LLM の担当領域。

## テスト

- 新規: finding-mechanical-classification.test.ts（分類・マージ・実バリデータ通過）/ finding-manager-mechanical-runner.test.ts（LLM スキップ・residual 縮小・conflict 経路）
- 既存: 全 unit シャード green、it-finding-contract-flow green
- codex $coding レビュー 3周（指摘3件修正済み、最終 APPROVE）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 指摘を「機械的に確定できるもの」と「残り」に分けて処理し、LLMへの入力を最小化する仕組みを追加しました。
  * 機械分類結果とLLM結果の統合（マージ）を導入し、再オープン・競合などの扱いを一貫化しました。
  * 以前の応答に「Disputed Findings」見出しがあるかを判定し、LLM実行要否に反映します。
* **テスト**
  * 機械分類、マージ統合、残余振り分け、無効な出力時の挙動、競合・再オープン関連を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->