### PR TITLE
fix(team-leader): stop feedback fallback on abort

### DIFF
--- a/src/__tests__/engine-team-leader.test.ts
+++ b/src/__tests__/engine-team-leader.test.ts
@@ -211,13 +211,25 @@ describe('WorkflowEngine Integration: TeamLeaderRunner', () => {
     expect(vi.mocked(runAgent).mock.calls[0]?.[2]?.abortSignal).toBe(abortController.signal);
   });
 
-  it('feedback call 中の親中断を workflow aborted として伝播し後続callを停止する', async () => {
+  it('timeout part 後の feedback call 中に親中断された場合は継続 part を routing しない', async () => {
     const config = buildTeamLeaderConfig();
     const abortController = new AbortController();
+    const autoRouting: AutoRoutingConfig = {
+      ...createAutoRoutingConfig(),
+      rules: undefined,
+    };
+    const routeStep = vi.fn().mockResolvedValue(autoRouting.candidates[0]);
+    const routeBatch = vi.fn(async (_autoRouting: AutoRoutingConfig, steps: Array<{ id: string }>) =>
+      new Map(steps.map((step) => [step.id, autoRouting.candidates[0]])));
     const engine = new WorkflowEngine(config, tmpDir, 'implement feature', {
       projectCwd: tmpDir,
-      provider: 'claude',
+      provider: 'mock',
       abortSignal: abortController.signal,
+      autoRouting,
+      autoRoutingAiRouter: {
+        routeStep,
+        routeBatch,
+      },
     });
     mockRunAgentWithPrompt(
       makeResponse({
@@ -226,7 +238,13 @@ describe('WorkflowEngine Integration: TeamLeaderRunner', () => {
           parts: [{ id: 'part-1', title: 'API', instruction: 'Implement API' }],
         },
       }),
-      makeResponse({ persona: 'coder', content: 'API done' }),
+      makeResponse({
+        persona: 'coder',
+        status: 'error',
+        content: '',
+        error: 'Part timeout after 1000ms',
+        failureCategory: 'part_timeout',
+      }),
     );
     vi.mocked(runAgent).mockImplementationOnce(async () => {
       abortController.abort(new Error('feedback aborted'));
@@ -238,6 +256,10 @@ describe('WorkflowEngine Integration: TeamLeaderRunner', () => {
     expect(state.status).toBe('aborted');
     expect(vi.mocked(runAgent)).toHaveBeenCalledTimes(3);
     expect(vi.mocked(runAgent).mock.calls[2]?.[2]?.abortSignal).toBe(abortController.signal);
+    expect(routeBatch).toHaveBeenCalledOnce();
+    expect(routeBatch.mock.calls[0]?.[1]).toEqual([
+      expect.objectContaining({ id: 'part-1' }),
+    ]);
   });
 
   // buildGitRules は team-leader-part-runner の buildTeamLeaderPartInstruction 経由でも

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -323,6 +323,9 @@ export class TeamLeaderRunner {
           await this.addPartAutoRouting(routedProviderInfoByPart, step, moreParts.parts, runtime);
           return moreParts;
         } catch (error) {
+          if (leaderBaseOptions.abortSignal?.aborted) {
+            throw error;
+          }
           const timeoutFallback = createTimeoutContinuationFeedback({
             partResults: currentResults,
             scheduledIds,


### PR DESCRIPTION
## 概要

#1084 のマージ後に CodeRabbit が検出した中断処理を修正します。

- Team Leader の feedback 呼び出し中に親 AbortSignal が中断された場合、timeout continuation fallback より先にエラーを伝播
- 中断後の continuation part 生成と追加 auto routing を防止
- 通常の feedback failure に対する timeout continuation fallback は維持

## テスト

- npm test -- src/__tests__/engine-team-leader.test.ts: 28 passed
- npm run build
- npm run lint

回帰テストでは timeout part 後の feedback 中断を再現し、workflow が aborted になること、runAgent が後続 part を開始しないこと、auto routing の batch 呼び出しが初回 part の1回だけであることを確認しています。

## レビュー

- 別 Codex によるフォローアップレビュー: APPROVE
- git diff --check: 問題なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 中断が発生した場合、タイムアウト後の継続処理や追加のルーティングを実行しないよう改善しました。
  * 中断時のエラーを誤ってタイムアウト継続処理として扱わないよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->