### PR TITLE
fix(kiro): strip ANSI escapes and resolve session ID from --list-sessions

### DIFF
--- a/src/__tests__/kiro-client.test.ts
+++ b/src/__tests__/kiro-client.test.ts
@@ -148,20 +148,28 @@ function mockSpawnSequence(scenarios: SpawnScenario[]): void {
     const child = createMockChildProcess();
 
     queueMicrotask(() => {
-      if (scenario?.stdout) {
+      if (!scenario) {
+        const error = Object.assign(new Error(`Unexpected spawn call #${callIndex} (only ${scenarios.length} scenarios defined)`), {
+          code: 'ERR_TEST_UNEXPECTED_SPAWN',
+        });
+        child.emit('error', error);
+        return;
+      }
+
+      if (scenario.stdout) {
         child.stdout.emit('data', Buffer.from(scenario.stdout, 'utf-8'));
       }
-      if (scenario?.stderr) {
+      if (scenario.stderr) {
         child.stderr.emit('data', Buffer.from(scenario.stderr, 'utf-8'));
       }
 
-      if (scenario?.error) {
+      if (scenario.error) {
         const error = Object.assign(new Error(scenario.error.message), scenario.error);
         child.emit('error', error);
         return;
       }
 
-      child.emit('close', scenario?.code ?? 0, scenario?.signal ?? null);
+      child.emit('close', scenario.code ?? 0, scenario.signal ?? null);
     });
 
     return child;

--- a/src/__tests__/kiro-client.test.ts
+++ b/src/__tests__/kiro-client.test.ts
@@ -1,12 +1,26 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockSpawn } = vi.hoisted(() => ({
+const { mockSpawn, debugSpy } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
+  debugSpy: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({
   spawn: mockSpawn,
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createLogger: vi.fn(() => ({
+    debug: debugSpy,
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    enter: vi.fn(),
+    exit: vi.fn(),
+  })),
 }));
 
 import { callKiro } from '../infra/kiro/client.js';
@@ -120,6 +134,34 @@ function mockSpawnWithScenario(scenario: SpawnScenario): void {
       }
 
       child.emit('close', scenario.code ?? 0, scenario.signal ?? null);
+    });
+
+    return child;
+  });
+}
+
+function mockSpawnSequence(scenarios: SpawnScenario[]): void {
+  let callIndex = 0;
+  mockSpawn.mockImplementation((_cmd: string, _args: string[], _options: object) => {
+    const scenario = scenarios[callIndex];
+    callIndex += 1;
+    const child = createMockChildProcess();
+
+    queueMicrotask(() => {
+      if (scenario?.stdout) {
+        child.stdout.emit('data', Buffer.from(scenario.stdout, 'utf-8'));
+      }
+      if (scenario?.stderr) {
+        child.stderr.emit('data', Buffer.from(scenario.stderr, 'utf-8'));
+      }
+
+      if (scenario?.error) {
+        const error = Object.assign(new Error(scenario.error.message), scenario.error);
+        child.emit('error', error);
+        return;
+      }
+
+      child.emit('close', scenario?.code ?? 0, scenario?.signal ?? null);
     });
 
     return child;
@@ -881,5 +923,288 @@ describe('callKiro', () => {
     expect(childProcess?.kill).toHaveBeenCalledWith('SIGTERM');
     await vi.advanceTimersByTimeAsync(1_000);
     expect(childProcess?.kill).not.toHaveBeenCalledWith('SIGKILL');
+  });
+});
+
+// Covers GitHub issue #781: real session ID resolution on the first turn and
+// output cleanup (ANSI escapes + leading "> " prompt marker) so multi-turn
+// context and response content survive a real kiro-cli 2.5.1 invocation.
+describe('callKiro session ID resolution (issue #781)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.KIRO_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    restoreEnv();
+  });
+
+  const uuid = '123e4567-e89b-12d3-a456-426614174000';
+
+  it('Given no session ID, When the main call succeeds, Then resolves the real session by invoking chat --list-sessions and returns its UUID', async () => {
+    mockSpawnSequence([
+      { stdout: 'Implementation complete.', code: 0 },
+      { stderr: `${uuid}  updated just now`, code: 0 },
+    ]);
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('Implementation complete.');
+    expect(result.sessionId).toBe(uuid);
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    const [, firstArgs] = mockSpawn.mock.calls[0] as [string, string[]];
+    const [, secondArgs, secondOptions] = mockSpawn.mock.calls[1] as [
+      string,
+      string[],
+      { cwd?: string },
+    ];
+    expect(firstArgs).toEqual(['chat', '--no-interactive', 'implement feature']);
+    expect(secondArgs).toEqual(['chat', '--list-sessions']);
+    expect(secondOptions.cwd).toBe('/repo');
+  });
+
+  it('Given an existing session ID (resume turn), When called, Then does not invoke --list-sessions and returns the same session ID', async () => {
+    mockSpawnWithScenario({ stdout: 'done', code: 0 });
+
+    const result = await callKiro('coder', 'continue', {
+      cwd: '/repo',
+      sessionId: 'sess-prev',
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.sessionId).toBe('sess-prev');
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('Given no session ID, When --list-sessions fails after the main call already succeeded, Then still returns success with an undefined session ID', async () => {
+    mockSpawnSequence([
+      { stdout: 'Implementation complete.', code: 0 },
+      { code: 1 },
+    ]);
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('Implementation complete.');
+    expect(result.sessionId).toBeUndefined();
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('Given no session ID, When --list-sessions fails after the main call already succeeded, Then records the failure via log.debug instead of swallowing it silently', async () => {
+    mockSpawnSequence([
+      { stdout: 'Implementation complete.', code: 0 },
+      { code: 1 },
+    ]);
+
+    await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      'kiro-cli --list-sessions failed; session ID unresolved for this turn',
+      expect.objectContaining({ error: expect.any(String) }),
+    );
+  });
+
+  it('Given no session ID and an abort signal already aborted after the main call succeeds, When resolving the session ID, Then skips --list-sessions and returns an undefined session ID', async () => {
+    const controller = new AbortController();
+
+    mockSpawn.mockImplementation(() => {
+      const child = createMockChildProcess();
+      queueMicrotask(() => {
+        child.stdout.emit('data', Buffer.from('Implementation complete.', 'utf-8'));
+        child.emit('close', 0, null);
+        // Abort after the main call's close event resolves but before the
+        // `await execKiro` continuation (which calls resolveLatestSessionId)
+        // runs on the next microtask tick.
+        controller.abort();
+      });
+      return child;
+    });
+
+    const result = await callKiro('coder', 'implement feature', {
+      cwd: '/repo',
+      abortSignal: controller.signal,
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('Implementation complete.');
+    expect(result.sessionId).toBeUndefined();
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('Given no session ID, When --list-sessions output has no UUID in either stream, Then still returns success with an undefined session ID', async () => {
+    mockSpawnSequence([
+      { stdout: 'done', code: 0 },
+      { stderr: 'no sessions found', code: 0 },
+    ]);
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('done');
+    expect(result.sessionId).toBeUndefined();
+  });
+
+  it('Given no session ID and a resolvable UUID, When onStream is provided, Then the result event carries the resolved session ID', async () => {
+    mockSpawnSequence([
+      { stdout: 'stream content', code: 0 },
+      { stderr: uuid, code: 0 },
+    ]);
+
+    const onStream = vi.fn();
+    await callKiro('coder', 'implement', { cwd: '/repo', onStream });
+
+    expect(onStream).toHaveBeenCalledWith({
+      type: 'result',
+      data: expect.objectContaining({ sessionId: uuid, success: true }),
+    });
+  });
+
+  it('Given no session ID and stdout that cleans to empty, When command succeeds, Then returns the empty-output error without attempting session resolution', async () => {
+    mockSpawnWithScenario({
+      stdout: '\x1b[32m> \x1b[0m',
+      code: 0,
+    });
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('error');
+    expect(result.content).toBe('kiro-cli returned empty output');
+    expect(result.sessionId).toBeUndefined();
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('Given no session ID, When the main call fails, Then does not attempt session resolution and reports the original error', async () => {
+    mockSpawnWithScenario({
+      error: { code: 'ENOENT', message: 'spawn kiro-cli ENOENT' },
+    });
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('error');
+    expect(result.content).toContain('kiro-cli binary not found');
+    expect(result.sessionId).toBeUndefined();
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  const otherUuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+  it('Given ANSI escapes wrapping the UUID in --list-sessions stderr, When resolving the session ID, Then strips them before extracting', async () => {
+    mockSpawnSequence([
+      { stdout: 'Implementation complete.', code: 0 },
+      { stderr: `\x1b[36m${uuid}\x1b[0m  updated just now`, code: 0 },
+    ]);
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('done');
+    expect(result.sessionId).toBe(uuid);
+  });
+
+  it('Given no UUID in --list-sessions stderr but one in stdout, When resolving the session ID, Then falls back to stdout', async () => {
+    mockSpawnSequence([
+      { stdout: 'Implementation complete.', code: 0 },
+      { stdout: `${uuid}  updated just now`, stderr: 'no sessions listed', code: 0 },
+    ]);
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('done');
+    expect(result.sessionId).toBe(uuid);
+  });
+
+  it('Given UUIDs in both --list-sessions stdout and stderr, When resolving the session ID, Then prefers the stderr UUID', async () => {
+    mockSpawnSequence([
+      { stdout: 'Implementation complete.', code: 0 },
+      { stdout: `${otherUuid}  updated 1m ago`, stderr: `${uuid}  updated 2m ago`, code: 0 },
+    ]);
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('done');
+    expect(result.sessionId).toBe(uuid);
+  });
+
+  it('Given multiple UUIDs in --list-sessions stderr, When resolving the session ID, Then returns the first one (most recent session listed first)', async () => {
+    mockSpawnSequence([
+      { stdout: 'Implementation complete.', code: 0 },
+      { stderr: `${uuid}  updated just now\n${otherUuid}  updated 1h ago`, code: 0 },
+    ]);
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('done');
+    expect(result.sessionId).toBe(uuid);
+  });
+
+  it('Given --list-sessions stderr text that merely resembles a UUID (wrong segment lengths), When resolving the session ID, Then does not match it and returns undefined', async () => {
+    mockSpawnSequence([
+      { stdout: 'Implementation complete.', code: 0 },
+      { stderr: '1234-5678-9012-3456', code: 0 },
+    ]);
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('done');
+    expect(result.sessionId).toBeUndefined();
+  });
+});
+
+describe('callKiro output cleanup (issue #781)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.KIRO_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    restoreEnv();
+  });
+
+  it('Given stdout with ANSI escapes and a leading prompt marker, When resuming a session, Then returns cleaned content and skips session resolution', async () => {
+    mockSpawnWithScenario({
+      stdout: '\x1b[32m> \x1b[0mImplementation complete.\x1b[0m',
+      code: 0,
+    });
+
+    const result = await callKiro('coder', 'continue', {
+      cwd: '/repo',
+      sessionId: 'sess-prev',
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('Implementation complete.');
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('Given stdout with a Markdown blockquote in the body, When called, Then only strips the leading prompt marker and keeps body "> " intact', async () => {
+    mockSpawnWithScenario({
+      stdout: '> Summary\n> This quoted line should remain',
+      code: 0,
+    });
+
+    const result = await callKiro('coder', 'continue', {
+      cwd: '/repo',
+      sessionId: 'sess-prev',
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('Summary\n> This quoted line should remain');
+  });
+
+  it('Given stdout with surrounding blank lines, a leading prompt marker, and trailing whitespace, When called, Then trims the result after marker removal', async () => {
+    mockSpawnWithScenario({
+      stdout: '\n\n  > Implementation complete.  \n\n',
+      code: 0,
+    });
+
+    const result = await callKiro('coder', 'continue', {
+      cwd: '/repo',
+      sessionId: 'sess-prev',
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('Implementation complete.');
   });
 });

--- a/src/__tests__/kiro-provider-integration.test.ts
+++ b/src/__tests__/kiro-provider-integration.test.ts
@@ -174,6 +174,61 @@ describe('KiroProvider integration', () => {
     expect(args.at(-1)).toBe('plan the feature');
   });
 
+  it('Given no session ID, When provider agent calls the real client and succeeds, Then resolves the session ID via a second --list-sessions spawn (issue #781)', async () => {
+    const kiroCliPath = join(testDir, 'kiro-cli');
+    writeFileSync(kiroCliPath, '#!/bin/sh\necho kiro\n', 'utf-8');
+    chmodSync(kiroCliPath, 0o755);
+    writeFileSync(
+      join(taktDir, 'config.yaml'),
+      [
+        'language: en',
+        'provider: kiro',
+        `kiro_cli_path: ${kiroCliPath}`,
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const uuid = '123e4567-e89b-12d3-a456-426614174000';
+    mockSpawn
+      .mockImplementationOnce(() => {
+        const child = createMockChildProcess();
+        queueMicrotask(() => {
+          child.stdout.emit('data', Buffer.from('turn one result', 'utf-8'));
+          child.emit('close', 0, null);
+        });
+        return child;
+      })
+      .mockImplementationOnce(() => {
+        const child = createMockChildProcess();
+        queueMicrotask(() => {
+          child.stderr.emit('data', Buffer.from(`${uuid}  updated just now`, 'utf-8'));
+          child.emit('close', 0, null);
+        });
+        return child;
+      });
+
+    const provider = new KiroProvider();
+    const agent = provider.setup({ name: 'coder' });
+
+    const result = await agent.call('implement feature', {
+      cwd: testDir,
+      permissionMode: 'edit',
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('turn one result');
+    expect(result.sessionId).toBe(uuid);
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+
+    const [, secondArgs, secondOptions] = mockSpawn.mock.calls[1] as [
+      string,
+      string[],
+      { cwd?: string },
+    ];
+    expect(secondArgs).toEqual(['chat', '--list-sessions']);
+    expect(secondOptions.cwd).toBe(testDir);
+  });
+
   it('Given no providerOptions, When provider agent calls real client, Then spawn args have no --agent flag', async () => {
     writeFileSync(
       join(taktDir, 'config.yaml'),

--- a/src/infra/kiro/client.ts
+++ b/src/infra/kiro/client.ts
@@ -199,6 +199,10 @@ async function resolveLatestSessionId(options: KiroCallOptions): Promise<string 
   const timer = setTimeout(() => controller.abort(), KIRO_LIST_SESSIONS_TIMEOUT_MS);
   timer.unref?.();
 
+  // Propagate parent abort to the list-sessions controller.
+  const parentAbortHandler = (): void => controller.abort();
+  options.abortSignal?.addEventListener('abort', parentAbortHandler, { once: true });
+
   try {
     const listOptions: KiroCallOptions = {
       ...options,
@@ -213,6 +217,7 @@ async function resolveLatestSessionId(options: KiroCallOptions): Promise<string 
     return undefined;
   } finally {
     clearTimeout(timer);
+    options.abortSignal?.removeEventListener('abort', parentAbortHandler);
   }
 }
 

--- a/src/infra/kiro/client.ts
+++ b/src/infra/kiro/client.ts
@@ -184,6 +184,8 @@ function parseLatestSessionId(stdout: string, stderr: string): string | undefine
   return stdoutMatch?.[0];
 }
 
+const KIRO_LIST_SESSIONS_TIMEOUT_MS = 10_000;
+
 // Runs only for a brand-new session (no `options.sessionId` yet): the main
 // turn already succeeded, so a failure here (non-zero exit, ENOENT, no UUID
 // found) must not turn the overall result into an error — it just leaves the
@@ -193,14 +195,24 @@ async function resolveLatestSessionId(options: KiroCallOptions): Promise<string 
     return undefined;
   }
 
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), KIRO_LIST_SESSIONS_TIMEOUT_MS);
+  timer.unref?.();
+
   try {
-    const { stdout, stderr } = await execKiro(['chat', '--list-sessions'], options);
+    const listOptions: KiroCallOptions = {
+      ...options,
+      abortSignal: controller.signal,
+    };
+    const { stdout, stderr } = await execKiro(['chat', '--list-sessions'], listOptions);
     return parseLatestSessionId(stdout, stderr);
   } catch (rawError) {
     log.debug('kiro-cli --list-sessions failed; session ID unresolved for this turn', {
       error: getErrorMessage(rawError),
     });
     return undefined;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/src/infra/kiro/client.ts
+++ b/src/infra/kiro/client.ts
@@ -1,14 +1,22 @@
 import type { AgentResponse } from '../../core/models/index.js';
-import { getErrorMessage } from '../../shared/utils/index.js';
+import { createLogger, getErrorMessage, stripAnsi } from '../../shared/utils/index.js';
 import { execKiro, type KiroExecError } from './process.js';
 import type { KiroCallOptions } from './types.js';
 
 export type { KiroCallOptions } from './types.js';
 
+const log = createLogger('kiro-client');
+
 const KIRO_ABORTED_MESSAGE = 'Kiro execution aborted';
 const KIRO_ERROR_DETAIL_MAX_LENGTH = 400;
 const KIRO_SESSION_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
 const KIRO_AGENT_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+// Matches only a leading prompt-echo marker (absolute start of the cleaned
+// output), so a Markdown blockquote ("> ") later in the body is left intact.
+const KIRO_LEADING_PROMPT_PATTERN = /^\s*> /;
+// UUID emitted by `kiro-cli chat --list-sessions` for each listed session.
+// No `g` flag: RegExp#exec always returns the first (most recent) match.
+const KIRO_SESSION_UUID_PATTERN = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
 
 function buildPrompt(prompt: string, systemPrompt?: string): string {
   if (!systemPrompt) {
@@ -156,11 +164,52 @@ function classifyExecutionError(error: KiroExecError, options: KiroCallOptions):
   return redactDetail(getErrorMessage(error), options.kiroApiKey);
 }
 
+// Shared cleanup used both for `AgentResponse.content` and for the raw
+// streams parsed by `parseLatestSessionId` below (DRY: single place that
+// strips ANSI escapes and the CLI's leading `> ` prompt-echo marker).
+function cleanKiroOutput(raw: string): string {
+  return stripAnsi(raw).replace(KIRO_LEADING_PROMPT_PATTERN, '').trim();
+}
+
+// Extracts the most recent session UUID from `kiro-cli chat --list-sessions`
+// output. That command writes its listing to stderr; stdout is checked as a
+// fallback in case the CLI's stream choice differs across versions.
+function parseLatestSessionId(stdout: string, stderr: string): string | undefined {
+  const stderrMatch = KIRO_SESSION_UUID_PATTERN.exec(cleanKiroOutput(stderr));
+  if (stderrMatch) {
+    return stderrMatch[0];
+  }
+
+  const stdoutMatch = KIRO_SESSION_UUID_PATTERN.exec(cleanKiroOutput(stdout));
+  return stdoutMatch?.[0];
+}
+
+// Runs only for a brand-new session (no `options.sessionId` yet): the main
+// turn already succeeded, so a failure here (non-zero exit, ENOENT, no UUID
+// found) must not turn the overall result into an error — it just leaves the
+// session ID unresolved for this turn.
+async function resolveLatestSessionId(options: KiroCallOptions): Promise<string | undefined> {
+  if (options.abortSignal?.aborted) {
+    return undefined;
+  }
+
+  try {
+    const { stdout, stderr } = await execKiro(['chat', '--list-sessions'], options);
+    return parseLatestSessionId(stdout, stderr);
+  } catch (rawError) {
+    log.debug('kiro-cli --list-sessions failed; session ID unresolved for this turn', {
+      error: getErrorMessage(rawError),
+    });
+    return undefined;
+  }
+}
+
 function emitResult(
   options: KiroCallOptions,
   result: string,
   success: boolean,
-  error?: string,
+  error: string | undefined,
+  sessionId: string | undefined,
 ): void {
   options.onStream?.({
     type: 'result',
@@ -168,7 +217,7 @@ function emitResult(
       result,
       success,
       error,
-      sessionId: options.sessionId ?? '',
+      sessionId: sessionId ?? '',
     },
   });
 }
@@ -184,10 +233,10 @@ export class KiroClient {
     try {
       const args = buildArgs(effectiveOptions, promptText);
       const { stdout } = await execKiro(args, effectiveOptions);
-      const content = stdout.trim();
+      const content = cleanKiroOutput(stdout);
       if (!content) {
         const message = 'kiro-cli returned empty output';
-        emitResult(options, '', false, message);
+        emitResult(options, '', false, message, options.sessionId);
         return {
           persona: agentType,
           status: 'error',
@@ -198,20 +247,25 @@ export class KiroClient {
         };
       }
 
+      // First turn (no session yet): resolve the real session ID now so the
+      // caller can resume with `--resume-id` on the next turn. Resume turns
+      // already know their session ID, so skip the extra process spawn.
+      const resolvedSessionId = options.sessionId ?? await resolveLatestSessionId(effectiveOptions);
+
       options.onStream?.({ type: 'text', data: { text: content } });
-      emitResult(options, content, true);
+      emitResult(options, content, true, undefined, resolvedSessionId);
 
       return {
         persona: agentType,
         status: 'done',
         content,
         timestamp: new Date(),
-        sessionId: options.sessionId,
+        sessionId: resolvedSessionId,
       };
     } catch (rawError) {
       const error = rawError as KiroExecError;
       const message = classifyExecutionError(error, effectiveOptions);
-      emitResult(options, '', false, message);
+      emitResult(options, '', false, message, options.sessionId);
       return {
         persona: agentType,
         status: 'error',


### PR DESCRIPTION
## Summary

Kiro CLI プロバイダーの出力から ANSI エスケープシーケンスを除去し、初回実行後に `--list-sessions` から実セッションIDを取得して後続ターンに `--resume-id` として渡す機能を追加します。

Addresses #781

## 背景

#781 で報告された2つの「重要」課題に対応します：

1. **ANSI エスケープ除去**: `kiro-cli chat --no-interactive` は非TTYパイプ出力でも ANSI カラーエスケープと先頭のプロンプト記号 `> ` を stdout に出力する。これにより `AgentResponse.content` やログに制御文字が混入し、runSlug の生成やルール判定に悪影響を与える。

2. **セッション ID 取得**: 初回ターンで `response.sessionId` が `undefined` のまま返されるため、同一 `session_key` を共有するステップ間でも `--resume-id` が渡されず、毎回新規会話になって文脈が失われる。

## 変更内容

- `cleanKiroOutput()`: `stripAnsi()` + 先頭プロンプト記号 `> ` の除去を一箇所に集約
- `parseLatestSessionId()`: `kiro-cli chat --list-sessions` の stderr/stdout から UUID を抽出
- `resolveLatestSessionId()`: 初回ターン（`sessionId` 未設定）成功後に `--list-sessions` を実行してセッション ID を返す。失敗時はエラーにせず `undefined` を返す（ベストエフォート）
- `emitResult` に `sessionId` パラメータを追加し、取得した ID を provider stream に反映
- ユニットテスト / インテグレーションテスト追加

## スコープ外（既知の制約）

- **並列ステップでの競合**: 同一 cwd で複数の新規 Kiro 会話を同時に開始した場合、`--list-sessions` が同じセッション ID を返す可能性がある。根本解決には kiro-cli 本体側で session ID を stdout/JSON に出力する機能が必要。

## 動作確認

以下の4パターンで確認しました。

### 1. Kiro CLI 単体（`--resume-id` なし、対照実験）

```bash
cd $(mktemp -d)
kiro-cli chat --no-interactive --model claude-sonnet-4.6 "秘密のトークンは q7m9-v4k2 です。覚えて。"
kiro-cli chat --no-interactive --model claude-sonnet-4.6 "前に伝えた秘密のトークンは？"
```

結果: 2回目は「共有されていません」と回答。`--no-interactive` では暗黙的なセッション再開は行われない。

### 2. main ブランチ（#781 対応なし）

同一 `session_key` を設定した2ステップのワークフローで実行。

- `Session:` 行が出力されない（セッションID未取得）
- step2 は「アクセスできません」と回答 → ワークフロー ABORT
- content に `\u001b[38;5;141m> \u001b[0m` が混入

### 3. fix ブランチ（#781 対応あり、同一 session_key）

```
Session: 3e5aaee2-419b-47d0-af5d-0babc9df7973  (step1)
Session: 3e5aaee2-419b-47d0-af5d-0babc9df7973  (step2 で再利用)
```

step2 の回答: `q7m9-v4k2` ← 正答。content もクリーン（ANSI なし）。

### 4. fix ブランチ（異なる session_key でセッション分離確認）

step2 に別の `session_key` を設定して実行。

- step1 Session: `75dfff27-...`
- step2 Session: `6b90476c-...` ← 別のセッションID
- step2 は「記憶はありません」と回答

セッションキーによる分離が正しく動作していることを確認。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **機能改善**
  - 初回のチャット実行時に自動で `--list-sessions` を行い、最新のセッションIDを結果に反映します（既存の `sessionId` 指定時はそのまま使用）。
  - 受信出力のANSIエスケープや先頭プロンプト表示を除去して整形し、再開時の表示を整理します。
  - `--list-sessions` が失敗してもメインの結果は維持し、詳細はdebugログに記録します。
- **テスト**
  - セッション解決・クレンジング・失敗時挙動、複数ステップの呼び出しを検証するテストを追加/拡張しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->