### PR TITLE
docs: improve README overview image placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
   <a href="./docs/README.ja.md">日本語</a>
 </p>
 
-![TAKT workflow control for AI coding agents](./docs/assets/description/01-hero.png)
-
 **Stop babysitting AI coding agents.**
 
 TAKT is an open-source CLI that turns AI coding agents into repeatable development workflows. Define planning, implementation, review, fix loops, human checkpoints, permissions, and output contracts in YAML, then run tasks with isolated worktrees and traceable logs.
 
 Instead of asking one agent to remember the whole process, TAKT gives each step its own role, context, and transition rules. Agents can code, but the workflow decides what happens next.
+
+![TAKT workflow control for AI coding agents](./docs/assets/description/01-hero.png)
 
 - Run plan → implement → review → fix loops as explicit workflow steps
 - Keep context focused with step-specific personas, policies, knowledge, instructions, and output contracts

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -19,6 +19,8 @@ TAKT は、AI コーディングエージェントを再現可能な開発ワー
 
 1つのエージェントにプロセス全体を覚えさせるのではなく、TAKT は step ごとに役割、文脈、遷移ルールを与えます。AI はコードを書きますが、次に何をするかは workflow が決めます。
 
+![AI コーディングエージェントのワークフローを制御する TAKT](./assets/description/01-hero.png)
+
 - 計画 → 実装 → レビュー → 修正ループを明示的な workflow step として実行
 - step ごとに persona、policy、knowledge、instruction、output contract を分け、コンテキストを肥大化させない
 - 積んだタスクを隔離された worktree で実行し、後からログとレポートを確認できる


### PR DESCRIPTION
## Summary

- move the overview image below the English introduction
- add the same overview image to the corresponding position in the Japanese README
- localize the Japanese image alt text

## Verification

- confirmed both Markdown image paths resolve to `docs/assets/description/01-hero.png`
- ran `git diff --check`