### PR TITLE
feat(mcp): add read-only takt_list_tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ See the [Builtin Catalog](./docs/builtin-catalog.md) for all workflows and perso
 
 See the [CLI Reference](./docs/cli-reference.md) for all commands and options.
 
-TAKT also ships two client-integration entrypoints: `takt-acp` runs TAKT as an [Agent Client Protocol](./docs/cli-reference.md#acp-agent) agent over stdio JSON-RPC, and `takt-mcp` runs it as a stdio [MCP server](./docs/cli-reference.md#mcp-server) so an MCP client (Codex, Claude Code, …) can enqueue tasks with an optional existing or newly created issue. Use `takt run` or `takt watch` to execute pending tasks.
+TAKT also ships two client-integration entrypoints: `takt-acp` runs TAKT as an [Agent Client Protocol](./docs/cli-reference.md#acp-agent) agent over stdio JSON-RPC, and `takt-mcp` runs it as a stdio [MCP server](./docs/cli-reference.md#mcp-server) so an MCP client (Codex, Claude Code, …) can enqueue tasks with an optional existing or newly created issue and read the task history without mutation. Use `takt run` or `takt watch` to execute pending tasks.
 
 ### Instant exec mode
 

--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -150,6 +150,7 @@ codex mcp add takt -- takt-mcp
 | Tool | 説明 |
 |------|------|
 | `takt_enqueue_task` | pending タスクを `.takt/tasks.yaml` に保存し、既存 Issue の紐付けまたは新規 Issue 作成を任意で行う。 |
+| `takt_list_tasks` | タスク履歴と状態別件数を、タスク保存領域を変更せずに読み取る。 |
 
 各 tool の `cwd` は `realpath` で解決され、MCP server の許可 project root 内にある必要があります。既定の許可 root は `takt-mcp` を起動したディレクトリです。
 
@@ -181,7 +182,17 @@ codex mcp add takt -- takt-mcp
 
 `issue` object は `{ "number": 123 }` または `{ "create": true, "title"?: "...", "labels"?: ["..."] }` のいずれかだけを指定します。混在 key、空の title・label、unknown key は拒否されます。Issue 付き enqueue の成功結果には `issueNumber` を含みます。Issue 番号の解決後にタスク保存が失敗またはキャンセルされた場合も Issue は open のまま残り、MCP error result は `issueCreated`、`issueNumber`、任意の `issueUrl`、`taskEnqueued`、`stage`、sanitize 済みの `error` を返します。`{ "issue": { "number": issueNumber } }` で再試行すれば、新しい Issue は作成されません。`stage` が `issue_number_parsing` の場合は `issueNumber` を返せないため、任意の `issueUrl` で作成済み Issue を特定し、番号を確認してから再試行してください。
 
-MCP はタスクの enqueue だけを担当します。pending タスクの実行には `takt run`、継続監視と実行には `takt watch` を使用してください。
+MCP はタスクの enqueue と読み取り専用の履歴参照を担当します。pending タスクの実行には `takt run`、継続監視と実行には `takt watch` を使用してください。
+
+### `takt_list_tasks`
+
+必須入力:
+
+| フィールド | 型 | 説明 |
+|-----------|----|------|
+| `cwd` | 絶対パス文字列 | `.takt/tasks.yaml` を読み取る project root。 |
+
+この tool は status filter も結果件数の上限も設けず、履歴全件を返します。`summary` には `total`、`pending`、`running`、`completed`、`failed`、`exceeded`、`pr_failed` の件数が含まれます。各 task に含まれるのは `name`、`status`、任意の `workflow` と `branch` だけです。タスク本文、failure 詳細、worktree/run/task-file path などのローカル path は返しません。`.takt/tasks.yaml` が存在しない場合は空の履歴を返し、`.takt` や task file などを作成しません。読み取り時に task の claim、fail、書き換えなどの状態変更は行いません。
 
 ## Instant Exec モード
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -151,6 +151,7 @@ The server exposes these tools:
 | Tool | Description |
 |------|-------------|
 | `takt_enqueue_task` | Save a pending task to `.takt/tasks.yaml`, optionally linking or creating an issue. |
+| `takt_list_tasks` | Read the complete task history and status counts without modifying task storage. |
 
 Every tool `cwd` is resolved with `realpath` and must stay inside the MCP server's allowed project root. By default that root is the directory where `takt-mcp` was started.
 
@@ -182,7 +183,17 @@ Input limits: `task` is limited to 128 KiB, `workflow` to 128 characters, an iss
 
 The `issue` object must be exactly one of `{ "number": 123 }` or `{ "create": true, "title"?: "...", "labels"?: ["..."] }`; mixed keys, empty titles or labels, and unknown keys are rejected. A successful issue-backed enqueue returns `issueNumber`. If issue creation succeeds but task saving fails or is cancelled after the issue number is resolved, the issue remains open and the MCP error result includes `issueCreated`, `issueNumber`, optional `issueUrl`, `taskEnqueued`, `stage`, and a sanitized `error`. Retry with `{ "issue": { "number": issueNumber } }` to avoid creating another issue. If `stage` is `issue_number_parsing`, `issueNumber` is unavailable; use the optional `issueUrl` to identify the created issue and obtain its number before retrying.
 
-MCP only enqueues tasks. Use `takt run` to execute pending tasks and `takt watch` to monitor and execute them continuously.
+MCP enqueues tasks and provides a read-only task history. Use `takt run` to execute pending tasks and `takt watch` to monitor and execute them continuously.
+
+### `takt_list_tasks`
+
+Required input:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cwd` | absolute path string | Project root whose `.takt/tasks.yaml` is read. |
+
+The tool returns every task in history without a status filter or result limit. The `summary` object contains `total`, `pending`, `running`, `completed`, `failed`, `exceeded`, and `pr_failed` counts. Each task contains only `name`, `status`, and the optional `workflow` and `branch` fields. Task bodies, failure details, worktree/run/task-file paths, and other local paths are not returned. If `.takt/tasks.yaml` is absent, the tool returns an empty history and does not create `.takt` or any task file. Reading does not claim, fail, rewrite, or otherwise mutate tasks.
 
 ## Instant Exec Mode
 

--- a/src/__tests__/mcp-entrypoint.integration.test.ts
+++ b/src/__tests__/mcp-entrypoint.integration.test.ts
@@ -49,11 +49,20 @@ describe('MCP stdio entrypoint integration', () => {
         },
       });
 
-      expect(tools.tools.map((tool) => tool.name)).toEqual(['takt_enqueue_task']);
+      expect(tools.tools.map((tool) => tool.name)).toEqual(['takt_enqueue_task', 'takt_list_tasks']);
       expect(result.isError).toBeUndefined();
       expect(JSON.parse(String(result.content[0]?.text))).toEqual(expect.objectContaining({
         tasksFile: join(cwd, '.takt', 'tasks.yaml'),
         workflow: 'default',
+      }));
+      const listed = await client.callTool({
+        name: 'takt_list_tasks',
+        arguments: { cwd },
+      });
+      expect(listed.isError).toBeUndefined();
+      expect(JSON.parse(String(listed.content[0]?.text))).toEqual(expect.objectContaining({
+        summary: expect.objectContaining({ total: 1, pending: 1 }),
+        tasks: [expect.objectContaining({ status: 'pending', workflow: 'default' })],
       }));
       const stderr = Buffer.concat(stderrChunks).toString('utf-8');
       expect(stderr).not.toMatch(/(?:^|\n)(?:Error|TypeError|ReferenceError|SyntaxError):/u);

--- a/src/__tests__/mcp-entrypoint.test.ts
+++ b/src/__tests__/mcp-entrypoint.test.ts
@@ -23,7 +23,7 @@ describe('MCP package entrypoint', () => {
     expect(entrypoint.connectTaktMcpServerToStdio).toEqual(expect.any(Function));
   });
 
-  it('exposes only takt_enqueue_task with nested issue input', async () => {
+  it('exposes enqueue and read-only task listing tools', async () => {
     const server = createTaktMcpServer();
     const client = new Client({ name: 'takt-mcp-test-client', version: '1.0.0' });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -31,13 +31,21 @@ describe('MCP package entrypoint', () => {
       await server.connect(serverTransport);
       await client.connect(clientTransport);
       const tools = await client.listTools();
-      expect(tools.tools.map((tool) => tool.name)).toEqual(['takt_enqueue_task']);
+      expect(tools.tools.map((tool) => tool.name)).toEqual(['takt_enqueue_task', 'takt_list_tasks']);
       expect(tools.tools[0]).toEqual(expect.objectContaining({
         title: 'Enqueue TAKT task',
         inputSchema: expect.objectContaining({
           type: 'object',
           required: expect.arrayContaining(['cwd', 'task', 'workflow', 'autoPr']),
           properties: expect.objectContaining({ issue: expect.any(Object) }),
+        }),
+      }));
+      expect(tools.tools[1]).toEqual(expect.objectContaining({
+        title: 'List TAKT tasks',
+        inputSchema: expect.objectContaining({
+          type: 'object',
+          required: ['cwd'],
+          properties: expect.objectContaining({ cwd: expect.any(Object) }),
         }),
       }));
     } finally {
@@ -66,6 +74,23 @@ describe('MCP package entrypoint', () => {
     try {
       await server.connect(serverTransport);
       await client.connect(clientTransport);
+      const listed = await client.callTool({
+        name: 'takt_list_tasks',
+        arguments: { cwd },
+      });
+      expect(listed.isError).toBeUndefined();
+      expect(JSON.parse(String(listed.content[0]?.text))).toEqual({
+        summary: {
+          total: 0,
+          pending: 0,
+          running: 0,
+          completed: 0,
+          failed: 0,
+          exceeded: 0,
+          pr_failed: 0,
+        },
+        tasks: [],
+      });
       await client.callTool({
         name: 'takt_enqueue_task',
         arguments: { cwd, task: 'Normal', workflow: 'default', autoPr: false },

--- a/src/__tests__/mcpOperations.test.ts
+++ b/src/__tests__/mcpOperations.test.ts
@@ -1,6 +1,45 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { stringify as stringifyYaml } from 'yaml';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { enqueueTaktTask, type McpOperationDependencies } from '../features/mcp/operations.js';
+import {
+  enqueueTaktTask,
+  listTaktTasks,
+  type McpOperationDependencies,
+} from '../features/mcp/operations.js';
 import type { EnqueueTaskInput } from '../features/mcp/schemas.js';
+import { TaskRecordSchema, type TaskRecord } from '../infra/task/schema.js';
+
+const { noFollowAvailable } = vi.hoisted(() => ({ noFollowAvailable: { value: true } }));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    constants: {
+      ...actual.constants,
+      get O_NOFOLLOW() {
+        if (!noFollowAvailable.value) {
+          return undefined;
+        }
+        if (actual.constants.O_NOFOLLOW === undefined) {
+          return actual.constants.O_RDONLY;
+        }
+        return actual.constants.O_NOFOLLOW;
+      },
+    },
+  };
+});
 
 const { mockInitGitProvider, mockGetGitProvider, mockGitProvider } = vi.hoisted(() => {
   const gitProvider = {
@@ -41,6 +80,35 @@ function enqueue(
   signal?: AbortSignal,
 ) {
   return enqueueTaktTask({ ...baseInput, ...extra }, deps, signal);
+}
+
+function createTaskRecord(overrides: Record<string, unknown>): TaskRecord {
+  return TaskRecordSchema.parse({
+    name: 'task',
+    status: 'pending',
+    content: 'Do work',
+    created_at: '2026-07-28T00:00:00.000Z',
+    started_at: null,
+    completed_at: null,
+    owner_pid: null,
+    ...overrides,
+  });
+}
+
+function writeTaskHistory(projectDir: string, tasks: TaskRecord[]): string {
+  const tasksDir = join(projectDir, '.takt');
+  mkdirSync(tasksDir, { recursive: true });
+  const tasksFile = join(tasksDir, 'tasks.yaml');
+  writeFileSync(tasksFile, stringifyYaml({ tasks }), 'utf-8');
+  return tasksFile;
+}
+
+function list(projectDir: string, allowedProjectRoot = projectDir) {
+  return listTaktTasks({ cwd: projectDir }, { allowedProjectRoot });
+}
+
+function parseResult(result: Awaited<ReturnType<typeof listTaktTasks>>): Record<string, unknown> {
+  return JSON.parse(String(result.content[0]?.text)) as Record<string, unknown>;
 }
 
 describe('MCP enqueue operation', () => {
@@ -225,5 +293,279 @@ describe('MCP enqueue operation', () => {
 
     expect(result.isError).toBe(true);
     expect(text(result)).toBe('Task enqueue failed: permission denied');
+  });
+});
+
+describe('MCP task listing operation', () => {
+  beforeEach(() => {
+    noFollowAvailable.value = true;
+  });
+
+  it('returns all task statuses with only the approved task fields', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-'));
+    try {
+      const tasks = [
+        createTaskRecord({
+          name: 'pending-task',
+          workflow: 'default',
+          branch: 'feature/list',
+          content: 'SECRET pending task body',
+        }),
+        createTaskRecord({
+          name: 'running-task',
+          status: 'running',
+          workflow: 'backend-mini',
+          started_at: '2026-07-28T00:01:00.000Z',
+          content: 'SECRET running task body',
+        }),
+        createTaskRecord({
+          name: 'completed-task',
+          status: 'completed',
+          branch: 'feature/completed',
+          started_at: '2026-07-28T00:01:00.000Z',
+          completed_at: '2026-07-28T00:02:00.000Z',
+          content: 'SECRET completed task body',
+        }),
+        createTaskRecord({
+          name: 'failed-task',
+          status: 'failed',
+          started_at: '2026-07-28T00:01:00.000Z',
+          completed_at: '2026-07-28T00:02:00.000Z',
+          failure: { error: 'SECRET failure details' },
+          content: 'SECRET failed task body',
+        }),
+        createTaskRecord({
+          name: 'exceeded-task',
+          status: 'exceeded',
+          started_at: '2026-07-28T00:01:00.000Z',
+          completed_at: '2026-07-28T00:02:00.000Z',
+          exceeded_max_steps: 10,
+          exceeded_current_iteration: 10,
+          content: 'SECRET exceeded task body',
+        }),
+        createTaskRecord({
+          name: 'pr-failed-task',
+          status: 'pr_failed',
+          started_at: '2026-07-28T00:01:00.000Z',
+          completed_at: '2026-07-28T00:02:00.000Z',
+          content: 'SECRET PR failure task body',
+        }),
+      ];
+      const tasksFile = writeTaskHistory(projectDir, tasks);
+      const beforeBytes = readFileSync(tasksFile);
+      const beforeMtime = statSync(tasksFile).mtimeMs;
+
+      const result = list(projectDir);
+
+      expect(result.isError).toBeUndefined();
+      const payload = parseResult(result);
+      expect(payload.summary).toEqual({
+        total: 6,
+        pending: 1,
+        running: 1,
+        completed: 1,
+        failed: 1,
+        exceeded: 1,
+        pr_failed: 1,
+      });
+      expect(payload.tasks).toEqual([
+        { name: 'pending-task', status: 'pending', workflow: 'default', branch: 'feature/list' },
+        { name: 'running-task', status: 'running', workflow: 'backend-mini' },
+        { name: 'completed-task', status: 'completed', branch: 'feature/completed' },
+        { name: 'failed-task', status: 'failed' },
+        { name: 'exceeded-task', status: 'exceeded' },
+        { name: 'pr-failed-task', status: 'pr_failed' },
+      ]);
+      for (const task of payload.tasks as Array<Record<string, unknown>>) {
+        expect(Object.keys(task).every((key) => ['name', 'status', 'workflow', 'branch'].includes(key))).toBe(true);
+      }
+      expect(JSON.stringify(payload)).not.toContain('SECRET');
+      expect(readFileSync(tasksFile)).toEqual(beforeBytes);
+      expect(statSync(tasksFile).mtimeMs).toBe(beforeMtime);
+      expect(existsSync(`${tasksFile}.lock`)).toBe(false);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns zero history without creating the task storage directory', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-empty-'));
+    try {
+      const result = list(projectDir);
+
+      expect(result.isError).toBeUndefined();
+      expect(parseResult(result)).toEqual({
+        summary: {
+          total: 0,
+          pending: 0,
+          running: 0,
+          completed: 0,
+          failed: 0,
+          exceeded: 0,
+          pr_failed: 0,
+        },
+        tasks: [],
+      });
+      expect(existsSync(join(projectDir, '.takt'))).toBe(false);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns zero history when the task storage file is absent', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-no-file-'));
+    try {
+      mkdirSync(join(projectDir, '.takt'));
+
+      const result = list(projectDir);
+
+      expect(result.isError).toBeUndefined();
+      expect(parseResult(result)).toEqual({
+        summary: {
+          total: 0,
+          pending: 0,
+          running: 0,
+          completed: 0,
+          failed: 0,
+          exceeded: 0,
+          pr_failed: 0,
+        },
+        tasks: [],
+      });
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a project outside the allowed root without exposing its path', () => {
+    const allowedRoot = mkdtempSync(join(tmpdir(), 'takt-mcp-list-root-'));
+    const outsideProject = mkdtempSync(join(tmpdir(), 'takt-mcp-list-outside-'));
+    try {
+      const result = list(outsideProject, allowedRoot);
+
+      expect(result.isError).toBe(true);
+      expect(String(result.content[0]?.text)).not.toContain(outsideProject);
+    } finally {
+      rmSync(allowedRoot, { recursive: true, force: true });
+      rmSync(outsideProject, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a stable error for invalid task storage without exposing raw content or paths', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-invalid-'));
+    try {
+      const tasksFile = writeTaskHistory(projectDir, []);
+      writeFileSync(tasksFile, 'tasks: [SECRET malformed task data', 'utf-8');
+
+      const result = list(projectDir);
+      const message = String(result.content[0]?.text);
+
+      expect(result.isError).toBe(true);
+      expect(message).toBe('Task list failed: Unable to read task history');
+      expect(message).not.toContain(projectDir);
+      expect(message).not.toContain('SECRET');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails safely when the task file is a broken symbolic link', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-link-'));
+    try {
+      const tasksDir = join(projectDir, '.takt');
+      mkdirSync(tasksDir, { recursive: true });
+      symlinkSync(join(tasksDir, 'missing-target.yaml'), join(tasksDir, 'tasks.yaml'));
+
+      const result = list(projectDir);
+
+      expect(result.isError).toBe(true);
+      expect(String(result.content[0]?.text)).toBe('Task list failed: Unable to read task history');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails safely when the task file is a valid symbolic link', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-valid-link-'));
+    const sourceProject = mkdtempSync(join(tmpdir(), 'takt-mcp-list-link-source-'));
+    try {
+      const sourceTasksFile = writeTaskHistory(sourceProject, [createTaskRecord({ name: 'secret-task' })]);
+      const tasksDir = join(projectDir, '.takt');
+      mkdirSync(tasksDir, { recursive: true });
+      symlinkSync(sourceTasksFile, join(tasksDir, 'tasks.yaml'));
+
+      const result = list(projectDir);
+
+      expect(result.isError).toBe(true);
+      expect(String(result.content[0]?.text)).toBe('Task list failed: Unable to read task history');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(sourceProject, { recursive: true, force: true });
+    }
+  });
+
+  it('fails safely when the task directory is a symbolic link', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-parent-link-'));
+    const sourceProject = mkdtempSync(join(tmpdir(), 'takt-mcp-list-parent-source-'));
+    try {
+      writeTaskHistory(sourceProject, [createTaskRecord({ name: 'secret-task' })]);
+      symlinkSync(join(sourceProject, '.takt'), join(projectDir, '.takt'), 'dir');
+
+      const result = list(projectDir);
+
+      expect(result.isError).toBe(true);
+      expect(String(result.content[0]?.text)).toBe('Task list failed: Unable to read task history');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(sourceProject, { recursive: true, force: true });
+    }
+  });
+
+  it('fails safely when the task directory is a symbolic link without a task file', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-empty-parent-link-'));
+    const sourceProject = mkdtempSync(join(tmpdir(), 'takt-mcp-list-empty-parent-source-'));
+    try {
+      mkdirSync(join(sourceProject, '.takt'));
+      symlinkSync(join(sourceProject, '.takt'), join(projectDir, '.takt'), 'dir');
+
+      const result = list(projectDir);
+
+      expect(result.isError).toBe(true);
+      expect(String(result.content[0]?.text)).toBe('Task list failed: Unable to read task history');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(sourceProject, { recursive: true, force: true });
+    }
+  });
+
+  it('fails safely when the task path is not a regular file', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-non-file-'));
+    try {
+      const tasksDir = join(projectDir, '.takt');
+      mkdirSync(join(tasksDir, 'tasks.yaml'), { recursive: true });
+
+      const result = list(projectDir);
+
+      expect(result.isError).toBe(true);
+      expect(String(result.content[0]?.text)).toBe('Task list failed: Unable to read task history');
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when no-follow file opens are unavailable', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-mcp-list-no-follow-'));
+    try {
+      writeTaskHistory(projectDir, [createTaskRecord({ name: 'protected-task' })]);
+      noFollowAvailable.value = false;
+
+      const result = list(projectDir);
+
+      expect(result.isError).toBe(true);
+      expect(String(result.content[0]?.text)).toBe('Task list failed: Unable to read task history');
+    } finally {
+      noFollowAvailable.value = true;
+      rmSync(projectDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/__tests__/mcpSchemas.test.ts
+++ b/src/__tests__/mcpSchemas.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import { enqueueTaskInputSchema } from '../features/mcp/schemas.js';
+import { enqueueTaskInputSchema, listTasksInputSchema } from '../features/mcp/schemas.js';
 
 const required = {
   cwd: '/repo',
@@ -10,6 +10,18 @@ const required = {
 } as const;
 
 describe('MCP tool input schema', () => {
+  it('accepts exactly an absolute cwd for task listing', () => {
+    expect(listTasksInputSchema.parse({ cwd: '/repo' })).toEqual({ cwd: '/repo' });
+  });
+
+  it.each([
+    {},
+    { cwd: 'repo' },
+    { cwd: '/repo', status: 'pending' },
+  ])('rejects non-minimal task listing input %#', (input) => {
+    expect(() => listTasksInputSchema.parse(input)).toThrow();
+  });
+
   it('preserves normal enqueue fields and task boundary whitespace', () => {
     const task = '\n# Implement MCP support\n\nKeep formatting.  \n';
     expect(enqueueTaskInputSchema.parse({

--- a/src/features/mcp/operations.ts
+++ b/src/features/mcp/operations.ts
@@ -7,12 +7,14 @@ import {
   enqueueTask,
   type IssueEnqueueFailure,
 } from '../../infra/task/enqueueService.js';
+import type { TaskRecord, TaskStatus } from '../../infra/task/schema.js';
+import { TaskStore } from '../../infra/task/store.js';
 import { safeExternalErrorMessage } from '../../shared/utils/safeExternalErrorMessage.js';
 import {
   createIssueFromTaskResult as defaultCreateIssueFromTaskResult,
   saveTaskFile as defaultSaveTaskFile,
 } from '../tasks/add/index.js';
-import type { EnqueueTaskInput } from './schemas.js';
+import type { EnqueueTaskInput, ListTasksInput } from './schemas.js';
 
 type SaveTaskFile = typeof defaultSaveTaskFile;
 type CreateIssueFromTaskResult = typeof defaultCreateIssueFromTaskResult;
@@ -51,6 +53,38 @@ function assertCwdAllowedByMcpRoot(cwd: string, allowedProjectRoot: string | und
   }
 
   throw new Error(`MCP cwd is outside the allowed project root: ${cwd}`);
+}
+
+type TaskSummary = { total: number } & Record<TaskStatus, number>;
+
+function summarizeTasks(tasks: TaskRecord[]): TaskSummary {
+  const counts = {
+    pending: 0,
+    running: 0,
+    completed: 0,
+    failed: 0,
+    exceeded: 0,
+    pr_failed: 0,
+  } satisfies Record<TaskStatus, number>;
+
+  for (const task of tasks) {
+    counts[task.status] += 1;
+  }
+
+  return { total: tasks.length, ...counts };
+}
+
+function projectTaskForMcp(task: TaskRecord): Record<string, unknown> {
+  return {
+    name: task.name,
+    status: task.status,
+    ...(task.workflow !== undefined ? { workflow: task.workflow } : {}),
+    ...(task.branch !== undefined ? { branch: task.branch } : {}),
+  };
+}
+
+function listTasksErrorResult(): CallToolResult {
+  return errorResult('Task list failed', new Error('Unable to read task history'));
 }
 
 function issueFailureResult(failure: IssueEnqueueFailure): CallToolResult {
@@ -123,5 +157,21 @@ export async function enqueueTaktTask(
     return result.success ? jsonResult(result.created) : issueFailureResult(result.failure);
   } catch (error) {
     return errorResult('Task enqueue failed', error);
+  }
+}
+
+export function listTaktTasks(
+  input: ListTasksInput,
+  deps: McpOperationDependencies = {},
+): CallToolResult {
+  try {
+    assertCwdAllowedByMcpRoot(input.cwd, deps.allowedProjectRoot);
+    const state = new TaskStore(input.cwd).readOnly();
+    return jsonResult({
+      summary: summarizeTasks(state.tasks),
+      tasks: state.tasks.map(projectTaskForMcp),
+    });
+  } catch {
+    return listTasksErrorResult();
   }
 }

--- a/src/features/mcp/schemas.ts
+++ b/src/features/mcp/schemas.ts
@@ -67,3 +67,9 @@ const taskSaveOptionsSchema = z.object({
 export const enqueueTaskInputSchema = taskSaveOptionsSchema;
 
 export type EnqueueTaskInput = z.infer<typeof enqueueTaskInputSchema>;
+
+export const listTasksInputSchema = z.object({
+  cwd: absolutePathSchema,
+}).strict();
+
+export type ListTasksInput = z.infer<typeof listTasksInputSchema>;

--- a/src/features/mcp/server.ts
+++ b/src/features/mcp/server.ts
@@ -2,9 +2,10 @@ import * as fs from 'node:fs';
 import * as process from 'node:process';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { packageVersion } from '../../shared/package-info.js';
-import { enqueueTaskInputSchema } from './schemas.js';
+import { enqueueTaskInputSchema, listTasksInputSchema } from './schemas.js';
 import {
   enqueueTaktTask,
+  listTaktTasks,
   type McpOperationDependencies,
 } from './operations.js';
 
@@ -40,6 +41,16 @@ export function createTaktMcpServer(
       inputSchema: enqueueTaskInputSchema,
     },
     (input, extra) => enqueueTaktTask(input, operationDeps, extra.signal),
+  );
+
+  server.registerTool(
+    'takt_list_tasks',
+    {
+      title: 'List TAKT tasks',
+      description: 'Read the complete TAKT task history without modifying .takt/tasks.yaml or claiming any task. Returns only task name, status, workflow, branch, and status counts.',
+      inputSchema: listTasksInputSchema,
+    },
+    (input) => listTaktTasks(input, operationDeps),
   );
 
   return server;

--- a/src/infra/task/store.ts
+++ b/src/infra/task/store.ts
@@ -2,7 +2,12 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { TasksFileSchema, serializeTasksFileData, type TasksFileData } from './schema.js';
-import { createLogger } from '../../shared/utils/index.js';
+import {
+  assertPathSegmentsAreSafe,
+  createLogger,
+  isRealPathInside,
+  lstatIfExists,
+} from '../../shared/utils/index.js';
 
 const log = createLogger('task-store');
 const LOCK_RETRY_DELAY_MS = 25;
@@ -16,6 +21,55 @@ function isFileSystemError(error: unknown, code: string): boolean {
 
 function waitForLockRetry(): void {
   Atomics.wait(lockWaitBuffer, 0, 0, LOCK_RETRY_DELAY_MS);
+}
+
+function buildInvalidTaskStorageError(): Error {
+  return new Error('Task storage must be a regular file without symbolic links');
+}
+
+function assertTaskStoragePath(projectDir: string, tasksFile: string): fs.Stats | null {
+  assertPathSegmentsAreSafe(
+    projectDir,
+    tasksFile,
+    (_violation, _segmentPath) => buildInvalidTaskStorageError(),
+    { rejectSamePath: true },
+  );
+  if (!isRealPathInside(projectDir, path.dirname(tasksFile))) {
+    throw buildInvalidTaskStorageError();
+  }
+
+  const stats = lstatIfExists(tasksFile);
+  if (stats !== null && (stats.isSymbolicLink() || !stats.isFile())) {
+    throw buildInvalidTaskStorageError();
+  }
+  return stats;
+}
+
+function readTaskStorageFile(projectDir: string, tasksFile: string): string | null {
+  let fileDescriptor: number | undefined;
+  try {
+    if (assertTaskStoragePath(projectDir, tasksFile) === null) {
+      return null;
+    }
+    const noFollowFlag = fs.constants.O_NOFOLLOW;
+    if (noFollowFlag === undefined) {
+      throw buildInvalidTaskStorageError();
+    }
+    fileDescriptor = fs.openSync(tasksFile, fs.constants.O_RDONLY | noFollowFlag);
+    if (!fs.fstatSync(fileDescriptor).isFile()) {
+      throw buildInvalidTaskStorageError();
+    }
+    return fs.readFileSync(fileDescriptor, 'utf-8');
+  } catch (error) {
+    if (isFileSystemError(error, 'ELOOP')) {
+      throw buildInvalidTaskStorageError();
+    }
+    throw error;
+  } finally {
+    if (fileDescriptor !== undefined) {
+      fs.closeSync(fileDescriptor);
+    }
+  }
 }
 
 export class TaskStore {
@@ -40,6 +94,22 @@ export class TaskStore {
 
   read(): TasksFileData {
     return this.withLock(() => this.readUnsafe());
+  }
+
+  readOnly(): TasksFileData {
+    let raw: string | null;
+    try {
+      raw = readTaskStorageFile(this.projectDir, this.tasksFile);
+    } catch (error) {
+      if (isFileSystemError(error, 'ENOENT')) {
+        return { tasks: [] };
+      }
+      throw error;
+    }
+    if (raw === null) {
+      return { tasks: [] };
+    }
+    return TasksFileSchema.parse(parseYaml(raw) as unknown);
   }
 
   update(mutator: (current: TasksFileData) => TasksFileData): TasksFileData {


### PR DESCRIPTION
## Summary

Add the read-only MCP tool `takt_list_tasks` requested in #1022.

- accepts only an absolute `cwd`
- returns the complete task history with per-status counts
- exposes only `name`, `status`, `workflow`, and `branch`
- does not create task storage, acquire a lock, claim tasks, or rewrite `tasks.yaml`
- rejects unsafe task-storage paths and returns sanitized errors
- documents the tool in the English and Japanese references

## Context

This deliberately adds one read-only tool alongside `takt_enqueue_task`. It therefore revisits the single-tool MCP inventory established by #1104. The narrower scope follows the maintainer guidance in #1022: no filters or limits in v1, no task body/failure details/raw paths, TaskStore/schema reuse in `infra/task`, and MCP-specific projection in `features/mcp`.

## Validation

- TAKT `backend-mini`: APPROVE after 11 iterations
- `npm run build`
- `npm run lint`
- focused MCP tests: 45 unit + 1 integration passed
- smoke E2E: 21 passed, 1 skipped
- `npm test`: 9,307 passed, 1 skipped
- `npm run test:it`: 893 passed, 3 skipped
- real built MCP stdio dogfood:
  - empty read created no `.takt`
  - `tasks.yaml` SHA-256 and mtime remained unchanged
  - no lock file was created
  - parent `.takt` symlink was rejected
  - sanitized error leaked no local path

Closes #1022
