### PR TITLE
feat: run deterministic effects on matched workflow rules

### DIFF
--- a/src/__tests__/it-rule-artifact-effects.test.ts
+++ b/src/__tests__/it-rule-artifact-effects.test.ts
@@ -1,0 +1,140 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowConfig } from '../core/models/index.js';
+
+vi.mock('../agents/runner.js', () => ({ runAgent: vi.fn() }));
+vi.mock('../core/workflow/evaluation/index.js', () => ({ detectMatchedRule: vi.fn() }));
+vi.mock('../core/workflow/phase-runner.js', () => ({
+  needsStatusJudgmentPhase: vi.fn().mockReturnValue(false),
+  runReportPhase: vi.fn().mockResolvedValue(undefined),
+  runStatusJudgmentPhase: vi.fn().mockResolvedValue({ tag: '', ruleIndex: 0, method: 'auto_select' }),
+}));
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
+}));
+
+import { runAgent } from '../agents/runner.js';
+import { detectMatchedRule } from '../core/workflow/evaluation/index.js';
+import { WorkflowEngine } from '../core/workflow/index.js';
+import { createDefaultSystemStepServices } from '../infra/workflow/system/DefaultSystemStepServices.js';
+import {
+  applyDefaultMocks,
+  cleanupWorkflowEngine,
+  createTestTmpDir,
+  makeResponse,
+  makeStep,
+} from './engine-test-helpers.js';
+
+describe('rule-bound artifact effects integration', () => {
+  let cwd: string;
+  let engine: WorkflowEngine | undefined;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    applyDefaultMocks();
+    cwd = createTestTmpDir();
+    execFileSync('git', ['init', '-q'], { cwd });
+    execFileSync('git', ['config', 'user.name', 'Takt Test'], { cwd });
+    execFileSync('git', ['config', 'user.email', 'takt@example.test'], { cwd });
+    writeFileSync(`${cwd}/README.md`, 'base\n');
+    execFileSync('git', ['add', 'README.md'], { cwd });
+    execFileSync('git', ['commit', '-q', '-m', 'base'], { cwd });
+  });
+
+  afterEach(() => {
+    if (engine) cleanupWorkflowEngine(engine);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('captures before review, injects exact paths, and commits only after Go', async () => {
+    const phaseDir = `${cwd}/specs/phase-42-proof`;
+    mkdirSync(phaseDir, { recursive: true });
+    writeFileSync(`${phaseDir}/plan.md`, 'plan\n');
+    writeFileSync(`${phaseDir}/task.md`, 'task\n');
+    writeFileSync(`${phaseDir}/test-plan.md`, 'tests\n');
+
+    const captureEffect = {
+      type: 'capture_artifacts' as const,
+      allowedPatterns: [
+        'specs/phase-*/plan.md',
+        'specs/phase-*/task.md',
+        'specs/phase-*/test-plan.md',
+      ],
+      requiredBasenames: ['plan.md', 'task.md', 'test-plan.md'],
+      sameParent: true as const,
+    };
+    const config: WorkflowConfig = {
+      name: 'artifact-flow',
+      maxSteps: 3,
+      initialStep: 'plan',
+      steps: [
+        makeStep('plan', {
+          instruction: 'plan',
+          rules: [{ condition: 'ready', next: 'plan-review', effects: [captureEffect] }],
+        }),
+        makeStep('plan-review', {
+          instruction: [
+            '{effect:plan.capture_artifacts.manifest.artifacts[0].path}',
+            '{effect:plan.capture_artifacts.manifest.artifacts[1].path}',
+            '{effect:plan.capture_artifacts.manifest.artifacts[2].path}',
+          ].join('\n'),
+          rules: [{
+            condition: 'Go',
+            next: 'COMPLETE',
+            effects: [{
+              type: 'commit_artifacts',
+              manifest: '{effect:plan.capture_artifacts.manifest}',
+              message: 'approve plan',
+            }],
+          }],
+        }),
+      ],
+    };
+
+    const prompts: string[] = [];
+    vi.mocked(runAgent)
+      .mockImplementationOnce(async (persona, task, options) => {
+        prompts.push(task);
+        options?.onPromptResolved?.({
+          systemPrompt: typeof persona === 'string' ? persona : '',
+          userInstruction: task,
+        });
+        return makeResponse({ persona: 'plan', content: 'ready' });
+      })
+      .mockImplementationOnce(async (persona, task, options) => {
+        prompts.push(task);
+        options?.onPromptResolved?.({
+          systemPrompt: typeof persona === 'string' ? persona : '',
+          userInstruction: task,
+        });
+        return makeResponse({ persona: 'plan-review', content: 'Go' });
+      });
+    vi.mocked(detectMatchedRule)
+      .mockResolvedValueOnce({ index: 0, method: 'phase1_tag' })
+      .mockResolvedValueOnce({ index: 0, method: 'phase1_tag' });
+
+    engine = new WorkflowEngine(config, cwd, 'test task', {
+      projectCwd: cwd,
+      provider: 'mock',
+      systemStepServicesFactory: createDefaultSystemStepServices,
+    });
+    let abortReason = '';
+    engine.on('workflow:abort', (_state, reason) => {
+      abortReason = String(reason);
+    });
+    const state = await engine.run();
+
+    expect(state.status, abortReason).toBe('completed');
+    expect(prompts[1]).toContain('specs/phase-42-proof/plan.md');
+    expect(prompts[1]).toContain('specs/phase-42-proof/task.md');
+    expect(prompts[1]).toContain('specs/phase-42-proof/test-plan.md');
+    expect(execFileSync('git', ['show', '--pretty=', '--name-only', 'HEAD'], { cwd, encoding: 'utf8' })
+      .trim().split('\n').sort()).toEqual([
+      'specs/phase-42-proof/plan.md',
+      'specs/phase-42-proof/task.md',
+      'specs/phase-42-proof/test-plan.md',
+    ]);
+  });
+});

--- a/src/__tests__/it-rule-artifact-effects.test.ts
+++ b/src/__tests__/it-rule-artifact-effects.test.ts
@@ -104,6 +104,8 @@ describe('rule-bound artifact effects integration', () => {
         return makeResponse({ persona: 'plan', content: 'ready' });
       })
       .mockImplementationOnce(async (persona, task, options) => {
+        expect(execFileSync('git', ['rev-list', '--count', 'HEAD'], { cwd, encoding: 'utf8' }).trim())
+          .toBe('1');
         prompts.push(task);
         options?.onPromptResolved?.({
           systemPrompt: typeof persona === 'string' ? persona : '',
@@ -136,5 +138,50 @@ describe('rule-bound artifact effects integration', () => {
       'specs/phase-42-proof/task.md',
       'specs/phase-42-proof/test-plan.md',
     ]);
+  });
+
+  it('aborts the workflow before transition when artifact capture fails', async () => {
+    const config: WorkflowConfig = {
+      name: 'artifact-capture-failure',
+      maxSteps: 1,
+      initialStep: 'plan',
+      steps: [makeStep('plan', {
+        instruction: 'plan',
+        rules: [{
+          condition: 'ready',
+          next: 'COMPLETE',
+          effects: [{
+            type: 'capture_artifacts',
+            allowedPatterns: ['specs/phase-*/plan.md'],
+            requiredBasenames: ['plan.md'],
+            sameParent: true,
+          }],
+        }],
+      })],
+    };
+    vi.mocked(runAgent).mockImplementationOnce(async (persona, task, options) => {
+      options?.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({ persona: 'plan', content: 'ready' });
+    });
+    vi.mocked(detectMatchedRule).mockResolvedValueOnce({ index: 0, method: 'phase1_tag' });
+
+    engine = new WorkflowEngine(config, cwd, 'test task', {
+      projectCwd: cwd,
+      provider: 'mock',
+      systemStepServicesFactory: createDefaultSystemStepServices,
+    });
+    let abortReason = '';
+    engine.on('workflow:abort', (_state, reason) => {
+      abortReason = String(reason);
+    });
+    const state = await engine.run();
+
+    expect(state.status).toBe('aborted');
+    expect(abortReason).toContain('capture_artifacts found no dirty allowed artifact paths');
+    expect(execFileSync('git', ['rev-list', '--count', 'HEAD'], { cwd, encoding: 'utf8' }).trim())
+      .toBe('1');
   });
 });

--- a/src/__tests__/system-artifact-effects.test.ts
+++ b/src/__tests__/system-artifact-effects.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -8,6 +8,7 @@ import {
   captureArtifactsEffect,
   commitArtifactsEffect,
 } from '../infra/workflow/system/system-artifact-effects.js';
+import { commitExactSnapshots } from '../infra/task/git.js';
 
 describe('artifact transition effects', () => {
   let cwd: string;
@@ -111,10 +112,62 @@ describe('artifact transition effects', () => {
     createPlan();
     const captured = capture();
     writeFileSync(join(cwd, 'specs/phase-42-proof/plan.md'), 'changed after review\n');
+    const headBefore = execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' });
+    const statusBefore = execFileSync('git', ['status', '--porcelain=v1'], { cwd, encoding: 'utf8' });
     expect(() => commitArtifactsEffect(options, {
       manifest: captured.manifest,
       message: 'approve plan',
     })).toThrow('Artifact changed after capture');
+    expect(execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' })).toBe(headBefore);
+    expect(execFileSync('git', ['status', '--porcelain=v1'], { cwd, encoding: 'utf8' })).toBe(statusBefore);
+  });
+
+  it('commits verified bytes without rereading a concurrently changed worktree file', () => {
+    const path = 'approved.md';
+    writeFileSync(join(cwd, path), 'approved\n');
+    const approved = readFileSync(join(cwd, path));
+    writeFileSync(join(cwd, path), 'changed after verification\n');
+
+    commitExactSnapshots(cwd, 'approved snapshot', [{
+      path,
+      contents: approved,
+      mode: '100644',
+    }]);
+
+    expect(execFileSync('git', ['show', `HEAD:${path}`], { cwd, encoding: 'utf8' })).toBe('approved\n');
+    expect(readFileSync(join(cwd, path), 'utf8')).toBe('changed after verification\n');
+    expect(execFileSync('git', ['status', '--porcelain=v1', '--', path], { cwd, encoding: 'utf8' }))
+      .toBe(` M ${path}\n`);
+  });
+
+  it('supports required artifacts at the repository root without adding a dot prefix', () => {
+    writeFileSync(join(cwd, 'plan.md'), 'root plan\n');
+    const result = captureArtifactsEffect(options, {
+      type: 'capture_artifacts',
+      allowedPatterns: ['plan.md'],
+      requiredBasenames: ['plan.md'],
+      sameParent: true,
+    });
+
+    expect(JSON.stringify(result)).toContain('"path":"plan.md"');
+    expect(JSON.stringify(result)).not.toContain('./plan.md');
+  });
+
+  it('rejects traversal patterns and symlink artifacts at the capture boundary', () => {
+    expect(() => captureArtifactsEffect(options, {
+      type: 'capture_artifacts',
+      allowedPatterns: ['../plan.md'],
+      requiredBasenames: ['plan.md'],
+      sameParent: true,
+    })).toThrow('safe repository-relative path');
+
+    const parent = join(cwd, 'specs/phase-42-proof');
+    mkdirSync(parent, { recursive: true });
+    writeFileSync(join(cwd, 'source.md'), 'source\n');
+    symlinkSync('../../source.md', join(parent, 'plan.md'));
+    writeFileSync(join(parent, 'task.md'), 'task\n');
+    writeFileSync(join(parent, 'test-plan.md'), 'tests\n');
+    expect(() => capture()).toThrow('must not contain symlinks');
   });
 
   it('persists a task-bound manifest for process restart and rejects another task', () => {

--- a/src/__tests__/system-artifact-effects.test.ts
+++ b/src/__tests__/system-artifact-effects.test.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { SystemStepServicesOptions } from '../core/workflow/system/system-step-services.js';
+import {
+  captureArtifactsEffect,
+  commitArtifactsEffect,
+} from '../infra/workflow/system/system-artifact-effects.js';
+
+describe('artifact transition effects', () => {
+  let cwd: string;
+  let options: SystemStepServicesOptions;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'takt-artifacts-'));
+    execFileSync('git', ['init', '-q'], { cwd });
+    execFileSync('git', ['config', 'user.name', 'Takt Test'], { cwd });
+    execFileSync('git', ['config', 'user.email', 'takt@example.test'], { cwd });
+    writeFileSync(join(cwd, 'README.md'), 'base\n');
+    execFileSync('git', ['add', 'README.md'], { cwd });
+    execFileSync('git', ['commit', '-q', '-m', 'base'], { cwd });
+    options = { cwd, projectCwd: cwd, task: 'test' };
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  function createPlan(parent = 'specs/phase-42-proof'): void {
+    mkdirSync(join(cwd, parent), { recursive: true });
+    writeFileSync(join(cwd, parent, 'plan.md'), 'plan\n');
+    writeFileSync(join(cwd, parent, 'task.md'), 'task\n');
+    writeFileSync(join(cwd, parent, 'test-plan.md'), 'tests\n');
+  }
+
+  function capture(manifestPath?: string): Record<string, unknown> {
+    return captureArtifactsEffect(options, {
+      type: 'capture_artifacts',
+      allowedPatterns: [
+        'specs/phase-*/plan.md',
+        'specs/phase-*/task.md',
+        'specs/phase-*/test-plan.md',
+      ],
+      requiredBasenames: ['plan.md', 'task.md', 'test-plan.md'],
+      sameParent: true,
+      ...(manifestPath !== undefined ? { manifestPath } : {}),
+    });
+  }
+
+  it('captures exactly one phase and commits only the captured artifacts', () => {
+    createPlan();
+    writeFileSync(join(cwd, 'other.md'), 'unrelated\n');
+    execFileSync('git', ['add', 'other.md'], { cwd });
+    const captured = capture();
+    const result = commitArtifactsEffect(options, {
+      manifest: captured.manifest,
+      message: 'approve plan',
+    });
+
+    expect(result.status).toBe('committed');
+    const committed = execFileSync('git', ['diff-tree', '--no-commit-id', '--name-only', '-r', 'HEAD'], {
+      cwd,
+      encoding: 'utf8',
+    }).trim().split('\n').sort();
+    expect(committed).toEqual([
+      'specs/phase-42-proof/plan.md',
+      'specs/phase-42-proof/task.md',
+      'specs/phase-42-proof/test-plan.md',
+    ]);
+    expect(execFileSync('git', ['status', '--porcelain', '--', 'other.md'], { cwd, encoding: 'utf8' }))
+      .toContain('A  other.md');
+
+    const retry = commitArtifactsEffect(options, {
+      manifest: captured.manifest,
+      message: 'approve plan',
+    });
+    expect(retry.status).toBe('already_committed');
+  });
+
+  it('rejects more than one complete dirty phase directory', () => {
+    createPlan('specs/phase-1-a');
+    createPlan('specs/phase-2-b');
+    expect(() => capture()).toThrow('could not identify one current artifact parent');
+  });
+
+  it('selects the unique complete phase when another phase has one dirty artifact', () => {
+    createPlan('specs/phase-1-old');
+    execFileSync('git', ['add', 'specs/phase-1-old'], { cwd });
+    execFileSync('git', ['commit', '-q', '-m', 'old plan'], { cwd });
+    writeFileSync(join(cwd, 'specs/phase-1-old/plan.md'), 'old changed\n');
+    createPlan('specs/phase-2-current');
+
+    const result = capture();
+    expect(JSON.stringify(result)).toContain('specs/phase-2-current/plan.md');
+    expect(JSON.stringify(result)).not.toContain('specs/phase-1-old/plan.md');
+  });
+
+  it('ignores an unrelated rename outside the artifact allow patterns', () => {
+    writeFileSync(join(cwd, 'old.md'), 'old\n');
+    execFileSync('git', ['add', 'old.md'], { cwd });
+    execFileSync('git', ['commit', '-q', '-m', 'old'], { cwd });
+    execFileSync('git', ['mv', 'old.md', 'new.md'], { cwd });
+    createPlan();
+
+    expect(() => capture()).not.toThrow();
+  });
+
+  it('rejects changes made after capture', () => {
+    createPlan();
+    const captured = capture();
+    writeFileSync(join(cwd, 'specs/phase-42-proof/plan.md'), 'changed after review\n');
+    expect(() => commitArtifactsEffect(options, {
+      manifest: captured.manifest,
+      message: 'approve plan',
+    })).toThrow('Artifact changed after capture');
+  });
+
+  it('persists a task-bound manifest for process restart and rejects another task', () => {
+    createPlan();
+    capture('.takt/state/plan-artifacts.json');
+    const result = commitArtifactsEffect(options, {
+      manifestPath: '.takt/state/plan-artifacts.json',
+      message: 'approve plan',
+    });
+    expect(result.status).toBe('committed');
+
+    expect(() => commitArtifactsEffect(
+      { ...options, task: 'another task' },
+      { manifestPath: '.takt/state/plan-artifacts.json', message: 'wrong task' },
+    )).toThrow('different task');
+  });
+
+  it('uses the persisted parent to disambiguate a partial replan', () => {
+    createPlan('specs/phase-1-current');
+    capture('.takt/state/plan-artifacts.json');
+    writeFileSync(join(cwd, 'specs/phase-2-unrelated-plan.md'), 'outside allow pattern\n');
+    mkdirSync(join(cwd, 'specs/phase-2-other'), { recursive: true });
+    writeFileSync(join(cwd, 'specs/phase-2-other/plan.md'), 'other dirty\n');
+    writeFileSync(join(cwd, 'specs/phase-1-current/plan.md'), 'current revised\n');
+
+    const result = capture('.takt/state/plan-artifacts.json');
+    expect(JSON.stringify(result)).toContain('specs/phase-1-current/plan.md');
+  });
+});

--- a/src/__tests__/system-artifact-effects.test.ts
+++ b/src/__tests__/system-artifact-effects.test.ts
@@ -185,6 +185,18 @@ describe('artifact transition effects', () => {
     )).toThrow('different task');
   });
 
+  it('replaces a stale manifest from another task during a new capture', () => {
+    createPlan();
+    capture('.takt/state/plan-artifacts.json');
+    options = { ...options, task: 'new task' };
+
+    expect(() => capture('.takt/state/plan-artifacts.json')).not.toThrow();
+    expect(() => commitArtifactsEffect(options, {
+      manifestPath: '.takt/state/plan-artifacts.json',
+      message: 'new task plan',
+    })).not.toThrow();
+  });
+
   it('uses the persisted parent to disambiguate a partial replan', () => {
     createPlan('specs/phase-1-current');
     capture('.takt/state/plan-artifacts.json');

--- a/src/__tests__/workflow-rule-effects.test.ts
+++ b/src/__tests__/workflow-rule-effects.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { WorkflowRuleSchema } from '../core/models/workflow-schemas.js';
+import { WorkflowConfigRawSchema, WorkflowRuleSchema } from '../core/models/workflow-schemas.js';
 import { determineRuleTransition } from '../core/workflow/engine/transitions.js';
 import { normalizeRule } from '../infra/config/loaders/workflowRuleNormalizer.js';
 import { makeStep } from './engine-test-helpers.js';
@@ -75,5 +75,32 @@ describe('workflow rule effects', () => {
         message: 'approve',
       }],
     })).toThrow(/exactly one/);
+  });
+
+  it('requires an explicit workflow capability before rule effects can execute', () => {
+    const workflow = {
+      name: 'rule-effects-capability',
+      steps: [{
+        name: 'plan',
+        persona: 'planner',
+        instruction: 'plan',
+        rules: [{
+          condition: 'ready',
+          next: 'COMPLETE',
+          effects: [{
+            type: 'capture_artifacts',
+            allowed_patterns: ['specs/phase-*/plan.md'],
+            required_basenames: ['plan.md'],
+            same_parent: true,
+          }],
+        }],
+      }],
+    };
+
+    expect(() => WorkflowConfigRawSchema.parse(workflow)).toThrow(/requires\.rule_effects/);
+    expect(() => WorkflowConfigRawSchema.parse({
+      ...workflow,
+      requires: { rule_effects: 1 },
+    })).not.toThrow();
   });
 });

--- a/src/__tests__/workflow-rule-effects.test.ts
+++ b/src/__tests__/workflow-rule-effects.test.ts
@@ -30,16 +30,50 @@ describe('workflow rule effects', () => {
     });
   });
 
-  it('rejects unknown or incomplete effect contracts', () => {
+  it('rejects an incomplete capture effect contract', () => {
     expect(() => WorkflowRuleSchema.parse({
       condition: 'plan ready',
       next: 'plan-review',
       effects: [{ type: 'capture_artifacts' }],
     })).toThrow();
+  });
+
+  it('rejects an unknown effect contract', () => {
     expect(() => WorkflowRuleSchema.parse({
       condition: 'plan ready',
       next: 'plan-review',
       effects: [{ type: 'shell', command: 'git add -A' }],
     })).toThrow();
+  });
+
+  it('rejects duplicate effect types that would overwrite the result binding', () => {
+    const capture = {
+      type: 'capture_artifacts',
+      allowed_patterns: ['specs/phase-*/plan.md'],
+      required_basenames: ['plan.md'],
+      same_parent: true,
+    };
+    expect(() => WorkflowRuleSchema.parse({
+      condition: 'plan ready',
+      next: 'plan-review',
+      effects: [capture, capture],
+    })).toThrow(/Duplicate effect type/);
+  });
+
+  it('requires exactly one commit manifest source', () => {
+    const baseRule = { condition: 'Go', next: 'COMPLETE' };
+    expect(() => WorkflowRuleSchema.parse({
+      ...baseRule,
+      effects: [{ type: 'commit_artifacts', message: 'approve' }],
+    })).toThrow(/exactly one/);
+    expect(() => WorkflowRuleSchema.parse({
+      ...baseRule,
+      effects: [{
+        type: 'commit_artifacts',
+        manifest: '{effect:plan.capture_artifacts.manifest}',
+        manifest_path: '.takt/state/plan-artifacts.json',
+        message: 'approve',
+      }],
+    })).toThrow(/exactly one/);
   });
 });

--- a/src/__tests__/workflow-rule-effects.test.ts
+++ b/src/__tests__/workflow-rule-effects.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { WorkflowRuleSchema } from '../core/models/workflow-schemas.js';
+import { determineRuleTransition } from '../core/workflow/engine/transitions.js';
+import { normalizeRule } from '../infra/config/loaders/workflowRuleNormalizer.js';
+import { makeStep } from './engine-test-helpers.js';
+
+describe('workflow rule effects', () => {
+  it('normalizes and exposes only the selected rule effects', () => {
+    const raw = WorkflowRuleSchema.parse({
+      condition: 'plan ready',
+      next: 'plan-review',
+      effects: [{
+        type: 'capture_artifacts',
+        allowed_patterns: ['specs/phase-*/plan.md'],
+        required_basenames: ['plan.md'],
+        same_parent: true,
+      }],
+    });
+    const rule = normalizeRule(raw);
+    const step = makeStep('plan', { rules: [rule] });
+
+    expect(determineRuleTransition(step, 0)).toEqual({
+      nextStep: 'plan-review',
+      effects: [{
+        type: 'capture_artifacts',
+        allowedPatterns: ['specs/phase-*/plan.md'],
+        requiredBasenames: ['plan.md'],
+        sameParent: true,
+      }],
+    });
+  });
+
+  it('rejects unknown or incomplete effect contracts', () => {
+    expect(() => WorkflowRuleSchema.parse({
+      condition: 'plan ready',
+      next: 'plan-review',
+      effects: [{ type: 'capture_artifacts' }],
+    })).toThrow();
+    expect(() => WorkflowRuleSchema.parse({
+      condition: 'plan ready',
+      next: 'plan-review',
+      effects: [{ type: 'shell', command: 'git add -A' }],
+    })).toThrow();
+  });
+});

--- a/src/__tests__/workflow-rule-effects.test.ts
+++ b/src/__tests__/workflow-rule-effects.test.ts
@@ -131,4 +131,31 @@ describe('workflow rule effects', () => {
       }],
     })).toThrow(/parallel sub-step rules do not support effects/);
   });
+
+  it('rejects rule effects on workflow-call parallel sub-steps', () => {
+    expect(() => WorkflowConfigRawSchema.parse({
+      name: 'parallel-workflow-call-effects',
+      requires: { rule_effects: 1 },
+      steps: [{
+        name: 'review',
+        persona: 'reviewer',
+        instruction: 'review',
+        parallel: [{
+          name: 'child',
+          kind: 'workflow_call',
+          call: 'child-workflow',
+          rules: [{
+            condition: 'COMPLETE',
+            next: 'COMPLETE',
+            effects: [{
+              type: 'commit_artifacts',
+              manifest_path: '.takt/state/plan-artifacts.json',
+              message: 'approve',
+            }],
+          }],
+        }],
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      }],
+    })).toThrow(/parallel sub-step rules do not support effects/);
+  });
 });

--- a/src/__tests__/workflow-rule-effects.test.ts
+++ b/src/__tests__/workflow-rule-effects.test.ts
@@ -103,4 +103,32 @@ describe('workflow rule effects', () => {
       requires: { rule_effects: 1 },
     })).not.toThrow();
   });
+
+  it('rejects rule effects on parallel sub-steps because they have no transition executor', () => {
+    expect(() => WorkflowConfigRawSchema.parse({
+      name: 'parallel-rule-effects',
+      requires: { rule_effects: 1 },
+      steps: [{
+        name: 'review',
+        persona: 'reviewer',
+        instruction: 'review',
+        parallel: [{
+          name: 'security',
+          persona: 'security-reviewer',
+          instruction: 'review security',
+          rules: [{
+            condition: 'Go',
+            next: 'COMPLETE',
+            effects: [{
+              type: 'capture_artifacts',
+              allowed_patterns: ['specs/phase-*/plan.md'],
+              required_basenames: ['plan.md'],
+              same_parent: true,
+            }],
+          }],
+        }],
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      }],
+    })).toThrow(/parallel sub-step rules do not support effects/);
+  });
 });

--- a/src/__tests__/workflow-run-loop-command-gates.test.ts
+++ b/src/__tests__/workflow-run-loop-command-gates.test.ts
@@ -50,8 +50,9 @@ function makeDeps(
     getStep: () => step,
     applyRuntimeEnvironment: vi.fn(),
     loopDetectorCheck: () => ({ count: 1, isLoop: false }),
-    cycleDetectorRecordAndCheck: () => ({ triggered: false, cycleCount: 0 }),
+    cycleDetectorRecordAndCheck: vi.fn(() => ({ triggered: false, cycleCount: 0 })),
     resolveDoneTransition: vi.fn(() => ({ nextStep: 'COMPLETE' })),
+    runTransitionEffects: vi.fn(async () => {}),
     runLoopMonitorJudge: vi.fn(),
     runStep,
     runQualityGates,
@@ -82,6 +83,31 @@ function makeDeps(
 }
 
 describe('WorkflowRunLoop command quality gates', () => {
+  it('runs matched rule effects after gate success and fails before advancing', async () => {
+    const step = makeStep('plan-review', {
+      rules: [makeRule('Go judgment', 'implement')],
+    });
+    const state = createInitialState(makeConfig(step), { projectCwd: '/worktree' });
+    const response = makeResponse({ persona: step.name, content: 'Go' });
+    const runStep = vi.fn(async (_step: WorkflowStep, instruction: string) => ({ response, instruction }));
+    const runQualityGates = vi.fn<() => Promise<CommandGateRunResult>>().mockResolvedValue({ ok: true });
+    const deps = makeDeps(state, step, runStep, runQualityGates);
+    deps.resolveDoneTransition.mockReturnValue({
+      nextStep: 'implement',
+      effects: [{ type: 'commit_artifacts', manifest: '{effect:plan.capture_artifacts.manifest}', message: 'approve' }],
+    });
+    deps.runTransitionEffects.mockRejectedValue(new Error('artifact hash mismatch'));
+
+    const result = await runWorkflowToCompletion(deps);
+    expect(result.abort).toMatchObject({
+      kind: 'runtime_error',
+      reason: 'Step execution failed: artifact hash mismatch',
+    });
+    expect(deps.runTransitionEffects).toHaveBeenCalledTimes(1);
+    expect(deps.cycleDetectorRecordAndCheck).not.toHaveBeenCalled();
+    expect(state.currentStep).toBe('plan-review');
+  });
+
   it('should rerun the same step with command gate feedback before resolving the done transition', async () => {
     const step = makeStep('implement', {
       qualityGates: [

--- a/src/__tests__/workflow-run-loop-failure-metadata.test.ts
+++ b/src/__tests__/workflow-run-loop-failure-metadata.test.ts
@@ -42,6 +42,7 @@ function makeDeps(
     loopDetectorCheck: () => ({ count: 1, isLoop: false }),
     cycleDetectorRecordAndCheck: () => ({ triggered: false, cycleCount: 0 }),
     resolveDoneTransition: vi.fn(() => ({ nextStep: 'COMPLETE' })),
+    runTransitionEffects: vi.fn(async () => {}),
     runLoopMonitorJudge: vi.fn(),
     runStep: vi.fn(async (_step: WorkflowStep, instruction: string) => ({ response, instruction })),
     runQualityGates: vi.fn(async () => ({ ok: true as const })),

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -72,8 +72,7 @@ const WorkflowProviderOptionsWithExtendsSchema = z.object({
   runtime: RuntimeConfigSchema,
 }).optional();
 
-const WorkflowEffectsRawSchema = z.array(WorkflowEffectRawSchema)
-  .superRefine((effects, ctx) => validateUniqueWorkflowEffectTypes(effects, ctx, []));
+const WorkflowEffectsRawSchema = z.array(WorkflowEffectRawSchema);
 
 const WorkflowParamDeclarationRawSchema = z.object({
   type: z.enum(['facet_ref', 'facet_ref[]']),
@@ -106,7 +105,9 @@ export const WorkflowRuleSchema = z.object({
   appendix: z.string().optional(),
   requires_user_input: z.boolean().optional(),
   interactive_only: z.boolean().optional(),
-  effects: WorkflowEffectsRawSchema.min(1).optional(),
+  effects: WorkflowEffectsRawSchema.min(1)
+    .superRefine((effects, ctx) => validateUniqueWorkflowEffectTypes(effects, ctx, [], 'in a single rule'))
+    .optional(),
 }).refine(
   (data) => (data.condition != null) !== (data.when != null),
   {

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -22,6 +22,7 @@ import {
   StructuredOutputRawSchema,
   SystemInputRawSchema,
   validateSystemStepFields,
+  validateUniqueWorkflowEffectTypes,
   WorkflowEffectRawSchema,
 } from './workflow-system-schemas.js';
 import {
@@ -71,6 +72,9 @@ const WorkflowProviderOptionsWithExtendsSchema = z.object({
   runtime: RuntimeConfigSchema,
 }).optional();
 
+const WorkflowEffectsRawSchema = z.array(WorkflowEffectRawSchema)
+  .superRefine((effects, ctx) => validateUniqueWorkflowEffectTypes(effects, ctx, []));
+
 const WorkflowParamDeclarationRawSchema = z.object({
   type: z.enum(['facet_ref', 'facet_ref[]']),
   facet_kind: z.enum(['knowledge', 'policy', 'instruction', 'report_format']),
@@ -102,7 +106,7 @@ export const WorkflowRuleSchema = z.object({
   appendix: z.string().optional(),
   requires_user_input: z.boolean().optional(),
   interactive_only: z.boolean().optional(),
-  effects: z.array(WorkflowEffectRawSchema).min(1).optional(),
+  effects: WorkflowEffectsRawSchema.min(1).optional(),
 }).refine(
   (data) => (data.condition != null) !== (data.when != null),
   {
@@ -424,7 +428,7 @@ function createWorkflowStepRawSchema(options?: { relaxWorkflowCallConditions?: b
     delay_before_ms: z.number().int().min(0).optional(),
     structured_output: StructuredOutputRawSchema.optional(),
     system_inputs: z.array(SystemInputRawSchema).optional(),
-    effects: z.array(WorkflowEffectRawSchema).optional(),
+    effects: WorkflowEffectsRawSchema.optional(),
     rules: z.array(WorkflowRuleSchema).optional(),
     output_contracts: OutputContractsFieldSchema,
     quality_gates: QualityGatesSchema,

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -116,6 +116,21 @@ export const WorkflowRuleSchema = z.object({
   },
 );
 
+function validateParallelRuleEffects(
+  rules: readonly z.output<typeof WorkflowRuleSchema>[] | undefined,
+  ctx: z.core.$RefinementCtx,
+): void {
+  rules?.forEach((rule, index) => {
+    if (rule.effects !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['rules', index, 'effects'],
+        message: 'parallel sub-step rules do not support effects',
+      });
+    }
+  });
+}
+
 function validateWorkflowCallRules(
   rules: readonly z.output<typeof WorkflowRuleSchema>[] | undefined,
   ctx: z.core.$RefinementCtx,
@@ -324,14 +339,8 @@ const AgentParallelSubStepRawSchema = z.object({
         message: 'parallel sub-step rules do not allow "return"',
       });
     }
-    if (rule.effects !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['rules', index, 'effects'],
-        message: 'parallel sub-step rules do not support effects',
-      });
-    }
   });
+  validateParallelRuleEffects(data.rules, ctx);
 });
 
 const WorkflowCallParallelSubStepRawSchema = z.object({
@@ -366,6 +375,7 @@ const WorkflowCallParallelSubStepRawSchema = z.object({
   pass_previous_response: z.never().optional(),
 }).superRefine((data, ctx) => {
   validateWorkflowCallRules(data.rules, ctx, { allowExtendedConditions: true });
+  validateParallelRuleEffects(data.rules, ctx);
 });
 
 /** Sub-step schema for parallel execution */
@@ -677,6 +687,9 @@ export const WorkflowConfigRawSchema = z.object({
 }).strict().superRefine((workflow, ctx) => {
   const usesRuleEffects = workflow.steps.some((step) => (
     step.rules?.some((rule) => rule.effects !== undefined) === true
+    || step.parallel?.some((subStep) => (
+      subStep.rules?.some((rule) => rule.effects !== undefined) === true
+    )) === true
   ));
   if (usesRuleEffects && workflow.requires?.rule_effects !== 1) {
     ctx.addIssue({

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -102,6 +102,7 @@ export const WorkflowRuleSchema = z.object({
   appendix: z.string().optional(),
   requires_user_input: z.boolean().optional(),
   interactive_only: z.boolean().optional(),
+  effects: z.array(WorkflowEffectRawSchema).min(1).optional(),
 }).refine(
   (data) => (data.condition != null) !== (data.when != null),
   {

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -641,10 +641,14 @@ export const LoopMonitorSchema = z.object({
 
 /** Interactive mode schema for workflow-level default */
 export const InteractiveModeSchema = z.enum(INTERACTIVE_MODES);
+const WorkflowRequirementsRawSchema = z.object({
+  rule_effects: z.literal(1).optional(),
+}).strict();
 /** Workflow configuration schema - raw YAML format */
 export const WorkflowConfigRawSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
+  requires: WorkflowRequirementsRawSchema.optional(),
   subworkflow: WorkflowSubworkflowRawSchema.optional(),
   finding_contract: FindingContractConfigRawSchema.optional(),
   workflow_config: WorkflowProviderOptionsWithExtendsSchema,
@@ -662,4 +666,15 @@ export const WorkflowConfigRawSchema = z.object({
   max_steps: z.union([z.number().int().positive(), z.literal('infinite')]).optional().default(10),
   loop_monitors: z.array(LoopMonitorSchema).optional(),
   interactive_mode: InteractiveModeSchema.optional(),
-}).strict();
+}).strict().superRefine((workflow, ctx) => {
+  const usesRuleEffects = workflow.steps.some((step) => (
+    step.rules?.some((rule) => rule.effects !== undefined) === true
+  ));
+  if (usesRuleEffects && workflow.requires?.rule_effects !== 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['requires', 'rule_effects'],
+      message: 'Rule effects require requires.rule_effects: 1',
+    });
+  }
+});

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -323,6 +323,13 @@ const AgentParallelSubStepRawSchema = z.object({
         message: 'parallel sub-step rules do not allow "return"',
       });
     }
+    if (rule.effects !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['rules', index, 'effects'],
+        message: 'parallel sub-step rules do not support effects',
+      });
+    }
   });
 });
 

--- a/src/core/models/workflow-system-input-types.ts
+++ b/src/core/models/workflow-system-input-types.ts
@@ -143,6 +143,19 @@ export type WorkflowEffectScalarReference = WorkflowTemplateReference | number;
 
 export type WorkflowEffect =
   | {
+    type: 'capture_artifacts';
+    allowedPatterns: string[];
+    requiredBasenames: string[];
+    sameParent: true;
+    manifestPath?: string;
+  }
+  | {
+    type: 'commit_artifacts';
+    manifest?: WorkflowTemplateReference;
+    manifestPath?: string;
+    message: string;
+  }
+  | {
     type: 'enqueue_task';
     mode: 'new' | 'from_pr';
     workflow: string;

--- a/src/core/models/workflow-system-schemas.ts
+++ b/src/core/models/workflow-system-schemas.ts
@@ -206,6 +206,7 @@ export function validateUniqueWorkflowEffectTypes(
   effects: readonly { readonly type: string }[],
   ctx: z.core.$RefinementCtx,
   pathPrefix: readonly PropertyKey[] = ['effects'],
+  scope = 'in a single step',
 ): void {
   const effectTypes = new Set<string>();
   for (const [index, effect] of effects.entries()) {
@@ -213,7 +214,7 @@ export function validateUniqueWorkflowEffectTypes(
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: [...pathPrefix, index, 'type'],
-        message: `Duplicate effect type "${effect.type}" is not allowed`,
+        message: `Duplicate effect type "${effect.type}" is not allowed ${scope}`,
       });
       continue;
     }

--- a/src/core/models/workflow-system-schemas.ts
+++ b/src/core/models/workflow-system-schemas.ts
@@ -202,6 +202,25 @@ export const WorkflowEffectRawSchema = z.discriminatedUnion('type', [
   }).strict(),
 ]);
 
+export function validateUniqueWorkflowEffectTypes(
+  effects: readonly { readonly type: string }[],
+  ctx: z.core.$RefinementCtx,
+  pathPrefix: readonly PropertyKey[] = ['effects'],
+): void {
+  const effectTypes = new Set<string>();
+  for (const [index, effect] of effects.entries()) {
+    if (effectTypes.has(effect.type)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [...pathPrefix, index, 'type'],
+        message: `Duplicate effect type "${effect.type}" is not allowed`,
+      });
+      continue;
+    }
+    effectTypes.add(effect.type);
+  }
+}
+
 export function validateSystemStepFields(
   data: {
     kind?: 'agent' | 'system' | 'workflow_call';
@@ -323,16 +342,5 @@ export function validateSystemStepFields(
     }
   }
 
-  const effectTypes = new Set<string>();
-  for (const [index, effect] of (data.effects ?? []).entries()) {
-    if (effectTypes.has(effect.type)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['effects', index, 'type'],
-        message: `Duplicate effect type "${effect.type}" is not allowed in a single step`,
-      });
-      continue;
-    }
-    effectTypes.add(effect.type);
-  }
+  validateUniqueWorkflowEffectTypes(data.effects ?? [], ctx);
 }

--- a/src/core/models/workflow-system-schemas.ts
+++ b/src/core/models/workflow-system-schemas.ts
@@ -133,6 +133,22 @@ const EnqueueTaskEffectBaseSchema = z.object({
 }).strict();
 
 export const WorkflowEffectRawSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('capture_artifacts'),
+    allowed_patterns: z.array(z.string().min(1)).min(1),
+    required_basenames: z.array(z.string().min(1)).min(1),
+    same_parent: z.literal(true),
+    manifest_path: z.string().min(1).optional(),
+  }).strict(),
+  z.object({
+    type: z.literal('commit_artifacts'),
+    manifest: TemplateReferenceSchema.optional(),
+    manifest_path: z.string().min(1).optional(),
+    message: z.string().min(1),
+  }).strict().refine(
+    (data) => (data.manifest !== undefined) !== (data.manifest_path !== undefined),
+    { message: 'commit_artifacts requires exactly one of manifest or manifest_path' },
+  ),
   EnqueueTaskEffectBaseSchema.superRefine((data, ctx) => {
     if (data.mode === 'from_pr' && data.pr === undefined) {
       ctx.addIssue({

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -65,6 +65,7 @@ export {
 
 export interface WorkflowRule {
   condition: string;
+  effects?: WorkflowEffect[];
   next?: string;
   returnValue?: string;
   appendix?: string;

--- a/src/core/workflow/engine/SystemStepExecutor.ts
+++ b/src/core/workflow/engine/SystemStepExecutor.ts
@@ -105,6 +105,21 @@ export class SystemStepExecutor {
     return services.executeEffect(effect, payload, state);
   }
 
+  async runTransitionEffects(
+    stepName: string,
+    effects: readonly WorkflowEffect[] | undefined,
+    state: WorkflowState,
+  ): Promise<void> {
+    if (!effects || effects.length === 0) {
+      return;
+    }
+    const stepEffectResults = { ...(state.effectResults.get(stepName) ?? {}) };
+    for (const effect of effects) {
+      stepEffectResults[effect.type] = await this.executeEffect(effect, state, this.deps.getCwd());
+      state.effectResults.set(stepName, { ...stepEffectResults });
+    }
+  }
+
   async run(step: WorkflowStep, state: WorkflowState): Promise<AgentResponse> {
     await waitForStepDelay(step);
     const ruleContext = this.deps.getRuleContext(step);
@@ -131,11 +146,7 @@ export class SystemStepExecutor {
     state.systemContexts.set(step.name, resolvedContext);
 
     if (step.effects && step.effects.length > 0) {
-      const stepEffectResults: Record<string, unknown> = {};
-      for (const effect of step.effects) {
-        stepEffectResults[effect.type] = await this.executeEffect(effect, state, ruleContext.cwd);
-        state.effectResults.set(step.name, { ...stepEffectResults });
-      }
+      await this.runTransitionEffects(step.name, step.effects, state);
     }
 
     const match = await detectMatchedRule(step, '', '', {

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -246,6 +246,11 @@ export class WorkflowEngine extends EventEmitter {
           },
           cycleDetectorRecordAndCheck: (stepName) => this.cycleDetector.recordAndCheck(stepName),
           resolveDoneTransition: this.stepCoordinator.resolveTransitionFromDone.bind(this.stepCoordinator),
+          runTransitionEffects: (stepName, transition) => this.systemStepExecutor.runTransitionEffects(
+            stepName,
+            transition.effects,
+            this.state,
+          ),
           runLoopMonitorJudge: this.stepCoordinator.runLoopMonitorJudge.bind(this.stepCoordinator),
           runStep: this.stepCoordinator.runStep.bind(this.stepCoordinator),
           runQualityGates,
@@ -448,6 +453,11 @@ export class WorkflowEngine extends EventEmitter {
           },
           cycleDetectorRecordAndCheck: (stepName) => this.cycleDetector.recordAndCheck(stepName),
           resolveDoneTransition: this.stepCoordinator.resolveTransitionFromDone.bind(this.stepCoordinator),
+          runTransitionEffects: (stepName, transition) => this.systemStepExecutor.runTransitionEffects(
+            stepName,
+            transition.effects,
+            this.state,
+          ),
           runLoopMonitorJudge: this.stepCoordinator.runLoopMonitorJudge.bind(this.stepCoordinator),
           runStep: this.stepCoordinator.runStep.bind(this.stepCoordinator),
           runQualityGates,

--- a/src/core/workflow/engine/WorkflowRunLoop.ts
+++ b/src/core/workflow/engine/WorkflowRunLoop.ts
@@ -44,6 +44,7 @@ interface WorkflowRunLoopDeps {
   loopDetectorCheck: (stepName: string) => { shouldWarn?: boolean; shouldAbort?: boolean; count: number; isLoop: boolean };
   cycleDetectorRecordAndCheck: (stepName: string) => { triggered: boolean; monitor?: LoopMonitorConfig; cycleCount: number };
   resolveDoneTransition: (step: WorkflowStep, response: AgentResponse) => WorkflowRuleTransition;
+  runTransitionEffects: (stepName: string, transition: WorkflowRuleTransition) => Promise<void>;
   runLoopMonitorJudge: (
     monitor: LoopMonitorConfig,
     cycleCount: number,
@@ -557,6 +558,7 @@ export async function runWorkflowToCompletion(deps: WorkflowRunLoopDeps): Promis
       }
 
       const transition = deps.resolveDoneTransition(step, response);
+      await deps.runTransitionEffects(step.name, transition);
       if (transition.requiresUserInput) {
         if (!deps.options.onUserInput) {
           abort = abortWorkflow(deps, 'user_input_required', 'User input required but no handler is configured');
@@ -784,6 +786,7 @@ async function runSingleWorkflowIterationCore(deps: WorkflowRunLoopDeps): Promis
   }
 
   const transition = deps.resolveDoneTransition(step, response);
+  await deps.runTransitionEffects(step.name, transition);
   if (transition.requiresUserInput) {
     if (!deps.options.onUserInput) {
       const abort = abortWorkflow(deps, 'user_input_required', 'User input required but no handler is configured');

--- a/src/core/workflow/engine/transitions.ts
+++ b/src/core/workflow/engine/transitions.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  WorkflowEffect,
   WorkflowStep,
 } from '../../models/types.js';
 
@@ -12,6 +13,7 @@ export interface WorkflowRuleTransition {
   nextStep?: string;
   returnValue?: string;
   requiresUserInput?: boolean;
+  effects?: WorkflowEffect[];
 }
 
 export function determineRuleTransition(
@@ -27,6 +29,7 @@ export function determineRuleTransition(
     ...(rule.next !== undefined ? { nextStep: rule.next } : {}),
     ...(rule.returnValue !== undefined ? { returnValue: rule.returnValue } : {}),
     ...(rule.requiresUserInput === true ? { requiresUserInput: true } : {}),
+    ...(rule.effects !== undefined ? { effects: rule.effects } : {}),
   };
 }
 

--- a/src/core/workflow/system/system-step-effect-runner.ts
+++ b/src/core/workflow/system/system-step-effect-runner.ts
@@ -93,6 +93,19 @@ export function validateSystemEffectPayload(
   effect: WorkflowEffect,
   payload: Record<string, unknown>,
 ): void {
+  if (effect.type === 'capture_artifacts') {
+    if (payload.type !== 'capture_artifacts') {
+      throw new Error('capture_artifacts payload type mismatch');
+    }
+  }
+  if (effect.type === 'commit_artifacts') {
+    if ((payload.manifest !== undefined) === (payload.manifestPath !== undefined)) {
+      throw new Error('commit_artifacts requires exactly one of manifest or manifestPath');
+    }
+    if (payload.manifest !== undefined) requireObject(payload.manifest, 'manifest');
+    if (payload.manifestPath !== undefined) requireString(payload.manifestPath, 'manifestPath');
+    requireString(payload.message, 'message');
+  }
   if (effect.type === 'enqueue_task') {
     if (payload.mode !== undefined) requireString(payload.mode, 'mode');
     if (payload.workflow !== undefined) requireString(payload.workflow, 'workflow');

--- a/src/infra/config/loaders/workflowRuleNormalizer.ts
+++ b/src/infra/config/loaders/workflowRuleNormalizer.ts
@@ -6,6 +6,10 @@ import {
   parseAiConditionExpression,
 } from '../../../core/models/workflow-condition-expression.js';
 import { isDeterministicCondition, unwrapWhenCondition } from '../../../core/workflow/evaluation/rule-utils.js';
+import {
+  normalizeWorkflowEffects,
+  type RawWorkflowEffect,
+} from './workflowSystemStepNormalizer.js';
 
 
 /**
@@ -73,6 +77,7 @@ export function normalizeRule(rule: {
   appendix?: string;
   requires_user_input?: boolean;
   interactive_only?: boolean;
+  effects?: RawWorkflowEffect[];
 }): WorkflowRule {
   // `when:` キーは決定的条件の宣言形: when(<式>) に包んで扱う。
   // 裸の式を condition: に書いた場合は通常のタグ条件（散文）として扱う。
@@ -91,6 +96,7 @@ export function normalizeRule(rule: {
       appendix: rule.appendix,
       requiresUserInput: rule.requires_user_input,
       interactiveOnly: rule.interactive_only,
+      effects: normalizeWorkflowEffects(rule.effects),
       isAiCondition: true,
       aiConditionText: aiExpression.text,
     };
@@ -106,6 +112,7 @@ export function normalizeRule(rule: {
       appendix: rule.appendix,
       requiresUserInput: rule.requires_user_input,
       interactiveOnly: rule.interactive_only,
+      effects: normalizeWorkflowEffects(rule.effects),
       isAggregateCondition: true,
       aggregateType: aggregateExpression.type,
       aggregateConditionText: conditions.length === 1 ? conditions[0]! : conditions,
@@ -124,6 +131,7 @@ export function normalizeRule(rule: {
       appendix: rule.appendix,
       requiresUserInput: rule.requires_user_input,
       interactiveOnly: rule.interactive_only,
+      effects: normalizeWorkflowEffects(rule.effects),
       guardCondition: compound.guard,
     };
   }
@@ -135,5 +143,6 @@ export function normalizeRule(rule: {
     appendix: rule.appendix,
     requiresUserInput: rule.requires_user_input,
     interactiveOnly: rule.interactive_only,
+    effects: normalizeWorkflowEffects(rule.effects),
   };
 }

--- a/src/infra/config/loaders/workflowSystemStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowSystemStepNormalizer.ts
@@ -2,13 +2,12 @@ import type { z } from 'zod';
 import type {
   WorkflowEffect,
   WorkflowEffectScalarReference,
-  WorkflowStep,
   WorkflowStepRawSchema,
   WorkflowTemplateReference,
 } from '../../../core/models/index.js';
 
 type RawStep = z.output<typeof WorkflowStepRawSchema>;
-type RawWorkflowEffect = NonNullable<RawStep['effects']>[number];
+export type RawWorkflowEffect = NonNullable<RawStep['effects']>[number];
 
 const TEMPLATE_REFERENCE_PATTERN = /^\{(?:context|structured|effect):[^}]+\}$/;
 
@@ -45,6 +44,23 @@ function requireEffectScalarReference(
 
 function normalizeWorkflowEffect(effect: RawWorkflowEffect): WorkflowEffect {
   switch (effect.type) {
+  case 'capture_artifacts':
+    return {
+      type: 'capture_artifacts',
+      allowedPatterns: effect.allowed_patterns,
+      requiredBasenames: effect.required_basenames,
+      sameParent: effect.same_parent,
+      ...(effect.manifest_path !== undefined ? { manifestPath: effect.manifest_path } : {}),
+    };
+  case 'commit_artifacts':
+    return {
+      type: 'commit_artifacts',
+      ...(effect.manifest !== undefined
+        ? { manifest: normalizeTemplateReference(effect.manifest, 'effects.manifest') }
+        : {}),
+      ...(effect.manifest_path !== undefined ? { manifestPath: effect.manifest_path } : {}),
+      message: effect.message,
+    };
   case 'enqueue_task':
     return {
       type: 'enqueue_task',
@@ -89,6 +105,6 @@ function normalizeWorkflowEffect(effect: RawWorkflowEffect): WorkflowEffect {
   }
 }
 
-export function normalizeWorkflowEffects(effects: RawStep['effects']): WorkflowStep['effects'] {
+export function normalizeWorkflowEffects(effects: RawWorkflowEffect[] | undefined): WorkflowEffect[] | undefined {
   return effects?.map((effect) => normalizeWorkflowEffect(effect));
 }

--- a/src/infra/config/loaders/workflowTrustBoundary.ts
+++ b/src/infra/config/loaders/workflowTrustBoundary.ts
@@ -1,4 +1,4 @@
-import type { WorkflowConfig } from '../../../core/models/index.js';
+import type { WorkflowConfig, WorkflowEffect } from '../../../core/models/index.js';
 import { getWorkflowStepKind } from '../../../core/models/workflow-step-kind.js';
 import { getWorkflowTrustInfo, type WorkflowTrustInfo } from './workflowTrustSource.js';
 
@@ -6,11 +6,13 @@ type SystemStepLike = Parameters<typeof getWorkflowStepKind>[0] & {
   name: string;
   allowGitCommit?: boolean;
   parallel?: SystemStepLike[];
+  rules?: Array<{ effects?: WorkflowEffect[] }>;
 };
 
 type PrivilegedCapability =
   | { step: SystemStepLike; reason: 'system' }
-  | { step: SystemStepLike; reason: 'allow_git_commit' };
+  | { step: SystemStepLike; reason: 'allow_git_commit' }
+  | { step: SystemStepLike; reason: 'rule_effect' };
 
 function hasPrivilegedRuntimePrepare(workflow: WorkflowConfig): boolean {
   return (workflow.runtime?.prepare?.length ?? 0) > 0;
@@ -32,6 +34,16 @@ function findPrivilegedAllowGitCommitStep(steps: SystemStepLike[]): SystemStepLi
 }
 
 function findPrivilegedCapability(steps: SystemStepLike[]): PrivilegedCapability | undefined {
+  for (const step of steps) {
+    if (step.rules?.some((rule) => (rule.effects?.length ?? 0) > 0)) {
+      return { step, reason: 'rule_effect' };
+    }
+    const nested = step.parallel ? findPrivilegedCapability(step.parallel) : undefined;
+    if (nested) {
+      return nested;
+    }
+  }
+
   const privilegedSystemStep = findPrivilegedSystemStep(steps);
   if (privilegedSystemStep) {
     return { step: privilegedSystemStep, reason: 'system' };

--- a/src/infra/task/git.ts
+++ b/src/infra/task/git.ts
@@ -3,7 +3,9 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { devNull } from 'node:os';
+import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { devNull, tmpdir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
 import { createLogger } from '../../shared/utils/index.js';
 
 const log = createLogger('git');
@@ -14,6 +16,12 @@ export const NON_FAST_FORWARD_PUSH_HINT =
 export interface StageAndCommitOptions {
   allowGitHooks?: boolean;
   allowGitFilters?: boolean;
+}
+
+export interface ExactPathSnapshot {
+  readonly path: string;
+  readonly contents: Buffer;
+  readonly mode: '100644' | '100755';
 }
 
 export function getCurrentBranch(cwd: string): string {
@@ -73,40 +81,99 @@ export function getSafeGitEnv(cwd: string, options: StageAndCommitOptions): Node
   return env;
 }
 
-export function commitExactPaths(
-  cwd: string,
-  message: string,
-  paths: readonly string[],
-  options: StageAndCommitOptions = {},
-): string | undefined {
-  if (paths.length === 0) {
-    throw new Error('Exact-path commit requires at least one path');
-  }
-  const env = getSafeGitEnv(cwd, options);
-  const literal = ['--literal-pathspecs'] as const;
-  execFileSync('git', [...literal, 'add', '--', ...paths], { cwd, stdio: 'pipe', env });
-
-  const staged = execFileSync('git', [...literal, 'diff', '--cached', '--name-only', 'HEAD', '--', ...paths], {
+function gitOutput(cwd: string, args: readonly string[], env?: NodeJS.ProcessEnv): string {
+  return execFileSync('git', args, {
     cwd,
     encoding: 'utf8',
     stdio: 'pipe',
     env,
   }).trim();
-  if (staged.length === 0) {
-    return undefined;
-  }
+}
 
-  execFileSync('git', [...literal, 'commit', '--no-verify', '--only', '-m', message, '--', ...paths], {
+function writeIndexEntries(
+  cwd: string,
+  snapshots: readonly ExactPathSnapshot[],
+  blobs: readonly string[],
+  env: NodeJS.ProcessEnv,
+): void {
+  const records = snapshots.map((snapshot, index) => (
+    `${snapshot.mode} ${blobs[index]}\t${snapshot.path}\0`
+  )).join('');
+  execFileSync('git', ['update-index', '-z', '--index-info'], {
     cwd,
-    stdio: 'pipe',
+    input: records,
+    stdio: ['pipe', 'pipe', 'pipe'],
     env,
   });
-  return execFileSync('git', ['rev-parse', 'HEAD'], {
-    cwd,
-    encoding: 'utf8',
-    stdio: 'pipe',
-    env,
-  }).trim();
+}
+
+export function commitExactSnapshots(
+  cwd: string,
+  message: string,
+  snapshots: readonly ExactPathSnapshot[],
+): string | undefined {
+  if (snapshots.length === 0) {
+    throw new Error('Exact-snapshot commit requires at least one path');
+  }
+  if (new Set(snapshots.map((snapshot) => snapshot.path)).size !== snapshots.length) {
+    throw new Error('Exact-snapshot commit requires unique paths');
+  }
+  const baseEnv = getSafeGitEnv(cwd, {
+    allowGitHooks: false,
+    allowGitFilters: false,
+  }) ?? process.env;
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'takt-exact-index-'));
+  const temporaryIndex = join(temporaryDirectory, 'index');
+  const temporaryEnv = { ...baseEnv, GIT_INDEX_FILE: temporaryIndex };
+  const head = gitOutput(cwd, ['rev-parse', 'HEAD'], baseEnv);
+  const headTree = gitOutput(cwd, ['rev-parse', 'HEAD^{tree}'], baseEnv);
+  const rawIndexPath = gitOutput(cwd, ['rev-parse', '--git-path', 'index'], baseEnv);
+  const indexPath = isAbsolute(rawIndexPath) ? rawIndexPath : join(cwd, rawIndexPath);
+  const hadIndex = existsSync(indexPath);
+  const originalIndex = hadIndex ? readFileSync(indexPath) : undefined;
+
+  try {
+    const blobs = snapshots.map((snapshot) => execFileSync(
+      'git',
+      ['hash-object', '-w', '--stdin'],
+      {
+        cwd,
+        input: snapshot.contents,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: baseEnv,
+      },
+    ).trim());
+    execFileSync('git', ['read-tree', head], { cwd, stdio: 'pipe', env: temporaryEnv });
+    writeIndexEntries(cwd, snapshots, blobs, temporaryEnv);
+    const tree = gitOutput(cwd, ['write-tree'], temporaryEnv);
+    if (tree === headTree) {
+      writeIndexEntries(cwd, snapshots, blobs, baseEnv);
+      return undefined;
+    }
+    const commit = execFileSync('git', ['commit-tree', tree, '-p', head, '-F', '-'], {
+      cwd,
+      input: `${message}\n`,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: baseEnv,
+    }).trim();
+
+    try {
+      writeIndexEntries(cwd, snapshots, blobs, baseEnv);
+      execFileSync('git', ['update-ref', 'HEAD', commit, head], { cwd, stdio: 'pipe', env: baseEnv });
+    } catch (error) {
+      if (originalIndex !== undefined) {
+        writeFileSync(indexPath, originalIndex);
+      } else if (existsSync(indexPath)) {
+        unlinkSync(indexPath);
+      }
+      throw error;
+    }
+    return commit;
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
 }
 
 /**

--- a/src/infra/task/git.ts
+++ b/src/infra/task/git.ts
@@ -41,7 +41,7 @@ function getFilterConfigNames(cwd: string): string[] {
   }
 }
 
-function getSafeGitEnv(cwd: string, options: StageAndCommitOptions): NodeJS.ProcessEnv | undefined {
+export function getSafeGitEnv(cwd: string, options: StageAndCommitOptions): NodeJS.ProcessEnv | undefined {
   const configEntries: Array<readonly [string, string]> = [];
 
   if (!options.allowGitHooks) {
@@ -71,6 +71,42 @@ function getSafeGitEnv(cwd: string, options: StageAndCommitOptions): NodeJS.Proc
   });
 
   return env;
+}
+
+export function commitExactPaths(
+  cwd: string,
+  message: string,
+  paths: readonly string[],
+  options: StageAndCommitOptions = {},
+): string | undefined {
+  if (paths.length === 0) {
+    throw new Error('Exact-path commit requires at least one path');
+  }
+  const env = getSafeGitEnv(cwd, options);
+  const literal = ['--literal-pathspecs'] as const;
+  execFileSync('git', [...literal, 'add', '--', ...paths], { cwd, stdio: 'pipe', env });
+
+  const staged = execFileSync('git', [...literal, 'diff', '--cached', '--name-only', 'HEAD', '--', ...paths], {
+    cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    env,
+  }).trim();
+  if (staged.length === 0) {
+    return undefined;
+  }
+
+  execFileSync('git', [...literal, 'commit', '--no-verify', '--only', '-m', message, '--', ...paths], {
+    cwd,
+    stdio: 'pipe',
+    env,
+  });
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    env,
+  }).trim();
 }
 
 /**

--- a/src/infra/workflow/system/DefaultSystemStepServices.ts
+++ b/src/infra/workflow/system/DefaultSystemStepServices.ts
@@ -25,6 +25,7 @@ import { enqueueTaskEffect } from './system-enqueue-effect.js';
 import { resolveConflictsWithAiEffect, syncWithRootEffect } from './system-sync-effects.js';
 import { resolveIssueListInput, resolveIssueSelectionInput } from './system-issue-input-resolver.js';
 import { resolvePrListInput, resolvePrSelectionInput } from './system-pr-input-resolver.js';
+import { captureArtifactsEffect, commitArtifactsEffect } from './system-artifact-effects.js';
 
 function listQueueTasks(projectCwd: string) {
   return new TaskRunner(projectCwd).listAllTaskItems();
@@ -168,6 +169,10 @@ async function runEffect(
   payload: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   switch (effect.type) {
+    case 'capture_artifacts':
+      return captureArtifactsEffect(options, effect);
+    case 'commit_artifacts':
+      return commitArtifactsEffect(options, payload);
     case 'enqueue_task':
       return enqueueTaskEffect(options, payload as Parameters<typeof enqueueTaskEffect>[1]);
     case 'comment_pr':

--- a/src/infra/workflow/system/system-artifact-effects.ts
+++ b/src/infra/workflow/system/system-artifact-effects.ts
@@ -1,0 +1,325 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path';
+import type { WorkflowEffect } from '../../../core/models/types.js';
+import type { SystemStepServicesOptions } from '../../../core/workflow/system/system-step-services.js';
+import { commitExactPaths } from '../../task/git.js';
+
+interface GitStatusEntry {
+  readonly status: string;
+  readonly path: string;
+  readonly sourcePath?: string;
+}
+
+interface ArtifactIdentity {
+  readonly path: string;
+  readonly sha256: string;
+}
+
+interface ArtifactManifest {
+  readonly schema_version: 1;
+  readonly task_hash: string;
+  readonly artifacts: readonly ArtifactIdentity[];
+}
+
+type CaptureArtifactsEffect = Extract<WorkflowEffect, { type: 'capture_artifacts' }>;
+
+function parseGitStatus(output: string): readonly GitStatusEntry[] {
+  const records = output.split('\0');
+  const entries: GitStatusEntry[] = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record) {
+      continue;
+    }
+    if (record.length < 4 || record[2] !== ' ') {
+      throw new Error(`Invalid git status record: ${JSON.stringify(record)}`);
+    }
+    const status = record.slice(0, 2);
+    const path = record.slice(3);
+    if (status.includes('R') || status.includes('C')) {
+      const sourcePath = records[index + 1];
+      if (!sourcePath) {
+        throw new Error(`Git status rename/copy is missing its source path: ${path}`);
+      }
+      index += 1;
+      entries.push({ status, path, sourcePath });
+      continue;
+    }
+    entries.push({ status, path });
+  }
+  return entries;
+}
+
+function readGitStatus(cwd: string): readonly GitStatusEntry[] {
+  const output = execFileSync(
+    'git',
+    ['status', '--porcelain=v1', '-z', '--untracked-files=all'],
+    { cwd, encoding: 'utf8', stdio: 'pipe' },
+  );
+  return parseGitStatus(output);
+}
+
+function globPatternToRegExp(pattern: string): RegExp {
+  if (isAbsolute(pattern) || pattern.includes('\\') || pattern.split('/').includes('..')) {
+    throw new Error(`Artifact allow pattern must be a safe repository-relative path: ${pattern}`);
+  }
+  const escaped = pattern
+    .split('*')
+    .map((part) => part.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+    .join('[^/]*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function assertSafeRegularFile(cwd: string, repositoryPath: string): string {
+  if (
+    repositoryPath.length === 0
+    || isAbsolute(repositoryPath)
+    || repositoryPath.includes('\\')
+    || repositoryPath.split('/').some((segment) => segment === '' || segment === '.' || segment === '..')
+    || repositoryPath === '.git'
+    || repositoryPath.startsWith('.git/')
+    || repositoryPath === '.takt'
+    || repositoryPath.startsWith('.takt/')
+  ) {
+    throw new Error(`Unsafe artifact path: ${repositoryPath}`);
+  }
+
+  let current = cwd;
+  for (const segment of repositoryPath.split('/')) {
+    current = join(current, segment);
+    const stat = lstatSync(current);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Artifact path must not contain symlinks: ${repositoryPath}`);
+    }
+  }
+  if (!lstatSync(current).isFile()) {
+    throw new Error(`Artifact path must be a regular file: ${repositoryPath}`);
+  }
+  const canonicalRoot = realpathSync(cwd);
+  const canonicalPath = realpathSync(current);
+  const fromRoot = relative(canonicalRoot, canonicalPath);
+  if (fromRoot === '..' || fromRoot.startsWith(`..${sep}`) || isAbsolute(fromRoot)) {
+    throw new Error(`Artifact path escapes repository: ${repositoryPath}`);
+  }
+  return canonicalPath;
+}
+
+function sha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function hashText(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function resolveManifestPath(cwd: string, repositoryPath: string): string {
+  if (
+    !repositoryPath.startsWith('.takt/state/')
+    || isAbsolute(repositoryPath)
+    || repositoryPath.includes('\\')
+    || repositoryPath.split('/').some((segment) => segment === '' || segment === '.' || segment === '..')
+  ) {
+    throw new Error(`Artifact manifest path must be under .takt/state/: ${repositoryPath}`);
+  }
+  let current = cwd;
+  const segments = repositoryPath.split('/');
+  for (const segment of segments.slice(0, -1)) {
+    current = join(current, segment);
+    try {
+      if (lstatSync(current).isSymbolicLink()) {
+        throw new Error(`Artifact manifest path must not contain symlinks: ${repositoryPath}`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+      mkdirSync(current, { mode: 0o700 });
+    }
+  }
+  return join(cwd, repositoryPath);
+}
+
+function persistManifest(cwd: string, repositoryPath: string, manifest: ArtifactManifest): void {
+  const path = resolveManifestPath(cwd, repositoryPath);
+  const temporaryPath = `${path}.${randomUUID()}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+    mode: 0o600,
+  });
+  renameSync(temporaryPath, path);
+}
+
+function readPersistedManifest(cwd: string, repositoryPath: string): unknown {
+  const path = resolveManifestPath(cwd, repositoryPath);
+  if (lstatSync(path).isSymbolicLink()) {
+    throw new Error(`Artifact manifest must not be a symlink: ${repositoryPath}`);
+  }
+  return JSON.parse(readFileSync(path, 'utf8')) as unknown;
+}
+
+function readPersistedManifestIfPresent(cwd: string, repositoryPath: string): ArtifactManifest | undefined {
+  try {
+    return mapArtifactManifest(readPersistedManifest(cwd, repositoryPath));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function createArtifactIdentity(cwd: string, repositoryPath: string): ArtifactIdentity {
+  const canonicalPath = assertSafeRegularFile(cwd, repositoryPath);
+  return { path: repositoryPath, sha256: sha256(canonicalPath) };
+}
+
+function requireStringArray(value: unknown, field: string): readonly string[] {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new Error(`Artifact manifest requires non-empty string array field "${field}"`);
+  }
+  return value;
+}
+
+function mapArtifactManifest(value: unknown): ArtifactManifest {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('commit_artifacts requires object field "manifest"');
+  }
+  const raw = value as Record<string, unknown>;
+  if (
+    raw.schema_version !== 1
+    || typeof raw.task_hash !== 'string'
+    || !/^[a-f0-9]{64}$/.test(raw.task_hash)
+    || !Array.isArray(raw.artifacts)
+    || raw.artifacts.length === 0
+  ) {
+    throw new Error('Invalid artifact manifest schema');
+  }
+  const artifacts = raw.artifacts.map((item, index): ArtifactIdentity => {
+    if (item == null || typeof item !== 'object' || Array.isArray(item)) {
+      throw new Error(`Invalid artifact manifest item at index ${index}`);
+    }
+    const rawItem = item as Record<string, unknown>;
+    if (typeof rawItem.path !== 'string' || typeof rawItem.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(rawItem.sha256)) {
+      throw new Error(`Invalid artifact identity at index ${index}`);
+    }
+    return { path: rawItem.path, sha256: rawItem.sha256 };
+  });
+  return { schema_version: 1, task_hash: raw.task_hash, artifacts };
+}
+
+export function captureArtifactsEffect(
+  options: SystemStepServicesOptions,
+  effect: CaptureArtifactsEffect,
+): Record<string, unknown> {
+  const allowedPatterns = effect.allowedPatterns.map(globPatternToRegExp);
+  const requiredBasenames = requireStringArray(effect.requiredBasenames, 'required_basenames');
+  if (new Set(requiredBasenames).size !== requiredBasenames.length) {
+    throw new Error('capture_artifacts required_basenames must be unique');
+  }
+
+  const candidates = readGitStatus(options.cwd)
+    .filter((entry) => allowedPatterns.some((pattern) => pattern.test(entry.path)));
+  const renamedCandidate = candidates.find((entry) => entry.status.includes('R') || entry.status.includes('C'));
+  if (renamedCandidate) {
+    throw new Error(`Artifact capture does not allow renamed or copied artifact paths: ${renamedCandidate.path}`);
+  }
+  if (candidates.length === 0) {
+    throw new Error('capture_artifacts found no dirty allowed artifact paths');
+  }
+  const candidatePaths = candidates.map((entry) => entry.path);
+  const parents = new Set(candidatePaths.map((path) => dirname(path)));
+  const previousManifest = effect.manifestPath !== undefined
+    ? readPersistedManifestIfPresent(options.cwd, effect.manifestPath)
+    : undefined;
+  if (previousManifest !== undefined && previousManifest.task_hash !== hashText(options.task)) {
+    throw new Error('Persisted artifact manifest belongs to a different task');
+  }
+  const previousParents = new Set(previousManifest?.artifacts.map((artifact) => dirname(artifact.path)) ?? []);
+  const previousParent = previousParents.size === 1 ? [...previousParents][0] : undefined;
+  const completeParents = [...parents].filter((parent) => {
+    const names = new Set(
+      candidatePaths.filter((path) => dirname(path) === parent).map((path) => basename(path)),
+    );
+    return requiredBasenames.every((name) => names.has(name));
+  });
+  const eligibleParents = previousParent !== undefined && parents.has(previousParent)
+    ? [previousParent]
+    : completeParents.length > 0 ? completeParents : [...parents];
+  if (effect.sameParent && eligibleParents.length !== 1) {
+    throw new Error(
+      `capture_artifacts could not identify one current artifact parent: `
+      + `${parents.size} dirty parent(s), ${completeParents.length} complete parent(s)`,
+    );
+  }
+  const parent = eligibleParents[0]!;
+  const candidateBasenames = new Set(
+    candidatePaths.filter((path) => dirname(path) === parent).map((path) => basename(path)),
+  );
+  for (const candidate of candidateBasenames) {
+    if (!requiredBasenames.includes(candidate)) {
+      throw new Error(`capture_artifacts found unexpected artifact basename: ${candidate}`);
+    }
+  }
+
+  const artifacts = requiredBasenames.map((name) => {
+    const path = `${parent}/${name}`;
+    if (!allowedPatterns.some((pattern) => pattern.test(path))) {
+      throw new Error(`Required artifact is outside the allow patterns: ${path}`);
+    }
+    return createArtifactIdentity(options.cwd, path);
+  });
+  const manifest: ArtifactManifest = {
+    schema_version: 1,
+    task_hash: hashText(options.task),
+    artifacts,
+  };
+  if (effect.manifestPath !== undefined) {
+    persistManifest(options.cwd, effect.manifestPath, manifest);
+  }
+  return { manifest };
+}
+
+export function commitArtifactsEffect(
+  options: SystemStepServicesOptions,
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  const manifest = mapArtifactManifest(
+    payload.manifestPath !== undefined
+      ? readPersistedManifest(options.cwd, String(payload.manifestPath))
+      : payload.manifest,
+  );
+  if (manifest.task_hash !== hashText(options.task)) {
+    throw new Error('Artifact manifest belongs to a different task');
+  }
+  if (typeof payload.message !== 'string' || payload.message.trim().length === 0) {
+    throw new Error('commit_artifacts requires non-empty string field "message"');
+  }
+  const paths = manifest.artifacts.map((artifact) => {
+    const identity = createArtifactIdentity(options.cwd, artifact.path);
+    if (identity.sha256 !== artifact.sha256) {
+      throw new Error(`Artifact changed after capture: ${artifact.path}`);
+    }
+    return artifact.path;
+  });
+  if (new Set(paths).size !== paths.length) {
+    throw new Error('Artifact manifest contains duplicate paths');
+  }
+
+  const commit = commitExactPaths(options.cwd, payload.message, paths, {
+    allowGitHooks: false,
+    allowGitFilters: false,
+  });
+  return commit === undefined
+    ? { status: 'already_committed', paths }
+    : { status: 'committed', commit, paths };
+}

--- a/src/infra/workflow/system/system-artifact-effects.ts
+++ b/src/infra/workflow/system/system-artifact-effects.ts
@@ -11,7 +11,8 @@ import {
 import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path';
 import type { WorkflowEffect } from '../../../core/models/types.js';
 import type { SystemStepServicesOptions } from '../../../core/workflow/system/system-step-services.js';
-import { commitExactPaths } from '../../task/git.js';
+import { commitExactSnapshots } from '../../task/git.js';
+import type { ExactPathSnapshot } from '../../task/git.js';
 
 interface GitStatusEntry {
   readonly status: string;
@@ -183,6 +184,20 @@ function createArtifactIdentity(cwd: string, repositoryPath: string): ArtifactId
   return { path: repositoryPath, sha256: sha256(canonicalPath) };
 }
 
+function readVerifiedArtifactSnapshot(
+  cwd: string,
+  artifact: ArtifactIdentity,
+): ExactPathSnapshot {
+  const canonicalPath = assertSafeRegularFile(cwd, artifact.path);
+  const contents = readFileSync(canonicalPath);
+  const actualHash = createHash('sha256').update(contents).digest('hex');
+  if (actualHash !== artifact.sha256) {
+    throw new Error(`Artifact changed after capture: ${artifact.path}`);
+  }
+  const mode = (lstatSync(canonicalPath).mode & 0o111) === 0 ? '100644' : '100755';
+  return { path: artifact.path, contents, mode };
+}
+
 function requireStringArray(value: unknown, field: string): readonly string[] {
   if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.length === 0)) {
     throw new Error(`Artifact manifest requires non-empty string array field "${field}"`);
@@ -270,9 +285,8 @@ export function captureArtifactsEffect(
       throw new Error(`capture_artifacts found unexpected artifact basename: ${candidate}`);
     }
   }
-
   const artifacts = requiredBasenames.map((name) => {
-    const path = `${parent}/${name}`;
+    const path = parent === '.' ? name : `${parent}/${name}`;
     if (!allowedPatterns.some((pattern) => pattern.test(path))) {
       throw new Error(`Required artifact is outside the allow patterns: ${path}`);
     }
@@ -304,21 +318,15 @@ export function commitArtifactsEffect(
   if (typeof payload.message !== 'string' || payload.message.trim().length === 0) {
     throw new Error('commit_artifacts requires non-empty string field "message"');
   }
-  const paths = manifest.artifacts.map((artifact) => {
-    const identity = createArtifactIdentity(options.cwd, artifact.path);
-    if (identity.sha256 !== artifact.sha256) {
-      throw new Error(`Artifact changed after capture: ${artifact.path}`);
-    }
-    return artifact.path;
-  });
+  const snapshots = manifest.artifacts.map((artifact) => (
+    readVerifiedArtifactSnapshot(options.cwd, artifact)
+  ));
+  const paths = snapshots.map((snapshot) => snapshot.path);
   if (new Set(paths).size !== paths.length) {
     throw new Error('Artifact manifest contains duplicate paths');
   }
 
-  const commit = commitExactPaths(options.cwd, payload.message, paths, {
-    allowGitHooks: false,
-    allowGitFilters: false,
-  });
+  const commit = commitExactSnapshots(options.cwd, payload.message, snapshots);
   return commit === undefined
     ? { status: 'already_committed', paths }
     : { status: 'committed', commit, paths };

--- a/src/infra/workflow/system/system-artifact-effects.ts
+++ b/src/infra/workflow/system/system-artifact-effects.ts
@@ -253,12 +253,12 @@ export function captureArtifactsEffect(
   }
   const candidatePaths = candidates.map((entry) => entry.path);
   const parents = new Set(candidatePaths.map((path) => dirname(path)));
-  const previousManifest = effect.manifestPath !== undefined
+  const persistedManifest = effect.manifestPath !== undefined
     ? readPersistedManifestIfPresent(options.cwd, effect.manifestPath)
     : undefined;
-  if (previousManifest !== undefined && previousManifest.task_hash !== hashText(options.task)) {
-    throw new Error('Persisted artifact manifest belongs to a different task');
-  }
+  const previousManifest = persistedManifest?.task_hash === hashText(options.task)
+    ? persistedManifest
+    : undefined;
   const previousParents = new Set(previousManifest?.artifacts.map((artifact) => dirname(artifact.path)) ?? []);
   const previousParent = previousParents.size === 1 ? [...previousParents][0] : undefined;
   const completeParents = [...parents].filter((parent) => {


### PR DESCRIPTION
## Problem

Workflow quality gates run before rule selection, while system steps run as separate movements. Neither can perform a deterministic side effect at the exact boundary after a specific rule is selected and before the next agent starts.

This made it impossible to atomically capture plan artifacts before review and commit only the reviewed bytes after a Go decision.

## Changes

- Add typed `effects` to workflow rules.
- Execute selected-rule effects after transition resolution and before user input, return, loop-monitor rerouting, or the next step.
- Treat effect failure as a fail-closed runtime error; the next agent is not started.
- Add two non-shell effects:
  - `capture_artifacts`: selects one dirty artifact parent from Git porcelain, validates required basenames and allowed patterns, rejects symlinks/path traversal, and records SHA-256 identities.
  - `commit_artifacts`: reads each artifact once, validates that byte snapshot against the captured hash, writes Git blobs from those exact bytes, and commits them through an isolated index with hooks and filters disabled.
- Preserve unrelated staged files when committing approved artifacts.
- Make crash-after-commit retry idempotent (`already_committed`, no empty commit).
- Optionally persist task-bound manifests under `.takt/state/` so a restarted process can resume the review/commit boundary without in-memory `effectResults`.
- Disambiguate replans by preferring the persisted parent, or otherwise the unique dirty parent containing the complete required basename set.
- Mark rule effects as privileged across workflow trust boundaries.
- Reject duplicate effect types at the schema boundary so result bindings cannot be silently overwritten.
- Require workflows using rule effects to declare `requires.rule_effects: 1`; pre-feature TAKT versions reject this unknown root key instead of silently stripping `effects`.
- Reject rule effects on both agent and workflow-call parallel sub-steps because that runner has no transition-effect executor.
- Treat a persisted manifest from a different task as stale during a new capture and overwrite it; commit still rejects a mismatched task.

## Why not structured output or shell commands

- Artifact identity is derived from filesystem/Git state, not model-authored JSON.
- No arbitrary shell effect is introduced.
- Workflows can inject captured scalar paths into the reviewer instruction through existing effect references.

## Proof

The integration test executes a real two-step `plan -> plan-review` WorkflowEngine flow in a temporary Git repository:

1. `plan` captures the three dirty artifacts.
2. `plan-review` receives those exact paths in its prompt.
3. Go commits exactly those three files.
4. Modified-after-capture bytes are rejected.
5. Unrelated staged files remain staged and are not included.
6. A transition-effect failure aborts before cycle monitoring or the next step.
7. An unrelated rename outside the allow patterns does not abort capture.
8. Persisted manifests reject a different task hash and survive process-local state loss.
9. A worktree file changed after byte verification cannot enter the commit: the verified bytes are committed and the later bytes remain a dirty worktree change.
10. Capture failure aborts a real WorkflowEngine run before transition; repository HEAD remains unchanged.
11. Repository-root artifacts, traversal rejection, and symlink rejection are covered.
12. A capability-contract test rejects rule effects without the explicit requirement and accepts them with it.
13. Agent and workflow-call parallel sub-step rule effects both fail at schema load instead of becoming a silent no-op.
14. A stale task manifest is replaced by the next capture, while commit-side task binding remains fail-closed.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] New unit and integration tests
- [x] Post-review regression tests: 21 unit + 1 WorkflowEngine integration
- [x] Latest review regression: 15 artifact/schema unit tests + 2 WorkflowEngine integrations
- [x] Related 274-test regression set
- [x] Workflow loader/trust/validator suite: 166 passed
- [x] Full unit run: 7,638 passed; 8 unrelated parallel timeouts, affected assertion suites passed when rerun with one worker (207/207)