### PR TITLE
Release v0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.54.0] - 2026-07-28
+
+### Added
+
+- The `simple` workflow family (#1117). Seven builtin workflows for capable models that trust the model's judgment and keep orchestration minimal: `simple` (plan → write tests → implement → code review → fix loop → final supervision), `simple-mini` (omits dedicated test writing and final supervision), and the domain variants `simple-frontend`, `simple-backend`, `simple-cqrs`, `simple-dual`, and `simple-dual-cqrs`, which inject the matching knowledge and policies into a shared internal `simple-core` subworkflow. The steps direct the model to select relevant available skills on its own, and on codex the family inherits repository and user Skills (`provider_options.codex.skills.repo/user: true`). The catalog gained a ✨ Simple category, and `simple` now leads the 🚀 Quick Start category.
+
+### Internal
+
+- Prose-coupled assertions were removed from the skill-docs tests, and the builtin-facet deployment test covers the new `use-relevant-skills` instruction partial (#1117).
+
 ## [0.53.0] - 2026-07-27
 
 ### Removed

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,16 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.54.0] - 2026-07-28
+
+### Added
+
+- `simple` ワークフローファミリー (#1117)。有能なモデルの判断を信頼し、オーケストレーションを最小限に抑えた 7 つのビルトインワークフローです。`simple`（計画 → テスト作成 → 実装 → コードレビュー → 修正ループ → 最終監督）、`simple-mini`（専用のテスト作成と最終監督を省略）、およびドメイン別の `simple-frontend`、`simple-backend`、`simple-cqrs`、`simple-dual`、`simple-dual-cqrs` で、各バリアントは共有の内部サブワークフロー `simple-core` に対応するナレッジとポリシーを注入します。各ステップはモデル自身に関連する利用可能スキルの選択を指示し、codex ではリポジトリ・ユーザーの Skill を継承します（`provider_options.codex.skills.repo/user: true`）。カタログに ✨ Simple カテゴリが追加され、🚀 Quick Start カテゴリの先頭が `simple` になりました。
+
+### Internal
+
+- スキルドキュメントのテストから文面に結合したアサーションを削除し、ビルトインファセット配備テストが新しい `use-relevant-skills` インストラクションパーシャルをカバーするようにしました (#1117)。
+
 ## [0.53.0] - 2026-07-27
 
 ### Removed

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-deSegyPrMz473NqqxAuNB0ItBT4BW0njkEq8G0b3tKw=";
+            npmDepsHash = "sha256-FYJuEaSSCc6LAvnuCpSDj/t+gTvrUT7/0KMyh+D25xQ=";
             nodejs = nodejs;
             ONNXRUNTIME_NODE_INSTALL = "skip";
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Workflow control for AI coding agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Added

- The `simple` workflow family (#1117). Seven builtin workflows for capable models that trust the model's judgment and keep orchestration minimal: `simple` (plan → write tests → implement → code review → fix loop → final supervision), `simple-mini` (omits dedicated test writing and final supervision), and the domain variants `simple-frontend`, `simple-backend`, `simple-cqrs`, `simple-dual`, and `simple-dual-cqrs`, which inject the matching knowledge and policies into a shared internal `simple-core` subworkflow. The steps direct the model to select relevant available skills on its own, and on codex the family inherits repository and user Skills (`provider_options.codex.skills.repo/user: true`). The catalog gained a ✨ Simple category, and `simple` now leads the 🚀 Quick Start category.

### Internal

- Prose-coupled assertions were removed from the skill-docs tests, and the builtin-facet deployment test covers the new `use-relevant-skills` instruction partial (#1117).

## Commits

- a2ff88df Release v0.54.0
- ad9af537 feat: add simple workflow family (#1117)
- 2c70157d Merge pull request #1115 from nrslib/release/v0.53.0