### PR TITLE
fix: レビュアー異常を再照合後も保持する

### DIFF
--- a/src/__tests__/finding-reconciler.test.ts
+++ b/src/__tests__/finding-reconciler.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { parseFindingManagerOutput } from '../core/workflow/findings/schemas.js';
-import { reconcileFindingLedger } from '../core/workflow/findings/reconciler.js';
+import {
+  reconcileFindingLedger,
+  reconcileManagerActionRecovery,
+} from '../core/workflow/findings/reconciler.js';
 import { formatConflictId } from '../core/workflow/findings/conflict-identity.js';
 import { computeLineageKey, computeRawEvidenceHash } from '../core/workflow/findings/raw-canonicalization.js';
 import type {
   FindingLedger,
   FindingManagerOutput,
   RawFinding,
+  ReviewerAnomalyEntry,
 } from '../core/workflow/findings/types.js';
 
 function makeLedger(overrides: Partial<FindingLedger> = {}): FindingLedger {
@@ -34,6 +38,23 @@ function makeRawFinding(overrides: Partial<RawFinding> = {}): RawFinding {
     description: 'The workflow cannot route on open findings.',
     suggestion: 'Read the consolidated finding ledger in deterministic rules.',
     relation: 'new',
+    ...overrides,
+  };
+}
+
+function makeReviewerAnomaly(overrides: Partial<ReviewerAnomalyEntry> = {}): ReviewerAnomalyEntry {
+  return {
+    id: 'RA-UNPROMOTED',
+    kind: 'quote-mismatch',
+    stableKey: 'reviewer-anomaly-unpromoted',
+    lineageKey: 'lineage-unpromoted',
+    sourceRawFindingIds: ['raw-anomaly-unpromoted'],
+    reviewers: ['coding-reviewer'],
+    title: 'Unverified finding',
+    mismatchReason: 'The quoted source does not match the reviewed snapshot.',
+    firstObserved: { runId: 'run-1', stepName: 'peer-review', timestamp: '2026-06-13T00:00:00.000Z' },
+    lastObserved: { runId: 'run-1', stepName: 'peer-review', timestamp: '2026-06-13T00:00:00.000Z' },
+    occurrences: 1,
     ...overrides,
   };
 }
@@ -157,6 +178,53 @@ describe('dispute/waiver transitions', () => {
 });
 
 describe('reconcileFindingLedger', () => {
+  it('should preserve unpromoted and promoted reviewer anomalies', () => {
+    const reviewerAnomalies: ReviewerAnomalyEntry[] = [
+      makeReviewerAnomaly(),
+      makeReviewerAnomaly({
+        id: 'RA-PROMOTED',
+        kind: 'stale-snapshot',
+        stableKey: 'reviewer-anomaly-promoted',
+        lineageKey: 'lineage-promoted',
+        sourceRawFindingIds: ['raw-anomaly-promoted'],
+        reviewers: ['architecture-reviewer'],
+        title: 'Previously stale finding',
+        mismatchReason: 'The reviewed snapshot changed before validation.',
+        promotedFindingId: 'F-0001',
+      }),
+    ];
+    const previousLedger = makeLedger({ reviewerAnomalies });
+
+    const ledger = reconcileFindingLedger({
+      previousLedger,
+      rawFindings: [],
+      managerOutput: makeManagerOutput(),
+      context: makeContext(),
+    });
+
+    expect(ledger.reviewerAnomalies).toBe(reviewerAnomalies);
+  });
+
+  it('should preserve reviewer anomalies through manager action recovery reconciliation', () => {
+    const reviewerAnomalies = [makeReviewerAnomaly({
+      id: 'RA-ACTION-RECOVERY',
+      stableKey: 'reviewer-anomaly-action-recovery',
+      lineageKey: 'lineage-action-recovery',
+      sourceRawFindingIds: ['raw-anomaly-action-recovery'],
+      reviewers: ['ai-antipattern-reviewer'],
+      title: 'Unverified recovery finding',
+    })];
+    const previousLedger = makeLedger({ reviewerAnomalies });
+
+    const ledger = reconcileManagerActionRecovery({
+      previousLedger,
+      managerOutput: makeManagerOutput(),
+      context: makeContext(),
+    });
+
+    expect(ledger.reviewerAnomalies).toBe(reviewerAnomalies);
+  });
+
   it('should assign engine-owned ids to new findings and ignore raw finding ids', () => {
     const rawFinding = makeRawFinding({ rawFindingId: 'reviewer-supplied-id' });
     const previousLedger = makeLedger({ nextId: 7 });

--- a/src/core/workflow/findings/reconciler.ts
+++ b/src/core/workflow/findings/reconciler.ts
@@ -772,6 +772,9 @@ function reconcileFindingLedgerWithValidator(
     ...(input.previousLedger.interpretations !== undefined
       ? { interpretations: input.previousLedger.interpretations }
       : {}),
+    ...(input.previousLedger.reviewerAnomalies !== undefined
+      ? { reviewerAnomalies: input.previousLedger.reviewerAnomalies }
+      : {}),
   });
 }
 


### PR DESCRIPTION
## Summary

- Finding Manager の再照合で、過去ラウンドの `reviewerAnomalies` が台帳から脱落する不具合を修正
- 通常 reconcile と manager action recovery が共有する台帳再構築点で、append-only の異常履歴を保持
- 未昇格・昇格済みの異常、および action recovery 経路の回帰テストを追加

## Execution Report

- `npm run build`
- `npm run lint`
- `npm test`（8,659 passed / 1 skipped）
- `npm run test:e2e:mock`
- gpt-5.6-sol による敵対レビュー: APPROVE（指摘なし）

## Scope

- workflow、provider/model、Finding Contract の型・永続化スキーマ、promotion・重複排除・fixpoint・reviewIntegrity の規則は変更していません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 所見台帳の再統合時に、既存のレビューアノマリー情報が保持されるようになりました。
  * マネージャーアクションからの回復処理でも、レビューアノマリー情報が失われなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->