### PR TITLE
Release v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.53.0] - 2026-07-27
+
+### Removed
+
+- **BREAKING:** The `for-local-llm` workflow family was removed (#1070): `takt-default-for-local-llm`, `frontend-for-local-llm`, `backend-for-local-llm`, `backend-cqrs-for-local-llm`, `dual-for-local-llm`, and `peer-review-for-local-llm`. Use `takt-default`, `takt-default-high`, or the corresponding domain workflows instead. Saved tasks or runs that reference a removed workflow must switch workflows before retrying or resuming.
+- **BREAKING:** The MCP tools `takt_create_issue_and_enqueue_task` and `takt_run_next_task` were removed (#1104). `takt_enqueue_task` is now the only MCP tool: pass `issue: { number }` to link an existing issue, or `issue: { title?, labels? }` to create one before enqueueing. Run queued tasks with `takt run` or `takt watch`.
+
+### Added
+
+- `takt-default-team-high` workflow (#1055). A Team Leader variant of `takt-default-high`: plan, tests, Team Leader-directed implementation, six compact specialist reviews, Team Leader-directed fixes, and a fail-closed final gate.
+- Team Leader Finding Contract fix mode (#1089, #1090, #1091, #1100). `team_leader.mode: finding_contract_fix` turns a team_leader step into a Finding Contract repair step: every part is assigned to explicit actionable findings, `complete` requires successful verification plus `fixCoverage` for every actionable finding present at step start, and the decision routes via mechanical conditions such as `when(structured.fix.decision == "complete")`. Wildcard contract paths are rejected (#1090), and part `writePaths` document coordination between parallel parts rather than acting as a sandbox (#1100).
+- The findings-manager now acts as an adjudicator (#1053): dismiss adjudication and duplicate consolidation actually take effect in the ledger, manager state is injected into the review-fix judge, and manager/interpreter LLM calls are recorded in usage events instead of being a token-accounting blind spot.
+- Multi-select facet prompts (#1065). The exec facet editor now offers multi-select prompts, so facet references can be picked in one pass instead of one-at-a-time dialogs.
+- Codex Skill inheritance control (#1081). New `provider_options.codex.skills.repo` / `.user` flags (plus `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_*` env overrides) control whether Codex discovers repository (`.agents/skills`) and user (`~/.agents/skills`, `$CODEX_HOME/skills`) Skills. Workflows now default to not inheriting either scope; `takt exec` defaults to inheriting and snapshots the resolved values into the generated workflow.
+- Resumed runs inherit review reports (#1059). Resuming a run carries prior review reports over (best effort), so a resumed fix step no longer starts blind; same-run requeues skip the resume snapshot.
+- Shared fix steps now persist a structured `fix-report` (#1116). The builtin workflows that use the shared fix instruction write addressed/unaddressed findings, verification results, and family coverage as a non-judging output contract, so the next iteration or a resumed run can pick up where the fix left off. Rules, transitions, and completion judgment are unchanged.
+
+### Changed
+
+- **BREAKING:** Node.js `>=24.15.0` is now required (#1111), up from `^20.20.0 || >=22.22.0`, because the new run storage uses the built-in `node:sqlite` module.
+- **BREAKING:** Auto-routing candidates were reworked around pools and tiers (#1103). `cost_tier` was renamed to `routing_tier` (`high` | `medium` | `low`), and `default_pool` plus `candidate_pools` (each with a pool-local `fallback`) are now required; optional `pool_rules` pin tags/steps/personas to a pool. The router now only estimates the required tier — from the normalized task, the raw step instruction, and current remaining work — and TAKT deterministically picks the candidate: `cost` and `balanced` take the lowest sufficient `routing_tier` in the selected pool, `performance` the highest. Existing configs must rename `cost_tier` and add `default_pool` / `candidate_pools`.
+- High workflows are capped at 50 steps (#1061): `max_steps` dropped from 200 to 50 on `takt-default-high`, `review-fix-takt-default-high`, and `takt-default-team-high`.
+- Merge-readiness now runs before final supervision in the high workflows (#1060), and the Finding Contract final gate was extracted into `merge-readiness-finding-contract-final-gate`.
+- The stop-budget time cap is now opt-in (#1052). `stop_budget.max_minutes` no longer defaults to 90 minutes — churn shows up in round counts, not minutes, and the time default had falsely stopped healthy large runs; the round cap (default 40) remains the deterministic stop guarantee. Reviewers are also barred from filing demands for quality-gate execution evidence as findings; evaluating verification results is the final gate's job.
+- The Team Leader total part limit was removed (#1084): the leader may keep adding batches until it judges the work complete, and `initial_max_parts` bounds only the first decomposition batch.
+
+### Fixed
+
+- Team Leader robustness: obsolete running parts are cancelled and completion judgment waits for still-running parts (#1105); invalid decompositions are regenerated with validation diagnostics instead of failing (#1113); the feedback fallback stops on abort (#1085); reviewer-anomaly invariants are passed to loop monitors (#1114); and the implementation judgment receives the agent's completion report (#1101).
+- Finding Contract convergence and recovery hardening (#1056, #1058, #1063, #1067, #1069, #1072, #1074, #1086, #1087, #1092, #1093). The findings-manager no longer discards its entire output on dedup/evidence conflicts and degrades to mechanical classification instead of an empty result (#1056); convergence state survives retries (#1058) and finding context survives resumes (#1074); stalled Finding Contract workflows re-plan and final-gate `needs_fix` decisions are honored (#1069); review target snapshots are bound to the structured output contract (#1086); reviewer anomalies are kept after re-matching (#1087); invalid manager decisions are retried (#1092) with hardened recovery (#1093); explanatory adjudication evidence citations are accepted (#1063); post-fix loop monitor states are distinguished (#1067); and re-plans justified only by external blockers abort instead of looping (#1072).
+- The fix loop now aborts with an explicit verdict when verification is impossible for environmental reasons (#1102), instead of spinning on unfixable findings.
+- PR-derived tasks and Instruct now use the same diff basis (#1106), with PR diff refs materialized so review context matches what is actually being merged.
+- Concurrent clone/worktree path collisions were fixed (#1110): clone directories get a unique random suffix, covering same-second task starts and PR-sync worktrees.
+- Isolated temporary paths were shortened (#1071) to stay within platform path-length limits, with Windows temp-env precedence covered.
+- `auto-improvement-loop` now completes a full issue → implement → PR → self-review → merge cycle on codex (#1045); it previously aborted at `plan_from_issue`.
+- OpenCode runs on local models were stabilized (#1017): tool-call failures now log the offending arguments to the debug log, and Finding Contract freezes under weak models were resolved.
+
+### Internal
+
+- Run-scoped SQLite storage foundation (#1111): a `node:sqlite`-backed per-run store (artifacts, findings, reports, unit-of-work) landed under `src/infra/run-storage/`, alongside a consolidation of the Finding Contract integrity model. Engine wiring comes later; `.takt/` output is unchanged in this release.
+- Builtin TAKT workflows were unified on first-match rule semantics (#1083).
+- The MCP stdio integration test now passes the isolated `TAKT_CONFIG_DIR` to the spawned server, so it no longer reads the operator's real `~/.takt/config.yaml`.
+- Docs: reusable TAKT overview assets (#1108, #1109) and YouTube tutorial links (#1112).
+
 ## [0.52.0] - 2026-07-19
 
 ### Removed

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,50 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.53.0] - 2026-07-27
+
+### Removed
+
+- **BREAKING:** `for-local-llm` ワークフローファミリーを削除しました (#1070)。対象は `takt-default-for-local-llm`、`frontend-for-local-llm`、`backend-for-local-llm`、`backend-cqrs-for-local-llm`、`dual-for-local-llm`、`peer-review-for-local-llm` です。代わりに `takt-default` / `takt-default-high` または対応するドメインワークフローを使用してください。削除されたワークフローを参照している保存済みタスクや run は、リトライ・再開の前にワークフローを切り替えるか作り直す必要があります。
+- **BREAKING:** MCP ツール `takt_create_issue_and_enqueue_task` と `takt_run_next_task` を削除しました (#1104)。MCP ツールは `takt_enqueue_task` のみになります。既存 issue の紐付けは `issue: { number }`、enqueue 前の issue 作成は `issue: { title?, labels? }` を渡してください。積んだタスクの実行は `takt run` または `takt watch` で行います。
+
+### Added
+
+- `takt-default-team-high` ワークフロー (#1055)。`takt-default-high` の Team Leader 版です。計画、テスト、Team Leader 主導の実装、6 つのコンパクトな専門レビュー、Team Leader 主導の修正、fail-closed な最終ゲートで構成されます。
+- Team Leader の Finding Contract 修正モード (#1089, #1090, #1091, #1100)。`team_leader.mode: finding_contract_fix` を設定すると team_leader ステップが Finding Contract の修正専用ステップになります。各 part は明示的な actionable finding に割り当てられ、`complete` には検証成功とステップ開始時点の全 actionable finding の `fixCoverage` が必要で、判定は `when(structured.fix.decision == "complete")` のような機械的条件でルーティングします。ワイルドカードの contract path は拒否され (#1090)、part の `writePaths` はサンドボックスではなく並行作業間の協調契約として扱われます (#1100)。
+- findings-manager が判定者に拡張されました (#1053)。dismiss 裁定と重複統合が ledger に実際に反映されるようになり、manager の状態が review-fix の judge に注入され、manager / interpreter の LLM 呼び出しが usage イベントに記録されてトークン集計の死角ではなくなりました。
+- ファセットのマルチセレクト選択 (#1065)。exec のファセットエディタがマルチセレクトプロンプトに対応し、ファセット参照を 1 つずつのダイアログではなく一括で選択できるようになりました。
+- Codex Skill 継承の制御 (#1081)。新しい `provider_options.codex.skills.repo` / `.user` フラグ（および `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_*` 環境変数オーバーライド）で、Codex がリポジトリ（`.agents/skills`）とユーザー（`~/.agents/skills`、`$CODEX_HOME/skills`）の Skill を発見するかを制御できます。ワークフローはデフォルトでどちらのスコープも継承しなくなりました。`takt exec` はデフォルトで継承し、解決済みの値を生成ワークフローにスナップショットします。
+- 再開した run がレビューレポートを引き継ぐようになりました (#1059)。run の再開時に過去のレビューレポートをベストエフォートで引き継ぐため、再開後の修正ステップがゼロから始まりません。同一 run 内の requeue では resume スナップショットをスキップします。
+- 共有 fix ステップが構造化された `fix-report` を保存するようになりました (#1116)。共有 fix instruction を使うビルトインワークフローが、対応済み・未対応の finding、検証結果、family coverage を非判定の output contract として書き出すため、次の反復や再開した run が修正の続きから始められます。rules・遷移・完了判定は変更ありません。
+
+### Changed
+
+- **BREAKING:** Node.js `>=24.15.0` が必須になりました (#1111)。従来は `^20.20.0 || >=22.22.0` でしたが、新しい run ストレージが組み込みの `node:sqlite` モジュールを使うためです。
+- **BREAKING:** Auto Routing の candidates をプールとティア中心に再設計しました (#1103)。`cost_tier` は `routing_tier`（`high` | `medium` | `low`）にリネームされ、`default_pool` と `candidate_pools`（各プールにプールローカルな `fallback`）が必須になりました。任意の `pool_rules` で tags / steps / personas をプールに固定できます。router は正規化されたタスク・ステップ指示・現在の残作業から必要ティアの推定のみを行い、候補は TAKT が決定的に選択します。`cost` と `balanced` は選択プール内で必要ティアを満たす最小の `routing_tier` を、`performance` は最大を選びます。既存の設定は `cost_tier` のリネームと `default_pool` / `candidate_pools` の追加が必要です。
+- high 系ワークフローのステップ上限を 50 にしました (#1061)。`takt-default-high`、`review-fix-takt-default-high`、`takt-default-team-high` の `max_steps` を 200 から 50 に引き下げました。
+- high 系ワークフローで merge-readiness を最終監督より前に実行するようにしました (#1060)。Finding Contract 用の最終ゲートは `merge-readiness-finding-contract-final-gate` として切り出されました。
+- stop budget の時間上限をオプトインにしました (#1052)。`stop_budget.max_minutes` の既定値（90 分）を廃止しました。守るべき病理（churn）はラウンド数に現れるのであって時間には現れず、時間の既定上限が健全な大型 run を誤停止させた実測があるためです。ラウンド上限（既定 40）は決定的な停止保証として残ります。また、品質ゲートの実行証跡を要求する指摘を finding として起票することを全レビュアーで禁止しました。検証結果の評価は最終ゲートの職掌です。
+- Team Leader の総 part 数上限を撤廃しました (#1084)。leader は作業完了と判断するまでバッチを追加でき、`initial_max_parts` は最初の分解バッチのみを制限します。
+
+### Fixed
+
+- Team Leader の堅牢化。旧 part を取り消し、完了判定で実行中 part を待つようになりました (#1105)。不正な分解は失敗ではなく検証診断付きで再生成されます (#1113)。中断時にフィードバックフォールバックが停止します (#1085)。reviewer anomaly の不変条件が loop monitor に渡されます (#1114)。実装判定にエージェントの完了報告が引き継がれます (#1101)。
+- Finding Contract の収束と復旧の強化 (#1056, #1058, #1063, #1067, #1069, #1072, #1074, #1086, #1087, #1092, #1093)。findings-manager は dedup と証拠衝突で出力全体を破棄せず、空の結果ではなく機械分類へ縮退します (#1056)。収束状態がリトライを跨いで維持され (#1058)、finding コンテキストが再開を跨いで維持されます (#1074)。滞留した Finding Contract ワークフローは再計画し、最終ゲートの `needs_fix` 判定が尊重されます (#1069)。レビュー対象スナップショットは構造化出力契約に束縛され (#1086)、reviewer anomaly は再照合後も保持されます (#1087)。不正な manager 判定はリトライされ (#1092)、その復旧が強化されました (#1093)。説明的な裁定証拠の引用が受理されます (#1063)。修正後の loop monitor 状態が区別されます (#1067)。外部要因のみを理由とする再計画はループせず中断します (#1072)。
+- 環境要因で検証不能な場合、修正ループが明示的な判定付きで中断するようになりました (#1102)。修正不能な finding で空転しません。
+- PR 由来タスクと Instruct の差分基準を統一しました (#1106)。PR の diff ref を実体化し、レビューコンテキストが実際にマージされる内容と一致します。
+- 並行実行時の clone / worktree パス衝突を修正しました (#1110)。clone ディレクトリに一意なランダムサフィックスが付き、同一秒のタスク開始や PR 同期 worktree でも衝突しません。
+- 隔離一時パスを短縮しました (#1071)。プラットフォームのパス長制限に収まるようにし、Windows の一時ディレクトリ環境変数の優先順位もカバーしています。
+- `auto-improvement-loop` が codex で Issue → 実装 → PR → セルフレビュー → マージの一巡を完走できるようになりました (#1045)。従来は `plan_from_issue` で即座に中断していました。
+- ローカルモデルでの OpenCode 実行を安定化しました (#1017)。ツール呼び出し失敗時に問題の引数が debug ログに記録されるようになり、弱いモデルでの Finding Contract の凍結が解消されました。
+
+### Internal
+
+- run 単位の SQLite ストレージ基盤 (#1111)。`node:sqlite` ベースの run 単位ストア（artifacts、findings、reports、unit-of-work）が `src/infra/run-storage/` に追加され、Finding Contract の整合性モデルの単一形式への再構成も行われました。エンジンへの接続は今後のリリースで行われ、本リリースでは `.takt/` の出力は変わりません。
+- ビルトインの TAKT ワークフローをルールの first-match セマンティクスに統一しました (#1083)。
+- MCP stdio 統合テストが隔離済み `TAKT_CONFIG_DIR` を起動したサーバーに渡すようになり、実行者の実際の `~/.takt/config.yaml` を読まなくなりました。
+- ドキュメント: 再利用可能な TAKT 概要アセット (#1108, #1109) と YouTube チュートリアルリンク (#1112) を追加しました。
+
 ## [0.52.0] - 2026-07-19
 
 ### Removed

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-dlbV3QO5oXcWWQLoE0AHQA0IVwWxINdeWtZzEVLUHXA=";
+            npmDepsHash = "sha256-deSegyPrMz473NqqxAuNB0ItBT4BW0njkEq8G0b3tKw=";
             nodejs = nodejs;
             ONNXRUNTIME_NODE_INSTALL = "skip";
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Workflow control for AI coding agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Removed

- **BREAKING:** The `for-local-llm` workflow family was removed (#1070): `takt-default-for-local-llm`, `frontend-for-local-llm`, `backend-for-local-llm`, `backend-cqrs-for-local-llm`, `dual-for-local-llm`, and `peer-review-for-local-llm`. Use `takt-default`, `takt-default-high`, or the corresponding domain workflows instead. Saved tasks or runs that reference a removed workflow must switch workflows before retrying or resuming.
- **BREAKING:** The MCP tools `takt_create_issue_and_enqueue_task` and `takt_run_next_task` were removed (#1104). `takt_enqueue_task` is now the only MCP tool: pass `issue: { number }` to link an existing issue, or `issue: { title?, labels? }` to create one before enqueueing. Run queued tasks with `takt run` or `takt watch`.

### Added

- `takt-default-team-high` workflow (#1055). A Team Leader variant of `takt-default-high`: plan, tests, Team Leader-directed implementation, six compact specialist reviews, Team Leader-directed fixes, and a fail-closed final gate.
- Team Leader Finding Contract fix mode (#1089, #1090, #1091, #1100). `team_leader.mode: finding_contract_fix` turns a team_leader step into a Finding Contract repair step.
- The findings-manager now acts as an adjudicator (#1053): dismiss adjudication and duplicate consolidation take effect in the ledger, manager state is injected into the review-fix judge, and manager/interpreter LLM calls are recorded in usage events.
- Multi-select facet prompts in the exec facet editor (#1065).
- Codex Skill inheritance control (#1081) via `provider_options.codex.skills.repo` / `.user`. Workflows default to not inheriting either scope; `takt exec` defaults to inheriting and snapshots resolved values.
- Resumed runs inherit review reports (#1059), so a resumed fix step no longer starts blind.
- Shared fix steps now persist a structured `fix-report` (#1116): addressed/unaddressed findings, verification results, and family coverage are written as a non-judging output contract for the next iteration or a resumed run.

### Changed

- **BREAKING:** Node.js `>=24.15.0` is now required (#1111), up from `^20.20.0 || >=22.22.0` (`node:sqlite`).
- **BREAKING:** Auto-routing candidates reworked around pools and tiers (#1103): `cost_tier` → `routing_tier`, required `default_pool` / `candidate_pools`, optional `pool_rules`; the router estimates only the required tier and TAKT deterministically selects the candidate.
- High workflows capped at 50 steps (#1061).
- Merge-readiness runs before final supervision in the high workflows (#1060); the Finding Contract final gate was extracted into `merge-readiness-finding-contract-final-gate`.
- The stop-budget time cap is now opt-in (#1052); the round cap (default 40) remains the deterministic stop guarantee.
- Team Leader total part limit removed (#1084); `initial_max_parts` bounds only the first decomposition batch.

### Fixed

- Team Leader robustness (#1085, #1101, #1105, #1113, #1114): obsolete parts cancelled, completion waits for running parts, decompositions regenerated with validation diagnostics, reviewer-anomaly invariants passed to loop monitors, implementation judgment receives the completion report.
- Finding Contract convergence and recovery hardening (#1056, #1058, #1063, #1067, #1069, #1072, #1074, #1086, #1087, #1092, #1093).
- Fix loop aborts with an explicit verdict when verification is impossible for environmental reasons (#1102).
- PR-derived tasks and Instruct use the same diff basis (#1106).
- Concurrent clone/worktree path collisions fixed (#1110).
- Isolated temporary paths shortened (#1071).
- `auto-improvement-loop` completes a full cycle on codex (#1045).
- OpenCode runs on local models stabilized (#1017).

### Internal

- Run-scoped SQLite storage foundation (#1111); engine wiring comes later, `.takt/` output unchanged in this release.
- Builtin TAKT workflows unified on first-match rule semantics (#1083).
- The MCP stdio integration test now passes the isolated `TAKT_CONFIG_DIR` to the spawned server.
- Docs: reusable TAKT overview assets (#1108, #1109) and YouTube tutorial links (#1112).

## Commits

- 5265948e Release v0.53.0
- a37b5a17 fix: persist shared fix step reports (#1116)
- 8403585d fix(test): MCP統合テストのサブプロセスに隔離済みTAKT_CONFIG_DIRを渡す
- 50156be1 fix: loop monitorにreviewer anomalyの不変条件を渡す (#1114)
- 4399fcad fix: Team Leader分解を検証診断付きで再生成する (#1113)
- a9574920 takt: fix-worktree-path-collisions (#1110)
- aae13781 docs: add YouTube tutorial links (#1112)
- bb20ba91 feat: run単位SQLiteストレージ基盤を追加する (#1111)
- d3e81b27 docs: place overview image after introduction (#1109)
- 6cd53de7 docs: add reusable TAKT overview assets (#1108)
- 1b6ce8dd fix(team-leader): 旧パートを取消し完了判定で実行中パートを待つ (#1105)
- 9eccc6c2 fix: PR由来タスクとInstructの差分基準を統一する (#1106)
- f5ef651d feat: MCP toolをtakt_enqueue_taskのみに整理する (#1104)
- 404f66eb feat: 残作業とroutingTierでAuto Routingを判定する (#1103)
- a7961cb7 fix: 環境要因で検証不能な場合に修正ループを中断する (#1102)
- 26af257c fix: implement判定に完了報告を引き継ぐ (#1101)
- 44f46a79 fix(team-leader): remove Finding Contract write path assignments (#1100)
- cbef7d7c fix(team-leader): unify Finding Contract recovery (#1096)
- 2dd588c3 fix: harden finding contract decision recovery (#1093)
- 144f880a fix: retry invalid finding contract decisions (#1092)
- 0fe5a6b4 perf(team-leader): improve Finding Contract fix convergence (#1091)
- 2365d859 fix(team-leader): reject wildcard contract paths (#1090)
- eb489e45 feat(team-leader): add Finding Contract fix mode (#1089)
- 052672a5 fix: レビュアー異常を再照合後も保持する (#1087)
- 3e450964 fix: レビュー対象スナップショットを構造化出力契約に束縛する (#1086)
- 1fcdb320 fix(team-leader): stop feedback fallback on abort (#1085)
- 581450ff fix(team-leader): remove total part limit (#1084)
- 750accc3 takt: unify-rule-first-match (#1083)
- cbec74ac fix(runtime): shorten isolated temporary paths (#1071)
- 7b72b853 feat(codex): control Skill inheritance (#1081)
- f00364bd fix(workflow): preserve finding context across resumes (#1074)
- bf5a7f49 fix(workflow): abort external-only replans (#1072)
- a54f6484 chore: remove for-local-llm workflows (#1070)
- f92fba02 fix: replan stalled finding contract workflows (#1069)
- 56581f3d fix: distinguish post-fix loop monitor states (#1067)
- 1fb69e51 feat: add multi-select facet prompts (#1065)
- ed69293e fix: accept explanatory adjudication evidence citations (#1063)
- ffd18ea4 fix: cap high workflows at 50 steps (#1061)
- a117e37a fix: run merge-readiness before final supervision (#1060)
- b92780d6 feat: resume fix with inherited review reports (#1059)
- f70a91e1 fix: preserve Finding Manager convergence across retries (#1058)
- 78ee71c7 change max step
- caa6ab41 fix: finding contract の provisional recovery アーキテクチャ — 出力破棄の解消と滞留クラスの一掃 (#1056)
- 83b6e1da feat: takt-default-team-high を追加する (#1055)
- 62c76d66 docs: takt-default-high の説明を「高能力モデル向け」から takt-default の強化版に修正 (#1054)
- 68973f8a feat: findings-manager を判定者へ拡張 — dismiss 裁定・重複統合の実効化・judge への状態注入 (#1053)
- 3c3ff9eb fix: auto-improvement-loop を codex/gpt-5.5 で実際に完走できるようにする (#1045)
- 81c4d364 fix: stop budget の時間上限を opt-in にしレビュアーの品質ゲート証跡指摘を入場から外す (#1052)
- e662ab1b fix: ローカルLLM 実行の安定化 — opencode の防護装置と Finding Contract の凍結解消 (#1017)
- 38944cfe Update README.md
- d1ab5796 docs: 自動ルーティングを新機能として記載しBREAKING表記を除去する
- 8422172c Merge pull request #1051 from nrslib/release/v0.52.0
