### PR TITLE
[#836] fix-worktree-path-collisions

### DIFF
--- a/src/__tests__/clone.test.ts
+++ b/src/__tests__/clone.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 
-const { mockLogInfo, mockLogDebug, mockLogError, mockSyncProjectLocalTaktForRetry } = vi.hoisted(() => ({
+const {
+  mockLogInfo,
+  mockLogDebug,
+  mockLogError,
+  mockRandomBytes,
+  mockSyncProjectLocalTaktForRetry,
+} = vi.hoisted(() => ({
   mockLogInfo: vi.fn(),
   mockLogDebug: vi.fn(),
   mockLogError: vi.fn(),
+  mockRandomBytes: vi.fn(),
   mockSyncProjectLocalTaktForRetry: vi.fn(),
+}));
+
+vi.mock('node:crypto', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:crypto')>()),
+  randomBytes: mockRandomBytes,
 }));
 
 vi.mock('node:child_process', () => ({
@@ -85,9 +97,25 @@ const mockLoadProjectConfig = vi.mocked(loadProjectConfig);
 const mockResolveConfigValue = vi.mocked(resolveConfigValue);
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
+  let randomByteValue = 1;
+  mockRandomBytes.mockImplementation((size: number) => {
+    const value = Buffer.alloc(size, randomByteValue);
+    randomByteValue += 1;
+    return value;
+  });
   vi.mocked(fs.statSync).mockImplementation(() => ({ isFile: () => false }) as unknown as fs.Stats);
-  vi.mocked(fs.readFileSync).mockReset();
+  vi.mocked(fs.realpathSync).mockImplementation((value: fs.PathLike) => String(value));
+  mockExecFileSync.mockImplementation((_cmd, args) => {
+    const argsArr = args as string[];
+    if (argsArr[0] === 'show-ref' || (argsArr[0] === 'config' && argsArr[1] === '--local')) {
+      throw new Error('not found');
+    }
+    if (argsArr[0] === 'symbolic-ref') {
+      return Buffer.from('refs/remotes/origin/main\n');
+    }
+    return Buffer.from('');
+  });
   mockLoadProjectConfig.mockReturnValue({});
   mockResolveConfigValue.mockReturnValue(undefined);
 });
@@ -430,7 +458,7 @@ describe('branch and worktree path formatting with issue numbers', () => {
     expect(result.branch).toMatch(/^takt\/\d{8}T\d{4}-regular-task$/);
   });
 
-  it('should format worktree path as {timestamp}-{issue}-{slug} when issue number is provided', () => {
+  it('should format worktree path as readable filesystem-safe stem with a unique suffix when issue number is provided', () => {
     setupMockForPathTest();
 
     const result = createSharedClone('/project', {
@@ -439,10 +467,11 @@ describe('branch and worktree path formatting with issue numbers', () => {
       issueNumber: 99,
     });
 
-    expect(result.path).toMatch(/\/\d{8}T\d{4}-99-fix-bug$/);
+    expect(result.path).toMatch(/\/\d{8}T\d{4}-99-fix-bug-[a-f0-9]{16}$/);
+    expect(path.basename(result.path)).toMatch(/^[a-zA-Z0-9-]+$/);
   });
 
-  it('should format worktree path as {timestamp}-{slug} when no issue number', () => {
+  it('should format worktree path as readable filesystem-safe stem with a unique suffix when no issue number', () => {
     setupMockForPathTest();
 
     const result = createSharedClone('/project', {
@@ -450,8 +479,8 @@ describe('branch and worktree path formatting with issue numbers', () => {
       taskSlug: 'regular-task',
     });
 
-    expect(result.path).toMatch(/\/\d{8}T\d{4}-regular-task$/);
-    expect(result.path).not.toMatch(/-\d+-/);
+    expect(result.path).toMatch(/\/\d{8}T\d{4}-regular-task-[a-f0-9]{16}$/);
+    expect(path.basename(result.path)).toMatch(/^[a-zA-Z0-9-]+$/);
   });
 
   it('should use custom branch when provided, ignoring issue number', () => {
@@ -479,7 +508,7 @@ describe('branch and worktree path formatting with issue numbers', () => {
     expect(result.path).toBe('/custom/path/to/worktree');
   });
 
-  it('should fall back to timestamp-only format when issue number provided but slug is empty', () => {
+  it('should append a unique suffix to the timestamp-only path when issue number is provided but slug is empty', () => {
     setupMockForPathTest();
 
     const result = createSharedClone('/project', {
@@ -489,7 +518,35 @@ describe('branch and worktree path formatting with issue numbers', () => {
     });
 
     expect(result.branch).toMatch(/^takt\/\d{8}T\d{4}$/);
-    expect(result.path).toMatch(/\/\d{8}T\d{4}$/);
+    expect(result.path).toMatch(/\/\d{8}T\d{4}-[a-f0-9]{16}$/);
+  });
+
+  it.each([
+    ['whitespace', 'fix review comments', undefined, 'fix-review-comments'],
+    ['path separators', '../../../escape', 99, 'escape'],
+    ['dot segments', '..', undefined, undefined],
+  ])('should keep the clone path inside its base directory when the task slug contains %s', (
+    _description,
+    taskSlug,
+    issueNumber,
+    normalizedSlug,
+  ) => {
+    setupMockForPathTest();
+
+    const result = createSharedClone('/project', {
+      worktree: true,
+      taskSlug,
+      ...(issueNumber === undefined ? {} : { issueNumber }),
+    });
+
+    const cloneBaseDir = '/takt-worktrees';
+    expect(path.relative(cloneBaseDir, result.path)).not.toMatch(/^\.\.(?:\/|$)/);
+    expect(path.basename(result.path)).toMatch(/^[a-zA-Z0-9-]+$/);
+    if (normalizedSlug === undefined) {
+      expect(path.basename(result.path)).not.toContain('..');
+    } else {
+      expect(path.basename(result.path)).toContain(normalizedSlug);
+    }
   });
 });
 
@@ -2476,7 +2533,6 @@ describe('auto clone path allocation', () => {
     mockResolveConfigValue.mockImplementation((_projectDir, key) => (
       key === 'worktreeDir' ? '/tmp/takt-worktrees' : undefined
     ));
-    vi.mocked(fs.existsSync).mockReturnValue(false);
     mockExecFileSync.mockImplementation((_cmd, args) => {
       const argsArr = args as string[];
       if (argsArr[0] === 'symbolic-ref') return Buffer.from('refs/remotes/origin/main\n');
@@ -2489,18 +2545,43 @@ describe('auto clone path allocation', () => {
 
     const result = new CloneManager().createTempCloneForBranch('/project', 'feature/temp-command-gate');
 
-    expect(result.path).toContain('/tmp/takt-worktrees/tmp-');
+    expect(result.path).toMatch(/^\/tmp\/takt-worktrees\/tmp-\d{8}T\d{4}-[a-f0-9]{16}$/);
     expect(mockSyncProjectLocalTaktForRetry).toHaveBeenCalledWith('/project', result.path);
   });
 
-  it('should allocate a suffixed path when the generated clone path already exists', () => {
+  it('should generate distinct temp clone paths in the same minute', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00.123Z'));
     mockResolveConfigValue.mockImplementation((_projectDir, key) => (
       key === 'worktreeDir' ? '/tmp/takt-worktrees' : undefined
     ));
-    vi.mocked(fs.existsSync).mockImplementation((value: fs.PathLike) => (
-      String(value) === '/tmp/takt-worktrees/20260101T0000-test-task'
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'symbolic-ref') return Buffer.from('refs/remotes/origin/main\n');
+      if (argsArr[0] === 'clone') return Buffer.from('');
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config' && argsArr[1] === '--local') throw new Error('not set');
+      if (argsArr[0] === 'config') return Buffer.from('');
+      return Buffer.from('');
+    });
+
+    try {
+      const first = new CloneManager().createTempCloneForBranch('/project', 'feature/first');
+      const second = new CloneManager().createTempCloneForBranch('/project', 'feature/second');
+
+      expect(first.path).toMatch(/^\/tmp\/takt-worktrees\/tmp-20260101T0000-[a-f0-9]{16}$/);
+      expect(second.path).toMatch(/^\/tmp\/takt-worktrees\/tmp-20260101T0000-[a-f0-9]{16}$/);
+      expect(first.path).not.toBe(second.path);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should generate distinct paths for synchronous clones with the same slug in the same minute', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.123Z'));
+    mockResolveConfigValue.mockImplementation((_projectDir, key) => (
+      key === 'worktreeDir' ? '/tmp/takt-worktrees' : undefined
     ));
     mockExecFileSync.mockImplementation((_cmd, args) => {
       const argsArr = args as string[];
@@ -2515,12 +2596,82 @@ describe('auto clone path allocation', () => {
     });
 
     try {
-      const result = new CloneManager().createSharedClone('/project', {
+      const first = new CloneManager().createSharedClone('/project', {
         worktree: true,
-        taskSlug: 'test-task',
+        taskSlug: 'fix-review-comments',
+        branch: 'takt/827/add-trace-task-metadata',
+      });
+      const second = new CloneManager().createSharedClone('/project', {
+        worktree: true,
+        taskSlug: 'fix-review-comments',
+        branch: 'takt/816/implement-finding-contract',
       });
 
-      expect(result.path).toBe('/tmp/takt-worktrees/20260101T0000-test-task-2');
+      expect(first.path).toMatch(/^\/tmp\/takt-worktrees\/20260101T0000-fix-review-comments-[a-f0-9]{16}$/);
+      expect(second.path).toMatch(/^\/tmp\/takt-worktrees\/20260101T0000-fix-review-comments-[a-f0-9]{16}$/);
+      expect(first.path).not.toBe(second.path);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should persist each abortable clone under its own generated path when same-slug tasks start in the same minute', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.123Z'));
+    mockResolveConfigValue.mockImplementation((_projectDir, key) => (
+      key === 'worktreeDir' ? '/tmp/takt-worktrees' : undefined
+    ));
+    mockGitSpawn((args) => {
+      if (args[0] === 'fetch') return 1;
+      if (args[0] === 'show-ref' && String(args[3]).startsWith('refs/remotes/origin/')) return 1;
+      if (args[0] === 'show-ref' && String(args[3]).startsWith('refs/heads/')) return 0;
+      return 0;
+    });
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'remote') return Buffer.from('');
+      if (argsArr[0] === 'config' && argsArr[1] === '--local') throw new Error('not set');
+      if (argsArr[0] === 'config') return Buffer.from('');
+      return Buffer.from('');
+    });
+
+    try {
+      const clonePromises = Promise.all([
+        new CloneManager().createSharedCloneAbortable('/project', {
+          worktree: true,
+          taskSlug: 'fix-review-comments',
+          branch: 'takt/827/add-trace-task-metadata',
+        }),
+        new CloneManager().createSharedCloneAbortable('/project', {
+          worktree: true,
+          taskSlug: 'fix-review-comments',
+          branch: 'takt/816/implement-finding-contract',
+        }),
+      ]);
+      await vi.runAllTimersAsync();
+      const [first, second] = await clonePromises;
+
+      expect(first.path).toMatch(/^\/tmp\/takt-worktrees\/20260101T0000-fix-review-comments-[a-f0-9]{16}$/);
+      expect(second.path).toMatch(/^\/tmp\/takt-worktrees\/20260101T0000-fix-review-comments-[a-f0-9]{16}$/);
+      expect(first.path).not.toBe(second.path);
+
+      const metadataByBranch = new Map<string, { filePath: string; clonePath: string }>(
+        vi.mocked(fs.writeFileSync).mock.calls
+          .filter(([filePath]) => String(filePath).includes('/.takt/clone-meta/'))
+          .map(([filePath, content]) => {
+            const metadata = JSON.parse(String(content)) as { branch: string; clonePath: string };
+            return [metadata.branch, { filePath: String(filePath), clonePath: metadata.clonePath }];
+          }),
+      );
+
+      expect(metadataByBranch.get(first.branch)).toEqual({
+        filePath: '/project/.takt/clone-meta/takt--827--add-trace-task-metadata.json',
+        clonePath: first.path,
+      });
+      expect(metadataByBranch.get(second.branch)).toEqual({
+        filePath: '/project/.takt/clone-meta/takt--816--implement-finding-contract.json',
+        clonePath: second.path,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/src/__tests__/system-pr-sync-worktree.test.ts
+++ b/src/__tests__/system-pr-sync-worktree.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCheckoutWorktreeBranchFromOrigin,
+  mockCloneAndIsolate,
+  mockRemoveClone,
+  mockRandomBytes,
+  mockResolveCloneBaseDir,
+} = vi.hoisted(() => ({
+  mockCheckoutWorktreeBranchFromOrigin: vi.fn(),
+  mockCloneAndIsolate: vi.fn(),
+  mockRemoveClone: vi.fn(),
+  mockRandomBytes: vi.fn(),
+  mockResolveCloneBaseDir: vi.fn(),
+}));
+
+vi.mock('node:crypto', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:crypto')>()),
+  randomBytes: mockRandomBytes,
+}));
+
+vi.mock('../infra/task/clone-exec.js', () => ({
+  cloneAndIsolate: mockCloneAndIsolate,
+}));
+
+vi.mock('../infra/task/index.js', () => ({
+  removeClone: mockRemoveClone,
+  resolveCloneBaseDir: mockResolveCloneBaseDir,
+}));
+
+vi.mock('../infra/workflow/system/system-effect-git-helpers.js', () => ({
+  checkoutWorktreeBranchFromOrigin: mockCheckoutWorktreeBranchFromOrigin,
+}));
+
+import {
+  acquirePrSyncSession,
+  releasePrSyncSession,
+  type PrSyncSession,
+} from '../infra/workflow/system/system-pr-sync-worktree.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  let randomByteValue = 1;
+  mockRandomBytes.mockImplementation((size: number) => {
+    const value = Buffer.alloc(size, randomByteValue);
+    randomByteValue += 1;
+    return value;
+  });
+  mockResolveCloneBaseDir.mockReturnValue('/tmp/takt-worktrees');
+});
+
+describe('PR sync worktree paths', () => {
+  it('should create separate readable filesystem-safe paths when distinct PR sessions start in the same millisecond', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.123Z'));
+
+    try {
+      const store = new Map<number, PrSyncSession>();
+      const first = acquirePrSyncSession(store, '/project', 816, 'takt/816/implement-finding-contract');
+      const second = acquirePrSyncSession(store, '/project', 827, 'takt/827/add-trace-task-metadata');
+
+      expect(first.worktreePath).toMatch(/^\/tmp\/takt-worktrees\/pr-sync-\d+-[a-f0-9]{16}$/);
+      expect(second.worktreePath).toMatch(/^\/tmp\/takt-worktrees\/pr-sync-\d+-[a-f0-9]{16}$/);
+      expect(first.worktreePath).not.toBe(second.worktreePath);
+      expect(mockCloneAndIsolate).toHaveBeenCalledWith('/project', first.worktreePath);
+      expect(mockCloneAndIsolate).toHaveBeenCalledWith('/project', second.worktreePath);
+      expect(mockCheckoutWorktreeBranchFromOrigin).toHaveBeenCalledWith(
+        '/project',
+        first.worktreePath,
+        'takt/816/implement-finding-contract',
+      );
+      expect(mockCheckoutWorktreeBranchFromOrigin).toHaveBeenCalledWith(
+        '/project',
+        second.worktreePath,
+        'takt/827/add-trace-task-metadata',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should remove the generated path associated with the released PR session', () => {
+    const store = new Map<number, PrSyncSession>();
+    const session = acquirePrSyncSession(store, '/project', 816, 'takt/816/implement-finding-contract');
+
+    releasePrSyncSession(store, 816);
+
+    expect(store.has(816)).toBe(false);
+    expect(mockRemoveClone).toHaveBeenCalledWith(session.worktreePath);
+  });
+
+  it('should remove the generated path when PR session creation fails', () => {
+    mockCheckoutWorktreeBranchFromOrigin.mockImplementation(() => {
+      throw new Error('checkout failed');
+    });
+    const store = new Map<number, PrSyncSession>();
+
+    expect(() => acquirePrSyncSession(store, '/project', 816, 'takt/816/implement-finding-contract'))
+      .toThrow('checkout failed');
+
+    const clonedPath = mockCloneAndIsolate.mock.calls[0]?.[1];
+    expect(store.size).toBe(0);
+    expect(mockRemoveClone).toHaveBeenCalledWith(clonedPath);
+  });
+});

--- a/src/infra/task/clone-path.ts
+++ b/src/infra/task/clone-path.ts
@@ -1,0 +1,34 @@
+import { randomBytes } from 'node:crypto';
+import * as path from 'node:path';
+import { slugify } from '../../shared/utils/slug.js';
+
+const UNIQUE_SUFFIX_BYTES = 8;
+
+function createUniqueClonePath(baseDir: string, name: string): string {
+  const suffix = randomBytes(UNIQUE_SUFFIX_BYTES).toString('hex');
+  return path.join(path.resolve(baseDir), `${name}-${suffix}`);
+}
+
+export function createTaskClonePath(
+  baseDir: string,
+  timestamp: string,
+  issueNumber: number | undefined,
+  taskSlug: string,
+): string {
+  const safeTaskSlug = slugify(taskSlug);
+  const nameParts = [
+    timestamp,
+    safeTaskSlug && issueNumber !== undefined ? String(issueNumber) : undefined,
+    safeTaskSlug,
+  ];
+
+  return createUniqueClonePath(baseDir, nameParts.filter(Boolean).join('-'));
+}
+
+export function createTempClonePath(baseDir: string, timestamp: string): string {
+  return createUniqueClonePath(baseDir, `tmp-${timestamp}`);
+}
+
+export function createPrSyncWorktreePath(baseDir: string, timestamp: number): string {
+  return createUniqueClonePath(baseDir, `pr-sync-${timestamp}`);
+}

--- a/src/infra/task/clone.ts
+++ b/src/infra/task/clone.ts
@@ -34,6 +34,7 @@ import {
   toRemoteTrackingBranchRef,
 } from '../../shared/utils/gitBranchValidation.js';
 import { isTaskAbortError } from './clone-errors.js';
+import { createTaskClonePath, createTempClonePath } from './clone-path.js';
 
 export type { WorktreeOptions, WorktreeResult };
 export {
@@ -81,43 +82,18 @@ export class CloneManager {
 
   private static resolveClonePath(projectDir: string, options: WorktreeOptions): string {
     const timestamp = CloneManager.generateTimestamp();
-    const slug = options.taskSlug;
-
-    let dirName: string;
-    if (options.issueNumber !== undefined && slug) {
-      dirName = `${timestamp}-${options.issueNumber}-${slug}`;
-    } else if (slug) {
-      dirName = `${timestamp}-${slug}`;
-    } else {
-      dirName = timestamp;
-    }
-
     if (typeof options.worktree === 'string') {
       return path.isAbsolute(options.worktree)
         ? options.worktree
         : path.resolve(projectDir, options.worktree);
     }
 
-    return CloneManager.resolveAvailableClonePath(
+    return createTaskClonePath(
       CloneManager.resolveCloneBaseDir(projectDir),
-      dirName,
+      timestamp,
+      options.issueNumber,
+      options.taskSlug,
     );
-  }
-
-  private static resolveAvailableClonePath(baseDir: string, dirName: string): string {
-    const firstCandidate = path.join(baseDir, dirName);
-    if (!fs.existsSync(firstCandidate)) {
-      return firstCandidate;
-    }
-
-    for (let suffix = 2; suffix <= 100; suffix += 1) {
-      const candidate = path.join(baseDir, `${dirName}-${suffix}`);
-      if (!fs.existsSync(candidate)) {
-        return candidate;
-      }
-    }
-
-    throw new Error(`Unable to allocate clone path in ${baseDir} for ${dirName}`);
   }
 
   private static resolveBranchName(options: WorktreeOptions): string {
@@ -335,9 +311,9 @@ export class CloneManager {
     CloneManager.resolveBaseBranch(projectDir);
 
     const timestamp = CloneManager.generateTimestamp();
-    const clonePath = CloneManager.resolveAvailableClonePath(
+    const clonePath = createTempClonePath(
       CloneManager.resolveCloneBaseDir(projectDir),
-      `tmp-${timestamp}`,
+      timestamp,
     );
 
     log.info('Creating temp clone for branch', { path: clonePath, branch });

--- a/src/infra/workflow/system/system-pr-sync-worktree.ts
+++ b/src/infra/workflow/system/system-pr-sync-worktree.ts
@@ -1,6 +1,6 @@
-import * as path from 'node:path';
 import type { SystemStepRuntimeState } from '../../../core/workflow/system/system-step-services.js';
 import { cloneAndIsolate } from '../../task/clone-exec.js';
+import { createPrSyncWorktreePath } from '../../task/clone-path.js';
 import {
   removeClone,
   resolveCloneBaseDir,
@@ -17,7 +17,7 @@ export interface PrSyncSession {
 }
 
 function buildWorktreePath(projectCwd: string): string {
-  return path.join(resolveCloneBaseDir(projectCwd), `pr-sync-${Date.now()}`);
+  return createPrSyncWorktreePath(resolveCloneBaseDir(projectCwd), Date.now());
 }
 
 function createPrSyncSession(projectCwd: string, branch: string): PrSyncSession {


### PR DESCRIPTION
## Summary

## Problem

When multiple TAKT tasks with the same slug start within the same minute, they can try to create the same worktree / shared clone directory.

Observed example:

```text
/Users/nrs/work/git/takt-worktrees/20260616T0314-fix-review-comments
```

Two tasks started at almost the same time:

```text
branch: takt/827/add-trace-task-metadata
branch: takt/816/implement-finding-contract
```

Both had the same slug:

```text
slug: fix-review-comments
```

The first task created the clone successfully. The second task failed immediately with:

```text
failure:
  error: Git clone failed
```

This happened before workflow execution or LLM execution started, so it is not an implementation failure in the task itself.

## Root cause

The generated worktree path appears to be based on a timestamp truncated to minute precision plus the task slug.

If two tasks have the same slug and start in the same minute, the path is not unique.

The task name may receive a suffix such as `fix-review-comments-1`, but the stored slug can still remain `fix-review-comments`, so the suffix does not protect the worktree path.

## Expected behavior

Parallel tasks must never share the same worktree / clone path unless explicitly intended.

Worktree path generation should be unique even when:

- tasks have the same slug
- tasks start in the same minute
- tasks target different branches
- tasks are created from similar PR review commands

## Proposed fix

Include a stable unique component in the worktree path.

Possible options:

- task id or task directory timestamp
- full task name after de-duplication, including suffix
- run id
- short random suffix
- branch-safe hash

A good default would be something like:

```text
YYYYMMDDTHHmm-<task-slug>-<short-task-or-run-id>
```

This should preserve human readability while preventing collisions.

## Requirements

- Worktree path generation must not rely only on minute timestamp + slug.
- If task names are de-duplicated, either the de-duplicated name or another unique id must be reflected in the path.
- Existing worktree cleanup and clone metadata should continue to work.
- The fix should apply to parallel task execution, not just this specific PR-review workflow.

## Tests

Add a regression test that creates or schedules two worktree tasks with the same slug in the same minute and verifies that their worktree paths differ.

Also test that:

- generated paths remain filesystem-safe
- generated paths remain reasonably readable
- clone metadata records the correct path for each task

## Acceptance criteria

- Two tasks with the same slug started in the same minute no longer collide.
- The second task no longer fails with `Git clone failed` due to pre-existing clone path.
- Worktree path includes a unique component beyond minute timestamp and slug.
- Existing single-task worktree behavior remains unchanged except for the path suffix.

## Execution Report

Workflow `takt-default` completed successfully.

Closes #836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * タスク用・一時用・PR同期用のクローンパスが一意に生成され、同時実行時の衝突を防止。
  * 危険な文字を含むタスク名でも、安全な作業ディレクトリ配下にパスを生成。
  * PR同期セッションの開始・解放・失敗時のクリーンアップ動作を安定化。
* **テスト**
  * クローンパスの形式、重複防止、メタデータ保存、異常時の後処理に関する検証を追加・更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->