### PR TITLE
[#971] fix-callable-gate-timeout

### DIFF
--- a/src/__tests__/it-workflow-loader.test.ts
+++ b/src/__tests__/it-workflow-loader.test.ts
@@ -1347,6 +1347,48 @@ steps:
     ]);
   });
 
+  it('should load a callable command quality gate with timeout_ms from YAML', () => {
+    const workflowsDir = join(testDir, '.takt', 'workflows');
+    mkdirSync(workflowsDir, { recursive: true });
+    writeFileSync(join(testDir, '.takt', 'config.yaml'), 'workflow_command_gates:\n  custom_scripts: true\n');
+
+    writeFileSync(join(workflowsDir, 'callable-command-gate.yaml'), `
+name: callable-command-gate
+description: Callable workflow with a command quality gate timeout
+subworkflow:
+  callable: true
+  visibility: internal
+max_steps: 5
+initial_step: implement
+
+steps:
+  - name: implement
+    persona: coder
+    edit: true
+    quality_gates:
+      - type: command
+        name: quality-check
+        command: "./.takt/quality-gates/check.sh"
+        timeout_ms: 900000
+    rules:
+      - condition: Done
+        next: COMPLETE
+    instruction: "Implement the feature"
+`);
+
+    const config = loadWorkflowConfig('callable-command-gate', testDir);
+
+    expect(config).not.toBeNull();
+    expect(config!.steps.find((step) => step.name === 'implement')?.qualityGates).toEqual([
+      {
+        type: 'command',
+        name: 'quality-check',
+        command: './.takt/quality-gates/check.sh',
+        timeoutMs: 900000,
+      },
+    ]);
+  });
+
   it('rejects workflow command quality gates by default', () => {
     const workflowsDir = join(testDir, '.takt', 'workflows');
     mkdirSync(workflowsDir, { recursive: true });
@@ -1499,6 +1541,7 @@ steps:
           - type: command
             name: arch-quality-check
             command: "./.takt/quality-gates/check.sh"
+            timeout_ms: 300000
         rules:
           - condition: approved
     rules:
@@ -1516,6 +1559,7 @@ steps:
         type: 'command',
         name: 'arch-quality-check',
         command: './.takt/quality-gates/check.sh',
+        timeoutMs: 300000,
       },
     ]);
   });

--- a/src/__tests__/system-workflow-schema.test.ts
+++ b/src/__tests__/system-workflow-schema.test.ts
@@ -1083,7 +1083,7 @@ describe('system workflow schema', () => {
     }
   });
 
-  it('agent step で string gate と command gate が混在する quality_gates を保持できる', () => {
+  it('agent step の quality_gates を raw 形式で保持できる', () => {
     const result = WorkflowStepRawSchema.safeParse({
       name: 'implement',
       persona: 'coder',
@@ -1116,10 +1116,41 @@ describe('system workflow schema', () => {
           name: 'quality-check',
           command: './.takt/quality-gates/check.sh',
           cwd: '.',
-          timeoutMs: 300000,
+          timeout_ms: 300000,
         },
       ]);
     }
+  });
+
+  it('command gate の timeoutMs を raw input として拒否する', () => {
+    const result = WorkflowStepRawSchema.safeParse({
+      name: 'implement',
+      persona: 'coder',
+      instruction: 'Implement the feature',
+      quality_gates: [
+        {
+          type: 'command',
+          command: './.takt/quality-gates/check.sh',
+          timeoutMs: 300000,
+        },
+      ],
+      rules: [
+        {
+          when: 'done',
+          next: 'COMPLETE',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ['quality_gates', 0],
+          message: 'Unrecognized key: "timeoutMs"',
+        }),
+      ]),
+    );
   });
 
   it('system step では agent 用フィールドを拒否する', () => {

--- a/src/__tests__/workflowCallResolver.test.ts
+++ b/src/__tests__/workflowCallResolver.test.ts
@@ -61,6 +61,67 @@ describe('workflowCallResolver module boundary', () => {
     expect(workflowLoader).not.toHaveProperty('validateWorkflowCallRulesAgainstChildReturns');
   });
 
+  it('loads a callable command quality gate with timeout_ms through workflow_call resolution', () => {
+    writeProjectWorkflow('parent.yaml', `name: parent
+initial_step: delegate
+max_steps: 3
+steps:
+  - name: delegate
+    kind: workflow_call
+    call: child
+    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+      - condition: ABORT
+        next: ABORT
+`);
+    writeProjectWorkflow('child.yaml', `name: child
+subworkflow:
+  callable: true
+  visibility: internal
+initial_step: implement
+max_steps: 3
+steps:
+  - name: implement
+    persona: coder
+    edit: true
+    quality_gates:
+      - type: command
+        name: quality-check
+        command: "./.takt/quality-gates/check.sh"
+        timeout_ms: 900000
+    instruction: Implement the feature
+    rules:
+      - condition: done
+        next: COMPLETE
+`);
+    writeFileSync(
+      join(projectDir, '.takt', 'config.yaml'),
+      'workflow_command_gates:\n  custom_scripts: true\n',
+      'utf-8',
+    );
+
+    const parentWorkflow = loadProjectWorkflow('parent.yaml');
+    expect(parentWorkflow).not.toBeNull();
+
+    const childWorkflow = workflowCallResolver.resolveWorkflowCallTarget(
+      parentWorkflow!,
+      findWorkflowCallStep(parentWorkflow!, 'delegate'),
+      projectDir,
+      projectDir,
+    );
+
+    expect(childWorkflow).not.toBeNull();
+    expect(childWorkflow!.steps.find((step) => step.name === 'implement')?.qualityGates).toEqual([
+      {
+        type: 'command',
+        name: 'quality-check',
+        command: './.takt/quality-gates/check.sh',
+        timeoutMs: 900000,
+      },
+    ]);
+  });
+
   it('prefers parent workflow metadata over fallback context for nested relative workflow_call resolution', () => {
     const rootWorkflowPath = join(externalDir, 'root.yaml');
     const childWorkflowPath = join(externalDir, 'child', 'child.yaml');

--- a/src/core/models/schema-base.ts
+++ b/src/core/models/schema-base.ts
@@ -319,16 +319,6 @@ const CommandQualityGateInputSchema = z.object({
   timeout_ms: z.number().int().positive().optional(),
 }).strict();
 
-function normalizeCommandQualityGate(gate: z.output<typeof CommandQualityGateInputSchema>) {
-  return {
-    type: gate.type,
-    ...(gate.name !== undefined ? { name: gate.name } : {}),
-    command: gate.command,
-    ...(gate.cwd !== undefined ? { cwd: gate.cwd } : {}),
-    ...(gate.timeout_ms !== undefined ? { timeoutMs: gate.timeout_ms } : {}),
-  };
-}
-
 const QualityGateRawSchema = z.unknown().superRefine((gate, ctx) => {
   if (typeof gate === 'string') {
     return;
@@ -357,7 +347,7 @@ const QualityGateRawSchema = z.unknown().superRefine((gate, ctx) => {
     return gate;
   }
 
-  return normalizeCommandQualityGate(CommandQualityGateInputSchema.parse(gate));
+  return CommandQualityGateInputSchema.parse(gate);
 });
 
 /** Quality gates schema - AI directives and command gates for step completion */

--- a/src/infra/config/configNormalizers.ts
+++ b/src/infra/config/configNormalizers.ts
@@ -1,10 +1,12 @@
 import type {
-  CommandQualityGate,
   QualityGate,
   RateLimitFallbackConfig,
   StepProviderOptions,
   WorkflowRuntimeConfig,
 } from '../../core/models/workflow-types.js';
+import type { z } from 'zod';
+import type { QualityGatesSchema } from '../../core/models/schema-base.js';
+import type { WorkflowOverridesSchema } from '../../core/models/config-schemas.js';
 import type { PermissionMode } from '../../core/models/status.js';
 import type { ProviderPermissionProfiles } from '../../core/models/provider-profiles.js';
 import type {
@@ -26,11 +28,6 @@ import {
 } from './providerReference.js';
 import { normalizeProviderOptions, type NormalizeProviderOptionsOptions } from './providerOptions.js';
 
-type RawCommandQualityGate = Omit<CommandQualityGate, 'timeoutMs'> & {
-  timeout_ms?: number;
-  timeoutMs?: number;
-};
-
 type RawProviderRoutingEntry = string | {
   type?: string;
   provider?: string;
@@ -38,8 +35,9 @@ type RawProviderRoutingEntry = string | {
   provider_options?: Record<string, unknown>;
 };
 
-type RawQualityGate = string | RawCommandQualityGate;
-type RawQualityGateOverride = { quality_gates?: RawQualityGate[] };
+type RawQualityGate = NonNullable<z.output<typeof QualityGatesSchema>>[number];
+type RawWorkflowOverrides = z.output<typeof WorkflowOverridesSchema>;
+type SerializedQualityGateOverride = { quality_gates?: RawQualityGate[] };
 
 type RawAutoRoutingConfig = {
   strategy: AutoRoutingConfig['strategy'];
@@ -67,13 +65,11 @@ function normalizeQualityGate(gate: RawQualityGate): QualityGate {
     ...(gate.name !== undefined ? { name: gate.name } : {}),
     command: gate.command,
     ...(gate.cwd !== undefined ? { cwd: gate.cwd } : {}),
-    ...(gate.timeoutMs !== undefined || gate.timeout_ms !== undefined
-      ? { timeoutMs: gate.timeoutMs ?? gate.timeout_ms }
-      : {}),
+    ...(gate.timeout_ms !== undefined ? { timeoutMs: gate.timeout_ms } : {}),
   };
 }
 
-function normalizeQualityGates(gates: RawQualityGate[] | undefined): QualityGate[] | undefined {
+export function normalizeQualityGates(gates: RawQualityGate[] | undefined): QualityGate[] | undefined {
   return gates?.map(normalizeQualityGate);
 }
 
@@ -272,12 +268,7 @@ export function denormalizeProviderProfiles(
 }
 
 export function normalizeWorkflowOverrides(
-  raw: {
-    quality_gates?: RawQualityGate[];
-    quality_gates_edit_only?: boolean;
-    steps?: Record<string, RawQualityGateOverride>;
-    personas?: Record<string, RawQualityGateOverride>;
-  } | undefined,
+  raw: RawWorkflowOverrides,
 ): WorkflowOverrides | undefined {
   if (!raw) return undefined;
   return {
@@ -287,7 +278,7 @@ export function normalizeWorkflowOverrides(
       ? Object.fromEntries(
         Object.entries(raw.steps).map(([name, override]) => [
           name,
-          { qualityGates: normalizeQualityGates(override.quality_gates) },
+          { qualityGates: normalizeQualityGates(override?.quality_gates) },
         ])
       )
       : undefined,
@@ -295,7 +286,7 @@ export function normalizeWorkflowOverrides(
       ? Object.fromEntries(
         Object.entries(raw.personas).map(([name, override]) => [
           name,
-          { qualityGates: normalizeQualityGates(override.quality_gates) },
+          { qualityGates: normalizeQualityGates(override?.quality_gates) },
         ])
       )
       : undefined,
@@ -307,15 +298,15 @@ export function denormalizeWorkflowOverrides(
 ): {
   quality_gates?: RawQualityGate[];
   quality_gates_edit_only?: boolean;
-  steps?: Record<string, RawQualityGateOverride>;
-  personas?: Record<string, RawQualityGateOverride>;
+  steps?: Record<string, SerializedQualityGateOverride>;
+  personas?: Record<string, SerializedQualityGateOverride>;
 } | undefined {
   if (!overrides) return undefined;
   const result: {
     quality_gates?: RawQualityGate[];
     quality_gates_edit_only?: boolean;
-    steps?: Record<string, RawQualityGateOverride>;
-    personas?: Record<string, RawQualityGateOverride>;
+    steps?: Record<string, SerializedQualityGateOverride>;
+    personas?: Record<string, SerializedQualityGateOverride>;
   } = {};
   if (overrides.qualityGates !== undefined) {
     result.quality_gates = denormalizeQualityGates(overrides.qualityGates);
@@ -326,7 +317,7 @@ export function denormalizeWorkflowOverrides(
   if (overrides.steps) {
     result.steps = Object.fromEntries(
       Object.entries(overrides.steps).map(([name, override]) => {
-        const stepOverride: RawQualityGateOverride = {};
+        const stepOverride: SerializedQualityGateOverride = {};
         if (override.qualityGates !== undefined) {
           stepOverride.quality_gates = denormalizeQualityGates(override.qualityGates);
         }
@@ -337,7 +328,7 @@ export function denormalizeWorkflowOverrides(
   if (overrides.personas) {
     result.personas = Object.fromEntries(
       Object.entries(overrides.personas).map(([name, override]) => {
-        const personaOverride: RawQualityGateOverride = {};
+        const personaOverride: SerializedQualityGateOverride = {};
         if (override.qualityGates !== undefined) {
           personaOverride.quality_gates = denormalizeQualityGates(override.qualityGates);
         }

--- a/src/infra/config/global/globalConfigCore.ts
+++ b/src/infra/config/global/globalConfigCore.ts
@@ -2,7 +2,6 @@ import { writeFileSync } from 'node:fs';
 import { stringify as stringifyYaml } from 'yaml';
 import { GlobalConfigSchema } from '../../../core/models/index.js';
 import type { GlobalConfig, TaktProviderConfigEntry } from '../../../core/models/config-types.js';
-import type { QualityGate } from '../../../core/models/workflow-types.js';
 import {
   normalizeConfigProviderReference,
   type ConfigProviderReference,
@@ -207,12 +206,7 @@ export class GlobalConfigManager {
       } : undefined,
       autoFetch: parsed.auto_fetch,
       baseBranch: parsed.base_branch,
-      workflowOverrides: normalizeWorkflowOverrides(parsed.workflow_overrides as {
-        quality_gates?: QualityGate[];
-        quality_gates_edit_only?: boolean;
-        steps?: Record<string, { quality_gates?: QualityGate[] }>;
-        personas?: Record<string, { quality_gates?: QualityGate[] }>;
-      } | undefined),
+      workflowOverrides: normalizeWorkflowOverrides(parsed.workflow_overrides),
       // Project-local keys (also accepted in global config)
       pipeline: normalizePipelineConfig(
         parsed.pipeline as { default_branch_prefix?: string; commit_message_template?: string; pr_body_template?: string } | undefined,

--- a/src/infra/config/loaders/qualityGateOverrides.ts
+++ b/src/infra/config/loaders/qualityGateOverrides.ts
@@ -18,10 +18,7 @@ function getStepQualityGates(
   overrides: WorkflowOverrides | undefined,
   stepName: string,
 ): QualityGate[] | undefined {
-  const withSteps = overrides as (WorkflowOverrides & {
-    steps?: Record<string, { qualityGates?: QualityGate[] }>;
-  }) | undefined;
-  return withSteps?.steps?.[stepName]?.qualityGates ?? overrides?.steps?.[stepName]?.qualityGates;
+  return overrides?.steps?.[stepName]?.qualityGates;
 }
 
 function normalizeCommandGateCwd(cwd: string | undefined): string {

--- a/src/infra/config/loaders/workflowStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepNormalizer.ts
@@ -35,6 +35,7 @@ import { normalizeWorkflowEffects } from './workflowSystemStepNormalizer.js';
 import { parseAiConditionExpression } from '../../../core/models/workflow-condition-expression.js';
 import { resolveWorkflowProviderOptions } from './workflowProviderOptionsResolver.js';
 import { isWorkflowParamReference } from './workflowCallableParamRef.js';
+import { normalizeQualityGates } from '../configNormalizers.js';
 
 type RawStep = z.output<typeof WorkflowStepRawSchema>;
 type RawProviderReference = RawStep['provider'];
@@ -288,7 +289,7 @@ export function normalizeStepFromRaw(
 
   const qualityGates = applyQualityGateOverrides(
     step.name,
-    step.quality_gates,
+    normalizeQualityGates(step.quality_gates),
     step.edit,
     personaOverrideKey,
     projectOverrides,

--- a/src/infra/config/project/projectConfig.ts
+++ b/src/infra/config/project/projectConfig.ts
@@ -1,7 +1,6 @@
 import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { stringify } from 'yaml';
 import { ProjectConfigSchema } from '../../../core/models/index.js';
-import type { QualityGate } from '../../../core/models/workflow-types.js';
 import { copyProjectResourcesToDir } from '../../resources/index.js';
 import type { ProjectConfig } from '../types.js';
 import type { TaktProviderConfigEntry } from '../../../core/models/config-types.js';
@@ -194,12 +193,7 @@ export function loadProjectConfig(projectDir: string): ProjectConfig {
         step_permission_overrides?: Record<string, string>;
       }> | undefined,
     ),
-    workflowOverrides: normalizeWorkflowOverrides(parsedConfigResult.workflow_overrides as {
-      quality_gates?: QualityGate[];
-      quality_gates_edit_only?: boolean;
-      steps?: Record<string, { quality_gates?: QualityGate[] }>;
-      personas?: Record<string, { quality_gates?: QualityGate[] }>;
-    } | undefined),
+    workflowOverrides: normalizeWorkflowOverrides(parsedConfigResult.workflow_overrides),
     runtime: normalizeRuntime(runtime),
     workflowRuntimePrepare: normalizeWorkflowRuntimePreparePolicy(parsedConfigResult.workflow_runtime_prepare),
     workflowCommandGates: normalizeWorkflowCommandGatesPolicy(parsedConfigResult.workflow_command_gates),


### PR DESCRIPTION
## Summary

## 概要

`subworkflow.callable: true` を宣言したワークフローの step に `type: command` の quality gate を **`timeout_ms` 付き**で書くと、そのワークフローはロード時に必ず Zod バリデーションエラーで失敗します（単体ロード・親からの `workflow_call` 経由の両方）。

- バージョン: takt v0.49.0（npm latest）
- 発生条件: `subworkflow.callable: true` × `type: command` gate × `timeout_ms` の3条件が揃った場合のみ
  - `timeout_ms` を外すとロード成功
  - callable でない（通常の）ワークフローなら `timeout_ms` 付きでもロード成功

## 再現手順

`.takt/config.yaml`:

```yaml
workflow_command_gates:
  custom_scripts: true
```

`.takt/workflows/child.yaml`:

```yaml
name: child
description: minimal callable subworkflow with a command quality gate
subworkflow:
  callable: true
  visibility: internal
max_steps: 5
initial_step: work
steps:
  - name: work
    edit: true
    quality_gates:
      - type: command
        name: tests-green
        command: "echo ok"
        timeout_ms: 900000
    instruction: |
      do the work
    rules:
      - condition: done
        next: COMPLETE
```

これを `workflow_call` で呼ぶ親を実行（または child を直接ロード）すると:

```
[ERROR] [
  {
    "code": "custom",
    "path": [ "steps", 0, "quality_gates", 0 ],
    "message": "Unrecognized key: \"timeoutMs\""
  }
]
```

エラーメッセージが、YAML には書いていない **camelCase の `timeoutMs`** を Unrecognized key として報告する点が特徴です。

## 原因（コード上の該当箇所）

`WorkflowConfigRawSchema` の parse が command gate に対して**非冪等**（parse(parse(x)) が失敗する）ため、callable 展開時の再パースで落ちます。

1. `QualityGateRawSchema`（`core/models/schema-base.ts`）は `.superRefine()` で `CommandQualityGateInputSchema`（**`.strict()`、`timeout_ms` のみ受理**）を検証した後、`.transform()` で `normalizeCommandQualityGate()` を適用し、出力キーを `timeout_ms` → `timeoutMs` にリネームする
2. `normalizeWorkflowConfig`（`infra/config/loaders/workflowParser.ts`）は最初に `WorkflowConfigRawSchema.parse(raw)` を実行 → この時点で gate は `timeoutMs` に変換済み
3. 続く `expandCallableSubworkflowRaw`（`infra/config/loaders/workflowCallableArgResolver.ts`）は、`subworkflow.callable: true` の場合のみ末尾で `WorkflowConfigRawSchema.parse(expanded)` を**再実行**する
4. 再パースに渡るのは手順1で変換済みの `timeoutMs` を持つオブジェクトだが、`CommandQualityGateInputSchema` は strict で `timeout_ms` しか知らないため `Unrecognized key: "timeoutMs"` で必ず失敗する

callable でないワークフローは `expandCallableSubworkflowRaw` が early return して再パースしないため発生しません。`cwd` / `name` / `command` はリネームされないので、キー名が変わる `timeout_ms` だけが引き金になります。

## 期待する挙動

callable subworkflow でも通常ワークフローと同様に `timeout_ms` 付き command gate をロードできること。

修正案（いずれか）:
- `expandCallableSubworkflowRaw` の再パースを、transform 済みオブジェクトではなく transform 前の raw を基に行う
- `CommandQualityGateInputSchema` が正規化済みの `timeoutMs` も受理してパスするようにし、parse を冪等にする
- 展開後の再検証で quality_gates を再検証対象から外す（既に正規化済みのため）

## ワークアラウンド（参考）

子ワークフロー YAML から command gate を外し、`.takt/config.yaml` の `workflow_overrides.steps.<step名>.quality_gates` から注入すると回避できます（config 経路は再パースを通らない）。ただし `workflow_overrides.steps` はワークフロー名でスコープできず全ワークフローのステップ名にマッチするため、builtin（例: `default-draft` の `ai-antipattern-fix`）への誤注入を避けるには子 step 名を一意にする必要があります。

## 環境

- takt: 0.49.0（`npm i -g takt`）
- Node.js: v22.22.3
- OS: macOS (Darwin 25.5.0)

## Execution Report

Workflow `takt-default` completed successfully.

Closes #971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - コマンド品質ゲートで `timeout_ms` を指定すると、設定値が正しく反映されるようになりました。
  - サブワークフローや並列ステップの品質ゲートでも、タイムアウト設定を利用できます。
  - 設定時のキー表記を統一し、不正な `timeoutMs` 入力は明確に拒否されます。

- **テスト**
  - ワークフロー読み込み、設定検証、サブワークフロー呼び出しにおける品質ゲートの動作確認を追加・強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->