### PR TITLE
fix: implement判定に完了報告を引き継ぐ

### DIFF
--- a/builtins/en/workflows/backend-cqrs-mini.yaml
+++ b/builtins/en/workflows/backend-cqrs-mini.yaml
@@ -92,8 +92,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/en/workflows/backend-cqrs.yaml
+++ b/builtins/en/workflows/backend-cqrs.yaml
@@ -148,8 +148,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/en/workflows/backend-maintenance.yaml
+++ b/builtins/en/workflows/backend-maintenance.yaml
@@ -150,8 +150,10 @@ steps:
       report:
         - name: maintenance-scope.md
           format: maintenance-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/en/workflows/backend-mini.yaml
+++ b/builtins/en/workflows/backend-mini.yaml
@@ -90,8 +90,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/en/workflows/backend.yaml
+++ b/builtins/en/workflows/backend.yaml
@@ -144,8 +144,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/en/workflows/default-draft.yaml
+++ b/builtins/en/workflows/default-draft.yaml
@@ -72,8 +72,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/en/workflows/draft.yaml
+++ b/builtins/en/workflows/draft.yaml
@@ -86,8 +86,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/en/workflows/dual-cqrs-mini.yaml
+++ b/builtins/en/workflows/dual-cqrs-mini.yaml
@@ -98,8 +98,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/en/workflows/dual-cqrs.yaml
+++ b/builtins/en/workflows/dual-cqrs.yaml
@@ -110,8 +110,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/en/workflows/dual-mini.yaml
+++ b/builtins/en/workflows/dual-mini.yaml
@@ -96,8 +96,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/en/workflows/dual.yaml
+++ b/builtins/en/workflows/dual.yaml
@@ -173,8 +173,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
     quality_gates:
       - When design references exist, verify major screens element by element for layout, copy, color, and spacing
       - When design references exist, record any platform-driven deviations in the decision log

--- a/builtins/en/workflows/frontend-maintenance.yaml
+++ b/builtins/en/workflows/frontend-maintenance.yaml
@@ -155,8 +155,10 @@ steps:
       report:
         - name: maintenance-scope.md
           format: maintenance-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/en/workflows/frontend-mini.yaml
+++ b/builtins/en/workflows/frontend-mini.yaml
@@ -93,8 +93,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/en/workflows/frontend.yaml
+++ b/builtins/en/workflows/frontend.yaml
@@ -150,8 +150,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/en/workflows/terraform.yaml
+++ b/builtins/en/workflows/terraform.yaml
@@ -73,8 +73,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/ja/workflows/backend-cqrs-mini.yaml
+++ b/builtins/ja/workflows/backend-cqrs-mini.yaml
@@ -92,8 +92,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/ja/workflows/backend-cqrs.yaml
+++ b/builtins/ja/workflows/backend-cqrs.yaml
@@ -148,8 +148,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/ja/workflows/backend-maintenance.yaml
+++ b/builtins/ja/workflows/backend-maintenance.yaml
@@ -150,8 +150,10 @@ steps:
       report:
         - name: maintenance-scope.md
           format: maintenance-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/ja/workflows/backend-mini.yaml
+++ b/builtins/ja/workflows/backend-mini.yaml
@@ -90,8 +90,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/ja/workflows/backend.yaml
+++ b/builtins/ja/workflows/backend.yaml
@@ -144,8 +144,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/ja/workflows/default-draft.yaml
+++ b/builtins/ja/workflows/default-draft.yaml
@@ -72,8 +72,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/ja/workflows/draft.yaml
+++ b/builtins/ja/workflows/draft.yaml
@@ -86,8 +86,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/ja/workflows/dual-cqrs-mini.yaml
+++ b/builtins/ja/workflows/dual-cqrs-mini.yaml
@@ -98,8 +98,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/ja/workflows/dual-cqrs.yaml
+++ b/builtins/ja/workflows/dual-cqrs.yaml
@@ -110,8 +110,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/ja/workflows/dual-mini.yaml
+++ b/builtins/ja/workflows/dual-mini.yaml
@@ -96,8 +96,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/ja/workflows/dual.yaml
+++ b/builtins/ja/workflows/dual.yaml
@@ -173,8 +173,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
     quality_gates:
       - デザイン参照がある場合、主要画面のレイアウト・文言・色・間隔を要素単位で照合したこと
       - デザイン参照がある場合、プラットフォーム制約による差分は決定ログに明記したこと

--- a/builtins/ja/workflows/frontend-maintenance.yaml
+++ b/builtins/ja/workflows/frontend-maintenance.yaml
@@ -155,8 +155,10 @@ steps:
       report:
         - name: maintenance-scope.md
           format: maintenance-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/ja/workflows/frontend-mini.yaml
+++ b/builtins/ja/workflows/frontend-mini.yaml
@@ -93,8 +93,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/builtins/ja/workflows/frontend.yaml
+++ b/builtins/ja/workflows/frontend.yaml
@@ -150,8 +150,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: ai-antipattern-review-1st
     tags:
       - review

--- a/builtins/ja/workflows/terraform.yaml
+++ b/builtins/ja/workflows/terraform.yaml
@@ -73,8 +73,10 @@ steps:
       report:
         - name: coder-scope.md
           format: coder-scope
+          use_judge: false
         - name: coder-decisions.md
           format: coder-decisions
+          use_judge: false
   - name: reviewers
     tags:
       - review

--- a/src/__tests__/builtin-implementation-judgment-input.test.ts
+++ b/src/__tests__/builtin-implementation-judgment-input.test.ts
@@ -3,7 +3,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { WorkflowConfig } from '../core/models/types.js';
-import { getJudgmentReportFiles } from '../core/workflow/output-contract-files.js';
 import { runStatusJudgmentPhase } from '../core/workflow/status-judgment-phase.js';
 import { loadAllWorkflowsWithSourcesFromDirs } from '../infra/config/loaders/workflowDiscovery.js';
 
@@ -31,17 +30,18 @@ describe('builtin implementation status judgment input', () => {
     'should exclude implementation metadata reports from status judgment in every shipped %s workflow',
     (language) => {
       const workflows = loadBuiltinWorkflows(language);
-      const implementationSteps = Array.from(workflows.values())
+      const implementationMetadataContracts = Array.from(workflows.values())
         .filter(({ source }) => source === 'builtin')
         .flatMap(({ config }) => config.steps)
-        .filter((step) => step.outputContracts?.some(
+        .flatMap((step) => step.outputContracts ?? [])
+        .filter(
           (contract) => contract.formatRef !== undefined
             && IMPLEMENTATION_METADATA_FORMATS.has(contract.formatRef),
-        ));
+        );
 
-      expect(implementationSteps.length).toBeGreaterThan(0);
-      for (const step of implementationSteps) {
-        expect(getJudgmentReportFiles(step.outputContracts)).toEqual([]);
+      expect(implementationMetadataContracts.length).toBeGreaterThan(0);
+      for (const contract of implementationMetadataContracts) {
+        expect(contract.useJudge).toBe(false);
       }
     },
   );

--- a/src/__tests__/builtin-implementation-judgment-input.test.ts
+++ b/src/__tests__/builtin-implementation-judgment-input.test.ts
@@ -6,12 +6,6 @@ import type { WorkflowConfig } from '../core/models/types.js';
 import { runStatusJudgmentPhase } from '../core/workflow/status-judgment-phase.js';
 import { loadAllWorkflowsWithSourcesFromDirs } from '../infra/config/loaders/workflowDiscovery.js';
 
-const IMPLEMENTATION_METADATA_FORMATS = new Set([
-  'coder-scope',
-  'coder-decisions',
-  'maintenance-scope',
-]);
-
 function loadBuiltinWorkflows(language: 'en' | 'ja') {
   return loadAllWorkflowsWithSourcesFromDirs<WorkflowConfig>(
     process.cwd(),
@@ -26,82 +20,67 @@ function loadBuiltinWorkflows(language: 'en' | 'ja') {
 }
 
 describe('builtin implementation status judgment input', () => {
-  it.each(['en', 'ja'] as const)(
-    'should exclude implementation metadata reports from status judgment in every shipped %s workflow',
-    (language) => {
-      const workflows = loadBuiltinWorkflows(language);
-      const implementationMetadataContracts = Array.from(workflows.values())
-        .filter(({ source }) => source === 'builtin')
-        .flatMap(({ config }) => config.steps)
-        .flatMap((step) => step.outputContracts ?? [])
-        .filter(
-          (contract) => contract.formatRef !== undefined
-            && IMPLEMENTATION_METADATA_FORMATS.has(contract.formatRef),
-        );
+  describe.each(['en', 'ja'] as const)('shipped %s workflows', (language) => {
+    it.each(['frontend-mini', 'backend-mini', 'backend-maintenance'] as const)(
+      'should judge the %s implementation from its Phase 1 response',
+      async (workflowName) => {
+        const reportDir = mkdtempSync(join(tmpdir(), 'takt-implementation-judgment-'));
+        const scopeMetadata = 'SCOPE_METADATA_MUST_NOT_REPLACE_IMPLEMENTATION_RESULT';
+        const decisionMetadata = 'DECISION_METADATA_MUST_NOT_REPLACE_IMPLEMENTATION_RESULT';
+        const maintenanceMetadata = 'MAINTENANCE_METADATA_MUST_NOT_REPLACE_IMPLEMENTATION_RESULT';
+        const implementationResult = 'IMPLEMENTATION_COMPLETE_AND_TESTS_PASSED';
 
-      expect(implementationMetadataContracts.length).toBeGreaterThan(0);
-      for (const contract of implementationMetadataContracts) {
-        expect(contract.useJudge).toBe(false);
-      }
-    },
-  );
+        try {
+          writeFileSync(join(reportDir, 'coder-scope.md'), scopeMetadata);
+          writeFileSync(join(reportDir, 'coder-decisions.md'), decisionMetadata);
+          writeFileSync(join(reportDir, 'maintenance-scope.md'), maintenanceMetadata);
 
-  it.each(['en', 'ja'] as const)(
-    'should judge the shipped %s frontend-mini implementation from its Phase 1 response',
-    async (language) => {
-      const reportDir = mkdtempSync(join(tmpdir(), 'takt-implementation-judgment-'));
-      const scopeMetadata = 'SCOPE_METADATA_MUST_NOT_REPLACE_IMPLEMENTATION_RESULT';
-      const decisionMetadata = 'DECISION_METADATA_MUST_NOT_REPLACE_IMPLEMENTATION_RESULT';
-      const implementationResult = 'IMPLEMENTATION_COMPLETE_AND_TESTS_PASSED';
+          const workflow = loadBuiltinWorkflows(language).get(workflowName)?.config;
+          const implementStep = workflow?.steps.find((step) => step.name === 'implement');
+          if (!implementStep) {
+            throw new Error(`Missing ${workflowName} implement step for ${language}`);
+          }
 
-      try {
-        writeFileSync(join(reportDir, 'coder-scope.md'), scopeMetadata);
-        writeFileSync(join(reportDir, 'coder-decisions.md'), decisionMetadata);
+          const structuredCaller = {
+            judgeStatus: vi.fn().mockImplementation(async (
+              _structuredInstruction,
+              _tagInstruction,
+              _candidates,
+              options,
+            ) => {
+              options.onStructuredPromptResolved?.({
+                systemPrompt: 'judge-system',
+                userInstruction: 'judge-instruction',
+              });
+              return { candidateIndex: 0, method: 'structured_output' as const };
+            }),
+          };
 
-        const workflow = loadBuiltinWorkflows(language).get('frontend-mini')?.config;
-        const implementStep = workflow?.steps.find((step) => step.name === 'implement');
-        if (!implementStep) {
-          throw new Error(`Missing frontend-mini implement step for ${language}`);
+          await runStatusJudgmentPhase(implementStep, {
+            cwd: process.cwd(),
+            reportDir,
+            language,
+            lastResponse: implementationResult,
+            workflowName: workflow.name,
+            iteration: 1,
+            resolveStepProviderModel: vi.fn().mockReturnValue({
+              provider: 'cursor',
+              model: undefined,
+            }),
+            structuredCaller,
+          });
+
+          const [structuredInstruction, tagInstruction] = structuredCaller.judgeStatus.mock.calls[0] ?? [];
+          for (const instruction of [structuredInstruction, tagInstruction]) {
+            expect(instruction).toContain(implementationResult);
+            expect(instruction).not.toContain(scopeMetadata);
+            expect(instruction).not.toContain(decisionMetadata);
+            expect(instruction).not.toContain(maintenanceMetadata);
+          }
+        } finally {
+          rmSync(reportDir, { recursive: true, force: true });
         }
-
-        const structuredCaller = {
-          judgeStatus: vi.fn().mockImplementation(async (
-            _structuredInstruction,
-            _tagInstruction,
-            _candidates,
-            options,
-          ) => {
-            options.onStructuredPromptResolved?.({
-              systemPrompt: 'judge-system',
-              userInstruction: 'judge-instruction',
-            });
-            return { candidateIndex: 0, method: 'structured_output' as const };
-          }),
-        };
-
-        await runStatusJudgmentPhase(implementStep, {
-          cwd: process.cwd(),
-          reportDir,
-          language,
-          lastResponse: implementationResult,
-          workflowName: workflow.name,
-          iteration: 1,
-          resolveStepProviderModel: vi.fn().mockReturnValue({
-            provider: 'cursor',
-            model: undefined,
-          }),
-          structuredCaller,
-        });
-
-        const [structuredInstruction, tagInstruction] = structuredCaller.judgeStatus.mock.calls[0] ?? [];
-        for (const instruction of [structuredInstruction, tagInstruction]) {
-          expect(instruction).toContain(implementationResult);
-          expect(instruction).not.toContain(scopeMetadata);
-          expect(instruction).not.toContain(decisionMetadata);
-        }
-      } finally {
-        rmSync(reportDir, { recursive: true, force: true });
-      }
-    },
-  );
+      },
+    );
+  });
 });

--- a/src/__tests__/builtin-implementation-judgment-input.test.ts
+++ b/src/__tests__/builtin-implementation-judgment-input.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkflowConfig } from '../core/models/types.js';
+import { getJudgmentReportFiles } from '../core/workflow/output-contract-files.js';
+import { runStatusJudgmentPhase } from '../core/workflow/status-judgment-phase.js';
+import { loadAllWorkflowsWithSourcesFromDirs } from '../infra/config/loaders/workflowDiscovery.js';
+
+const IMPLEMENTATION_METADATA_FORMATS = new Set([
+  'coder-scope',
+  'coder-decisions',
+  'maintenance-scope',
+]);
+
+function loadBuiltinWorkflows(language: 'en' | 'ja') {
+  return loadAllWorkflowsWithSourcesFromDirs<WorkflowConfig>(
+    process.cwd(),
+    [{
+      dir: join(process.cwd(), 'builtins', language, 'workflows'),
+      source: 'builtin',
+    }],
+    undefined,
+    undefined,
+    true,
+  );
+}
+
+describe('builtin implementation status judgment input', () => {
+  it.each(['en', 'ja'] as const)(
+    'should exclude implementation metadata reports from status judgment in every shipped %s workflow',
+    (language) => {
+      const workflows = loadBuiltinWorkflows(language);
+      const implementationSteps = Array.from(workflows.values())
+        .filter(({ source }) => source === 'builtin')
+        .flatMap(({ config }) => config.steps)
+        .filter((step) => step.outputContracts?.some(
+          (contract) => contract.formatRef !== undefined
+            && IMPLEMENTATION_METADATA_FORMATS.has(contract.formatRef),
+        ));
+
+      expect(implementationSteps.length).toBeGreaterThan(0);
+      for (const step of implementationSteps) {
+        expect(getJudgmentReportFiles(step.outputContracts)).toEqual([]);
+      }
+    },
+  );
+
+  it.each(['en', 'ja'] as const)(
+    'should judge the shipped %s frontend-mini implementation from its Phase 1 response',
+    async (language) => {
+      const reportDir = mkdtempSync(join(tmpdir(), 'takt-implementation-judgment-'));
+      const scopeMetadata = 'SCOPE_METADATA_MUST_NOT_REPLACE_IMPLEMENTATION_RESULT';
+      const decisionMetadata = 'DECISION_METADATA_MUST_NOT_REPLACE_IMPLEMENTATION_RESULT';
+      const implementationResult = 'IMPLEMENTATION_COMPLETE_AND_TESTS_PASSED';
+
+      try {
+        writeFileSync(join(reportDir, 'coder-scope.md'), scopeMetadata);
+        writeFileSync(join(reportDir, 'coder-decisions.md'), decisionMetadata);
+
+        const workflow = loadBuiltinWorkflows(language).get('frontend-mini')?.config;
+        const implementStep = workflow?.steps.find((step) => step.name === 'implement');
+        if (!implementStep) {
+          throw new Error(`Missing frontend-mini implement step for ${language}`);
+        }
+
+        const structuredCaller = {
+          judgeStatus: vi.fn().mockImplementation(async (
+            _structuredInstruction,
+            _tagInstruction,
+            _candidates,
+            options,
+          ) => {
+            options.onStructuredPromptResolved?.({
+              systemPrompt: 'judge-system',
+              userInstruction: 'judge-instruction',
+            });
+            return { candidateIndex: 0, method: 'structured_output' as const };
+          }),
+        };
+
+        await runStatusJudgmentPhase(implementStep, {
+          cwd: process.cwd(),
+          reportDir,
+          language,
+          lastResponse: implementationResult,
+          workflowName: workflow.name,
+          iteration: 1,
+          resolveStepProviderModel: vi.fn().mockReturnValue({
+            provider: 'cursor',
+            model: undefined,
+          }),
+          structuredCaller,
+        });
+
+        const [structuredInstruction, tagInstruction] = structuredCaller.judgeStatus.mock.calls[0] ?? [];
+        for (const instruction of [structuredInstruction, tagInstruction]) {
+          expect(instruction).toContain(implementationResult);
+          expect(instruction).not.toContain(scopeMetadata);
+          expect(instruction).not.toContain(decisionMetadata);
+        }
+      } finally {
+        rmSync(reportDir, { recursive: true, force: true });
+      }
+    },
+  );
+});


### PR DESCRIPTION
## 概要

`frontend-mini` などのimplement Phase 3が、Phase 1の完了報告ではなく、完了証拠を持たないscope/decision reportだけを参照して誤って `ABORT` する問題を修正します。

## 原因

`use_judge` reportが1件でもある場合、status judgmentはreportだけを入力に使い、Phase 1の `lastResponse` を含めません。scope/decision reportは既定の `use_judge: true` でしたが、実装完了状態や検証結果を記録する契約ではありません。

## 変更

- 日英各15 workflow、計30 workflowのimplement metadata reportへ `use_judge: false` を明示
- `coder-scope`、`coder-decisions`、`maintenance-scope` をstatus judgment対象から除外
- Phase 3がPhase 1の完了報告を参照する実行経路テストを追加
- 将来 `implementation-result` などの専用judge reportを追加できる余地は維持

## 検証

- 新規回帰テスト: 4/4 passed
- 関連unit: 12/12 passed
- 関連IT: 6/6 passed
- `npm run build`: passed
- `npm run lint`: passed
- `git diff --check`: passed
- `npm test`: shard 2〜4 passed、shard 1は1,966 passed / 既存ACP stdio test 1件のみfailed
  - 単独再実行でもcold起動時の10秒timeoutとして再現
  - 今回の差分はbuiltins YAMLと回帰テストのみでACP実装は変更していない

## レビュー

実装担当とは別のCodexが `$coding` と TAKT facet設計基準でレビューしました。過剰な将来制約となるテスト指摘1件を修正し、再レビューで `APPROVE`（blocking finding 0件）を確認しました。

Closes #1099


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ビルトインワークフロー全体で、実装範囲・判断・保守範囲に関するメタデータレポートを自動判定の対象外として明示しました。
  * 日本語・英語の各ワークフローでレポート出力設定を統一しました。
  * 実装完了判定に不要なメタデータが含まれないことを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->