### PR TITLE
fix: loop monitorにreviewer anomalyの不変条件を渡す

### DIFF
--- a/src/__tests__/finding-loop-monitor-summary.test.ts
+++ b/src/__tests__/finding-loop-monitor-summary.test.ts
@@ -3,7 +3,11 @@ import { buildLoopMonitorFindingsSummaryData, renderLoopMonitorFindingsSummary }
 import { reconcileFindingLedger } from '../core/workflow/findings/reconciler.js';
 import { createEmptyManagerOutput } from '../core/workflow/findings/manager-output.js';
 import { computeReviewerStableKey, computeLineageKey, computeProvisionalStableKey } from '../core/workflow/findings/raw-canonicalization.js';
-import type { FindingLedger, FindingLedgerEntry } from '../core/workflow/findings/types.js';
+import type {
+  FindingLedger,
+  FindingLedgerEntry,
+  ReviewerAnomalyEntry,
+} from '../core/workflow/findings/types.js';
 import { storedRawReconcileProvenance } from './helpers/finding-integrity.js';
 
 function provisionalEntry(
@@ -50,6 +54,28 @@ function makeLedger(findings: FindingLedgerEntry[], roundMarkers: string[] = [])
   };
 }
 
+function reviewerAnomaly(overrides: Partial<ReviewerAnomalyEntry> = {}): ReviewerAnomalyEntry {
+  const observation = {
+    runId: 'run-1',
+    stepName: 'reviewers',
+    timestamp: '2026-07-01T00:00:00.000Z',
+  };
+  return {
+    id: 'RA-0001',
+    kind: 'quote-mismatch',
+    stableKey: 'reviewer-anomaly-stable-key',
+    lineageKey: 'reviewer-anomaly-lineage-key',
+    sourceRawFindingIds: ['raw-anomaly-1'],
+    reviewers: ['coding-review'],
+    title: 'Unverified reviewer claim',
+    mismatchReason: 'The quoted source did not match',
+    firstObserved: observation,
+    lastObserved: observation,
+    occurrences: 1,
+    ...overrides,
+  };
+}
+
 describe('renderLoopMonitorFindingsSummary', () => {
   it('完了ゲート充足状況・滞留ラウンド数・解消経路を構造として導出する', () => {
     const ledger = makeLedger(
@@ -77,6 +103,10 @@ describe('renderLoopMonitorFindingsSummary', () => {
       activeConflictCount: 0,
       roundsCompleted: 6,
       maxRounds: 40,
+      reviewerAnomalies: {
+        count: 0,
+        budgetExhausted: false,
+      },
     });
     expect(data.openProvisional).toEqual([
       // firstObservedRound=1、6ラウンド完了 → 6ラウンド滞留。locationless は裁定可能
@@ -122,6 +152,111 @@ describe('renderLoopMonitorFindingsSummary', () => {
   it('provisional が無ければ暫定リストは空になる', () => {
     const data = buildLoopMonitorFindingsSummaryData(makeLedger([]), {});
     expect(data.openProvisional).toEqual([]);
+  });
+
+  it('anomaly のみの台帳では未昇格件数を product finding と分離して要約する', () => {
+    const ledger: FindingLedger = {
+      ...makeLedger([]),
+      reviewerAnomalies: [reviewerAnomaly()],
+    };
+
+    const data = buildLoopMonitorFindingsSummaryData(ledger, {});
+    const summary = renderLoopMonitorFindingsSummary(ledger, {});
+
+    expect(data.openCount).toBe(0);
+    expect(data.reviewerAnomalies).toEqual({
+      count: 1,
+      budgetExhausted: false,
+    });
+    expect(summary).toContain('findings.reviewerAnomalies.count: 1');
+  });
+
+  it('promoted/unpromoted anomaly が混在しても未昇格だけを数える', () => {
+    const ledger: FindingLedger = {
+      ...makeLedger([]),
+      reviewerAnomalies: [
+        reviewerAnomaly({ id: 'RA-UNPROMOTED' }),
+        reviewerAnomaly({
+          id: 'RA-PROMOTED',
+          stableKey: 'promoted-stable-key',
+          promotedFindingId: 'F-0001',
+        }),
+      ],
+    };
+
+    const data = buildLoopMonitorFindingsSummaryData(ledger, {});
+    const summary = renderLoopMonitorFindingsSummary(ledger, {});
+
+    expect(data.reviewerAnomalies.count).toBe(1);
+    expect(summary).toContain('findings.reviewerAnomalies.count: 1');
+    expect(summary).not.toContain('RA-UNPROMOTED');
+    expect(summary).not.toContain('RA-PROMOTED');
+  });
+
+  it.each([false, true])(
+    'review-integrity budget exhaustion=%s をそのまま要約する',
+    (budgetExhausted) => {
+      const ledger: FindingLedger = {
+        ...makeLedger([]),
+        reviewerAnomalies: [reviewerAnomaly()],
+        reviewIntegrity: {
+          roundMarkers: ['review-round-1'],
+          firstRoundAt: '2026-07-01T00:00:00.000Z',
+          exhausted: budgetExhausted,
+        },
+      };
+
+      const data = buildLoopMonitorFindingsSummaryData(ledger, {});
+      const summary = renderLoopMonitorFindingsSummary(ledger, {});
+
+      expect(data.reviewerAnomalies.budgetExhausted).toBe(budgetExhausted);
+      expect(summary).toContain(
+        `findings.reviewerAnomalies.budgetExhausted: ${budgetExhausted}`,
+      );
+    },
+  );
+
+  it('anomaly の claimed content と raw reviewer text をプロンプト要約へ出さない', () => {
+    const ledger: FindingLedger = {
+      ...makeLedger([]),
+      reviewerAnomalies: [reviewerAnomaly({
+        id: 'SECRET_ANOMALY_ID',
+        title: 'SECRET_REVIEWER_TITLE',
+        claimedLocation: 'SECRET_CLAIMED_LOCATION',
+        claimedExcerpt: 'SECRET_CLAIMED_EXCERPT',
+        mismatchReason: 'SECRET_MISMATCH_REASON',
+        sourceRawFindingIds: ['SECRET_RAW_FINDING_ID'],
+        reviewers: ['SECRET_REVIEWER_NAME'],
+      })],
+    };
+
+    const summary = renderLoopMonitorFindingsSummary(ledger, {});
+
+    for (const secret of [
+      'SECRET_ANOMALY_ID',
+      'SECRET_REVIEWER_TITLE',
+      'SECRET_CLAIMED_LOCATION',
+      'SECRET_CLAIMED_EXCERPT',
+      'SECRET_MISMATCH_REASON',
+      'SECRET_RAW_FINDING_ID',
+      'SECRET_REVIEWER_NAME',
+    ]) {
+      expect(summary).not.toContain(secret);
+    }
+  });
+
+  it('anomaly を repairable finding と表現せず fix routing を禁止する', () => {
+    const ledger: FindingLedger = {
+      ...makeLedger([]),
+      reviewerAnomalies: [reviewerAnomaly()],
+    };
+
+    const summary = renderLoopMonitorFindingsSummary(ledger, {});
+
+    expect(summary).toContain('reviewer anomalies are unverified reviewer claims');
+    expect(summary).toContain('not repairable product findings');
+    expect(summary).toContain('Never route a reviewer anomaly to fix');
+    expect(summary).toContain('only actionable open findings may be routed to fix');
   });
 });
 

--- a/src/core/workflow/findings/loop-monitor-summary.ts
+++ b/src/core/workflow/findings/loop-monitor-summary.ts
@@ -1,5 +1,5 @@
 import type { FindingLedger } from './types.js';
-import type { FindingProvisionalKind } from '../../models/finding-types.js';
+import type { FindingProvisionalKind, FindingsRuleContext } from '../../models/finding-types.js';
 import { isDismissCandidate } from './manager-utils.js';
 import { stopBudgetRoundsCompleted } from './stop-budget.js';
 import { resolveStopBudgetLimits } from './stop-budget.js';
@@ -21,16 +21,17 @@ export interface LoopMonitorFindingsSummaryData {
   activeConflictCount: number;
   roundsCompleted: number;
   maxRounds: number;
+  reviewerAnomalies: Pick<FindingsRuleContext['reviewerAnomalies'], 'count' | 'budgetExhausted'>;
 }
 
 /**
  * loop monitor judge へ注入する findings 状態の派生データ。judge は台帳の
  * 生データ（ledger summary）を既に受けているが、「進捗があるのに完走不能」
  * を見抜くのに必要な派生情報 — 完了ゲートの充足状況、暫定の滞留ラウンド数、
- * 解消経路の有無 — は生データからの再導出を要求されていた（実測: 健全な
- * resolved 増加だけを見て『続行』と判定し続け、ゲートを塞ぐ暫定の滞留を
- * 見逃した）。意味契約はこのデータ構造が持ち、文面は renderLoopMonitorFindingsSummary
- * が担う。
+ * 解消経路の有無、reviewer anomaly の状態 — は生データからの再導出を要求
+ * されていた（実測: 健全な resolved 増加だけを見て『続行』と判定し続け、
+ * ゲートを塞ぐ暫定の滞留を見逃した）。意味契約はこのデータ構造が持ち、
+ * 文面は renderLoopMonitorFindingsSummary が担う。
  */
 export function buildLoopMonitorFindingsSummaryData(
   ledger: FindingLedger,
@@ -57,6 +58,11 @@ export function buildLoopMonitorFindingsSummaryData(
     activeConflictCount: ledger.conflicts.filter((conflict) => conflict.status === 'active').length,
     roundsCompleted,
     maxRounds: limits.maxRounds,
+    reviewerAnomalies: {
+      count: (ledger.reviewerAnomalies ?? [])
+        .filter((anomaly) => anomaly.promotedFindingId === undefined).length,
+      budgetExhausted: ledger.reviewIntegrity?.exhausted ?? false,
+    },
   };
 }
 
@@ -75,6 +81,7 @@ export function renderLoopMonitorFindingsSummary(
   return [
     `Completion gate requires findings.open.count == 0; currently ${data.openCount} open (${data.openSubstantiveCount} substantive, ${data.openProvisional.length} gate-blocking provisional). Active conflicts: ${data.activeConflictCount}.`,
     `Manager rounds completed: ${data.roundsCompleted}/${data.maxRounds}.`,
+    `findings.reviewerAnomalies.count: ${data.reviewerAnomalies.count}; findings.reviewerAnomalies.budgetExhausted: ${data.reviewerAnomalies.budgetExhausted}. Engine invariant: reviewer anomalies are unverified reviewer claims, not repairable product findings. Never route a reviewer anomaly to fix; only actionable open findings may be routed to fix.`,
     ...(provisionalLines.length > 0
       ? ['Open provisional findings (these block completion until settled):', ...provisionalLines]
       : []),


### PR DESCRIPTION
## 目的

旧PR #1094で得られた汎用的な改善のうち、最新mainでも欠けていたloop monitor向けreviewer anomaly要約だけを移植します。

## 変更内容

- 未昇格reviewer anomalyだけを集計
- review-integrity budget exhaustionをloop monitorへ通知
- anomalyは未検証のreviewer claimであり、修正可能なproduct findingではないことを明示
- anomalyを`fix`へ送らず、actionable open findingだけを修正対象にする不変条件を注入
- anomalyのID、title、claimed location/excerpt、mismatch reason、raw ID、reviewer名は要約へ出さない

## 対象外

- completion gateとFinding Contract台帳ポリシーの変更
- acknowledgement、attestation、fail-open
- LocalLLM用workflow、facet、eval
- provider固有処理、後方互換層、V1/V2

## 検証

- 対象unitテスト: 11件成功
- `npm run test:type-contracts`
- `npm run lint`
- `npm run build`
- `git diff --check`

別セッションのgpt-5.6-solによる敵対レビューで承認済みです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * レビュアー異常の件数と予算上限到達状況を、ループ監視サマリーに表示するようになりました。
  * 商品上の指摘とレビュアー異常を分離して要約します。
  * 未昇格の異常のみを集計し、異常を修正対象や修正ルーティング対象として扱わない旨を明示します。

* **テスト**
  * レビュアー異常、予算上限到達、機密情報の非表示など、サマリー表示の検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->