### PR TITLE
feat: preserve worktree run artifacts outside clones

### DIFF
--- a/src/__tests__/clone.test.ts
+++ b/src/__tests__/clone.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 
-const { mockLogInfo, mockLogDebug, mockLogError, mockSyncProjectLocalTaktForRetry } = vi.hoisted(() => ({
+const { mockLogInfo, mockLogDebug, mockLogError, mockSyncProjectLocalTaktForRetry, mockInitializeWorktreeRunStorage } = vi.hoisted(() => ({
   mockLogInfo: vi.fn(),
   mockLogDebug: vi.fn(),
   mockLogError: vi.fn(),
   mockSyncProjectLocalTaktForRetry: vi.fn(),
+  mockInitializeWorktreeRunStorage: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({
@@ -61,6 +62,10 @@ vi.mock('../infra/config/index.js', () => ({
 
 vi.mock('../infra/task/projectLocalTaktSync.js', () => ({
   syncProjectLocalTaktForRetry: mockSyncProjectLocalTaktForRetry,
+}));
+
+vi.mock('../infra/task/worktree-run-storage.js', () => ({
+  initializeWorktreeRunStorage: mockInitializeWorktreeRunStorage,
 }));
 
 import { execFileSync, spawn } from 'node:child_process';
@@ -2343,6 +2348,11 @@ describe('auto clone path allocation', () => {
 
     expect(result.path).toBe('/tmp/takt-command-gate-clone');
     expect(mockSyncProjectLocalTaktForRetry).toHaveBeenCalledWith('/project', '/tmp/takt-command-gate-clone');
+    expect(mockInitializeWorktreeRunStorage).toHaveBeenCalledWith(
+      '/project',
+      '/tmp/takt-command-gate-clone',
+      expect.any(String),
+    );
   });
 
   it('should sync project-local quality gate assets after creating an abortable shared clone', async () => {
@@ -2372,6 +2382,11 @@ describe('auto clone path allocation', () => {
       '/project',
       '/tmp/takt-command-gate-abortable-clone',
     );
+    expect(mockInitializeWorktreeRunStorage).toHaveBeenCalledWith(
+      '/project',
+      '/tmp/takt-command-gate-abortable-clone',
+      'feature/local-command-gate',
+    );
   });
 
   it('should sync project-local quality gate assets after creating a temp clone', () => {
@@ -2394,6 +2409,7 @@ describe('auto clone path allocation', () => {
 
     expect(result.path).toContain('/tmp/takt-worktrees/tmp-');
     expect(mockSyncProjectLocalTaktForRetry).toHaveBeenCalledWith('/project', result.path);
+    expect(mockInitializeWorktreeRunStorage).not.toHaveBeenCalled();
   });
 
   it('should allocate a suffixed path when the generated clone path already exists', () => {

--- a/src/__tests__/worktree-run-storage.test.ts
+++ b/src/__tests__/worktree-run-storage.test.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildRunPaths } from '../core/workflow/run/run-paths.js';
+import { readRunContextOrderContent } from '../core/workflow/run/order-content.js';
+import { readRunMetaBySlug } from '../core/workflow/run/run-meta.js';
+import { initializeWorktreeRunStorage } from '../infra/task/worktree-run-storage.js';
+
+describe('initializeWorktreeRunStorage', () => {
+  let root: string;
+  let previousConfigDir: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'takt-run-store-'));
+    previousConfigDir = process.env.TAKT_CONFIG_DIR;
+    process.env.TAKT_CONFIG_DIR = join(root, 'global');
+  });
+
+  afterEach(() => {
+    if (previousConfigDir === undefined) {
+      delete process.env.TAKT_CONFIG_DIR;
+    } else {
+      process.env.TAKT_CONFIG_DIR = previousConfigDir;
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function createClone(name: string): string {
+    const clonePath = join(root, name);
+    mkdirSync(join(clonePath, '.takt'), { recursive: true });
+    return clonePath;
+  }
+
+  it('isolates equal run slugs across clones and survives clone deletion', () => {
+    const projectDir = join(root, 'project');
+    mkdirSync(projectDir);
+    const first = initializeWorktreeRunStorage(projectDir, createClone('clone-a'), 'feature/a');
+    const second = initializeWorktreeRunStorage(projectDir, createClone('clone-b'), 'feature/b');
+
+    expect(first.cloneId).not.toBe(second.cloneId);
+    expect(realpathSync(first.linkPath)).not.toBe(realpathSync(second.linkPath));
+
+    const firstRun = join(first.linkPath, 'same-slug', 'meta.json');
+    const secondRun = join(second.linkPath, 'same-slug', 'meta.json');
+    mkdirSync(join(first.linkPath, 'same-slug'), { recursive: true });
+    mkdirSync(join(second.linkPath, 'same-slug'), { recursive: true });
+    writeFileSync(firstRun, 'first');
+    writeFileSync(secondRun, 'second');
+    expect(readFileSync(join(first.storePath, 'same-slug', 'meta.json'), 'utf8')).toBe('first');
+    expect(readFileSync(join(second.storePath, 'same-slug', 'meta.json'), 'utf8')).toBe('second');
+
+    rmSync(join(root, 'clone-a'), { recursive: true, force: true });
+    expect(readFileSync(join(first.storePath, 'same-slug', 'meta.json'), 'utf8')).toBe('first');
+  });
+
+  it('migrates an existing runs directory without losing its contents', () => {
+    const projectDir = join(root, 'project');
+    mkdirSync(projectDir);
+    const clonePath = createClone('clone');
+    const runsPath = join(clonePath, '.takt', 'runs');
+    mkdirSync(runsPath);
+    writeFileSync(join(runsPath, 'keep.txt'), 'keep');
+
+    const storage = initializeWorktreeRunStorage(projectDir, clonePath, 'feature/existing');
+    expect(readFileSync(join(runsPath, 'keep.txt'), 'utf8')).toBe('keep');
+    expect(readFileSync(join(storage.storePath, 'keep.txt'), 'utf8')).toBe('keep');
+  });
+
+  it('stores only hashed project identity in the manifest', () => {
+    const projectDir = join(root, 'sensitive-project-name');
+    mkdirSync(projectDir);
+    const storage = initializeWorktreeRunStorage(projectDir, createClone('clone'), 'feature/private');
+    const manifest = readFileSync(join(storage.storePath, '..', 'store.json'), 'utf8');
+
+    expect(manifest).not.toContain(projectDir);
+    expect(manifest).not.toContain('sensitive-project-name');
+    expect(manifest).toContain(storage.cloneId);
+  });
+
+  it('reuses an already initialized store without allocating another clone id', () => {
+    const projectDir = join(root, 'project');
+    mkdirSync(projectDir);
+    const clonePath = createClone('clone');
+    const first = initializeWorktreeRunStorage(projectDir, clonePath, 'feature/retry');
+    const second = initializeWorktreeRunStorage(projectDir, clonePath, 'feature/retry');
+
+    expect(second).toEqual(first);
+  });
+
+  it('supports the canonical run path, metadata, and order readers through the link', () => {
+    const projectDir = join(root, 'project');
+    mkdirSync(projectDir);
+    const clonePath = createClone('clone');
+    const storage = initializeWorktreeRunStorage(projectDir, clonePath, 'feature/readers');
+    const paths = buildRunPaths(clonePath, 'run-1');
+    mkdirSync(paths.contextTaskAbs, { recursive: true });
+    writeFileSync(paths.contextTaskOrderAbs, '# order\n');
+    writeFileSync(paths.metaAbs, JSON.stringify({
+      task: 'task',
+      workflow: 'workflow',
+      runSlug: 'run-1',
+      runRoot: paths.runRootRel,
+      reportDirectory: paths.reportsRel,
+      contextDirectory: paths.contextRel,
+      logsDirectory: paths.logsRel,
+      status: 'completed',
+      startTime: '2026-07-12T00:00:00.000Z',
+    }));
+
+    expect(readRunContextOrderContent(clonePath, 'run-1')).toBe('# order\n');
+    expect(readRunMetaBySlug(clonePath, 'run-1')?.status).toBe('completed');
+    expect(readFileSync(join(storage.storePath, 'run-1', 'meta.json'), 'utf8')).toContain('completed');
+  });
+});

--- a/src/__tests__/worktree-run-storage.test.ts
+++ b/src/__tests__/worktree-run-storage.test.ts
@@ -133,6 +133,24 @@ describe('initializeWorktreeRunStorage', () => {
     }
   });
 
+  it('lists healthy preserved runs when an interrupted store has no manifest', () => {
+    const projectDir = join(root, 'project');
+    mkdirSync(projectDir);
+    const storage = initializeWorktreeRunStorage(projectDir, createClone('clone'), 'feature/healthy');
+    mkdirSync(join(storage.storePath, 'healthy-run'));
+    const projectStore = join(storage.storePath, '..', '..');
+    mkdirSync(join(projectStore, 'orphan-clone-id', 'runs', 'partial-run'), { recursive: true });
+    const warnings: string[] = [];
+
+    expect(listStoredProjectRuns(projectDir, (warning) => warnings.push(warning))).toContainEqual({
+      cloneId: storage.cloneId,
+      runSlug: 'healthy-run',
+      runPath: join(storage.storePath, 'healthy-run'),
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('orphan-clone-id');
+  });
+
   it('supports the canonical run path, metadata, and order readers through the link', () => {
     const projectDir = join(root, 'project');
     mkdirSync(projectDir);

--- a/src/__tests__/worktree-run-storage.test.ts
+++ b/src/__tests__/worktree-run-storage.test.ts
@@ -1,11 +1,14 @@
-import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildRunPaths } from '../core/workflow/run/run-paths.js';
 import { readRunContextOrderContent } from '../core/workflow/run/order-content.js';
 import { readRunMetaBySlug } from '../core/workflow/run/run-meta.js';
-import { initializeWorktreeRunStorage } from '../infra/task/worktree-run-storage.js';
+import {
+  initializeWorktreeRunStorage,
+  listStoredProjectRuns,
+} from '../infra/task/worktree-run-storage.js';
 
 describe('initializeWorktreeRunStorage', () => {
   let root: string;
@@ -52,6 +55,11 @@ describe('initializeWorktreeRunStorage', () => {
 
     rmSync(join(root, 'clone-a'), { recursive: true, force: true });
     expect(readFileSync(join(first.storePath, 'same-slug', 'meta.json'), 'utf8')).toBe('first');
+    expect(listStoredProjectRuns(projectDir)).toContainEqual({
+      cloneId: first.cloneId,
+      runSlug: 'same-slug',
+      runPath: join(first.storePath, 'same-slug'),
+    });
   });
 
   it('migrates an existing runs directory without losing its contents', () => {
@@ -65,6 +73,30 @@ describe('initializeWorktreeRunStorage', () => {
     const storage = initializeWorktreeRunStorage(projectDir, clonePath, 'feature/existing');
     expect(readFileSync(join(runsPath, 'keep.txt'), 'utf8')).toBe('keep');
     expect(readFileSync(join(storage.storePath, 'keep.txt'), 'utf8')).toBe('keep');
+  });
+
+  it('migrates a legacy runs directory across filesystems on Linux', () => {
+    if (process.platform !== 'linux' || !existsSync('/dev/shm')) {
+      return;
+    }
+    expect(statSync('/dev/shm').dev).not.toBe(statSync(root).dev);
+    const externalConfigRoot = mkdtempSync('/dev/shm/takt-run-store-');
+    process.env.TAKT_CONFIG_DIR = externalConfigRoot;
+    try {
+      const projectDir = join(root, 'project');
+      mkdirSync(projectDir);
+      const clonePath = createClone('cross-device-clone');
+      const runsPath = join(clonePath, '.takt', 'runs');
+      mkdirSync(runsPath);
+      writeFileSync(join(runsPath, 'keep.txt'), 'cross-device');
+
+      const storage = initializeWorktreeRunStorage(projectDir, clonePath, 'feature/cross-device');
+      expect(readFileSync(join(storage.storePath, 'keep.txt'), 'utf8')).toBe('cross-device');
+      expect(readFileSync(join(runsPath, 'keep.txt'), 'utf8')).toBe('cross-device');
+    } finally {
+      rmSync(externalConfigRoot, { recursive: true, force: true });
+      process.env.TAKT_CONFIG_DIR = join(root, 'global');
+    }
   });
 
   it('stores only hashed project identity in the manifest', () => {

--- a/src/__tests__/worktree-run-storage.test.ts
+++ b/src/__tests__/worktree-run-storage.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -86,6 +86,19 @@ describe('initializeWorktreeRunStorage', () => {
     const second = initializeWorktreeRunStorage(projectDir, clonePath, 'feature/retry');
 
     expect(second).toEqual(first);
+  });
+
+  it('restricts every run-store directory that exposes project or clone identities', () => {
+    const projectDir = join(root, 'project');
+    mkdirSync(projectDir);
+    const storage = initializeWorktreeRunStorage(projectDir, createClone('clone'), 'feature/private');
+    const cloneStore = join(storage.storePath, '..');
+    const projectStore = join(cloneStore, '..');
+    const runStore = join(projectStore, '..');
+
+    for (const directory of [runStore, projectStore, cloneStore, storage.storePath]) {
+      expect(statSync(directory).mode & 0o777).toBe(0o700);
+    }
   });
 
   it('supports the canonical run path, metadata, and order readers through the link', () => {

--- a/src/features/tasks/execute/reusedWorktree.ts
+++ b/src/features/tasks/execute/reusedWorktree.ts
@@ -7,6 +7,7 @@ import {
   type TaskInfo,
 } from '../../../infra/task/index.js';
 import { syncProjectLocalTaktForRetry } from '../../../infra/task/projectLocalTaktSync.js';
+import { initializeWorktreeRunStorage } from '../../../infra/task/worktree-run-storage.js';
 import { isRealPathInside } from '../../../shared/utils/index.js';
 
 export interface ReusedWorktreeExecution {
@@ -59,6 +60,7 @@ export function resolveReusedWorktreeExecution(
   ) {
     syncProjectLocalTaktForRetry(projectDir, worktreePath);
   }
+  initializeWorktreeRunStorage(projectDir, worktreePath, task.data?.branch ?? '(unknown)');
 
   return {
     execCwd: worktreePath,

--- a/src/infra/config/paths.ts
+++ b/src/infra/config/paths.ts
@@ -53,6 +53,11 @@ export function getGlobalLogsDir(): string {
   return join(getGlobalConfigDir(), 'logs');
 }
 
+/** Get durable run storage root outside TAKT-managed worktrees. */
+export function getGlobalRunStoreDir(): string {
+  return join(getGlobalConfigDir(), 'run-store');
+}
+
 /** Get takt global config file path */
 export function getGlobalConfigPath(): string {
   return join(getGlobalConfigDir(), 'config.yaml');

--- a/src/infra/task/clone.ts
+++ b/src/infra/task/clone.ts
@@ -25,6 +25,7 @@ import {
 } from './clone-exec.js';
 import { loadCloneMeta, removeCloneMeta as removeCloneMetaFile, saveCloneMeta as saveCloneMetaFile } from './clone-meta.js';
 import { syncProjectLocalTaktForRetry } from './projectLocalTaktSync.js';
+import { initializeWorktreeRunStorage } from './worktree-run-storage.js';
 
 export type { WorktreeOptions, WorktreeResult };
 export {
@@ -178,6 +179,7 @@ export class CloneManager {
     }
 
     syncProjectLocalTaktForRetry(projectDir, clonePath);
+    initializeWorktreeRunStorage(projectDir, clonePath, branch);
     this.saveCloneMeta(projectDir, branch, clonePath);
     log.info('Clone created', { path: clonePath, branch });
 
@@ -227,6 +229,7 @@ export class CloneManager {
     }
 
     syncProjectLocalTaktForRetry(projectDir, clonePath);
+    initializeWorktreeRunStorage(projectDir, clonePath, branch);
     this.saveCloneMeta(projectDir, branch, clonePath);
     log.info('Clone created', { path: clonePath, branch });
 

--- a/src/infra/task/index.ts
+++ b/src/infra/task/index.ts
@@ -77,3 +77,7 @@ export { autoCommitAndPush, type AutoCommitResult } from './autoCommit.js';
 export { summarizeTaskName } from './summarize.js';
 export { TaskWatcher, type TaskWatcherOptions } from './watcher.js';
 export { isStaleRunningTask } from './process.js';
+export {
+  listStoredProjectRuns,
+  type StoredProjectRun,
+} from './worktree-run-storage.js';

--- a/src/infra/task/index.ts
+++ b/src/infra/task/index.ts
@@ -80,4 +80,5 @@ export { isStaleRunningTask } from './process.js';
 export {
   listStoredProjectRuns,
   type StoredProjectRun,
+  type StoredProjectRunWarningHandler,
 } from './worktree-run-storage.js';

--- a/src/infra/task/worktree-run-storage.ts
+++ b/src/infra/task/worktree-run-storage.ts
@@ -115,12 +115,18 @@ export function initializeWorktreeRunStorage(
   }
   const migrateLegacyRuns = isLegacyRunsDirectory(linkPath);
   const cloneId = randomUUID();
-  const storeContainer = join(getGlobalRunStoreDir(), projectId, cloneId);
+  const runStoreRoot = getGlobalRunStoreDir();
+  const projectStore = join(runStoreRoot, projectId);
+  const storeContainer = join(projectStore, cloneId);
   const storePath = join(storeContainer, 'runs');
 
   try {
     mkdirSync(taktDir, { recursive: true });
-    mkdirSync(storeContainer, { recursive: true, mode: STORE_DIRECTORY_MODE });
+    mkdirSync(runStoreRoot, { recursive: true, mode: STORE_DIRECTORY_MODE });
+    chmodSync(runStoreRoot, STORE_DIRECTORY_MODE);
+    mkdirSync(projectStore, { recursive: true, mode: STORE_DIRECTORY_MODE });
+    chmodSync(projectStore, STORE_DIRECTORY_MODE);
+    mkdirSync(storeContainer, { mode: STORE_DIRECTORY_MODE });
     if (migrateLegacyRuns) {
       renameSync(linkPath, storePath);
     } else {

--- a/src/infra/task/worktree-run-storage.ts
+++ b/src/infra/task/worktree-run-storage.ts
@@ -1,0 +1,163 @@
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { dirname, join, relative } from 'node:path';
+import { getGlobalRunStoreDir } from '../config/paths.js';
+
+const STORE_DIRECTORY_MODE = 0o700;
+const STORE_FILE_MODE = 0o600;
+
+interface RunStoreManifest {
+  readonly schema_version: 1;
+  readonly project_id: string;
+  readonly clone_id: string;
+  readonly created_at: string;
+  readonly branch: string;
+}
+
+export interface WorktreeRunStorage {
+  readonly cloneId: string;
+  readonly linkPath: string;
+  readonly storePath: string;
+}
+
+function hashProjectIdentity(projectDir: string): string {
+  const canonicalProjectDir = realpathSync(projectDir);
+  return createHash('sha256').update(canonicalProjectDir).digest('hex').slice(0, 24);
+}
+
+function readExistingStorage(linkPath: string, projectId: string): WorktreeRunStorage | undefined {
+  try {
+    const stat = lstatSync(linkPath);
+    if (!stat.isSymbolicLink()) {
+      return undefined;
+    }
+    const storePath = realpathSync(linkPath);
+    const storeRoot = realpathSync(getGlobalRunStoreDir());
+    const relativeStore = relative(storeRoot, storePath);
+    if (relativeStore.startsWith('..') || relativeStore.startsWith(`/`) || relativeStore.startsWith('\\')) {
+      throw new Error(`Existing worktree run link points outside the TAKT run store: ${linkPath}`);
+    }
+    const manifestPath = join(storePath, '..', 'store.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Partial<RunStoreManifest>;
+    if (
+      manifest.schema_version !== 1
+      || manifest.project_id !== projectId
+      || typeof manifest.clone_id !== 'string'
+      || manifest.clone_id.length === 0
+    ) {
+      throw new Error(`Existing worktree run store manifest is invalid: ${manifestPath}`);
+    }
+    return { cloneId: manifest.clone_id, linkPath, storePath };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function isLegacyRunsDirectory(linkPath: string): boolean {
+  try {
+    const stat = lstatSync(linkPath);
+    if (stat.isSymbolicLink()) {
+      return false;
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`Refusing to replace non-directory worktree run path: ${linkPath}`);
+    }
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function writeManifest(path: string, manifest: RunStoreManifest): void {
+  writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+    mode: STORE_FILE_MODE,
+  });
+}
+
+function verifyWritable(storePath: string): void {
+  const probePath = join(storePath, '.write-probe');
+  writeFileSync(probePath, '', { flag: 'wx', mode: STORE_FILE_MODE });
+  unlinkSync(probePath);
+}
+
+export function initializeWorktreeRunStorage(
+  projectDir: string,
+  clonePath: string,
+  branch: string,
+): WorktreeRunStorage {
+  const taktDir = join(clonePath, '.takt');
+  const linkPath = join(taktDir, 'runs');
+  const projectId = hashProjectIdentity(projectDir);
+  const existing = readExistingStorage(linkPath, projectId);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const migrateLegacyRuns = isLegacyRunsDirectory(linkPath);
+  const cloneId = randomUUID();
+  const storeContainer = join(getGlobalRunStoreDir(), projectId, cloneId);
+  const storePath = join(storeContainer, 'runs');
+
+  try {
+    mkdirSync(taktDir, { recursive: true });
+    mkdirSync(storeContainer, { recursive: true, mode: STORE_DIRECTORY_MODE });
+    if (migrateLegacyRuns) {
+      renameSync(linkPath, storePath);
+    } else {
+      mkdirSync(storePath, { mode: STORE_DIRECTORY_MODE });
+    }
+    chmodSync(storeContainer, STORE_DIRECTORY_MODE);
+    chmodSync(storePath, STORE_DIRECTORY_MODE);
+    writeManifest(join(storeContainer, 'store.json'), {
+      schema_version: 1,
+      project_id: projectId,
+      clone_id: cloneId,
+      created_at: new Date().toISOString(),
+      branch,
+    });
+    verifyWritable(storePath);
+    const type = process.platform === 'win32' ? 'junction' : 'dir';
+    const target = process.platform === 'win32'
+      ? storePath
+      : relative(dirname(linkPath), storePath);
+    symlinkSync(target, linkPath, type);
+    if (!existsSync(linkPath) || realpathSync(linkPath) !== realpathSync(storePath)) {
+      throw new Error(`Worktree run storage link verification failed: ${linkPath}`);
+    }
+  } catch (error) {
+    try {
+      if (lstatSync(linkPath).isSymbolicLink()) {
+        unlinkSync(linkPath);
+      }
+    } catch {
+      // The link may not have been created.
+    }
+    if (migrateLegacyRuns && existsSync(storePath) && !existsSync(linkPath)) {
+      renameSync(storePath, linkPath);
+    }
+    rmSync(storeContainer, { recursive: true, force: true });
+    throw error;
+  }
+
+  return { cloneId, linkPath, storePath };
+}

--- a/src/infra/task/worktree-run-storage.ts
+++ b/src/infra/task/worktree-run-storage.ts
@@ -40,6 +40,8 @@ export interface StoredProjectRun {
   readonly runPath: string;
 }
 
+export type StoredProjectRunWarningHandler = (warning: string) => void;
+
 function hashProjectIdentity(projectDir: string): string {
   const canonicalProjectDir = realpathSync(projectDir);
   return createHash('sha256').update(canonicalProjectDir).digest('hex').slice(0, 24);
@@ -106,7 +108,10 @@ function moveDirectory(source: string, destination: string): void {
   }
 }
 
-export function listStoredProjectRuns(projectDir: string): readonly StoredProjectRun[] {
+export function listStoredProjectRuns(
+  projectDir: string,
+  onWarning?: StoredProjectRunWarningHandler,
+): readonly StoredProjectRun[] {
   const projectId = hashProjectIdentity(projectDir);
   const projectStore = join(getGlobalRunStoreDir(), projectId);
   if (!existsSync(projectStore)) {
@@ -118,7 +123,13 @@ export function listStoredProjectRuns(projectDir: string): readonly StoredProjec
       continue;
     }
     const cloneStore = join(projectStore, cloneEntry.name);
-    readStoreManifest(join(cloneStore, 'store.json'), projectId, cloneEntry.name);
+    try {
+      readStoreManifest(join(cloneStore, 'store.json'), projectId, cloneEntry.name);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      onWarning?.(`Skipping incomplete or invalid run store ${cloneEntry.name}: ${message}`);
+      continue;
+    }
     const runsPath = join(cloneStore, 'runs');
     if (!existsSync(runsPath)) {
       continue;

--- a/src/infra/task/worktree-run-storage.ts
+++ b/src/infra/task/worktree-run-storage.ts
@@ -1,9 +1,11 @@
 import {
   chmodSync,
+  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -32,9 +34,35 @@ export interface WorktreeRunStorage {
   readonly storePath: string;
 }
 
+export interface StoredProjectRun {
+  readonly cloneId: string;
+  readonly runSlug: string;
+  readonly runPath: string;
+}
+
 function hashProjectIdentity(projectDir: string): string {
   const canonicalProjectDir = realpathSync(projectDir);
   return createHash('sha256').update(canonicalProjectDir).digest('hex').slice(0, 24);
+}
+
+function readStoreManifest(
+  manifestPath: string,
+  projectId: string,
+  cloneId?: string,
+): RunStoreManifest {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Partial<RunStoreManifest>;
+  if (
+    manifest.schema_version !== 1
+    || manifest.project_id !== projectId
+    || typeof manifest.clone_id !== 'string'
+    || manifest.clone_id.length === 0
+    || (cloneId !== undefined && manifest.clone_id !== cloneId)
+    || typeof manifest.created_at !== 'string'
+    || typeof manifest.branch !== 'string'
+  ) {
+    throw new Error(`Run store manifest is invalid: ${manifestPath}`);
+  }
+  return manifest as RunStoreManifest;
 }
 
 function readExistingStorage(linkPath: string, projectId: string): WorktreeRunStorage | undefined {
@@ -50,15 +78,7 @@ function readExistingStorage(linkPath: string, projectId: string): WorktreeRunSt
       throw new Error(`Existing worktree run link points outside the TAKT run store: ${linkPath}`);
     }
     const manifestPath = join(storePath, '..', 'store.json');
-    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Partial<RunStoreManifest>;
-    if (
-      manifest.schema_version !== 1
-      || manifest.project_id !== projectId
-      || typeof manifest.clone_id !== 'string'
-      || manifest.clone_id.length === 0
-    ) {
-      throw new Error(`Existing worktree run store manifest is invalid: ${manifestPath}`);
-    }
+    const manifest = readStoreManifest(manifestPath, projectId);
     return { cloneId: manifest.clone_id, linkPath, storePath };
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
@@ -67,6 +87,53 @@ function readExistingStorage(linkPath: string, projectId: string): WorktreeRunSt
     }
     throw error;
   }
+}
+
+function moveDirectory(source: string, destination: string): void {
+  try {
+    renameSync(source, destination);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EXDEV') {
+      throw error;
+    }
+    cpSync(source, destination, {
+      recursive: true,
+      errorOnExist: true,
+      force: false,
+      preserveTimestamps: true,
+    });
+    rmSync(source, { recursive: true, force: true });
+  }
+}
+
+export function listStoredProjectRuns(projectDir: string): readonly StoredProjectRun[] {
+  const projectId = hashProjectIdentity(projectDir);
+  const projectStore = join(getGlobalRunStoreDir(), projectId);
+  if (!existsSync(projectStore)) {
+    return [];
+  }
+  const runs: StoredProjectRun[] = [];
+  for (const cloneEntry of readdirSync(projectStore, { withFileTypes: true })) {
+    if (!cloneEntry.isDirectory()) {
+      continue;
+    }
+    const cloneStore = join(projectStore, cloneEntry.name);
+    readStoreManifest(join(cloneStore, 'store.json'), projectId, cloneEntry.name);
+    const runsPath = join(cloneStore, 'runs');
+    if (!existsSync(runsPath)) {
+      continue;
+    }
+    for (const runEntry of readdirSync(runsPath, { withFileTypes: true })) {
+      if (runEntry.isDirectory()) {
+        runs.push({
+          cloneId: cloneEntry.name,
+          runSlug: runEntry.name,
+          runPath: join(runsPath, runEntry.name),
+        });
+      }
+    }
+  }
+  return runs;
 }
 
 function isLegacyRunsDirectory(linkPath: string): boolean {
@@ -128,7 +195,7 @@ export function initializeWorktreeRunStorage(
     chmodSync(projectStore, STORE_DIRECTORY_MODE);
     mkdirSync(storeContainer, { mode: STORE_DIRECTORY_MODE });
     if (migrateLegacyRuns) {
-      renameSync(linkPath, storePath);
+      moveDirectory(linkPath, storePath);
     } else {
       mkdirSync(storePath, { mode: STORE_DIRECTORY_MODE });
     }
@@ -159,7 +226,7 @@ export function initializeWorktreeRunStorage(
       // The link may not have been created.
     }
     if (migrateLegacyRuns && existsSync(storePath) && !existsSync(linkPath)) {
-      renameSync(storePath, linkPath);
+      moveDirectory(storePath, linkPath);
     }
     rmSync(storeContainer, { recursive: true, force: true });
     throw error;


### PR DESCRIPTION
## Problem

TAKT stores worktree run artifacts under `<clone>/.takt/runs`. Removing a managed clone therefore deletes the only copy of its trace, logs, metadata, and reports. A single shared symlink is unsafe because different clones can expose and select each other's run slugs.

## Changes

- Initialize a unique UUID-backed run store immediately after each managed clone is created.
- Link `<clone>/.takt/runs` to `~/.takt/run-store/<project-hash>/<clone-id>/runs`.
- Keep the existing relative `.takt/runs/...` contract unchanged.
- Migrate an existing `.takt/runs` directory by rename, then roll it back if linking or verification fails.
- Use mode `0700` for the run-store root, project, clone, and runs directories, and `0600` for metadata/probes.
- Store only a project hash and clone UUID in `store.json`; no absolute project path.
- Roll back an unused store if link creation or verification fails.
- Adopt existing worktrees on first reuse by moving their current `.takt/runs` directory into the store and rolling it back on link failure.
- Reuse an already initialized link only after validating its project-bound manifest.
- Skip run-store allocation for merge-only temporary clones.
- Fall back to copy-then-remove when legacy migration crosses filesystem boundaries (`EXDEV`).
- Expose `listStoredProjectRuns(projectDir)` so preserved runs remain discoverable after clone deletion.
- Isolate incomplete/corrupt clone stores during discovery: warn and skip them without hiding healthy runs.

## Proof

- Two clones using the same run slug write to different physical stores.
- Removing a clone recursively leaves its run metadata intact.
- Existing `.takt/runs` contents survive migration into the external store.
- Store metadata does not contain the project path.
- Clone creation tests verify initialization occurs after project-local TAKT sync.
- Canonical `buildRunPaths`, order reader, and run-meta reader operate through the external link.
- Existing worktree run contents survive migration.
- Every directory that exposes project or clone identities is verified as `0700`.
- A real Linux `/tmp` → `/dev/shm` migration preserves legacy contents and links them from the clone.
- After clone deletion, the project-scoped discovery API resolves the preserved run path without retaining an in-memory handle.
- An orphan store without `store.json` does not prevent a healthy preserved run from being listed.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `worktree-run-storage.test.ts`
- [x] `clone.test.ts`
- [x] Related 274-test regression set
- [x] Post-review regression: lint/build + 124 clone/reuse/run-reader tests
- [x] Latest focused regression: 72 clone/run-storage tests
- [x] Full unit run: 7,638 passed; 8 unrelated parallel timeouts, all affected assertion suites passed when rerun with one worker (207/207)

## Scope boundary

This PR preserves raw evidence. Retention/receipt-based purge policy is intentionally separate; incomplete or unreceipted runs are not deleted here.