### PR TITLE
fix: implement の行き詰まりを ABORT ではなく plan（再計画）へ流す

### DIFF
--- a/builtins/en/workflows/backend-cqrs-for-local-llm.yaml
+++ b/builtins/en/workflows/backend-cqrs-for-local-llm.yaml
@@ -145,7 +145,7 @@ steps:
       - condition: Implementation is complete
         next: reviewers
       - condition: Cannot proceed with implementation (environment issue or missing information)
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:

--- a/builtins/en/workflows/backend-for-local-llm.yaml
+++ b/builtins/en/workflows/backend-for-local-llm.yaml
@@ -142,7 +142,7 @@ steps:
       - condition: Implementation is complete
         next: reviewers
       - condition: Cannot proceed with implementation (environment issue or missing information)
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:

--- a/builtins/en/workflows/dual-for-local-llm.yaml
+++ b/builtins/en/workflows/dual-for-local-llm.yaml
@@ -148,7 +148,7 @@ steps:
       - condition: Implementation is complete
         next: reviewers
       - condition: Cannot proceed with implementation (environment issue or missing information)
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:

--- a/builtins/en/workflows/frontend-for-local-llm.yaml
+++ b/builtins/en/workflows/frontend-for-local-llm.yaml
@@ -145,7 +145,7 @@ steps:
       - condition: Implementation is complete
         next: reviewers
       - condition: Cannot proceed with implementation (environment issue or missing information)
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:

--- a/builtins/en/workflows/takt-default-for-local-llm.yaml
+++ b/builtins/en/workflows/takt-default-for-local-llm.yaml
@@ -141,7 +141,7 @@ steps:
       - condition: Implementation is complete
         next: reviewers
       - condition: Cannot proceed with implementation (environment issue or missing information)
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:

--- a/builtins/ja/workflows/backend-cqrs-for-local-llm.yaml
+++ b/builtins/ja/workflows/backend-cqrs-for-local-llm.yaml
@@ -145,7 +145,7 @@ steps:
       - condition: 実装完了
         next: reviewers
       - condition: 実装を進められない（環境問題・情報不足）
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:

--- a/builtins/ja/workflows/backend-for-local-llm.yaml
+++ b/builtins/ja/workflows/backend-for-local-llm.yaml
@@ -142,7 +142,7 @@ steps:
       - condition: 実装完了
         next: reviewers
       - condition: 実装を進められない（環境問題・情報不足）
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:

--- a/builtins/ja/workflows/dual-for-local-llm.yaml
+++ b/builtins/ja/workflows/dual-for-local-llm.yaml
@@ -148,7 +148,7 @@ steps:
       - condition: 実装完了
         next: reviewers
       - condition: 実装を進められない（環境問題・情報不足）
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:

--- a/builtins/ja/workflows/frontend-for-local-llm.yaml
+++ b/builtins/ja/workflows/frontend-for-local-llm.yaml
@@ -145,7 +145,7 @@ steps:
       - condition: 実装完了
         next: reviewers
       - condition: 実装を進められない（環境問題・情報不足）
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:

--- a/builtins/ja/workflows/takt-default-for-local-llm.yaml
+++ b/builtins/ja/workflows/takt-default-for-local-llm.yaml
@@ -141,7 +141,7 @@ steps:
       - condition: 実装完了
         next: reviewers
       - condition: 実装を進められない（環境問題・情報不足）
-        next: ABORT
+        next: plan
 
   - name: reviewers
     tags:


### PR DESCRIPTION
## 問題

for-local-llm ファミリー（ja/en × takt-default / backend / backend-cqrs / dual / frontend の10ファイル）で、`implement` ステップの「実装を進められない（環境問題・情報不足）」だけが `next: ABORT` に繋がっていた。

同じファイルの `write_tests` と `fix` は既に `next: plan` へ流れており、implement だけが一貫していない。#986 の replan 対応で fix を直した際の漏れ。

## 実測

9万行のリポジトリ（takt 本体）への機能追加を qwen3-coder-next に実装させたところ、implement の途中でツール呼び出しが崩れ（`Could not find oldString`、`File not found`、`SchemaError`）、coder が「進められない」と自己申告 → 走行が即 ABORT した。

小さい題材ではこのルールに触れる機会がなく（v2 の全走行で該当ステータスは 0 回）、実務規模で初めて露呈した。

## 変更

implement の行き詰まり → `plan`（再計画）。planner の instruction には既に「Previous Response がある場合は差し戻しのため計画を見直す（replan）」が入っており、再計画で作業を分割し直して再挑戦できる。

ABORT に残すのは、loop monitor の裁定（非生産的な繰り返し）、plan の要件不明確、レビュワーの見解対立の3経路のみ。

## 検証

- build / lint / 対象テスト（for-local-llm-replan-wiring、workflow-validator）green
- 変更は各ワークフローの1行のみ（10ファイル × 1行）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 実装を進められない状況（環境要因や情報不足）の際に、処理が中断されず再計画へ戻るようになりました。
  * 複数のワークフローで、該当条件時の遷移先が終了ではなく計画フェーズに統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->