### PR TITLE
feat: MCP toolをtakt_enqueue_taskのみに整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ See the [Builtin Catalog](./docs/builtin-catalog.md) for all workflows and perso
 
 See the [CLI Reference](./docs/cli-reference.md) for all commands and options.
 
-TAKT also ships two client-integration entrypoints: `takt-acp` runs TAKT as an [Agent Client Protocol](./docs/cli-reference.md#acp-agent) agent over stdio JSON-RPC, and `takt-mcp` runs it as a stdio [MCP server](./docs/cli-reference.md#mcp-server) so an MCP client (Codex, Claude Code, …) can enqueue tasks, create an issue and enqueue, or run the next pending task.
+TAKT also ships two client-integration entrypoints: `takt-acp` runs TAKT as an [Agent Client Protocol](./docs/cli-reference.md#acp-agent) agent over stdio JSON-RPC, and `takt-mcp` runs it as a stdio [MCP server](./docs/cli-reference.md#mcp-server) so an MCP client (Codex, Claude Code, …) can enqueue tasks with an optional existing or newly created issue. Use `takt run` or `takt watch` to execute pending tasks.
 
 ### Instant exec mode
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -248,7 +248,7 @@ workflow ファイルの正式ディレクトリ名は `workflows/` です。
 
 全コマンド・オプションは [CLI Reference](./cli-reference.ja.md) を参照してください。
 
-クライアント連携用のエントリポイントも 2 つ同梱しています。`takt-acp` は TAKT を stdio JSON-RPC 上の [Agent Client Protocol](./cli-reference.ja.md#acp-agent) エージェントとして起動し、`takt-mcp` は stdio の [MCP サーバー](./cli-reference.ja.md#mcp-server) として起動して、MCP クライアント（Codex、Claude Code など）からタスクを積んだり、issue を作成して積んだり、次の pending タスクを実行したりできます。
+クライアント連携用のエントリポイントも 2 つ同梱しています。`takt-acp` は TAKT を stdio JSON-RPC 上の [Agent Client Protocol](./cli-reference.ja.md#acp-agent) エージェントとして起動し、`takt-mcp` は stdio の [MCP サーバー](./cli-reference.ja.md#mcp-server) として起動して、MCP クライアント（Codex、Claude Code など）から既存または新規 Issue を任意で紐付けたタスクを積めます。pending タスクの実行には `takt run` または `takt watch` を使用します。
 
 ### インスタント exec モード
 

--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -171,15 +171,15 @@ codex mcp add takt -- takt-mcp
 | `worktree` | boolean | `true` は自動の隔離 worktree を作成する。省略時は `true`。MCP 入力では任意の worktree パスを受け取りません。 |
 | `issue.number` | 正の safe integer | issue provider を呼ばずに既存 Issue を紐付ける。 |
 | `issue.create` | `true` | enqueue 前に設定済み issue provider で Issue を作成する。 |
-| `issue.title` | string | 新規 Issue 用の任意の非空 title。 |
+| `issue.title` | string | 新規 Issue 用の任意の非空 title。上限は 255 文字。 |
 | `issue.labels` | string array | 新規 Issue 用の任意の非空 label。 |
 | `taskContext.branch` | string | タスクに保存するローカルブランチ名。 |
 | `taskContext.baseBranch` | string | タスクに保存するベースブランチ名。 |
 | `taskContext.prNumber` | 正の safe integer | タスクに保存する Pull Request 番号。`Number.MAX_SAFE_INTEGER` を超える値は拒否されます。 |
 
-入力上限: `task` は 128 KiB、`workflow` は 128 文字、Issue label は 1 件 100 文字、最大 20 件までです。
+入力上限: `task` は 128 KiB、`workflow` は 128 文字、Issue title は 255 文字、Issue label は 1 件 100 文字、最大 20 件までです。
 
-`issue` object は `{ "number": 123 }` または `{ "create": true, "title"?: "...", "labels"?: ["..."] }` のいずれかだけを指定します。混在 key、空の title・label、unknown key は拒否されます。Issue 付き enqueue の成功結果には `issueNumber` を含みます。Issue 作成後にタスク保存が失敗またはキャンセルされた場合も Issue は open のまま残り、MCP error result は `issueCreated`、`issueNumber`、任意の `issueUrl`、`taskEnqueued`、`stage`、sanitize 済みの `error` を返します。`{ "issue": { "number": issueNumber } }` で再試行すれば、新しい Issue は作成されません。
+`issue` object は `{ "number": 123 }` または `{ "create": true, "title"?: "...", "labels"?: ["..."] }` のいずれかだけを指定します。混在 key、空の title・label、unknown key は拒否されます。Issue 付き enqueue の成功結果には `issueNumber` を含みます。Issue 番号の解決後にタスク保存が失敗またはキャンセルされた場合も Issue は open のまま残り、MCP error result は `issueCreated`、`issueNumber`、任意の `issueUrl`、`taskEnqueued`、`stage`、sanitize 済みの `error` を返します。`{ "issue": { "number": issueNumber } }` で再試行すれば、新しい Issue は作成されません。`stage` が `issue_number_parsing` の場合は `issueNumber` を返せないため、任意の `issueUrl` で作成済み Issue を特定し、番号を確認してから再試行してください。
 
 MCP はタスクの enqueue だけを担当します。pending タスクの実行には `takt run`、継続監視と実行には `takt watch` を使用してください。
 

--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -126,7 +126,7 @@ ACP prompt がタスクを作成または直接実行する場合、会話結果
 
 ## MCP Server
 
-`takt-mcp` は TAKT を stdio Model Context Protocol server として起動します。MCP client から、shell 経由で `takt add` や `takt run` を直接呼ばずに、TAKT タスクの enqueue、設定済み issue provider による Issue 作成付き enqueue、次の pending タスク実行を行いたい場合に登録します。
+`takt-mcp` は TAKT を stdio Model Context Protocol server として起動します。MCP client から shell 経由で `takt add` を直接呼ばずに TAKT タスクを enqueue したい場合に登録します。
 
 ```bash
 takt-mcp
@@ -149,9 +149,7 @@ codex mcp add takt -- takt-mcp
 
 | Tool | 説明 |
 |------|------|
-| `takt_enqueue_task` | pending タスクを `.takt/tasks.yaml` に保存する。 |
-| `takt_create_issue_and_enqueue_task` | 設定済み issue provider で Issue を作成し、作成された Issue 番号付きで pending タスクを保存する。 |
-| `takt_run_next_task` | 次の pending タスクを取得し、TAKT の既存タスク実行経路で実行する。 |
+| `takt_enqueue_task` | pending タスクを `.takt/tasks.yaml` に保存し、既存 Issue の紐付けまたは新規 Issue 作成を任意で行う。 |
 
 各 tool の `cwd` は `realpath` で解決され、MCP server の許可 project root 内にある必要があります。既定の許可 root は `takt-mcp` を起動したディレクトリです。
 
@@ -171,43 +169,19 @@ codex mcp add takt -- takt-mcp
 | フィールド | 型 | 説明 |
 |-----------|----|------|
 | `worktree` | boolean | `true` は自動の隔離 worktree を作成する。省略時は `true`。MCP 入力では任意の worktree パスを受け取りません。 |
+| `issue.number` | 正の safe integer | issue provider を呼ばずに既存 Issue を紐付ける。 |
+| `issue.create` | `true` | enqueue 前に設定済み issue provider で Issue を作成する。 |
+| `issue.title` | string | 新規 Issue 用の任意の非空 title。 |
+| `issue.labels` | string array | 新規 Issue 用の任意の非空 label。 |
 | `taskContext.branch` | string | タスクに保存するローカルブランチ名。 |
 | `taskContext.baseBranch` | string | タスクに保存するベースブランチ名。 |
 | `taskContext.prNumber` | 正の safe integer | タスクに保存する Pull Request 番号。`Number.MAX_SAFE_INTEGER` を超える値は拒否されます。 |
 
 入力上限: `task` は 128 KiB、`workflow` は 128 文字、Issue label は 1 件 100 文字、最大 20 件までです。
 
-### `takt_create_issue_and_enqueue_task`
+`issue` object は `{ "number": 123 }` または `{ "create": true, "title"?: "...", "labels"?: ["..."] }` のいずれかだけを指定します。混在 key、空の title・label、unknown key は拒否されます。Issue 付き enqueue の成功結果には `issueNumber` を含みます。Issue 作成後にタスク保存が失敗またはキャンセルされた場合も Issue は open のまま残り、MCP error result は `issueCreated`、`issueNumber`、任意の `issueUrl`、`taskEnqueued`、`stage`、sanitize 済みの `error` を返します。`{ "issue": { "number": issueNumber } }` で再試行すれば、新しい Issue は作成されません。
 
-この tool は `takt_enqueue_task` と同じフィールドに加えて、次の入力を受け取ります。
-
-| フィールド | 型 | 説明 |
-|-----------|----|------|
-| `labels` | string array | Issue 作成時に要求する label。 |
-
-Issue 作成は設定済み TAKT issue provider を使用し、silent output mode で実行されます。Issue 作成に失敗した場合、tool は MCP error result を返し、タスクは保存しません。Issue 作成後にタスク保存が失敗した場合、TAKT は作成済み Issue に固定の補償コメントを追加して close し、pending タスクのない Issue がリポジトリに残らないようにします。close に成功した場合、MCP error result は Issue が作成後に close されたこととローカルのタスク保存エラーを返します。close に失敗した場合、MCP error result はタスク保存エラーと Issue close エラーの両方を返します。
-
-### `takt_run_next_task`
-
-必須入力:
-
-| フィールド | 型 | 説明 |
-|-----------|----|------|
-| `cwd` | 絶対パス文字列 | `.takt/tasks.yaml` を含む project root。 |
-
-任意入力:
-
-| フィールド | 型 | 説明 |
-|-----------|----|------|
-| `provider` | string | タスク実行時の provider 上書き。 |
-| `model` | string | タスク実行時の model 上書き。 |
-| `taskContext.branch` | string | ローカルブランチ context。 |
-| `taskContext.baseBranch` | string | ベースブランチ context。 |
-| `taskContext.prNumber` | 正の safe integer | Pull Request context。`Number.MAX_SAFE_INTEGER` を超える値は拒否されます。 |
-
-入力上限: `provider` は TAKT の既知 provider identifier のみ、`model` は 128 文字までです。
-
-この tool は最大 1 件の pending タスクだけを実行し、stdio を MCP message 専用に保つため通常の workflow 出力を抑制します。pending タスクがない場合は `{ "ran": false }` を返します。
+MCP はタスクの enqueue だけを担当します。pending タスクの実行には `takt run`、継続監視と実行には `takt watch` を使用してください。
 
 ## Instant Exec モード
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -127,7 +127,7 @@ TAKT currently supports `initialize`, `session/new`, `session/prompt`, `session/
 
 ## MCP Server
 
-`takt-mcp` starts TAKT as a stdio Model Context Protocol server. Register it in an MCP client when you want the client to enqueue TAKT tasks, create an issue through the configured issue provider and enqueue the task, or run the next pending task without shelling out to `takt add` or `takt run`.
+`takt-mcp` starts TAKT as a stdio Model Context Protocol server. Register it in an MCP client when you want the client to enqueue TAKT tasks without shelling out to `takt add`.
 
 ```bash
 takt-mcp
@@ -150,9 +150,7 @@ The server exposes these tools:
 
 | Tool | Description |
 |------|-------------|
-| `takt_enqueue_task` | Save a pending task to `.takt/tasks.yaml`. |
-| `takt_create_issue_and_enqueue_task` | Create an issue through the configured issue provider, then save a pending task with the created issue number. |
-| `takt_run_next_task` | Claim and execute the next pending task through TAKT's existing task execution path. |
+| `takt_enqueue_task` | Save a pending task to `.takt/tasks.yaml`, optionally linking or creating an issue. |
 
 Every tool `cwd` is resolved with `realpath` and must stay inside the MCP server's allowed project root. By default that root is the directory where `takt-mcp` was started.
 
@@ -172,43 +170,19 @@ Optional input:
 | Field | Type | Description |
 |-------|------|-------------|
 | `worktree` | boolean | `true` creates an automatic isolated worktree. Defaults to `true`. MCP input does not accept custom worktree paths. |
+| `issue.number` | positive safe integer | Link an existing issue without calling an issue provider. |
+| `issue.create` | `true` | Create an issue through the configured issue provider before enqueueing. |
+| `issue.title` | string | Optional non-empty title for a newly created issue. |
+| `issue.labels` | string array | Optional non-empty labels for a newly created issue. |
 | `taskContext.branch` | string | Local branch name to save with the task. |
 | `taskContext.baseBranch` | string | Base branch name to save with the task. |
 | `taskContext.prNumber` | positive safe integer | Pull request number to save with the task. Values greater than `Number.MAX_SAFE_INTEGER` are rejected. |
 
 Input limits: `task` is limited to 128 KiB, `workflow` to 128 characters, each issue label to 100 characters, and at most 20 labels.
 
-### `takt_create_issue_and_enqueue_task`
+The `issue` object must be exactly one of `{ "number": 123 }` or `{ "create": true, "title"?: "...", "labels"?: ["..."] }`; mixed keys, empty titles or labels, and unknown keys are rejected. A successful issue-backed enqueue returns `issueNumber`. If issue creation succeeds but task saving fails or is cancelled, the issue remains open and the MCP error result includes `issueCreated`, `issueNumber`, optional `issueUrl`, `taskEnqueued`, `stage`, and a sanitized `error`. Retry with `{ "issue": { "number": issueNumber } }` to avoid creating another issue.
 
-This tool accepts the same fields as `takt_enqueue_task`, plus:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `labels` | string array | Labels to request when creating the issue. |
-
-Issue creation uses the configured TAKT issue provider and runs in silent output mode. If issue creation fails, the tool returns an MCP error result and does not save the task. If task saving fails after the issue is created, TAKT adds a fixed compensation comment to the created issue and closes it so the repository does not retain an issue without a pending task. When that close succeeds, the MCP error result reports that the issue was created and closed along with the local task-saving error. When that close fails, the MCP error result includes both the task-saving error and the issue close error.
-
-### `takt_run_next_task`
-
-Required input:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `cwd` | absolute path string | Project root containing `.takt/tasks.yaml`. |
-
-Optional input:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `provider` | string | Provider override for the task execution. |
-| `model` | string | Model override for the task execution. |
-| `taskContext.branch` | string | Local branch context. |
-| `taskContext.baseBranch` | string | Base branch context. |
-| `taskContext.prNumber` | positive safe integer | Pull request context. Values greater than `Number.MAX_SAFE_INTEGER` are rejected. |
-
-Input limits: `provider` must be one of TAKT's known provider identifiers and `model` is limited to 128 characters.
-
-The tool executes at most one pending task and suppresses normal workflow output so stdout remains reserved for MCP messages. When no pending task exists, it returns `{ "ran": false }`.
+MCP only enqueues tasks. Use `takt run` to execute pending tasks and `takt watch` to monitor and execute them continuously.
 
 ## Instant Exec Mode
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -172,15 +172,15 @@ Optional input:
 | `worktree` | boolean | `true` creates an automatic isolated worktree. Defaults to `true`. MCP input does not accept custom worktree paths. |
 | `issue.number` | positive safe integer | Link an existing issue without calling an issue provider. |
 | `issue.create` | `true` | Create an issue through the configured issue provider before enqueueing. |
-| `issue.title` | string | Optional non-empty title for a newly created issue. |
+| `issue.title` | string | Optional non-empty title for a newly created issue. Limited to 255 characters. |
 | `issue.labels` | string array | Optional non-empty labels for a newly created issue. |
 | `taskContext.branch` | string | Local branch name to save with the task. |
 | `taskContext.baseBranch` | string | Base branch name to save with the task. |
 | `taskContext.prNumber` | positive safe integer | Pull request number to save with the task. Values greater than `Number.MAX_SAFE_INTEGER` are rejected. |
 
-Input limits: `task` is limited to 128 KiB, `workflow` to 128 characters, each issue label to 100 characters, and at most 20 labels.
+Input limits: `task` is limited to 128 KiB, `workflow` to 128 characters, an issue title to 255 characters, each issue label to 100 characters, and at most 20 labels.
 
-The `issue` object must be exactly one of `{ "number": 123 }` or `{ "create": true, "title"?: "...", "labels"?: ["..."] }`; mixed keys, empty titles or labels, and unknown keys are rejected. A successful issue-backed enqueue returns `issueNumber`. If issue creation succeeds but task saving fails or is cancelled, the issue remains open and the MCP error result includes `issueCreated`, `issueNumber`, optional `issueUrl`, `taskEnqueued`, `stage`, and a sanitized `error`. Retry with `{ "issue": { "number": issueNumber } }` to avoid creating another issue.
+The `issue` object must be exactly one of `{ "number": 123 }` or `{ "create": true, "title"?: "...", "labels"?: ["..."] }`; mixed keys, empty titles or labels, and unknown keys are rejected. A successful issue-backed enqueue returns `issueNumber`. If issue creation succeeds but task saving fails or is cancelled after the issue number is resolved, the issue remains open and the MCP error result includes `issueCreated`, `issueNumber`, optional `issueUrl`, `taskEnqueued`, `stage`, and a sanitized `error`. Retry with `{ "issue": { "number": issueNumber } }` to avoid creating another issue. If `stage` is `issue_number_parsing`, `issueNumber` is unavailable; use the optional `issueUrl` to identify the created issue and obtain its number before retrying.
 
 MCP only enqueues tasks. Use `takt run` to execute pending tasks and `takt watch` to monitor and execute them continuously.
 

--- a/docs/task-management.ja.md
+++ b/docs/task-management.ja.md
@@ -44,7 +44,7 @@ Issue 参照（例: `#28`）を渡すと、TAKT は GitHub CLI（`gh`）を介�
 
 ### MCP Client からのタスク保存
 
-MCP client は `takt-mcp` stdio server を使って、shell command を直接呼ばずに pending タスクを保存できます。`takt_enqueue_task` は `.takt/tasks.yaml` に pending レコードを書き込み、任意の `issue` object で既存 Issue を紐付けるか、設定済み TAKT issue provider で新規 Issue を作成します。Issue 作成後に保存が失敗しても Issue は open のまま残り、MCP error result は再試行用の番号を返します。この tool は絶対パスの `cwd` と空でないタスク本文を必須入力とします。pending タスクの実行には `takt run`、継続監視と実行には `takt watch` を使用してください。設定方法と tool 入力の詳細は [CLI リファレンス](./cli-reference.ja.md#mcp-server) を参照してください。
+MCP client は `takt-mcp` stdio server を使って、shell command を直接呼ばずに pending タスクを保存できます。`takt_enqueue_task` は `.takt/tasks.yaml` に pending レコードを書き込み、任意の `issue` object で既存 Issue を紐付けるか、設定済み TAKT issue provider で新規 Issue を作成します。Issue 作成後に保存が失敗し、Issue 番号まで解決済みなら、Issue は open のまま残り、MCP error result は再試行用の番号を返します。番号抽出に失敗した場合は、代わりに Issue URL を返すことがあります。この tool は絶対パスの `cwd` と空でないタスク本文を必須入力とします。pending タスクの実行には `takt run`、継続監視と実行には `takt watch` を使用してください。設定方法と tool 入力の詳細は [CLI リファレンス](./cli-reference.ja.md#mcp-server) を参照してください。
 
 ## タスクディレクトリ形式
 

--- a/docs/task-management.ja.md
+++ b/docs/task-management.ja.md
@@ -44,7 +44,7 @@ Issue 参照（例: `#28`）を渡すと、TAKT は GitHub CLI（`gh`）を介�
 
 ### MCP Client からのタスク保存
 
-MCP client は `takt-mcp` stdio server を使って、shell command を直接呼ばずに pending タスクを保存できます。`takt_enqueue_task` は `.takt/tasks.yaml` に pending レコードを書き込みます。`takt_create_issue_and_enqueue_task` は設定済み TAKT issue provider で Issue を作成してから、Issue 番号付きの pending レコードを書き込みます。Issue 作成後にタスク保存が失敗した場合、TAKT は作成済み Issue に固定の補償コメントを追加して close します。その close も失敗した場合、MCP error result はタスク保存エラーと Issue close エラーの両方を返します。どちらの tool も絶対パスの `cwd` と空でないタスク本文を必須入力とします。設定方法と tool 入力の詳細は [CLI リファレンス](./cli-reference.ja.md#mcp-server) を参照してください。
+MCP client は `takt-mcp` stdio server を使って、shell command を直接呼ばずに pending タスクを保存できます。`takt_enqueue_task` は `.takt/tasks.yaml` に pending レコードを書き込み、任意の `issue` object で既存 Issue を紐付けるか、設定済み TAKT issue provider で新規 Issue を作成します。Issue 作成後に保存が失敗しても Issue は open のまま残り、MCP error result は再試行用の番号を返します。この tool は絶対パスの `cwd` と空でないタスク本文を必須入力とします。pending タスクの実行には `takt run`、継続監視と実行には `takt watch` を使用してください。設定方法と tool 入力の詳細は [CLI リファレンス](./cli-reference.ja.md#mcp-server) を参照してください。
 
 ## タスクディレクトリ形式
 
@@ -120,7 +120,7 @@ takt run --ignore-exceed
 
 workflow が `max_steps` に到達した場合、通常の `takt run` はタスクを `exceeded` として停止し、`exceeded_max_steps`、`exceeded_current_iteration`、`resume_point` などの再実行メタデータを保存します。`--ignore-exceed` を付けると、この iteration limit だけを無視して workflow を継続し、exceeded 用の再実行メタデータは保存しません。
 
-MCP client は `takt_run_next_task` で pending タスクを 1 件実行できます。この tool は `takt run` と同じタスク取得・実行経路を使いますが、1 件だけを取得し、stdio MCP の安全性のため通常の workflow 出力を抑制します。
+MCP client はタスクの enqueue だけを担当します。pending タスクの実行には `takt run`、継続監視と実行には `takt watch` を使用してください。
 
 ### 並列実行（Concurrency）
 

--- a/docs/task-management.md
+++ b/docs/task-management.md
@@ -44,7 +44,7 @@ You can also save tasks from interactive mode. After refining requirements throu
 
 ### Saving Tasks from MCP Clients
 
-MCP clients can use the `takt-mcp` stdio server to save pending tasks without invoking shell commands. `takt_enqueue_task` writes a pending record to `.takt/tasks.yaml`. `takt_create_issue_and_enqueue_task` first creates an issue through the configured TAKT issue provider, then writes the pending record with the issue number. If task saving fails after issue creation, TAKT adds a fixed compensation comment to the created issue and closes it; if that close also fails, the MCP error result reports both failures. Both tools require an absolute `cwd` and a non-empty task body. See [CLI Reference](./cli-reference.md#mcp-server) for setup and tool input details.
+MCP clients can use the `takt-mcp` stdio server to save pending tasks without invoking shell commands. `takt_enqueue_task` writes a pending record to `.takt/tasks.yaml`; its optional `issue` object links an existing issue or creates one through the configured TAKT issue provider. If saving fails after issue creation, the issue remains open and the MCP error result returns its number for retry. The tool requires an absolute `cwd` and a non-empty task body. Use `takt run` to execute pending tasks or `takt watch` to monitor and execute them continuously. See [CLI Reference](./cli-reference.md#mcp-server) for setup and tool input details.
 
 ## Task Directory Format
 
@@ -120,7 +120,7 @@ The `run` command claims pending tasks and executes them through the configured 
 
 When a workflow reaches `max_steps`, the default `takt run` behavior stops the task with `exceeded` status and saves retry metadata such as `exceeded_max_steps`, `exceeded_current_iteration`, and `resume_point`. Passing `--ignore-exceed` makes `takt run` ignore only that iteration limit, continue the workflow, and skip writing exceeded retry metadata.
 
-MCP clients can execute one pending task with `takt_run_next_task`. This uses the same task claiming and execution path as `takt run`, but claims only one task and suppresses normal workflow output for stdio MCP safety.
+MCP clients enqueue tasks only. Use `takt run` to execute pending tasks or `takt watch` for continuous monitoring and execution.
 
 ### Parallel Execution (Concurrency)
 

--- a/docs/task-management.md
+++ b/docs/task-management.md
@@ -44,7 +44,7 @@ You can also save tasks from interactive mode. After refining requirements throu
 
 ### Saving Tasks from MCP Clients
 
-MCP clients can use the `takt-mcp` stdio server to save pending tasks without invoking shell commands. `takt_enqueue_task` writes a pending record to `.takt/tasks.yaml`; its optional `issue` object links an existing issue or creates one through the configured TAKT issue provider. If saving fails after issue creation, the issue remains open and the MCP error result returns its number for retry. The tool requires an absolute `cwd` and a non-empty task body. Use `takt run` to execute pending tasks or `takt watch` to monitor and execute them continuously. See [CLI Reference](./cli-reference.md#mcp-server) for setup and tool input details.
+MCP clients can use the `takt-mcp` stdio server to save pending tasks without invoking shell commands. `takt_enqueue_task` writes a pending record to `.takt/tasks.yaml`; its optional `issue` object links an existing issue or creates one through the configured TAKT issue provider. If saving fails after issue creation and the issue number was resolved, the issue remains open and the MCP error result returns its number for retry. If number extraction fails, the result can provide the issue URL instead. The tool requires an absolute `cwd` and a non-empty task body. Use `takt run` to execute pending tasks or `takt watch` to monitor and execute them continuously. See [CLI Reference](./cli-reference.md#mcp-server) for setup and tool input details.
 
 ## Task Directory Format
 

--- a/src/__tests__/acpAgent.test.ts
+++ b/src/__tests__/acpAgent.test.ts
@@ -731,7 +731,7 @@ describe('TAKT ACP agent adapter', () => {
       worktree: true,
       autoPr: false,
       issue: 913,
-    });
+    }, undefined, expect.any(AbortSignal));
     expect(createIssueFromTaskResult.mock.invocationCallOrder[0]).toBeLessThan(
       saveTaskFile.mock.invocationCallOrder[0],
     );

--- a/src/__tests__/acpEnqueue.test.ts
+++ b/src/__tests__/acpEnqueue.test.ts
@@ -19,7 +19,7 @@ describe('ACP enqueue service integration', () => {
     vi.clearAllMocks();
   });
 
-  it('closes the created issue when ACP task saving fails after issue creation', async () => {
+  it('leaves the created issue open when ACP task saving fails after issue creation', async () => {
     mockGitProvider.closeIssue.mockReturnValue({ success: true, commentCreated: true });
     const saveTaskFile = vi.fn().mockRejectedValue(new Error('disk full'));
     const createIssueFromTaskResult = vi.fn().mockReturnValue({ success: true, issueNumber: 913 });
@@ -37,17 +37,13 @@ describe('ACP enqueue service integration', () => {
       workflow: 'review',
       saveTaskFile,
       createIssueFromTaskResult,
-    })).rejects.toThrow('Issue #913 was created and closed because task saving failed');
+    })).rejects.toThrow('Issue #913 was created, but task saving failed: disk full');
 
     expect(mockInitGitProvider).toHaveBeenCalledWith('/repo');
-    expect(mockGitProvider.closeIssue).toHaveBeenCalledWith(
-      913,
-      expect.stringContaining('saving the pending task failed'),
-      '/repo',
-    );
+    expect(mockGitProvider.closeIssue).not.toHaveBeenCalled();
   });
 
-  it('closes the created issue when ACP cancellation happens after issue creation', async () => {
+  it('leaves the created issue open when ACP cancellation happens after issue creation', async () => {
     const abortController = new AbortController();
     mockGitProvider.closeIssue.mockReturnValue({ success: true, commentCreated: true });
     const saveTaskFile = vi.fn();
@@ -70,19 +66,13 @@ describe('ACP enqueue service integration', () => {
       saveTaskFile,
       createIssueFromTaskResult,
       abortSignal: abortController.signal,
-    })).rejects.toThrow('Issue #913 was created and closed because task enqueue was cancelled');
+    })).rejects.toThrow('Issue #913 was created and remains open, but task enqueue was cancelled');
 
     expect(saveTaskFile).not.toHaveBeenCalled();
-    expect(mockGitProvider.closeIssue).toHaveBeenCalledWith(
-      913,
-      expect.stringContaining('task enqueue was cancelled before saving the pending task'),
-      '/repo',
-    );
-    const compensationComment = String(mockGitProvider.closeIssue.mock.calls[0]?.[1]);
-    expect(compensationComment).not.toContain('saving the pending task failed');
+    expect(mockGitProvider.closeIssue).not.toHaveBeenCalled();
   });
 
-  it('reports compensation comment partial success when ACP issue close fails after the comment', async () => {
+  it('does not call issue close even when the provider close method would fail', async () => {
     mockGitProvider.closeIssue.mockReturnValue({
       success: false,
       commentCreated: true,
@@ -104,7 +94,8 @@ describe('ACP enqueue service integration', () => {
       workflow: 'review',
       saveTaskFile,
       createIssueFromTaskResult,
-    })).rejects.toThrow('Issue compensation comment was created, but issue close failed: glab issue close failed');
+    })).rejects.toThrow('Issue #913 was created, but task saving failed: disk full');
+    expect(mockGitProvider.closeIssue).not.toHaveBeenCalled();
   });
 
   it('preserves the issue creation failure reason from the result dependency', async () => {
@@ -135,11 +126,6 @@ describe('ACP enqueue service integration', () => {
   });
 
   it('redacts secrets and local paths from ACP issue enqueue failures', async () => {
-    mockGitProvider.closeIssue.mockReturnValue({
-      success: false,
-      commentCreated: true,
-      error: 'Authorization: Bearer ghp_123456789\nfile:///Users/nrs/secret/close.log',
-    });
     const saveTaskFile = vi.fn().mockRejectedValue(
       new Error('api_key=plain-secret\nCannot write /Users/nrs/secret/.takt/tasks.yaml'),
     );
@@ -167,7 +153,7 @@ describe('ACP enqueue service integration', () => {
 
     expect(thrown).toBeInstanceOf(Error);
     const message = (thrown as Error).message;
-    expect(message).toMatch(/api_key=\[REDACTED\][\s\S]*\[path\][\s\S]*Authorization: Bearer \[REDACTED\][\s\S]*\[path\]/);
-    expect(message).not.toMatch(/ghp_123456789|plain-secret|\/Users\/nrs\/secret|file:\/\/\/Users\/nrs\/secret/);
+    expect(message).toMatch(/api_key=\[REDACTED\][\s\S]*\[path\]/);
+    expect(message).not.toMatch(/plain-secret|\/Users\/nrs\/secret/);
   });
 });

--- a/src/__tests__/createIssue.test.ts
+++ b/src/__tests__/createIssue.test.ts
@@ -197,9 +197,9 @@ describe('createIssue', () => {
 
     expect(result).toEqual({
       success: false,
-      error: expect.stringContaining(
-        'Issue URL must end with a positive issue number: https://github.com/owner/repo/issues/not-a-number',
-      ),
+      issueCreated: true,
+      url: 'https://github.com/owner/repo/issues/not-a-number',
+      error: 'Failed to extract issue number from created issue URL',
     });
   });
 
@@ -212,9 +212,9 @@ describe('createIssue', () => {
 
     expect(result).toEqual({
       success: false,
-      error: expect.stringContaining(
-        'Issue URL must end with a positive issue number: https://github.com/owner/repo/issues/42/',
-      ),
+      issueCreated: true,
+      url: 'https://github.com/owner/repo/issues/42/',
+      error: 'Failed to extract issue number from created issue URL',
     });
   });
 });

--- a/src/__tests__/createIssue.test.ts
+++ b/src/__tests__/createIssue.test.ts
@@ -9,16 +9,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
 
+const { mockLogError } = vi.hoisted(() => ({
+  mockLogError: vi.fn(),
+}));
+
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
 }));
 
-vi.mock('../../shared/utils/index.js', async (importOriginal) => ({
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   createLogger: () => ({
     info: vi.fn(),
     debug: vi.fn(),
-    error: vi.fn(),
+    error: mockLogError,
   }),
 }));
 
@@ -201,6 +205,13 @@ describe('createIssue', () => {
       url: 'https://github.com/owner/repo/issues/not-a-number',
       error: 'Failed to extract issue number from created issue URL',
     });
+    expect(mockLogError).toHaveBeenCalledWith(
+      'Issue number extraction failed after issue creation',
+      {
+        error: 'Failed to extract issue number from created issue URL',
+        url: 'https://github.com/owner/repo/issues/not-a-number',
+      },
+    );
   });
 
   it('should return error when gh issue create returns a URL with a trailing slash', () => {

--- a/src/__tests__/createIssueFromTask.test.ts
+++ b/src/__tests__/createIssueFromTask.test.ts
@@ -175,6 +175,35 @@ describe('createIssueFromTask', () => {
 
       expect(result).toBe(42);
     });
+
+    it('returns a sanitized public issue URL with the issue number', () => {
+      mockCreateIssue.mockReturnValue({
+        success: true,
+        issueNumber: 42,
+        url: 'https://user:secret@example.test/issues/42?token=secret#fragment',
+      });
+
+      expect(createIssueFromTaskResult('Test task', { outputMode: 'silent' })).toEqual({
+        success: true,
+        issueNumber: 42,
+        issueUrl: 'https://example.test/issues/42',
+      });
+    });
+
+    it('reports that an issue was created when its number is invalid', () => {
+      mockCreateIssue.mockReturnValue({
+        success: true,
+        issueNumber: 0,
+        url: 'https://example.test/issues/unknown',
+      });
+
+      expect(createIssueFromTaskResult('Test task', { outputMode: 'silent' })).toEqual({
+        success: false,
+        issueCreated: true,
+        issueUrl: 'https://example.test/issues/unknown',
+        error: expect.stringContaining('positive safe integer'),
+      });
+    });
   });
 
   it('should use first line as title and full text as body for multi-line task', () => {
@@ -281,6 +310,20 @@ describe('createIssueFromTask', () => {
   });
 
   describe('structured output title', () => {
+    it('uses an explicit MCP title without generated-title fallback rules', () => {
+      mockCreateIssue.mockReturnValue(createIssueSuccess(7));
+
+      createIssueFromTaskResult('Long task body', {
+        explicitTitle: 'A',
+        outputMode: 'silent',
+      });
+
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        { title: 'A', body: 'Long task body' },
+        undefined,
+      );
+    });
+
     it('uses a valid structured output title as the issue title', () => {
       // Given
       const task = '## Generic task heading\nImplement AI issue title generation';

--- a/src/__tests__/enqueueService.test.ts
+++ b/src/__tests__/enqueueService.test.ts
@@ -4,6 +4,7 @@ import {
   IssueEnqueueCancelledError,
 } from '../infra/task/enqueueService.js';
 import type { GitProvider, Issue } from '../infra/git/index.js';
+import { createIssueFromTaskResult } from '../infra/task/issueTask.js';
 
 function createTestGitProvider(overrides: Partial<GitProvider> = {}): GitProvider {
   const issue: Issue = {
@@ -41,6 +42,36 @@ function createTestGitProvider(overrides: Partial<GitProvider> = {}): GitProvide
 }
 
 describe('createIssueAndEnqueueTask', () => {
+  it.each([
+    ['a prohibited title', '# Task Order'],
+    ['a title shorter than the minimum', 'abc'],
+  ])('falls back to a task-derived title for %s', async (_case, title) => {
+    const createIssue = vi.fn(() => ({ success: true as const, issueNumber: 913 }));
+    const gitProvider = createTestGitProvider({ createIssue });
+    const saveTaskFile = vi.fn().mockResolvedValue({
+      taskName: 'task-1',
+      tasksFile: '/repo/.takt/tasks.yaml',
+    });
+    const task = '## Implement enqueue title fallback\nDetails';
+
+    const result = await createIssueAndEnqueueTask({
+      cwd: '/repo',
+      task,
+      workflow: 'review',
+      title,
+      gitProvider,
+    }, {
+      createIssueFromTaskResult,
+      saveTaskFile,
+    });
+
+    expect(result.success).toBe(true);
+    expect(createIssue).toHaveBeenCalledWith({
+      title: 'Implement enqueue title fallback',
+      body: task,
+    }, '/repo');
+  });
+
   it('does not create an issue when the abort signal is already aborted', async () => {
     const closeIssue = vi.fn(() => ({ success: true as const }));
     const gitProvider = createTestGitProvider({ closeIssue });

--- a/src/__tests__/enqueueService.test.ts
+++ b/src/__tests__/enqueueService.test.ts
@@ -67,7 +67,7 @@ describe('createIssueAndEnqueueTask', () => {
     expect(closeIssue).not.toHaveBeenCalled();
   });
 
-  it('returns a task_saving failure result when default compensation handles a save failure', async () => {
+  it('returns a task_saving failure and leaves the created issue open', async () => {
     const closeIssue = vi.fn(() => ({ success: true as const }));
     const gitProvider = createTestGitProvider({ closeIssue });
     const createIssueFromTaskResult = vi.fn(() => ({ success: true as const, issueNumber: 913 }));
@@ -89,13 +89,12 @@ describe('createIssueAndEnqueueTask', () => {
     if (!result.success) {
       expect(result.failure.stage).toBe('task_saving');
       expect(result.failure.issueNumber).toBe(913);
-      expect(result.failure.compensation).toEqual({ success: true });
+      expect(result.failure).toEqual(expect.objectContaining({
+        issueCreated: true,
+        taskEnqueued: false,
+      }));
     }
-    expect(closeIssue).toHaveBeenCalledWith(
-      913,
-      expect.stringContaining('TAKT created this issue'),
-      '/repo',
-    );
+    expect(closeIssue).not.toHaveBeenCalled();
   });
 
   it('returns an issue_creation failure result without saving or compensation when issue creation fails', async () => {
@@ -122,6 +121,8 @@ describe('createIssueAndEnqueueTask', () => {
     expect(result).toEqual({
       success: false,
       failure: {
+        issueCreated: false,
+        taskEnqueued: false,
         stage: 'issue_creation',
         error: 'gh issue create failed',
       },
@@ -130,7 +131,7 @@ describe('createIssueAndEnqueueTask', () => {
     expect(closeIssue).not.toHaveBeenCalled();
   });
 
-  it('uses a cancellation compensation comment when enqueue is cancelled after issue creation', async () => {
+  it('returns cancellation details and leaves the created issue open', async () => {
     const closeIssue = vi.fn(() => ({ success: true as const }));
     const gitProvider = createTestGitProvider({ closeIssue });
     const createIssueFromTaskResult = vi.fn(() => ({ success: true as const, issueNumber: 913 }));
@@ -151,17 +152,12 @@ describe('createIssueAndEnqueueTask', () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.failure.stage).toBe('cancelled_after_issue_creation');
+      expect(result.failure).toEqual(expect.objectContaining({
+        issueCreated: true,
+        issueNumber: 913,
+        taskEnqueued: false,
+      }));
     }
-    expect(closeIssue).toHaveBeenCalledWith(
-      913,
-      [
-        'TAKT created this issue, but task enqueue was cancelled before saving the pending task.',
-        '',
-        'The issue is being closed to keep the repository state consistent.',
-      ].join('\n'),
-      '/repo',
-    );
-    const compensationComment = String(closeIssue.mock.calls[0]?.[1]);
-    expect(compensationComment).not.toContain('saving the pending task failed');
+    expect(closeIssue).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/gitIssueUrl.test.ts
+++ b/src/__tests__/gitIssueUrl.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePublicIssueUrl } from '../infra/git/types.js';
+
+describe('normalizePublicIssueUrl', () => {
+  it('keeps only the public origin and path for a valid HTTP(S) URL', () => {
+    expect(normalizePublicIssueUrl(
+      'https://user:secret@example.test/issues/42?token=secret#fragment',
+    )).toBe('https://example.test/issues/42');
+  });
+
+  it.each([
+    ['an absent URL', undefined],
+    ['control characters', 'https://example.test/issues/42\ninjected'],
+    ['a non-HTTP(S) protocol', 'ftp://example.test/issues/42'],
+    ['a URL parsing failure', 'not a URL'],
+    ['an empty hostname', 'file:///issues/42'],
+  ] as const)('rejects %s', (_case, url) => {
+    expect(normalizePublicIssueUrl(url)).toBeUndefined();
+  });
+});

--- a/src/__tests__/gitlab-issue.test.ts
+++ b/src/__tests__/gitlab-issue.test.ts
@@ -10,7 +10,10 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockExecFileSync = vi.fn();
+const { mockExecFileSync, mockLogError } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockLogError: vi.fn(),
+}));
 vi.mock('node:child_process', () => ({
   execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }));
@@ -20,7 +23,7 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   createLogger: () => ({
     info: vi.fn(),
     debug: vi.fn(),
-    error: vi.fn(),
+    error: mockLogError,
   }),
   getErrorMessage: (e: unknown) => String(e),
 }));
@@ -500,6 +503,13 @@ describe('createIssue', () => {
       url: 'https://gitlab.com/org/repo/-/issues/not-a-number',
       error: 'Failed to extract issue number from created issue URL',
     });
+    expect(mockLogError).toHaveBeenCalledWith(
+      'Issue number extraction failed after issue creation',
+      {
+        error: 'Failed to extract issue number from created issue URL',
+        url: 'https://gitlab.com/org/repo/-/issues/not-a-number',
+      },
+    );
   });
 
   it('glab issue create が trailing slash 付き URL を返した場合は success: false を返す', () => {

--- a/src/__tests__/gitlab-issue.test.ts
+++ b/src/__tests__/gitlab-issue.test.ts
@@ -496,9 +496,9 @@ describe('createIssue', () => {
 
     expect(result).toEqual({
       success: false,
-      error: expect.stringContaining(
-        'Issue URL must end with a positive issue number: https://gitlab.com/org/repo/-/issues/not-a-number',
-      ),
+      issueCreated: true,
+      url: 'https://gitlab.com/org/repo/-/issues/not-a-number',
+      error: 'Failed to extract issue number from created issue URL',
     });
   });
 
@@ -512,9 +512,9 @@ describe('createIssue', () => {
 
     expect(result).toEqual({
       success: false,
-      error: expect.stringContaining(
-        'Issue URL must end with a positive issue number: https://gitlab.com/org/repo/-/issues/42/',
-      ),
+      issueCreated: true,
+      url: 'https://gitlab.com/org/repo/-/issues/42/',
+      error: 'Failed to extract issue number from created issue URL',
     });
   });
 

--- a/src/__tests__/mcp-entrypoint.integration.test.ts
+++ b/src/__tests__/mcp-entrypoint.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -9,6 +9,8 @@ const SOURCE_STDIO_ENTRYPOINT_RUNNER = 'src/__tests__/helpers/mcp-source-stdio-e
 describe('MCP stdio entrypoint integration', () => {
   it('Given the source MCP entrypoint, When a stdio MCP client lists and calls tools, Then stdout remains valid MCP protocol', async () => {
     const cwd = mkdtempSync(join(process.cwd(), '.tmp-takt-mcp-stdio-'));
+    mkdirSync(join(cwd, '.takt'), { recursive: true });
+    writeFileSync(join(cwd, '.takt', 'config.yaml'), 'branch_name_strategy: romaji\n', 'utf-8');
     const client = new Client({ name: 'takt-mcp-stdio-test-client', version: '1.0.0' });
     const transport = new StdioClientTransport({
       command: process.execPath,
@@ -30,20 +32,21 @@ describe('MCP stdio entrypoint integration', () => {
 
       const tools = await client.listTools();
       const result = await client.callTool({
-        name: 'takt_run_next_task',
-        arguments: { cwd },
+        name: 'takt_enqueue_task',
+        arguments: {
+          cwd,
+          task: 'Enqueue through the stdio MCP server',
+          workflow: 'default',
+          autoPr: false,
+        },
       });
 
-      expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
-        'takt_create_issue_and_enqueue_task',
-        'takt_enqueue_task',
-        'takt_run_next_task',
-      ]);
+      expect(tools.tools.map((tool) => tool.name)).toEqual(['takt_enqueue_task']);
       expect(result.isError).toBeUndefined();
-      expect(JSON.parse(String(result.content[0]?.text))).toEqual({
-        ran: false,
-        message: 'No pending tasks in .takt/tasks.yaml',
-      });
+      expect(JSON.parse(String(result.content[0]?.text))).toEqual(expect.objectContaining({
+        tasksFile: join(cwd, '.takt', 'tasks.yaml'),
+        workflow: 'default',
+      }));
       const stderr = Buffer.concat(stderrChunks).toString('utf-8');
       expect(stderr).not.toMatch(/(?:^|\n)(?:Error|TypeError|ReferenceError|SyntaxError):/u);
       expect(stderr).not.toMatch(/(?:^|\n)\s+at\s+/u);

--- a/src/__tests__/mcp-entrypoint.test.ts
+++ b/src/__tests__/mcp-entrypoint.test.ts
@@ -6,201 +6,99 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { describe, expect, it, vi } from 'vitest';
 import { createTaktMcpServer } from '../app/mcp/server.js';
 
-function objectProperties(schema: unknown): Record<string, Record<string, unknown>> {
-  const value = schema as { properties?: Record<string, Record<string, unknown>> };
-  return value.properties ?? {};
-}
-
 describe('MCP package entrypoint', () => {
-  it('Given package metadata, When bin entries are read, Then takt-mcp points at the stdio MCP entrypoint', () => {
+  it('declares the stdio binary and official MCP SDK', () => {
     const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8')) as {
       bin?: Record<string, string>;
-    };
-
-    expect(packageJson.bin).toEqual(expect.objectContaining({
-      'takt-mcp': './dist/app/mcp/index.js',
-    }));
-  });
-
-  it('Given package metadata, When dependencies are read, Then the official MCP TypeScript SDK is declared', () => {
-    const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8')) as {
       dependencies?: Record<string, string>;
     };
-
-    expect(packageJson.dependencies).toEqual(expect.objectContaining({
-      '@modelcontextprotocol/sdk': expect.any(String),
-    }));
+    expect(packageJson.bin?.['takt-mcp']).toBe('./dist/app/mcp/index.js');
+    expect(packageJson.dependencies?.['@modelcontextprotocol/sdk']).toEqual(expect.any(String));
   });
 
-  it('Given the source entrypoint, When it is imported, Then it exports the stdio connector function', async () => {
-    const mcpEntrypoint = await import('../app/mcp/index.js') as {
+  it('exports the stdio connector', async () => {
+    const entrypoint = await import('../app/mcp/index.js') as {
       connectTaktMcpServerToStdio?: unknown;
     };
-
-    expect(mcpEntrypoint.connectTaktMcpServerToStdio).toEqual(expect.any(Function));
+    expect(entrypoint.connectTaktMcpServerToStdio).toEqual(expect.any(Function));
   });
 
-  it('Given an MCP client connection, When tools are listed, Then TAKT tools and schemas are exposed', async () => {
+  it('exposes only takt_enqueue_task with nested issue input', async () => {
     const server = createTaktMcpServer();
     const client = new Client({ name: 'takt-mcp-test-client', version: '1.0.0' });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8')) as {
-      version: string;
-    };
-
     try {
       await server.connect(serverTransport);
       await client.connect(clientTransport);
-
-      expect(client.getServerVersion()).toEqual({
-        name: 'takt',
-        version: packageJson.version,
-      });
-
       const tools = await client.listTools();
-      const toolsByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
-
-      expect([...toolsByName.keys()].sort()).toEqual([
-        'takt_create_issue_and_enqueue_task',
-        'takt_enqueue_task',
-        'takt_run_next_task',
-      ]);
-      expect(toolsByName.get('takt_enqueue_task')).toEqual(expect.objectContaining({
+      expect(tools.tools.map((tool) => tool.name)).toEqual(['takt_enqueue_task']);
+      expect(tools.tools[0]).toEqual(expect.objectContaining({
         title: 'Enqueue TAKT task',
         inputSchema: expect.objectContaining({
           type: 'object',
           required: expect.arrayContaining(['cwd', 'task', 'workflow', 'autoPr']),
+          properties: expect.objectContaining({ issue: expect.any(Object) }),
         }),
       }));
-      expect(toolsByName.get('takt_create_issue_and_enqueue_task')?.inputSchema.properties).toEqual(
-        expect.objectContaining({
-          labels: expect.any(Object),
-        }),
-      );
-      expect(toolsByName.get('takt_run_next_task')?.inputSchema.required).toEqual(['cwd']);
-
-      const enqueueProperties = objectProperties(toolsByName.get('takt_enqueue_task')?.inputSchema);
-      const issueProperties = objectProperties(toolsByName.get('takt_create_issue_and_enqueue_task')?.inputSchema);
-      const runNextProperties = objectProperties(toolsByName.get('takt_run_next_task')?.inputSchema);
-      const enqueueTaskContext = objectProperties(enqueueProperties.taskContext);
-      const runNextTaskContext = objectProperties(runNextProperties.taskContext);
-
-      expect(enqueueProperties.workflow?.description).toBe('Workflow identifier to store on the queued task. Ask the user which workflow to use before enqueueing.');
-      expect(enqueueProperties.worktree?.description).toBe('Whether the queued task should run in a TAKT-managed worktree. When true, successful execution attempts to auto-commit resulting changes locally; autoPr false does not disable that.');
-      expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should push the branch and automatically open a pull request. Ask the user before enqueueing; do not infer this from branch or PR context. When false, worktree execution may still auto-commit local changes.');
-      expect(issueProperties.labels?.description).toBe('Issue labels to request from the configured issue provider.');
-      expect(runNextProperties.provider?.description).toBe('Agent provider override for this task execution.');
-      expect(runNextProperties.model?.description).toBe('Model override for this task execution.');
-      expect(enqueueTaskContext.branch?.description).toBe('Plain local Git branch name for task execution context.');
-      expect(enqueueTaskContext.baseBranch?.description).toBe('Plain local Git base branch name used when creating or resolving a task worktree.');
-      expect(enqueueTaskContext.baseBranch?.description).not.toBe(enqueueTaskContext.branch?.description);
-      expect(runNextTaskContext.prNumber?.description).toBe('PR number used as task execution context, not as PR-review provenance.');
     } finally {
       await client.close();
       await server.close();
     }
   });
 
-  it('Given an MCP client connection, When tools are called with root arguments, Then arguments reach TAKT operations', async () => {
-    const cwd = mkdtempSync(join(process.cwd(), '.tmp-takt-mcp-root-'));
-    const saveTaskFile = vi.fn().mockResolvedValue({
-      taskName: '20260702-add-mcp',
-      tasksFile: join(cwd, '.takt', 'tasks.yaml'),
-    });
+  it('routes normal, existing-issue, and create-issue calls through the single tool', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'takt-mcp-root-'));
+    const saveTaskFile = vi.fn()
+      .mockResolvedValueOnce({ taskName: 'normal', tasksFile: join(cwd, '.takt', 'tasks.yaml') })
+      .mockResolvedValueOnce({ taskName: 'existing', tasksFile: join(cwd, '.takt', 'tasks.yaml') })
+      .mockResolvedValueOnce({ taskName: 'created', tasksFile: join(cwd, '.takt', 'tasks.yaml') });
     const createIssueFromTaskResult = vi.fn().mockReturnValue({
       success: true,
       issueNumber: 938,
+      issueUrl: 'https://example.test/issues/938',
     });
-    const task = {
-      name: '20260702-add-mcp',
-      content: 'Task: 20260702-add-mcp',
-      filePath: join(cwd, '.takt', 'tasks', '20260702-add-mcp.yaml'),
-      createdAt: '2026-07-02T00:00:00.000Z',
-      status: 'running',
-      data: {
-        task: 'Task: 20260702-add-mcp',
-        workflow: 'default',
-      },
-    };
-    const taskRunner = {
-      failInterruptedRunningTasks: vi.fn(() => 0),
-      claimNextTasks: vi.fn(() => [task]),
-    };
-    const createTaskRunner = vi.fn(() => taskRunner);
-    const executeRunTaskAndCompleteWithDetails = vi.fn().mockResolvedValue({ success: true });
-    const server = createTaktMcpServer({
-      saveTaskFile,
-      createIssueFromTaskResult,
-      createTaskRunner,
-      executeRunTaskAndCompleteWithDetails,
-    });
+    const server = createTaktMcpServer(
+      { saveTaskFile, createIssueFromTaskResult },
+      { allowedProjectRoot: cwd },
+    );
     const client = new Client({ name: 'takt-mcp-test-client', version: '1.0.0' });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
     try {
       await server.connect(serverTransport);
       await client.connect(clientTransport);
-
+      await client.callTool({
+        name: 'takt_enqueue_task',
+        arguments: { cwd, task: 'Normal', workflow: 'default', autoPr: false },
+      });
       await client.callTool({
         name: 'takt_enqueue_task',
         arguments: {
           cwd,
-          task: 'Implement MCP support',
-          workflow: 'review',
-          autoPr: false,
-        },
-      });
-      await client.callTool({
-        name: 'takt_create_issue_and_enqueue_task',
-        arguments: {
-          cwd,
-          task: 'Implement MCP support',
+          task: 'Existing',
           workflow: 'default',
           autoPr: false,
-          labels: ['enhancement'],
+          issue: { number: 937 },
         },
       });
-      await client.callTool({
-        name: 'takt_run_next_task',
+      const created = await client.callTool({
+        name: 'takt_enqueue_task',
         arguments: {
           cwd,
-          provider: 'mock',
-          model: 'mock-model',
+          task: 'Created',
+          workflow: 'default',
+          autoPr: false,
+          issue: { create: true, title: 'Explicit title', labels: ['mcp'] },
         },
       });
-
-      expect(saveTaskFile).toHaveBeenNthCalledWith(1, cwd, 'Implement MCP support', {
-        workflow: 'review',
-        worktree: true,
-        autoPr: false,
-      });
-      expect(createIssueFromTaskResult).toHaveBeenCalledWith('Implement MCP support', expect.objectContaining({
-        cwd,
-        labels: ['enhancement'],
-        outputMode: 'silent',
+      expect(created.isError).toBeUndefined();
+      expect(JSON.parse(String(created.content[0]?.text))).toEqual(expect.objectContaining({
+        issueNumber: 938,
       }));
-      expect(saveTaskFile).toHaveBeenNthCalledWith(2, cwd, 'Implement MCP support', {
-        workflow: 'default',
-        worktree: true,
-        autoPr: false,
-        issue: 938,
-      });
-      expect(createTaskRunner).toHaveBeenCalledWith(cwd);
-      expect(executeRunTaskAndCompleteWithDetails).toHaveBeenCalledWith(
-        task,
-        taskRunner,
-        cwd,
-        {
-          provider: 'mock',
-          model: 'mock-model',
-        },
-        expect.objectContaining({
-          outputMode: 'silent',
-        }),
-        expect.objectContaining({
-          gitProvider: expect.any(Object),
-        }),
-      );
+      expect(saveTaskFile).toHaveBeenCalledTimes(3);
+      expect(createIssueFromTaskResult).toHaveBeenCalledWith('Created', expect.objectContaining({
+        explicitTitle: 'Explicit title',
+        labels: ['mcp'],
+      }));
     } finally {
       await client.close();
       await server.close();
@@ -208,68 +106,72 @@ describe('MCP package entrypoint', () => {
     }
   });
 
-  it('Given a cwd outside the MCP server root, When a tool is called, Then the operation is rejected before saving', async () => {
-    const allowedRoot = mkdtempSync(join(tmpdir(), 'takt-mcp-allowed-'));
-    const outsideRoot = mkdtempSync(join(tmpdir(), 'takt-mcp-outside-'));
-    const saveTaskFile = vi.fn();
-    const server = createTaktMcpServer({ saveTaskFile }, { allowedProjectRoot: allowedRoot });
+  it('returns a structured partial-success result through a real MCP client', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'takt-mcp-partial-'));
+    const server = createTaktMcpServer({
+      saveTaskFile: vi.fn().mockRejectedValue(new Error('EACCES: permission denied')),
+      createIssueFromTaskResult: vi.fn().mockReturnValue({
+        success: true,
+        issueNumber: 938,
+        issueUrl: 'https://example.test/issues/938',
+      }),
+    }, { allowedProjectRoot: cwd });
     const client = new Client({ name: 'takt-mcp-test-client', version: '1.0.0' });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
     try {
       await server.connect(serverTransport);
       await client.connect(clientTransport);
-
       const result = await client.callTool({
         name: 'takt_enqueue_task',
         arguments: {
-          cwd: outsideRoot,
-          task: 'Implement MCP support',
+          cwd,
+          task: 'Created',
           workflow: 'default',
           autoPr: false,
+          issue: { create: true },
         },
       });
-
       expect(result.isError).toBe(true);
-      expect(String(result.content[0]?.text)).toContain('outside the allowed project root');
-      expect(saveTaskFile).not.toHaveBeenCalled();
+      expect(JSON.parse(String(result.content[0]?.text))).toEqual({
+        issueCreated: true,
+        issueNumber: 938,
+        issueUrl: 'https://example.test/issues/938',
+        taskEnqueued: false,
+        stage: 'task_saving',
+        error: 'permission denied',
+      });
     } finally {
       await client.close();
       await server.close();
-      rmSync(allowedRoot, { recursive: true, force: true });
-      rmSync(outsideRoot, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
     }
   });
 
-  it('Given an MCP client connection, When response-envelope input is sent, Then the tool call is rejected before operations run', async () => {
+  it('rejects removed tools and invalid nested issue shapes before saving', async () => {
     const saveTaskFile = vi.fn();
     const server = createTaktMcpServer({ saveTaskFile });
     const client = new Client({ name: 'takt-mcp-test-client', version: '1.0.0' });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
     try {
       await server.connect(serverTransport);
       await client.connect(clientTransport);
-
-      const result = await client.callTool({
+      const removed = await client.callTool({
+        name: 'takt_run_next_task',
+        arguments: { cwd: '/repo' },
+      });
+      expect(removed.isError).toBe(true);
+      expect(String(removed.content[0]?.text)).toContain('not found');
+      const invalid = await client.callTool({
         name: 'takt_enqueue_task',
         arguments: {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              cwd: '/repo',
-              task: 'Implement MCP support',
-            }),
-          }],
+          cwd: '/repo',
+          task: 'Invalid',
+          workflow: 'default',
+          autoPr: false,
+          issue: { number: 938, create: true },
         },
       });
-
-      expect(result.isError).toBe(true);
-      expect(result.content).toEqual([
-        expect.objectContaining({
-          text: expect.stringMatching(/cwd|task/i),
-        }),
-      ]);
+      expect(invalid.isError).toBe(true);
       expect(saveTaskFile).not.toHaveBeenCalled();
     } finally {
       await client.close();

--- a/src/__tests__/mcp-entrypoint.test.ts
+++ b/src/__tests__/mcp-entrypoint.test.ts
@@ -95,6 +95,12 @@ describe('MCP package entrypoint', () => {
         issueNumber: 938,
       }));
       expect(saveTaskFile).toHaveBeenCalledTimes(3);
+      expect(saveTaskFile).toHaveBeenNthCalledWith(2, cwd, 'Existing', {
+        workflow: 'default',
+        worktree: true,
+        autoPr: false,
+        issue: 937,
+      }, undefined, expect.any(AbortSignal));
       expect(createIssueFromTaskResult).toHaveBeenCalledWith('Created', expect.objectContaining({
         explicitTitle: 'Explicit title',
         labels: ['mcp'],

--- a/src/__tests__/mcpOperations.test.ts
+++ b/src/__tests__/mcpOperations.test.ts
@@ -1,48 +1,16 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { parse as parseYaml } from 'yaml';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  createIssueAndEnqueueTaktTask as createIssueAndEnqueueTaktTaskOperation,
-  enqueueTaktTask as enqueueTaktTaskOperation,
-  type McpOperationDependencies,
-  runNextTaktTask,
-} from '../features/mcp/operations.js';
-import type {
-  CreateIssueAndEnqueueTaskInput,
-  EnqueueTaskInput,
-} from '../features/mcp/schemas.js';
-import { TaskRunner, type TaskInfo } from '../infra/task/index.js';
+import { enqueueTaktTask, type McpOperationDependencies } from '../features/mcp/operations.js';
+import type { EnqueueTaskInput } from '../features/mcp/schemas.js';
 
-vi.mock('../infra/task/summarize.js', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  summarizeTaskName: vi.fn().mockResolvedValue('implement-mcp-support'),
-}));
-
-const {
-  mockCreateIssue,
-  mockCloseIssue,
-  mockInitGitProvider,
-  mockIssueInfo,
-  mockIssueSuccess,
-  mockIssueError,
-  mockGitProvider,
-  mockGetGitProvider,
-} = vi.hoisted(() => {
+const { mockInitGitProvider, mockGetGitProvider, mockGitProvider } = vi.hoisted(() => {
   const gitProvider = {
     createIssue: vi.fn(),
     closeIssue: vi.fn(),
   };
   return {
-  mockCreateIssue: vi.fn(),
-  mockCloseIssue: vi.fn(),
-  mockInitGitProvider: vi.fn(),
-  mockIssueInfo: vi.fn(),
-    mockIssueSuccess: vi.fn(),
-    mockIssueError: vi.fn(),
-    mockGitProvider: gitProvider,
+    mockInitGitProvider: vi.fn(),
     mockGetGitProvider: vi.fn(() => gitProvider),
+    mockGitProvider: gitProvider,
   };
 });
 
@@ -52,881 +20,210 @@ vi.mock('../infra/git/index.js', async (importOriginal) => ({
   getGitProvider: () => mockGetGitProvider(),
 }));
 
-vi.mock('../shared/ui/index.js', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  info: (...args: unknown[]) => mockIssueInfo(...args),
-  success: (...args: unknown[]) => mockIssueSuccess(...args),
-  error: (...args: unknown[]) => mockIssueError(...args),
-}));
-
-type ToolTextContent = {
-  type: 'text';
-  text: string;
+const baseInput: EnqueueTaskInput = {
+  cwd: '/repo',
+  task: 'Implement MCP support',
+  workflow: 'default',
+  autoPr: false,
 };
 
-type ToolResult = {
-  isError?: boolean;
-  content: ToolTextContent[];
-};
-
-function asToolResult(result: unknown): ToolResult {
-  return result as ToolResult;
+function text(result: Awaited<ReturnType<typeof enqueueTaktTask>>): string {
+  return String(result.content[0]?.text);
 }
 
-function getToolText(result: unknown): string {
-  return asToolResult(result).content.map((item) => item.text).join('\n');
+function json(result: Awaited<ReturnType<typeof enqueueTaktTask>>): Record<string, unknown> {
+  return JSON.parse(text(result)) as Record<string, unknown>;
 }
 
-function parseToolJson(result: unknown): Record<string, unknown> {
-  return JSON.parse(getToolText(result)) as Record<string, unknown>;
+function enqueue(
+  extra: Partial<EnqueueTaskInput> = {},
+  deps: McpOperationDependencies = {},
+  signal?: AbortSignal,
+) {
+  return enqueueTaktTask({ ...baseInput, ...extra }, deps, signal);
 }
 
-const RAW_LOCAL_ERROR = "EACCES: permission denied, open '/Users/nrs/secret/.takt/tasks.yaml'";
-
-type EnqueueInputForTest = Omit<EnqueueTaskInput, 'workflow' | 'autoPr'> & Partial<Pick<EnqueueTaskInput, 'workflow' | 'autoPr'>>;
-type IssueEnqueueInputForTest = Omit<CreateIssueAndEnqueueTaskInput, 'workflow' | 'autoPr'> & Partial<Pick<CreateIssueAndEnqueueTaskInput, 'workflow' | 'autoPr'>>;
-
-function withRequiredTaskOptions<T extends EnqueueInputForTest | IssueEnqueueInputForTest>(input: T): T & {
-  workflow: string;
-  autoPr: boolean;
-} {
-  return {
-    workflow: 'default',
-    autoPr: false,
-    ...input,
-  };
-}
-
-function enqueueTaktTask(input: EnqueueInputForTest, deps?: McpOperationDependencies) {
-  return enqueueTaktTaskOperation(withRequiredTaskOptions(input), deps);
-}
-
-function createIssueAndEnqueueTaktTask(input: IssueEnqueueInputForTest, deps?: McpOperationDependencies) {
-  return createIssueAndEnqueueTaktTaskOperation(withRequiredTaskOptions(input), deps);
-}
-
-function expectNoRawLocalError(result: unknown): void {
-  const text = getToolText(result);
-  expect(text).not.toContain('/Users/nrs/secret');
-  expect(text).not.toContain('.takt/tasks.yaml');
-  expect(text).not.toContain('EACCES');
-}
-
-function loadTasks(cwd: string): { tasks: Array<Record<string, unknown>> } {
-  const raw = readFileSync(join(cwd, '.takt', 'tasks.yaml'), 'utf-8');
-  return parseYaml(raw) as { tasks: Array<Record<string, unknown>> };
-}
-
-function createTask(name: string): TaskInfo {
-  return {
-    name,
-    content: `Task: ${name}`,
-    filePath: `/repo/.takt/tasks/${name}.yaml`,
-    createdAt: '2026-07-02T00:00:00.000Z',
-    status: 'running',
-    data: {
-      task: `Task: ${name}`,
-      workflow: 'default',
-    },
-  };
-}
-
-describe('MCP task operations', () => {
+describe('MCP enqueue operation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGitProvider.createIssue.mockImplementation((...args: unknown[]) => mockCreateIssue(...args));
-    mockGitProvider.closeIssue.mockImplementation((...args: unknown[]) => mockCloseIssue(...args));
     mockGetGitProvider.mockReturnValue(mockGitProvider);
   });
 
-  it('Given required enqueue input, When takt_enqueue_task runs, Then saveTaskFile receives explicit MCP decisions', async () => {
+  it('enqueues a normal task without initializing an issue provider', async () => {
     const saveTaskFile = vi.fn().mockResolvedValue({
-      taskName: '20260702-add-mcp',
+      taskName: 'normal-task',
       tasksFile: '/repo/.takt/tasks.yaml',
     });
 
-    const result = await enqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      workflow: 'default',
-      autoPr: false,
-    }, { saveTaskFile });
+    const result = await enqueue({}, { saveTaskFile });
 
-    expect(saveTaskFile).toHaveBeenCalledWith('/repo', 'Implement MCP support', {
-      workflow: 'default',
-      worktree: true,
-      autoPr: false,
-    });
     expect(result.isError).toBeUndefined();
-    expect(parseToolJson(result)).toEqual({
-      taskName: '20260702-add-mcp',
-      tasksFile: '/repo/.takt/tasks.yaml',
-      workflow: 'default',
-    });
-  });
-
-  it('Given real enqueue dependencies, When takt_enqueue_task runs, Then a pending task file and order are created', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'takt-mcp-enqueue-'));
-    try {
-      const result = await enqueueTaktTask({
-        cwd,
-        task: 'Implement MCP support\n\nUse the existing task storage path.',
-        workflow: 'review',
-        worktree: true,
-        autoPr: true,
-        taskContext: {
-          branch: 'takt/938/add-mcp',
-          baseBranch: 'main',
-        },
-      });
-
-      const parsedResult = parseToolJson(result);
-      const task = loadTasks(cwd).tasks[0];
-      const taskDir = join(cwd, String(task?.task_dir));
-
-      expect(result.isError).toBeUndefined();
-      expect(parsedResult.tasksFile).toBe(join(cwd, '.takt', 'tasks.yaml'));
-      expect(parsedResult.workflow).toBe('review');
-      expect(task).toEqual(expect.objectContaining({
-        workflow: 'review',
-        worktree: true,
-        branch: 'takt/938/add-mcp',
-        base_branch: 'main',
-        auto_pr: true,
-        slug: 'implement-mcp-support',
-      }));
-      expect(existsSync(join(taskDir, 'order.md'))).toBe(true);
-      expect(readFileSync(join(taskDir, 'order.md'), 'utf-8')).toContain('Implement MCP support');
-    } finally {
-      rmSync(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('Given explicit task options, When takt_enqueue_task runs, Then options reach task saving', async () => {
-    const saveTaskFile = vi.fn().mockResolvedValue({
-      taskName: '20260702-add-mcp',
-      tasksFile: '/repo/.takt/tasks.yaml',
-    });
-
-    await enqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      workflow: 'review',
-      worktree: true,
-      autoPr: true,
-      taskContext: {
-        branch: 'takt/938/add-mcp',
-        baseBranch: 'main',
-        prNumber: 938,
-      },
-    }, { saveTaskFile });
-
     expect(saveTaskFile).toHaveBeenCalledWith('/repo', 'Implement MCP support', {
-      workflow: 'review',
+      workflow: 'default',
       worktree: true,
-      autoPr: true,
-      branch: 'takt/938/add-mcp',
-      baseBranch: 'main',
-      contextPrNumber: 938,
+      autoPr: false,
     });
+    expect(mockInitGitProvider).not.toHaveBeenCalled();
   });
 
-  it('Given PR context on normal enqueue, When the task is saved, Then it does not become PR review provenance', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'takt-mcp-pr-context-'));
-    try {
-      const result = await enqueueTaktTask({
-        cwd,
-        task: 'Implement MCP support',
-        taskContext: {
-          prNumber: 938,
-        },
-      });
-      const task = loadTasks(cwd).tasks[0];
-
-      expect(result.isError).toBeUndefined();
-      expect(task).toMatchObject({
-        context_pr_number: 938,
-        workflow: 'default',
-      });
-      expect(task).not.toHaveProperty('source');
-      expect(task).not.toHaveProperty('pr_number');
-    } finally {
-      rmSync(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('Given real issue and task dependencies, When issue creation succeeds, Then the task is saved with the issue number', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'takt-mcp-issue-enqueue-'));
-    mockCreateIssue.mockReturnValue({
-      success: true,
-      issueNumber: 938,
-      url: 'https://github.com/nrslib/takt/issues/938',
+  it('links an existing issue without creating another issue', async () => {
+    const saveTaskFile = vi.fn().mockResolvedValue({
+      taskName: 'existing-issue-task',
+      tasksFile: '/repo/.takt/tasks.yaml',
     });
 
-    try {
-      const result = await createIssueAndEnqueueTaktTask({
-        cwd,
-        task: 'Implement MCP support\n\nUse the existing task storage path.',
-        labels: ['enhancement', 'mcp'],
-      });
-      const task = loadTasks(cwd).tasks[0];
+    const result = await enqueue({ issue: { number: 938 } }, { saveTaskFile });
 
-      expect(mockInitGitProvider).toHaveBeenCalledWith(cwd);
-      expect(mockCreateIssue).toHaveBeenCalledWith(
-        {
-          title: 'Implement MCP support',
-          body: 'Implement MCP support\n\nUse the existing task storage path.',
-          labels: ['enhancement', 'mcp'],
-        },
-        cwd,
-      );
-      expect(result.isError).toBeUndefined();
-      expect(parseToolJson(result)).toMatchObject({
-        tasksFile: join(cwd, '.takt', 'tasks.yaml'),
-        workflow: 'default',
-        issueNumber: 938,
-      });
-      expect(task).toEqual(expect.objectContaining({
-        issue: 938,
-        workflow: 'default',
-        worktree: true,
-        auto_pr: false,
-        slug: 'implement-mcp-support',
-      }));
-      expect(mockIssueInfo).not.toHaveBeenCalled();
-      expect(mockIssueSuccess).not.toHaveBeenCalled();
-      expect(mockIssueError).not.toHaveBeenCalled();
-    } finally {
-      rmSync(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('Given boundary whitespace in task content, When issue enqueue runs, Then issue body and saved order preserve the original body', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'takt-mcp-issue-body-'));
-    const taskBody = '\n# Implement MCP support\n\nKeep trailing whitespace.  \n';
-    mockCreateIssue.mockReturnValue({
-      success: true,
-      issueNumber: 938,
-      url: 'https://github.com/nrslib/takt/issues/938',
+    expect(result.isError).toBeUndefined();
+    expect(json(result)).toEqual(expect.objectContaining({ issueNumber: 938 }));
+    expect(saveTaskFile).toHaveBeenCalledWith('/repo', 'Implement MCP support', {
+      workflow: 'default',
+      worktree: true,
+      autoPr: false,
+      issue: 938,
     });
-
-    try {
-      const result = await createIssueAndEnqueueTaktTask({
-        cwd,
-        task: taskBody,
-        labels: ['mcp'],
-      });
-      const task = loadTasks(cwd).tasks[0];
-      const taskDir = join(cwd, String(task?.task_dir));
-
-      expect(result.isError).toBeUndefined();
-      expect(mockCreateIssue).toHaveBeenCalledWith(
-        {
-          title: 'Implement MCP support',
-          body: taskBody,
-          labels: ['mcp'],
-        },
-        cwd,
-      );
-      expect(readFileSync(join(taskDir, 'order.md'), 'utf-8')).toBe(taskBody);
-    } finally {
-      rmSync(cwd, { recursive: true, force: true });
-    }
+    expect(mockInitGitProvider).not.toHaveBeenCalled();
   });
 
-  it('Given issue enqueue input, When issue creation fails, Then saving is skipped and an MCP error is returned', async () => {
-    const createIssueFromTaskResult = vi.fn().mockReturnValue({
-      success: false,
-      error: 'GitHub CLI is not authenticated',
+  it('creates an issue from the unchanged task body, explicit title, and labels', async () => {
+    const task = '\n# Implement MCP support\n\nKeep whitespace.  \n';
+    const saveTaskFile = vi.fn().mockResolvedValue({
+      taskName: 'created-issue-task',
+      tasksFile: '/repo/.takt/tasks.yaml',
     });
-    const saveTaskFile = vi.fn();
-
-    const result = await createIssueAndEnqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { createIssueFromTaskResult, saveTaskFile });
-
-    expect(result.isError).toBe(true);
-    expect(getToolText(result)).toContain('GitHub CLI is not authenticated');
-    expect(saveTaskFile).not.toHaveBeenCalled();
-  });
-
-  it('Given issue enqueue cwd outside the MCP root, When the operation runs, Then issue creation and saving are skipped', async () => {
-    const allowedRoot = mkdtempSync(join(tmpdir(), 'takt-mcp-allowed-'));
-    const outsideRoot = mkdtempSync(join(tmpdir(), 'takt-mcp-outside-'));
-    const createIssueFromTaskResult = vi.fn();
-    const saveTaskFile = vi.fn();
-
-    try {
-      const result = await createIssueAndEnqueueTaktTask({
-        cwd: outsideRoot,
-        task: 'Implement MCP support',
-      }, {
-        allowedProjectRoot: allowedRoot,
-        createIssueFromTaskResult,
-        saveTaskFile,
-      });
-
-      expect(result.isError).toBe(true);
-      expect(getToolText(result)).toContain('outside the allowed project root');
-      expect(mockInitGitProvider).not.toHaveBeenCalled();
-      expect(createIssueFromTaskResult).not.toHaveBeenCalled();
-      expect(saveTaskFile).not.toHaveBeenCalled();
-    } finally {
-      rmSync(allowedRoot, { recursive: true, force: true });
-      rmSync(outsideRoot, { recursive: true, force: true });
-    }
-  });
-
-  it('Given issue creation fails with a local error, When issue enqueue runs, Then the MCP error does not expose the raw error', async () => {
-    const createIssueFromTaskResult = vi.fn().mockReturnValue({
-      success: false,
-      error: RAW_LOCAL_ERROR,
-    });
-    const saveTaskFile = vi.fn();
-
-    const result = await createIssueAndEnqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { createIssueFromTaskResult, saveTaskFile });
-
-    expect(result.isError).toBe(true);
-    expect(getToolText(result)).toBe('permission denied');
-    expectNoRawLocalError(result);
-    expect(saveTaskFile).not.toHaveBeenCalled();
-  });
-
-  it('Given real issue creation fails, When issue enqueue runs, Then saving is skipped and UI output stays silent', async () => {
-    mockCreateIssue.mockReturnValue({
-      success: false,
-      error: 'GitHub CLI is not authenticated',
-    });
-    const saveTaskFile = vi.fn();
-
-    const result = await createIssueAndEnqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      labels: ['enhancement'],
-    }, { saveTaskFile });
-
-    expect(mockInitGitProvider).toHaveBeenCalledWith('/repo');
-    expect(mockCreateIssue).toHaveBeenCalledWith(
-      {
-        title: 'Implement MCP support',
-        body: 'Implement MCP support',
-        labels: ['enhancement'],
-      },
-      '/repo',
-    );
-    expect(result.isError).toBe(true);
-    expect(getToolText(result)).toContain('GitHub CLI is not authenticated');
-    expect(saveTaskFile).not.toHaveBeenCalled();
-    expect(mockIssueInfo).not.toHaveBeenCalled();
-    expect(mockIssueSuccess).not.toHaveBeenCalled();
-    expect(mockIssueError).not.toHaveBeenCalled();
-  });
-
-  it('Given issue creation succeeds but task saving fails, When issue enqueue runs, Then the created issue is closed', async () => {
     const createIssueFromTaskResult = vi.fn().mockReturnValue({
       success: true,
       issueNumber: 938,
-    });
-    const saveTaskFile = vi.fn().mockRejectedValue(new Error('EACCES: permission denied'));
-    const compensateCreatedIssue: NonNullable<McpOperationDependencies['compensateCreatedIssue']> = vi.fn((input) => {
-      expect(input.stage).toBe('task_saving');
-      return { success: true };
+      issueUrl: 'https://example.test/issues/938',
     });
 
-    const result = await createIssueAndEnqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { createIssueFromTaskResult, saveTaskFile, compensateCreatedIssue });
-
-    expect(result.isError).toBe(true);
-    expect(compensateCreatedIssue).toHaveBeenCalledWith({
-      cwd: '/repo',
-      gitProvider: mockGitProvider,
-      issueNumber: 938,
-      stage: 'task_saving',
-    });
-    expect(getToolText(result)).toContain('Issue #938 was created and closed');
-    expect(getToolText(result)).toContain('task saving failed: permission denied');
-  });
-
-  it('Given default compensation, When task saving fails after issue creation, Then the Git provider closes the issue without raw local errors', async () => {
-    const createIssueFromTaskResult = vi.fn().mockReturnValue({
-      success: true,
-      issueNumber: 938,
-    });
-    const saveTaskFile = vi.fn().mockRejectedValue(
-      new Error(RAW_LOCAL_ERROR),
-    );
-    mockCloseIssue.mockReturnValue({ success: true });
-
-    const result = await createIssueAndEnqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { createIssueFromTaskResult, saveTaskFile });
-
-    expect(result.isError).toBe(true);
-    expect(mockCloseIssue).toHaveBeenCalledWith(
-      938,
-      [
-        'TAKT created this issue, but saving the pending task failed.',
-        '',
-        'The issue is being closed to keep the repository state consistent.',
-      ].join('\n'),
-      '/repo',
-    );
-    const compensationComment = String(mockCloseIssue.mock.calls[0]?.[1]);
-    expect(compensationComment).not.toContain('/Users/nrs/secret');
-    expect(compensationComment).not.toContain('EACCES');
-    expect(getToolText(result)).toContain('task saving failed: permission denied');
-    expectNoRawLocalError(result);
-  });
-
-  it('Given default compensation fails with a local error, When task saving fails after issue creation, Then both MCP errors are sanitized', async () => {
-    const createIssueFromTaskResult = vi.fn().mockReturnValue({
-      success: true,
-      issueNumber: 938,
-    });
-    const saveTaskFile = vi.fn().mockRejectedValue(new Error('EACCES: permission denied'));
-    mockCloseIssue.mockReturnValue({
-      success: false,
-      error: RAW_LOCAL_ERROR,
-    });
-
-    const result = await createIssueAndEnqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { createIssueFromTaskResult, saveTaskFile });
-
-    expect(result.isError).toBe(true);
-    expect(mockCloseIssue).toHaveBeenCalledWith(
-      938,
-      expect.stringContaining('TAKT created this issue'),
-      '/repo',
-    );
-    expect(getToolText(result)).toContain('Issue #938 was created, but task saving failed');
-    expect(getToolText(result)).toContain('task saving failed: permission denied');
-    expect(getToolText(result)).toContain('Issue close failed: permission denied');
-    expectNoRawLocalError(result);
-  });
-
-  it('Given the global provider changes while saving, When compensation runs, Then the request provider closes the issue', async () => {
-    const requestProvider = {
-      createIssue: vi.fn(),
-      closeIssue: vi.fn().mockReturnValue({ success: true }),
-    };
-    const laterProvider = {
-      createIssue: vi.fn(),
-      closeIssue: vi.fn().mockReturnValue({ success: true }),
-    };
-    mockGetGitProvider.mockReturnValueOnce(requestProvider).mockReturnValue(laterProvider);
-    const saveTaskFile = vi.fn().mockImplementation(async () => {
-      throw new Error('EACCES: permission denied');
-    });
-    requestProvider.createIssue.mockReturnValue({
-      success: true,
-      issueNumber: 938,
-    });
-
-    const result = await createIssueAndEnqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { saveTaskFile });
-
-    expect(result.isError).toBe(true);
-    expect(requestProvider.createIssue).toHaveBeenCalledTimes(1);
-    expect(requestProvider.closeIssue).toHaveBeenCalledWith(
-      938,
-      expect.stringContaining('TAKT created this issue'),
-      '/repo',
-    );
-    expect(laterProvider.closeIssue).not.toHaveBeenCalled();
-  });
-
-  it('Given concurrent issue enqueue requests, When task saving fails, Then each request provider closes its own issue', async () => {
-    const firstProvider = {
-      createIssue: vi.fn().mockReturnValue({ success: true, issueNumber: 101 }),
-      closeIssue: vi.fn().mockReturnValue({ success: true }),
-    };
-    const secondProvider = {
-      createIssue: vi.fn().mockReturnValue({ success: true, issueNumber: 202 }),
-      closeIssue: vi.fn().mockReturnValue({ success: true }),
-    };
-    const fallbackProvider = {
-      createIssue: vi.fn().mockReturnValue({ success: true, issueNumber: 303 }),
-      closeIssue: vi.fn().mockReturnValue({ success: true }),
-    };
-    mockGetGitProvider
-      .mockReturnValueOnce(firstProvider)
-      .mockReturnValueOnce(secondProvider)
-      .mockReturnValue(fallbackProvider);
-    const saveTaskFile = vi.fn().mockRejectedValue(new Error('disk full'));
-
-    const [firstResult, secondResult] = await Promise.all([
-      createIssueAndEnqueueTaktTask({
-        cwd: '/repo-a',
-        task: 'Implement first MCP task',
-      }, { saveTaskFile }),
-      createIssueAndEnqueueTaktTask({
-        cwd: '/repo-b',
-        task: 'Implement second MCP task',
-      }, { saveTaskFile }),
-    ]);
-
-    expect(firstResult.isError).toBe(true);
-    expect(secondResult.isError).toBe(true);
-    expect(firstProvider.createIssue).toHaveBeenCalledTimes(1);
-    expect(secondProvider.createIssue).toHaveBeenCalledTimes(1);
-    expect(firstProvider.closeIssue).toHaveBeenCalledWith(
-      101,
-      expect.stringContaining('TAKT created this issue'),
-      '/repo-a',
-    );
-    expect(secondProvider.closeIssue).toHaveBeenCalledWith(
-      202,
-      expect.stringContaining('TAKT created this issue'),
-      '/repo-b',
-    );
-    expect(fallbackProvider.createIssue).not.toHaveBeenCalled();
-    expect(fallbackProvider.closeIssue).not.toHaveBeenCalled();
-  });
-
-  it('Given a URL appears in an MCP error, When it is sanitized, Then the URL is not treated as a local path', async () => {
-    const saveTaskFile = vi.fn().mockRejectedValue(
-      new Error('Request failed for https://example.com/path'),
-    );
-
-    const result = await enqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { saveTaskFile });
-
-    expect(result.isError).toBe(true);
-    expect(getToolText(result)).toContain('https://example.com/path');
-  });
-
-  it('Given secrets and a file URL appear in an MCP error, When it is sanitized, Then secrets and local paths are redacted', async () => {
-    const saveTaskFile = vi.fn().mockRejectedValue(
-      new Error(
-        'Request failed\n' +
-        'Authorization: Bearer ghp_123456789\n' +
-        'api_key=plain-secret\n' +
-        'https://user:pass@example.com/repo\n' +
-        'file:///Users/nrs/secret/token.txt',
-      ),
-    );
-
-    const result = await enqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { saveTaskFile });
-
-    const text = getToolText(result);
-    expect(result.isError).toBe(true);
-    expect(text).toContain('Authorization: Bearer [REDACTED]');
-    expect(text).toContain('api_key=[REDACTED]');
-    expect(text).toContain('https://[REDACTED]@example.com/repo');
-    expect(text).toContain('[path]');
-    expect(text).not.toContain('ghp_123456789');
-    expect(text).not.toContain('plain-secret');
-    expect(text).not.toContain('user:pass');
-    expect(text).not.toContain('/Users/nrs/secret');
-    expect(text).not.toContain('file:///Users/nrs/secret');
-  });
-
-  it('Given a file URL appears in an MCP error, When it is sanitized, Then the local path is not exposed', async () => {
-    const saveTaskFile = vi.fn().mockRejectedValue(
-      new Error('Cannot read file:///Users/nrs/secret/order.md'),
-    );
-
-    const result = await enqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { saveTaskFile });
-
-    expect(result.isError).toBe(true);
-    expect(getToolText(result)).toBe('Task saving failed: Cannot read [path]');
-    expect(getToolText(result)).not.toContain('file:///Users/nrs/secret');
-    expect(getToolText(result)).not.toContain('/Users/nrs/secret');
-  });
-
-  it('Given issue close compensation fails, When task saving fails after issue creation, Then both failures are returned', async () => {
-    const createIssueFromTaskResult = vi.fn().mockReturnValue({
-      success: true,
-      issueNumber: 938,
-    });
-    const saveTaskFile = vi.fn().mockRejectedValue(new Error('EACCES: permission denied'));
-    const compensateCreatedIssue = vi.fn().mockReturnValue({
-      success: false,
-      commentCreated: true,
-      error: 'GitHub CLI is not authenticated',
-    });
-
-    const result = await createIssueAndEnqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { createIssueFromTaskResult, saveTaskFile, compensateCreatedIssue });
-
-    expect(result.isError).toBe(true);
-    expect(getToolText(result)).toContain('Issue #938 was created, but task saving failed');
-    expect(getToolText(result)).toContain('task saving failed: permission denied');
-    expect(getToolText(result)).toContain(
-      'Issue compensation comment was created, but issue close failed: GitHub CLI is not authenticated',
-    );
-  });
-
-  it('Given task saving fails with a local path, When enqueue runs, Then the MCP error does not expose the path', async () => {
-    const saveTaskFile = vi.fn().mockRejectedValue(
-      new Error(RAW_LOCAL_ERROR),
-    );
-
-    const result = await enqueueTaktTask({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    }, { saveTaskFile });
-
-    expect(result.isError).toBe(true);
-    expect(getToolText(result)).toBe('Task saving failed: permission denied');
-    expectNoRawLocalError(result);
-  });
-
-  it('Given one pending task, When takt_run_next_task runs, Then only that task reaches the existing execution path', async () => {
-    const task = createTask('20260702-add-mcp');
-    const taskRunner = {
-      failInterruptedRunningTasks: vi.fn(() => 0),
-      claimNextTasks: vi.fn(() => [task]),
-    };
-    const createTaskRunner = vi.fn(() => taskRunner);
-    const executeRunTaskAndCompleteWithDetails = vi.fn().mockResolvedValue({ success: true });
-
-    const result = await runNextTaktTask({
-      cwd: '/repo',
-      provider: 'mock',
-      model: 'mock-model',
-      taskContext: {
-        branch: 'takt/938/add-mcp',
-        baseBranch: 'main',
-        prNumber: 938,
-      },
-    }, { createTaskRunner, executeRunTaskAndCompleteWithDetails });
-
-    expect(mockInitGitProvider).toHaveBeenCalledWith('/repo');
-    expect(createTaskRunner).toHaveBeenCalledWith('/repo');
-    expect(taskRunner.failInterruptedRunningTasks).toHaveBeenCalledTimes(1);
-    expect(taskRunner.claimNextTasks).toHaveBeenCalledWith(1);
-    expect(executeRunTaskAndCompleteWithDetails).toHaveBeenCalledWith(
+    const result = await enqueue({
       task,
-      taskRunner,
-      '/repo',
-      {
-        provider: 'mock',
-        model: 'mock-model',
-      },
-      expect.objectContaining({
-        outputMode: 'silent',
-      }),
-      {
-        gitProvider: mockGitProvider,
-        taskContext: {
-          branch: 'takt/938/add-mcp',
-          baseBranch: 'main',
-          prNumber: 938,
-        },
-      },
-    );
+      issue: { create: true, title: 'MCP consolidation', labels: ['enhancement'] },
+    }, { saveTaskFile, createIssueFromTaskResult });
+
     expect(result.isError).toBeUndefined();
-    expect(parseToolJson(result)).toMatchObject({
-      ran: true,
-      taskName: '20260702-add-mcp',
-      success: true,
-    });
-  });
-
-  it('Given concurrent run-next requests, When tasks execute, Then each execution receives its request provider', async () => {
-    const firstProvider = { name: 'first-provider' };
-    const secondProvider = { name: 'second-provider' };
-    mockGetGitProvider
-      .mockReturnValueOnce(firstProvider)
-      .mockReturnValueOnce(secondProvider);
-    const firstTask = createTask('20260702-first-mcp-task');
-    const secondTask = createTask('20260702-second-mcp-task');
-    const taskRunnersByCwd = new Map([
-      ['/repo-a', {
-        failInterruptedRunningTasks: vi.fn(() => 0),
-        claimNextTasks: vi.fn(() => [firstTask]),
-      }],
-      ['/repo-b', {
-        failInterruptedRunningTasks: vi.fn(() => 0),
-        claimNextTasks: vi.fn(() => [secondTask]),
-      }],
-    ]);
-    const createTaskRunner = vi.fn((cwd: string) => {
-      const taskRunner = taskRunnersByCwd.get(cwd);
-      if (!taskRunner) {
-        throw new Error(`Unexpected cwd: ${cwd}`);
-      }
-      return taskRunner;
-    });
-    const executeRunTaskAndCompleteWithDetails = vi.fn().mockResolvedValue({ success: true });
-
-    const [firstResult, secondResult] = await Promise.all([
-      runNextTaktTask({
-        cwd: '/repo-a',
-      }, { createTaskRunner, executeRunTaskAndCompleteWithDetails }),
-      runNextTaktTask({
-        cwd: '/repo-b',
-      }, { createTaskRunner, executeRunTaskAndCompleteWithDetails }),
-    ]);
-
-    expect(firstResult.isError).toBeUndefined();
-    expect(secondResult.isError).toBeUndefined();
-    expect(executeRunTaskAndCompleteWithDetails).toHaveBeenCalledTimes(2);
-    expect(executeRunTaskAndCompleteWithDetails.mock.calls[0]?.[5]).toEqual({
-      gitProvider: firstProvider,
-    });
-    expect(executeRunTaskAndCompleteWithDetails.mock.calls[1]?.[5]).toEqual({
-      gitProvider: secondProvider,
-    });
-  });
-
-  it('Given a real pending task file, When takt_run_next_task runs, Then real TaskRunner claims the task before execution', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'takt-mcp-run-next-'));
-    const executeRunTaskAndCompleteWithDetails = vi.fn().mockResolvedValue({ success: true });
-
-    try {
-      await enqueueTaktTask({
-        cwd,
-        task: 'Implement MCP support\n\nRun through the real task runner.',
-        workflow: 'review',
-      });
-
-      const result = await runNextTaktTask({
-        cwd,
-        provider: 'mock',
-      }, { executeRunTaskAndCompleteWithDetails });
-      const persistedTask = loadTasks(cwd).tasks[0];
-      const executedTask = executeRunTaskAndCompleteWithDetails.mock.calls[0]?.[0] as TaskInfo | undefined;
-      const taskRunner = executeRunTaskAndCompleteWithDetails.mock.calls[0]?.[1] as TaskRunner | undefined;
-
-      expect(mockInitGitProvider).toHaveBeenCalledWith(cwd);
-      expect(executeRunTaskAndCompleteWithDetails).toHaveBeenCalledTimes(1);
-      expect(executedTask).toEqual(expect.objectContaining({
-        name: persistedTask?.name,
-        status: 'running',
-      }));
-      expect(taskRunner).toBeInstanceOf(TaskRunner);
-      expect(persistedTask).toEqual(expect.objectContaining({
-        status: 'running',
-        workflow: 'review',
-        owner_pid: process.pid,
-      }));
-      expect(parseToolJson(result)).toMatchObject({
-        ran: true,
-        taskName: persistedTask?.name,
-        success: true,
-      });
-    } finally {
-      rmSync(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('Given no pending task, When takt_run_next_task runs, Then it returns ran false', async () => {
-    const taskRunner = {
-      failInterruptedRunningTasks: vi.fn(() => 0),
-      claimNextTasks: vi.fn(() => []),
-    };
-    const executeRunTaskAndCompleteWithDetails = vi.fn();
-
-    const result = await runNextTaktTask({
+    expect(mockInitGitProvider).toHaveBeenCalledWith('/repo');
+    expect(createIssueFromTaskResult).toHaveBeenCalledWith(task, expect.objectContaining({
       cwd: '/repo',
-    }, {
-      createTaskRunner: vi.fn(() => taskRunner),
-      executeRunTaskAndCompleteWithDetails,
-    });
-
-    expect(executeRunTaskAndCompleteWithDetails).not.toHaveBeenCalled();
-    expect(result.isError).toBeUndefined();
-    expect(parseToolJson(result)).toEqual({
-      ran: false,
-      message: 'No pending tasks in .takt/tasks.yaml',
+      explicitTitle: 'MCP consolidation',
+      labels: ['enhancement'],
+      outputMode: 'silent',
+      gitProvider: mockGitProvider,
+    }));
+    expect(saveTaskFile).toHaveBeenCalledWith('/repo', task, {
+      workflow: 'default',
+      worktree: true,
+      autoPr: false,
+      issue: 938,
     });
   });
 
-  it('Given run-next cwd outside the MCP root, When the operation runs, Then task claim and execution are skipped', async () => {
-    const allowedRoot = mkdtempSync(join(tmpdir(), 'takt-mcp-allowed-'));
-    const outsideRoot = mkdtempSync(join(tmpdir(), 'takt-mcp-outside-'));
-    const createTaskRunner = vi.fn();
-    const executeRunTaskAndCompleteWithDetails = vi.fn();
-
-    try {
-      const result = await runNextTaktTask({
-        cwd: outsideRoot,
-      }, {
-        allowedProjectRoot: allowedRoot,
-        createTaskRunner,
-        executeRunTaskAndCompleteWithDetails,
-      });
-
-      expect(result.isError).toBe(true);
-      expect(getToolText(result)).toContain('outside the allowed project root');
-      expect(mockInitGitProvider).not.toHaveBeenCalled();
-      expect(createTaskRunner).not.toHaveBeenCalled();
-      expect(executeRunTaskAndCompleteWithDetails).not.toHaveBeenCalled();
-    } finally {
-      rmSync(allowedRoot, { recursive: true, force: true });
-      rmSync(outsideRoot, { recursive: true, force: true });
-    }
-  });
-
-  it('Given a claimed task, When execution fails, Then an MCP error result includes the failure reason', async () => {
-    const task = createTask('20260702-add-mcp');
-    const taskRunner = {
-      failInterruptedRunningTasks: vi.fn(() => 0),
-      claimNextTasks: vi.fn(() => [task]),
-    };
-    const executeRunTaskAndCompleteWithDetails = vi.fn().mockResolvedValue({
+  it('returns a structured issue creation error and skips saving', async () => {
+    const saveTaskFile = vi.fn();
+    const createIssueFromTaskResult = vi.fn().mockReturnValue({
       success: false,
-      failureReason: RAW_LOCAL_ERROR,
+      error: 'GitHub CLI is not authenticated',
     });
 
-    const result = await runNextTaktTask({
-      cwd: '/repo',
-    }, {
-      createTaskRunner: vi.fn(() => taskRunner),
-      executeRunTaskAndCompleteWithDetails,
+    const result = await enqueue({ issue: { create: true } }, {
+      saveTaskFile,
+      createIssueFromTaskResult,
     });
 
     expect(result.isError).toBe(true);
-    expect(getToolText(result)).toContain('20260702-add-mcp');
-    expect(getToolText(result)).toContain('permission denied');
-    expectNoRawLocalError(result);
+    expect(json(result)).toEqual({
+      issueCreated: false,
+      taskEnqueued: false,
+      stage: 'issue_creation',
+      error: 'GitHub CLI is not authenticated',
+    });
+    expect(saveTaskFile).not.toHaveBeenCalled();
   });
 
-  it('Given a claimed task, When PR post-execution fails, Then an MCP error result includes the PR failure reason', async () => {
-    const task = createTask('20260702-add-mcp');
-    const taskRunner = {
-      failInterruptedRunningTasks: vi.fn(() => 0),
-      claimNextTasks: vi.fn(() => [task]),
-    };
-    const executeRunTaskAndCompleteWithDetails = vi.fn().mockResolvedValue({
+  it('keeps a created issue open and returns sanitized retry details when saving fails', async () => {
+    const saveTaskFile = vi.fn().mockRejectedValue(
+      new Error("EACCES: permission denied, open '/Users/reviewer/secret/.takt/tasks.yaml'"),
+    );
+    const createIssueFromTaskResult = vi.fn().mockReturnValue({
       success: true,
-      prFailed: true,
-      postExecutionFailureReason: RAW_LOCAL_ERROR,
+      issueNumber: 938,
+      issueUrl: 'https://user:secret@example.test/issues/938?token=secret#fragment',
     });
 
-    const result = await runNextTaktTask({
-      cwd: '/repo',
-    }, {
-      createTaskRunner: vi.fn(() => taskRunner),
-      executeRunTaskAndCompleteWithDetails,
+    const result = await enqueue({ issue: { create: true } }, {
+      saveTaskFile,
+      createIssueFromTaskResult,
     });
 
     expect(result.isError).toBe(true);
-    expect(getToolText(result)).toContain('20260702-add-mcp');
-    expect(getToolText(result)).toContain('permission denied');
-    expectNoRawLocalError(result);
+    expect(json(result)).toEqual({
+      issueCreated: true,
+      issueNumber: 938,
+      issueUrl: 'https://example.test/issues/938',
+      taskEnqueued: false,
+      stage: 'task_saving',
+      error: 'permission denied',
+    });
+    expect(mockGitProvider.closeIssue).not.toHaveBeenCalled();
+  });
+
+  it('reports issue-number parsing as partial success without an issue number', async () => {
+    const saveTaskFile = vi.fn();
+    const createIssueFromTaskResult = vi.fn().mockReturnValue({
+      success: false,
+      issueCreated: true,
+      issueUrl: 'https://example.test/issues/unknown',
+      error: 'Failed to extract issue number',
+    });
+
+    const result = await enqueue({ issue: { create: true } }, {
+      saveTaskFile,
+      createIssueFromTaskResult,
+    });
+
+    expect(json(result)).toEqual({
+      issueCreated: true,
+      issueUrl: 'https://example.test/issues/unknown',
+      taskEnqueued: false,
+      stage: 'issue_number_parsing',
+      error: 'Failed to extract issue number',
+    });
+    expect(saveTaskFile).not.toHaveBeenCalled();
+  });
+
+  it('returns cancellation details after issue creation and does not close the issue', async () => {
+    const controller = new AbortController();
+    const saveTaskFile = vi.fn();
+    const createIssueFromTaskResult = vi.fn(() => {
+      setImmediate(() => controller.abort());
+      return { success: true as const, issueNumber: 938 };
+    });
+
+    const result = await enqueue({ issue: { create: true } }, {
+      saveTaskFile,
+      createIssueFromTaskResult,
+    }, controller.signal);
+
+    expect(json(result)).toEqual({
+      issueCreated: true,
+      issueNumber: 938,
+      taskEnqueued: false,
+      stage: 'cancelled_after_issue_creation',
+      error: 'Task enqueue was cancelled.',
+    });
+    expect(saveTaskFile).not.toHaveBeenCalled();
+    expect(mockGitProvider.closeIssue).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes normal enqueue failures', async () => {
+    const saveTaskFile = vi.fn().mockRejectedValue(
+      new Error("EACCES: permission denied, open '/Users/reviewer/secret/.takt/tasks.yaml'"),
+    );
+
+    const result = await enqueue({}, { saveTaskFile });
+
+    expect(result.isError).toBe(true);
+    expect(text(result)).toBe('Task enqueue failed: permission denied');
   });
 });

--- a/src/__tests__/mcpSchemas.test.ts
+++ b/src/__tests__/mcpSchemas.test.ts
@@ -1,236 +1,89 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import {
-  createIssueAndEnqueueTaskInputSchema,
-  enqueueTaskInputSchema,
-  runNextTaskInputSchema,
-} from '../features/mcp/schemas.js';
+import { enqueueTaskInputSchema } from '../features/mcp/schemas.js';
 
-type JsonSchemaObject = {
-  description?: string;
-  properties?: Record<string, JsonSchemaObject>;
-};
+const required = {
+  cwd: '/repo',
+  task: 'Implement MCP support',
+  workflow: 'default',
+  autoPr: false,
+} as const;
 
-function schemaProperties(schema: JsonSchemaObject): Record<string, JsonSchemaObject> {
-  if (schema.properties === undefined) {
-    throw new Error('Expected JSON Schema object with properties');
-  }
-  return schema.properties;
-}
-
-function requireSchema(schema: JsonSchemaObject | undefined, name: string): JsonSchemaObject {
-  if (schema === undefined) {
-    throw new Error(`Expected JSON Schema property: ${name}`);
-  }
-  return schema;
-}
-
-describe('MCP tool input schemas', () => {
-  const requiredTaskOptions = {
-    workflow: 'default',
-    autoPr: false,
-  } as const;
-
-  it('Given root tool arguments, When enqueue input is parsed, Then task settings are preserved', () => {
-    const parsed = enqueueTaskInputSchema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      workflow: 'review',
-      worktree: true,
-      autoPr: true,
-      taskContext: {
-        branch: 'takt/938/add-mcp',
-        baseBranch: 'main',
-        prNumber: 938,
-      },
-    });
-
-    expect(parsed).toEqual({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      workflow: 'review',
-      worktree: true,
-      autoPr: true,
-      taskContext: {
-        branch: 'takt/938/add-mcp',
-        baseBranch: 'main',
-        prNumber: 938,
-      },
-    });
-  });
-
-  it('Given task content with boundary whitespace, When enqueue input is parsed, Then the original task body is preserved', () => {
-    const task = '\n  # Implement MCP support\n\nKeep formatting.  \n';
-
-    const parsed = enqueueTaskInputSchema.parse({
-      cwd: '/repo',
+describe('MCP tool input schema', () => {
+  it('preserves normal enqueue fields and task boundary whitespace', () => {
+    const task = '\n# Implement MCP support\n\nKeep formatting.  \n';
+    expect(enqueueTaskInputSchema.parse({
+      ...required,
       task,
-      ...requiredTaskOptions,
+      worktree: true,
+      taskContext: { branch: 'feature/mcp', baseBranch: 'main', prNumber: 938 },
+    })).toEqual({
+      ...required,
+      task,
+      worktree: true,
+      taskContext: { branch: 'feature/mcp', baseBranch: 'main', prNumber: 938 },
     });
-
-    expect(parsed.task).toBe(task);
   });
 
-  it('Given a response-envelope shaped payload, When enqueue input is parsed, Then it is rejected', () => {
-    expect(() => enqueueTaskInputSchema.parse({
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          cwd: '/repo',
-          task: 'Implement MCP support',
-          ...requiredTaskOptions,
-        }),
-      }],
-    })).toThrow(/cwd|task/i);
-  });
-
-  it('Given a relative cwd, When enqueue input is parsed, Then it is rejected before filesystem work', () => {
-    expect(() => enqueueTaskInputSchema.parse({
-      cwd: 'relative/repo',
-      task: 'Implement MCP support',
-      ...requiredTaskOptions,
-    })).toThrow(/absolute/i);
-  });
-
-  it('Given enqueue input without workflow or autoPr, When parsing, Then it asks callers to provide both decisions', () => {
-    expect(() => enqueueTaskInputSchema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    })).toThrow(/workflow|autoPr/i);
-    expect(() => createIssueAndEnqueueTaskInputSchema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-    })).toThrow(/workflow|autoPr/i);
-  });
-
-  it.each([
-    ['enqueue', enqueueTaskInputSchema],
-    ['issue enqueue', createIssueAndEnqueueTaskInputSchema],
-  ])('Given %s input missing one task decision, When parsing, Then each decision is required independently', (_name, schema) => {
-    expect(() => schema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      autoPr: false,
-    })).toThrow(/workflow/i);
-    expect(() => schema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      workflow: 'default',
-    })).toThrow(/autoPr/i);
-  });
-
-  it.each([
-    '/tmp/takt/unsafe-worktree',
-    '../outside-project',
-    'feature/mcp',
-  ])('Given MCP worktree path "%s", When enqueue input is parsed, Then it is rejected', (worktree) => {
-    expect(() => enqueueTaskInputSchema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      ...requiredTaskOptions,
-      worktree,
-    })).toThrow(/boolean|worktree/i);
-  });
-
-  it.each([
-    'HEAD:refs/heads/takt/injected',
-    '@{-1}',
-    '-bad',
-    '--upload-pack=echo',
-    'refs/heads/feature/mcp',
-    'origin/main',
-    'refs/remotes/origin/main',
-    'invalid..name',
-  ])('Given unsafe taskContext branch "%s", When enqueue input is parsed, Then it is rejected', (branch) => {
-    expect(() => enqueueTaskInputSchema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      ...requiredTaskOptions,
-      taskContext: { branch },
-    })).toThrow(/branch|Invalid/i);
-  });
-
-  it('Given labels at the root tool arguments, When issue enqueue input is parsed, Then labels are preserved', () => {
-    const parsed = createIssueAndEnqueueTaskInputSchema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      ...requiredTaskOptions,
+  it('accepts either an existing issue number or issue creation settings', () => {
+    expect(enqueueTaskInputSchema.parse({
+      ...required,
+      issue: { number: 938 },
+    }).issue).toEqual({ number: 938 });
+    expect(enqueueTaskInputSchema.parse({
+      ...required,
+      issue: { create: true, title: 'MCP consolidation', labels: ['enhancement', 'mcp'] },
+    }).issue).toEqual({
+      create: true,
+      title: 'MCP consolidation',
       labels: ['enhancement', 'mcp'],
     });
-
-    expect(parsed.labels).toEqual(['enhancement', 'mcp']);
-    expect(parsed.task).toBe('Implement MCP support');
-  });
-
-  it('Given oversized MCP input fields, When inputs are parsed, Then they are rejected at the tool boundary', () => {
-    expect(() => enqueueTaskInputSchema.parse({
-      cwd: '/repo',
-      task: 'x'.repeat((128 * 1024) + 1),
-      ...requiredTaskOptions,
-    })).toThrow(/too big|maximum|at most/i);
-    expect(() => enqueueTaskInputSchema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      autoPr: false,
-      workflow: 'w'.repeat(129),
-    })).toThrow(/too big|maximum|at most/i);
-    expect(() => createIssueAndEnqueueTaskInputSchema.parse({
-      cwd: '/repo',
-      task: 'Implement MCP support',
-      ...requiredTaskOptions,
-      labels: Array.from({ length: 21 }, (_, index) => `label-${index}`),
-    })).toThrow(/too big|maximum|at most/i);
-    expect(() => runNextTaskInputSchema.parse({
-      cwd: '/repo',
-      model: 'm'.repeat(129),
-    })).toThrow(/too big|maximum|at most/i);
   });
 
   it.each([
-    ['enqueue', enqueueTaskInputSchema, { cwd: '/repo', task: 'Implement MCP support', ...requiredTaskOptions }],
-    ['issue enqueue', createIssueAndEnqueueTaskInputSchema, { cwd: '/repo', task: 'Implement MCP support', ...requiredTaskOptions }],
-    ['run-next', runNextTaskInputSchema, { cwd: '/repo' }],
-  ])('Given unsafe PR numbers, When %s input is parsed, Then they are rejected', (_name, schema, baseInput) => {
-    for (const prNumber of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
-      expect(() => schema.parse({
-        ...baseInput,
-        taskContext: { prNumber },
-      })).toThrow(/prNumber|safe integer|positive/i);
-    }
+    { issue: { number: 0 } },
+    { issue: { number: Number.MAX_SAFE_INTEGER + 1 } },
+    { issue: { number: 1.5 } },
+    { issue: { create: true, title: '   ' } },
+    { issue: { create: true, labels: [''] } },
+    { issue: { create: true, labels: ['  '] } },
+    { issue: { number: 938, create: true } },
+    { issue: { number: 938, unknown: true } },
+    { issue: { create: true, unknown: true } },
+  ])('rejects invalid or ambiguous issue input %#', (extra) => {
+    expect(() => enqueueTaskInputSchema.parse({ ...required, ...extra })).toThrow();
   });
 
-  it('Given run-next task context, When run-next input is parsed, Then context fields are preserved', () => {
-    const parsed = runNextTaskInputSchema.parse({
+  it('rejects root labels from the removed issue-specific tool', () => {
+    expect(() => enqueueTaskInputSchema.parse({
+      ...required,
+      labels: ['enhancement'],
+    })).toThrow(/unrecognized|unknown/i);
+  });
+
+  it('requires explicit workflow and autoPr decisions', () => {
+    expect(() => enqueueTaskInputSchema.parse({
       cwd: '/repo',
-      taskContext: {
-        branch: 'takt/938/add-mcp',
-        baseBranch: 'main',
-        prNumber: 938,
-      },
-    });
-
-    expect(parsed.taskContext).toEqual({
-      branch: 'takt/938/add-mcp',
-      baseBranch: 'main',
-      prNumber: 938,
-    });
+      task: 'Implement MCP support',
+    })).toThrow(/workflow|autoPr/i);
   });
 
-  it('Given MCP input schemas, When converted to JSON Schema, Then optional field descriptions are preserved', () => {
-    const enqueueProperties = schemaProperties(z.toJSONSchema(enqueueTaskInputSchema, { io: 'input' }));
-    const issueProperties = schemaProperties(z.toJSONSchema(createIssueAndEnqueueTaskInputSchema, { io: 'input' }));
-    const runNextProperties = schemaProperties(z.toJSONSchema(runNextTaskInputSchema, { io: 'input' }));
-    const taskContextProperties = schemaProperties(requireSchema(enqueueProperties.taskContext, 'taskContext'));
+  it('rejects relative cwd, blank task, oversized values, and custom worktree paths', () => {
+    expect(() => enqueueTaskInputSchema.parse({ ...required, cwd: 'repo' })).toThrow(/absolute/i);
+    expect(() => enqueueTaskInputSchema.parse({ ...required, task: '  ' })).toThrow(/task/i);
+    expect(() => enqueueTaskInputSchema.parse({ ...required, task: 'x'.repeat((128 * 1024) + 1) })).toThrow();
+    expect(() => enqueueTaskInputSchema.parse({ ...required, workflow: 'w'.repeat(129) })).toThrow();
+    expect(() => enqueueTaskInputSchema.parse({ ...required, worktree: '/tmp/worktree' })).toThrow();
+    expect(() => enqueueTaskInputSchema.parse({
+      ...required,
+      issue: { create: true, labels: Array.from({ length: 21 }, (_, index) => `label-${index}`) },
+    })).toThrow();
+  });
 
-    expect(enqueueProperties.workflow?.description).toBe('Workflow identifier to store on the queued task. Ask the user which workflow to use before enqueueing.');
-    expect(enqueueProperties.worktree?.description).toBe('Whether the queued task should run in a TAKT-managed worktree. When true, successful execution attempts to auto-commit resulting changes locally; autoPr false does not disable that.');
-    expect(enqueueProperties.autoPr?.description).toBe('Whether successful worktree execution should push the branch and automatically open a pull request. Ask the user before enqueueing; do not infer this from branch or PR context. When false, worktree execution may still auto-commit local changes.');
-    expect(issueProperties.labels?.description).toBe('Issue labels to request from the configured issue provider.');
-    expect(runNextProperties.provider?.description).toBe('Agent provider override for this task execution.');
-    expect(runNextProperties.model?.description).toBe('Model override for this task execution.');
-    expect(taskContextProperties.branch?.description).toBe('Plain local Git branch name for task execution context.');
-    expect(taskContextProperties.baseBranch?.description).toBe('Plain local Git base branch name used when creating or resolving a task worktree.');
-    expect(taskContextProperties.baseBranch?.description).not.toBe(taskContextProperties.branch?.description);
-    expect(taskContextProperties.prNumber?.description).toBe('PR number used as task execution context, not as PR-review provenance.');
+  it('exposes the nested issue schema in generated JSON Schema', () => {
+    const schema = z.toJSONSchema(enqueueTaskInputSchema, { io: 'input' }) as {
+      properties?: Record<string, { description?: string }>;
+    };
+    expect(schema.properties?.issue?.description).toContain('existing issue number or create settings');
   });
 });

--- a/src/__tests__/mcpSchemas.test.ts
+++ b/src/__tests__/mcpSchemas.test.ts
@@ -80,6 +80,29 @@ describe('MCP tool input schema', () => {
     })).toThrow();
   });
 
+  it('enforces issue title and label length boundaries', () => {
+    expect(enqueueTaskInputSchema.parse({
+      ...required,
+      issue: {
+        create: true,
+        title: 't'.repeat(255),
+        labels: ['l'.repeat(100)],
+      },
+    }).issue).toEqual({
+      create: true,
+      title: 't'.repeat(255),
+      labels: ['l'.repeat(100)],
+    });
+    expect(() => enqueueTaskInputSchema.parse({
+      ...required,
+      issue: { create: true, title: 't'.repeat(256) },
+    })).toThrow();
+    expect(() => enqueueTaskInputSchema.parse({
+      ...required,
+      issue: { create: true, labels: ['l'.repeat(101)] },
+    })).toThrow();
+  });
+
   it('exposes the nested issue schema in generated JSON Schema', () => {
     const schema = z.toJSONSchema(enqueueTaskInputSchema, { io: 'input' }) as {
       properties?: Record<string, { description?: string }>;

--- a/src/__tests__/saveTaskFile.test.ts
+++ b/src/__tests__/saveTaskFile.test.ts
@@ -583,7 +583,7 @@ describe('createIssueAndSaveTask', () => {
     expect(fs.readFileSync(path.join(taskDir, 'attachments', 'image-1.png'), 'utf-8')).toBe('issue-image');
   });
 
-  it('should close the created issue when the user declines saving the issue task', async () => {
+  it('should leave the created issue open when the user declines saving the issue task', async () => {
     mockConfirm.mockResolvedValueOnce(false);
 
     await createIssueAndSaveTask(testDir, 'Create issue only', 'default', {
@@ -594,17 +594,11 @@ describe('createIssueAndSaveTask', () => {
       { title: 'Create issue only', body: 'Create issue only', labels: undefined },
       testDir,
     );
-    expect(mockCloseIssue).toHaveBeenCalledWith(
-      42,
-      expect.stringContaining('task enqueue was cancelled before saving the pending task'),
-      testDir,
-    );
-    const compensationComment = String(mockCloseIssue.mock.calls[0]?.[1]);
-    expect(compensationComment).not.toContain('saving the pending task failed');
+    expect(mockCloseIssue).not.toHaveBeenCalled();
     expectNoTaskArtifacts(testDir);
   });
 
-  it('should close the created issue when interactive task saving fails', async () => {
+  it('should leave the created issue open when interactive task saving fails', async () => {
     const directoryAttachment = path.join(testDir, 'attachment-dir');
     fs.mkdirSync(directoryAttachment);
     mockPromptInput.mockResolvedValueOnce('');
@@ -619,15 +613,14 @@ describe('createIssueAndSaveTask', () => {
       }],
     });
 
-    expect(mockCloseIssue).toHaveBeenCalledWith(
-      42,
-      expect.stringContaining('TAKT created this issue'),
-      testDir,
-    );
+    expect(mockCloseIssue).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining(
+      'Issue #42 was created, but task saving failed:',
+    ));
     expectNoTaskArtifacts(testDir);
   });
 
-  it('should report partial success when closing the created issue fails after task saving fails', async () => {
+  it('should not attempt issue close after task saving fails', async () => {
     const directoryAttachment = path.join(testDir, 'attachment-dir');
     fs.mkdirSync(directoryAttachment);
     mockCloseIssue.mockReturnValue({
@@ -647,16 +640,9 @@ describe('createIssueAndSaveTask', () => {
       }],
     });
 
-    expect(mockCloseIssue).toHaveBeenCalledWith(
-      42,
-      expect.stringContaining('TAKT created this issue'),
-      testDir,
-    );
+    expect(mockCloseIssue).not.toHaveBeenCalled();
     expect(mockError).toHaveBeenCalledWith(expect.stringContaining(
       'Issue #42 was created, but task saving failed:',
-    ));
-    expect(mockError).toHaveBeenCalledWith(expect.stringContaining(
-      'Issue compensation comment was created, but issue close failed: glab issue close failed',
     ));
     expectNoTaskArtifacts(testDir);
   });

--- a/src/__tests__/system-step-services.test.ts
+++ b/src/__tests__/system-step-services.test.ts
@@ -1775,7 +1775,7 @@ describe('DefaultSystemStepServices', () => {
     expect(getGitProvider).not.toHaveBeenCalled();
     expect(mockCreateIssueFromTaskResult).toHaveBeenCalledWith('Implement follow-up effect', {
       cwd: '/repo',
-      explicitTitle: 'Implement follow-up effect with issue title',
+      title: 'Implement follow-up effect with issue title',
       outputMode: 'silent',
       gitProvider: requestProvider,
     });
@@ -1871,7 +1871,7 @@ describe('DefaultSystemStepServices', () => {
 
     expect(mockCreateIssueFromTaskResult).toHaveBeenCalledWith('Implement follow-up effect', {
       cwd: '/repo',
-      explicitTitle: 'Implement follow-up effect with issue title',
+      title: 'Implement follow-up effect with issue title',
       labels: ['bug', 'enhancement'],
       outputMode: 'silent',
       gitProvider: expect.objectContaining({

--- a/src/__tests__/system-step-services.test.ts
+++ b/src/__tests__/system-step-services.test.ts
@@ -1775,7 +1775,7 @@ describe('DefaultSystemStepServices', () => {
     expect(getGitProvider).not.toHaveBeenCalled();
     expect(mockCreateIssueFromTaskResult).toHaveBeenCalledWith('Implement follow-up effect', {
       cwd: '/repo',
-      title: 'Implement follow-up effect with issue title',
+      explicitTitle: 'Implement follow-up effect with issue title',
       outputMode: 'silent',
       gitProvider: requestProvider,
     });
@@ -1871,7 +1871,7 @@ describe('DefaultSystemStepServices', () => {
 
     expect(mockCreateIssueFromTaskResult).toHaveBeenCalledWith('Implement follow-up effect', {
       cwd: '/repo',
-      title: 'Implement follow-up effect with issue title',
+      explicitTitle: 'Implement follow-up effect with issue title',
       labels: ['bug', 'enhancement'],
       outputMode: 'silent',
       gitProvider: expect.objectContaining({
@@ -2006,13 +2006,53 @@ describe('DefaultSystemStepServices', () => {
     expect(result).toEqual({
       success: false,
       failed: true,
+      issueCreated: false,
+      taskEnqueued: false,
       stage: 'issue_creation',
       error: 'Failed to create issue from task',
     });
     expect(mockSaveTaskFile).not.toHaveBeenCalled();
   });
 
-  it('closes the created issue when enqueue_task task saving fails after issue creation', async () => {
+  it('returns partial success when an issue is created without a usable number', async () => {
+    mockCreateIssueFromTaskResult.mockReturnValue({
+      success: false,
+      issueCreated: true,
+      issueUrl: 'https://example.test/issues/unknown',
+      error: 'Failed to extract issue number from created issue URL',
+    });
+    const services = new DefaultSystemStepServices({
+      cwd: '/repo/worktree',
+      projectCwd: '/repo',
+      task: 'Plan follow-up',
+    });
+
+    const result = await services.executeEffect({
+      type: 'enqueue_task',
+      mode: 'new',
+      workflow: 'takt-default',
+      task: '{structured:plan.dummy_field}',
+      issue: { create: true },
+    }, {
+      mode: 'new',
+      workflow: 'takt-default',
+      task: 'Implement follow-up effect',
+      issue: { create: true },
+    }, {} as never);
+
+    expect(result).toEqual({
+      success: false,
+      failed: true,
+      issueCreated: true,
+      taskEnqueued: false,
+      stage: 'issue_number_parsing',
+      issueUrl: 'https://example.test/issues/unknown',
+      error: 'Failed to extract issue number from created issue URL',
+    });
+    expect(mockSaveTaskFile).not.toHaveBeenCalled();
+  });
+
+  it('leaves the created issue open when enqueue_task task saving fails after issue creation', async () => {
     mockCreateIssueFromTaskResult.mockReturnValue({ success: true, issueNumber: 586 });
     mockSaveTaskFile.mockRejectedValueOnce(new Error('disk full'));
 
@@ -2035,18 +2075,15 @@ describe('DefaultSystemStepServices', () => {
       issue: { create: true },
     }, {} as never);
 
-    expect(mockCloseIssue).toHaveBeenCalledWith(
-      586,
-      expect.stringContaining('TAKT created this issue'),
-      '/repo',
-    );
+    expect(mockCloseIssue).not.toHaveBeenCalled();
     expect(result).toEqual({
       success: false,
       failed: true,
+      issueCreated: true,
+      taskEnqueued: false,
       stage: 'task_saving',
       issueNumber: 586,
       error: 'disk full',
-      compensation: { success: true },
     });
   });
 
@@ -2083,14 +2120,11 @@ describe('DefaultSystemStepServices', () => {
     expect(result).toEqual({
       success: false,
       failed: true,
+      issueCreated: true,
+      taskEnqueued: false,
       stage: 'task_saving',
       issueNumber: 586,
       error: 'token=[REDACTED]\nCannot write [path]',
-      compensation: {
-        success: false,
-        commentCreated: true,
-        error: 'Authorization: Bearer [REDACTED]\nCannot close [path]',
-      },
     });
   });
 

--- a/src/app/acp/enqueue.ts
+++ b/src/app/acp/enqueue.ts
@@ -9,7 +9,6 @@ import {
   createIssueAndEnqueueTask,
   enqueueTask,
   formatIssueEnqueueFailure,
-  joinIssueEnqueueFailureText,
 } from '../../infra/task/enqueueService.js';
 import type { AcpTaskContext } from './types.js';
 
@@ -79,10 +78,7 @@ export async function createIssueAndEnqueueAcpTask(input: {
     createIssueFromTaskResult: input.createIssueFromTaskResult ?? defaultCreateIssueFromTaskResult,
   });
   if (!result.success) {
-    throw new Error(joinIssueEnqueueFailureText(
-      formatIssueEnqueueFailure(result.failure, safeExternalErrorMessage),
-      '\n',
-    ));
+    throw new Error(formatIssueEnqueueFailure(result.failure, safeExternalErrorMessage));
   }
   return result.created;
 }

--- a/src/features/mcp/operations.ts
+++ b/src/features/mcp/operations.ts
@@ -111,7 +111,7 @@ export async function enqueueTaktTask(
       worktree: input.worktree ?? true,
       autoPr: input.autoPr,
       taskContext: input.taskContext,
-      ...(input.issue.title !== undefined ? { title: input.issue.title } : {}),
+      ...(input.issue.title !== undefined ? { explicitTitle: input.issue.title } : {}),
       ...(input.issue.labels !== undefined ? { labels: input.issue.labels } : {}),
       gitProvider: getGitProvider(),
       abortSignal,

--- a/src/features/mcp/operations.ts
+++ b/src/features/mcp/operations.ts
@@ -1,45 +1,25 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { getGitProvider, initGitProvider } from '../../infra/git/index.js';
+import {
+  createIssueAndEnqueueTask,
+  enqueueTask,
+  type IssueEnqueueFailure,
+} from '../../infra/task/enqueueService.js';
 import { safeExternalErrorMessage } from '../../shared/utils/safeExternalErrorMessage.js';
-import { TaskRunner, type TaskInfo } from '../../infra/task/index.js';
-import { getGitProvider, initGitProvider, type CloseIssueResult, type GitProvider } from '../../infra/git/index.js';
 import {
   createIssueFromTaskResult as defaultCreateIssueFromTaskResult,
   saveTaskFile as defaultSaveTaskFile,
 } from '../tasks/add/index.js';
-import {
-  createIssueAndEnqueueTask,
-  enqueueTask,
-  formatIssueEnqueueFailure,
-  joinIssueEnqueueFailureText,
-  type IssueEnqueueCompensationInput,
-  type IssueEnqueueFailure,
-} from '../../infra/task/enqueueService.js';
-import {
-  executeRunTaskAndCompleteWithDetails as defaultExecuteRunTaskAndCompleteWithDetails,
-  type TaskCompletionResult,
-  type RunTaskExecutionContext,
-} from '../tasks/execute/runTaskExecution.js';
-import type { TaskExecutionOptions, TaskExecutionParallelOptions } from '../tasks/execute/types.js';
-import type {
-  CreateIssueAndEnqueueTaskInput,
-  EnqueueTaskInput,
-  RunNextTaskInput,
-} from './schemas.js';
+import type { EnqueueTaskInput } from './schemas.js';
 
 type SaveTaskFile = typeof defaultSaveTaskFile;
 type CreateIssueFromTaskResult = typeof defaultCreateIssueFromTaskResult;
-type ExecuteRunTaskAndCompleteWithDetails = typeof defaultExecuteRunTaskAndCompleteWithDetails;
-type CreateTaskRunner = (cwd: string) => TaskRunner;
-type CompensateCreatedIssue = (input: IssueEnqueueCompensationInput) => CloseIssueResult;
 
 export interface McpOperationDependencies {
   saveTaskFile?: SaveTaskFile;
   createIssueFromTaskResult?: CreateIssueFromTaskResult;
-  compensateCreatedIssue?: CompensateCreatedIssue;
-  createTaskRunner?: CreateTaskRunner;
-  executeRunTaskAndCompleteWithDetails?: ExecuteRunTaskAndCompleteWithDetails;
   allowedProjectRoot?: string;
 }
 
@@ -50,16 +30,12 @@ function textResult(text: string, isError?: boolean): CallToolResult {
   };
 }
 
-function jsonResult(value: Record<string, unknown>): CallToolResult {
-  return textResult(JSON.stringify(value));
-}
-
-function safeMcpErrorCause(error: unknown): string {
-  return safeExternalErrorMessage(error);
+function jsonResult(value: Record<string, unknown>, isError?: boolean): CallToolResult {
+  return textResult(JSON.stringify(value), isError);
 }
 
 function errorResult(action: string, error: unknown): CallToolResult {
-  return textResult(`${action}: ${safeMcpErrorCause(error)}`, true);
+  return textResult(`${action}: ${safeExternalErrorMessage(error)}`, true);
 }
 
 function assertCwdAllowedByMcpRoot(cwd: string, allowedProjectRoot: string | undefined): void {
@@ -77,146 +53,75 @@ function assertCwdAllowedByMcpRoot(cwd: string, allowedProjectRoot: string | und
   throw new Error(`MCP cwd is outside the allowed project root: ${cwd}`);
 }
 
-function buildTaskExecutionOptions(input: RunNextTaskInput): TaskExecutionOptions | undefined {
-  if (input.provider === undefined && input.model === undefined) {
-    return undefined;
+function issueFailureResult(failure: IssueEnqueueFailure): CallToolResult {
+  if (failure.stage === 'issue_creation') {
+    return jsonResult({
+      issueCreated: false,
+      taskEnqueued: false,
+      stage: failure.stage,
+      error: safeExternalErrorMessage(failure.error),
+    }, true);
   }
-  return {
-    ...(input.provider !== undefined ? { provider: input.provider } : {}),
-    ...(input.model !== undefined ? { model: input.model } : {}),
-  };
-}
-
-function buildSilentParallelOptions(): TaskExecutionParallelOptions {
-  return { outputMode: 'silent' };
-}
-
-function buildRunTaskExecutionContext(
-  input: RunNextTaskInput,
-  gitProvider: GitProvider,
-): RunTaskExecutionContext {
-  return {
-    gitProvider,
-    ...(input.taskContext === undefined ? {} : { taskContext: input.taskContext }),
-  };
-}
-
-function buildTaskFailureText(taskName: string, result: TaskCompletionResult): string {
-  if (result.failureReason === undefined) {
-    throw new Error(`Task failed without failure reason: ${taskName}`);
+  if (failure.stage === 'issue_number_parsing') {
+    return jsonResult({
+      issueCreated: true,
+      ...(failure.issueUrl !== undefined ? { issueUrl: failure.issueUrl } : {}),
+      taskEnqueued: false,
+      stage: failure.stage,
+      error: safeExternalErrorMessage(failure.error),
+    }, true);
   }
-  return `Task failed: ${taskName}\n${safeMcpErrorCause(result.failureReason)}`;
-}
-
-function buildTaskPostExecutionFailureText(taskName: string, result: TaskCompletionResult): string {
-  if (result.postExecutionFailureReason === undefined) {
-    throw new Error(`Task post-execution failed without failure reason: ${taskName}`);
-  }
-  return `Task post-execution failed: ${taskName}\n${safeMcpErrorCause(result.postExecutionFailureReason)}`;
-}
-
-function buildIssueEnqueueFailureResult(failure: IssueEnqueueFailure): CallToolResult {
-  return textResult(joinIssueEnqueueFailureText(
-    formatIssueEnqueueFailure(failure, safeMcpErrorCause),
-    '\n\n',
-  ), true);
+  return jsonResult({
+    issueCreated: true,
+    issueNumber: failure.issueNumber,
+    ...(failure.issueUrl !== undefined ? { issueUrl: failure.issueUrl } : {}),
+    taskEnqueued: false,
+    stage: failure.stage,
+    error: safeExternalErrorMessage(failure.error),
+  }, true);
 }
 
 export async function enqueueTaktTask(
   input: EnqueueTaskInput,
   deps: McpOperationDependencies = {},
+  abortSignal?: AbortSignal,
 ): Promise<CallToolResult> {
   try {
     assertCwdAllowedByMcpRoot(input.cwd, deps.allowedProjectRoot);
     const saveTaskFile = deps.saveTaskFile ?? defaultSaveTaskFile;
-    const created = await enqueueTask({
-      cwd: input.cwd,
-      task: input.task,
-      workflow: input.workflow,
-      worktree: input.worktree ?? true,
-      autoPr: input.autoPr,
-      taskContext: input.taskContext,
-    }, saveTaskFile);
-    return jsonResult(created);
-  } catch (error) {
-    return errorResult('Task saving failed', error);
-  }
-}
+    if (input.issue === undefined || 'number' in input.issue) {
+      const created = await enqueueTask({
+        cwd: input.cwd,
+        task: input.task,
+        workflow: input.workflow,
+        worktree: input.worktree ?? true,
+        autoPr: input.autoPr,
+        taskContext: input.taskContext,
+        abortSignal,
+        ...(input.issue !== undefined ? { issueNumber: input.issue.number } : {}),
+      }, saveTaskFile);
+      return jsonResult(created);
+    }
 
-export async function createIssueAndEnqueueTaktTask(
-  input: CreateIssueAndEnqueueTaskInput,
-  deps: McpOperationDependencies = {},
-): Promise<CallToolResult> {
-  try {
-    assertCwdAllowedByMcpRoot(input.cwd, deps.allowedProjectRoot);
     initGitProvider(input.cwd);
-    const gitProvider = getGitProvider();
-    const issueResult = await createIssueAndEnqueueTask({
+    const result = await createIssueAndEnqueueTask({
       cwd: input.cwd,
       task: input.task,
       workflow: input.workflow,
       worktree: input.worktree ?? true,
       autoPr: input.autoPr,
-      labels: input.labels,
       taskContext: input.taskContext,
-      gitProvider,
+      ...(input.issue.title !== undefined ? { title: input.issue.title } : {}),
+      ...(input.issue.labels !== undefined ? { labels: input.issue.labels } : {}),
+      gitProvider: getGitProvider(),
+      abortSignal,
+      issueOutputMode: 'silent',
     }, {
-      saveTaskFile: deps.saveTaskFile ?? defaultSaveTaskFile,
+      saveTaskFile,
       createIssueFromTaskResult: deps.createIssueFromTaskResult ?? defaultCreateIssueFromTaskResult,
-      compensateCreatedIssue: deps.compensateCreatedIssue,
     });
-    if (!issueResult.success) {
-      return buildIssueEnqueueFailureResult(issueResult.failure);
-    }
-    return jsonResult(issueResult.created);
+    return result.success ? jsonResult(result.created) : issueFailureResult(result.failure);
   } catch (error) {
-    return errorResult('Issue task enqueue failed', error);
-  }
-}
-
-export async function runNextTaktTask(
-  input: RunNextTaskInput,
-  deps: McpOperationDependencies = {},
-): Promise<CallToolResult> {
-  try {
-    assertCwdAllowedByMcpRoot(input.cwd, deps.allowedProjectRoot);
-    initGitProvider(input.cwd);
-    const gitProvider = getGitProvider();
-    const createTaskRunner = deps.createTaskRunner ?? ((cwd: string) => new TaskRunner(cwd));
-    const executeRunTaskAndCompleteWithDetails = deps.executeRunTaskAndCompleteWithDetails
-      ?? defaultExecuteRunTaskAndCompleteWithDetails;
-    const taskRunner = createTaskRunner(input.cwd);
-    taskRunner.failInterruptedRunningTasks();
-    const tasks = taskRunner.claimNextTasks(1);
-    const task = tasks[0];
-    if (!task) {
-      return jsonResult({
-        ran: false,
-        message: 'No pending tasks in .takt/tasks.yaml',
-      });
-    }
-
-    const executionResult = await executeRunTaskAndCompleteWithDetails(
-      task as TaskInfo,
-      taskRunner,
-      input.cwd,
-      buildTaskExecutionOptions(input),
-      buildSilentParallelOptions(),
-      buildRunTaskExecutionContext(input, gitProvider),
-    );
-    if (!executionResult.success) {
-      return textResult(buildTaskFailureText(task.name, executionResult), true);
-    }
-    if (executionResult.prFailed) {
-      return textResult(buildTaskPostExecutionFailureText(task.name, executionResult), true);
-    }
-
-    return jsonResult({
-      ran: true,
-      taskName: task.name,
-      success: executionResult.success,
-    });
-  } catch (error) {
-    return errorResult('Task execution failed', error);
+    return errorResult('Task enqueue failed', error);
   }
 }

--- a/src/features/mcp/schemas.ts
+++ b/src/features/mcp/schemas.ts
@@ -1,6 +1,5 @@
 import { isAbsolute } from 'node:path';
 import { z } from 'zod/v4';
-import { PROVIDER_TYPES } from '../../shared/types/provider.js';
 import {
   isValidTaskContextBranchName,
   isValidTaskContextPrNumber,
@@ -8,7 +7,6 @@ import {
 
 const MCP_TASK_MAX_LENGTH = 128 * 1024;
 const MCP_WORKFLOW_MAX_LENGTH = 128;
-const MCP_MODEL_MAX_LENGTH = 128;
 const MCP_LABEL_MAX_LENGTH = 100;
 const MCP_LABEL_MAX_COUNT = 20;
 
@@ -39,6 +37,21 @@ const taskContextSchema = z.object({
   .optional()
   .describe('Optional Git context to pass to the queued or executed task without changing task provenance.');
 
+const issueNumberSchema = z.number().int().safe().positive({
+  message: 'issue number must be a positive safe integer',
+});
+const issueTitleSchema = z.string().trim().min(1).max(MCP_TASK_MAX_LENGTH);
+const issueLabelsSchema = z.array(z.string().trim().min(1).max(MCP_LABEL_MAX_LENGTH))
+  .max(MCP_LABEL_MAX_COUNT);
+const issueSchema = z.union([
+  z.object({ number: issueNumberSchema }).strict(),
+  z.object({
+    create: z.literal(true),
+    title: issueTitleSchema.optional(),
+    labels: issueLabelsSchema.optional(),
+  }).strict(),
+]).describe('Optional issue linkage. Provide either an existing issue number or create settings.');
+
 const taskSaveOptionsSchema = z.object({
   cwd: absolutePathSchema,
   task: taskContentSchema,
@@ -46,28 +59,10 @@ const taskSaveOptionsSchema = z.object({
   worktree: worktreeSchema,
   autoPr: z.boolean()
     .describe('Whether successful worktree execution should push the branch and automatically open a pull request. Ask the user before enqueueing; do not infer this from branch or PR context. When false, worktree execution may still auto-commit local changes.'),
+  issue: issueSchema.optional(),
   taskContext: taskContextSchema,
 }).strict();
 
 export const enqueueTaskInputSchema = taskSaveOptionsSchema;
 
-export const createIssueAndEnqueueTaskInputSchema = taskSaveOptionsSchema.extend({
-  labels: z.array(z.string().trim().min(1).max(MCP_LABEL_MAX_LENGTH)).max(MCP_LABEL_MAX_COUNT)
-    .optional()
-    .describe('Issue labels to request from the configured issue provider.'),
-}).strict();
-
-export const runNextTaskInputSchema = z.object({
-  cwd: absolutePathSchema,
-  provider: z.enum(PROVIDER_TYPES)
-    .optional()
-    .describe('Agent provider override for this task execution.'),
-  model: z.string().trim().min(1).max(MCP_MODEL_MAX_LENGTH)
-    .optional()
-    .describe('Model override for this task execution.'),
-  taskContext: taskContextSchema,
-}).strict();
-
 export type EnqueueTaskInput = z.infer<typeof enqueueTaskInputSchema>;
-export type CreateIssueAndEnqueueTaskInput = z.infer<typeof createIssueAndEnqueueTaskInputSchema>;
-export type RunNextTaskInput = z.infer<typeof runNextTaskInputSchema>;

--- a/src/features/mcp/schemas.ts
+++ b/src/features/mcp/schemas.ts
@@ -7,6 +7,7 @@ import {
 
 const MCP_TASK_MAX_LENGTH = 128 * 1024;
 const MCP_WORKFLOW_MAX_LENGTH = 128;
+const MCP_ISSUE_TITLE_MAX_LENGTH = 255;
 const MCP_LABEL_MAX_LENGTH = 100;
 const MCP_LABEL_MAX_COUNT = 20;
 
@@ -40,7 +41,7 @@ const taskContextSchema = z.object({
 const issueNumberSchema = z.number().int().safe().positive({
   message: 'issue number must be a positive safe integer',
 });
-const issueTitleSchema = z.string().trim().min(1).max(MCP_TASK_MAX_LENGTH);
+const issueTitleSchema = z.string().trim().min(1).max(MCP_ISSUE_TITLE_MAX_LENGTH);
 const issueLabelsSchema = z.array(z.string().trim().min(1).max(MCP_LABEL_MAX_LENGTH))
   .max(MCP_LABEL_MAX_COUNT);
 const issueSchema = z.union([

--- a/src/features/mcp/server.ts
+++ b/src/features/mcp/server.ts
@@ -2,15 +2,9 @@ import * as fs from 'node:fs';
 import * as process from 'node:process';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { packageVersion } from '../../shared/package-info.js';
+import { enqueueTaskInputSchema } from './schemas.js';
 import {
-  createIssueAndEnqueueTaskInputSchema,
-  enqueueTaskInputSchema,
-  runNextTaskInputSchema,
-} from './schemas.js';
-import {
-  createIssueAndEnqueueTaktTask,
   enqueueTaktTask,
-  runNextTaktTask,
   type McpOperationDependencies,
 } from './operations.js';
 
@@ -42,30 +36,10 @@ export function createTaktMcpServer(
     'takt_enqueue_task',
     {
       title: 'Enqueue TAKT task',
-      description: 'Save a pending TAKT task into .takt/tasks.yaml.',
+      description: 'Save a pending TAKT task into .takt/tasks.yaml. Optionally link an existing issue or create one. Run queued tasks with `takt run` or monitor continuously with `takt watch`.',
       inputSchema: enqueueTaskInputSchema,
     },
-    (input) => enqueueTaktTask(input, operationDeps),
-  );
-
-  server.registerTool(
-    'takt_create_issue_and_enqueue_task',
-    {
-      title: 'Create issue and enqueue TAKT task',
-      description: 'Create an issue with the configured issue provider, then save a pending TAKT task with the issue number.',
-      inputSchema: createIssueAndEnqueueTaskInputSchema,
-    },
-    (input) => createIssueAndEnqueueTaktTask(input, operationDeps),
-  );
-
-  server.registerTool(
-    'takt_run_next_task',
-    {
-      title: 'Run next TAKT task',
-      description: 'Claim and execute the next pending TAKT task.',
-      inputSchema: runNextTaskInputSchema,
-    },
-    (input) => runNextTaktTask(input, operationDeps),
+    (input, extra) => enqueueTaktTask(input, operationDeps, extra.signal),
   );
 
   return server;

--- a/src/features/tasks/add/index.ts
+++ b/src/features/tasks/add/index.ts
@@ -20,7 +20,7 @@ import {
   createIssueAndEnqueueTask,
   formatIssueEnqueueFailure,
   IssueEnqueueCancelledError,
-  joinIssueEnqueueFailureText,
+  type PrepareEnqueuedTaskSpec,
   type SaveEnqueuedTaskFile,
   type SaveEnqueuedTaskFileOptions,
 } from '../../../infra/task/enqueueService.js';
@@ -40,12 +40,14 @@ export async function saveTaskFile(
   cwd: string,
   taskContent: string,
   options?: SaveTaskOptions,
+  prepareTaskSpec?: PrepareEnqueuedTaskSpec,
+  abortSignal?: AbortSignal,
 ): Promise<{ taskName: string; tasksFile: string }> {
   const { attachments, ...saveOptions } = options ?? {};
-  const prepareTaskSpec = attachments !== undefined
+  const attachmentPrepareTaskSpec = attachments !== undefined
     ? (saveCwd: string, saveTaskContent: string) => prepareTaskSpecDirectory(saveCwd, saveTaskContent, attachments)
-    : undefined;
-  return saveEnqueuedTaskFile(cwd, taskContent, saveOptions, prepareTaskSpec);
+    : prepareTaskSpec;
+  return saveEnqueuedTaskFile(cwd, taskContent, saveOptions, attachmentPrepareTaskSpec, abortSignal);
 }
 
 
@@ -143,10 +145,7 @@ export async function createIssueAndSaveTask(
   });
   if (!result.success) {
     if (result.failure.stage !== 'issue_creation') {
-      error(joinIssueEnqueueFailureText(
-        formatIssueEnqueueFailure(result.failure, getErrorMessage),
-        '; ',
-      ));
+      error(formatIssueEnqueueFailure(result.failure, getErrorMessage));
     }
     return;
   }

--- a/src/infra/git/types.ts
+++ b/src/infra/git/types.ts
@@ -68,7 +68,37 @@ export interface CreateIssueOptions {
 
 export type CreateIssueResult =
   | { success: true; issueNumber: number; url?: string }
-  | { success: false; error: string };
+  | { success: false; issueCreated: true; url?: string; error: string }
+  | { success: false; issueCreated?: false; error: string };
+
+export function normalizePublicIssueUrl(url: string | undefined): string | undefined {
+  if (url === undefined || containsControlCharacter(url)) {
+    return undefined;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return undefined;
+  }
+
+  if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') || parsed.hostname.length === 0) {
+    return undefined;
+  }
+
+  return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+}
+
+function containsControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export type CloseIssueResult =
   | { success: true; commentCreated?: boolean }

--- a/src/infra/github/issue.ts
+++ b/src/infra/github/issue.ts
@@ -173,7 +173,10 @@ export function createIssue(options: CreateIssueOptions, cwd: string): CreateIss
     };
   } catch {
     const errorMessage = 'Failed to extract issue number from created issue URL';
-    log.error('Issue number extraction failed after issue creation', { error: errorMessage });
+    log.error('Issue number extraction failed after issue creation', {
+      error: errorMessage,
+      ...(publicUrl !== undefined ? { url: publicUrl } : {}),
+    });
     return {
       success: false,
       issueCreated: true,

--- a/src/infra/github/issue.ts
+++ b/src/infra/github/issue.ts
@@ -14,6 +14,7 @@ import type {
   Issue,
   IssueListItem,
 } from '../git/types.js';
+import { normalizePublicIssueUrl } from '../git/types.js';
 import { parseIssueNumberFromUrl } from '../git/format.js';
 
 const log = createLogger('github');
@@ -147,22 +148,38 @@ export function createIssue(options: CreateIssueOptions, cwd: string): CreateIss
 
   log.info('Creating issue', { title: options.title });
 
+  let output: string;
   try {
-    const output = execFileSync('gh', args, {
+    output = execFileSync('gh', args, {
       cwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-
-    const url = output.trim();
-    const issueNumber = parseIssueNumberFromUrl(url);
-    log.info('Issue created', { url, issueNumber });
-
-    return { success: true, issueNumber, url };
   } catch (err) {
     const errorMessage = getErrorMessage(err);
     log.error('Issue creation failed', { error: errorMessage });
     return { success: false, error: errorMessage };
+  }
+
+  const url = output.trim();
+  const publicUrl = normalizePublicIssueUrl(url);
+  try {
+    const issueNumber = parseIssueNumberFromUrl(url);
+    log.info('Issue created', { url: publicUrl, issueNumber });
+    return {
+      success: true,
+      issueNumber,
+      ...(publicUrl !== undefined ? { url: publicUrl } : {}),
+    };
+  } catch {
+    const errorMessage = 'Failed to extract issue number from created issue URL';
+    log.error('Issue number extraction failed after issue creation', { error: errorMessage });
+    return {
+      success: false,
+      issueCreated: true,
+      ...(publicUrl !== undefined ? { url: publicUrl } : {}),
+      error: errorMessage,
+    };
   }
 }
 

--- a/src/infra/gitlab/issue.ts
+++ b/src/infra/gitlab/issue.ts
@@ -135,7 +135,10 @@ export function createIssue(options: CreateIssueOptions, cwd: string): CreateIss
     };
   } catch {
     const errorMessage = 'Failed to extract issue number from created issue URL';
-    log.error('Issue number extraction failed after issue creation', { error: errorMessage });
+    log.error('Issue number extraction failed after issue creation', {
+      error: errorMessage,
+      ...(publicUrl !== undefined ? { url: publicUrl } : {}),
+    });
     return {
       success: false,
       issueCreated: true,

--- a/src/infra/gitlab/issue.ts
+++ b/src/infra/gitlab/issue.ts
@@ -13,6 +13,7 @@ import type {
   Issue,
   IssueListItem,
 } from '../git/types.js';
+import { normalizePublicIssueUrl } from '../git/types.js';
 import { parseIssueNumberFromUrl } from '../git/format.js';
 import { checkGlabCli, fetchAllPages, parseJson, ITEMS_PER_PAGE } from './utils.js';
 
@@ -109,22 +110,38 @@ export function createIssue(options: CreateIssueOptions, cwd: string): CreateIss
 
   log.info('Creating issue', { title: options.title });
 
+  let output: string;
   try {
-    const output = execFileSync('glab', args, {
+    output = execFileSync('glab', args, {
       cwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-
-    const url = output.trim();
-    const issueNumber = parseIssueNumberFromUrl(url);
-    log.info('Issue created', { url, issueNumber });
-
-    return { success: true, issueNumber, url };
   } catch (err) {
     const errorMessage = getErrorMessage(err);
     log.error('Issue creation failed', { error: errorMessage });
     return { success: false, error: errorMessage };
+  }
+
+  const url = output.trim();
+  const publicUrl = normalizePublicIssueUrl(url);
+  try {
+    const issueNumber = parseIssueNumberFromUrl(url);
+    log.info('Issue created', { url: publicUrl, issueNumber });
+    return {
+      success: true,
+      issueNumber,
+      ...(publicUrl !== undefined ? { url: publicUrl } : {}),
+    };
+  } catch {
+    const errorMessage = 'Failed to extract issue number from created issue URL';
+    log.error('Issue number extraction failed after issue creation', { error: errorMessage });
+    return {
+      success: false,
+      issueCreated: true,
+      ...(publicUrl !== undefined ? { url: publicUrl } : {}),
+      error: errorMessage,
+    };
   }
 }
 

--- a/src/infra/task/enqueueService.ts
+++ b/src/infra/task/enqueueService.ts
@@ -312,6 +312,11 @@ export async function createIssueAndEnqueueTask(
   }
 }
 
+/**
+ * Best-effort mitigation for an abort notification racing with issue creation.
+ * One macrotask yield narrows that window, but cannot observe cancellations that
+ * arrive after the yield has completed.
+ */
 function waitForAbortSignalPropagation(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }

--- a/src/infra/task/enqueueService.ts
+++ b/src/infra/task/enqueueService.ts
@@ -1,9 +1,10 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { CloseIssueResult, GitProvider } from '../git/index.js';
+import type { GitProvider } from '../git/index.js';
+import { normalizePublicIssueUrl } from '../git/types.js';
 import { generateReportDir } from '../../shared/utils/index.js';
 
-export type IssueEnqueueGitProvider = Pick<GitProvider, 'createIssue' | 'closeIssue'>;
+export type IssueEnqueueGitProvider = Pick<GitProvider, 'createIssue'>;
 
 export interface SaveEnqueuedTaskFileOptions extends Record<string, unknown> {
   workflow?: string;
@@ -36,6 +37,7 @@ export type SaveEnqueuedTaskFile = (
   taskContent: string,
   options?: SaveEnqueuedTaskFileOptions,
   prepareTaskSpec?: PrepareEnqueuedTaskSpec,
+  abortSignal?: AbortSignal,
 ) => Promise<{ taskName: string; tasksFile: string }>;
 
 export type CreateEnqueueIssueFromTaskResult = (
@@ -44,10 +46,14 @@ export type CreateEnqueueIssueFromTaskResult = (
     labels?: string[];
     cwd?: string;
     title?: string;
+    explicitTitle?: string;
     outputMode?: 'terminal' | 'silent';
     gitProvider?: Pick<IssueEnqueueGitProvider, 'createIssue'>;
   },
-) => { success: true; issueNumber: number } | { success: false; error: string };
+  ) =>
+    | { success: true; issueNumber: number; issueUrl?: string }
+    | { success: false; issueCreated: true; issueUrl?: string; error: string }
+    | { success: false; issueCreated?: false; error: string };
 
 export interface EnqueueTaskContext {
   branch?: string;
@@ -69,27 +75,19 @@ export interface SaveEnqueuedTaskOptions {
 export interface EnqueueTaskRequest extends SaveEnqueuedTaskOptions {
   cwd: string;
   task: string;
+  abortSignal?: AbortSignal;
 }
 
 export interface IssueEnqueueTaskRequest extends EnqueueTaskRequest {
   labels?: string[];
   title?: string;
   gitProvider: IssueEnqueueGitProvider;
-  abortSignal?: AbortSignal;
   issueOutputMode?: 'terminal' | 'silent';
-}
-
-export interface IssueEnqueueCompensationInput {
-  cwd: string;
-  gitProvider: IssueEnqueueGitProvider;
-  issueNumber: number;
-  stage: IssueEnqueueCompensationStage;
 }
 
 export interface IssueEnqueueDependencies {
   saveTaskFile: SaveEnqueuedTaskFile;
   createIssueFromTaskResult: CreateEnqueueIssueFromTaskResult;
-  compensateCreatedIssue?: (input: IssueEnqueueCompensationInput) => CloseIssueResult;
 }
 
 export type EnqueueTaskResult = Awaited<ReturnType<SaveEnqueuedTaskFile>> & {
@@ -98,24 +96,33 @@ export type EnqueueTaskResult = Awaited<ReturnType<SaveEnqueuedTaskFile>> & {
 };
 
 export type IssueEnqueueFailure =
-  | { stage: 'issue_creation'; error: string }
   | {
-    stage: IssueEnqueueCompensationStage;
+    issueCreated: false;
+    taskEnqueued: false;
+    stage: 'issue_creation';
+    error: string;
+  }
+  | {
+    issueCreated: true;
+    taskEnqueued: false;
+    stage: 'issue_number_parsing';
+    issueUrl?: string;
+    error: string;
+  }
+  | {
+    issueCreated: true;
     issueNumber: number;
+    issueUrl?: string;
+    taskEnqueued: false;
+    stage: IssueEnqueueFailureStage;
     error: unknown;
-    compensation: CloseIssueResult;
   };
 
-export type IssueEnqueueCompensationStage = 'task_saving' | 'cancelled_after_issue_creation';
+export type IssueEnqueueFailureStage = 'task_saving' | 'cancelled_after_issue_creation';
 
 export type IssueEnqueueResult =
   | { success: true; created: EnqueueTaskResult }
   | { success: false; failure: IssueEnqueueFailure };
-
-export interface FormattedIssueEnqueueFailure {
-  primary: string;
-  compensationFailure?: string;
-}
 
 export interface PrepareTaskSpecDirectoryOptions {
   orderContent?: string;
@@ -181,52 +188,22 @@ export function prepareTaskSpecDirectory(
 export function formatIssueEnqueueFailure(
   failure: IssueEnqueueFailure,
   formatError: (error: unknown) => string,
-): FormattedIssueEnqueueFailure {
+): string {
   if (failure.stage === 'issue_creation') {
-    return { primary: formatError(failure.error) };
+    return formatError(failure.error);
+  }
+  const issueUrl = failure.issueUrl === undefined ? '' : ` Issue URL: ${failure.issueUrl}.`;
+  if (failure.stage === 'issue_number_parsing') {
+    return `An issue was created, but its number could not be extracted: ${formatError(failure.error)}.${issueUrl}`;
   }
   if (failure.stage === 'cancelled_after_issue_creation') {
-    if (failure.compensation.success) {
-      return {
-        primary: `Issue #${failure.issueNumber} was created and closed because task enqueue was cancelled`,
-      };
-    }
-    return {
-      primary: `Issue #${failure.issueNumber} was created, but task enqueue was cancelled`,
-      compensationFailure: formatIssueCloseFailure(failure.compensation, formatError),
-    };
+    return `Issue #${failure.issueNumber} was created and remains open, but task enqueue was cancelled: ${formatError(failure.error)}${issueUrl}`;
   }
-  if (failure.compensation.success) {
-    return {
-      primary: `Issue #${failure.issueNumber} was created and closed because task saving failed: ${formatError(failure.error)}`,
-    };
-  }
-  return {
-    primary: `Issue #${failure.issueNumber} was created, but task saving failed: ${formatError(failure.error)}`,
-    compensationFailure: formatIssueCloseFailure(failure.compensation, formatError),
-  };
-}
-
-export function joinIssueEnqueueFailureText(
-  formatted: FormattedIssueEnqueueFailure,
-  separator: string,
-): string {
-  return formatted.compensationFailure === undefined
-    ? formatted.primary
-    : `${formatted.primary}${separator}${formatted.compensationFailure}`;
+  return `Issue #${failure.issueNumber} was created, but task saving failed: ${formatError(failure.error)}.${issueUrl} The issue remains open for retry.`;
 }
 
 function isFileExistsError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'EEXIST';
-}
-
-function formatIssueCloseFailure(
-  compensation: Extract<CloseIssueResult, { success: false }>,
-  formatError: (error: unknown) => string,
-): string {
-  return compensation.commentCreated === true
-    ? `Issue compensation comment was created, but issue close failed: ${formatError(compensation.error)}`
-    : `Issue close failed: ${formatError(compensation.error)}`;
 }
 
 function buildEnqueuedTaskSaveOptions(
@@ -252,11 +229,11 @@ export async function enqueueTask(
   input: EnqueueTaskRequest,
   saveTaskFile: SaveEnqueuedTaskFile,
 ): Promise<EnqueueTaskResult> {
-  const created = await saveTaskFile(
-    input.cwd,
-    input.task,
-    buildEnqueuedTaskSaveOptions(input),
-  );
+  throwIfIssueEnqueueAborted(input.abortSignal);
+  const saveOptions = buildEnqueuedTaskSaveOptions(input);
+  const created = input.abortSignal === undefined
+    ? await saveTaskFile(input.cwd, input.task, saveOptions)
+    : await saveTaskFile(input.cwd, input.task, saveOptions, undefined, input.abortSignal);
   return {
     ...created,
     workflow: input.workflow,
@@ -272,15 +249,39 @@ export async function createIssueAndEnqueueTask(
   const issueResult = deps.createIssueFromTaskResult(input.task, {
     cwd: input.cwd,
     ...(input.labels !== undefined ? { labels: input.labels } : {}),
-    ...(input.title !== undefined ? { title: input.title } : {}),
+    ...(input.title !== undefined ? { explicitTitle: input.title } : {}),
     outputMode: input.issueOutputMode ?? 'silent',
     gitProvider: input.gitProvider,
   });
   if (!issueResult.success) {
-    return { success: false, failure: { stage: 'issue_creation', error: issueResult.error } };
+    if ('issueCreated' in issueResult && issueResult.issueCreated) {
+      const issueUrl = normalizePublicIssueUrl(issueResult.issueUrl);
+      return {
+        success: false,
+        failure: {
+          issueCreated: true,
+          taskEnqueued: false,
+          stage: 'issue_number_parsing',
+          ...(issueUrl !== undefined ? { issueUrl } : {}),
+          error: issueResult.error,
+        },
+      };
+    }
+    return {
+      success: false,
+      failure: {
+        issueCreated: false,
+        taskEnqueued: false,
+        stage: 'issue_creation',
+        error: issueResult.error,
+      },
+    };
   }
 
   try {
+    if (input.abortSignal !== undefined) {
+      await waitForAbortSignalPropagation();
+    }
     throwIfIssueEnqueueAborted(input.abortSignal);
     const created = await enqueueTask(
       {
@@ -292,26 +293,26 @@ export async function createIssueAndEnqueueTask(
     return { success: true, created };
   } catch (error) {
     const stage = resolveIssueEnqueueFailureStage(error);
-    const compensate = deps.compensateCreatedIssue ?? closeCreatedIssueForFailedTaskSave;
-    const compensation = compensate({
-      cwd: input.cwd,
-      gitProvider: input.gitProvider,
-      issueNumber: issueResult.issueNumber,
-      stage,
-    });
+    const issueUrl = normalizePublicIssueUrl(issueResult.issueUrl);
     return {
       success: false,
       failure: {
+        issueCreated: true,
         stage,
         issueNumber: issueResult.issueNumber,
+        ...(issueUrl !== undefined ? { issueUrl } : {}),
+        taskEnqueued: false,
         error,
-        compensation,
       },
     };
   }
 }
 
-function resolveIssueEnqueueFailureStage(error: unknown): IssueEnqueueCompensationStage {
+function waitForAbortSignalPropagation(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function resolveIssueEnqueueFailureStage(error: unknown): IssueEnqueueFailureStage {
   return error instanceof IssueEnqueueCancelledError
     ? 'cancelled_after_issue_creation'
     : 'task_saving';
@@ -319,7 +320,7 @@ function resolveIssueEnqueueFailureStage(error: unknown): IssueEnqueueCompensati
 
 export class IssueEnqueueCancelledError extends Error {
   constructor() {
-    super('Task enqueue was cancelled after issue creation.');
+    super('Task enqueue was cancelled.');
   }
 }
 
@@ -327,29 +328,4 @@ function throwIfIssueEnqueueAborted(abortSignal: AbortSignal | undefined): void 
   if (abortSignal?.aborted) {
     throw new IssueEnqueueCancelledError();
   }
-}
-
-function buildIssueEnqueueCompensationComment(stage: IssueEnqueueCompensationStage): string {
-  switch (stage) {
-    case 'cancelled_after_issue_creation':
-      return [
-        'TAKT created this issue, but task enqueue was cancelled before saving the pending task.',
-        '',
-        'The issue is being closed to keep the repository state consistent.',
-      ].join('\n');
-    case 'task_saving':
-      return [
-        'TAKT created this issue, but saving the pending task failed.',
-        '',
-        'The issue is being closed to keep the repository state consistent.',
-      ].join('\n');
-  }
-}
-
-function closeCreatedIssueForFailedTaskSave(input: IssueEnqueueCompensationInput): CloseIssueResult {
-  return input.gitProvider.closeIssue(
-    input.issueNumber,
-    buildIssueEnqueueCompensationComment(input.stage),
-    input.cwd,
-  );
 }

--- a/src/infra/task/enqueueService.ts
+++ b/src/infra/task/enqueueService.ts
@@ -80,7 +80,10 @@ export interface EnqueueTaskRequest extends SaveEnqueuedTaskOptions {
 
 export interface IssueEnqueueTaskRequest extends EnqueueTaskRequest {
   labels?: string[];
+  /** Generated title that must pass the issue-title fallback rules. */
   title?: string;
+  /** User-supplied title that intentionally bypasses generated-title fallback rules. */
+  explicitTitle?: string;
   gitProvider: IssueEnqueueGitProvider;
   issueOutputMode?: 'terminal' | 'silent';
 }
@@ -249,7 +252,8 @@ export async function createIssueAndEnqueueTask(
   const issueResult = deps.createIssueFromTaskResult(input.task, {
     cwd: input.cwd,
     ...(input.labels !== undefined ? { labels: input.labels } : {}),
-    ...(input.title !== undefined ? { explicitTitle: input.title } : {}),
+    ...(input.title !== undefined ? { title: input.title } : {}),
+    ...(input.explicitTitle !== undefined ? { explicitTitle: input.explicitTitle } : {}),
     outputMode: input.issueOutputMode ?? 'silent',
     gitProvider: input.gitProvider,
   });

--- a/src/infra/task/enqueuedTaskFile.ts
+++ b/src/infra/task/enqueuedTaskFile.ts
@@ -6,6 +6,7 @@ import { summarizeTaskName } from './summarize.js';
 import { firstLine } from './naming.js';
 import {
   cleanupTaskSpecDirectory,
+  IssueEnqueueCancelledError,
   prepareTaskSpecDirectory,
   type PrepareEnqueuedTaskSpec,
   type SaveEnqueuedTaskFileOptions,
@@ -42,14 +43,18 @@ export async function saveEnqueuedTaskFile(
   taskContent: string,
   options?: SaveEnqueuedTaskFileOptions,
   prepareTaskSpec: PrepareEnqueuedTaskSpec = prepareTaskSpecDirectory,
+  abortSignal?: AbortSignal,
 ): Promise<{ taskName: string; tasksFile: string }> {
+  throwIfTaskSaveAborted(abortSignal);
   const runner = new TaskRunner(cwd);
   const config = buildValidatedTaskConfig(options);
   const slug = await summarizeTaskName(taskContent, { cwd });
+  throwIfTaskSaveAborted(abortSignal);
   const summary = firstLine(taskContent);
   const preparedSpec = prepareTaskSpec(cwd, taskContent);
   let created;
   try {
+    throwIfTaskSaveAborted(abortSignal);
     created = runner.addTask(taskContent, {
       ...config,
       task_dir: preparedSpec.taskDirRelative,
@@ -63,4 +68,10 @@ export async function saveEnqueuedTaskFile(
   const tasksFile = path.join(cwd, '.takt', 'tasks.yaml');
   log.info('Task created', { taskName: created.name, tasksFile, config });
   return { taskName: created.name, tasksFile };
+}
+
+function throwIfTaskSaveAborted(abortSignal: AbortSignal | undefined): void {
+  if (abortSignal?.aborted) {
+    throw new IssueEnqueueCancelledError();
+  }
 }

--- a/src/infra/task/issueTask.ts
+++ b/src/infra/task/issueTask.ts
@@ -1,6 +1,8 @@
 import { info, success, error } from '../../shared/ui/index.js';
 import { getGitProvider, type CreateIssueResult, type GitProvider } from '../git/index.js';
+import { normalizePublicIssueUrl } from '../git/types.js';
 import { createLogger } from '../../shared/utils/index.js';
+import { safeExternalErrorMessage } from '../../shared/utils/safeExternalErrorMessage.js';
 
 const TITLE_MAX_LENGTH = 100;
 const TITLE_TRUNCATE_LENGTH = 97;
@@ -88,10 +90,14 @@ export function extractTitle(task: string): string {
 
 function resolveIssueTitle(
   task: string,
-  structuredTitle: string | undefined,
+  generatedTitle: string | undefined,
+  explicitTitle: string | undefined,
 ): { title: string; usedStructuredOutput: boolean; fallbackReason?: StructuredTitleFallbackReason } {
-  if (structuredTitle !== undefined && isValidGeneratedTitle(structuredTitle)) {
-    return { title: truncateTitle(normalizeTitleCandidate(structuredTitle)), usedStructuredOutput: true };
+  if (explicitTitle !== undefined) {
+    return { title: explicitTitle, usedStructuredOutput: true };
+  }
+  if (generatedTitle !== undefined && isValidGeneratedTitle(generatedTitle)) {
+    return { title: truncateTitle(normalizeTitleCandidate(generatedTitle)), usedStructuredOutput: true };
   }
   const derivedTitle = resolveTaskDerivedIssueTitle(task);
   if (derivedTitle === undefined) {
@@ -100,7 +106,7 @@ function resolveIssueTitle(
   return {
     title: derivedTitle,
     usedStructuredOutput: false,
-    fallbackReason: getStructuredTitleFallbackReason(structuredTitle),
+    fallbackReason: getStructuredTitleFallbackReason(generatedTitle),
   };
 }
 
@@ -108,13 +114,15 @@ type CreateIssueFromTaskOptions = {
   labels?: string[];
   cwd?: string;
   title?: string;
+  explicitTitle?: string;
   outputMode?: 'terminal' | 'silent';
   gitProvider?: Pick<GitProvider, 'createIssue'>;
 };
 
 export type CreateIssueFromTaskResult =
-  | { success: true; issueNumber: number }
-  | { success: false; error: string };
+  | { success: true; issueNumber: number; issueUrl?: string }
+  | { success: false; issueCreated: true; issueUrl?: string; error: string }
+  | { success: false; issueCreated?: false; error: string };
 
 function shouldWriteIssueOutput(options: CreateIssueFromTaskOptions | undefined): boolean {
   return options?.outputMode !== 'silent';
@@ -136,7 +144,7 @@ function resolveCreatedIssueNumber(issueResult: Extract<CreateIssueResult, { suc
 
 function formatIssueNumberExtractionError(extractionError: unknown): string {
   const cause = extractionError instanceof Error ? extractionError.message : String(extractionError);
-  return `Failed to extract issue number: ${cause}`;
+  return safeExternalErrorMessage(`Failed to extract issue number: ${cause}`);
 }
 
 export function createIssueFromTaskResult(
@@ -148,7 +156,7 @@ export function createIssueFromTaskResult(
   }
   let resolvedTitle: ReturnType<typeof resolveIssueTitle>;
   try {
-    resolvedTitle = resolveIssueTitle(task, options?.title);
+    resolvedTitle = resolveIssueTitle(task, options?.title, options?.explicitTitle);
   } catch (titleError) {
     const message = titleError instanceof Error ? titleError.message : String(titleError);
     if (shouldWriteIssueOutput(options)) {
@@ -181,18 +189,48 @@ export function createIssueFromTaskResult(
         used_structured_output: usedStructuredOutput,
         ...(fallbackReason !== undefined ? { fallback_reason: fallbackReason } : {}),
       });
-      return { success: false, error: message };
+      const issueUrl = normalizePublicIssueUrl(issueResult.url);
+      return {
+        success: false,
+        issueCreated: true,
+        ...(issueUrl !== undefined ? { issueUrl } : {}),
+        error: message,
+      };
     }
+    const issueUrl = normalizePublicIssueUrl(issueResult.url);
     if (shouldWriteIssueOutput(options)) {
-      success(issueResult.url ? `Issue created: ${issueResult.url}` : `Issue created: #${issueNumber}`);
+      success(issueUrl ? `Issue created: ${issueUrl}` : `Issue created: #${issueNumber}`);
     }
     log.info('Issue created', {
-      url: issueResult.url,
+      url: issueUrl,
       issueNumber,
       used_structured_output: usedStructuredOutput,
       ...(fallbackReason !== undefined ? { fallback_reason: fallbackReason } : {}),
     });
-    return { success: true, issueNumber };
+    return {
+      success: true,
+      issueNumber,
+      ...(issueUrl !== undefined ? { issueUrl } : {}),
+    };
+  }
+
+  if (issueResult.issueCreated) {
+    const message = requireIssueFailureMessage(issueResult.error);
+    if (shouldWriteIssueOutput(options)) {
+      error(`Issue was created, but its number could not be extracted: ${message}`);
+    }
+    log.error('Issue number extraction failed after issue creation', {
+      error: message,
+      used_structured_output: usedStructuredOutput,
+      ...(fallbackReason !== undefined ? { fallback_reason: fallbackReason } : {}),
+    });
+    const issueUrl = normalizePublicIssueUrl(issueResult.url);
+    return {
+      success: false,
+      issueCreated: true,
+      ...(issueUrl !== undefined ? { issueUrl } : {}),
+      error: message,
+    };
   }
 
   const message = requireIssueFailureMessage(issueResult.error);

--- a/src/infra/workflow/system/system-enqueue-effect.ts
+++ b/src/infra/workflow/system/system-enqueue-effect.ts
@@ -14,7 +14,6 @@ import { saveEnqueuedTaskFile } from '../../task/enqueuedTaskFile.js';
 import { createIssueFromTaskResult } from '../../task/issueTask.js';
 import { fetchPrContext } from './system-git-context.js';
 import { safeExternalErrorMessage } from '../../../shared/utils/safeExternalErrorMessage.js';
-import type { CloseIssueResult } from '../../git/index.js';
 import { existsSync } from 'node:fs';
 import { ActiveTaskTargetConflictError, findActiveTaskTargetConflict } from '../../task/activeTaskTarget.js';
 import { TaskStore } from '../../task/store.js';
@@ -37,32 +36,37 @@ function resolveValidatedBaseBranch(
   return resolveBaseBranch(projectCwd, baseBranch).branch;
 }
 
-function sanitizeCloseIssueResult(result: CloseIssueResult): CloseIssueResult {
-  if (result.success) {
-    return result;
-  }
-  return {
-    ...result,
-    error: safeExternalErrorMessage(result.error),
-  };
-}
-
 function buildIssueEnqueueFailureResult(failure: IssueEnqueueFailure): Record<string, unknown> {
   if (failure.stage === 'issue_creation') {
     return {
       success: false,
       failed: true,
+      issueCreated: false,
+      taskEnqueued: false,
       stage: failure.stage,
+      error: safeExternalErrorMessage(failure.error),
+    };
+  }
+  if (failure.stage === 'issue_number_parsing') {
+    return {
+      success: false,
+      failed: true,
+      issueCreated: true,
+      taskEnqueued: false,
+      stage: failure.stage,
+      ...(failure.issueUrl !== undefined ? { issueUrl: failure.issueUrl } : {}),
       error: safeExternalErrorMessage(failure.error),
     };
   }
   return {
     success: false,
     failed: true,
+    issueCreated: true,
+    taskEnqueued: false,
     stage: failure.stage,
     issueNumber: failure.issueNumber,
+    ...(failure.issueUrl !== undefined ? { issueUrl: failure.issueUrl } : {}),
     error: safeExternalErrorMessage(failure.error),
-    compensation: sanitizeCloseIssueResult(failure.compensation),
   };
 }
 


### PR DESCRIPTION
Closes #1062

## 概要
MCPからのtask enqueue入口をtakt_enqueue_taskへ一本化し、既存Issueと新規Issueの両方を同一サービス契約で扱います。

## 主な変更
- MCP toolをtakt_enqueue_taskへ統合し、既存Issue・新規Issueのstrict union入力を追加
- GitHub/GitLab URL解析、enqueue、部分成功、AbortSignalの境界を共通serviceへ集約
- system enqueue effectも同じserviceを利用
- MCPの明示titleとsystem effectの生成titleを分離し、生成titleの検証・fallbackを維持
- 英日ドキュメントと回帰テストを更新

## 検証
- npm run build
- npm run lint
- 関連166 tests pass
- npm run test:e2e:mock 全shard pass
- フルunitは変更外の既知ACP stdio 1件を除きpass

## レビュー
別Codexによる相互レビューを実施し、生成titleが明示title扱いになる指摘を修正後、APPROVE確認済みです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * MCPからタスクをキューに追加する機能を `takt_enqueue_task` に集約しました。
  * 既存Issueの紐付け、または新規Issueの作成とタスク追加に対応しました。
  * Issue作成後の部分的な失敗状況を、詳細な結果として確認できるようになりました。

* **仕様変更**
  * 保留中タスクの実行は `takt run`、継続的な監視・実行は `takt watch` を使用します。
  * タスク保存に失敗しても、作成済みIssueはクローズされず開いたまま保持されます。

* **ドキュメント**
  * MCP/ACPの利用方法と入力仕様を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->