### PR TITLE
chore: codex-sdk 0.144.1 / claude-agent-sdk 0.3.206 へ更新

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-bETaKbQO+WKDlyEy9uuDzMSnowvOWa988d+1p3a3zc4=";
+            npmDepsHash = "sha256-0XGv3uMwMWpv/jOhrCBj7X5uZFGMh4cCNiDx6WbRJ+4=";
             nodejs = nodejs;
             ONNXRUNTIME_NODE_INSTALL = "skip";
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.0.0",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.170",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.206",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/codex-sdk": "^0.137.0",
+        "@openai/codex-sdk": "^0.144.1",
         "@opencode-ai/sdk": "^1.17.3",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
@@ -124,22 +124,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.170.tgz",
-      "integrity": "sha512-pAvhfk+iTodXZ6RF18Kz7BEUWFjL7EcR3tKuhUNdPpE1NAYCR3mSHGbafi72JsrNwKEDIs7FU31z3fqhwy8QzA==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.206.tgz",
+      "integrity": "sha512-KljDh9Pg4YCYpoXS8dnWoVSsOHtU4yLCW268K2iOruSxFXE8/Tay6DPvmJzYuqjP5YLNYfj05ZGykwZSUn6GXA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.170",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.170"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.206",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.206"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.170.tgz",
-      "integrity": "sha512-rwfgArIa5WI0QPNqFsRBgvtSI0mrtpynUm0oK6+l6/KX4hcgnYGEzciZR1bOeD9/7sSZlTdIgt+T9alKeZmXcg==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.206.tgz",
+      "integrity": "sha512-FL2+NKcMMN47vcnCW2Fkt3AOgeRRlQxrisbPNaxrxqPJFzhUKs17x5j0XzLefd0xRbDAr74hd0PK/tnp6PHM6w==",
       "cpu": [
         "arm64"
       ],
@@ -161,9 +161,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.170.tgz",
-      "integrity": "sha512-0e58h8UQMtsQxLGIv9r4foxfBFWKZ7NeDtoplLhuD7EwQonehomw1sBXCch77t/IfUS+q5vQ5zv+fOGmap5nLQ==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.206.tgz",
+      "integrity": "sha512-mRW8PPMfQN15EunLwpdmcVzk3XuM4DXQUM8DOzaeA1Hr1yxYPaVVBLr9hkdBKOqr8XTl3ueoTR6RZAy6a/n7OA==",
       "cpu": [
         "x64"
       ],
@@ -174,9 +174,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.170.tgz",
-      "integrity": "sha512-gLbaFqcGppFJQd4DLNV4IXoeahejT/p2/M8bSSvRDbla9GOsBr1AxV5XLRyBn1e7xFGozZIAIQr3+1chp7NJgQ==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.206.tgz",
+      "integrity": "sha512-Id6H8l6EsGb7849EAZDOB4Ic+FQpbzt4D5HGOwp59CTW3o/1c4etjQA/Kl1K+DSEWn3FGo6D5UMVgc/rwhBj8g==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.170.tgz",
-      "integrity": "sha512-SRYfQcsXlOq+CD/FqkQBTSHbaD++w73GnnO+NUV9adLYrca3kfetRwWT1iguY1cNS0l34dCR3rlzCPq78vg1Jg==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.206.tgz",
+      "integrity": "sha512-aMZe1Kl+kYv5QlA15W9Ae25MAzBsA9FA40f5TOtJebA+M/xliF0r2LLb2NdyBviiZCDllcE31l0zgYE0rQqFQw==",
       "cpu": [
         "arm64"
       ],
@@ -200,9 +200,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.170.tgz",
-      "integrity": "sha512-Xl/m7TaSC3T5IDBdHrZQ9fCQYyDmPELN34CL+MoyPIf7uSmuZnjE9fUOqDh2Rv26JxWssi1M6X+BBvVuKd6Cpg==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.206.tgz",
+      "integrity": "sha512-egZhOC1RlEVhZyq6Oa1b04AF7hh4hO+8oCsJCZ3gOifJQuHih1oW3lZ8fOUxU85jlT2ytAnt5kRp4uQr6PJgbg==",
       "cpu": [
         "x64"
       ],
@@ -213,9 +213,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.170.tgz",
-      "integrity": "sha512-m4+I0qBEk7cxRKS+pL+eoWXbXTFOAo83fQ0tQvap4z/mDMm06IWJtEPoYTaMBwsp32GJWLkHWKbZSBCHZnp2DQ==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.206.tgz",
+      "integrity": "sha512-xQBOBhlcmTNc7YeYT5qLZOikpSq3WHlsJ/t6i7kJqUWrcXlOPaAoSMdKp5xO/V0CjAdzdJoWB88I55UAh8mclQ==",
       "cpu": [
         "x64"
       ],
@@ -226,9 +226,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.170.tgz",
-      "integrity": "sha512-IG+8isJNNJKbnnhO7m+PGhfVCg+XoQ/MDxGde5eigFI0WsEfitjuWSWwx82bT9ghxI1aa6qNvI+UPgPcZuo5Fg==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.206.tgz",
+      "integrity": "sha512-oRQk23bFXSz4QRhOxqnnvlLWq/KiF2PtSBYXrMg1AQrCOHJd2k66aOAS7AJ4ZSzejiyV4N6sS6UThfmF6ipHBQ==",
       "cpu": [
         "arm64"
       ],
@@ -239,9 +239,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.170",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.170.tgz",
-      "integrity": "sha512-7cuqSKbHVItPGVwRbd3A0BEJwcNtc7Fhoh6qHN4C6yrmjSrvdYYx3MLvq/VI768/RoG7mAMDxb+j7WfEfoP9BA==",
+      "version": "0.3.206",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.206.tgz",
+      "integrity": "sha512-BdjKmDojZjc5RjN+8Q6K7Yqf1WYhel6I3DkMXc9zdxS/xIuN42sx7zgQpdMGY73pm7ROPLqo3LieOeMhVH161w==",
       "cpu": [
         "x64"
       ],
@@ -3491,9 +3491,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0.tgz",
-      "integrity": "sha512-1jUsCnzDBwv7Z4VFZajIlsz41fC18qg6d5qK4PEZhiUk0zJHS90/uGBA70aQPUJLTUZShvyKVAANjw6J/D9eYQ==",
+      "version": "0.144.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
+      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -3502,19 +3502,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.137.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.137.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.137.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.137.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.137.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.137.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.137.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-darwin-arm64.tgz",
-      "integrity": "sha512-YjKmre7DlKslQVhSfocHscgxntZKaZc1LQySKh7q+hNL8jdK+c8nSWSePi583yKFNIxZ8Z/zCkewtjFNvOpQiQ==",
+      "version": "0.144.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
+      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
       "cpu": [
         "arm64"
       ],
@@ -3529,9 +3529,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.137.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-darwin-x64.tgz",
-      "integrity": "sha512-zjzrFV80LZby9et44dan82e3cwUd46U7u1LSVXTIz5AUcY4y1KZpAeN6cSLVKMZuOHXTDpi15MUQdRwzdeqIOg==",
+      "version": "0.144.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
+      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
       "cpu": [
         "x64"
       ],
@@ -3546,9 +3546,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.137.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-linux-arm64.tgz",
-      "integrity": "sha512-R3ZZymQQA1qpp6OpowN49XJ4scHwSckq7CjVvgmLv3bIs3X+F0XXK3xPFkC9vs2mX3wPekPi3ONpxx+yPAsJ6Q==",
+      "version": "0.144.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
+      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
       "cpu": [
         "arm64"
       ],
@@ -3563,9 +3563,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.137.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-linux-x64.tgz",
-      "integrity": "sha512-n+26MUj8rekbEDUeYTGoD6HXuGS0MmLHn2LOn0i5qTNYIJvXV82B7cCLSTzVKF/RJxRMRl22se9Q0Z035JIVng==",
+      "version": "0.144.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
+      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
       "cpu": [
         "x64"
       ],
@@ -3579,12 +3579,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.137.0.tgz",
-      "integrity": "sha512-KYNY7shsKYOLRNV+kjOoaBaLVHy+FUolHPFraOU4JGeyNR1pORxINTAlwHSxDcuXTibj/3OC6jMGDl7X0q4MUw==",
+      "version": "0.144.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.144.1.tgz",
+      "integrity": "sha512-NVb1R5+QJBecLrLrtljHkS7djXu/fGWVaA0FUhop6KgPTdeDzvgMo9uhgAuLi+4mwgf29IhMyNGU/kHG3aV4NA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.137.0"
+        "@openai/codex": "0.144.1"
       },
       "engines": {
         "node": ">=18"
@@ -3592,9 +3592,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.137.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-win32-arm64.tgz",
-      "integrity": "sha512-Cofktt213TycdQ/v+nAUuwXUBzjMWfA/ZkXyqefyXxDgw0TMtaiM3cgDna3I8YdXnR0PM9AMbx4t7VloJ3ZZYQ==",
+      "version": "0.144.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
+      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
       "cpu": [
         "arm64"
       ],
@@ -3609,9 +3609,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.137.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-win32-x64.tgz",
-      "integrity": "sha512-g9qZ9ERrm5OWXMWJOgojYv1kOc5jajTKq37PBMSe56aJfAr9Jk/qBvIOy7LKq3rABdXuz8k+W65PIt2E1hXilw==",
+      "version": "0.144.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
+      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
   ],
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.0.0",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.170",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.206",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex-sdk": "^0.137.0",
+    "@openai/codex-sdk": "^0.144.1",
     "@opencode-ai/sdk": "^1.17.3",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",


### PR DESCRIPTION
## 概要

- `@openai/codex-sdk` `^0.137.0` → `^0.144.1`
- `@anthropic-ai/claude-agent-sdk` `^0.3.170` → `^0.3.206`

## 検証

`npm run check:release`（build / lint / unit / test:it / e2e:mock / e2e:provider）を #1014 込みの main 上で実施。

- codex provider e2e: 全通過（0.144.1）
- claude / claude-sdk provider e2e: 全通過（0.3.206）
- opencode provider e2e で1件失敗したが、原因は本更新と無関係（opencode SDK は未更新。qwen3-coder-next が phase 1 でツールのみ実行しテキストを返さないケースを TAKT が空応答として abort する既存挙動。別途対応）
- `npm ls` 整合確認済み（lockfile の巻き添え変更なし）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * AI機能で利用する主要SDKの依存バージョンを更新し、最新の改善点を取り込みました。
  * これにより安定性やパフォーマンスの向上が期待でき、より快適にご利用いただけます。
* **その他**
  * パッケージ検証用のハッシュ情報を更新し、ビルドの整合性を保ちました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->