### PR TITLE
fix: use strict schemas for auto routing output

### DIFF
--- a/src/__tests__/auto-routing-usecase.test.ts
+++ b/src/__tests__/auto-routing-usecase.test.ts
@@ -80,8 +80,16 @@ describe('createAutoRoutingAiRouter', () => {
       permissionMode: 'readonly',
       language: 'ja',
       childProcessEnv: { TAKT_TEST: '1' },
-      outputSchema: expect.objectContaining({ type: 'object' }),
     });
+    expect(options?.outputSchema).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        selected_candidate: { type: 'string' },
+      },
+      required: ['selected_candidate'],
+    });
+    expect(prompt).toContain('Return JSON only as {"selected_candidate":"name"}.');
   });
 
   it('Given multiple no-rule steps, When AI returns selections, Then each id maps to the selected candidate', async () => {
@@ -104,6 +112,27 @@ describe('createAutoRoutingAiRouter', () => {
 
     expect(candidates.get('a')?.name).toBe('coding');
     expect(candidates.get('b')?.name).toBe('review');
+    const [, prompt, options] = vi.mocked(runAgent).mock.calls[0] ?? [];
+    expect(options?.outputSchema).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        selections: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              id: { type: 'string' },
+              selected_candidate: { type: 'string' },
+            },
+            required: ['id', 'selected_candidate'],
+          },
+        },
+      },
+      required: ['selections'],
+    });
+    expect(prompt).toContain('Return JSON only as {"selections":[{"id":"step-id","selected_candidate":"name"}]}.');
   });
 
   it('Given AI returns an unknown candidate, When routing, Then the adapter rejects without echoing the raw candidate', async () => {
@@ -399,6 +428,16 @@ describe('createAutoRoutingAiRouter', () => {
     const secondPrompt = vi.mocked(runAgent).mock.calls[1]?.[1];
     expect(secondPrompt).not.toContain('id: a');
     expect(secondPrompt).toContain('id: c');
+    expect(secondPrompt).toContain('Return JSON only as {"selected_candidate":"name"}.');
+    expect(secondPrompt).not.toContain('"selections"');
+    expect(vi.mocked(runAgent).mock.calls[1]?.[2]?.outputSchema).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        selected_candidate: { type: 'string' },
+      },
+      required: ['selected_candidate'],
+    });
   });
 
   it('Given AI router does not respond, When timeout elapses, Then the router aborts the request and rejects for default fallback', async () => {

--- a/src/agents/auto-routing-usecase.ts
+++ b/src/agents/auto-routing-usecase.ts
@@ -25,11 +25,19 @@ export interface AutoRoutingAiRouter {
   routeBatch(autoRouting: AutoRoutingConfig, steps: AutoRoutingAiStep[]): Promise<Map<string, AutoRoutingCandidate | undefined>>;
 }
 
-const ROUTING_OUTPUT_SCHEMA = {
+const SINGLE_ROUTING_OUTPUT_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   properties: {
     selected_candidate: { type: 'string' },
+  },
+  required: ['selected_candidate'],
+};
+
+const BATCH_ROUTING_OUTPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
     selections: {
       type: 'array',
       items: {
@@ -43,6 +51,7 @@ const ROUTING_OUTPUT_SCHEMA = {
       },
     },
   },
+  required: ['selections'],
 };
 
 const AUTO_ROUTING_AI_TIMEOUT_MS = 30_000;
@@ -92,7 +101,9 @@ function buildRoutingPrompt(
     'Steps:',
     steps.map(formatStep).join('\n\n'),
     '',
-    'Return JSON only. For one step use {"selected_candidate":"name"}. For multiple steps use {"selections":[{"id":"step-id","selected_candidate":"name"}]}.',
+    steps.length === 1
+      ? 'Return JSON only as {"selected_candidate":"name"}.'
+      : 'Return JSON only as {"selections":[{"id":"step-id","selected_candidate":"name"}]}.',
   ].join('\n');
 }
 
@@ -187,6 +198,7 @@ async function runAutoRouterAgent(
   autoRouting: AutoRoutingConfig,
   options: AutoRoutingAiRouterOptions,
   prompt: string,
+  outputSchema: Record<string, unknown>,
 ): Promise<Awaited<ReturnType<typeof runAgent>>> {
   const controller = new AbortController();
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -211,7 +223,7 @@ async function runAutoRouterAgent(
         language: options.language,
         childProcessEnv: options.childProcessEnv,
         onStream: options.onStream,
-        outputSchema: ROUTING_OUTPUT_SCHEMA,
+        outputSchema,
       }),
       timeout,
     ]);
@@ -248,7 +260,10 @@ export function createAutoRoutingAiRouter(options: AutoRoutingAiRouterOptions): 
     }
 
     const prompt = buildRoutingPrompt(options.workflowName, autoRouting, uncachedSteps);
-    const response = await runAutoRouterAgent(autoRouting, options, prompt);
+    const outputSchema = uncachedSteps.length === 1
+      ? SINGLE_ROUTING_OUTPUT_SCHEMA
+      : BATCH_ROUTING_OUTPUT_SCHEMA;
+    const response = await runAutoRouterAgent(autoRouting, options, prompt, outputSchema);
     if (response.status !== 'done') {
       throw new Error('Auto routing AI router returned a non-done status');
     }


### PR DESCRIPTION
## 概要

- auto routing の Structured Output schema を単一ステップ用とバッチ用に分離
- Codex strict schema の要件に合わせ、各 object の properties をすべて required に指定
- 未キャッシュのステップ数を基準に prompt・schema・parser の形式を統一
- 単一、バッチ、キャッシュ混在経路の回帰テストを追加

## 原因

従来は単一応答とバッチ応答を1つの schema に併記していました。Codex の strict Structured Output では properties に含まれる全キーを required に含める必要があるため、invalid_json_schema でルーター呼び出しが失敗し、balanced fallback によって意図しないモデルが選択されていました。

## 検証

- npm run build
- npm run lint
- npm test
- npm run test:it
- npm run test:e2e:mock
- 対象テスト 13件成功
- Structured Output／provider伝搬／fallback関連テスト 73件成功
- git diff --check

## レビュー

codex exec を gpt-5.6-sol、read-only で実行し、APPROVE を確認済みです。ブロッキング問題・警告はありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 自動ルーティングの出力形式を、単一ステップと複数ステップで適切に切り替えるよう改善しました。
  * 複数ステップでは、各選択結果を含む配列形式で返却されるようになりました。
  * キャッシュ済みの結果と未処理の結果が混在する場合も、処理状況に応じた正しい形式で出力されます。
  * 返却データの形式チェックを厳密化し、不正な構造の結果を検出しやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->