### PR TITLE
fix(opencode): allow concurrent prompts across sessions

### DIFF
--- a/e2e/specs/opencode-parallel-sessions.e2e.ts
+++ b/e2e/specs/opencode-parallel-sessions.e2e.ts
@@ -4,6 +4,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { resolve as resolvePath } from 'node:path';
 import { createOpencode, type Event as OpenCodeEvent } from '@opencode-ai/sdk/v2';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentResponse } from '../../src/core/models/response.js';
 
 const { createOpencodeMock } = vi.hoisted(() => ({
   createOpencodeMock: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock('@opencode-ai/sdk/v2', async () => {
 const INTEGRATION_ENV = 'TAKT_OPENCODE_PARALLEL_INTEGRATION';
 const SERVER_START_TIMEOUT = 60_000;
 const SESSION_TIMEOUT = 240_000;
+const NO_UPSTREAM_REQUEST_WINDOW_MS = 1_000;
 const DUMMY_API_KEY = 'takt-test-dummy-api-key';
 const MODEL = { providerID: 'opencode', modelID: 'deepseek-v4-flash-free' } as const;
 const RESPONSE_MODEL = 'opencode/deepseek-v4-flash-free';
@@ -922,6 +924,10 @@ describe.skipIf(shouldSkip)('OpenCode parallel sessions', () => {
       model: MODEL,
       parts: [{ type: 'text' as const, text: 'SESSION-FIFO-1 first prompt' }],
     });
+
+    await upstream.waitForMarkerRequest('SESSION-FIFO-1', 60_000);
+    expect(upstream.requests.length).toBe(1);
+
     const prompt2 = ocClient.session.promptAsync({
       sessionID: sessionId,
       directory: dir,
@@ -929,14 +935,16 @@ describe.skipIf(shouldSkip)('OpenCode parallel sessions', () => {
       parts: [{ type: 'text' as const, text: 'SESSION-FIFO-2 second prompt' }],
     });
 
-    // The OpenCode server queues prompts per session: the second
-    // prompt is not sent until the first completes.  Gate the first
-    // response so we can verify FIFO ordering.
-    await upstream.waitForMarkerRequest('SESSION-FIFO-1', 60_000);
-    expect(upstream.requests.length).toBe(1);
-    expect(upstream.hasBodyContaining('SESSION-FIFO-2')).toBe(false);
+    // FIFO-2 must not reach upstream while FIFO-1 is still gated.
+    // OpenCode SDK provides no acknowledgement when it accepts FIFO-2, so in this
+    // real-process integration test we use a bounded observation window instead.
+    await expect(
+      upstream.waitForBodyMatch(
+        'SESSION-FIFO-2',
+        NO_UPSTREAM_REQUEST_WINDOW_MS,
+      ),
+    ).rejects.toThrow(/Timed out waiting for request body/);
 
-    // Release the first — the now-completed prompt unblocks the second.
     upstream.releaseGate('SESSION-FIFO-1');
     await upstream.waitForBodyMatch('SESSION-FIFO-2', 60_000);
     upstream.releaseBodyGate('SESSION-FIFO-2');
@@ -1216,6 +1224,48 @@ describe.skipIf(shouldSkip)('OpenCodeClient via Takt adapter (integration)', () 
     taktUpstream.releaseBodyGate('TAKT-FIFO-2');
 
     const results = await Promise.all([call1, call2]);
+    expect(results[0].status).toBe('done');
+    expect(results[1].status).toBe('done');
+    expect(taktUpstream.pendingRequests()).toBe(0);
+  }, SESSION_TIMEOUT * 3);
+
+  it('should queue a follow-up call started from init callback behind the first', async () => {
+    if (!taktUpstream || !taktOcClient) {
+      throw new Error('setup failed');
+    }
+
+    taktUpstream.clearRequests();
+    taktUpstream.activateGate('TAKT-INIT-FIRST');
+    taktUpstream.activateBodyGate('TAKT-INIT-SECOND');
+
+    let call2Promise: Promise<AgentResponse> | undefined;
+    const onStream = vi.fn((event) => {
+      if (event.type === 'init' && typeof event.data?.sessionId === 'string') {
+        call2Promise = taktOcClient!.call('coder', 'TAKT-INIT-SECOND follow-up', {
+          cwd: process.cwd(),
+          model: RESPONSE_MODEL,
+          sessionId: event.data.sessionId,
+        });
+      }
+    });
+
+    const call1 = taktOcClient.call('coder', 'TAKT-INIT-FIRST initial', {
+      cwd: process.cwd(),
+      model: RESPONSE_MODEL,
+      onStream,
+    });
+
+    await taktUpstream.waitForMarkerRequest('TAKT-INIT-FIRST', 60_000);
+
+    expect(call2Promise).toBeDefined();
+    expect(taktUpstream.hasBodyContaining('TAKT-INIT-SECOND')).toBe(false);
+    expect(taktUpstream.pendingRequests()).toBe(1);
+
+    taktUpstream.releaseGate('TAKT-INIT-FIRST');
+    await taktUpstream.waitForBodyMatch('TAKT-INIT-SECOND', 60_000);
+    taktUpstream.releaseBodyGate('TAKT-INIT-SECOND');
+
+    const results = await Promise.all([call1, call2Promise!]);
     expect(results[0].status).toBe('done');
     expect(results[1].status).toBe('done');
     expect(taktUpstream.pendingRequests()).toBe(0);

--- a/e2e/specs/opencode-parallel-sessions.e2e.ts
+++ b/e2e/specs/opencode-parallel-sessions.e2e.ts
@@ -25,7 +25,7 @@ vi.mock('@opencode-ai/sdk/v2', async () => {
 const INTEGRATION_ENV = 'TAKT_OPENCODE_PARALLEL_INTEGRATION';
 const SERVER_START_TIMEOUT = 60_000;
 const SESSION_TIMEOUT = 240_000;
-const NO_UPSTREAM_REQUEST_WINDOW_MS = 1_000;
+
 const DUMMY_API_KEY = 'takt-test-dummy-api-key';
 const MODEL = { providerID: 'opencode', modelID: 'deepseek-v4-flash-free' } as const;
 const RESPONSE_MODEL = 'opencode/deepseek-v4-flash-free';
@@ -928,6 +928,7 @@ describe.skipIf(shouldSkip)('OpenCode parallel sessions', () => {
     await upstream.waitForMarkerRequest('SESSION-FIFO-1', 60_000);
     expect(upstream.requests.length).toBe(1);
 
+    const prePrompt2EventCount = allEvents.length;
     const prompt2 = ocClient.session.promptAsync({
       sessionID: sessionId,
       directory: dir,
@@ -935,15 +936,22 @@ describe.skipIf(shouldSkip)('OpenCode parallel sessions', () => {
       parts: [{ type: 'text' as const, text: 'SESSION-FIFO-2 second prompt' }],
     });
 
-    // FIFO-2 must not reach upstream while FIFO-1 is still gated.
-    // OpenCode SDK provides no acknowledgement when it accepts FIFO-2, so in this
-    // real-process integration test we use a bounded observation window instead.
-    await expect(
-      upstream.waitForBodyMatch(
-        'SESSION-FIFO-2',
-        NO_UPSTREAM_REQUEST_WINDOW_MS,
+    await waitForCondition(
+      () => allEvents.slice(prePrompt2EventCount).some(
+        (event) =>
+          extractSessionID(event) === sessionId &&
+          getEventTextFragments(event).some((text) =>
+            text.includes('SESSION-FIFO-2'),
+          ),
       ),
-    ).rejects.toThrow(/Timed out waiting for request body/);
+      30_000,
+      'timed out waiting for second prompt acknowledgement',
+      () => `events=[${describeRecentEvents(allEvents.slice(prePrompt2EventCount))}]`,
+    );
+
+    // FIFO-2 must not reach the upstream provider while FIFO-1 is still
+    // gated — the gate is released below.
+    expect(upstream.hasBodyContaining('SESSION-FIFO-2')).toBe(false);
 
     upstream.releaseGate('SESSION-FIFO-1');
     await upstream.waitForBodyMatch('SESSION-FIFO-2', 60_000);
@@ -1199,6 +1207,9 @@ describe.skipIf(shouldSkip)('OpenCodeClient via Takt adapter (integration)', () 
     taktUpstream.activateGate('TAKT-FIFO-1');
     taktUpstream.activateBodyGate('TAKT-FIFO-2');
 
+    const ac2 = new AbortController();
+    const registerAbortSpy = vi.spyOn(ac2.signal, 'addEventListener');
+
     const call1 = taktOcClient.call('coder', 'TAKT-FIFO-1 first', {
       cwd: process.cwd(),
       model: RESPONSE_MODEL,
@@ -1208,11 +1219,22 @@ describe.skipIf(shouldSkip)('OpenCodeClient via Takt adapter (integration)', () 
       cwd: process.cwd(),
       model: RESPONSE_MODEL,
       sessionId,
+      abortSignal: ac2.signal,
     });
 
-    // Hold the first call's response via marker gate so we can verify
-    // that the second call has not reached upstream before the first
-    // completes (FIFO queuing at OpenCodeClient level).
+    // Wait for call2 to be enqueued — visible via the abort listener
+    // registration in acquireSharedServer.  This ensures call2 has been
+    // accepted by the queue before we assert it hasn't reached upstream.
+    await vi.waitFor(() => {
+      expect(registerAbortSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    expect(registerAbortSpy.mock.calls[1]).toEqual([
+      'abort',
+      expect.any(Function),
+      { once: true },
+    ]);
+
     await taktUpstream.waitForMarkerRequest('TAKT-FIFO-1', 60_000);
     expect(taktUpstream.pendingRequests()).toBe(1);
     expect(taktUpstream.hasBodyContaining('TAKT-FIFO-2')).toBe(false);
@@ -1239,12 +1261,15 @@ describe.skipIf(shouldSkip)('OpenCodeClient via Takt adapter (integration)', () 
     taktUpstream.activateBodyGate('TAKT-INIT-SECOND');
 
     let call2Promise: Promise<AgentResponse> | undefined;
+    const ac2 = new AbortController();
+    const registerAbortSpy = vi.spyOn(ac2.signal, 'addEventListener');
     const onStream = vi.fn((event) => {
       if (event.type === 'init' && typeof event.data?.sessionId === 'string') {
         call2Promise = taktOcClient!.call('coder', 'TAKT-INIT-SECOND follow-up', {
           cwd: process.cwd(),
           model: RESPONSE_MODEL,
           sessionId: event.data.sessionId,
+          abortSignal: ac2.signal,
         });
       }
     });
@@ -1257,7 +1282,17 @@ describe.skipIf(shouldSkip)('OpenCodeClient via Takt adapter (integration)', () 
 
     await taktUpstream.waitForMarkerRequest('TAKT-INIT-FIRST', 60_000);
 
-    expect(call2Promise).toBeDefined();
+    await vi.waitFor(() => {
+      expect(call2Promise).toBeDefined();
+      expect(registerAbortSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    expect(registerAbortSpy.mock.calls[1]).toEqual([
+      'abort',
+      expect.any(Function),
+      { once: true },
+    ]);
+
     expect(taktUpstream.hasBodyContaining('TAKT-INIT-SECOND')).toBe(false);
     expect(taktUpstream.pendingRequests()).toBe(1);
 

--- a/e2e/specs/opencode-parallel-sessions.e2e.ts
+++ b/e2e/specs/opencode-parallel-sessions.e2e.ts
@@ -1,0 +1,1223 @@
+import { accessSync, constants as fsConstants } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { resolve as resolvePath } from 'node:path';
+import { createOpencode, type Event as OpenCodeEvent } from '@opencode-ai/sdk/v2';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createOpencodeMock } = vi.hoisted(() => ({
+  createOpencodeMock: vi.fn(),
+}));
+
+vi.mock('@opencode-ai/sdk/v2', async () => {
+  const actual = await vi.importActual<{ createOpencode: typeof createOpencode }>('@opencode-ai/sdk/v2');
+  const realCreateOpencode = actual.createOpencode;
+  createOpencodeMock.mockImplementation((...args: unknown[]) => {
+    return (realCreateOpencode as (...a: unknown[]) => unknown)(...args);
+  });
+  return {
+    ...actual,
+    createOpencode: createOpencodeMock,
+  };
+});
+
+const INTEGRATION_ENV = 'TAKT_OPENCODE_PARALLEL_INTEGRATION';
+const SERVER_START_TIMEOUT = 60_000;
+const SESSION_TIMEOUT = 240_000;
+const DUMMY_API_KEY = 'takt-test-dummy-api-key';
+const MODEL = { providerID: 'opencode', modelID: 'deepseek-v4-flash-free' } as const;
+const RESPONSE_MODEL = 'opencode/deepseek-v4-flash-free';
+
+type RequestRecord = {
+  body: string;
+  time: number;
+  marker: string;
+  authHeader: string | undefined;
+  model: string;
+  url: string;
+  stream: boolean;
+};
+
+type Gate = {
+  resolve: () => void;
+  promise: Promise<void>;
+};
+
+const isEnabled = process.env[INTEGRATION_ENV] === '1';
+const opencodePath = resolveExecutableOnPath('opencode');
+
+if (!isEnabled) {
+  console.log(`[opencode-parallel] skip: set ${INTEGRATION_ENV}=1 to enable`);
+} else if (opencodePath === null) {
+  console.log('[opencode-parallel] skip: opencode CLI not found on PATH');
+}
+
+function resolveExecutableOnPath(command: string): string | null {
+  const pathValue = process.env.PATH;
+  if (!pathValue) {
+    return null;
+  }
+
+  for (const entry of pathValue.split(':')) {
+    if (!entry) {
+      continue;
+    }
+
+    const candidate = resolvePath(entry, command);
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      return candidate;
+    } catch {
+      // keep searching PATH
+    }
+  }
+
+  return null;
+}
+
+async function runCommand(command: string, args: string[], timeoutMs: number): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`Timeout running ${command} ${args.join(' ')}`));
+    }, timeoutMs);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`Command failed with code ${code}: ${stderr.trim() || stdout.trim() || command}`));
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function extractSessionID(event: OpenCodeEvent): string | undefined {
+  if (!isRecord(event.properties)) {
+    return undefined;
+  }
+
+  return typeof event.properties.sessionID === 'string' ? event.properties.sessionID : undefined;
+}
+
+function getEventTextFragments(event: OpenCodeEvent): string[] {
+  if (!isRecord(event.properties)) {
+    return [];
+  }
+
+  if (event.type === 'message.part.updated') {
+    const part = event.properties.part;
+    if (isRecord(part) && typeof part.text === 'string') {
+      return [part.text];
+    }
+    return [];
+  }
+
+  if (event.type === 'message.part.delta' && typeof event.properties.delta === 'string') {
+    return [event.properties.delta];
+  }
+
+  if (event.type === 'session.status') {
+    const status = event.properties.status;
+    if (isRecord(status) && typeof status.message === 'string') {
+      return [status.message];
+    }
+  }
+
+  return [];
+}
+
+function hasSessionIdle(events: OpenCodeEvent[], sessionID: string): boolean {
+  return events.some((event) => event.type === 'session.idle' && extractSessionID(event) === sessionID);
+}
+
+function describeRecentEvents(events: OpenCodeEvent[]): string {
+  return events
+    .map((event) => {
+      if (event.type === 'message.part.updated') {
+        const part = isRecord(event.properties.part) ? event.properties.part : {};
+        return `message.part.updated:${extractSessionID(event)}:part=${JSON.stringify(part)}`;
+      }
+      if (event.type === 'message.part.delta') {
+        return `message.part.delta:${extractSessionID(event)}:delta=${JSON.stringify(event.properties.delta)}`;
+      }
+      if (event.type === 'session.status') {
+        const status = isRecord(event.properties.status) ? event.properties.status : {};
+        return `session.status:${extractSessionID(event)}:status=${JSON.stringify(status)}`;
+      }
+      if (event.type === 'session.idle') {
+        return `session.idle:${extractSessionID(event)}`;
+      }
+      return event.type;
+    })
+    .join(', ');
+}
+
+function describeRawEvents(events: unknown[]): string {
+  return events
+    .map((event) => {
+      if (!isRecord(event)) {
+        return 'non-record';
+      }
+      return typeof event.type === 'string' ? event.type : 'unknown';
+    })
+    .join(', ');
+}
+
+function describeRequests(requests: RequestRecord[]): string {
+  return requests
+    .map((request) => `${request.marker}:${request.model}:${request.url}:stream=${request.stream}`)
+    .join(', ');
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  timeoutMs: number,
+  failureMessage: string,
+  describeState?: () => string,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (!condition()) {
+    if (Date.now() - startedAt >= timeoutMs) {
+      throw new Error(describeState === undefined ? failureMessage : `${failureMessage}; ${describeState()}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+async function waitForPromiseWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  failureMessage: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(failureMessage)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function assertSessionEventIsolation(events: OpenCodeEvent[], ownMarker: string, foreignMarker: string): void {
+  const fragments = events.flatMap((event) => getEventTextFragments(event));
+
+  expect(fragments.length).toBeGreaterThan(0);
+  expect(fragments.some((fragment) => fragment.includes(ownMarker))).toBe(true);
+  expect(fragments.some((fragment) => fragment.includes(foreignMarker))).toBe(false);
+}
+
+function assertNoForeignMarker(events: OpenCodeEvent[], foreignMarker: string): void {
+  const fragments = events.flatMap((event) => getEventTextFragments(event));
+
+  expect(fragments.some((fragment) => fragment.includes(foreignMarker))).toBe(false);
+}
+
+function extractMarker(body: string): string {
+  const match = body.match(/\b(SESSION-[A-Z0-9-]+|TAKT-[A-Z0-9-]+)\b/);
+  return match ? match[1] : 'unknown';
+}
+
+function extractModel(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as { model?: unknown };
+    if (typeof parsed.model === 'string') {
+      return parsed.model;
+    }
+    if (isRecord(parsed.model)) {
+      const providerID = typeof parsed.model.providerID === 'string' ? parsed.model.providerID : undefined;
+      const modelID = typeof parsed.model.modelID === 'string'
+        ? parsed.model.modelID
+        : (typeof parsed.model.id === 'string' ? parsed.model.id : undefined);
+      if (providerID && modelID) {
+        return `${providerID}/${modelID}`;
+      }
+      if (modelID) {
+        return modelID;
+      }
+    }
+    return '';
+  } catch {
+    return '';
+  }
+}
+
+function isStreamRequest(body: string): boolean {
+  try {
+    const parsed = JSON.parse(body) as { stream?: unknown };
+    return parsed.stream === true;
+  } catch {
+    return false;
+  }
+}
+
+class DummyUpstream {
+  readonly server: ReturnType<typeof createServer>;
+  readonly requests: RequestRecord[] = [];
+  private readonly gates = new Map<string, Gate>();
+  private readonly bodyGates = new Map<string, Gate>();
+  private nextRequestIndex = 0;
+  private pending_ = 0;
+  private destroyed_ = 0;
+  private responsesStarted_ = 0;
+  private port_ = 0;
+
+  constructor() {
+    this.server = createServer({ keepAliveTimeout: 5000 }, (req, res) => this.handleRequest(req, res));
+  }
+
+  get port(): number {
+    return this.port_;
+  }
+
+  activateGate(marker: string): void {
+    if (this.gates.has(marker)) {
+      throw new Error(`Gate already exists: ${marker}`);
+    }
+
+    let resolveFn: () => void = () => {};
+    const promise = new Promise<void>((resolve) => {
+      resolveFn = resolve;
+    });
+    this.gates.set(marker, { resolve: resolveFn, promise });
+  }
+
+  releaseGate(marker: string): void {
+    const gate = this.gates.get(marker);
+    if (!gate) {
+      throw new Error(`Gate not found: ${marker}`);
+    }
+
+    gate.resolve();
+    this.gates.delete(marker);
+  }
+
+  releaseAllGates(): void {
+    for (const marker of [...this.gates.keys()]) {
+      this.releaseGate(marker);
+    }
+    for (const text of [...this.bodyGates.keys()]) {
+      this.releaseBodyGate(text);
+    }
+  }
+
+  activateBodyGate(text: string): void {
+    if (this.bodyGates.has(text)) {
+      throw new Error(`Body gate already exists: ${text}`);
+    }
+
+    let resolveFn: () => void = () => {};
+    const promise = new Promise<void>((resolve) => {
+      resolveFn = resolve;
+    });
+    this.bodyGates.set(text, { resolve: resolveFn, promise });
+  }
+
+  releaseBodyGate(text: string): void {
+    const gate = this.bodyGates.get(text);
+    if (!gate) {
+      throw new Error(`Body gate not found: ${text}`);
+    }
+
+    gate.resolve();
+    this.bodyGates.delete(text);
+  }
+
+  waitForBodyMatch(text: string, timeoutMs = 30_000): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const startedAt = Date.now();
+      const check = (): void => {
+        const idx = this.requests.findIndex((r) => r.body.includes(text));
+        if (idx !== -1) {
+          resolve(idx);
+          return;
+        }
+        if (Date.now() - startedAt >= timeoutMs) {
+          reject(new Error(`Timed out waiting for request body containing "${text}"; seen=${this.requests.length}`));
+          return;
+        }
+        setTimeout(check, 50);
+      };
+      check();
+    });
+  }
+
+  hasBodyContaining(text: string): boolean {
+    return this.requests.some((r) => r.body.includes(text));
+  }
+
+  pendingRequests(): number {
+    return this.pending_;
+  }
+
+  destroyedRequests(): number {
+    return this.destroyed_;
+  }
+
+  responsesStarted(): number {
+    return this.responsesStarted_;
+  }
+
+  clearRequests(): void {
+    this.requests.length = 0;
+    this.pending_ = 0;
+    this.responsesStarted_ = 0;
+    this.destroyed_ = 0;
+  }
+
+  async start(): Promise<number> {
+    return await new Promise((resolve) => {
+      this.server.listen(0, '127.0.0.1', () => {
+        const addr = this.server.address();
+        this.port_ = addr && typeof addr === 'object' ? addr.port : 0;
+        resolve(this.port_);
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    this.releaseAllGates();
+    this.server.closeAllConnections?.();
+    await new Promise<void>((resolve, reject) => {
+      this.server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+
+  waitForRequests(count: number, timeoutMs = 30_000): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const startedAt = Date.now();
+      const check = (): void => {
+        if (this.requests.length >= count) {
+          resolve();
+          return;
+        }
+        if (Date.now() - startedAt >= timeoutMs) {
+          reject(new Error(`Timed out waiting for ${count} request(s); seen=${this.requests.length}`));
+          return;
+        }
+        setTimeout(check, 50);
+      };
+      check();
+    });
+  }
+
+  waitForMarkerRequest(marker: string, timeoutMs = 30_000): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const startedAt = Date.now();
+      const check = (): void => {
+        if (this.requests.some((r) => r.marker === marker)) {
+          resolve();
+          return;
+        }
+        if (Date.now() - startedAt >= timeoutMs) {
+          const markers = this.requests.map((r) => r.marker).join(', ');
+          reject(new Error(`Timed out waiting for marker "${marker}"; seen markers=[${markers}]`));
+          return;
+        }
+        setTimeout(check, 50);
+      };
+      check();
+    });
+  }
+
+  getMarkerRequest(marker: string): RequestRecord | undefined {
+    return this.requests.find((r) => r.marker === marker);
+  }
+
+  assertNoMarkerRequest(marker: string): void {
+    const found = this.requests.find((r) => r.marker === marker);
+    if (found !== undefined) {
+      throw new Error(`Expected no request with marker "${marker}" but found one at index ${this.requests.indexOf(found)}`);
+    }
+  }
+
+  private handleRequest(req: IncomingMessage, res: ServerResponse): void {
+    const url = req.url ?? '';
+    const method = req.method ?? 'GET';
+    const authHeader = typeof req.headers.authorization === 'string' ? req.headers.authorization : undefined;
+
+    if (method === 'POST' && (url.includes('/chat/completions') || url.includes('/v1/chat/completions'))) {
+      let body = '';
+      req.on('data', (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      req.on('end', () => {
+        const idx = this.nextRequestIndex++;
+        const marker = extractMarker(body);
+        const model = extractModel(body);
+        const stream = isStreamRequest(body);
+        const responseModel = model || RESPONSE_MODEL;
+        this.requests.push({
+          body,
+          time: Date.now(),
+          marker,
+          authHeader,
+          model,
+          url,
+          stream,
+        });
+        this.pending_++;
+
+        let finished = false;
+        let destroyedCounted = false;
+        const markFinished = (): void => {
+          if (finished) {
+            return;
+          }
+          finished = true;
+          this.pending_--;
+        };
+        const markAborted = (): void => {
+          if (destroyedCounted) {
+            return;
+          }
+          destroyedCounted = true;
+          if (!finished) {
+            this.destroyed_++;
+          }
+          markFinished();
+        };
+
+        req.on('aborted', markAborted);
+        res.on('close', markAborted);
+
+        const sendResponse = (): void => {
+          if (finished) {
+            return;
+          }
+
+          const rid = `cmpl-${Date.now()}-${idx}`;
+          const created = Math.floor(Date.now() / 1000);
+          const assistantText = `Response-from-session-${marker}-${idx}`;
+
+          this.responsesStarted_++;
+
+          if (stream) {
+            const streamChunk = (chunk: unknown): void => {
+              res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+            };
+
+            res.writeHead(200, {
+              'Content-Type': 'text/event-stream; charset=utf-8',
+              'Cache-Control': 'no-cache',
+              Connection: 'keep-alive',
+            });
+            streamChunk({
+              id: rid,
+              object: 'chat.completion.chunk',
+              created,
+              model: responseModel,
+              choices: [{
+                index: 0,
+                delta: { role: 'assistant' },
+                finish_reason: null,
+              }],
+            });
+            streamChunk({
+              id: rid,
+              object: 'chat.completion.chunk',
+              created,
+              model: responseModel,
+              choices: [{
+                index: 0,
+                delta: { content: assistantText },
+                finish_reason: null,
+              }],
+            });
+            streamChunk({
+              id: rid,
+              object: 'chat.completion.chunk',
+              created,
+              model: responseModel,
+              choices: [{
+                index: 0,
+                finish_reason: 'stop',
+              }],
+              usage: {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+              },
+            });
+            res.write('data: [DONE]\n\n');
+            res.end();
+            markFinished();
+            return;
+          }
+
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-cache',
+            Connection: 'close',
+          });
+          res.end(JSON.stringify({
+            id: rid,
+            object: 'chat.completion',
+            created,
+            model: responseModel,
+            choices: [{
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: assistantText,
+              },
+              finish_reason: 'stop',
+            }],
+            usage: {
+              prompt_tokens: 1,
+              completion_tokens: 1,
+              total_tokens: 2,
+            },
+          }));
+          markFinished();
+        };
+
+        const markerGate = this.gates.get(marker);
+        if (markerGate) {
+          void markerGate.promise.then(sendResponse);
+        } else {
+          const bodyGate = [...this.bodyGates.entries()].find(([text]) => body.includes(text));
+          if (bodyGate) {
+            void bodyGate[1].promise.then(sendResponse);
+          } else {
+            sendResponse();
+          }
+        }
+      });
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  }
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close(() => reject(new Error('Failed to get free port')));
+        return;
+      }
+
+      const port = addr.port;
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+const shouldSkip = !isEnabled || opencodePath === null;
+
+describe.skipIf(shouldSkip)('OpenCode parallel sessions', () => {
+  let upstream: DummyUpstream | undefined;
+  let ocClient: Awaited<ReturnType<typeof createOpencode>>['client'] | undefined;
+  let ocServer: { close: () => void } | undefined;
+  let eventCollectPromise: Promise<void> | undefined;
+  let eventSubscriptionAbortController: AbortController | undefined;
+  const allEvents: OpenCodeEvent[] = [];
+  const rawEvents: unknown[] = [];
+
+  beforeAll(async () => {
+    if (opencodePath === null) {
+      throw new Error('opencode CLI not found on PATH');
+    }
+
+    const version = await runCommand(opencodePath, ['--version'], 5_000);
+    console.log(`[opencode-parallel] resolved: ${opencodePath}`);
+    console.log(`[opencode-parallel] version: ${version}`);
+
+    upstream = new DummyUpstream();
+    await upstream.start();
+
+    const opencodePort = await getFreePort();
+    const { client, server } = await createOpencode({
+      port: opencodePort,
+      timeout: SERVER_START_TIMEOUT,
+      config: {
+        model: RESPONSE_MODEL,
+        small_model: RESPONSE_MODEL,
+        provider: {
+          opencode: {
+            options: {
+              baseURL: `http://127.0.0.1:${upstream.port}`,
+              apiKey: DUMMY_API_KEY,
+            },
+          },
+        },
+      },
+    });
+    ocClient = client;
+    ocServer = server;
+
+    eventSubscriptionAbortController = new AbortController();
+    const { stream } = await client.event.subscribe(
+      { directory: process.cwd() },
+      { signal: eventSubscriptionAbortController.signal },
+    );
+    eventCollectPromise = (async () => {
+      for await (const event of stream) {
+        rawEvents.push(event);
+        allEvents.push(event);
+      }
+    })();
+  }, SERVER_START_TIMEOUT + 10_000);
+
+  afterAll(async () => {
+    const cleanupErrors: string[] = [];
+    const runCleanup = async (label: string, action: () => void | Promise<void>): Promise<void> => {
+      try {
+        await action();
+      } catch (error) {
+        cleanupErrors.push(`${label}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    };
+
+    if (upstream) {
+      await runCleanup('release gates', () => upstream.releaseAllGates());
+    }
+    if (eventSubscriptionAbortController) {
+      await runCleanup('abort event subscription', () => {
+        eventSubscriptionAbortController.abort();
+      });
+    }
+    if (ocClient) {
+      await runCleanup('dispose client', () => ocClient.global.dispose());
+    }
+    if (ocServer) {
+      await runCleanup('close server', () => {
+        ocServer.close();
+      });
+    }
+    if (upstream) {
+      await runCleanup('close upstream', () => upstream.close());
+    }
+    if (eventCollectPromise) {
+      await runCleanup('stop event subscription', () => waitForPromiseWithTimeout(
+        eventCollectPromise,
+        10_000,
+        'event subscription did not stop during cleanup',
+      ));
+    }
+
+    if (cleanupErrors.length > 0) {
+      throw new Error(`Cleanup had ${cleanupErrors.length} failure(s): ${cleanupErrors.join('; ')}`);
+    }
+  }, 30_000);
+
+  it('should run two parallel sessions with isolation', async () => {
+    if (!ocClient || !upstream) {
+      throw new Error('setup failed');
+    }
+
+    const dir = process.cwd();
+    const baseEventIndex = allEvents.length;
+
+    upstream.clearRequests();
+    upstream.activateGate('SESSION-MARKER-A');
+    upstream.activateGate('SESSION-MARKER-B');
+
+    const [sessionA, sessionB] = await Promise.all([
+      ocClient.session.create({ directory: dir, title: 'Session-A' }),
+      ocClient.session.create({ directory: dir, title: 'Session-B' }),
+    ]);
+    const sessionAId = sessionA.data?.id;
+    const sessionBId = sessionB.data?.id;
+    if (!sessionAId || !sessionBId) {
+      throw new Error('session creation failed');
+    }
+
+    const promptA = ocClient.session.promptAsync({
+      sessionID: sessionAId,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-MARKER-A tell me about apples' }],
+    });
+    const promptB = ocClient.session.promptAsync({
+      sessionID: sessionBId,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-MARKER-B tell me about oranges' }],
+    });
+
+    await upstream.waitForRequests(2, 60_000);
+    expect(upstream.pendingRequests()).toBe(2);
+    expect(upstream.responsesStarted()).toBe(0);
+
+    const requestA = upstream.requests.find((request) => request.marker === 'SESSION-MARKER-A');
+    const requestB = upstream.requests.find((request) => request.marker === 'SESSION-MARKER-B');
+    if (!requestA || !requestB) {
+      throw new Error('expected both session requests to reach the upstream');
+    }
+
+    expect(requestA.model).toBe(requestB.model);
+    expect(requestA.model).not.toBe('');
+    expect(requestA.authHeader).toBe(`Bearer ${DUMMY_API_KEY}`);
+    expect(requestB.authHeader).toBe(`Bearer ${DUMMY_API_KEY}`);
+    expect(requestA.url).toContain('chat/completions');
+    expect(requestB.url).toContain('chat/completions');
+
+    upstream.releaseGate('SESSION-MARKER-A');
+    upstream.releaseGate('SESSION-MARKER-B');
+
+    await Promise.all([promptA, promptB]);
+
+    await Promise.all([
+      waitForCondition(
+        () => hasSessionIdle(allEvents.slice(baseEventIndex), sessionAId),
+        SESSION_TIMEOUT,
+        'timed out waiting for session A to finish',
+        () => `collected=[${describeRecentEvents(allEvents.slice(baseEventIndex))}] raw=[${describeRawEvents(rawEvents.slice(baseEventIndex))}] requests=[${describeRequests(upstream.requests)}]`,
+      ),
+      waitForCondition(
+        () => hasSessionIdle(allEvents.slice(baseEventIndex), sessionBId),
+        SESSION_TIMEOUT,
+        'timed out waiting for session B to finish',
+        () => `collected=[${describeRecentEvents(allEvents.slice(baseEventIndex))}] raw=[${describeRawEvents(rawEvents.slice(baseEventIndex))}] requests=[${describeRequests(upstream.requests)}]`,
+      ),
+    ]);
+    const testEvents = allEvents.slice(baseEventIndex);
+    const sessionAEvents = testEvents.filter((event) => extractSessionID(event) === sessionAId);
+    const sessionBEvents = testEvents.filter((event) => extractSessionID(event) === sessionBId);
+    assertSessionEventIsolation(sessionAEvents, 'SESSION-MARKER-A', 'SESSION-MARKER-B');
+    assertSessionEventIsolation(sessionBEvents, 'SESSION-MARKER-B', 'SESSION-MARKER-A');
+    expect(hasSessionIdle(testEvents, sessionAId)).toBe(true);
+    expect(hasSessionIdle(testEvents, sessionBId)).toBe(true);
+    expect(upstream.pendingRequests()).toBe(0);
+  }, SESSION_TIMEOUT * 3);
+
+  it('should abort target session and let survivor complete', async () => {
+    if (!ocClient || !upstream) {
+      throw new Error('setup failed');
+    }
+
+    const dir = process.cwd();
+    const baseEventIndex = allEvents.length;
+
+    upstream.clearRequests();
+    upstream.activateGate('SESSION-ABORT-TARGET');
+    upstream.activateGate('SESSION-SURVIVOR');
+
+    const [abortSession, survivorSession] = await Promise.all([
+      ocClient.session.create({ directory: dir, title: 'Abort-Target' }),
+      ocClient.session.create({ directory: dir, title: 'Survivor' }),
+    ]);
+    const abortId = abortSession.data?.id;
+    const survivorId = survivorSession.data?.id;
+    if (!abortId || !survivorId) {
+      throw new Error('abort test session creation failed');
+    }
+
+    const abortPrompt = ocClient.session.promptAsync({
+      sessionID: abortId,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-ABORT-TARGET will be aborted' }],
+    });
+    const survivorPrompt = ocClient.session.promptAsync({
+      sessionID: survivorId,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-SURVIVOR must complete' }],
+    });
+
+    await upstream.waitForRequests(2, 30_000);
+    expect(upstream.pendingRequests()).toBe(2);
+    expect(upstream.responsesStarted()).toBe(0);
+
+    const abortResult = await ocClient.session.abort({ sessionID: abortId, directory: dir });
+    if (abortResult.error !== undefined) {
+      throw new Error(`abort failed: ${JSON.stringify(abortResult.error)}`);
+    }
+
+    await waitForCondition(
+      () => upstream.destroyedRequests() >= 1,
+      15_000,
+      'timed out waiting for aborted upstream connection to close',
+    );
+
+    expect(upstream.responsesStarted()).toBe(0);
+    upstream.releaseGate('SESSION-SURVIVOR');
+
+    const settledResults = await Promise.allSettled([abortPrompt, survivorPrompt]);
+    const [abortSettled, survivorSettled] = settledResults;
+    if (abortSettled.status === 'rejected') {
+      throw new Error(`Abort prompt should have settled with null data but was rejected: ${abortSettled.reason instanceof Error ? abortSettled.reason.message : String(abortSettled.reason)}`);
+    }
+    if (abortSettled.value?.data !== null) {
+      throw new Error(`Abort prompt should have null data but got: ${JSON.stringify(abortSettled.value)}`);
+    }
+    if (survivorSettled.status === 'rejected') {
+      throw new Error(`Survivor prompt should have succeeded but was rejected: ${survivorSettled.reason instanceof Error ? survivorSettled.reason.message : String(survivorSettled.reason)}`);
+    }
+
+    await waitForCondition(
+      () => hasSessionIdle(allEvents.slice(baseEventIndex), survivorId),
+      SESSION_TIMEOUT,
+      'timed out waiting for survivor session to finish',
+      () => `collected=[${describeRecentEvents(allEvents.slice(baseEventIndex))}] raw=[${describeRawEvents(rawEvents.slice(baseEventIndex))}] requests=[${describeRequests(upstream.requests)}]`,
+    );
+    const testEvents = allEvents.slice(baseEventIndex);
+    const abortEvents = testEvents.filter((event) => extractSessionID(event) === abortId);
+    const survivorEvents = testEvents.filter((event) => extractSessionID(event) === survivorId);
+
+    assertNoForeignMarker(abortEvents, 'SESSION-SURVIVOR');
+    assertSessionEventIsolation(survivorEvents, 'SESSION-SURVIVOR', 'SESSION-ABORT-TARGET');
+    expect(hasSessionIdle(testEvents, survivorId)).toBe(true);
+    expect(upstream.destroyedRequests()).toBeGreaterThanOrEqual(1);
+    expect(upstream.pendingRequests()).toBe(0);
+  }, SESSION_TIMEOUT * 3);
+
+  it('should handle two prompts in the same session', async () => {
+    if (!ocClient || !upstream) {
+      throw new Error('setup failed');
+    }
+
+    const dir = process.cwd();
+    const baseEventIndex = allEvents.length;
+
+    upstream.clearRequests();
+    upstream.activateGate('SESSION-FIFO-1');
+    upstream.activateBodyGate('SESSION-FIFO-2');
+
+    const newSession = await ocClient.session.create({ directory: dir, title: 'FIFO-Test' });
+    const sessionId = newSession.data?.id;
+    if (!sessionId) {
+      throw new Error('session creation failed');
+    }
+
+    const prompt1 = ocClient.session.promptAsync({
+      sessionID: sessionId,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-FIFO-1 first prompt' }],
+    });
+    const prompt2 = ocClient.session.promptAsync({
+      sessionID: sessionId,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-FIFO-2 second prompt' }],
+    });
+
+    // The OpenCode server queues prompts per session: the second
+    // prompt is not sent until the first completes.  Gate the first
+    // response so we can verify FIFO ordering.
+    await upstream.waitForMarkerRequest('SESSION-FIFO-1', 60_000);
+    expect(upstream.requests.length).toBe(1);
+    expect(upstream.hasBodyContaining('SESSION-FIFO-2')).toBe(false);
+
+    // Release the first — the now-completed prompt unblocks the second.
+    upstream.releaseGate('SESSION-FIFO-1');
+    await upstream.waitForBodyMatch('SESSION-FIFO-2', 60_000);
+    upstream.releaseBodyGate('SESSION-FIFO-2');
+
+    await waitForCondition(
+      () => hasSessionIdle(allEvents.slice(baseEventIndex), sessionId),
+      SESSION_TIMEOUT,
+      'timed out waiting for FIFO session to complete',
+      () => `collected=[${describeRecentEvents(allEvents.slice(baseEventIndex))}] requests=[${describeRequests(upstream.requests)}]`,
+    );
+
+    await expect(prompt1).resolves.toBeDefined();
+    await expect(prompt2).resolves.toBeDefined();
+    expect(upstream.pendingRequests()).toBe(0);
+  }, SESSION_TIMEOUT * 3);
+
+  it('should allow reuse of completed sessions for new prompts', async () => {
+    if (!ocClient || !upstream) {
+      throw new Error('setup failed');
+    }
+
+    const dir = process.cwd();
+    const baseEventIndex = allEvents.length;
+
+    upstream.clearRequests();
+    upstream.activateGate('SESSION-REUSE-FIRST');
+    upstream.activateGate('SESSION-REUSE-SECOND');
+
+    const [sessionReuse1, sessionReuse2] = await Promise.all([
+      ocClient.session.create({ directory: dir, title: 'Reuse-A' }),
+      ocClient.session.create({ directory: dir, title: 'Reuse-B' }),
+    ]);
+    const reuseId1 = sessionReuse1.data?.id;
+    const reuseId2 = sessionReuse2.data?.id;
+    if (!reuseId1 || !reuseId2) {
+      throw new Error('reuse test session creation failed');
+    }
+
+    const prompt1 = ocClient.session.promptAsync({
+      sessionID: reuseId1,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-REUSE-FIRST initial' }],
+    });
+    const prompt2 = ocClient.session.promptAsync({
+      sessionID: reuseId2,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-REUSE-SECOND initial' }],
+    });
+
+    await upstream.waitForRequests(2, 30_000);
+    upstream.releaseAllGates();
+
+    await Promise.all([
+      waitForCondition(
+        () => hasSessionIdle(allEvents.slice(baseEventIndex), reuseId1),
+        SESSION_TIMEOUT,
+        'timed out waiting for reuse session 1',
+        () => `collected=[${describeRecentEvents(allEvents.slice(baseEventIndex))}] requests=[${describeRequests(upstream.requests)}]`,
+      ),
+      waitForCondition(
+        () => hasSessionIdle(allEvents.slice(baseEventIndex), reuseId2),
+        SESSION_TIMEOUT,
+        'timed out waiting for reuse session 2',
+        () => `collected=[${describeRecentEvents(allEvents.slice(baseEventIndex))}] requests=[${describeRequests(upstream.requests)}]`,
+      ),
+    ]);
+    await Promise.all([prompt1, prompt2]);
+
+    upstream.clearRequests();
+    upstream.activateGate('SESSION-REUSE-AGAIN');
+    const prompt3 = ocClient.session.promptAsync({
+      sessionID: reuseId1,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-REUSE-AGAIN fresh turn' }],
+    });
+    const prompt4 = ocClient.session.promptAsync({
+      sessionID: reuseId2,
+      directory: dir,
+      model: MODEL,
+      parts: [{ type: 'text' as const, text: 'SESSION-REUSE-AGAIN another turn' }],
+    });
+
+    await upstream.waitForRequests(2, 30_000);
+    upstream.releaseAllGates();
+
+    await Promise.all([
+      waitForCondition(
+        () => hasSessionIdle(allEvents.slice(baseEventIndex), reuseId1),
+        SESSION_TIMEOUT,
+        'timed out waiting for reuse session 1 second turn',
+        () => `collected=[${describeRecentEvents(allEvents.slice(baseEventIndex))}] requests=[${describeRequests(upstream.requests)}]`,
+      ),
+      waitForCondition(
+        () => hasSessionIdle(allEvents.slice(baseEventIndex), reuseId2),
+        SESSION_TIMEOUT,
+        'timed out waiting for reuse session 2 second turn',
+        () => `collected=[${describeRecentEvents(allEvents.slice(baseEventIndex))}] requests=[${describeRequests(upstream.requests)}]`,
+      ),
+    ]);
+    await Promise.all([prompt3, prompt4]);
+
+    expect(upstream.pendingRequests()).toBe(0);
+  }, SESSION_TIMEOUT * 3);
+});
+
+describe.skipIf(shouldSkip)('OpenCodeClient via Takt adapter (integration)', () => {
+  let taktUpstream: DummyUpstream | undefined;
+  let taktOcClient: import('../../src/infra/opencode/client.js').OpenCodeClient | undefined;
+  let taktResetSharedServer: (() => void) | undefined;
+
+  beforeAll(async () => {
+    vi.clearAllMocks();
+    const upstream = new DummyUpstream();
+    taktUpstream = upstream;
+    await upstream.start();
+
+    createOpencodeMock.mockImplementation(async (config: Record<string, unknown>) => {
+      const mod = await vi.importActual<typeof import('@opencode-ai/sdk/v2')>('@opencode-ai/sdk/v2');
+      const serverConfig = (config.config ?? {}) as Record<string, unknown>;
+      const injectedConfig = {
+        ...config,
+        config: {
+          ...serverConfig,
+          model: RESPONSE_MODEL,
+          small_model: RESPONSE_MODEL,
+          provider: {
+            opencode: {
+              options: {
+                baseURL: `http://127.0.0.1:${upstream.port}`,
+                apiKey: DUMMY_API_KEY,
+              },
+            },
+          },
+        },
+      };
+      return mod.createOpencode(injectedConfig);
+    });
+
+    const { OpenCodeClient, resetSharedServer } = await import('../../src/infra/opencode/client.js');
+    taktResetSharedServer = resetSharedServer;
+    resetSharedServer();
+    taktOcClient = new OpenCodeClient();
+  });
+
+  beforeEach(() => {
+    taktUpstream?.releaseAllGates();
+    taktUpstream?.clearRequests();
+    taktResetSharedServer?.();
+  });
+
+  afterAll(async () => {
+    if (taktUpstream) {
+      taktUpstream.releaseAllGates();
+      await taktUpstream.close();
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('should send two new session (no sessionId) calls to upstream concurrently', async () => {
+    if (!taktUpstream || !taktOcClient) {
+      throw new Error('setup failed');
+    }
+
+    taktUpstream.clearRequests();
+    taktUpstream.activateGate('TAKT-CONCURRENT-A');
+    taktUpstream.activateGate('TAKT-CONCURRENT-B');
+
+    const callA = taktOcClient.call('coder', 'TAKT-CONCURRENT-A message', {
+      cwd: process.cwd(),
+      model: RESPONSE_MODEL,
+    });
+    const callB = taktOcClient.call('coder', 'TAKT-CONCURRENT-B message', {
+      cwd: process.cwd(),
+      model: RESPONSE_MODEL,
+    });
+
+    await Promise.all([
+      taktUpstream.waitForMarkerRequest('TAKT-CONCURRENT-A', 60_000),
+      taktUpstream.waitForMarkerRequest('TAKT-CONCURRENT-B', 60_000),
+    ]);
+
+    expect(taktUpstream.pendingRequests()).toBe(2);
+
+    taktUpstream.releaseAllGates();
+
+    const results = await Promise.all([callA, callB]);
+    expect(results[0].status).toBe('done');
+    expect(results[1].status).toBe('done');
+    expect(taktUpstream.pendingRequests()).toBe(0);
+  }, SESSION_TIMEOUT * 3);
+
+  it('should not let one call abort interrupt another concurrent call', async () => {
+    if (!taktUpstream || !taktOcClient) {
+      throw new Error('setup failed');
+    }
+
+    taktUpstream.clearRequests();
+    taktUpstream.activateGate('TAKT-ABORT-TARGET');
+    taktUpstream.activateGate('TAKT-SURVIVOR');
+
+    const abortController = new AbortController();
+    const abortTarget = taktOcClient.call('coder', 'TAKT-ABORT-TARGET message', {
+      cwd: process.cwd(),
+      model: RESPONSE_MODEL,
+      abortSignal: abortController.signal,
+    });
+    const survivor = taktOcClient.call('coder', 'TAKT-SURVIVOR message', {
+      cwd: process.cwd(),
+      model: RESPONSE_MODEL,
+    });
+
+    await Promise.all([
+      taktUpstream.waitForMarkerRequest('TAKT-ABORT-TARGET', 60_000),
+      taktUpstream.waitForMarkerRequest('TAKT-SURVIVOR', 60_000),
+    ]);
+
+    expect(taktUpstream.pendingRequests()).toBe(2);
+
+    abortController.abort();
+    const abortResult = await abortTarget;
+    expect(abortResult.status).toBe('error');
+
+    expect(taktUpstream.getMarkerRequest('TAKT-SURVIVOR')).toBeDefined();
+
+    taktUpstream.releaseGate('TAKT-SURVIVOR');
+
+    const survivorResult = await survivor;
+    expect(survivorResult.status).toBe('done');
+  }, SESSION_TIMEOUT * 3);
+
+  it('should serialize same session ID calls in FIFO order', async () => {
+    if (!taktUpstream || !taktOcClient) {
+      throw new Error('setup failed');
+    }
+
+    // Create a real session to get a valid session ID
+    taktUpstream.clearRequests();
+    const seedResult = await taktOcClient.call('coder', 'seed session for FIFO', {
+      cwd: process.cwd(),
+      model: RESPONSE_MODEL,
+    });
+    expect(seedResult.status).toBe('done');
+    const sessionId = seedResult.sessionId;
+    if (!sessionId) {
+      throw new Error('FIFO test seed call returned no sessionId');
+    }
+
+    taktUpstream.clearRequests();
+    taktUpstream.activateGate('TAKT-FIFO-1');
+    taktUpstream.activateBodyGate('TAKT-FIFO-2');
+
+    const call1 = taktOcClient.call('coder', 'TAKT-FIFO-1 first', {
+      cwd: process.cwd(),
+      model: RESPONSE_MODEL,
+      sessionId,
+    });
+    const call2 = taktOcClient.call('coder', 'TAKT-FIFO-2 second', {
+      cwd: process.cwd(),
+      model: RESPONSE_MODEL,
+      sessionId,
+    });
+
+    // Hold the first call's response via marker gate so we can verify
+    // that the second call has not reached upstream before the first
+    // completes (FIFO queuing at OpenCodeClient level).
+    await taktUpstream.waitForMarkerRequest('TAKT-FIFO-1', 60_000);
+    expect(taktUpstream.pendingRequests()).toBe(1);
+    expect(taktUpstream.hasBodyContaining('TAKT-FIFO-2')).toBe(false);
+
+    // Release the first — the second call is now unblocked.  Wait for
+    // the second request body to arrive (body-gated).
+    taktUpstream.releaseGate('TAKT-FIFO-1');
+    await taktUpstream.waitForBodyMatch('TAKT-FIFO-2', 60_000);
+    taktUpstream.releaseBodyGate('TAKT-FIFO-2');
+
+    const results = await Promise.all([call1, call2]);
+    expect(results[0].status).toBe('done');
+    expect(results[1].status).toBe('done');
+    expect(taktUpstream.pendingRequests()).toBe(0);
+  }, SESSION_TIMEOUT * 3);
+});

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -3196,8 +3196,8 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(result.status).toBe('done');
     expect(result.content).toBe('recovered');
     expect(firstStream).toBeDefined();
-    // Session is reused on retry (not created again)
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    // Each retry creates a new session (not reused)
+    expect(sessionCreate).toHaveBeenCalledTimes(2);
     expect(promptAsync).toHaveBeenCalledTimes(2);
     expect(subscribe).toHaveBeenCalledTimes(2);
   });

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -1736,8 +1736,10 @@ describe('OpenCodeClient stream cleanup', () => {
       .mockResolvedValueOnce({ data: {} })
       .mockResolvedValueOnce({ data: { id: 'session-after-create-failure-2' } })
       .mockResolvedValueOnce({ data: { id: 'session-after-create-failure-3' } });
+    let subscribeCount = 0;
     const subscribe = vi.fn().mockImplementation(() => {
-      const sessionId = sessionCreate.mock.results.length === 2
+      subscribeCount++;
+      const sessionId = subscribeCount === 1
         ? 'session-after-create-failure-2'
         : 'session-after-create-failure-3';
       return Promise.resolve({
@@ -1772,24 +1774,24 @@ describe('OpenCodeClient stream cleanup', () => {
     });
 
     const failed = await failedPromise;
-    await vi.waitFor(() => {
-      expect(sessionCreate).toHaveBeenCalledTimes(2);
-    });
-    await new Promise((resolve) => setImmediate(resolve));
 
     expect(failed.status).toBe('error');
     expect(failed.content).toContain('Failed to create OpenCode session');
     expect(createOpencodeMock).toHaveBeenCalledTimes(1);
-    expect(sessionCreate).toHaveBeenCalledTimes(2);
+    // With provisional keys, all 3 calls create sessions concurrently
+    expect(sessionCreate).toHaveBeenCalledTimes(3);
 
     finishSecondPrompt!();
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+    });
+
     const [second, third] = await Promise.all([secondPromise, thirdPromise]);
     expect(second.status).toBe('done');
     expect(third.status).toBe('done');
-    expect(sessionCreate).toHaveBeenCalledTimes(3);
-    expect(promptAsync).toHaveBeenCalledTimes(2);
     expect(subscribe).toHaveBeenCalledTimes(2);
   });
+
 
   it('should not update permission ruleset when resuming without allowed tools', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
@@ -3007,9 +3009,8 @@ describe('OpenCodeClient stream cleanup', () => {
   it('should wait for rejected permission promptAsync settlement before releasing same config queue', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const firstPrompt = deferred();
-    const sessionCreate = vi.fn()
-      .mockResolvedValueOnce({ data: { id: 'session-permission-reject' } })
-      .mockResolvedValueOnce({ data: { id: 'session-after-reject' } });
+    const sharedSessionId = 'session-permission-reject';
+    const sessionCreate = vi.fn();
     const promptAsync = vi.fn()
       .mockImplementationOnce(() => firstPrompt.promise)
       .mockResolvedValueOnce(undefined);
@@ -3021,18 +3022,18 @@ describe('OpenCodeClient stream cleanup', () => {
             type: 'permission.asked',
             properties: {
               id: 'perm-reject-before-queue',
-              sessionID: 'session-permission-reject',
+              sessionID: sharedSessionId,
               permission: 'read',
               patterns: ['**'],
               always: [],
             },
           },
-          { type: 'session.idle', properties: { sessionID: 'session-permission-reject' } },
+          { type: 'session.idle', properties: { sessionID: sharedSessionId } },
         ]),
       })
       .mockResolvedValueOnce({
         stream: new MockEventStream([
-          { type: 'session.idle', properties: { sessionID: 'session-after-reject' } },
+          { type: 'session.idle', properties: { sessionID: sharedSessionId } },
         ]),
       });
 
@@ -3052,6 +3053,7 @@ describe('OpenCodeClient stream cleanup', () => {
       model: 'opencode/big-pickle',
       permissionMode: 'edit',
       allowedTools: [],
+      sessionId: sharedSessionId,
     });
     await vi.waitFor(() => {
       expect(permissionReply).toHaveBeenCalledTimes(1);
@@ -3060,10 +3062,11 @@ describe('OpenCodeClient stream cleanup', () => {
     const secondCall = client.call('coder', 'second', {
       cwd: '/tmp',
       model: 'opencode/big-pickle',
+      sessionId: sharedSessionId,
     });
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(sessionCreate).not.toHaveBeenCalled();
     expect(promptAsync).toHaveBeenCalledTimes(1);
 
     firstPrompt.resolve();
@@ -3072,16 +3075,14 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(firstResult.status).not.toBe('error');
     expect(firstResult.error).toBeUndefined();
     expect(secondResult.status).toBe('done');
-    expect(sessionCreate).toHaveBeenCalledTimes(2);
     expect(promptAsync).toHaveBeenCalledTimes(2);
   });
 
   it('should wait for stream exceptions to settle promptAsync before releasing same config queue', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const firstPrompt = deferred();
-    const sessionCreate = vi.fn()
-      .mockResolvedValueOnce({ data: { id: 'session-stream-error' } })
-      .mockResolvedValueOnce({ data: { id: 'session-after-stream-error' } });
+    const sharedSessionId = 'session-stream-error';
+    const sessionCreate = vi.fn();
     const promptAsync = vi.fn()
       .mockImplementationOnce(() => firstPrompt.promise)
       .mockResolvedValueOnce(undefined);
@@ -3097,7 +3098,7 @@ describe('OpenCodeClient stream cleanup', () => {
       })
       .mockResolvedValueOnce({
         stream: new MockEventStream([
-          { type: 'session.idle', properties: { sessionID: 'session-after-stream-error' } },
+          { type: 'session.idle', properties: { sessionID: sharedSessionId } },
         ]),
       });
 
@@ -3115,6 +3116,7 @@ describe('OpenCodeClient stream cleanup', () => {
     const firstCall = client.call('coder', 'first', {
       cwd: '/tmp',
       model: 'opencode/big-pickle',
+      sessionId: sharedSessionId,
     });
     await vi.waitFor(() => {
       expect(promptAsync).toHaveBeenCalledTimes(1);
@@ -3123,10 +3125,11 @@ describe('OpenCodeClient stream cleanup', () => {
     const secondCall = client.call('coder', 'second', {
       cwd: '/tmp',
       model: 'opencode/big-pickle',
+      sessionId: sharedSessionId,
     });
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(sessionCreate).not.toHaveBeenCalled();
     expect(promptAsync).toHaveBeenCalledTimes(1);
 
     firstPrompt.resolve();
@@ -3135,7 +3138,6 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(firstResult.status).toBe('error');
     expect(firstResult.content).toContain('stream exploded');
     expect(secondResult.status).toBe('done');
-    expect(sessionCreate).toHaveBeenCalledTimes(2);
     expect(promptAsync).toHaveBeenCalledTimes(2);
   });
 
@@ -3194,7 +3196,8 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(result.status).toBe('done');
     expect(result.content).toBe('recovered');
     expect(firstStream).toBeDefined();
-    expect(sessionCreate).toHaveBeenCalledTimes(2);
+    // Session is reused on retry (not created again)
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
     expect(promptAsync).toHaveBeenCalledTimes(2);
     expect(subscribe).toHaveBeenCalledTimes(2);
   });
@@ -3323,48 +3326,6 @@ describe('OpenCodeClient stream cleanup', () => {
       directory: '/tmp',
       reply: 'once',
     }, expect.any(Object));
-  });
-
-  it('should reuse shared server for parallel calls with same config', async () => {
-    const { OpenCodeClient, resetSharedServer } = await import('../infra/opencode/client.js');
-    resetSharedServer();
-
-    let callCount = 0;
-    const sessionCreate = vi.fn().mockImplementation(() => {
-      callCount += 1;
-      return Promise.resolve({ data: { id: `session-${callCount}` } });
-    });
-    const promptAsync = vi.fn().mockResolvedValue(undefined);
-    const disposeInstance = vi.fn().mockResolvedValue({ data: {} });
-    const serverClose = vi.fn();
-
-    createOpencodeMock.mockResolvedValue({
-      client: {
-        instance: { dispose: disposeInstance },
-        session: { create: sessionCreate, promptAsync },
-        event: { subscribe: vi.fn().mockImplementation(() => {
-          const events = [{ type: 'session.idle', properties: { sessionID: `session-${callCount}` } }];
-          return Promise.resolve({ stream: new MockEventStream(events) });
-        }) },
-        permission: { reply: vi.fn() },
-      },
-      server: { close: serverClose },
-    });
-
-    const client = new OpenCodeClient();
-
-    const [result1, result2, result3] = await Promise.all([
-      client.call('coder', 'task1', { cwd: '/tmp', model: 'opencode/big-pickle' }),
-      client.call('coder', 'task2', { cwd: '/tmp', model: 'opencode/big-pickle' }),
-      client.call('coder', 'task3', { cwd: '/tmp', model: 'opencode/big-pickle' }),
-    ]);
-
-    expect(createOpencodeMock).toHaveBeenCalledTimes(1);
-    expect(sessionCreate).toHaveBeenCalledTimes(3);
-    expect(result1.status).toBe('done');
-    expect(result2.status).toBe('done');
-    expect(result3.status).toBe('done');
-    expect(serverClose).not.toHaveBeenCalled();
   });
 
   it('should keep the existing server open when model changes', async () => {
@@ -3588,9 +3549,8 @@ describe('OpenCodeClient stream cleanup', () => {
     const promptA = deferred();
     const promptB1 = deferred();
     const promptB2 = deferred();
-    const sessionCreateB = vi.fn()
-      .mockResolvedValueOnce({ data: { id: 'session-b-1' } })
-      .mockResolvedValueOnce({ data: { id: 'session-b-2' } });
+    const sharedSessionB = 'shared-session-b';
+    const sessionCreateB = vi.fn();
     const promptAsyncB = vi.fn()
       .mockImplementationOnce(() => promptB1.promise)
       .mockImplementationOnce(() => promptB2.promise);
@@ -3619,9 +3579,8 @@ describe('OpenCodeClient stream cleanup', () => {
         },
         event: {
           subscribe: vi.fn().mockImplementation(() => {
-            const sessionID = sessionCreateB.mock.calls.length === 1 ? 'session-b-1' : 'session-b-2';
             return Promise.resolve({
-              stream: new MockEventStream([{ type: 'session.idle', properties: { sessionID } }]),
+              stream: new MockEventStream([{ type: 'session.idle', properties: { sessionID: sharedSessionB } }]),
             });
           }),
         },
@@ -3636,25 +3595,25 @@ describe('OpenCodeClient stream cleanup', () => {
       expect(createOpencodeMock).toHaveBeenCalledTimes(1);
     });
 
-    const callB1 = client.call('coder', 'task-b-1', { cwd: '/tmp', model: 'opencode/model-b' });
+    const callB1 = client.call('coder', 'task-b-1', { cwd: '/tmp', model: 'opencode/model-b', sessionId: sharedSessionB });
     await vi.waitFor(() => {
       expect(promptAsyncB).toHaveBeenCalledTimes(1);
     });
 
-    const callB2 = client.call('coder', 'task-b-2', { cwd: '/tmp', model: 'opencode/model-b' });
+    const callB2 = client.call('coder', 'task-b-2', { cwd: '/tmp', model: 'opencode/model-b', sessionId: sharedSessionB });
     await new Promise((resolve) => setImmediate(resolve));
-    expect(sessionCreateB).toHaveBeenCalledTimes(1);
+    expect(sessionCreateB).not.toHaveBeenCalled();
     expect(promptAsyncB).toHaveBeenCalledTimes(1);
 
     promptA.resolve();
     await callA;
     await new Promise((resolve) => setImmediate(resolve));
-    expect(sessionCreateB).toHaveBeenCalledTimes(1);
+    expect(sessionCreateB).not.toHaveBeenCalled();
     expect(promptAsyncB).toHaveBeenCalledTimes(1);
 
     promptB1.resolve();
     await vi.waitFor(() => {
-      expect(sessionCreateB).toHaveBeenCalledTimes(2);
+      expect(promptAsyncB).toHaveBeenCalledTimes(2);
     });
     promptB2.resolve();
 
@@ -3667,19 +3626,15 @@ describe('OpenCodeClient stream cleanup', () => {
     const { OpenCodeClient, resetSharedServer } = await import('../infra/opencode/client.js');
     resetSharedServer();
 
+    const sharedSessionId = 'session-queue-abort';
     const firstPrompt = deferred();
-    const sessionCreate = vi.fn()
-      .mockResolvedValueOnce({ data: { id: 'session-before-abort' } })
-      .mockResolvedValueOnce({ data: { id: 'session-after-abort' } });
+    const sessionCreate = vi.fn();
     const promptAsync = vi.fn()
       .mockImplementationOnce(() => firstPrompt.promise)
       .mockResolvedValueOnce(undefined);
     const subscribe = vi.fn().mockImplementation(() => {
-      const sessionID = sessionCreate.mock.calls.length === 1
-        ? 'session-before-abort'
-        : 'session-after-abort';
       return Promise.resolve({
-        stream: new MockEventStream([{ type: 'session.idle', properties: { sessionID } }]),
+        stream: new MockEventStream([{ type: 'session.idle', properties: { sessionID: sharedSessionId } }]),
       });
     });
 
@@ -3697,6 +3652,7 @@ describe('OpenCodeClient stream cleanup', () => {
     const firstCall = client.call('coder', 'first', {
       cwd: '/tmp',
       model: 'opencode/big-pickle',
+      sessionId: sharedSessionId,
     });
     await vi.waitFor(() => {
       expect(promptAsync).toHaveBeenCalledTimes(1);
@@ -3706,6 +3662,7 @@ describe('OpenCodeClient stream cleanup', () => {
     const abortedCall = client.call('coder', 'aborted', {
       cwd: '/tmp',
       model: 'opencode/big-pickle',
+      sessionId: sharedSessionId,
       abortSignal: controller.signal,
     });
     await new Promise((resolve) => setImmediate(resolve));
@@ -3714,7 +3671,7 @@ describe('OpenCodeClient stream cleanup', () => {
     const abortedResult = await abortedCall;
     expect(abortedResult.status).toBe('error');
     expect(abortedResult.content).toContain('OpenCode execution aborted');
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(sessionCreate).not.toHaveBeenCalled();
     expect(promptAsync).toHaveBeenCalledTimes(1);
 
     firstPrompt.resolve();
@@ -3724,9 +3681,9 @@ describe('OpenCodeClient stream cleanup', () => {
     const afterAbortResult = await client.call('coder', 'after abort', {
       cwd: '/tmp',
       model: 'opencode/big-pickle',
+      sessionId: sharedSessionId,
     });
     expect(afterAbortResult.status).toBe('done');
-    expect(sessionCreate).toHaveBeenCalledTimes(2);
     expect(promptAsync).toHaveBeenCalledTimes(2);
   });
 

--- a/src/__tests__/opencode-client-queue.test.ts
+++ b/src/__tests__/opencode-client-queue.test.ts
@@ -177,11 +177,11 @@ describe('OpenCodeClient session queue', () => {
       return callCount === 1 ? firstPrompt.promise : secondPrompt.promise;
     });
     const sessionCreate = vi.fn();
-    const subscribe = vi.fn().mockResolvedValue({
+    const subscribe = vi.fn().mockImplementation(() => Promise.resolve({
       stream: new MockEventStream([
         { type: 'session.idle', properties: { sessionID: sessionId } },
       ]),
-    });
+    }));
 
     createOpencodeMock.mockResolvedValue({
       client: {
@@ -266,11 +266,11 @@ describe('OpenCodeClient session queue', () => {
       return secondPrompt.promise;
     });
     const sessionCreate = vi.fn();
-    const subscribe = vi.fn().mockResolvedValue({
+    const subscribe = vi.fn().mockImplementation(() => Promise.resolve({
       stream: new MockEventStream([
         { type: 'session.idle', properties: { sessionID: sessionId } },
       ]),
-    });
+    }));
 
     createOpencodeMock.mockResolvedValue({
       client: {
@@ -309,11 +309,11 @@ describe('OpenCodeClient session queue', () => {
       .mockImplementationOnce(() => firstPrompt.promise)
       .mockImplementationOnce(() => secondPrompt.promise);
     const sessionCreate = vi.fn();
-    const subscribe = vi.fn().mockResolvedValue({
+    const subscribe = vi.fn().mockImplementation(() => Promise.resolve({
       stream: new MockEventStream([
         { type: 'session.idle', properties: { sessionID: sessionId } },
       ]),
-    });
+    }));
 
     createOpencodeMock.mockResolvedValue({
       client: {
@@ -366,11 +366,11 @@ describe('OpenCodeClient session queue', () => {
       if (promptCount === 2) return retryHeld.promise;
       return call2Held.promise;
     });
-    const subscribe = vi.fn().mockResolvedValue({
+    const subscribe = vi.fn().mockImplementation(() => Promise.resolve({
       stream: new MockEventStream([
         { type: 'session.idle', properties: { sessionID: 'session-retry-key' } },
       ]),
-    });
+    }));
 
     createOpencodeMock.mockResolvedValue({
       client: {

--- a/src/__tests__/opencode-client-queue.test.ts
+++ b/src/__tests__/opencode-client-queue.test.ts
@@ -443,12 +443,15 @@ describe('OpenCodeClient session queue', () => {
     const client = new OpenCodeClient();
 
     let call2Promise: Promise<AgentResponse> | undefined;
+    const ac2 = new AbortController();
+    const registerAbortSpy = vi.spyOn(ac2.signal, 'addEventListener');
     const onStream = vi.fn((event) => {
       if (event.type === 'init' && event.data.sessionId === SID) {
         call2Promise = client.call('coder', 'second', {
           cwd: '/tmp',
           model: 'opencode/test-model',
           sessionId: SID,
+          abortSignal: ac2.signal,
         });
       }
     });
@@ -468,7 +471,14 @@ describe('OpenCodeClient session queue', () => {
 
     await vi.waitFor(() => {
       expect(call2Promise).toBeDefined();
+      expect(registerAbortSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
+
+    expect(registerAbortSpy.mock.calls[1]).toEqual([
+      'abort',
+      expect.any(Function),
+      { once: true },
+    ]);
 
     expect(promptCallCount).toBe(1);
 

--- a/src/__tests__/opencode-client-queue.test.ts
+++ b/src/__tests__/opencode-client-queue.test.ts
@@ -351,26 +351,28 @@ describe('OpenCodeClient session queue', () => {
     expect(result2.status).toBe('done');
   });
 
-  it('should use acquired session ID as queue key on retry', async () => {
+  it('should create new session on each retry when no explicit sessionId', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
 
-    const retryHeld = deferred<void>();
-    const call2Held = deferred<void>();
     const sessionCreate = vi.fn()
-      .mockResolvedValue({ data: { id: 'session-retry-key' } });
-
+      .mockResolvedValueOnce({ data: { id: 'session-retry-1' } })
+      .mockResolvedValueOnce({ data: { id: 'session-retry-2' } });
     let promptCount = 0;
     const promptAsync = vi.fn().mockImplementation(() => {
       promptCount++;
       if (promptCount === 1) return Promise.reject(new Error('transport error'));
-      if (promptCount === 2) return retryHeld.promise;
-      return call2Held.promise;
+      return Promise.resolve(undefined);
     });
-    const subscribe = vi.fn().mockImplementation(() => Promise.resolve({
-      stream: new MockEventStream([
-        { type: 'session.idle', properties: { sessionID: 'session-retry-key' } },
-      ]),
-    }));
+    let subCount = 0;
+    const subscribe = vi.fn().mockImplementation(() => {
+      subCount++;
+      const sid = subCount === 1 ? 'session-retry-1' : 'session-retry-2';
+      return Promise.resolve({
+        stream: new MockEventStream([
+          { type: 'session.idle', properties: { sessionID: sid } },
+        ]),
+      });
+    });
 
     createOpencodeMock.mockResolvedValue({
       client: {
@@ -383,39 +385,17 @@ describe('OpenCodeClient session queue', () => {
     });
 
     const client = new OpenCodeClient();
-    const call1 = client.call('coder', 'task1', {
+    const result = await client.call('coder', 'task', {
       cwd: '/tmp',
       model: 'opencode/big-pickle',
     });
 
-    await vi.waitFor(() => {
-      expect(promptAsync).toHaveBeenCalledTimes(2);
-    });
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
-
-    const call2 = client.call('coder', 'task2', {
-      cwd: '/tmp',
-      model: 'opencode/big-pickle',
-      sessionId: 'session-retry-key',
-    });
-
-    // Yield to microtask queue; call2 must NOT start promptAsync
-    // while retry is still pending — otherwise the queue key didn't switch.
-    await new Promise(resolve => setImmediate(resolve));
+    expect(result.status).toBe('done');
+    expect(sessionCreate).toHaveBeenCalledTimes(2);
     expect(promptAsync).toHaveBeenCalledTimes(2);
-
-    retryHeld.resolve();
-    const result1 = await call1;
-    expect(result1.status).toBe('done');
-
-    // Yield to microtask queue; after retry completes, call2 should start.
-    await new Promise(resolve => setImmediate(resolve));
-    expect(promptAsync).toHaveBeenCalledTimes(3);
-
-    call2Held.resolve();
-    const result2 = await call2;
-    expect(result2.status).toBe('done');
-
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(subscribe).toHaveBeenCalledTimes(2);
+    expect(promptAsync.mock.calls[0][0].sessionID).toBe('session-retry-1');
+    expect(promptAsync.mock.calls[1][0].sessionID).toBe('session-retry-2');
+    expect(promptAsync.mock.calls[0][0].sessionID).not.toBe(promptAsync.mock.calls[1][0].sessionID);
   });
 });

--- a/src/__tests__/opencode-client-queue.test.ts
+++ b/src/__tests__/opencode-client-queue.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AgentResponse } from '../core/models/response.js';
 
 class MockEventStream implements AsyncGenerator<unknown, void, unknown> {
   private index = 0;
@@ -131,7 +132,13 @@ describe('OpenCodeClient session queue', () => {
   it('should run two calls with different sessionIds in parallel', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
 
-    const promptAsync = vi.fn().mockReturnValue(new Promise<void>(() => {}));
+    const firstPrompt = deferred<void>();
+    const secondPrompt = deferred<void>();
+    let promptCallCount = 0;
+    const promptAsync = vi.fn().mockImplementation(() => {
+      promptCallCount++;
+      return promptCallCount === 1 ? firstPrompt.promise : secondPrompt.promise;
+    });
     const sessionCreate = vi.fn();
     let subCount = 0;
     const subscribe = vi.fn().mockImplementation(() => {
@@ -163,6 +170,12 @@ describe('OpenCodeClient session queue', () => {
 
     expect(sessionCreate).not.toHaveBeenCalled();
     expect(createOpencodeMock).toHaveBeenCalledTimes(1);
+
+    firstPrompt.resolve();
+    secondPrompt.resolve();
+    const [r1, r2] = await Promise.all([call1, call2]);
+    expect(r1.status).toBe('done');
+    expect(r2.status).toBe('done');
   });
 
   it('should serialize same-session calls in FIFO order', async () => {
@@ -397,5 +410,81 @@ describe('OpenCodeClient session queue', () => {
     expect(promptAsync.mock.calls[0][0].sessionID).toBe('session-retry-1');
     expect(promptAsync.mock.calls[1][0].sessionID).toBe('session-retry-2');
     expect(promptAsync.mock.calls[0][0].sessionID).not.toBe(promptAsync.mock.calls[1][0].sessionID);
+  });
+
+  it('should queue second call started from init behind the first (same session follow-up)', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+
+    const firstPrompt = deferred<void>();
+    const secondPrompt = deferred<void>();
+    const SID = 'session-init-followup';
+    const sessionCreate = vi.fn().mockResolvedValueOnce({ data: { id: SID } });
+    let promptCallCount = 0;
+    const promptAsync = vi.fn().mockImplementation(() => {
+      promptCallCount++;
+      return promptCallCount === 1 ? firstPrompt.promise : secondPrompt.promise;
+    });
+    const subscribe = vi.fn().mockResolvedValue({
+      stream: new MockEventStream([
+        { type: 'session.idle', properties: { sessionID: SID } },
+      ]),
+    });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+
+    let call2Promise: Promise<AgentResponse> | undefined;
+    const onStream = vi.fn((event) => {
+      if (event.type === 'init' && event.data.sessionId === SID) {
+        call2Promise = client.call('coder', 'second', {
+          cwd: '/tmp',
+          model: 'opencode/test-model',
+          sessionId: SID,
+        });
+      }
+    });
+
+    const call1 = client.call('coder', 'first', {
+      cwd: '/tmp',
+      model: 'opencode/test-model',
+      onStream,
+    });
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(1);
+    });
+
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(promptCallCount).toBe(1);
+
+    await vi.waitFor(() => {
+      expect(call2Promise).toBeDefined();
+    });
+
+    expect(promptCallCount).toBe(1);
+
+    firstPrompt.resolve();
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+    });
+
+    expect(promptAsync.mock.calls[0][0].sessionID).toBe(SID);
+    expect(promptAsync.mock.calls[1][0].sessionID).toBe(SID);
+
+    secondPrompt.resolve();
+
+    const [r1, r2] = await Promise.all([call1, call2Promise!]);
+    expect(r1.status).toBe('done');
+    expect(r2.status).toBe('done');
   });
 });

--- a/src/__tests__/opencode-client-queue.test.ts
+++ b/src/__tests__/opencode-client-queue.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+class MockEventStream implements AsyncGenerator<unknown, void, unknown> {
+  private index = 0;
+  private readonly events: unknown[];
+  readonly returnSpy = vi.fn(async () => ({ done: true as const, value: undefined }));
+
+  constructor(events: unknown[]) {
+    this.events = events;
+  }
+
+  [Symbol.asyncIterator](): AsyncGenerator<unknown, void, unknown> {
+    return this;
+  }
+
+  async next(): Promise<IteratorResult<unknown, void>> {
+    if (this.index >= this.events.length) {
+      return { done: true, value: undefined };
+    }
+    const value = this.events[this.index];
+    this.index += 1;
+    return { done: false, value };
+  }
+
+  async return(): Promise<IteratorResult<unknown, void>> {
+    return this.returnSpy();
+  }
+
+  async throw(e?: unknown): Promise<IteratorResult<unknown, void>> {
+    throw e;
+  }
+}
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value?: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value?: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const { createOpencodeMock } = vi.hoisted(() => ({
+  createOpencodeMock: vi.fn(),
+}));
+
+vi.mock('node:net', () => ({
+  createServer: () => {
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    return {
+      unref: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        handlers.set(event, handler);
+      }),
+      listen: vi.fn((_port: number, _host: string, cb: () => void) => {
+        cb();
+      }),
+      address: vi.fn(() => ({ port: 62000 })),
+      close: vi.fn((cb?: (err?: Error) => void) => cb?.()),
+    };
+  },
+}));
+
+vi.mock('@opencode-ai/sdk/v2', () => ({
+  createOpencode: createOpencodeMock,
+}));
+
+describe('OpenCodeClient session queue', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { resetSharedServer } = await import('../infra/opencode/client.js');
+    resetSharedServer();
+  });
+
+  it('should run two new sessions (no sessionId) concurrently', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+
+    const firstPrompt = deferred<void>();
+    const secondPrompt = deferred<void>();
+    const sessionCreate = vi.fn()
+      .mockResolvedValueOnce({ data: { id: 'session-concurrent-1' } })
+      .mockResolvedValueOnce({ data: { id: 'session-concurrent-2' } });
+    const promptAsync = vi.fn()
+      .mockImplementationOnce(() => firstPrompt.promise)
+      .mockImplementationOnce(() => secondPrompt.promise);
+
+    let subCount = 0;
+    const subscribe = vi.fn().mockImplementation(() => {
+      subCount += 1;
+      const sid = subCount === 1 ? 'session-concurrent-1' : 'session-concurrent-2';
+      return Promise.resolve({
+        stream: new MockEventStream([
+          { type: 'session.idle', properties: { sessionID: sid } },
+        ]),
+      });
+    });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const call1 = client.call('coder', 'task1', { cwd: '/tmp', model: 'opencode/test-model' });
+    const call2 = client.call('coder', 'task2', { cwd: '/tmp', model: 'opencode/test-model' });
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+    });
+
+    expect(sessionCreate).toHaveBeenCalledTimes(2);
+    expect(createOpencodeMock).toHaveBeenCalledTimes(1);
+
+    firstPrompt.resolve();
+    secondPrompt.resolve();
+    const [r1, r2] = await Promise.all([call1, call2]);
+    expect(r1.status).toBe('done');
+    expect(r2.status).toBe('done');
+  });
+
+  it('should run two calls with different sessionIds in parallel', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+
+    const promptAsync = vi.fn().mockReturnValue(new Promise<void>(() => {}));
+    const sessionCreate = vi.fn();
+    let subCount = 0;
+    const subscribe = vi.fn().mockImplementation(() => {
+      subCount += 1;
+      return Promise.resolve({
+        stream: new MockEventStream([
+          { type: 'session.idle', properties: { sessionID: `session-diff-${subCount}` } },
+        ]),
+      });
+    });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const call1 = client.call('coder', 'first', { cwd: '/tmp', model: 'opencode/test-model', sessionId: 'session-diff-a' });
+    const call2 = client.call('coder', 'second', { cwd: '/tmp', model: 'opencode/test-model', sessionId: 'session-diff-b' });
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+    });
+
+    expect(sessionCreate).not.toHaveBeenCalled();
+    expect(createOpencodeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should serialize same-session calls in FIFO order', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+
+    const sessionId = 'fifo-session';
+    const firstPrompt = deferred<void>();
+    const secondPrompt = deferred<void>();
+    let callCount = 0;
+    const promptAsync = vi.fn().mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? firstPrompt.promise : secondPrompt.promise;
+    });
+    const sessionCreate = vi.fn();
+    const subscribe = vi.fn().mockResolvedValue({
+      stream: new MockEventStream([
+        { type: 'session.idle', properties: { sessionID: sessionId } },
+      ]),
+    });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const call1 = client.call('coder', 'first', { cwd: '/tmp', model: 'opencode/test-model', sessionId });
+    const call2 = client.call('coder', 'second', { cwd: '/tmp', model: 'opencode/test-model', sessionId });
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(1);
+    });
+
+    expect(sessionCreate).not.toHaveBeenCalled();
+
+    firstPrompt.resolve();
+    await call1;
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+    });
+
+    secondPrompt.resolve();
+    await call2;
+    expect(sessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('should release queue after normal completion, allowing subsequent same-session call', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+
+    const sessionId = 'release-normal-session';
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn();
+    let subCount = 0;
+    const subscribe = vi.fn().mockImplementation(() => {
+      subCount++;
+      return Promise.resolve({
+        stream: new MockEventStream([
+          { type: 'session.idle', properties: { sessionID: sessionId } },
+        ]),
+      });
+    });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const call1 = client.call('coder', 'first', { cwd: '/tmp', model: 'opencode/test-model', sessionId });
+    const call2 = client.call('coder', 'second', { cwd: '/tmp', model: 'opencode/test-model', sessionId });
+
+    const result1 = await call1;
+    expect(result1.status).toBe('done');
+
+    const result2 = await call2;
+    expect(result2.status).toBe('done');
+    expect(promptAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('should release queue after error, allowing subsequent same-session call', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+
+    const sessionId = 'release-error-session';
+    const firstPrompt = deferred<void>();
+    const secondPrompt = deferred<void>();
+    let callCount = 0;
+    const promptAsync = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.reject(new Error('first call failed'));
+      return secondPrompt.promise;
+    });
+    const sessionCreate = vi.fn();
+    const subscribe = vi.fn().mockResolvedValue({
+      stream: new MockEventStream([
+        { type: 'session.idle', properties: { sessionID: sessionId } },
+      ]),
+    });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const call1 = client.call('coder', 'first', { cwd: '/tmp', model: 'opencode/test-model', sessionId });
+    const call2 = client.call('coder', 'second', { cwd: '/tmp', model: 'opencode/test-model', sessionId });
+
+    const result1 = await call1;
+    expect(result1.status).toBe('error');
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+    });
+
+    secondPrompt.resolve();
+    const result2 = await call2;
+    expect(result2.status).toBe('done');
+  });
+
+  it('should release queue after abort, allowing subsequent same-session call', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+
+    const sessionId = 'release-abort-session';
+    const abortController = new AbortController();
+    const firstPrompt = deferred<void>();
+    const secondPrompt = deferred<void>();
+    const promptAsync = vi.fn()
+      .mockImplementationOnce(() => firstPrompt.promise)
+      .mockImplementationOnce(() => secondPrompt.promise);
+    const sessionCreate = vi.fn();
+    const subscribe = vi.fn().mockResolvedValue({
+      stream: new MockEventStream([
+        { type: 'session.idle', properties: { sessionID: sessionId } },
+      ]),
+    });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const call1 = client.call('coder', 'first', {
+      cwd: '/tmp', model: 'opencode/test-model', sessionId,
+      abortSignal: abortController.signal,
+    });
+    const call2 = client.call('coder', 'second', {
+      cwd: '/tmp', model: 'opencode/test-model', sessionId,
+    });
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(1);
+    });
+
+    abortController.abort();
+    const result1 = await call1;
+    expect(result1.status).toBe('error');
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+    });
+
+    secondPrompt.resolve();
+    const result2 = await call2;
+    expect(result2.status).toBe('done');
+  });
+
+  it('should use acquired session ID as queue key on retry', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+
+    const retryHeld = deferred<void>();
+    const call2Held = deferred<void>();
+    const sessionCreate = vi.fn()
+      .mockResolvedValue({ data: { id: 'session-retry-key' } });
+
+    let promptCount = 0;
+    const promptAsync = vi.fn().mockImplementation(() => {
+      promptCount++;
+      if (promptCount === 1) return Promise.reject(new Error('transport error'));
+      if (promptCount === 2) return retryHeld.promise;
+      return call2Held.promise;
+    });
+    const subscribe = vi.fn().mockResolvedValue({
+      stream: new MockEventStream([
+        { type: 'session.idle', properties: { sessionID: 'session-retry-key' } },
+      ]),
+    });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: { create: sessionCreate, promptAsync },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const client = new OpenCodeClient();
+    const call1 = client.call('coder', 'task1', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+    });
+
+    await vi.waitFor(() => {
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+    });
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
+
+    const call2 = client.call('coder', 'task2', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      sessionId: 'session-retry-key',
+    });
+
+    // Yield to microtask queue; call2 must NOT start promptAsync
+    // while retry is still pending — otherwise the queue key didn't switch.
+    await new Promise(resolve => setImmediate(resolve));
+    expect(promptAsync).toHaveBeenCalledTimes(2);
+
+    retryHeld.resolve();
+    const result1 = await call1;
+    expect(result1.status).toBe('done');
+
+    // Yield to microtask queue; after retry completes, call2 should start.
+    await new Promise(resolve => setImmediate(resolve));
+    expect(promptAsync).toHaveBeenCalledTimes(3);
+
+    call2Held.resolve();
+    const result2 = await call2;
+    expect(result2.status).toBe('done');
+
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -182,12 +182,16 @@ describe('OpenCodeClient retry', () => {
               delta: 'timeout retry succeeded',
             },
           },
-          { type: 'session.idle', properties: { sessionID: 'session-1' } },
+          { type: 'session.idle', properties: { sessionID: 'session-timeout-retry-2' } },
         ],
       },
     ];
 
     const { sessionCreate, promptAsync, subscribe } = installOpenCodeMock();
+    sessionCreate
+      .mockReset()
+      .mockResolvedValueOnce({ data: { id: 'session-timeout-retry-1' } })
+      .mockResolvedValueOnce({ data: { id: 'session-timeout-retry-2' } });
     const client = new OpenCodeClient();
     const resultPromise = client.call('coder', 'prompt', {
       cwd: '/tmp',
@@ -199,19 +203,20 @@ describe('OpenCodeClient retry', () => {
     expect(promptAsync).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(249);
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
     const result = await resultPromise;
 
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(sessionCreate).toHaveBeenCalledTimes(2);
     expect(promptAsync).toHaveBeenCalledTimes(2);
     expect(subscribe).toHaveBeenCalledTimes(2);
     expect(result.status).toBe('done');
     expect(result.content).toBe('timeout retry succeeded');
+    expect(promptAsync.mock.calls[0][0].sessionID).toBe('session-timeout-retry-1');
+    expect(promptAsync.mock.calls[1][0].sessionID).toBe('session-timeout-retry-2');
+    expect(promptAsync.mock.calls[0][0].sessionID).not.toBe(promptAsync.mock.calls[1][0].sessionID);
   });
 
   it('ストリームの idle timeout は 2 回 retry 後に停止する', async () => {
@@ -225,6 +230,11 @@ describe('OpenCodeClient retry', () => {
     }));
 
     const { sessionCreate, promptAsync, subscribe } = installOpenCodeMock();
+    sessionCreate
+      .mockReset()
+      .mockResolvedValueOnce({ data: { id: 'session-fail-1' } })
+      .mockResolvedValueOnce({ data: { id: 'session-fail-2' } })
+      .mockResolvedValueOnce({ data: { id: 'session-fail-3' } });
     const client = new OpenCodeClient();
     const resultPromise = client.call('coder', 'prompt', {
       cwd: '/tmp',
@@ -232,19 +242,24 @@ describe('OpenCodeClient retry', () => {
     });
 
     await vi.advanceTimersByTimeAsync(OPENCODE_STREAM_IDLE_TIMEOUT_MS + 250);
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(sessionCreate).toHaveBeenCalledTimes(2);
     expect(promptAsync).toHaveBeenCalledTimes(2);
 
     await vi.advanceTimersByTimeAsync(OPENCODE_STREAM_IDLE_TIMEOUT_MS + 500);
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(sessionCreate).toHaveBeenCalledTimes(3);
     expect(promptAsync).toHaveBeenCalledTimes(3);
 
     await vi.advanceTimersByTimeAsync(OPENCODE_STREAM_IDLE_TIMEOUT_MS);
     const result = await resultPromise;
 
-    expect(sessionCreate).toHaveBeenCalledTimes(1);
+    expect(sessionCreate).toHaveBeenCalledTimes(3);
     expect(promptAsync).toHaveBeenCalledTimes(3);
     expect(subscribe).toHaveBeenCalledTimes(3);
+    expect(promptAsync.mock.calls[0][0].sessionID).toBe('session-fail-1');
+    expect(promptAsync.mock.calls[1][0].sessionID).toBe('session-fail-2');
+    expect(promptAsync.mock.calls[2][0].sessionID).toBe('session-fail-3');
+    expect(promptAsync.mock.calls[0][0].sessionID).not.toBe(promptAsync.mock.calls[1][0].sessionID);
+    expect(promptAsync.mock.calls[1][0].sessionID).not.toBe(promptAsync.mock.calls[2][0].sessionID);
     expect(result.status).toBe('error');
     expect(result.content).toBe('OpenCode stream timed out after 10 minutes of inactivity');
   });

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -207,7 +207,7 @@ describe('OpenCodeClient retry', () => {
     await vi.advanceTimersByTimeAsync(1);
     const result = await resultPromise;
 
-    expect(sessionCreate).toHaveBeenCalledTimes(2);
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
     expect(promptAsync).toHaveBeenCalledTimes(2);
     expect(subscribe).toHaveBeenCalledTimes(2);
     expect(result.status).toBe('done');
@@ -232,17 +232,17 @@ describe('OpenCodeClient retry', () => {
     });
 
     await vi.advanceTimersByTimeAsync(OPENCODE_STREAM_IDLE_TIMEOUT_MS + 250);
-    expect(sessionCreate).toHaveBeenCalledTimes(2);
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
     expect(promptAsync).toHaveBeenCalledTimes(2);
 
     await vi.advanceTimersByTimeAsync(OPENCODE_STREAM_IDLE_TIMEOUT_MS + 500);
-    expect(sessionCreate).toHaveBeenCalledTimes(3);
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
     expect(promptAsync).toHaveBeenCalledTimes(3);
 
     await vi.advanceTimersByTimeAsync(OPENCODE_STREAM_IDLE_TIMEOUT_MS);
     const result = await resultPromise;
 
-    expect(sessionCreate).toHaveBeenCalledTimes(3);
+    expect(sessionCreate).toHaveBeenCalledTimes(1);
     expect(promptAsync).toHaveBeenCalledTimes(3);
     expect(subscribe).toHaveBeenCalledTimes(3);
     expect(result.status).toBe('error');

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -750,7 +750,6 @@ export class OpenCodeClient {
     const provisionalKey = options.sessionId === undefined
       ? `provisional-${nextProvisionalId++}`
       : undefined;
-    let resolvedSessionId: string | undefined;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
       const streamAbortController = new AbortController();
@@ -760,7 +759,7 @@ export class OpenCodeClient {
       let diagRef: StreamDiagnostics | undefined;
       let release: (() => void) | undefined;
       let opencodeApiClient: OpencodeClient | undefined;
-      let sessionId: string | undefined = resolvedSessionId ?? options.sessionId;
+      let sessionId: string | undefined = options.sessionId;
       let promptCompletion: Promise<unknown> | undefined;
       let promptCompletionWait: Promise<void> | undefined;
       let promptError: string | undefined;
@@ -874,7 +873,6 @@ export class OpenCodeClient {
           if (!sessionId) {
             throw new Error('Failed to create OpenCode session');
           }
-          resolvedSessionId = sessionId;
         }
 
         const activeSessionId = sessionId;

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -873,6 +873,18 @@ export class OpenCodeClient {
           if (!sessionId) {
             throw new Error('Failed to create OpenCode session');
           }
+
+          if (provisionalKey !== undefined) {
+            const realAcquired = await acquireClient(
+              fullModel,
+              options.opencodeApiKey,
+              options.childProcessEnv,
+              options.abortSignal,
+              sessionId,
+            );
+            release!();
+            release = realAcquired.release;
+          }
         }
 
         const activeSessionId = sessionId;

--- a/src/infra/opencode/client.ts
+++ b/src/infra/opencode/client.ts
@@ -117,8 +117,8 @@ interface SharedServer {
   close: () => void;
   model: string;
   apiKey?: string;
-  busy: boolean;
-  queue: SharedServerQueueEntry[];
+  sessionBusy: Set<string>;
+  sessionQueues: Map<string, SharedServerQueueEntry[]>;
 }
 
 interface SharedServerQueueEntry {
@@ -138,6 +138,8 @@ interface AcquiredOpenCodeClient {
   release: () => void;
 }
 
+let nextProvisionalId = 1;
+
 const sharedServers = new Map<string, SharedServerEntry>();
 
 async function acquireClient(
@@ -145,19 +147,21 @@ async function acquireClient(
   apiKey: string | undefined,
   childProcessEnv: Readonly<Record<string, string>> | undefined,
   abortSignal?: AbortSignal,
+  sessionId?: string,
 ): Promise<AcquiredOpenCodeClient> {
   throwIfAborted(abortSignal);
   const key = buildSharedServerKey(model, apiKey, childProcessEnv);
   const entry = getSharedServerEntry(key);
+  const sessionKey = sessionId ?? '';
 
   if (entry.initPromise) {
     const server = await entry.initPromise;
     throwIfAborted(abortSignal);
-    return acquireSharedServer(server, abortSignal);
+    return acquireSharedServer(server, sessionKey, abortSignal);
   }
 
   if (entry.server) {
-    return acquireSharedServer(entry.server, abortSignal);
+    return acquireSharedServer(entry.server, sessionKey, abortSignal);
   }
 
   entry.initPromise = createSharedServer(model, apiKey, childProcessEnv)
@@ -171,7 +175,7 @@ async function acquireClient(
 
   const server = await entry.initPromise;
   throwIfAborted(abortSignal);
-  return acquireSharedServer(server, abortSignal);
+  return acquireSharedServer(server, sessionKey, abortSignal);
 }
 
 function buildSharedServerKey(
@@ -250,29 +254,35 @@ async function createSharedServer(
   };
 
   log.debug('OpenCode server started', { model, port });
-  return { client, close: closeServer, model, apiKey, busy: false, queue: [] };
+  return { client, close: closeServer, model, apiKey, sessionBusy: new Set(), sessionQueues: new Map() };
 }
 
 function acquireSharedServer(
   server: SharedServer,
+  sessionKey: string,
   abortSignal?: AbortSignal,
 ): AcquiredOpenCodeClient | Promise<AcquiredOpenCodeClient> {
   throwIfAborted(abortSignal);
-  if (!server.busy) {
-    server.busy = true;
-    return { client: server.client, release: createReleaseHandle(server) };
+  if (!server.sessionBusy.has(sessionKey)) {
+    server.sessionBusy.add(sessionKey);
+    return { client: server.client, release: createReleaseHandle(server, sessionKey) };
   }
 
   return new Promise((resolve, reject) => {
     const entry: SharedServerQueueEntry = { resolve, reject, signal: abortSignal };
     if (abortSignal) {
       entry.onAbort = () => {
-        removeQueuedClient(server, entry);
+        removeQueuedClient(server, sessionKey, entry);
         reject(new Error(OPENCODE_STREAM_ABORTED_MESSAGE));
       };
       abortSignal.addEventListener('abort', entry.onAbort, { once: true });
     }
-    server.queue.push(entry);
+    let queue = server.sessionQueues.get(sessionKey);
+    if (!queue) {
+      queue = [];
+      server.sessionQueues.set(sessionKey, queue);
+    }
+    queue.push(entry);
   });
 }
 
@@ -282,7 +292,7 @@ export async function getOpenCodeSessionSnapshot(
   directory: string,
   apiKey?: string,
 ): Promise<OpenCodeSessionSnapshot> {
-  const { client, release } = await acquireClient(model, apiKey, undefined);
+  const { client, release } = await acquireClient(model, apiKey, undefined, undefined, sessionID);
   try {
     const result = await client.session.get({ sessionID, directory });
     if (!result.data) {
@@ -388,7 +398,7 @@ export async function getOpenCodeSessionMessages(
   directory: string,
   apiKey?: string,
 ): Promise<OpenCodeSessionMessages> {
-  const { client, release } = await acquireClient(model, apiKey, undefined);
+  const { client, release } = await acquireClient(model, apiKey, undefined, undefined, sessionID);
   try {
     const result = await client.session.messages({ sessionID, directory });
     if (!result.data) {
@@ -400,20 +410,32 @@ export async function getOpenCodeSessionMessages(
   }
 }
 
-function releaseClient(server: SharedServer): void {
-  const next = server.queue.shift();
+function releaseClient(server: SharedServer, sessionKey: string): void {
+  const queue = server.sessionQueues.get(sessionKey);
+  const next = queue?.shift();
   if (next) {
     if (next.signal && next.onAbort) {
       next.signal.removeEventListener('abort', next.onAbort);
     }
-    next.resolve({ client: server.client, release: createReleaseHandle(server) });
+    next.resolve({ client: server.client, release: createReleaseHandle(server, sessionKey) });
     return;
   }
-  server.busy = false;
+  if (queue !== undefined) {
+    server.sessionQueues.delete(sessionKey);
+  }
+  server.sessionBusy.delete(sessionKey);
 }
 
-function removeQueuedClient(server: SharedServer, entry: SharedServerQueueEntry): void {
-  server.queue = server.queue.filter((queued) => queued !== entry);
+function removeQueuedClient(server: SharedServer, sessionKey: string, entry: SharedServerQueueEntry): void {
+  const queue = server.sessionQueues.get(sessionKey);
+  if (queue) {
+    const filtered = queue.filter((queued) => queued !== entry);
+    if (filtered.length === 0) {
+      server.sessionQueues.delete(sessionKey);
+    } else {
+      server.sessionQueues.set(sessionKey, filtered);
+    }
+  }
   if (entry.signal && entry.onAbort) {
     entry.signal.removeEventListener('abort', entry.onAbort);
   }
@@ -448,12 +470,12 @@ function createExternalAbortPromise(
   return { promise, removeListener };
 }
 
-function createReleaseHandle(server: SharedServer): () => void {
+function createReleaseHandle(server: SharedServer, sessionKey: string): () => void {
   let released = false;
   return () => {
     if (released) return;
     released = true;
-    releaseClient(server);
+    releaseClient(server, sessionKey);
   };
 }
 
@@ -725,6 +747,10 @@ export class OpenCodeClient {
     // 1回だけ確保する: 先行の transient エラーで予算を使い切っていても、
     // 最終試行の format 失敗から救済できるようにする。
     let maxAttempts = OPENCODE_RETRY_MAX_ATTEMPTS;
+    const provisionalKey = options.sessionId === undefined
+      ? `provisional-${nextProvisionalId++}`
+      : undefined;
+    let resolvedSessionId: string | undefined;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
       const streamAbortController = new AbortController();
@@ -734,7 +760,7 @@ export class OpenCodeClient {
       let diagRef: StreamDiagnostics | undefined;
       let release: (() => void) | undefined;
       let opencodeApiClient: OpencodeClient | undefined;
-      let sessionId: string | undefined = options.sessionId;
+      let sessionId: string | undefined = resolvedSessionId ?? options.sessionId;
       let promptCompletion: Promise<unknown> | undefined;
       let promptCompletionWait: Promise<void> | undefined;
       let promptError: string | undefined;
@@ -813,6 +839,7 @@ export class OpenCodeClient {
           options.opencodeApiKey,
           options.childProcessEnv,
           options.abortSignal,
+          sessionId ?? provisionalKey,
         );
         opencodeApiClient = acquired.client;
         release = acquired.release;
@@ -847,6 +874,7 @@ export class OpenCodeClient {
           if (!sessionId) {
             throw new Error('Failed to create OpenCode session');
           }
+          resolvedSessionId = sessionId;
         }
 
         const activeSessionId = sessionId;
@@ -1485,6 +1513,7 @@ export class OpenCodeClient {
       options.opencodeApiKey,
       options.childProcessEnv,
       options.abortSignal,
+      options.sessionId,
     );
 
     try {

--- a/vitest.config.e2e.opencode-parallel.ts
+++ b/vitest.config.e2e.opencode-parallel.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import { e2eBaseTestConfig } from './vitest.config.e2e.base';
+
+export default defineConfig({
+  test: {
+    ...e2eBaseTestConfig,
+    reporters: ['verbose'],
+    include: ['e2e/specs/opencode-parallel-sessions.e2e.ts'],
+    testTimeout: 480000,
+    hookTimeout: 120000,
+  },
+});


### PR DESCRIPTION
## Summary

Closes #1025.

OpenCode provider の shared server queue を server 全体の単一 FIFO から session 単位の FIFO へ変更します。

これにより、同一 model / API key を使う独立した OpenCode session は並列に prompt を実行できます。一方、同一 session の prompt は従来どおり順序を維持して直列に実行されます。

新規 session は queue 取得時点で session ID を持たないため、呼び出し単位の provisional key を使用します。これにより、workflow の初回 parallel child step が空キーに集約されることを防ぎます。

## Changes

- OpenCode shared server の `busy` / 単一 queue を session 単位の busy state / FIFO queue へ置換
- 新規 session call に一意な provisional queue key を導入
- retry 後は取得済み session ID を queue key として使用
- session snapshot / message 取得、compact でも対象 session ID を queue key として使用
- OpenCode queue の unit test を `opencode-client-queue.test.ts` へ分離
- 実 CLI とダミー upstream を使う opt-in integration test を追加
  - 新規 session の並列実行
  - abort 時の別 session への非干渉
  - 同一 session の FIFO

## Validation

- `npm test`
- `npm run build`
- `npm run lint -- --quiet`
- `TAKT_OPENCODE_PARALLEL_INTEGRATION=1 npx vitest run --config vitest.config.e2e.opencode-parallel.ts`
  - 7 tests passed
  - OpenCode SDK 直接経路と Takt adapter 経由の両方を確認

- `TAKT_E2E_MODEL=opencode-go/deepseek-v4-flash npm run test:e2e:provider:opencode`
  - conversation、structured output、add-and-run などは成功
  - team-leader はモデルが必須の JSON block を出力せず失敗
  - failure は team leader の最初の出力契約違反であり、今回の session queue 変更や parallel 実行の前に発生

## Notes

- shared server の再利用、起動、終了処理は変更していません。
- 同一 session の prompt は引き続き FIFO で直列化されます。
- 異なる session の並列化により、provider の rate limit に到達する速度は上がる可能性があります。
- workflow YAML や provider 全体の concurrency 上限は変更していません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 複数セッションを並列実行しても、セッション間のイベント混在や影響を抑制します。
  - 同一セッション内はFIFOで順序制御されます。
  - 中断・エラー・再試行時もキューを適切に解放し、完了済みセッションの再利用に対応します。
- **テスト**
  - 並列隔離・中断影響範囲・FIFO直列化・完了再利用をE2Eで検証します。
  - セッションキュー／リトライ／例外時の挙動テストを強化・更新しました。
- **設定**
  - 並列実行向けのE2E Vitest設定を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->