### PR TITLE
fix: allow Codex auto-routing structured output

### DIFF
--- a/src/__tests__/structured-output-schema-validator.test.ts
+++ b/src/__tests__/structured-output-schema-validator.test.ts
@@ -2,9 +2,50 @@ import { describe, expect, it } from 'vitest';
 import {
   StructuredOutputSchemaError,
   StructuredOutputValueValidationError,
+  assertStrictStructuredOutputSchema,
   assertStructuredOutputSchema,
   validateStructuredOutputAgainstSchema,
 } from '../core/workflow/engine/structured-output-schema-validator.js';
+
+function createStrictRoot(valueSchema: unknown): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      value: valueSchema,
+    },
+    required: ['value'],
+    additionalProperties: false,
+  };
+}
+
+function createComplexObjectConstSchema(value: unknown): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      metadata: {
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+        },
+        required: ['count'],
+        additionalProperties: false,
+      },
+    },
+    required: ['name', 'metadata'],
+    additionalProperties: false,
+    const: value,
+  };
+}
+
+function expectStrictSubsetRejection(
+  schema: Record<string, unknown>,
+  expectedMessage: string,
+): void {
+  expect(() => assertStructuredOutputSchema(schema)).not.toThrow();
+  expect(() => assertStrictStructuredOutputSchema(schema)).toThrow(StructuredOutputSchemaError);
+  expect(() => assertStrictStructuredOutputSchema(schema)).toThrow(expectedMessage);
+}
 
 describe('structured output schema validator', () => {
   it('separates terminal schema compilation errors from model value issues', () => {
@@ -37,5 +78,685 @@ describe('structured output schema validator', () => {
       expect.objectContaining({ path: '$.second', keyword: 'required' }),
       expect.objectContaining({ path: '$.extra', keyword: 'additionalProperties' }),
     ]));
+  });
+
+  it.each([
+    {
+      name: 'a root property is omitted from required',
+      schema: {
+        type: 'object',
+        properties: {
+          required_value: { type: 'string' },
+          optional_value: { type: 'string' },
+        },
+        required: ['required_value'],
+        additionalProperties: false,
+      },
+      expectedMessage: 'missing: optional_value',
+    },
+    {
+      name: 'a nested property is omitted from required',
+      schema: {
+        type: 'object',
+        properties: {
+          nested: {
+            type: 'object',
+            properties: {
+              value: { type: 'string' },
+            },
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        required: ['nested'],
+        additionalProperties: false,
+      },
+      expectedMessage: '$.nested',
+    },
+    {
+      name: 'required lists a property that is not declared',
+      schema: {
+        type: 'object',
+        properties: {
+          value: { type: 'string' },
+        },
+        required: ['value', 'extra'],
+        additionalProperties: false,
+      },
+      expectedMessage: 'unknown: extra',
+    },
+    {
+      name: 'a nested object allows additional properties',
+      schema: {
+        type: 'object',
+        properties: {
+          nested: {
+            type: 'object',
+            properties: {},
+            required: [],
+          },
+        },
+        required: ['nested'],
+        additionalProperties: false,
+      },
+      expectedMessage: '$.nested must set additionalProperties to false',
+    },
+  ])('rejects a JSON Schema that is valid but not strict when $name', ({ schema, expectedMessage }) => {
+    expectStrictSubsetRejection(schema, expectedMessage);
+  });
+
+  it('accepts the Codex and Claude raw structured output subset', () => {
+    const schema = {
+      $defs: {
+        entry: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              const: 'entry',
+              format: 'hostname',
+            },
+          },
+          required: ['name'],
+          additionalProperties: false,
+        },
+      },
+      type: 'object',
+      properties: {
+        payload: {
+          anyOf: [
+            {
+              $ref: '#/$defs/entry',
+              description: 'An entry reference',
+            },
+            {
+              type: 'array',
+              items: {
+                type: 'string',
+                enum: ['ready', 'done'],
+              },
+            },
+          ],
+        },
+        confidence: {
+          anyOf: [
+            { type: 'number' },
+            { type: 'null' },
+          ],
+        },
+        count: { type: 'integer' },
+        enabled: { type: 'boolean' },
+      },
+      required: ['payload', 'confidence', 'count', 'enabled'],
+      additionalProperties: false,
+    };
+
+    expect(() => assertStrictStructuredOutputSchema(schema)).not.toThrow();
+  });
+
+  it('accepts const on a typed nested schema', () => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot({ type: 'string', const: 'fixed' }),
+    )).not.toThrow();
+  });
+
+  it.each([
+    ['string', { type: 'string', enum: ['ready', 'done'] }],
+    ['number', { type: 'number', enum: [1, 1.5] }],
+    ['integer', { type: 'integer', enum: [1, 2] }],
+    ['boolean', { type: 'boolean', enum: [true, false] }],
+    ['null', { type: 'null', enum: [null] }],
+    ['nullable string', { type: ['string', 'null'], enum: ['ready', null] }],
+  ])('accepts primitive enum values matching the declared %s type', (_name, valueSchema) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).not.toThrow();
+  });
+
+  it.each([
+    ['null', { type: 'null', const: null }],
+    ['nullable object', {
+      type: ['object', 'null'],
+      properties: {},
+      required: [],
+      additionalProperties: false,
+      const: null,
+    }],
+  ])('accepts a lossless JSON const matching the declared %s type', (_name, valueSchema) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).not.toThrow();
+  });
+
+  it.each([
+    ['an object satisfying its schema', createComplexObjectConstSchema({
+      name: 'entry',
+      metadata: { count: 1 },
+    })],
+    ['an object missing a required property', createComplexObjectConstSchema({
+      name: 'entry',
+    })],
+    ['an object containing an additional property', createComplexObjectConstSchema({
+      name: 'entry',
+      metadata: { count: 1 },
+      extra: true,
+    })],
+    ['an object containing a nested type mismatch', createComplexObjectConstSchema({
+      name: 'entry',
+      metadata: { count: '1' },
+    })],
+    ['an array satisfying its items schema', {
+      type: 'array',
+      items: { type: 'number' },
+      const: [1, 2],
+    }],
+    ['an array violating its items schema', {
+      type: 'array',
+      items: { type: 'number' },
+      const: [1, '2'],
+    }],
+  ])('rejects a complex const containing %s', (_name, valueSchema) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow('const must be a lossless primitive JSON value');
+  });
+
+  it('accepts a standalone null schema in a nested anyOf branch', () => {
+    expect(() => assertStrictStructuredOutputSchema(createStrictRoot({
+      anyOf: [
+        { type: 'number' },
+        { type: 'null' },
+      ],
+    }))).not.toThrow();
+  });
+
+  it.each([
+    ['allOf', [{ type: 'string' }]],
+    ['not', { type: 'string' }],
+    ['dependentRequired', { value: ['other'] }],
+    ['dependentSchemas', { value: { type: 'string' } }],
+    ['if', { type: 'string' }],
+    ['then', { type: 'string' }],
+    ['else', { type: 'string' }],
+    ['oneOf', [{ type: 'string' }]],
+    ['uniqueItems', true],
+    ['contains', { type: 'string' }],
+    ['propertyNames', { type: 'string' }],
+    ['unevaluatedItems', false],
+    ['unevaluatedProperties', false],
+    ['definitions', { value: { type: 'string' } }],
+    ['prefixItems', [{ type: 'string' }]],
+    ['title', 'A title'],
+    ['futureKeyword', true],
+  ])('rejects the unsupported strict structured output keyword %s', (keyword, value) => {
+    const schema = createStrictRoot({
+      type: 'string',
+      [keyword]: value,
+    });
+
+    expectStrictSubsetRejection(
+      schema,
+      `$.value uses unsupported keyword ${keyword}`,
+    );
+  });
+
+  it.each([
+    {
+      name: 'the root uses anyOf',
+      schema: {
+        ...createStrictRoot({ type: 'string' }),
+        anyOf: [
+          createStrictRoot({ type: 'string' }),
+          createStrictRoot({ type: 'number' }),
+        ],
+      },
+      expectedMessage: '$ must not use anyOf',
+    },
+    {
+      name: 'the root is nullable',
+      schema: {
+        type: ['object', 'null'],
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+      expectedMessage: '$ must have type object',
+    },
+    {
+      name: 'array items use tuple validation',
+      schema: createStrictRoot({
+        type: 'array',
+        items: [{ type: 'string' }, { type: 'number' }],
+      }),
+      expectedMessage: '$.value.items must be a schema object',
+    },
+    {
+      name: 'a nested object omits its type',
+      schema: createStrictRoot({
+        properties: {
+          nested_value: { type: 'string' },
+        },
+        required: ['nested_value'],
+        additionalProperties: false,
+      }),
+      expectedMessage: '$.value must declare type, anyOf, or $ref',
+    },
+    {
+      name: 'a schema node is empty',
+      schema: createStrictRoot({}),
+      expectedMessage: '$.value must declare type, anyOf, or $ref',
+    },
+    {
+      name: 'a schema node only declares enum',
+      schema: createStrictRoot({ enum: ['ready', 'done'] }),
+      expectedMessage: '$.value must declare type, anyOf, or $ref',
+    },
+    {
+      name: 'a property uses a boolean schema',
+      schema: createStrictRoot(true),
+      expectedMessage: '$.value must be a schema object',
+    },
+    {
+      name: 'array items use a boolean schema',
+      schema: createStrictRoot({
+        type: 'array',
+        items: true,
+      }),
+      expectedMessage: '$.value.items must be a schema object',
+    },
+    {
+      name: 'an anyOf branch uses a boolean schema',
+      schema: createStrictRoot({
+        anyOf: [
+          { type: 'string' },
+          false,
+        ],
+      }),
+      expectedMessage: '$.value.anyOf[1] must be a schema object',
+    },
+    {
+      name: '$defs is not an object map',
+      schema: {
+        ...createStrictRoot({ type: 'string' }),
+        $defs: true,
+      },
+      expectedMessage: '$.$defs must be a schema object map',
+    },
+  ])('rejects an unsupported strict schema shape when $name', ({ schema, expectedMessage }) => {
+    expectStrictSubsetRejection(schema, expectedMessage);
+  });
+
+  it.each([
+    ['a non-null type array', ['string']],
+    ['multiple non-null union members', ['string', 'number']],
+  ])('rejects %s', (_name, type) => {
+    expectStrictSubsetRejection(
+      createStrictRoot({ type }),
+      '$.value.type must be a supported type or nullable type union',
+    );
+  });
+
+  it.each([
+    ['string', 'minLength', 1],
+    ['string', 'maxLength', 3],
+    ['number', 'multipleOf', 2],
+    ['number', 'minimum', 0],
+    ['number', 'exclusiveMinimum', 0],
+    ['number', 'maximum', 10],
+    ['number', 'exclusiveMaximum', 10],
+    ['array', 'minItems', 1],
+    ['array', 'maxItems', 3],
+    ['string', 'pattern', '^[a-z]+$'],
+  ])('rejects %s schemas using the Claude raw unsupported %s constraint', (type, keyword, value) => {
+    const schema = type === 'array'
+      ? { type, items: { type: 'string' }, [keyword]: value }
+      : { type, [keyword]: value };
+    expectStrictSubsetRejection(
+      createStrictRoot(schema),
+      `$.value uses unsupported keyword ${keyword}`,
+    );
+  });
+
+  it('rejects an unsupported raw string format', () => {
+    const schema = createStrictRoot({ type: 'string', format: 'future-format' });
+
+    expect(() => assertStrictStructuredOutputSchema(schema)).toThrow(
+      new StructuredOutputSchemaError(
+        'Structured output schema is not strict: $.value uses unsupported format future-format',
+      ),
+    );
+  });
+
+  it.each([
+    'date-time',
+    'time',
+    'date',
+    'duration',
+    'email',
+    'hostname',
+    'ipv4',
+    'ipv6',
+    'uuid',
+  ])('accepts the common raw string format %s', (format) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot({ type: 'string', format }),
+    )).not.toThrow();
+  });
+
+  it('rejects a non-string format value synchronously', () => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot({ type: 'string', format: true }),
+    )).toThrow(StructuredOutputSchemaError);
+  });
+
+  it.each([
+    ['an object enum member', { type: 'object', properties: {}, required: [], additionalProperties: false, enum: [{}] }],
+    ['an array enum member', { type: 'array', items: { type: 'string' }, enum: [['ready']] }],
+  ])('rejects %s', (_name, valueSchema) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow('enum must contain only lossless primitive JSON values');
+  });
+
+  it.each([
+    ['positive infinity', { type: 'number', enum: [Number.POSITIVE_INFINITY] }],
+    ['negative infinity', { type: 'number', enum: [Number.NEGATIVE_INFINITY] }],
+    ['negative zero', { type: 'number', enum: [-0] }],
+    ['undefined', { type: 'string', enum: [undefined] }],
+    ['a bigint', { type: 'integer', enum: [1n] }],
+    ['a symbol', { type: 'string', enum: [Symbol('value')] }],
+    ['a function', { type: 'string', enum: [() => 'value'] }],
+  ])('rejects %s', (_name, valueSchema) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow('schema must be a lossless JSON object');
+  });
+
+  it.each([
+    ['string enum with number', { type: 'string', enum: [1] }],
+    ['number enum with string', { type: 'number', enum: ['1'] }],
+    ['integer enum with fraction', { type: 'integer', enum: [1.5] }],
+    ['boolean enum with null', { type: 'boolean', enum: [null] }],
+    ['nullable string enum with number', { type: ['string', 'null'], enum: [1] }],
+  ])('rejects a declared type mismatch for %s', (_name, valueSchema) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow('enum value does not match its declared type');
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['NaN', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
+    ['negative infinity', Number.NEGATIVE_INFINITY],
+    ['negative zero', -0],
+    ['a bigint', 1n],
+    ['a symbol', Symbol('value')],
+    ['a function', () => 'value'],
+    ['a date', new Date('2026-01-01T00:00:00.000Z')],
+    ['an array containing undefined', [undefined]],
+    ['a sparse array', new Array(1)],
+    ['an array with an extra property', Object.assign([1], { extra: true })],
+    ['an object containing undefined', { value: undefined }],
+    ['an object with a getter', Object.defineProperty({}, 'value', {
+      enumerable: true,
+      get: () => 'value',
+    })],
+    ['an object with a symbol key', { [Symbol('value')]: 'value' }],
+  ])('rejects a non-lossless JSON const: %s', (_name, value) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot({ type: 'string', const: value }),
+    )).toThrow('schema must be a lossless JSON object');
+  });
+
+  it('rejects a circular const value', () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot({
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+        const: circular,
+      }),
+    )).toThrow('schema must be a lossless JSON object');
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['NaN', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
+    ['negative infinity', Number.NEGATIVE_INFINITY],
+    ['negative zero', -0],
+    ['a bigint', 1n],
+    ['a symbol', Symbol('description')],
+    ['a function', () => 'description'],
+  ])('rejects a schema containing a non-lossless description value: %s', (_name, description) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot({ type: 'string', description }),
+    )).toThrow('schema must be a lossless JSON object');
+  });
+
+  it('rejects a schema containing an enumerable getter', () => {
+    const valueSchema = { type: 'string' };
+    Object.defineProperty(valueSchema, 'description', {
+      enumerable: true,
+      get: () => 'description',
+    });
+
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow('schema must be a lossless JSON object');
+  });
+
+  it.each([
+    ['a sparse array', new Array(1)],
+    ['an array with an extra property', Object.assign([{ type: 'string' }], { extra: true })],
+  ])('rejects a schema containing %s', (_name, anyOf) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot({ anyOf }),
+    )).toThrow('schema must be a lossless JSON object');
+  });
+
+  it('rejects a schema containing a non-plain schema node', () => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(new Date('2026-01-01T00:00:00.000Z')),
+    )).toThrow('schema must be a lossless JSON object');
+  });
+
+  it('rejects a non-plain root schema object', () => {
+    expect(() => assertStrictStructuredOutputSchema(
+      new Date('2026-01-01T00:00:00.000Z') as unknown as Record<string, unknown>,
+    )).toThrow('Structured output schema must be an object');
+  });
+
+  it('rejects a schema containing a symbol-keyed property', () => {
+    const valueSchema = {
+      type: 'string',
+      [Symbol('description')]: 'description',
+    };
+
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow('schema must be a lossless JSON object');
+  });
+
+  it('rejects a schema with a non-enumerable toJSON property', () => {
+    const schema = createStrictRoot({ type: 'string' });
+    Object.defineProperty(schema, 'toJSON', {
+      value: () => ({ type: 'object' }),
+    });
+
+    expect(() => assertStrictStructuredOutputSchema(schema)).toThrow(
+      'schema must be a lossless JSON object',
+    );
+  });
+
+  it('rejects a schema whose properties graph is circular', () => {
+    const schema = createStrictRoot({ type: 'string' });
+    const properties = schema.properties as Record<string, unknown>;
+    properties.circular = schema;
+
+    expect(() => assertStrictStructuredOutputSchema(schema)).toThrow(
+      'schema must be a lossless JSON object',
+    );
+  });
+
+  it.each([
+    ['string const with number', { type: 'string', const: 1 }],
+    ['number const with string', { type: 'number', const: '1' }],
+    ['integer const with fraction', { type: 'integer', const: 1.5 }],
+    ['object const with string', {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+      const: 'value',
+    }],
+    ['array const with number', {
+      type: 'array',
+      items: { type: 'number' },
+      const: 1,
+    }],
+    ['nullable string const with number', { type: ['string', 'null'], const: 1 }],
+  ])('rejects a declared type mismatch for %s', (_name, valueSchema) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow('const value does not match its declared type');
+  });
+
+  it.each([
+    ['type and anyOf', {
+      type: 'string',
+      anyOf: [
+        { type: 'string' },
+        { type: 'null' },
+      ],
+      const: 'fixed',
+    }],
+    ['type and $ref', {
+      type: 'string',
+      $ref: '#/$defs/value',
+      $defs: {
+        value: { type: 'string' },
+      },
+      enum: ['fixed'],
+    }],
+    ['anyOf and $ref', {
+      anyOf: [
+        { type: 'string' },
+        { type: 'null' },
+      ],
+      $ref: '#/$defs/value',
+      $defs: {
+        value: { type: 'string' },
+      },
+    }],
+  ])('rejects a schema node combining %s', (_name, valueSchema) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow('must declare exactly one of type, anyOf, or $ref');
+  });
+
+  it.each([
+    ['enum on an anyOf wrapper', {
+      anyOf: [
+        { type: 'string' },
+        { type: 'null' },
+      ],
+      enum: ['fixed'],
+    }],
+    ['const on a $ref wrapper', {
+      $ref: '#/$defs/value',
+      const: 'fixed',
+      $defs: {
+        value: { type: 'string' },
+      },
+    }],
+  ])('rejects %s because the effective type is not local', (_name, valueSchema) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow(/uses unsupported keyword (enum|const)/);
+  });
+
+  it.each([
+    {
+      name: 'string properties',
+      schema: { type: 'string', properties: {} },
+      keyword: 'properties',
+    },
+    {
+      name: 'number items',
+      schema: { type: 'number', items: { type: 'string' } },
+      keyword: 'items',
+    },
+    {
+      name: 'array required',
+      schema: { type: 'array', items: { type: 'string' }, required: [] },
+      keyword: 'required',
+    },
+    {
+      name: 'object items',
+      schema: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+        items: { type: 'string' },
+      },
+      keyword: 'items',
+    },
+    {
+      name: 'number pattern',
+      schema: { type: 'number', pattern: '^x' },
+      keyword: 'pattern',
+    },
+    {
+      name: 'array format',
+      schema: { type: 'array', items: { type: 'string' }, format: 'date' },
+      keyword: 'format',
+    },
+  ])('rejects type-mismatched structural keyword: $name', ({ schema, keyword }) => {
+    expectStrictSubsetRejection(
+      createStrictRoot(schema),
+      `$.value uses unsupported keyword ${keyword}`,
+    );
+  });
+
+  it.each([
+    {
+      name: 'a direct self-reference',
+      schema: {
+        type: 'object',
+        properties: {
+          child: { $ref: '#' },
+        },
+        required: ['child'],
+        additionalProperties: false,
+      },
+      expectedMessage: 'contains recursive $ref',
+    },
+    {
+      name: 'mutually recursive definitions',
+      schema: {
+        type: 'object',
+        properties: {
+          value: { $ref: '#/$defs/first' },
+        },
+        required: ['value'],
+        additionalProperties: false,
+        $defs: {
+          first: { $ref: '#/$defs/second' },
+          second: { $ref: '#/$defs/first' },
+        },
+      },
+      expectedMessage: 'contains recursive $ref',
+    },
+  ])('rejects $name', ({ schema, expectedMessage }) => {
+    expect(() => assertStrictStructuredOutputSchema(schema)).toThrow(
+      expectedMessage,
+    );
   });
 });

--- a/src/__tests__/structured-output-schema-validator.test.ts
+++ b/src/__tests__/structured-output-schema-validator.test.ts
@@ -111,7 +111,7 @@ describe('structured output schema validator', () => {
         required: ['nested'],
         additionalProperties: false,
       },
-      expectedMessage: '$.nested',
+      expectedMessage: '$.nested must list every property in required (missing: value)',
     },
     {
       name: 'required lists a property that is not declared',
@@ -446,7 +446,63 @@ describe('structured output schema validator', () => {
   it('rejects a non-string format value synchronously', () => {
     expect(() => assertStrictStructuredOutputSchema(
       createStrictRoot({ type: 'string', format: true }),
-    )).toThrow(StructuredOutputSchemaError);
+    )).toThrow(
+      new StructuredOutputSchemaError(
+        'Structured output schema is not strict: $.value.format must be a string',
+      ),
+    );
+  });
+
+  it.each([
+    {
+      name: 'properties is not a plain object',
+      valueSchema: {
+        type: 'object',
+        properties: [],
+        required: [],
+        additionalProperties: false,
+      },
+      expectedMessage: '$.value.properties must be a plain object',
+    },
+    {
+      name: 'required is not an array',
+      valueSchema: {
+        type: 'object',
+        properties: {},
+        required: 'value',
+        additionalProperties: false,
+      },
+      expectedMessage: '$.value.required must be an array',
+    },
+    {
+      name: 'required contains a non-string entry',
+      valueSchema: {
+        type: 'object',
+        properties: {},
+        required: [1],
+        additionalProperties: false,
+      },
+      expectedMessage: '$.value.required must contain only strings',
+    },
+  ])('rejects an object schema when $name', ({ valueSchema, expectedMessage }) => {
+    expect(() => assertStrictStructuredOutputSchema(
+      createStrictRoot(valueSchema),
+    )).toThrow(
+      new StructuredOutputSchemaError(
+        `Structured output schema is not strict: ${expectedMessage}`,
+      ),
+    );
+  });
+
+  it('accepts a strict object schema with plain properties and string required entries', () => {
+    expect(() => assertStrictStructuredOutputSchema(createStrictRoot({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+      additionalProperties: false,
+    }))).not.toThrow();
   });
 
   it.each([

--- a/src/__tests__/work-requirement-estimator-claude.integration.test.ts
+++ b/src/__tests__/work-requirement-estimator-claude.integration.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RoutingModelInput } from '../core/workflow/auto-routing/contracts.js';
+
+const { query } = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query,
+  AbortError: class AbortError extends Error {},
+}));
+
+vi.mock('../infra/config/index.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../infra/config/index.js')>(),
+  loadAgentPrompt: vi.fn(() => ''),
+  loadCustomAgents: vi.fn(() => new Map()),
+  loadGlobalConfig: vi.fn(() => ({})),
+  loadPersonaPromptFromPath: vi.fn(() => ''),
+  loadProjectConfig: vi.fn(() => ({})),
+  resolveAnthropicApiKey: vi.fn(() => undefined),
+  resolveClaudeCliPath: vi.fn(() => undefined),
+}));
+
+vi.mock('../infra/config/resolveConfigValue.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../infra/config/resolveConfigValue.js')>(),
+  resolveConfigValue: vi.fn(() => undefined),
+  resolveProviderOptionsWithTrace: vi.fn(() => ({
+    value: undefined,
+    source: 'default',
+    originResolver: () => 'default',
+  })),
+}));
+
+import { createWorkRequirementEstimator } from '../agents/auto-routing-usecase.js';
+import { ProviderRegistry } from '../infra/providers/index.js';
+import { QueryRegistry } from '../infra/claude/query-manager.js';
+
+function createSdkQuery(structuredOutput: Record<string, unknown>) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'done',
+        structured_output: structuredOutput,
+      };
+    },
+    interrupt: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createModelInput(): RoutingModelInput {
+  return {
+    version: 'routing-model-input/v1',
+    goal: 'Implement a focused validation fix',
+    step: {
+      name: 'implement',
+      tags: ['implementation'],
+      stepType: 'normal',
+      edit: true,
+    },
+    remainingWork: [{ source: 'finding', description: 'A validation branch is incomplete.' }],
+    progress: {
+      previousAttemptFailed: false,
+      noProgress: false,
+      retryingSameWork: false,
+    },
+  };
+}
+
+describe('work requirement estimator Claude provider integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ProviderRegistry.resetInstance();
+    QueryRegistry.resetInstance();
+  });
+
+  it('Given a Claude SDK router, When querying the Agent SDK, Then the common raw schema reaches outputFormat and its structured value is used', async () => {
+    query.mockReturnValue(createSdkQuery({
+      required_tier: 'high',
+      reason_codes: ['critical-finding'],
+      confidence: null,
+    }));
+    const estimator = createWorkRequirementEstimator({
+      cwd: '/repo',
+      provider: 'claude-sdk',
+      model: 'claude-haiku-4-5-20251001',
+    });
+
+    await expect(estimator.estimate(createModelInput())).resolves.toEqual({
+      requiredTier: 'high',
+      reasonCodes: ['critical-finding'],
+    });
+
+    expect(query).toHaveBeenCalledOnce();
+    const queryInput = query.mock.calls[0]?.[0] as {
+      options?: {
+        outputFormat?: {
+          type?: unknown;
+          schema?: Record<string, unknown>;
+        };
+      };
+    } | undefined;
+    expect(queryInput?.options?.outputFormat).toEqual({
+      type: 'json_schema',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          required_tier: { type: 'string', enum: ['low', 'medium', 'high'] },
+          reason_codes: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: [
+                'api-change',
+                'complex-work',
+                'critical-finding',
+                'focused-change',
+                'formatting',
+                'initial-complexity',
+                'local-change',
+              ],
+            },
+          },
+          confidence: { type: ['number', 'null'] },
+        },
+        required: ['required_tier', 'reason_codes', 'confidence'],
+      },
+    });
+  });
+});

--- a/src/__tests__/work-requirement-estimator.test.ts
+++ b/src/__tests__/work-requirement-estimator.test.ts
@@ -61,6 +61,28 @@ describe('createWorkRequirementEstimator', () => {
     });
   });
 
+  it('Given a router without native structured output, When its JSON response omits optional confidence, Then the estimate is accepted', async () => {
+    vi.mocked(runAgent).mockResolvedValue({
+      persona: 'auto-router',
+      status: 'done',
+      content: JSON.stringify({
+        required_tier: 'medium',
+        reason_codes: ['focused-change'],
+      }),
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const estimator = createWorkRequirementEstimator({
+      cwd: '/repo',
+      provider: 'cursor',
+      model: 'cursor/gpt-5',
+    });
+
+    await expect(estimator.estimate(createModelInput())).resolves.toEqual({
+      requiredTier: 'medium',
+      reasonCodes: ['focused-change'],
+    });
+  });
+
   it('Given provider-native structured output, When content is not JSON, Then the structured estimate is used', async () => {
     vi.mocked(runAgent).mockResolvedValue({
       persona: 'auto-router',

--- a/src/__tests__/work-requirement-estimator.test.ts
+++ b/src/__tests__/work-requirement-estimator.test.ts
@@ -2,9 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createWorkRequirementEstimator } from '../agents/auto-routing-usecase.js';
 import { runAgent } from '../agents/runner.js';
 import type { RoutingModelInput } from '../core/workflow/auto-routing/contracts.js';
+import { StructuredOutputSchemaError } from '../core/workflow/engine/structured-output-schema-validator.js';
+
+const { assertStrictStructuredOutputSchema } = vi.hoisted(() => ({
+  assertStrictStructuredOutputSchema: vi.fn(),
+}));
 
 vi.mock('../agents/runner.js', () => ({
   runAgent: vi.fn(),
+}));
+
+vi.mock('../core/workflow/engine/structured-output-schema-validator.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../core/workflow/engine/structured-output-schema-validator.js')>(),
+  assertStrictStructuredOutputSchema,
 }));
 
 function createModelInput(): RoutingModelInput {
@@ -33,6 +43,20 @@ describe('createWorkRequirementEstimator', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('Given the estimator output schema is invalid, When constructing the estimator, Then it fails before calling a provider', () => {
+    const schemaError = new StructuredOutputSchemaError('Structured output schema is not strict');
+    assertStrictStructuredOutputSchema.mockImplementationOnce(() => {
+      throw schemaError;
+    });
+
+    expect(() => createWorkRequirementEstimator({
+      cwd: '/repo',
+      provider: 'codex',
+      model: 'gpt-5.6-luna',
+    })).toThrow(schemaError);
+    expect(runAgent).not.toHaveBeenCalled();
   });
 
   it('Given a normalized model input, When the router returns a tier estimate, Then the adapter returns requiredTier and reason codes', async () => {
@@ -149,6 +173,11 @@ describe('createWorkRequirementEstimator', () => {
         required: ['required_tier', 'reason_codes', 'confidence'],
       },
     });
+    const outputProperties = options?.outputSchema?.properties as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    expect(outputProperties?.reason_codes).not.toHaveProperty('maxItems');
+    expect(outputProperties?.reason_codes?.items).not.toHaveProperty('maxLength');
   });
 
   it('Given a Codex router, When the strict output schema is submitted, Then the estimator returns a dynamic tier instead of failing', async () => {
@@ -212,6 +241,37 @@ describe('createWorkRequirementEstimator', () => {
       return;
     }
     throw new Error('Expected invalid estimator response to reject');
+  });
+
+  it.each([
+    {
+      name: 'too many reason codes',
+      reasonCodes: Array.from({ length: 5 }, () => 'focused-change'),
+    },
+    {
+      name: 'an oversized reason code',
+      reasonCodes: ['x'.repeat(33)],
+    },
+  ])('Given $name, When parsing the estimate, Then runtime validation rejects it', async ({ reasonCodes }) => {
+    vi.mocked(runAgent).mockResolvedValue({
+      persona: 'auto-router',
+      status: 'done',
+      content: JSON.stringify({
+        required_tier: 'medium',
+        reason_codes: reasonCodes,
+        confidence: null,
+      }),
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const estimator = createWorkRequirementEstimator({
+      cwd: '/repo',
+      provider: 'claude-sdk',
+      model: 'claude-haiku-4-5-20251001',
+    });
+
+    await expect(estimator.estimate(createModelInput())).rejects.toThrow(
+      'Auto routing estimator response has invalid reason_codes',
+    );
   });
 
   it('Given an already aborted parent signal, When estimating work requirements, Then no provider call starts', async () => {

--- a/src/__tests__/work-requirement-estimator.test.ts
+++ b/src/__tests__/work-requirement-estimator.test.ts
@@ -69,6 +69,7 @@ describe('createWorkRequirementEstimator', () => {
       structuredOutput: {
         required_tier: 'high',
         reason_codes: ['critical-finding'],
+        confidence: null,
       },
       timestamp: new Date('2026-01-01T00:00:00.000Z'),
     });
@@ -88,7 +89,11 @@ describe('createWorkRequirementEstimator', () => {
     vi.mocked(runAgent).mockResolvedValue({
       persona: 'auto-router',
       status: 'done',
-      content: JSON.stringify({ required_tier: 'high', reason_codes: ['critical-finding'] }),
+      content: JSON.stringify({
+        required_tier: 'high',
+        reason_codes: ['critical-finding'],
+        confidence: null,
+      }),
       timestamp: new Date('2026-01-01T00:00:00.000Z'),
     });
     const estimator = createWorkRequirementEstimator({
@@ -117,9 +122,45 @@ describe('createWorkRequirementEstimator', () => {
         properties: {
           required_tier: { type: 'string' },
           reason_codes: { type: 'array' },
+          confidence: { type: ['number', 'null'] },
         },
-        required: ['required_tier', 'reason_codes'],
+        required: ['required_tier', 'reason_codes', 'confidence'],
       },
+    });
+  });
+
+  it('Given a Codex router, When the strict output schema is submitted, Then the estimator returns a dynamic tier instead of failing', async () => {
+    vi.mocked(runAgent).mockImplementation(async (_persona, _prompt, options) => {
+      const schema = options?.outputSchema;
+      const properties = schema?.properties;
+      const required = schema?.required;
+      if (typeof properties !== 'object' || properties === null || !Array.isArray(required)) {
+        throw new Error('Codex rejected an invalid structured output schema');
+      }
+      expect(new Set(required)).toEqual(new Set(Object.keys(properties)));
+      expect(properties).toMatchObject({
+        confidence: { type: ['number', 'null'] },
+      });
+      return {
+        persona: 'auto-router',
+        status: 'done',
+        content: JSON.stringify({
+          required_tier: 'medium',
+          reason_codes: ['focused-change'],
+          confidence: null,
+        }),
+        timestamp: new Date('2026-01-01T00:00:00.000Z'),
+      };
+    });
+    const estimator = createWorkRequirementEstimator({
+      cwd: '/repo',
+      provider: 'codex',
+      model: 'gpt-5.6-luna',
+    });
+
+    await expect(estimator.estimate(createModelInput())).resolves.toEqual({
+      requiredTier: 'medium',
+      reasonCodes: ['focused-change'],
     });
   });
 

--- a/src/agents/auto-routing-usecase.ts
+++ b/src/agents/auto-routing-usecase.ts
@@ -1,13 +1,12 @@
 import type { AutoRoutingConfig } from '../core/models/config-types.js';
 import {
-  MAX_ROUTING_REASON_CODE_LENGTH,
-  MAX_ROUTING_REASON_CODES,
   ROUTING_REASON_CODE_VALUES,
   validateRoutingReasonCodes,
   type WorkRequirementEstimator,
   type WorkRequirementEstimate,
   type RoutingModelInput,
 } from '../core/workflow/auto-routing/contracts.js';
+import { assertStrictStructuredOutputSchema } from '../core/workflow/engine/structured-output-schema-validator.js';
 import { runAgent, type RunAgentOptions } from './runner.js';
 import { buildMaxTurnsOption } from './provider-call-options.js';
 
@@ -21,9 +20,7 @@ const OUTPUT_SCHEMA = {
       items: {
         type: 'string',
         enum: ROUTING_REASON_CODE_VALUES,
-        maxLength: MAX_ROUTING_REASON_CODE_LENGTH,
       },
-      maxItems: MAX_ROUTING_REASON_CODES,
     },
     confidence: { type: ['number', 'null'] },
   },
@@ -127,6 +124,8 @@ function buildPrompt(input: RoutingModelInput): string {
 }
 
 export function createWorkRequirementEstimator(options: WorkRequirementEstimatorOptions): WorkRequirementEstimator {
+  assertStrictStructuredOutputSchema(OUTPUT_SCHEMA);
+
   return {
     async estimate(
       input: RoutingModelInput,

--- a/src/agents/auto-routing-usecase.ts
+++ b/src/agents/auto-routing-usecase.ts
@@ -25,9 +25,9 @@ const OUTPUT_SCHEMA = {
       },
       maxItems: MAX_ROUTING_REASON_CODES,
     },
-    confidence: { type: 'number' },
+    confidence: { type: ['number', 'null'] },
   },
-  required: ['required_tier', 'reason_codes'],
+  required: ['required_tier', 'reason_codes', 'confidence'],
 };
 
 const WORK_REQUIREMENT_ESTIMATOR_TIMEOUT_MS = 30_000;
@@ -107,13 +107,13 @@ function parseEstimate(parsed: unknown): WorkRequirementEstimate {
     throw new Error('Auto routing estimator response has an invalid required_tier');
   }
   validateRoutingReasonCodes(value.reason_codes);
-  if (value.confidence !== undefined && typeof value.confidence !== 'number') {
+  if (value.confidence !== undefined && value.confidence !== null && typeof value.confidence !== 'number') {
     throw new Error('Auto routing estimator response has invalid confidence');
   }
   return {
     requiredTier: value.required_tier,
     reasonCodes: [...value.reason_codes],
-    ...(value.confidence !== undefined ? { confidence: value.confidence } : {}),
+    ...(typeof value.confidence === 'number' ? { confidence: value.confidence } : {}),
   };
 }
 

--- a/src/core/workflow/engine/structured-output-schema-validator.ts
+++ b/src/core/workflow/engine/structured-output-schema-validator.ts
@@ -8,6 +8,42 @@ const ajv = new Ajv({
 
 const validatorCache = new WeakMap<Record<string, unknown>, ValidateFunction>();
 
+type StrictSchemaType = 'string' | 'number' | 'boolean' | 'integer' | 'object' | 'array' | 'null';
+
+const TYPED_RAW_STRUCTURED_OUTPUT_KEYWORDS = [
+  '$defs',
+  'type',
+  'description',
+  'enum',
+  'const',
+] as const;
+
+const RAW_STRUCTURED_OUTPUT_KEYWORDS_BY_TYPE: Record<StrictSchemaType, readonly string[]> = {
+  string: ['format'],
+  number: [],
+  boolean: [],
+  integer: [],
+  object: ['properties', 'required', 'additionalProperties'],
+  array: ['items'],
+  null: [],
+};
+
+const SUPPORTED_RAW_STRING_FORMATS = new Set([
+  'date-time',
+  'time',
+  'date',
+  'duration',
+  'email',
+  'hostname',
+  'ipv4',
+  'ipv6',
+  'uuid',
+]);
+
+const STRICT_SCHEMA_TYPES = new Set<StrictSchemaType>(
+  Object.keys(RAW_STRUCTURED_OUTPUT_KEYWORDS_BY_TYPE) as StrictSchemaType[],
+);
+
 export class StructuredOutputSchemaError extends Error {
   constructor(message: string) {
     super(message);
@@ -31,7 +67,11 @@ export interface StructuredOutputValueValidationIssue {
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value != null && !Array.isArray(value);
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function formatPathSegment(segment: string): string {
@@ -105,12 +145,391 @@ function getValidator(schema: Record<string, unknown>): ValidateFunction {
   }
 }
 
+function strictSchemaError(message: string): StructuredOutputSchemaError {
+  return new StructuredOutputSchemaError(
+    `Structured output schema is not strict: ${message}`,
+  );
+}
+
+function getStrictSchemaTypes(
+  schema: Record<string, unknown>,
+  path: string,
+): readonly StrictSchemaType[] | undefined {
+  const schemaForms = [schema.type, schema.anyOf, schema.$ref]
+    .filter((value) => value !== undefined);
+  if (schemaForms.length === 0) {
+    throw strictSchemaError(
+      `${path} must declare type, anyOf, or $ref`,
+    );
+  }
+  if (schemaForms.length !== 1) {
+    throw strictSchemaError(
+      `${path} must declare exactly one of type, anyOf, or $ref`,
+    );
+  }
+  if (schema.type === undefined) {
+    return undefined;
+  }
+
+  if (typeof schema.type === 'string' && STRICT_SCHEMA_TYPES.has(schema.type as StrictSchemaType)) {
+    return [schema.type as StrictSchemaType];
+  }
+
+  if (Array.isArray(schema.type) && schema.type.length === 2) {
+    const nonNullTypes = schema.type.filter((type) => type !== 'null');
+    if (
+      schema.type.includes('null')
+      && nonNullTypes.length === 1
+      && typeof nonNullTypes[0] === 'string'
+      && STRICT_SCHEMA_TYPES.has(nonNullTypes[0] as StrictSchemaType)
+    ) {
+      return [nonNullTypes[0] as StrictSchemaType, 'null'];
+    }
+  }
+
+  throw strictSchemaError(
+    `${path}.type must be a supported type or nullable type union`,
+  );
+}
+
+function assertSupportedStrictSchemaKeywords(
+  schema: Record<string, unknown>,
+  schemaTypes: readonly StrictSchemaType[] | undefined,
+  path: string,
+): void {
+  const supportedKeywords = schemaTypes === undefined
+    ? new Set<string>(
+      schema.anyOf !== undefined
+        ? ['anyOf', 'description']
+        : ['$ref', 'description'],
+    )
+    : new Set<string>(TYPED_RAW_STRUCTURED_OUTPUT_KEYWORDS);
+  if (schemaTypes !== undefined) {
+    for (const schemaType of schemaTypes) {
+      for (const keyword of RAW_STRUCTURED_OUTPUT_KEYWORDS_BY_TYPE[schemaType]) {
+        supportedKeywords.add(keyword);
+      }
+    }
+  }
+
+  for (const keyword of Object.keys(schema)) {
+    if (!supportedKeywords.has(keyword)) {
+      throw strictSchemaError(
+        `${path} uses unsupported keyword ${keyword}`,
+      );
+    }
+  }
+
+  if (
+    schemaTypes?.includes('string')
+    && typeof schema.format === 'string'
+    && !SUPPORTED_RAW_STRING_FORMATS.has(schema.format)
+  ) {
+    throw strictSchemaError(`${path} uses unsupported format ${schema.format}`);
+  }
+}
+
+function isLosslessPrimitiveJsonValue(value: unknown): boolean {
+  return value === null
+    || typeof value === 'string'
+    || typeof value === 'boolean'
+    || (
+      typeof value === 'number'
+      && Number.isFinite(value)
+      && !Object.is(value, -0)
+    );
+}
+
+function isLosslessJsonValue(
+  value: unknown,
+  ancestors: ReadonlySet<object> = new Set(),
+): boolean {
+  if (isLosslessPrimitiveJsonValue(value)) {
+    return true;
+  }
+  if (typeof value !== 'object' || value === null || ancestors.has(value)) {
+    return false;
+  }
+
+  const nextAncestors = new Set([...ancestors, value]);
+  if (Array.isArray(value)) {
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.length !== value.length + 1 || !ownKeys.includes('length')) {
+      return false;
+    }
+    for (let index = 0; index < value.length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      if (
+        descriptor?.enumerable !== true
+        || !Object.hasOwn(descriptor, 'value')
+        || !isLosslessJsonValue(descriptor.value, nextAncestors)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return false;
+  }
+  return Reflect.ownKeys(value).every((key) => {
+    if (typeof key !== 'string') {
+      return false;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor?.enumerable === true
+      && Object.hasOwn(descriptor, 'value')
+      && isLosslessJsonValue(descriptor.value, nextAncestors);
+  });
+}
+
+function valueMatchesSchemaTypes(
+  value: unknown,
+  schemaTypes: readonly StrictSchemaType[],
+): boolean {
+  return schemaTypes.some((schemaType) => {
+    switch (schemaType) {
+      case 'string':
+        return typeof value === 'string';
+      case 'number':
+        return typeof value === 'number' && Number.isFinite(value);
+      case 'integer':
+        return typeof value === 'number' && Number.isInteger(value);
+      case 'boolean':
+        return typeof value === 'boolean';
+      case 'object':
+        return isPlainObject(value);
+      case 'array':
+        return Array.isArray(value);
+      case 'null':
+        return value === null;
+    }
+  });
+}
+
+function assertTypedValueKeywords(
+  schema: Record<string, unknown>,
+  schemaTypes: readonly StrictSchemaType[],
+  path: string,
+): void {
+  if (Object.hasOwn(schema, 'enum')) {
+    if (
+      !Array.isArray(schema.enum)
+      || !schema.enum.every(isLosslessPrimitiveJsonValue)
+    ) {
+      throw strictSchemaError(
+        `${path}.enum must contain only lossless primitive JSON values`,
+      );
+    }
+    if (!schema.enum.every((value) => valueMatchesSchemaTypes(value, schemaTypes))) {
+      throw strictSchemaError(
+        `${path}.enum value does not match its declared type`,
+      );
+    }
+  }
+
+  if (Object.hasOwn(schema, 'const')) {
+    if (!isLosslessPrimitiveJsonValue(schema.const)) {
+      throw strictSchemaError(
+        `${path}.const must be a lossless primitive JSON value`,
+      );
+    }
+    if (!valueMatchesSchemaTypes(schema.const, schemaTypes)) {
+      throw strictSchemaError(
+        `${path}.const value does not match its declared type`,
+      );
+    }
+  }
+}
+
+function assertStrictObjectSchema(
+  schema: Record<string, unknown>,
+  path: string,
+): void {
+  if (schema.additionalProperties !== false) {
+    throw strictSchemaError(
+      `${path} must set additionalProperties to false`,
+    );
+  }
+
+  const properties = isPlainObject(schema.properties) ? schema.properties : {};
+  const requiredProperties = Array.isArray(schema.required)
+    ? schema.required
+    : [];
+  const required = new Set(requiredProperties);
+  const missingProperties = Object.keys(properties).filter((property) => !required.has(property));
+  if (missingProperties.length > 0) {
+    throw strictSchemaError(
+      `${path} must list every property in required (missing: ${missingProperties.join(', ')})`,
+    );
+  }
+  const unknownProperties = requiredProperties.filter(
+    (property): property is string => (
+      typeof property === 'string'
+      && !Object.hasOwn(properties, property)
+    ),
+  );
+  if (unknownProperties.length > 0) {
+    throw strictSchemaError(
+      `${path} must only require declared properties (unknown: ${unknownProperties.join(', ')})`,
+    );
+  }
+}
+
+function getNestedSubschemas(
+  schema: Record<string, unknown>,
+  path: string,
+): Array<{ schema: unknown; path: string }> {
+  const nested: Array<{ schema: unknown; path: string }> = [];
+  if (isPlainObject(schema.properties)) {
+    for (const [property, propertySchema] of Object.entries(schema.properties)) {
+      nested.push({
+        schema: propertySchema,
+        path: `${path}${formatPathSegment(property)}`,
+      });
+    }
+  }
+  if (schema.items !== undefined) {
+    nested.push({ schema: schema.items, path: `${path}.items` });
+  }
+  if (Array.isArray(schema.anyOf)) {
+    schema.anyOf.forEach((alternative, index) => {
+      nested.push({ schema: alternative, path: `${path}.anyOf[${index}]` });
+    });
+  }
+  if (isPlainObject(schema.$defs)) {
+    for (const [name, definition] of Object.entries(schema.$defs)) {
+      nested.push({
+        schema: definition,
+        path: `${path}.$defs${formatPathSegment(name)}`,
+      });
+    }
+  }
+  return nested;
+}
+
+function assertStrictSubschema(
+  schema: unknown,
+  path: string,
+): void {
+  if (!isPlainObject(schema)) {
+    throw strictSchemaError(`${path} must be a schema object`);
+  }
+
+  const schemaTypes = getStrictSchemaTypes(schema, path);
+  assertSupportedStrictSchemaKeywords(schema, schemaTypes, path);
+  if (schemaTypes !== undefined) {
+    assertTypedValueKeywords(schema, schemaTypes, path);
+  }
+  if (schemaTypes?.includes('object')) {
+    assertStrictObjectSchema(schema, path);
+  }
+
+  const definitions = schema.$defs;
+  if (definitions !== undefined && !isPlainObject(definitions)) {
+    throw strictSchemaError(
+      `${path}.$defs must be a schema object map`,
+    );
+  }
+
+  for (const nested of getNestedSubschemas(schema, path)) {
+    assertStrictSubschema(nested.schema, nested.path);
+  }
+}
+
+function resolveLocalSchemaRef(
+  rootSchema: Record<string, unknown>,
+  ref: string,
+  path: string,
+): Record<string, unknown> {
+  if (ref !== '#' && !ref.startsWith('#/')) {
+    throw strictSchemaError(`${path} uses unsupported non-local $ref ${ref}`);
+  }
+
+  let pointer: string;
+  try {
+    pointer = decodeURIComponent(ref.slice(1));
+  } catch {
+    throw strictSchemaError(`${path} uses invalid $ref ${ref}`);
+  }
+
+  let target: unknown = rootSchema;
+  for (const encodedSegment of pointer.split('/').slice(1)) {
+    const segment = encodedSegment.replace(/~1/g, '/').replace(/~0/g, '~');
+    if (!isPlainObject(target) || !Object.hasOwn(target, segment)) {
+      throw strictSchemaError(`${path} uses unresolved $ref ${ref}`);
+    }
+    target = target[segment];
+  }
+
+  if (!isPlainObject(target)) {
+    throw strictSchemaError(`${path} $ref ${ref} must resolve to a schema object`);
+  }
+  return target;
+}
+
+function assertNoRecursiveRefs(rootSchema: Record<string, unknown>): void {
+  const visit = (
+    schema: Record<string, unknown>,
+    path: string,
+    activeSchemas: ReadonlySet<Record<string, unknown>>,
+  ): void => {
+    if (typeof schema.$ref === 'string') {
+      const target = resolveLocalSchemaRef(rootSchema, schema.$ref, path);
+      if (activeSchemas.has(target)) {
+        throw strictSchemaError(
+          `${path} contains recursive $ref ${schema.$ref}`,
+        );
+      }
+      visit(target, path, new Set([...activeSchemas, target]));
+    }
+
+    for (const nested of getNestedSubschemas(schema, path)) {
+      if (isPlainObject(nested.schema)) {
+        visit(
+          nested.schema,
+          nested.path,
+          new Set([...activeSchemas, nested.schema]),
+        );
+      }
+    }
+  };
+
+  visit(rootSchema, '$', new Set([rootSchema]));
+}
+
+function assertStrictRootSchema(schema: Record<string, unknown>): void {
+  if (schema.type !== 'object') {
+    throw strictSchemaError('$ must have type object');
+  }
+  if (schema.anyOf !== undefined) {
+    throw strictSchemaError('$ must not use anyOf');
+  }
+}
+
 export function assertStructuredOutputSchema(schema: Record<string, unknown>): void {
   if (!isPlainObject(schema)) {
     throw new StructuredOutputSchemaError('Structured output schema must be an object');
   }
 
   getValidator(schema);
+}
+
+export function assertStrictStructuredOutputSchema(schema: Record<string, unknown>): void {
+  if (!isPlainObject(schema)) {
+    throw new StructuredOutputSchemaError('Structured output schema must be an object');
+  }
+  if (!isLosslessJsonValue(schema)) {
+    throw new StructuredOutputSchemaError(
+      'Structured output schema must be a lossless JSON object',
+    );
+  }
+  assertStrictRootSchema(schema);
+  assertStrictSubschema(schema, '$');
+  assertNoRecursiveRefs(schema);
+  assertStructuredOutputSchema(schema);
 }
 
 export function validateStructuredOutputAgainstSchema(

--- a/src/core/workflow/engine/structured-output-schema-validator.ts
+++ b/src/core/workflow/engine/structured-output-schema-validator.ts
@@ -220,12 +220,13 @@ function assertSupportedStrictSchemaKeywords(
     }
   }
 
-  if (
-    schemaTypes?.includes('string')
-    && typeof schema.format === 'string'
-    && !SUPPORTED_RAW_STRING_FORMATS.has(schema.format)
-  ) {
-    throw strictSchemaError(`${path} uses unsupported format ${schema.format}`);
+  if (schemaTypes?.includes('string') && Object.hasOwn(schema, 'format')) {
+    if (typeof schema.format !== 'string') {
+      throw strictSchemaError(`${path}.format must be a string`);
+    }
+    if (!SUPPORTED_RAW_STRING_FORMATS.has(schema.format)) {
+      throw strictSchemaError(`${path} uses unsupported format ${schema.format}`);
+    }
   }
 }
 
@@ -348,16 +349,25 @@ function assertStrictObjectSchema(
   schema: Record<string, unknown>,
   path: string,
 ): void {
+  const properties = schema.properties;
+  if (!isPlainObject(properties)) {
+    throw strictSchemaError(`${path}.properties must be a plain object`);
+  }
+
+  const requiredProperties = schema.required;
+  if (!Array.isArray(requiredProperties)) {
+    throw strictSchemaError(`${path}.required must be an array`);
+  }
+  if (!requiredProperties.every((property): property is string => typeof property === 'string')) {
+    throw strictSchemaError(`${path}.required must contain only strings`);
+  }
+
   if (schema.additionalProperties !== false) {
     throw strictSchemaError(
       `${path} must set additionalProperties to false`,
     );
   }
 
-  const properties = isPlainObject(schema.properties) ? schema.properties : {};
-  const requiredProperties = Array.isArray(schema.required)
-    ? schema.required
-    : [];
   const required = new Set(requiredProperties);
   const missingProperties = Object.keys(properties).filter((property) => !required.has(property));
   if (missingProperties.length > 0) {
@@ -366,10 +376,7 @@ function assertStrictObjectSchema(
     );
   }
   const unknownProperties = requiredProperties.filter(
-    (property): property is string => (
-      typeof property === 'string'
-      && !Object.hasOwn(properties, property)
-    ),
+    (property) => !Object.hasOwn(properties, property),
   );
   if (unknownProperties.length > 0) {
     throw strictSchemaError(


### PR DESCRIPTION
## Summary

- make the auto-routing estimator schema valid for Codex strict structured output
- represent optional confidence as a required nullable field and normalize null to an omitted internal value
- fail fast while constructing the estimator when its structured-output schema is invalid, instead of silently selecting `auto.fallback`
- keep the router schema within the raw structured-output subset shared by Codex and Claude, with wire-lossless validation
- add Codex regression coverage and a Claude integration test through the Agent SDK `query()` boundary

## Root cause

The estimator schema declared `confidence` in `properties` but omitted it from `required`. Codex rejects that strict output schema, so every estimator call was handled as a failure and selected the configured `auto.fallback` candidate.

No additional user configuration is required. `confidence` is part of TAKT's internal estimator response contract, not an `auto_routing` configuration field.

## Failure policy

- deterministic schema/configuration mismatches fail synchronously before the provider call
- runtime provider failures and invalid model responses continue to use the configured fallback

## Verification

- `npm run build`
- `npm run lint`
- type-contracts
- 170 related unit tests
- Claude Agent SDK `query()` integration test
- `git diff --check`
- independent Codex sol review using `$coding`: APPROVE, 0 findings

A local full `npm test` run used Node 22.22.1 and failed only in Node 24.15+ `node:sqlite` API coverage (`DatabaseSync.enableDefensive`) and a sandbox-restricted Unix socket test. The affected auto-routing tests passed, and CI runs with the repository-supported runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **機能改善**
  * ワーク要件の推定結果に信頼度（confidence / number または null）を追加し、null の場合は返却に含めない仕様にしました。
  * 返却形式の厳密なスキーマ検証を強化し、不正な structured output や schema 不整合を適切に拒否するよう調整しました。
* **テスト**
  * confidence の省略／null／無効値の扱い、および厳格スキーマ条件での受理・拒否を追加・更新しました。
  * Claude 経由の統合テストを追加し、期待する出力形式を確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
