### PR TITLE
fix(workflow): preserve finding context across resumes

### DIFF
--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -222,6 +222,15 @@ provisional finding は final gate を塞ぎます。
 
 provisional finding を確定・解消できるのは後続ラウンドの clean なレビュー証拠だけです。同じ claim の clean な再観測は確定 finding へ昇格させ、既存 finding への決定的な対応づけは resolved にします。「後のラウンドで言及されなかった」だけでは決して解消されず、waive / invalidate / supersede もできません。
 
+open finding の各 item は、fixer instruction と `when()` の rule state の両方で `familyTags` を公開します。配列順に依存せず family でルーティングするには、`exists()` 内で `contains()` を使います。
+
+```yaml
+- condition: when(exists(findings.open.items, contains(item.familyTags, "provider-e2e")))
+  next: fix
+```
+
+ledger が既に存在しない raw finding を参照している場合、その id は黙って破棄されたり ledger 全体を読めなくしたりせず、`unknownRawFindingIds` に公開されます。どちらの配列も重複排除・ソート済みで、`contains(item.unknownRawFindingIds, "raw-id")` も同じ包含構文を使います。
+
 **v2 以前の invalid-manager-output ルーティングからの移行:** 旧 workflow は、Finding Manager output が retry 後も意味論的に invalid なとき、エンジンが決定的な迂回 rule（`return: need_replan` / `return: needs_fix` / 非AI `next: fix`）を自動選択することに依存していました。この run-level の失敗経路は廃止されています — invalid・欠落した manager の判断は provisional finding として台帳へ着地して run が継続するため、これらの迂回 rule が自動選択されることはもうありません。移行するには、`COMPLETE` の rule より*前*に `when(findings.provisional.count > 0 && findings.conflicts.count == 0)` を再計画ステップへ向ける rule を追加してください（配線の参考は builtin の `takt-default-high` workflow）。`finding_contract` を使う workflow が `findings.provisional` を一切参照していない場合、`takt workflow doctor` が警告します。
 
 ### Arpeggio Step（データ駆動バッチ）

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -223,6 +223,15 @@ Provisional findings block the final gate:
 
 Provisional findings are settled only by later clean review evidence: a clean re-observation of the same claim confirms it as a real finding, and a deterministic mapping to an existing finding resolves it. They are never resolved just because a later round did not mention them, and they cannot be waived, invalidated, or superseded.
 
+Open finding items expose `familyTags` to both fixer instructions and `when()` rule state. Use `contains()` inside `exists()` to route by family without depending on array order:
+
+```yaml
+- condition: when(exists(findings.open.items, contains(item.familyTags, "provider-e2e")))
+  next: fix
+```
+
+If a ledger references a raw finding that is no longer present, its id is exposed in `unknownRawFindingIds` instead of being silently discarded or making the ledger unreadable. Both arrays are deduplicated and sorted; `contains(item.unknownRawFindingIds, "raw-id")` uses the same membership syntax.
+
 **Migrating from the pre-v2 invalid-manager-output routing:** older workflows relied on the engine auto-selecting a deterministic detour rule (`return: need_replan`, `return: needs_fix`, or non-AI `next: fix`) when the Finding Manager output stayed semantically invalid. That run-level failure path no longer exists — invalid or missing manager decisions land as provisional findings and the run continues, so those detour rules are never auto-selected anymore. To migrate, add a rule such as `when(findings.provisional.count > 0 && findings.conflicts.count == 0)` routed to your replan step *before* the `COMPLETE` rule (see the builtin `takt-default-high` workflow for the reference wiring). `takt workflow doctor` warns when a `finding_contract` workflow has no rule referencing `findings.provisional`.
 
 ### Arpeggio Step (data-driven batch)

--- a/src/__tests__/engine-happy-path.test.ts
+++ b/src/__tests__/engine-happy-path.test.ts
@@ -562,7 +562,13 @@ describe('WorkflowEngine Integration: Happy Path', () => {
       ]);
 
       const startFn = vi.fn();
-      engine.on('step:start', startFn);
+      let resumePointAtParallelStart: ReturnType<WorkflowEngine['getResumePoint']>;
+      engine.on('step:start', (...args) => {
+        startFn(...args);
+        if (args[0].name === 'reviewers') {
+          resumePointAtParallelStart = engine.getResumePoint();
+        }
+      });
 
       await engine.run();
 
@@ -574,6 +580,8 @@ describe('WorkflowEngine Integration: Happy Path', () => {
       // Parallel steps emit empty string for instruction
       const [, , instruction] = reviewersCall!;
       expect(instruction).toBe('');
+      expect(reviewersCall?.[6]).toBe(1);
+      expect(resumePointAtParallelStart?.stack[0]?.step_iterations?.reviewers).toBe(1);
     });
 
     it('should emit iteration:limit when max iterations reached', async () => {
@@ -765,6 +773,51 @@ describe('WorkflowEngine Integration: Happy Path', () => {
   // 9. startStep option
   // =====================================================
   describe('startStep option', () => {
+    it('should continue the resumed step iteration in instructions, events, and the next resume point', async () => {
+      const config = buildDefaultWorkflowConfig({
+        name: 'resume-workflow',
+        maxSteps: 11,
+        initialStep: 'implement',
+        steps: [
+          makeStep('implement', {
+            persona: 'coder',
+            rules: [makeRule('done', 'COMPLETE')],
+          }),
+        ],
+      });
+      engine = new WorkflowEngine(config, tmpDir, 'test task', {
+        projectCwd: tmpDir,
+        startStep: 'implement',
+        initialIteration: 10,
+        resumePoint: {
+          version: 1,
+          stack: [{
+            workflow: 'resume-workflow',
+            step: 'implement',
+            kind: 'agent',
+            step_iterations: { implement: 4, reviewers: 2 },
+          }],
+          iteration: 10,
+          elapsed_ms: 1_000,
+        },
+      });
+      mockRunAgentSequence([makeResponse({ persona: 'coder', content: 'done' })]);
+      mockDetectMatchedRuleSequence([{ index: 0, method: 'phase1_tag' }]);
+      const startFn = vi.fn();
+      engine.on('step:start', startFn);
+
+      const state = await engine.run();
+
+      expect(state.stepIterations.get('implement')).toBe(5);
+      expect(state.stepIterations.get('reviewers')).toBe(2);
+      expect(startFn.mock.calls[0]?.[2]).toContain('Step Iteration: 5');
+      expect(startFn.mock.calls[0]?.[6]).toBe(5);
+      expect(engine.getResumePoint()?.stack[0]?.step_iterations).toEqual({
+        implement: 5,
+        reviewers: 2,
+      });
+    });
+
     it('should start from specified step instead of initialStep', async () => {
       const config = buildDefaultWorkflowConfig();
       // Start from ai_review, skipping plan and implement

--- a/src/__tests__/engine-workflow-call.test.ts
+++ b/src/__tests__/engine-workflow-call.test.ts
@@ -47,7 +47,7 @@ import {
   mockRunAgentSequence,
 } from './engine-test-helpers.js';
 import { findWorkflowCallStep } from './testUtils/workflowCallStepTestHelper.js';
-import type { AutoRoutingConfig, WorkflowConfig } from '../core/models/index.js';
+import type { AutoRoutingConfig, WorkflowConfig, WorkflowStep } from '../core/models/index.js';
 import { initAnalyticsWriter } from '../features/analytics/index.js';
 import { resetAnalyticsWriter } from '../features/analytics/writer.js';
 import { AnalyticsEmitter } from '../features/tasks/execute/analyticsEmitter.js';
@@ -3966,6 +3966,7 @@ steps:
       workflow: 'parent',
       step: 'delegate',
       kind: 'workflow_call',
+      step_iterations: { delegate: 1 },
     });
     expect(capturedResumePoint?.stack[1]).toEqual(expect.objectContaining({
       workflow: 'takt/coding',
@@ -4553,19 +4554,34 @@ steps:
       resumePoint: {
         version: 1,
         stack: [
-          { workflow: 'parent', step: 'delegate', kind: 'workflow_call' },
-          { workflow: 'takt/coding', step: 'fix', kind: 'agent' },
+          {
+            workflow: 'parent',
+            step: 'delegate',
+            kind: 'workflow_call',
+            step_iterations: { delegate: 3 },
+          },
+          {
+            workflow: 'takt/coding',
+            step: 'fix',
+            kind: 'agent',
+            step_iterations: { review: 4, fix: 6 },
+          },
         ],
         iteration: 7,
         elapsed_ms: 183245,
       },
     }));
+    const startFn = vi.fn();
+    engine.on('step:start', startFn);
 
     const state = await engine.run();
     const calledPersona = vi.mocked(runAgent).mock.calls[0]?.[0];
+    const fixStart = startFn.mock.calls.find((call) => (call[0] as WorkflowStep).name === 'fix');
 
     expect(state.status).toBeDefined();
     expect(calledPersona).toContain('fixer');
+    expect(fixStart?.[2]).toContain('Step Iteration: 7');
+    expect(fixStart?.[6]).toBe(7);
   });
 
   it('resume_point の深い child step が消えていたら直近の workflow_call から再開する', async () => {

--- a/src/__tests__/finding-conflict-adjudication.test.ts
+++ b/src/__tests__/finding-conflict-adjudication.test.ts
@@ -74,7 +74,16 @@ function makeLedger(overrides: Partial<FindingLedger> = {}): FindingLedger {
     nextId: 2,
     updatedAt: '2026-06-13T00:00:00.000Z',
     findings: [makeFinding()],
-    rawFindings: [],
+    rawFindings: [{
+      rawFindingId: 'raw-1',
+      stepName: 'reviewers',
+      reviewer: 'coding-review',
+      familyTag: 'bug',
+      severity: 'high',
+      title: 'Disputed issue',
+      location: 'src/a.ts:10',
+      description: 'The bug is present.',
+    }],
     conflicts: [makeConflict()],
     ...overrides,
   };

--- a/src/__tests__/finding-convergence.test.ts
+++ b/src/__tests__/finding-convergence.test.ts
@@ -761,6 +761,60 @@ describe('B5: invalidated / superseded audit visibility', () => {
   });
 });
 
+describe('finding family visibility', () => {
+  it('Given one canonical finding backed by multiple raw families When fixer contexts are built Then all family tags are exposed once in stable order', async () => {
+    const ledger = makeLedger({
+      rawFindings: [
+        makeRawFinding({ rawFindingId: 'raw-b', familyTag: 'testing' }),
+        makeRawFinding({ rawFindingId: 'raw-a', familyTag: 'architecture' }),
+        makeRawFinding({ rawFindingId: 'raw-c', familyTag: 'testing' }),
+      ],
+      findings: [makeFinding({ rawFindingIds: ['raw-b', 'raw-a', 'raw-c'] })],
+    });
+
+    const ruleContext = buildFindingsRuleContext(ledger);
+    expect(ruleContext.open.items[0]?.familyTags).toEqual(['architecture', 'testing']);
+    expect(ruleContext.open.items[0]?.unknownRawFindingIds).toEqual([]);
+
+    const { renderFindingLedgerInstructionSummary } = await import('../core/workflow/findings/context.js');
+    const instructionSummary = JSON.parse(renderFindingLedgerInstructionSummary(ledger)) as {
+      open: Array<{ familyTags: string[]; unknownRawFindingIds: string[] }>;
+    };
+    expect(instructionSummary.open[0]?.familyTags).toEqual(['architecture', 'testing']);
+    expect(instructionSummary.open[0]?.unknownRawFindingIds).toEqual([]);
+  });
+
+  it('Given a canonical finding with an unknown raw reference When contexts are built Then the missing reference stays visible', async () => {
+    const ledger = makeLedger({
+      findings: [makeFinding({ rawFindingIds: ['raw-missing'] })],
+    });
+
+    const ruleContext = buildFindingsRuleContext(ledger);
+    expect(ruleContext.open.items[0]?.familyTags).toEqual([]);
+    expect(ruleContext.open.items[0]?.unknownRawFindingIds).toEqual(['raw-missing']);
+
+    const { renderFindingLedgerInstructionSummary } = await import('../core/workflow/findings/context.js');
+    const instructionSummary = JSON.parse(renderFindingLedgerInstructionSummary(ledger)) as {
+      open: Array<{ familyTags: string[]; unknownRawFindingIds: string[] }>;
+    };
+    expect(instructionSummary.open[0]?.unknownRawFindingIds).toEqual(['raw-missing']);
+  });
+
+  it('Given duplicate raw IDs with different families When context is built Then the ambiguous family is rejected', () => {
+    const ledger = makeLedger({
+      rawFindings: [
+        makeRawFinding({ rawFindingId: 'raw-1', familyTag: 'architecture' }),
+        makeRawFinding({ rawFindingId: 'raw-1', familyTag: 'testing' }),
+      ],
+      findings: [makeFinding({ rawFindingIds: ['raw-1'] })],
+    });
+
+    expect(() => buildFindingsRuleContext(ledger)).toThrow(
+      'Raw finding "raw-1" has conflicting family tags: "architecture" and "testing"',
+    );
+  });
+});
+
 // B4: v3-r2 実台帳の F-0016 raw 群（AI-PERSIST-F-0011-ROUTING /
 // AI-PERSIST-F-0006-ROUTING / AI-PERSIST-F-0017-ROUTING）の replay。旧エンジンの
 // familyTag + exact location 機械マージは、この3件（同じ familyTag=resource-leak、

--- a/src/__tests__/finding-rule-evaluator.test.ts
+++ b/src/__tests__/finding-rule-evaluator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { RuleEvaluator, type RuleEvaluatorContext } from '../core/workflow/evaluation/RuleEvaluator.js';
+import { evaluateWhenExpression } from '../core/workflow/evaluation/when-evaluator.js';
 import { isDeterministicCondition } from '../core/workflow/evaluation/rule-utils.js';
 import type { AgentResponse, WorkflowState } from '../core/models/types.js';
 import { makeRule, makeStep } from './test-helpers.js';
@@ -9,7 +10,7 @@ type FindingsRuleContext = {
     open: {
       count: number;
       bySeverity: Record<string, number>;
-        items: Array<{ id: string; severity: string; title: string }>;
+        items: Array<{ id: string; severity: string; title: string; familyTags?: string[] }>;
       };
     resolved: {
       count: number;
@@ -123,6 +124,103 @@ describe('RuleEvaluator findings conditions', () => {
     const result = await new RuleEvaluator(step, makeContext(state)).evaluate('', '');
 
     expect(result).toEqual({ index: 0, method: 'auto_select' });
+  });
+
+  it('should evaluate family membership without relying on array order', async () => {
+    const state = makeState({
+      open: {
+        count: 2,
+        bySeverity: { high: 1, medium: 1 },
+        items: [
+          {
+            id: 'F-0001',
+            severity: 'high',
+            title: 'Provider E2E is incomplete',
+            familyTags: ['architecture', 'provider-e2e'],
+          },
+          {
+            id: 'F-0002',
+            severity: 'medium',
+            title: 'Unit coverage is incomplete',
+            familyTags: ['testing'],
+          },
+        ],
+      },
+      resolved: { count: 0 },
+      conflicts: { count: 0, items: [] },
+    });
+    const step = makeStep({
+      name: 'peer-review',
+      rules: [
+        {
+          condition: 'when(exists(findings.open.items, contains(item.familyTags, "provider-e2e")))',
+          next: 'fix',
+        },
+        { condition: 'when(true)', next: 'COMPLETE' },
+      ],
+    });
+
+    const result = await new RuleEvaluator(step, makeContext(state)).evaluate('', '');
+
+    expect(result).toEqual({ index: 0, method: 'auto_select' });
+
+    const withoutProviderE2e = makeState({
+      ...state.findings!,
+      open: {
+        ...state.findings!.open,
+        items: state.findings!.open.items.map((item) => ({
+          ...item,
+          familyTags: item.familyTags?.filter((familyTag) => familyTag !== 'provider-e2e'),
+        })),
+      },
+    });
+    const fallbackResult = await new RuleEvaluator(step, makeContext(withoutProviderE2e)).evaluate('', '');
+
+    expect(fallbackResult).toEqual({ index: 1, method: 'auto_select' });
+  });
+
+  it('should reject malformed contains() arity instead of silently routing to fallback', () => {
+    const state = makeState({
+      open: {
+        count: 1,
+        bySeverity: { high: 1 },
+        items: [{
+          id: 'F-0001',
+          severity: 'high',
+          title: 'Provider E2E is incomplete',
+          familyTags: ['provider-e2e'],
+        }],
+      },
+      resolved: { count: 0 },
+      conflicts: { count: 0, items: [] },
+    });
+
+    expect(() => evaluateWhenExpression(
+      'exists(findings.open.items, contains(item.familyTags, "provider-e2e", "testing"))',
+      state,
+    )).toThrow('contains() requires exactly two arguments');
+  });
+
+  it('should decode escaped string literals in contains()', () => {
+    const state = makeState({
+      open: {
+        count: 1,
+        bySeverity: { high: 1 },
+        items: [{
+          id: 'F-0001',
+          severity: 'high',
+          title: 'Quoted family',
+          familyTags: ['tag"quote'],
+        }],
+      },
+      resolved: { count: 0 },
+      conflicts: { count: 0, items: [] },
+    });
+
+    expect(evaluateWhenExpression(
+      String.raw`exists(findings.open.items, contains(item.familyTags, "tag\"quote"))`,
+      state,
+    )).toBe(true);
   });
 
   it('should use AI adjudication when conflicts exist with open findings', async () => {

--- a/src/__tests__/state-manager.test.ts
+++ b/src/__tests__/state-manager.test.ts
@@ -89,6 +89,62 @@ describe('StateManager', () => {
 
       expect(manager.state.userInputs).toEqual(['input1', 'input2']);
     });
+
+    it('should continue step iterations from the matching resume workflow frame', () => {
+      const manager = new StateManager(
+        makeConfig(),
+        makeOptions({
+          startStep: 'review',
+          resumePoint: {
+            version: 1,
+            stack: [
+              {
+                workflow: 'parent',
+                step: 'delegate',
+                kind: 'workflow_call',
+                step_iterations: { delegate: 3 },
+              },
+              {
+                workflow: 'test-workflow',
+                step: 'review',
+                kind: 'agent',
+                step_iterations: { review: 6, fix: 2 },
+              },
+            ],
+            iteration: 12,
+            elapsed_ms: 100,
+          },
+          resumeStackPrefix: [
+            { workflow: 'parent', step: 'delegate', kind: 'workflow_call' },
+          ],
+        }),
+      );
+
+      expect(manager.incrementStepIteration('review')).toBe(7);
+      expect(manager.state.stepIterations.get('fix')).toBe(2);
+    });
+
+    it('should not restore step iterations from a different resume target', () => {
+      const manager = new StateManager(
+        makeConfig(),
+        makeOptions({
+          startStep: 'implement',
+          resumePoint: {
+            version: 1,
+            stack: [{
+              workflow: 'test-workflow',
+              step: 'review',
+              kind: 'agent',
+              step_iterations: { review: 6 },
+            }],
+            iteration: 12,
+            elapsed_ms: 100,
+          },
+        }),
+      );
+
+      expect(manager.state.stepIterations).toEqual(new Map());
+    });
   });
 
   describe('incrementStepIteration', () => {

--- a/src/__tests__/task-schema.test.ts
+++ b/src/__tests__/task-schema.test.ts
@@ -146,6 +146,53 @@ describe('TaskExecutionConfigSchema', () => {
     expect(config.start_step).toBe('plan');
   });
 
+  it('should accept resume point entries with omitted or positive integer step iterations', () => {
+    const baseResumePoint = {
+      version: 1,
+      iteration: 3,
+      elapsed_ms: 100,
+    };
+
+    expect(() => TaskExecutionConfigSchema.parse({
+      resume_point: {
+        ...baseResumePoint,
+        stack: [{ workflow: 'default', step: 'implement', kind: 'agent' }],
+      },
+    })).not.toThrow();
+    expect(() => TaskExecutionConfigSchema.parse({
+      resume_point: {
+        ...baseResumePoint,
+        stack: [{
+          workflow: 'default',
+          step: 'implement',
+          kind: 'agent',
+          step_iterations: { implement: 1, review: 4 },
+        }],
+      },
+    })).not.toThrow();
+  });
+
+  it.each([
+    ['an empty key', { '': 1 }],
+    ['zero', { implement: 0 }],
+    ['a negative value', { implement: -1 }],
+    ['a decimal value', { implement: 1.5 }],
+  ])('should reject step iterations containing %s', (_name, stepIterations) => {
+    expect(() => TaskExecutionConfigSchema.parse({
+      resume_point: {
+        version: 1,
+        stack: [{
+          workflow: 'default',
+          step: 'implement',
+          kind: 'agent',
+          step_iterations: stepIterations,
+        }],
+        iteration: 3,
+        elapsed_ms: 100,
+      },
+    })).toThrow();
+  });
+
 
   it('should reject conflicting start_step and start_movement values', () => {
     expect(() => TaskExecutionConfigSchema.parse({

--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -1247,8 +1247,18 @@ describe('TaskRunner (tasks.yaml)', () => {
     const resumePoint = {
       version: 1 as const,
       stack: [
-        { workflow: 'default', step: 'implement', kind: 'workflow_call' as const },
-        { workflow: 'takt/coding', step: 'review', kind: 'agent' as const },
+        {
+          workflow: 'default',
+          step: 'implement',
+          kind: 'workflow_call' as const,
+          step_iterations: { implement: 3 },
+        },
+        {
+          workflow: 'takt/coding',
+          step: 'review',
+          kind: 'agent' as const,
+          step_iterations: { review: 6, fix: 2 },
+        },
       ],
       iteration: 7,
       elapsed_ms: 183245,

--- a/src/__tests__/workflowCallExecutor.test.ts
+++ b/src/__tests__/workflowCallExecutor.test.ts
@@ -110,6 +110,7 @@ describe('WorkflowCallExecutor', () => {
       instruction: '',
     } as WorkflowCallStep;
     const state = makeState(parentConfig.name, 'running', 2);
+    state.stepIterations.set('delegate', 3);
     const childState = makeState(childConfig.name, 'completed', 4);
     childState.lastOutput = makeResponse({ content: 'child complete' });
     childState.personaSessions.set('coder', 'session-2');
@@ -180,6 +181,12 @@ describe('WorkflowCallExecutor', () => {
     );
     const childOptions = createEngine.mock.calls[0]?.[3];
     expect(childOptions?.traceTaskMetadata).toBe(traceTaskMetadata);
+    expect(childOptions?.resumeStackPrefix).toEqual([{
+      workflow: 'parent',
+      step: 'delegate',
+      kind: 'workflow_call',
+      step_iterations: { delegate: 3 },
+    }]);
     expect(childEngine.on).toHaveBeenCalledWith('step:start', expect.any(Function));
     const childStep = childConfig.steps[0];
     const childProviderInfo = { provider: 'mock', model: 'test-model' };
@@ -190,6 +197,7 @@ describe('WorkflowCallExecutor', () => {
       childProviderInfo,
       childConfig.name,
       childStep?.name,
+      5,
     );
     expect(emit).toHaveBeenCalledWith(
       'step:start',
@@ -199,6 +207,7 @@ describe('WorkflowCallExecutor', () => {
       childProviderInfo,
       childConfig.name,
       step.name,
+      5,
     );
     expect(childEngine.on).toHaveBeenCalledWith('step:complete', expect.any(Function));
     const childResponse = makeResponse({ content: 'relayed response' });

--- a/src/__tests__/workflowExecution-debug-prompts.test.ts
+++ b/src/__tests__/workflowExecution-debug-prompts.test.ts
@@ -61,7 +61,7 @@ const {
         phase: 3,
         sequence: 1,
       });
-      this.emit('step:start', step, 1, 'step instruction', providerInfo, this.config.name, step.name);
+      this.emit('step:start', step, 1, 'step instruction', providerInfo, this.config.name, step.name, 1);
       if (shouldReversePhaseCompletion) {
         this.emit('phase:start', step, 1, 'execute', 'phase prompt first', {
           systemPrompt: '../agents/coder.md',
@@ -132,6 +132,7 @@ const {
           providerInfo,
           this.config.name,
           step.name,
+          2,
         );
         this.emit(
           'step:complete',

--- a/src/__tests__/workflowExecutionEvents.test.ts
+++ b/src/__tests__/workflowExecutionEvents.test.ts
@@ -135,6 +135,7 @@ function createBridgeHarness(options?: {
     engine,
     out,
     runMetaManager,
+    prefixWriter,
     resumePoint,
     analyticsEmitter,
     usageEventLogger,
@@ -143,7 +144,7 @@ function createBridgeHarness(options?: {
 
 describe('bindWorkflowExecutionEvents', () => {
   it('event bridge が run meta と実行結果を同期する', () => {
-    const { bridge, engine, runMetaManager, resumePoint } = createBridgeHarness();
+    const { bridge, engine, runMetaManager, prefixWriter, resumePoint } = createBridgeHarness();
 
     const step = {
       name: 'review',
@@ -159,13 +160,28 @@ describe('bindWorkflowExecutionEvents', () => {
       matchedRuleIndex: 0,
     };
 
-    engine.emit('step:start', step, 2, 'instruction', { provider: 'mock', model: 'gpt-test' }, 'parent', step.name);
+    engine.emit(
+      'step:start',
+      step,
+      2,
+      'instruction',
+      { provider: 'mock', model: 'gpt-test' },
+      'parent',
+      step.name,
+      7,
+    );
     engine.emit('phase:start', step, 1, 'main', 'instruction', [], 'phase-1', 2);
     engine.emit('phase:complete', step, 1, 'main', 'approved', 'done', undefined, 'phase-1', 2);
     engine.emit('step:complete', step, response, 'instruction', step.name);
     engine.emit('workflow:complete', { iteration: 2 });
 
     expect(runMetaManager.updateStep).toHaveBeenCalledWith('review', 2, resumePoint);
+    expect(prefixWriter.setStepContext).toHaveBeenCalledWith({
+      stepName: 'review',
+      iteration: 2,
+      maxSteps: 5,
+      stepIteration: 7,
+    });
     expect(runMetaManager.updatePhase).toHaveBeenCalledTimes(2);
     expect(runMetaManager.updatePhase.mock.calls[0]?.slice(0, 3)).toEqual(['review', 2, 1]);
     expect(runMetaManager.updatePhase.mock.calls[1]?.slice(0, 3)).toEqual(['review', 2, 1]);

--- a/src/core/models/finding-types.ts
+++ b/src/core/models/finding-types.ts
@@ -320,8 +320,8 @@ export interface FindingLedgerStopBudgetState {
    * stepIteration) から作る run 内一意の値であり、進捗（resolved の増加等）では
    * 変化しないため、予算は単調累積のみとなる。
    *
-   * 注意: 実 `takt resume` は run slug（= runId）を採り直し stepIterations を
-   * リセットするため、resume 後の reviewers 再走はマーカーが変わり「新しい
+   * 注意: 実 `takt resume` は stepIterations を継続する一方、run slug（= runId）を
+   * 採り直す。したがって resume 後の reviewers 再走はマーカーが変わり「新しい
    * ラウンド」として1回だけ計上される。これは意図した挙動で、resume ごとに
    * 実際にレビューが再実行される（＝実作業が発生する）以上、liveness 予算は
    * それを1ラウンドとして数えるのが安全側（無料の再レビュー枠を作らない）。
@@ -1055,6 +1055,8 @@ export interface FindingsRuleContext {
       description?: string;
       suggestion?: string;
       reviewers: string[];
+      familyTags: string[];
+      unknownRawFindingIds: string[];
     }>;
   };
   resolved: {

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -152,6 +152,7 @@ export interface WorkflowResumePointEntry {
   workflow_ref?: string;
   step: string;
   kind: WorkflowStepKind;
+  step_iterations?: Record<string, number>;
 }
 
 export interface WorkflowResumePoint {

--- a/src/core/workflow/engine/ArpeggioRunner.ts
+++ b/src/core/workflow/engine/ArpeggioRunner.ts
@@ -251,13 +251,14 @@ export class ArpeggioRunner {
     step: WorkflowStep,
     state: WorkflowState,
     runtime?: RuntimeStepResolution,
+    activeStepIteration?: number,
   ): Promise<StepRunResult> {
     const arpeggioConfig = step.arpeggio;
     if (!arpeggioConfig) {
       throw new Error(`Step "${step.name}" has no arpeggio configuration`);
     }
 
-    const stepIteration = incrementStepIteration(state, step.name);
+    const stepIteration = activeStepIteration ?? incrementStepIteration(state, step.name);
     log.debug('Running arpeggio step', {
       step: step.name,
       source: arpeggioConfig.source,

--- a/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
+++ b/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
@@ -19,7 +19,14 @@ interface LoopMonitorJudgeRunnerDeps {
   language?: string;
   updatePersonaSession: (persona: string, sessionId: string | undefined) => void;
   resolveNextStepFromDone: (step: WorkflowStep, response: AgentResponse) => string;
-  onStepStart: (step: WorkflowStep, iteration: number, instruction: string, providerInfo: StepProviderInfo | undefined, resumeStepName: string) => void;
+  onStepStart: (
+    step: WorkflowStep,
+    iteration: number,
+    instruction: string,
+    providerInfo: StepProviderInfo | undefined,
+    resumeStepName: string,
+    stepIteration: number,
+  ) => void;
   onStepComplete: (step: WorkflowStep, response: AgentResponse, instruction: string, resumeStepName: string) => void;
   emitCollectedReports: () => void;
   resetCycleDetector: () => void;
@@ -72,6 +79,7 @@ export class LoopMonitorJudgeRunner {
       prebuiltInstruction,
       providerInfo,
       triggeringStep.name,
+      stepIteration,
     );
 
     const { response, instruction } = await this.deps.stepExecutor.runNormalStep(

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -204,6 +204,7 @@ export class ParallelRunner {
     maxSteps: WorkflowMaxSteps,
     updatePersonaSession: (persona: string, sessionId: string | undefined) => void,
     runtime?: RuntimeStepResolution,
+    activeStepIteration?: number,
   ): Promise<StepRunResult> {
     if (!step.parallel) {
       throw new Error(`Step "${step.name}" has no parallel sub-steps`);
@@ -212,7 +213,7 @@ export class ParallelRunner {
     // 直前ステップ（通常は coder の fix）の応答。異議申告の裁定材料として
     // manager に渡すため、サブステップ実行で lastOutput が変わる前に捕捉する。
     const priorStepResponseText = state.lastOutput?.content;
-    const stepIteration = incrementStepIteration(state, step.name);
+    const stepIteration = activeStepIteration ?? incrementStepIteration(state, step.name);
     log.debug('Running parallel step', {
       step: step.name,
       subSteps: subSteps.map(s => s.name),

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -90,16 +90,17 @@ export class TeamLeaderRunner {
     maxSteps: WorkflowMaxSteps,
     updatePersonaSession: (persona: string, sessionId: string | undefined) => void,
     runtime?: RuntimeStepResolution,
+    activeStepIteration?: number,
   ): Promise<StepRunResult> {
     if (!step.teamLeader) {
       throw new Error(`Step "${step.name}" has no teamLeader configuration`);
     }
     const teamLeaderConfig = step.teamLeader;
     const parentIteration = state.iteration;
-    const attemptState = captureTeamLeaderAttemptState(state);
+    const attemptState = captureTeamLeaderAttemptState(state, step.name, activeStepIteration);
     const instructionTransaction = new InstructionBuildTransaction();
 
-    const stepIteration = incrementStepIteration(state, step.name);
+    const stepIteration = activeStepIteration ?? incrementStepIteration(state, step.name);
     const leaderStep = createTeamLeaderPlanningStep(step);
     const instruction = this.deps.stepExecutor.buildInstruction(
       leaderStep,
@@ -696,14 +697,32 @@ interface TeamLeaderAttemptState {
   readonly stepIterations: Map<string, number>;
 }
 
-function captureTeamLeaderAttemptState(state: WorkflowState): TeamLeaderAttemptState {
+function captureTeamLeaderAttemptState(
+  state: WorkflowState,
+  stepName: string,
+  activeStepIteration?: number,
+): TeamLeaderAttemptState {
+  const stepIterations = new Map(state.stepIterations);
+  if (activeStepIteration !== undefined) {
+    if (stepIterations.get(stepName) !== activeStepIteration) {
+      throw new Error(
+        `Active step iteration mismatch for "${stepName}": expected ${activeStepIteration}`,
+      );
+    }
+    const previousStepIteration = activeStepIteration - 1;
+    if (previousStepIteration > 0) {
+      stepIterations.set(stepName, previousStepIteration);
+    } else {
+      stepIterations.delete(stepName);
+    }
+  }
   return {
     lastOutput: state.lastOutput,
     previousResponseSourcePath: state.previousResponseSourcePath,
     pendingFallback: state.pendingFallback,
     stepOutputs: new Map(state.stepOutputs),
     personaSessions: new Map(state.personaSessions),
-    stepIterations: new Map(state.stepIterations),
+    stepIterations,
   };
 }
 

--- a/src/core/workflow/engine/WorkflowCallExecutor.ts
+++ b/src/core/workflow/engine/WorkflowCallExecutor.ts
@@ -122,6 +122,7 @@ interface WorkflowCallExecutorDeps {
   state: {
     iteration: number;
     personaSessions: Map<string, string>;
+    stepIterations: Map<string, number>;
   };
   setActiveResumePoint: (step: WorkflowCallStep, iteration: number) => void;
   /** 自前 or 継承済みの、この engine で有効な Finding Contract。子へ引き継ぐ。 */
@@ -169,9 +170,9 @@ export class WorkflowCallExecutor {
    * 親自身が undefined のままなら raw finding id の形は変わらない。
    *
    * ステップ名だけでは、同じ workflow_call ステップがループで再実行された
-   * ケースを区別できない。子エンジンはループのたびに新規生成され
-   * stepIterations が空から始まるため、子の最初のレビューは常に
-   * stepIteration=1 になる。ステップ名・parentStepName・stepIteration・
+   * ケースを区別できない。resume continuation では stepIterations を復元するが、
+   * 同一 run 内の新規 workflow_call は子エンジンを新規生成するため、子の最初の
+   * レビューは stepIteration=1 になる。ステップ名・parentStepName・stepIteration・
    * subStepName が全て一致すれば、ローカルの raw finding id が同じ場合に
    * 正規化後の id も完全に一致し、後勝ちで前回の raw finding が台帳から
    * 消える。buildWorkflowCallNamespace() と同じ「親のこの呼び出し時点の
@@ -226,7 +227,12 @@ export class WorkflowCallExecutor {
       resumePoint: options.resumePoint,
       resumeStackPrefix: [
         ...this.deps.resumeStackPrefix,
-        buildWorkflowResumePointEntry(parentConfig, step.name, 'workflow_call'),
+        buildWorkflowResumePointEntry(
+          parentConfig,
+          step.name,
+          'workflow_call',
+          this.deps.state.stepIterations,
+        ),
       ],
       resolveWorkflowCall: (parentWorkflow, nestedStep) => this.deps.resolveWorkflowCall({
         parentWorkflow,
@@ -239,7 +245,7 @@ export class WorkflowCallExecutor {
 
   private relayChildEvents(childEngine: WorkflowCallChildEngine, resumeStepName: string): void {
     childEngine.on('step:start', (...args) => {
-      const [step, iteration, instruction, providerInfo, workflowName] = args;
+      const [step, iteration, instruction, providerInfo, workflowName, , stepIteration] = args;
       this.deps.emit(
         'step:start',
         step,
@@ -248,6 +254,7 @@ export class WorkflowCallExecutor {
         providerInfo,
         workflowName,
         resumeStepName,
+        stepIteration,
       );
     });
     childEngine.on('step:complete', (...args) => {
@@ -343,7 +350,12 @@ export class WorkflowCallExecutor {
       sharedRuntime: this.deps.sharedRuntime,
       resumeStackPrefix: [
         ...this.deps.resumeStackPrefix,
-        buildWorkflowResumePointEntry(parentConfig, request.step.name, 'workflow_call'),
+        buildWorkflowResumePointEntry(
+          parentConfig,
+          request.step.name,
+          'workflow_call',
+          this.deps.state.stepIterations,
+        ),
       ],
       // 親の Finding Contract を子エンジンへ継承する。継承しないと子の
       // parallel レビューが出す raw findings が台帳に入らず、fix に届かないまま

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -583,7 +583,15 @@ export class WorkflowEngine extends EventEmitter {
   private buildResumePoint(step: WorkflowStep, iteration: number): WorkflowResumePoint {
     return {
       version: 1,
-      stack: [...this.resumeStackPrefix, buildWorkflowResumePointEntry(this.config, step.name, getWorkflowStepKind(step))],
+      stack: [
+        ...this.resumeStackPrefix,
+        buildWorkflowResumePointEntry(
+          this.config,
+          step.name,
+          getWorkflowStepKind(step),
+          this.state.stepIterations,
+        ),
+      ],
       iteration,
       elapsed_ms: Date.now() - this.sharedRuntime.startedAtMs,
     };
@@ -594,7 +602,22 @@ export class WorkflowEngine extends EventEmitter {
   }
 
   getResumePoint(): WorkflowResumePoint | undefined {
-    return this.sharedRuntime.activeResumePoint;
+    const activeResumePoint = this.sharedRuntime.activeResumePoint;
+    const activeEntry = activeResumePoint?.stack[this.resumeStackPrefix.length];
+    if (activeResumePoint === undefined || activeEntry === undefined) {
+      return activeResumePoint;
+    }
+
+    const stack = [...activeResumePoint.stack];
+    stack[this.resumeStackPrefix.length] = buildWorkflowResumePointEntry(
+      this.config,
+      activeEntry.step,
+      activeEntry.kind,
+      this.state.stepIterations,
+    );
+    const refreshedResumePoint = { ...activeResumePoint, stack };
+    this.sharedRuntime.activeResumePoint = refreshedResumePoint;
+    return refreshedResumePoint;
   }
 
   buildResumePointForStepName(stepName: string): WorkflowResumePoint | undefined {

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -340,7 +340,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     language: params.options.language,
     updatePersonaSession: params.updatePersonaSession,
     resolveNextStepFromDone: params.resolveNextStepFromDone as never,
-    onStepStart: (step, iteration, instruction, providerInfo, resumeStepName) => {
+    onStepStart: (step, iteration, instruction, providerInfo, resumeStepName, stepIteration) => {
       params.emitEvent(
         'step:start',
         step,
@@ -349,6 +349,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
         providerInfo,
         params.config.name,
         resumeStepName,
+        stepIteration,
       );
     },
     onStepComplete: (step, response, instruction, resumeStepName) => {

--- a/src/core/workflow/engine/WorkflowEngineStepCoordinator.ts
+++ b/src/core/workflow/engine/WorkflowEngineStepCoordinator.ts
@@ -41,6 +41,7 @@ interface WorkflowEngineStepCoordinatorDeps {
       maxSteps: WorkflowMaxSteps,
       updateSession: (persona: string, sessionId: string | undefined) => void,
       runtime?: RuntimeStepResolution,
+      activeStepIteration?: number,
     ) => Promise<StepRunResult>;
   };
   arpeggioRunner: {
@@ -48,6 +49,7 @@ interface WorkflowEngineStepCoordinatorDeps {
       step: WorkflowStep,
       state: WorkflowState,
       runtime?: RuntimeStepResolution,
+      activeStepIteration?: number,
     ) => Promise<StepRunResult>;
   };
   teamLeaderRunner: {
@@ -58,6 +60,7 @@ interface WorkflowEngineStepCoordinatorDeps {
       maxSteps: WorkflowMaxSteps,
       updateSession: (persona: string, sessionId: string | undefined) => void,
       runtime?: RuntimeStepResolution,
+      activeStepIteration?: number,
     ) => Promise<StepRunResult>;
   };
   systemStepExecutor: {
@@ -111,6 +114,7 @@ export class WorkflowEngineStepCoordinator {
     step: WorkflowStep,
     prebuiltInstruction?: string,
     runtime?: RuntimeStepResolution,
+    stepIteration?: number,
   ): Promise<StepRunResult> {
     const updateSession = this.deps.updatePersonaSession;
     let result: StepRunResult;
@@ -131,9 +135,15 @@ export class WorkflowEngineStepCoordinator {
         this.deps.getMaxSteps(),
         updateSession,
         runtime,
+        stepIteration,
       );
     } else if (step.arpeggio) {
-      result = await this.deps.arpeggioRunner.runArpeggioStep(step, this.deps.state, runtime);
+      result = await this.deps.arpeggioRunner.runArpeggioStep(
+        step,
+        this.deps.state,
+        runtime,
+        stepIteration,
+      );
     } else if (step.teamLeader) {
       result = await this.deps.teamLeaderRunner.runTeamLeaderStep(
         step,
@@ -142,6 +152,7 @@ export class WorkflowEngineStepCoordinator {
         this.deps.getMaxSteps(),
         updateSession,
         runtime,
+        stepIteration,
       );
     } else if (isSystemWorkflowStep(step)) {
       result = {

--- a/src/core/workflow/engine/WorkflowRunLoop.ts
+++ b/src/core/workflow/engine/WorkflowRunLoop.ts
@@ -55,6 +55,7 @@ interface WorkflowRunLoopDeps {
     step: WorkflowStep,
     prebuiltInstruction?: string,
     runtime?: RuntimeStepResolution,
+    stepIteration?: number,
   ) => Promise<StepRunResult>;
   runQualityGates: (options: {
     qualityGates: WorkflowStep['qualityGates'];
@@ -541,12 +542,15 @@ export async function runWorkflowToCompletion(deps: WorkflowRunLoopDeps): Promis
     const isDelegated = isDelegatedWorkflowStep(step);
     const activeIteration = deps.state.iteration;
     const baseStepRuntime = deps.resolveRuntimeForStep(step);
-    const stepIteration = isDelegated
-      ? undefined
-      : incrementStepIteration(deps.state, step.name);
-    const promotedRuntime = await resolveStepPromotionRuntime(deps, step, stepIteration, baseStepRuntime);
+    const stepIteration = incrementStepIteration(deps.state, step.name);
+    const promotedRuntime = await resolveStepPromotionRuntime(
+      deps,
+      step,
+      isDelegated ? undefined : stepIteration,
+      baseStepRuntime,
+    );
     const fallbackRuntime = withFallbackRuntime(deps.state, promotedRuntime);
-    const prebuiltInstruction = stepIteration !== undefined
+    const prebuiltInstruction = !isDelegated
       ? deps.buildInstruction(step, stepIteration)
       : undefined;
     let stepRuntime: RuntimeStepResolution | undefined;
@@ -576,6 +580,7 @@ export async function runWorkflowToCompletion(deps: WorkflowRunLoopDeps): Promis
       providerInfo,
       deps.getWorkflowName(),
       step.name,
+      stepIteration,
     );
 
     try {
@@ -593,7 +598,7 @@ export async function runWorkflowToCompletion(deps: WorkflowRunLoopDeps): Promis
         providerInfo,
         getFinalStepIteration: () => deps.state.stepIterations.get(step.name),
         traceTaskMetadata: deps.options.traceTaskMetadata,
-      }, () => deps.runStep(step, prebuiltInstruction, stepRuntime));
+      }, () => deps.runStep(step, prebuiltInstruction, stepRuntime, stepIteration));
       const { response, instruction, providerInfo: resultProviderInfo } = result;
       const completedProviderInfo = resultProviderInfo ?? providerInfo;
       emitNormalRoutingDecision(
@@ -793,17 +798,19 @@ async function runSingleWorkflowIterationCore(deps: WorkflowRunLoopDeps): Promis
 
   deps.state.iteration++;
   const activeIteration = deps.state.iteration;
-  deps.setActiveStep(step, activeIteration);
   const isDelegated = isDelegatedWorkflowStep(step);
   const baseStepRuntime = deps.resolveRuntimeForStep(step);
-  let stepIteration: number | undefined;
-  if (!isDelegated) {
-    stepIteration = incrementStepIteration(deps.state, step.name);
-  }
-  const promotedRuntime = await resolveStepPromotionRuntime(deps, step, stepIteration, baseStepRuntime);
+  const stepIteration = incrementStepIteration(deps.state, step.name);
+  deps.setActiveStep(step, activeIteration);
+  const promotedRuntime = await resolveStepPromotionRuntime(
+    deps,
+    step,
+    isDelegated ? undefined : stepIteration,
+    baseStepRuntime,
+  );
   const fallbackRuntime = withFallbackRuntime(deps.state, promotedRuntime);
   let prebuiltInstruction: string | undefined;
-  if (!isDelegated && stepIteration !== undefined) {
+  if (!isDelegated) {
     prebuiltInstruction = deps.buildInstruction(step, stepIteration);
   }
   let stepRuntime: RuntimeStepResolution | undefined;
@@ -835,7 +842,7 @@ async function runSingleWorkflowIterationCore(deps: WorkflowRunLoopDeps): Promis
     providerInfo,
     getFinalStepIteration: () => deps.state.stepIterations.get(step.name),
     traceTaskMetadata: deps.options.traceTaskMetadata,
-  }, () => deps.runStep(step, prebuiltInstruction, stepRuntime));
+  }, () => deps.runStep(step, prebuiltInstruction, stepRuntime, stepIteration));
   const { response, providerInfo: resultProviderInfo } = result;
   const completedProviderInfo = resultProviderInfo ?? providerInfo;
   emitNormalRoutingDecision(

--- a/src/core/workflow/engine/state-manager.ts
+++ b/src/core/workflow/engine/state-manager.ts
@@ -11,6 +11,7 @@ import {
   MAX_INPUT_LENGTH,
 } from '../constants.js';
 import type { WorkflowEngineOptions } from '../types.js';
+import { workflowEntryMatchesWorkflow } from '../workflow-reference.js';
 
 /**
  * Manages workflow execution state.
@@ -34,9 +35,17 @@ export class StateManager {
       ? [...options.initialUserInputs]
       : [];
 
+    const currentStep = options.startStep ?? config.initialStep;
+    const resumeEntry = options.resumePoint?.stack[options.resumeStackPrefix?.length ?? 0];
+    const stepIterations = resumeEntry !== undefined
+      && resumeEntry.step === currentStep
+      && workflowEntryMatchesWorkflow(resumeEntry, config)
+      ? new Map(Object.entries(resumeEntry.step_iterations ?? {}))
+      : new Map<string, number>();
+
     this.state = {
       workflowName: config.name,
-      currentStep: options.startStep ?? config.initialStep,
+      currentStep,
       iteration: options.initialIteration ?? 0,
       stepOutputs: new Map(),
       structuredOutputs: new Map(),
@@ -46,7 +55,7 @@ export class StateManager {
       previousResponseSourcePath: undefined,
       userInputs,
       personaSessions,
-      stepIterations: new Map(),
+      stepIterations,
       status: 'running',
     };
   }

--- a/src/core/workflow/evaluation/when-evaluator.ts
+++ b/src/core/workflow/evaluation/when-evaluator.ts
@@ -31,9 +31,10 @@ function findOperator(expression: string): { operator: string; index: number } |
   return undefined;
 }
 
-function splitFunctionArgs(argsText: string): [string, string] {
+function splitFunctionArgs(argsText: string, functionName: string): [string, string] {
   let inString = false;
   let depth = 0;
+  let separatorIndex: number | undefined;
 
   for (let index = 0; index < argsText.length; index++) {
     const current = argsText[index];
@@ -50,17 +51,28 @@ function splitFunctionArgs(argsText: string): [string, string] {
     }
     if (current === ')') {
       depth--;
+      if (depth < 0) {
+        throw new Error(`Invalid ${functionName}() expression "${argsText}"`);
+      }
       continue;
     }
     if (current === ',' && depth === 0) {
-      return [
-        argsText.slice(0, index).trim(),
-        argsText.slice(index + 1).trim(),
-      ];
+      if (separatorIndex !== undefined) {
+        throw new Error(`${functionName}() requires exactly two arguments`);
+      }
+      separatorIndex = index;
     }
   }
 
-  throw new Error(`Invalid exists() expression "${argsText}"`);
+  if (inString || depth !== 0 || separatorIndex === undefined) {
+    throw new Error(`Invalid ${functionName}() expression "${argsText}"`);
+  }
+  const first = argsText.slice(0, separatorIndex).trim();
+  const second = argsText.slice(separatorIndex + 1).trim();
+  if (first.length === 0 || second.length === 0) {
+    throw new Error(`${functionName}() requires exactly two arguments`);
+  }
+  return [first, second];
 }
 
 function resolveReference(reference: string, state: WorkflowState): unknown {
@@ -92,7 +104,11 @@ function parseLiteral(raw: string, state: WorkflowState, item?: unknown): unknow
   if (value === 'null') return null;
   if (/^-?\d+(\.\d+)?$/.test(value)) return Number(value);
   if (value.startsWith('"') && value.endsWith('"')) {
-    return value.slice(1, -1);
+    try {
+      return JSON.parse(value) as unknown;
+    } catch {
+      throw new Error(`Invalid string literal "${value}"`);
+    }
   }
   if (
     value.startsWith('context.')
@@ -110,9 +126,13 @@ function parseLiteral(raw: string, state: WorkflowState, item?: unknown): unknow
 
 function evaluateExistsPredicate(predicate: string, item: unknown, state: WorkflowState): boolean {
   return splitTopLevel(predicate, '&&').every((clause) => {
+    const normalized = clause.trim();
+    if (normalized.startsWith('contains(') && normalized.endsWith(')')) {
+      return evaluateContainsClause(normalized, state, item);
+    }
     const operatorMatch = findOperator(clause);
     if (operatorMatch?.operator !== '==') {
-      throw new Error(`exists() only supports "==" and "&&": "${predicate}"`);
+      throw new Error(`exists() only supports "==", "contains()", and "&&": "${predicate}"`);
     }
 
     const leftRaw = clause.slice(0, operatorMatch.index);
@@ -131,7 +151,7 @@ function evaluateExistsClause(clause: string, state: WorkflowState): boolean {
     throw new Error(`Invalid exists() clause "${clause}"`);
   }
 
-  const [listExpression, predicate] = splitFunctionArgs(match[1]);
+  const [listExpression, predicate] = splitFunctionArgs(match[1], 'exists');
   const list = parseLiteral(listExpression, state);
   if (!Array.isArray(list)) {
     throw new Error(`exists() requires an array expression: "${listExpression}"`);
@@ -140,12 +160,30 @@ function evaluateExistsClause(clause: string, state: WorkflowState): boolean {
   return list.some((item) => evaluateExistsPredicate(predicate, item, state));
 }
 
+function evaluateContainsClause(clause: string, state: WorkflowState, item?: unknown): boolean {
+  const match = clause.match(/^contains\((.*)\)$/);
+  if (!match?.[1]) {
+    throw new Error(`Invalid contains() clause "${clause}"`);
+  }
+
+  const [listExpression, valueExpression] = splitFunctionArgs(match[1], 'contains');
+  const list = parseLiteral(listExpression, state, item);
+  if (!Array.isArray(list)) {
+    throw new Error(`contains() requires an array expression: "${listExpression}"`);
+  }
+  const value = parseLiteral(valueExpression, state, item);
+  return list.some((candidate) => candidate === value);
+}
+
 function evaluateClause(clause: string, state: WorkflowState): boolean {
   const normalized = clause.trim();
   if (normalized === 'true') return true;
   if (normalized === 'false') return false;
   if (normalized.startsWith('exists(') && normalized.endsWith(')')) {
     return evaluateExistsClause(normalized, state);
+  }
+  if (normalized.startsWith('contains(') && normalized.endsWith(')')) {
+    return evaluateContainsClause(normalized, state);
   }
 
   const operatorMatch = findOperator(normalized);

--- a/src/core/workflow/findings/context.ts
+++ b/src/core/workflow/findings/context.ts
@@ -1,28 +1,74 @@
-import { FINDING_SEVERITIES, type FindingLedger, type FindingSeverity, type FindingsRuleContext } from './types.js';
+import {
+  FINDING_SEVERITIES,
+  type FindingLedger,
+  type FindingLedgerEntry,
+  type FindingSeverity,
+  type FindingsRuleContext,
+} from './types.js';
 import { isLedgerConflictUnadjudicated } from './adjudication-evidence.js';
 import { computeReviewScopeSnapshotId } from './snapshot.js';
 
+function indexRawFindingFamilyTags(ledger: FindingLedger): ReadonlyMap<string, string> {
+  const familyTagsByRawFindingId = new Map<string, string>();
+  for (const finding of ledger.rawFindings) {
+    const existingFamilyTag = familyTagsByRawFindingId.get(finding.rawFindingId);
+    if (existingFamilyTag !== undefined && existingFamilyTag !== finding.familyTag) {
+      throw new Error(
+        `Raw finding "${finding.rawFindingId}" has conflicting family tags: `
+        + `"${existingFamilyTag}" and "${finding.familyTag}"`,
+      );
+    }
+    familyTagsByRawFindingId.set(finding.rawFindingId, finding.familyTag);
+  }
+  return familyTagsByRawFindingId;
+}
+
+function deriveFindingFamilyTags(
+  finding: FindingLedgerEntry,
+  familyTagsByRawFindingId: ReadonlyMap<string, string>,
+): { familyTags: string[]; unknownRawFindingIds: string[] } {
+  const familyTags = new Set<string>();
+  const unknownRawFindingIds: string[] = [];
+  for (const rawFindingId of finding.rawFindingIds) {
+    const familyTag = familyTagsByRawFindingId.get(rawFindingId);
+    if (familyTag === undefined) {
+      unknownRawFindingIds.push(rawFindingId);
+    } else {
+      familyTags.add(familyTag);
+    }
+  }
+  return {
+    familyTags: [...familyTags].sort(),
+    unknownRawFindingIds: [...new Set(unknownRawFindingIds)].sort(),
+  };
+}
+
 export function renderFindingLedgerInstructionSummary(ledger: FindingLedger): string {
+  const familyTagsByRawFindingId = indexRawFindingFamilyTags(ledger);
   return JSON.stringify({
     version: ledger.version,
     workflowName: ledger.workflowName,
     open: ledger.findings
       .filter((finding) => finding.status === 'open')
-      .map((finding) => ({
-        id: finding.id,
-        lifecycle: finding.lifecycle,
-        severity: finding.severity,
-        title: finding.title,
-        location: finding.location,
-        description: finding.description,
-        suggestion: finding.suggestion,
-        reviewers: finding.reviewers,
-        // provisional は fixer が直接直せない system finding なので、agent が
-        // 識別できるようサマリへ kind/reason を出す。
-        ...(finding.provisional !== undefined
-          ? { provisional: { kind: finding.provisional.kind, reason: finding.provisional.reason } }
-          : {}),
-      })),
+      .map((finding) => {
+        const familyContext = deriveFindingFamilyTags(finding, familyTagsByRawFindingId);
+        return {
+          id: finding.id,
+          lifecycle: finding.lifecycle,
+          severity: finding.severity,
+          title: finding.title,
+          location: finding.location,
+          description: finding.description,
+          suggestion: finding.suggestion,
+          reviewers: finding.reviewers,
+          ...familyContext,
+          // provisional は fixer が直接直せない system finding なので、agent が
+          // 識別できるようサマリへ kind/reason を出す。
+          ...(finding.provisional !== undefined
+            ? { provisional: { kind: finding.provisional.kind, reason: finding.provisional.reason } }
+            : {}),
+        };
+      }),
     resolved: ledger.findings
       .filter((finding) => finding.status === 'resolved')
       .map((finding) => ({
@@ -121,6 +167,7 @@ export function ledgerHasDismissedFindings(ledger: FindingLedger): boolean {
 
 export function buildFindingsRuleContext(ledger: FindingLedger, cwd: string): FindingsRuleContext {
   const openItems = ledger.findings.filter((finding) => finding.status === 'open');
+  const familyTagsByRawFindingId = indexRawFindingFamilyTags(ledger);
   const activeConflicts = ledger.conflicts.filter((conflict) => conflict.status === 'active');
   let unadjudicatedConflictCount = 0;
   if (activeConflicts.length > 0) {
@@ -148,6 +195,7 @@ export function buildFindingsRuleContext(ledger: FindingLedger, cwd: string): Fi
         ...(finding.description !== undefined ? { description: finding.description } : {}),
         ...(finding.suggestion !== undefined ? { suggestion: finding.suggestion } : {}),
         reviewers: finding.reviewers,
+        ...deriveFindingFamilyTags(finding, familyTagsByRawFindingId),
       })),
     },
     // provisional は status=open の finding に付く optional メタデータなので

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -205,7 +205,15 @@ export type WorkflowCallResolver = (request: WorkflowCallResolutionRequest) => W
 
 /** Events emitted by workflow engine */
 export interface WorkflowEvents {
-  'step:start': (step: WorkflowStep, iteration: number, instruction: string, providerInfo: StepProviderInfo, workflowName: string, resumeStepName: string) => void;
+  'step:start': (
+    step: WorkflowStep,
+    iteration: number,
+    instruction: string,
+    providerInfo: StepProviderInfo,
+    workflowName: string,
+    resumeStepName: string,
+    stepIteration: number,
+  ) => void;
   'step:complete': (step: WorkflowStep, response: AgentResponse, instruction: string, resumeStepName: string) => void;
   'routing:decision': (
     step: WorkflowStep,

--- a/src/core/workflow/workflow-reference.ts
+++ b/src/core/workflow/workflow-reference.ts
@@ -14,6 +14,7 @@ export function buildWorkflowResumePointEntry(
   workflow: WorkflowConfig,
   step: string,
   kind: WorkflowStepKind,
+  stepIterations?: ReadonlyMap<string, number>,
 ): WorkflowResumePointEntry {
   const workflowRef = getWorkflowReference(workflow);
   return {
@@ -21,6 +22,9 @@ export function buildWorkflowResumePointEntry(
     ...(workflowRef !== workflow.name ? { workflow_ref: workflowRef } : {}),
     step,
     kind,
+    ...(stepIterations !== undefined
+      ? { step_iterations: Object.fromEntries(stepIterations) }
+      : {}),
   };
 }
 

--- a/src/features/tasks/execute/workflowExecutionEvents.ts
+++ b/src/features/tasks/execute/workflowExecutionEvents.ts
@@ -327,7 +327,6 @@ export function bindWorkflowExecutionEvents(
     }
     deps.engine.abort();
   };
-  const stepIterations = new Map<string, number>();
   const syncLatestResumePoint = (): void => {
     if (!canReadResumePoint()) {
       return;
@@ -390,7 +389,15 @@ export function bindWorkflowExecutionEvents(
     );
   });
 
-  deps.engine.on('step:start', (step, iteration, instruction, providerInfo, workflowName, resumeStepName) => {
+  deps.engine.on('step:start', (
+    step,
+    iteration,
+    instruction,
+    providerInfo,
+    workflowName,
+    resumeStepName,
+    stepIteration,
+  ) => {
     state.currentIteration = iteration;
     state.currentStepName = resumeStepName;
     state.lastResumePoint = getResumePoint();
@@ -416,9 +423,6 @@ export function bindWorkflowExecutionEvents(
       onEventSinkFailure,
       eventSinkDispatchState,
     );
-
-    const stepIteration = (stepIterations.get(step.name) ?? 0) + 1;
-    stepIterations.set(step.name, stepIteration);
 
     const safeStepName = sanitizeTerminalText(step.name);
     const safePersonaDisplayName = sanitizeTerminalText(step.personaDisplayName);

--- a/src/infra/task/taskExecutionSchemas.ts
+++ b/src/infra/task/taskExecutionSchemas.ts
@@ -6,6 +6,10 @@ const ResumePointEntrySchema = z.object({
   workflow_ref: z.string().min(1).optional(),
   step: z.string().min(1),
   kind: z.enum(['agent', 'system', 'workflow_call']),
+  step_iterations: z.record(
+    z.string().min(1),
+    z.number().int().positive(),
+  ).optional(),
 }).strict();
 
 const ResumePointSchema = z.object({


### PR DESCRIPTION
## 概要

- canonical finding の raw finding から family tag を決定的に導出し、fixer instruction と `findings.open.items` の両方へ公開
- raw 本体が欠けた既存 ledger は `unknownRawFindingIds` として可視化し、family tag の矛盾だけを fail-fast
- `when(exists(...))` で配列包含を判定する `contains(array, value)` を追加し、不正な引数数や文字列 escape を厳格に処理
- resume point の各 workflow frame に `step_iterations` を保存・復元し、requeue/resume と nested workflow call で継続
- step iteration の採番を run loop に統一し、`step:start` 時点の checkpoint と表示を同じ値に統一
- Team Leader の rate-limit retry は親・member counter を同じ論理試行へ rollback

## テスト

- `npm run build`
- `npm run lint`
- `npm test`（4 shard、8,455 tests）
- `npm run test:prompt-evals`
- `npm run test:e2e:mock`
- `npm run test:it:serial:git`（127 tests）
- `npm run test:it:serial:workflow`（454 tests）
- parallel integration 40 files のうち38 files / 286 tests が一括成功。実 OpenCode 起動と MCP stdio の2件は一括実行時に timeout したため単独再実行し、それぞれ成功

実 provider E2E は実行していません。

## レビュー

3つの独立した Codex レビューで、delegated checkpoint、Team Leader rollback、family 欠損、`contains()` の構文反例を相互確認し、修正後は全レビューが APPROVE です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Finding Contract の open finding で `familyTags` と未解決の raw finding ID（未知ID）を確認できるようになりました。
  * `exists()` / `contains()` を使った finding 条件の判定に対応しました。
  * ワークフロー再開時のステップ反復回数（stepIterations）を保持・復元し、`step:start` でも取得できるようになりました。
* **ドキュメント**
  * family タグ／未解決 raw finding／条件式の利用例を追加・更新しました。
* **テスト**
  * 再開・反復・finding 条件の評価に関するケースを拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->