### PR TITLE
fix: 無音タイムアウト時にセッションを検死して 429 を rate_limited として返す

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2606,6 +2606,100 @@ describe('OpenCodeClient stream cleanup', () => {
     }
   }, 20_000);
 
+  it('Given an older assistant message carries a 429 but the latest one does not When the idle watchdog fires Then the stale rate limit is not reported', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      const result = await runStalledSessionScenario([
+        {
+          info: {
+            role: 'assistant',
+            error: { name: 'APIError', data: { message: 'Too Many Requests', statusCode: 429, isRetryable: true } },
+          },
+          parts: [],
+        },
+        { info: { role: 'user' }, parts: [] },
+        { info: { role: 'assistant' }, parts: [] },
+      ]);
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('timed out');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 20_000);
+
+  it('Given the latest assistant error exposes the rate limit only in a top level message When the idle watchdog fires Then it is reported as rate limited', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      const result = await runStalledSessionScenario([
+        {
+          info: {
+            role: 'assistant',
+            error: { name: 'UnknownError', message: 'AI_APICallError: Too Many Requests' },
+          },
+          parts: [],
+        },
+      ]);
+
+      expect(result.status).toBe('rate_limited');
+      expect(result.errorKind).toBe('rate_limit');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 20_000);
+
+  it('Given the latest assistant error carries a string status code When the idle watchdog fires Then it is reported as rate limited', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      const result = await runStalledSessionScenario([
+        {
+          info: {
+            role: 'assistant',
+            error: { name: 'APIError', data: { message: 'rate exceeded', statusCode: '429' } },
+          },
+          parts: [],
+        },
+      ]);
+
+      expect(result.status).toBe('rate_limited');
+      expect(result.errorKind).toBe('rate_limit');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 20_000);
+
+  it('Given the postmortem query hangs When the idle watchdog fires Then the timeout error is preserved without hanging', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      const { OpenCodeClient } = await import('../infra/opencode/client.js');
+      const chatterStream = new ChatterOnlyEventStream(100);
+      createOpencodeMock.mockResolvedValue({
+        client: {
+          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+          session: {
+            create: vi.fn().mockResolvedValue({ data: { id: 'session-stalled' } }),
+            promptAsync: vi.fn().mockReturnValue(new Promise(() => { /* 完了しない */ })),
+            messages: vi.fn().mockReturnValue(new Promise(() => { /* 応答しない */ })),
+          },
+          event: { subscribe: vi.fn().mockResolvedValue({ stream: chatterStream }) },
+          permission: { reply: vi.fn() },
+        },
+        server: { close: vi.fn() },
+      });
+
+      const result = await new OpenCodeClient().call('coder', 'do it', {
+        cwd: '/tmp',
+        model: 'opencode/big-pickle',
+        interactionTimeoutMs: 500,
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('timed out');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 30_000);
+
   it('Given the postmortem query itself fails When the idle watchdog fires Then the timeout error is preserved', async () => {
     process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
     try {

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2693,6 +2693,8 @@ describe('OpenCodeClient stream cleanup', () => {
 
   it('Given the postmortem query hangs When the idle watchdog fires Then the timeout error is preserved without hanging', async () => {
     process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    // 検死 RPC のハングを実時間 5 秒待たない（CI でのフレークを避ける）
+    process.env.TAKT_OPENCODE_POSTMORTEM_TIMEOUT_MS = '200';
     try {
       const { OpenCodeClient } = await import('../infra/opencode/client.js');
       const chatterStream = new ChatterOnlyEventStream(100);
@@ -2720,8 +2722,9 @@ describe('OpenCodeClient stream cleanup', () => {
       expect(result.error).toContain('timed out');
     } finally {
       delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+      delete process.env.TAKT_OPENCODE_POSTMORTEM_TIMEOUT_MS;
     }
-  }, 30_000);
+  }, 20_000);
 
   it('Given the postmortem query itself fails When the idle watchdog fires Then the timeout error is preserved', async () => {
     process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2524,6 +2524,120 @@ describe('OpenCodeClient stream cleanup', () => {
     }
   }, 20_000);
 
+  /** 無音タイムアウトで止めたセッションを検死する共通シナリオ */
+  async function runStalledSessionScenario(
+    messagesData: unknown,
+  ): Promise<import('../core/models/index.js').AgentResponse> {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const chatterStream = new ChatterOnlyEventStream(100);
+    const messages = vi.fn().mockResolvedValue({ data: messagesData });
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: 'session-stalled' } }),
+          promptAsync: vi.fn().mockReturnValue(new Promise(() => { /* 完了しない */ })),
+          messages,
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream: chatterStream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    return new OpenCodeClient().call('coder', 'do it', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      interactionTimeoutMs: 500,
+    });
+  }
+
+  it('Given a stalled session whose last assistant message carries a 429 When the idle watchdog fires Then the call is reported as rate limited', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      const result = await runStalledSessionScenario([
+        {
+          info: {
+            role: 'assistant',
+            error: { name: 'APIError', data: { message: 'Too Many Requests', statusCode: 429, isRetryable: true } },
+          },
+          parts: [],
+        },
+      ]);
+
+      expect(result.status).toBe('rate_limited');
+      expect(result.errorKind).toBe('rate_limit');
+      expect(result.error).toContain('Too Many Requests');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 20_000);
+
+  it('Given a stalled session whose last assistant error is unrelated When the idle watchdog fires Then the timeout error is preserved', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      const result = await runStalledSessionScenario([
+        {
+          info: {
+            role: 'assistant',
+            error: { name: 'UnknownError', data: { message: 'boom' } },
+          },
+          parts: [],
+        },
+      ]);
+
+      expect(result.status).toBe('error');
+      expect(result.errorKind).toBeUndefined();
+      expect(result.error).toContain('timed out');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 20_000);
+
+  it('Given a stalled session with no assistant error When the idle watchdog fires Then the timeout error is preserved', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      const result = await runStalledSessionScenario([{ info: { role: 'assistant' }, parts: [] }]);
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('timed out');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 20_000);
+
+  it('Given the postmortem query itself fails When the idle watchdog fires Then the timeout error is preserved', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      const { OpenCodeClient } = await import('../infra/opencode/client.js');
+      const chatterStream = new ChatterOnlyEventStream(100);
+      createOpencodeMock.mockResolvedValue({
+        client: {
+          instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+          session: {
+            create: vi.fn().mockResolvedValue({ data: { id: 'session-stalled' } }),
+            promptAsync: vi.fn().mockReturnValue(new Promise(() => { /* 完了しない */ })),
+            messages: vi.fn().mockRejectedValue(new Error('server gone')),
+          },
+          event: { subscribe: vi.fn().mockResolvedValue({ stream: chatterStream }) },
+          permission: { reply: vi.fn() },
+        },
+        server: { close: vi.fn() },
+      });
+
+      const result = await new OpenCodeClient().call('coder', 'do it', {
+        cwd: '/tmp',
+        model: 'opencode/big-pickle',
+        interactionTimeoutMs: 500,
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('timed out');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 20_000);
+
   /** 予算系4テスト共通: イベント列を流して call の結果だけ返す */
   async function runBudgetScenario(sessionId: string, events: unknown[]): Promise<import('../core/models/index.js').AgentResponse> {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -2628,6 +2628,29 @@ describe('OpenCodeClient stream cleanup', () => {
     }
   }, 20_000);
 
+  it('Given an older assistant carries a 429 and the latest message is still a user turn When the idle watchdog fires Then the stale rate limit is not reported', async () => {
+    process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
+    try {
+      // セッション再利用で「前回 assistant の 429 → 今回 user prompt → assistant
+      // 未生成のまま無音停止」という並びを再現する。
+      const result = await runStalledSessionScenario([
+        {
+          info: {
+            role: 'assistant',
+            error: { name: 'APIError', data: { message: 'Too Many Requests', statusCode: 429, isRetryable: true } },
+          },
+          parts: [],
+        },
+        { info: { role: 'user' }, parts: [] },
+      ]);
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('timed out');
+    } finally {
+      delete process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS;
+    }
+  }, 20_000);
+
   it('Given the latest assistant error exposes the rate limit only in a top level message When the idle watchdog fires Then it is reported as rate limited', async () => {
     process.env.TAKT_OPENCODE_STREAM_IDLE_TIMEOUT_MS = '300';
     try {

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -298,8 +298,15 @@ export type OpenCodeSessionMessages = NonNullable<Awaited<ReturnType<OpencodeCli
 
 /** レート制限を示す HTTP ステータス。プロバイダは 429 を返す。 */
 const RATE_LIMIT_STATUS_CODE = 429;
-/** 検死 RPC の上限。検死自体がハングして再度の無限待ちを招かないようにする。 */
-const OPENCODE_POSTMORTEM_TIMEOUT_MS = 5000;
+
+/**
+ * 検死 RPC の上限。検死自体がハングして再度の無限待ちを招かないようにする。
+ * 呼び出し時に評価する（テストで env から上書きできるようにする）。
+ */
+function resolvePostmortemTimeoutMs(): number {
+  const fromEnv = Number(process.env.TAKT_OPENCODE_POSTMORTEM_TIMEOUT_MS);
+  return fromEnv > 0 ? fromEnv : 5000;
+}
 
 /** statusCode は数値でも文字列でも来うるため正規化する。 */
 function extractStatusCode(error: unknown): number | undefined {
@@ -338,7 +345,7 @@ async function postmortemRateLimitError(
   try {
     const result = await withTimeout(
       (signal) => client.session.messages({ sessionID, directory }, { signal }),
-      OPENCODE_POSTMORTEM_TIMEOUT_MS,
+      resolvePostmortemTimeoutMs(),
       'OpenCode rate limit postmortem timed out',
     );
     if (!result.data) {
@@ -1318,10 +1325,11 @@ export class OpenCodeClient {
               options.cwd,
             );
             if (rateLimitMessage !== undefined) {
+              // プロバイダ由来の生エラー文はリクエスト内容やアカウント情報を
+              // 含みうるため、分類済みの事実だけを永続化する。
               log.warn('OpenCode stream stalled on a provider rate limit', {
                 sessionId: activeSessionId,
                 model: options.model,
-                error: rateLimitMessage,
               });
               // 検死で 429 と確定済み。message 文字列に 429 の語が含まれるとは
               // 限らない（statusCode だけで判定した場合）ため再判定はしない。

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -296,6 +296,60 @@ export async function getOpenCodeSessionSnapshot(
 
 export type OpenCodeSessionMessages = NonNullable<Awaited<ReturnType<OpencodeClient['session']['messages']>>['data']>;
 
+/** レート制限を示す HTTP ステータス。プロバイダは 429 を返す。 */
+const RATE_LIMIT_STATUS_CODE = 429;
+
+/**
+ * セッションの最後の assistant メッセージのエラーを検死し、レート制限なら
+ * その内容を返す。
+ *
+ * OpenCode サーバはプロバイダの 429 を内部リトライで握り、イベントバスへ
+ * session.error を流さない。takt からは「無音のまま停止したセッション」に
+ * 見えるため、無音ウォッチドッグのタイムアウト後にここで死因を確かめる。
+ */
+async function postmortemRateLimitError(
+  client: OpencodeClient,
+  sessionID: string,
+  directory: string,
+): Promise<string | undefined> {
+  let messages: OpenCodeSessionMessages;
+  try {
+    const result = await client.session.messages({ sessionID, directory });
+    if (!result.data) {
+      return undefined;
+    }
+    messages = result.data;
+  } catch (error) {
+    // 検死そのものの失敗で本来のエラーを覆い隠さない。
+    log.debug('Rate limit postmortem could not read session messages', {
+      sessionID,
+      error: getErrorMessage(error),
+    });
+    return undefined;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const info = messages[index]?.info;
+    if (info?.role !== 'assistant') {
+      continue;
+    }
+    const error = info.error;
+    if (error === undefined) {
+      continue;
+    }
+    const data = error.data as { message?: unknown; statusCode?: unknown } | undefined;
+    const message = typeof data?.message === 'string' ? data.message : undefined;
+    const statusCode = typeof data?.statusCode === 'number' ? data.statusCode : undefined;
+    if (statusCode === RATE_LIMIT_STATUS_CODE || (message !== undefined && containsRateLimitError(message))) {
+      return message ?? `HTTP ${RATE_LIMIT_STATUS_CODE} Too Many Requests`;
+    }
+    // 直近の assistant メッセージにレート制限以外のエラーが乗っているなら、
+    // それが死因なので探索を打ち切る。
+    return undefined;
+  }
+  return undefined;
+}
+
 export async function getOpenCodeSessionMessages(
   model: string,
   sessionID: string,
@@ -1224,7 +1278,29 @@ export class OpenCodeClient {
         diag.onCompleted(success ? 'normal' : 'error', success ? undefined : failureMessage);
 
         if (!success) {
-          const message = failureMessage || 'OpenCode execution failed';
+          let message = failureMessage || 'OpenCode execution failed';
+          // 無音タイムアウトで止めた場合、死因はサーバが握った 429 かもしれない。
+          // メッセージ文字列だけでは判別できないため、セッションを検死する。
+          if (
+            abortCause === 'timeout'
+            && !containsRateLimitError(message)
+            && opencodeApiClient !== undefined
+            && activeSessionId !== undefined
+          ) {
+            const rateLimitMessage = await postmortemRateLimitError(
+              opencodeApiClient,
+              activeSessionId,
+              options.cwd,
+            );
+            if (rateLimitMessage !== undefined) {
+              log.warn('OpenCode stream stalled on a provider rate limit', {
+                sessionId: activeSessionId,
+                model: options.model,
+                error: rateLimitMessage,
+              });
+              message = rateLimitMessage;
+            }
+          }
           if (containsRateLimitError(message)) {
             const rateLimitedResponse = this.buildRateLimitedResponse(agentType, activeSessionId, message);
             emitResult(options.onStream, false, rateLimitedResponse.error ?? rateLimitedResponse.content, activeSessionId);

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -298,14 +298,36 @@ export type OpenCodeSessionMessages = NonNullable<Awaited<ReturnType<OpencodeCli
 
 /** レート制限を示す HTTP ステータス。プロバイダは 429 を返す。 */
 const RATE_LIMIT_STATUS_CODE = 429;
+/** 検死 RPC の上限。検死自体がハングして再度の無限待ちを招かないようにする。 */
+const OPENCODE_POSTMORTEM_TIMEOUT_MS = 5000;
+
+/** statusCode は数値でも文字列でも来うるため正規化する。 */
+function extractStatusCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+  const data = (error as { data?: { statusCode?: unknown } }).data;
+  const raw = data?.statusCode;
+  if (typeof raw === 'number') {
+    return raw;
+  }
+  if (typeof raw === 'string') {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
 
 /**
- * セッションの最後の assistant メッセージのエラーを検死し、レート制限なら
- * その内容を返す。
+ * 直近の assistant メッセージのエラーを検死し、レート制限ならその内容を返す。
  *
  * OpenCode サーバはプロバイダの 429 を内部リトライで握り、イベントバスへ
  * session.error を流さない。takt からは「無音のまま停止したセッション」に
  * 見えるため、無音ウォッチドッグのタイムアウト後にここで死因を確かめる。
+ *
+ * 判定するのは「最新の assistant メッセージ」だけに限る。sessionId は phase や
+ * resume で再利用されるため、過去の assistant に残る古い 429 を今回の死因と
+ * 誤認しないようにする。
  */
 async function postmortemRateLimitError(
   client: OpencodeClient,
@@ -314,13 +336,23 @@ async function postmortemRateLimitError(
 ): Promise<string | undefined> {
   let messages: OpenCodeSessionMessages;
   try {
-    const result = await client.session.messages({ sessionID, directory });
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      client.session.messages({ sessionID, directory }),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('OpenCode postmortem timed out')), OPENCODE_POSTMORTEM_TIMEOUT_MS);
+      }),
+    ]).finally(() => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    });
     if (!result.data) {
       return undefined;
     }
     messages = result.data;
   } catch (error) {
-    // 検死そのものの失敗で本来のエラーを覆い隠さない。
+    // 検死そのものの失敗（RPC エラー・ハング）で本来のエラーを覆い隠さない。
     log.debug('Rate limit postmortem could not read session messages', {
       sessionID,
       error: getErrorMessage(error),
@@ -328,24 +360,20 @@ async function postmortemRateLimitError(
     return undefined;
   }
 
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const info = messages[index]?.info;
-    if (info?.role !== 'assistant') {
-      continue;
-    }
-    const error = info.error;
-    if (error === undefined) {
-      continue;
-    }
-    const data = error.data as { message?: unknown; statusCode?: unknown } | undefined;
-    const message = typeof data?.message === 'string' ? data.message : undefined;
-    const statusCode = typeof data?.statusCode === 'number' ? data.statusCode : undefined;
-    if (statusCode === RATE_LIMIT_STATUS_CODE || (message !== undefined && containsRateLimitError(message))) {
-      return message ?? `HTTP ${RATE_LIMIT_STATUS_CODE} Too Many Requests`;
-    }
-    // 直近の assistant メッセージにレート制限以外のエラーが乗っているなら、
-    // それが死因なので探索を打ち切る。
+  const latestAssistantInfo = [...messages]
+    .reverse()
+    .map((message) => message.info)
+    .find((info): info is Extract<typeof info, { role: 'assistant' }> => info?.role === 'assistant');
+  const error = latestAssistantInfo?.error;
+  if (error === undefined) {
     return undefined;
+  }
+  const message = extractOpenCodeErrorMessage(error);
+  if (extractStatusCode(error) === RATE_LIMIT_STATUS_CODE) {
+    return message ?? `HTTP ${RATE_LIMIT_STATUS_CODE} Too Many Requests`;
+  }
+  if (message !== undefined && containsRateLimitError(message)) {
+    return message;
   }
   return undefined;
 }
@@ -1278,7 +1306,7 @@ export class OpenCodeClient {
         diag.onCompleted(success ? 'normal' : 'error', success ? undefined : failureMessage);
 
         if (!success) {
-          let message = failureMessage || 'OpenCode execution failed';
+          const message = failureMessage || 'OpenCode execution failed';
           // 無音タイムアウトで止めた場合、死因はサーバが握った 429 かもしれない。
           // メッセージ文字列だけでは判別できないため、セッションを検死する。
           if (
@@ -1298,7 +1326,11 @@ export class OpenCodeClient {
                 model: options.model,
                 error: rateLimitMessage,
               });
-              message = rateLimitMessage;
+              // 検死で 429 と確定済み。message 文字列に 429 の語が含まれるとは
+              // 限らない（statusCode だけで判定した場合）ため再判定はしない。
+              const rateLimitedResponse = this.buildRateLimitedResponse(agentType, activeSessionId, rateLimitMessage);
+              emitResult(options.onStream, false, rateLimitedResponse.error ?? rateLimitedResponse.content, activeSessionId);
+              return rateLimitedResponse;
             }
           }
           if (containsRateLimitError(message)) {

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -354,11 +354,14 @@ async function postmortemRateLimitError(
     return undefined;
   }
 
-  const latestAssistantInfo = [...messages]
-    .reverse()
-    .map((message) => message.info)
-    .find((info): info is Extract<typeof info, { role: 'assistant' }> => info?.role === 'assistant');
-  const error = latestAssistantInfo?.error;
+  // 末尾が assistant でないなら、今回のターンの応答はまだ作られていない。
+  // ここで過去へ遡ると、セッション再利用時に前回ターンの 429 を今回の死因と
+  // 誤認する（[前回 assistant 429, 今回 user prompt] のまま無音停止する形）。
+  const latestInfo = messages[messages.length - 1]?.info;
+  if (latestInfo?.role !== 'assistant') {
+    return undefined;
+  }
+  const error = latestInfo.error;
   if (error === undefined) {
     return undefined;
   }

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -336,17 +336,11 @@ async function postmortemRateLimitError(
 ): Promise<string | undefined> {
   let messages: OpenCodeSessionMessages;
   try {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    const result = await Promise.race([
-      client.session.messages({ sessionID, directory }),
-      new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => reject(new Error('OpenCode postmortem timed out')), OPENCODE_POSTMORTEM_TIMEOUT_MS);
-      }),
-    ]).finally(() => {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-      }
-    });
+    const result = await withTimeout(
+      (signal) => client.session.messages({ sessionID, directory }, { signal }),
+      OPENCODE_POSTMORTEM_TIMEOUT_MS,
+      'OpenCode rate limit postmortem timed out',
+    );
     if (!result.data) {
       return undefined;
     }


### PR DESCRIPTION
Closes #985

## 問題（実測）

OpenCode サーバはプロバイダの 429 を内部リトライで握り、イベントバスへ `session.error` を流さない。セッションは進捗ゼロのまま生存し、takt からは無音に見える。無音ウォッチドッグ（#984）はタイムアウトエラーで落とすが、その文字列は `OpenCode stream timed out after N minutes of inactivity` なので `containsRateLimitError()` に到達せず、`rate_limited` に分類されない。結果、エンジンのレート制限バックオフに接続できない。

2026-07-09 のベンチ実走で ollama-cloud の 429 により qwen の implement が3本とも無音停止した。opencode.log には `AI_APICallError: Too Many Requests` が並ぶが、takt のセッションログには 1 件も届いていなかった。

## 変更

無音タイムアウトで abort した場合に限り `session.messages` を照会し、**最新の assistant メッセージ**の `error` を検死する。

- `ApiError.data.statusCode`（数値・文字列とも正規化）が 429、または既存の `extractOpenCodeErrorMessage` が取り出したメッセージが rate limit パターンに合致すれば `status: 'rate_limited'` / `errorKind: 'rate_limit'` で返す
- 検死 RPC は既存の `withTimeout` で 5 秒に bound。検死自体のハングで再度の無限待ちにならない
- 判定は最新の assistant のみ。sessionId は phase / resume で再利用されるため、過去の assistant に残る古い 429 を誤検出しない
- 検死の失敗、無関係なエラー、external abort、prompt 失敗では元のタイムアウトエラーを保つ
- 検死で 429 が確定した場合は message 文字列の再判定をしない（statusCode だけで判定した場合を取りこぼさないため）

## テスト

`opencode-client-cleanup.test.ts` に 8 件追加（既存の `ChatterOnlyEventStream` を流用）。

- 429 → rate_limited / statusCode が文字列 → rate_limited / top-level message に 429 → rate_limited
- 無関係なエラー → timeout 保持 / エラーなし → timeout 保持
- 古い assistant に 429、最新にはなし → 誤検出しない
- 検死クエリが失敗 → timeout 保持 / 検死クエリがハング → timeout 保持（ハングしない）

build / lint / 全 unit shard green。codex $coding レビュー 2 周（指摘3件修正 → APPROVE）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 無音タイムアウト（idle watchdog）で停止したセッションについて、補足情報も参照してレート制限（429）か通常エラーかの判定精度を向上しました。
  * 429の表現（本文に含まれる/数値・文字列）や、過去の429が混在する場合でも誤判定しにくくしました。
  * 補足取得がハング/失敗しても、タイムアウト結果が正常に完了する挙動を維持しました。
* **Tests**
  * stalled時の判定分岐、混在ケース、補足取得のハング/失敗時挙動を追加で検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->