### PR TITLE
fix: 関連テストゲートをファイル個別実行に誘導する

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -7,31 +7,31 @@ workflow_overrides:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the test files (unit and integration) covering the code you changed and run them. All must pass"
+        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     fix:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the test files (unit and integration) covering the code you changed and run them. All must pass"
+        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     ai_fix:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the test files (unit and integration) covering the code you changed and run them. All must pass"
+        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     ai-antipattern-fix:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the test files (unit and integration) covering the code you changed and run them. All must pass"
+        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     fix_supervisor:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the test files (unit and integration) covering the code you changed and run them. All must pass"
+        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     merge-readiness-review:
       quality_gates:

--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -7,31 +7,36 @@ workflow_overrides:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
+        - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
+        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     fix:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
+        - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
+        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     ai_fix:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
+        - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
+        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     ai-antipattern-fix:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
+        - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
+        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     fix_supervisor:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
-        - "Identify the specific test files covering the code you changed and run them individually (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Exception: if you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), run the affected test group instead. Never run the full suite. All must pass"
+        - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
+        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
         - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
     merge-readiness-review:
       quality_gates:


### PR DESCRIPTION
## 背景

#1048 で fix 系ステップのゲートを軽量化したが、「関連テストを実行」の文言では fix エージェントが serial workflow グループ丸ごと（11ファイル509件、実測250秒）を「関連テスト」として選ぶケースが実運用で観測された。同じ検証はファイル個別指定なら実測230msで済む。

## 変更内容

`implement` / `fix` / `ai_fix` / `ai-antipattern-fix` / `fix_supervisor` の関連テストゲート文言を次の通り変更。

- テストファイルを個別に特定して実行（例: `npm test -- src/__tests__/<name>.test.ts`。integration ファイルも同様に動作）
- 例外: テスト基盤自体（vitest 設定・test runner スクリプト・共有 fixture/setup）を変更した場合は該当テストグループを実行
- フルスイートは常に禁止（final-gate の責務）

## 検証（すべて実測）

- unit ファイル個別指定: 230ms で正常動作
- integration ファイル個別指定: ルータが正しく処理（exit 0）
- 存在しないファイル指定: exit 1 で fail-closed（タイポでゲートを素通りできない）
- e2e ファイルを `npm test --` に渡した場合: exit 1 で fail-closed
- 「グループ禁止」が裏目に出る唯一のケース（テスト基盤自体の変更でファイル個別では退行検出不能）は例外節でカバー。実例として本 config が対象とする実運用中のランで `scripts/run-npm-test.mjs` を修正した fix がこの例外に該当した