### PR TITLE
fix(opencode): separate reasoning from text stream tracking

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -17,6 +17,7 @@ import {
   OPENCODE_STREAM_ID_LIMIT,
   OPENCODE_STREAM_TEXT_BYTE_LIMIT,
 } from '../infra/opencode/OpenCodeStreamHandler.js';
+import { MAX_TRACKED_SENSITIVE_SOURCES } from '../shared/utils/sensitiveText.js';
 
 /**
  * 自セッションの進捗が止まったまま、サーバ全体のバスに無関係イベントが
@@ -736,16 +737,23 @@ describe('OpenCodeClient stream cleanup', () => {
 
     expect(result.status).toBe('done');
     expect(result.content).toBe(supportedText);
-    expect(onStream.mock.calls.filter(([event]) => event.type === 'text')).toEqual([
-      [{ type: 'text', data: { text: supportedText } }],
+    const visibleEvents = onStream.mock.calls
+      .map(([event]) => event as { type: string; data?: { text?: string; thinking?: string } })
+      .filter((event) => event.type === 'text' || event.type === 'thinking');
+    expect(visibleEvents.filter((event) => event.type === 'text')).toEqual([
+      { type: 'text', data: { text: supportedText } },
     ]);
-    expect(JSON.stringify(onStream.mock.calls)).not.toContain(unsupportedDelta);
+    expect(visibleEvents.filter((event) => event.type === 'thinking')).toEqual([]);
+    for (const event of visibleEvents) {
+      const value = event.type === 'text' ? event.data?.text : event.data?.thinking;
+      expect(value).not.toContain(unsupportedDelta);
+    }
   });
 
   it('fails an attempt when sensitive source tracking is exhausted and reports sensitive_sources', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const sessionId = 'session-sensitive-source-limit';
-    const events = Array.from({ length: 260 }, (_, index) => (
+    const events = Array.from({ length: MAX_TRACKED_SENSITIVE_SOURCES + 1 }, (_, index) => (
       sensitiveToolPartUpdated(sessionId, `tool-${index}`, `secret-${index}`)
     ));
     const stream = new MockEventStream(events, sessionId);

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -14,8 +14,8 @@ import { AskUserQuestionDeniedError } from '../core/workflow/ask-user-question-e
 import { resetDebugLogger, setVerboseConsole } from '../shared/utils/index.js';
 import {
   OPENCODE_STREAM_EVENT_LIMIT,
+  OPENCODE_STREAM_ID_LIMIT,
   OPENCODE_STREAM_TEXT_BYTE_LIMIT,
-  OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE,
 } from '../infra/opencode/OpenCodeStreamHandler.js';
 
 /**
@@ -563,7 +563,38 @@ describe('OpenCodeClient stream cleanup', () => {
     });
 
     expect(result.status).toBe('error');
-    expect(result.error).toBe(OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE);
+    expect(result.error).toContain('event_count');
+    expect(stream.returnSpy).toHaveBeenCalled();
+  });
+
+  it('fails an attempt when tracked ids exceed the limit and reports tracked_id_count', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const sessionId = 'session-tracked-id-limit';
+    const events = Array.from({ length: OPENCODE_STREAM_ID_LIMIT + 1 }, (_, index) => (
+      textPartUpdated(sessionId, `text-${index}`, 'x')
+    ));
+    const stream = new MockEventStream(events, sessionId);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: sessionId } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+          abort: successfulSessionAbort(),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('tracked_id_count');
     expect(stream.returnSpy).toHaveBeenCalled();
   });
 
@@ -632,8 +663,113 @@ describe('OpenCodeClient stream cleanup', () => {
     });
 
     expect(result.status).toBe('error');
-    expect(result.error).toBe(OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE);
-    expect(result.content).toBe(OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE);
+    expect(result.error).toContain('text_bytes');
+    expect(result.content).toContain('text_bytes');
+    expect(result.error).not.toContain('event_count');
+    expect(result.error).not.toContain('tracked_id_count');
+    expect(stream.returnSpy).toHaveBeenCalled();
+  });
+
+  it('ignores unsupported part type delta while continuing with later text output', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const sessionId = 'session-unsupported-part-type';
+    const unsupportedDelta = 'ignored unsupported delta';
+    const supportedText = 'kept text output';
+    const stream = new MockEventStream([
+      {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: sessionId,
+          part: {
+            id: 'unsupported-part',
+            sessionID: sessionId,
+            type: 'image',
+            text: 'unsupported snapshot',
+          },
+        },
+      },
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: sessionId,
+          partID: 'unsupported-part',
+          field: 'text',
+          delta: unsupportedDelta,
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: sessionId,
+          part: {
+            id: 'text-1',
+            sessionID: sessionId,
+            type: 'text',
+            text: supportedText,
+          },
+          delta: supportedText,
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: sessionId } },
+    ], sessionId);
+    const onStream = vi.fn();
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: sessionId } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+          abort: successfulSessionAbort(),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      onStream,
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe(supportedText);
+    expect(onStream.mock.calls.filter(([event]) => event.type === 'text')).toEqual([
+      [{ type: 'text', data: { text: supportedText } }],
+    ]);
+    expect(JSON.stringify(onStream.mock.calls)).not.toContain(unsupportedDelta);
+  });
+
+  it('fails an attempt when sensitive source tracking is exhausted and reports sensitive_sources', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const sessionId = 'session-sensitive-source-limit';
+    const events = Array.from({ length: 260 }, (_, index) => (
+      sensitiveToolPartUpdated(sessionId, `tool-${index}`, `secret-${index}`)
+    ));
+    const stream = new MockEventStream(events, sessionId);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: sessionId } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+          abort: successfulSessionAbort(),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('sensitive_sources');
     expect(stream.returnSpy).toHaveBeenCalled();
   });
 

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createProviderEventLogger } from '../core/logging/providerEventLogger.js';
+import { OPENCODE_STREAM_TEXT_BYTE_LIMIT } from '../infra/opencode/OpenCodeStreamHandler.js';
 
 type MockStreamEvent = Record<string, unknown>;
 type RunPlan =
@@ -42,6 +43,67 @@ function waitForAbort(signal?: AbortSignal): Promise<never> {
 
     signal?.addEventListener('abort', onAbort, { once: true });
   });
+}
+
+function textPartUpdated(sessionID: string, id: string, text: string): MockStreamEvent {
+  return {
+    type: 'message.part.updated',
+    properties: {
+      sessionID,
+      part: { id, sessionID, type: 'text', text },
+    },
+  };
+}
+
+function reasoningPartUpdated(sessionID: string, id: string, thinking: string): MockStreamEvent {
+  return {
+    type: 'message.part.updated',
+    properties: {
+      sessionID,
+      part: { id, sessionID, type: 'reasoning', text: thinking },
+    },
+  };
+}
+
+class MockEventStream implements AsyncGenerator<MockStreamEvent, void, unknown> {
+  private index = 0;
+  readonly returnSpy = vi.fn(async () => ({ done: true as const, value: undefined }));
+
+  constructor(private readonly events: MockStreamEvent[], private readonly sessionID: string) {}
+
+  [Symbol.asyncIterator](): AsyncGenerator<MockStreamEvent, void, unknown> {
+    return this;
+  }
+
+  async next(): Promise<IteratorResult<MockStreamEvent, void>> {
+    if (this.index >= this.events.length) {
+      return { done: true, value: undefined };
+    }
+    const event = this.events[this.index];
+    this.index += 1;
+    return {
+      done: false,
+      value: {
+        ...event,
+        properties: {
+          ...(event.properties as Record<string, unknown>),
+          sessionID: this.sessionID,
+        },
+      },
+    };
+  }
+
+  async return(): Promise<IteratorResult<MockStreamEvent, void>> {
+    return this.returnSpy();
+  }
+
+  async throw(error?: unknown): Promise<IteratorResult<MockStreamEvent, void>> {
+    throw error;
+  }
+}
+
+function successfulSessionAbort() {
+  return vi.fn().mockResolvedValue({ data: true });
 }
 
 const { createOpencodeMock } = vi.hoisted(() => ({
@@ -463,6 +525,440 @@ describe('OpenCodeClient retry', () => {
     expect(promptAsync.mock.calls[1][0].sessionID).not.toBe(promptAsync.mock.calls[2][0].sessionID);
     expect(result.status).toBe('error');
     expect(result.content).toBe('OpenCode stream timed out after 10 minutes of inactivity');
+  });
+
+  it('replays the OpenCode event order from issue #1130 without mixing reasoning and text', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const reasoningPartOne = 'Reasoning '.repeat(6_600);
+    const reasoningPartTwo = 'tail';
+    const textPartOne = 'text delta one ';
+    const textPartTwo = 'text delta two';
+    const reasoning = `${reasoningPartOne}${reasoningPartTwo}`;
+    const content = `${textPartOne}${textPartTwo}`;
+    const stream = new MockEventStream([
+      reasoningPartUpdated('session-reasoning-delta', 'reasoning-1', ''),
+      textPartUpdated('session-reasoning-delta', 'text-1', ''),
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-reasoning-delta',
+          partID: 'reasoning-1',
+          field: 'text',
+          delta: reasoningPartOne,
+        },
+      },
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-reasoning-delta',
+          partID: 'text-1',
+          field: 'text',
+          delta: textPartOne,
+        },
+      },
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-reasoning-delta',
+          partID: 'reasoning-1',
+          field: 'text',
+          delta: reasoningPartTwo,
+        },
+      },
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-reasoning-delta',
+          partID: 'text-1',
+          field: 'text',
+          delta: textPartTwo,
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-reasoning-delta',
+          part: {
+            id: 'reasoning-1',
+            sessionID: 'session-reasoning-delta',
+            type: 'reasoning',
+            text: reasoning,
+          },
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-reasoning-delta',
+          part: {
+            id: 'text-1',
+            sessionID: 'session-reasoning-delta',
+            type: 'text',
+            text: content,
+          },
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-reasoning-delta' } },
+    ], 'session-reasoning-delta');
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-reasoning-delta' } });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+    const onStream = vi.fn();
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: { create: sessionCreate, promptAsync, abort: successfulSessionAbort() },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      onStream,
+    });
+
+    expect(result.status, JSON.stringify(result)).toBe('done');
+    expect(result.content).toBe(content);
+    const streamEvents = onStream.mock.calls
+      .map(([event]) => event as { type: string; data?: { thinking?: string; text?: string } })
+      .filter((event) => event.type === 'thinking' || event.type === 'text');
+    expect(streamEvents).toHaveLength(4);
+    const thinkingOutput = streamEvents
+      .filter((event) => event.type === 'thinking')
+      .map((event) => event.data?.thinking ?? '')
+      .join('');
+    expect(thinkingOutput).toBe(reasoning);
+    const textOutput = streamEvents
+      .filter((event) => event.type === 'text')
+      .map((event) => event.data?.text ?? '')
+      .join('');
+    expect(textOutput).toBe(content);
+    expect(thinkingOutput).not.toContain(content);
+    expect(textOutput).not.toContain(reasoning);
+    expect(streamEvents.filter((event) => event.type === 'thinking')).toHaveLength(2);
+    expect(streamEvents.filter((event) => event.type === 'text')).toHaveLength(2);
+  });
+
+  it('handles large reasoning delta after the part type is known without applying the text byte limit', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const reasoningPartOne = 'Reasoning '.repeat(6_600);
+    const reasoningPartTwo = 'tail';
+    const textPart = 'short body';
+    const reasoning = `${reasoningPartOne}${reasoningPartTwo}`;
+    const stream = new MockEventStream([
+      {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-reasoning-delta-first',
+          part: {
+            id: 'reasoning-1',
+            sessionID: 'session-reasoning-delta-first',
+            type: 'reasoning',
+            text: '',
+          },
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-reasoning-delta-first',
+          part: {
+            id: 'text-1',
+            sessionID: 'session-reasoning-delta-first',
+            type: 'text',
+            text: '',
+          },
+        },
+      },
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-reasoning-delta-first',
+          partID: 'reasoning-1',
+          field: 'text',
+          delta: reasoningPartOne,
+        },
+      },
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-reasoning-delta-first',
+          partID: 'text-1',
+          field: 'text',
+          delta: textPart,
+        },
+      },
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-reasoning-delta-first',
+          partID: 'reasoning-1',
+          field: 'text',
+          delta: reasoningPartTwo,
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-reasoning-delta-first',
+          part: {
+            id: 'text-1',
+            sessionID: 'session-reasoning-delta-first',
+            type: 'text',
+            text: textPart,
+          },
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'session-reasoning-delta-first',
+          part: {
+            id: 'reasoning-1',
+            sessionID: 'session-reasoning-delta-first',
+            type: 'reasoning',
+            text: reasoning,
+          },
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-reasoning-delta-first' } },
+    ], 'session-reasoning-delta-first');
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-reasoning-delta-first' } });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+    const onStream = vi.fn();
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: { create: sessionCreate, promptAsync, abort: successfulSessionAbort() },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      onStream,
+    });
+
+    expect(result.status, JSON.stringify(result)).toBe('done');
+    expect(result.content).toBe(textPart);
+    expect(result.content).not.toContain(reasoningPartOne.slice(0, 16));
+    const thinkingOutput = onStream.mock.calls
+      .map(([event]) => event as { type: string; data?: { thinking?: string; text?: string } })
+      .filter((event) => event.type === 'thinking')
+      .map((event) => event.data?.thinking ?? '')
+      .join('');
+    expect(thinkingOutput).toBe(reasoning);
+    expect(thinkingOutput).not.toContain(textPart);
+  });
+  it('ignores empty reasoning and text parts without emitting stream content', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const stream = new MockEventStream([
+      textPartUpdated('session-empty-parts', 'text-1', ''),
+      reasoningPartUpdated('session-empty-parts', 'reasoning-1', ''),
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-empty-parts',
+          partID: 'text-1',
+          field: 'text',
+          delta: '',
+        },
+      },
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-empty-parts',
+          partID: 'reasoning-1',
+          field: 'text',
+          delta: '',
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-empty-parts' } },
+    ], 'session-empty-parts');
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-empty-parts' } });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+    const onStream = vi.fn();
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: { create: sessionCreate, promptAsync, abort: successfulSessionAbort() },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      onStream,
+    });
+
+    expect(result.status, JSON.stringify(result)).toBe('done');
+    expect(result.content).toBe('');
+    expect(onStream.mock.calls
+      .map(([event]) => event as { type: string })
+      .filter((event) => event.type === 'text' || event.type === 'thinking'))
+      .toHaveLength(0);
+  });
+
+  it('routes an undefined part type delta through text processing', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const sessionId = 'session-undefined-part-type';
+    const delta = 'plain delta text';
+    const stream = new MockEventStream([
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: sessionId,
+          partID: 'text-undefined',
+          field: 'text',
+          delta,
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: sessionId } },
+    ], sessionId);
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: sessionId } });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+    const onStream = vi.fn();
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: { create: sessionCreate, promptAsync, abort: successfulSessionAbort() },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      onStream,
+    });
+
+    expect(result.status, JSON.stringify(result)).toBe('done');
+    expect(result.content).toBe(delta);
+    expect(onStream.mock.calls.filter(([event]) => event.type === 'text')).toEqual([
+      [{ type: 'text', data: { text: delta } }],
+    ]);
+  });
+
+  it('keeps reasoning offsets in sync when an unknown delta is later identified as reasoning', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const sessionId = 'session-unknown-delta-reasoning';
+    const reasoningPrefix = 'x'.repeat(40_000);
+    const reasoningSuffix = 'tail';
+    const fallbackDelta = reasoningPrefix;
+    const reasoningText = `${reasoningPrefix}${reasoningSuffix}`;
+    const stream = new MockEventStream([
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: sessionId,
+          partID: 'reasoning-1',
+          field: 'text',
+          delta: fallbackDelta,
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: sessionId,
+          part: {
+            id: 'reasoning-1',
+            sessionID: sessionId,
+            type: 'reasoning',
+            text: reasoningText,
+          },
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: sessionId } },
+    ], sessionId);
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: sessionId } });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+    const onStream = vi.fn();
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: { create: sessionCreate, promptAsync, abort: successfulSessionAbort() },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      onStream,
+    });
+
+    expect(result.status, JSON.stringify(result)).toBe('done');
+    expect(result.content).toBe(fallbackDelta);
+    const textOutput = onStream.mock.calls
+      .map(([event]) => event as { type: string; data?: { text?: string; thinking?: string } })
+      .filter((event) => event.type === 'text')
+      .map((event) => event.data?.text ?? '')
+      .join('');
+    const thinkingOutput = onStream.mock.calls
+      .map(([event]) => event as { type: string; data?: { text?: string; thinking?: string } })
+      .filter((event) => event.type === 'thinking')
+      .map((event) => event.data?.thinking ?? '')
+      .join('');
+    expect(textOutput).toBe(fallbackDelta);
+    expect(thinkingOutput).toBe(reasoningSuffix);
+  });
+
+  it('fails text byte tracking with a reason that identifies text_bytes', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const stream = new MockEventStream([
+      textPartUpdated('session-text-bytes', 'text-1', 'x'.repeat(OPENCODE_STREAM_TEXT_BYTE_LIMIT + 1)),
+      { type: 'session.idle', properties: { sessionID: 'session-text-bytes' } },
+    ], 'session-text-bytes');
+
+    const promptAsync = vi.fn().mockResolvedValue(undefined);
+    const sessionCreate = vi.fn().mockResolvedValue({ data: { id: 'session-text-bytes' } });
+    const subscribe = vi.fn().mockResolvedValue({ stream });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn().mockResolvedValue({ data: {} }) },
+        session: { create: sessionCreate, promptAsync, abort: successfulSessionAbort() },
+        event: { subscribe },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('text_bytes');
+    expect(result.content).toContain('text_bytes');
   });
 
   it('external abort は retry せずに停止する', async () => {

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -80,6 +80,9 @@ class MockEventStream implements AsyncGenerator<MockStreamEvent, void, unknown> 
       return { done: true, value: undefined };
     }
     const event = this.events[this.index];
+    if (event === undefined) {
+      return { done: true, value: undefined };
+    }
     this.index += 1;
     return {
       done: false,
@@ -861,13 +864,15 @@ describe('OpenCodeClient retry', () => {
     ]);
   });
 
-  it('keeps reasoning offsets in sync when an unknown delta is later identified as reasoning', async () => {
+  it('keeps an unknown delta as text when the part is later identified as reasoning', async () => {
     const { OpenCodeClient } = await import('../infra/opencode/client.js');
     const sessionId = 'session-unknown-delta-reasoning';
     const reasoningPrefix = 'x'.repeat(40_000);
     const reasoningSuffix = 'tail';
     const fallbackDelta = reasoningPrefix;
     const reasoningText = `${reasoningPrefix}${reasoningSuffix}`;
+    // Once emitted through the compatibility fallback, the prefix remains text.
+    // The later reasoning snapshot emits only the previously unseen suffix.
     const stream = new MockEventStream([
       {
         type: 'message.part.delta',

--- a/src/__tests__/opencode-client-tool-error-log-sanitize.test.ts
+++ b/src/__tests__/opencode-client-tool-error-log-sanitize.test.ts
@@ -264,6 +264,49 @@ describe('OpenCodeClient tool call failure logging', () => {
     expect(evidence).toContain('[REDACTED]');
   });
 
+  it('unknown message.part.delta part types do not leak secrets while staying out of text processing', async () => {
+    const secret = 'unknown-delta-secret';
+    const partId = 'mystery-part';
+    installOpenCodeMock([
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: partId,
+            sessionID: 'session-1',
+            type: 'mystery',
+          },
+        },
+      },
+      {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'session-1',
+          partID: partId,
+          field: 'text',
+          delta: secret,
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-1' } },
+    ]);
+    const client = new OpenCodeClient();
+
+    const result = await client.call('coder', 'prompt', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+    });
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('');
+
+    const evidence = JSON.stringify({
+      result,
+      debugCalls: debugLogSpy.mock.calls,
+    });
+    expect(evidence).not.toContain(secret);
+    expect(evidence).not.toContain(partId);
+  });
+
   it('onStream なしのtool inputを同一attemptのprompt例外とretry結果からマスクする', async () => {
     const toolSecret = 'silent-tool-prompt-exception-secret';
     const { promptAsync } = installOpenCodeMock([
@@ -694,5 +737,60 @@ describe('OpenCodeClient tool call failure logging', () => {
 
     expect(data.input.offset).toBe('290.0');
     expect(data.input.filepaath).toBe('/x');
+  });
+
+  it.each([
+    'message.updated',
+    'message.completed',
+    'message.failed',
+    'session.error',
+  ])('%s の tracking-limit 風エラーでも known secret をマスクする', async (eventType) => {
+    const knownSecret = `known-tracking-limit-${eventType}-secret`;
+    const rawError = `OpenCode stream tracking limit exceeded: provider rejected ${knownSecret}`;
+    installOpenCodeMock([
+      sensitiveToolEvent(knownSecret),
+      providerErrorEvent(eventType, { name: 'ProviderError', data: { message: rawError } }),
+    ]);
+    const logsDir = mkdtempSync(join(tmpdir(), 'takt-opencode-provider-error-'));
+
+    try {
+      const providerLogger = createProviderEventLogger({
+        logsDir,
+        sessionId: `provider-error-tracking-limit-${eventType}`,
+        runId: 'provider-error-tracking-limit-run',
+        enabled: true,
+      });
+      const observed = vi.fn();
+      const client = new OpenCodeClient();
+      const result = await client.call('coder', 'prompt', {
+        cwd: '/tmp',
+        model: 'opencode/big-pickle',
+        onStream: (event) => {
+          providerLogger.logEvent({
+            provider: 'opencode',
+            providerModel: 'big-pickle',
+            step: 'review',
+          }, event);
+          observed(event);
+        },
+        opencodeApiKey: `opaque-api-key-${eventType}`,
+        childProcessEnv: { OPENCODE_ACCESS_TOKEN: `opaque-child-env-${eventType}` },
+      });
+      const evidence = JSON.stringify({
+        result,
+        debugCalls: debugLogSpy.mock.calls,
+        infoCalls: infoLogSpy.mock.calls,
+        streamCalls: observed.mock.calls,
+        jsonl: readFileSync(providerLogger.filepath, 'utf8'),
+      });
+      expect(result.status).toBe('error');
+      expect(evidence).not.toContain(knownSecret);
+      expect(evidence).not.toContain(`opaque-api-key-${eventType}`);
+      expect(evidence).not.toContain(`opaque-child-env-${eventType}`);
+      expect(evidence).toContain('[REDACTED]');
+      expect(evidence).toContain('OpenCode stream tracking limit exceeded');
+    } finally {
+      rmSync(logsDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/__tests__/opencode-client-tool-error-log-sanitize.test.ts
+++ b/src/__tests__/opencode-client-tool-error-log-sanitize.test.ts
@@ -290,14 +290,26 @@ describe('OpenCodeClient tool call failure logging', () => {
       { type: 'session.idle', properties: { sessionID: 'session-1' } },
     ]);
     const client = new OpenCodeClient();
+    const observed = vi.fn();
 
     const result = await client.call('coder', 'prompt', {
       cwd: '/tmp',
       model: 'opencode/big-pickle',
+      onStream: observed,
     });
 
     expect(result.status).toBe('done');
     expect(result.content).toBe('');
+
+    const visibleEvents = observed.mock.calls
+      .map(([event]) => event as { type: string; data?: { text?: string; thinking?: string } })
+      .filter((event) => event.type === 'text' || event.type === 'thinking');
+    expect(visibleEvents).toEqual([]);
+    for (const event of visibleEvents) {
+      const value = event.type === 'text' ? event.data?.text : event.data?.thinking;
+      expect(value).not.toContain(secret);
+      expect(value).not.toContain(partId);
+    }
 
     const evidence = JSON.stringify({
       result,
@@ -789,6 +801,15 @@ describe('OpenCodeClient tool call failure logging', () => {
       expect(evidence).not.toContain(`opaque-child-env-${eventType}`);
       expect(evidence).toContain('[REDACTED]');
       expect(evidence).toContain('OpenCode stream tracking limit exceeded');
+      for (const internalReason of [
+        'event_count',
+        'tracked_id_count',
+        'text_bytes',
+        'sensitive_sources',
+      ]) {
+        expect(result.error).not.toContain(internalReason);
+        expect(evidence).not.toContain(internalReason);
+      }
     } finally {
       rmSync(logsDir, { recursive: true, force: true });
     }

--- a/src/__tests__/opencode-stream-handler.test.ts
+++ b/src/__tests__/opencode-stream-handler.test.ts
@@ -387,6 +387,43 @@ describe('handlePartUpdated', () => {
     });
   });
 
+  it('should keep text and reasoning offsets independent across delta and snapshot updates', () => {
+    const onStream = vi.fn();
+    const state = createStreamTrackingState();
+
+    handlePartUpdated(
+      { id: 'text-1', type: 'text', text: 'Hello world' },
+      'Hello',
+      onStream,
+      state,
+    );
+    handlePartUpdated(
+      { id: 'reasoning-1', type: 'reasoning', text: 'Thinking...' },
+      'Think',
+      onStream,
+      state,
+    );
+    handlePartUpdated(
+      { id: 'text-1', type: 'text', text: 'Hello world' },
+      undefined,
+      onStream,
+      state,
+    );
+    handlePartUpdated(
+      { id: 'reasoning-1', type: 'reasoning', text: 'Thinking...' },
+      undefined,
+      onStream,
+      state,
+    );
+
+    expect(onStream.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'text', data: { text: 'Hello' } },
+      { type: 'thinking', data: { thinking: 'Think' } },
+      { type: 'text', data: { text: ' world' } },
+      { type: 'thinking', data: { thinking: 'ing...' } },
+    ]);
+  });
+
   it('should redact a known secret split at every text delta boundary', () => {
     const secret = 'split-opencode-secret';
     for (let split = 1; split < secret.length; split += 1) {
@@ -454,6 +491,23 @@ describe('handlePartUpdated', () => {
       type: 'thinking',
       data: { thinking: 'Thinking' },
     });
+  });
+
+  it('should not apply the text byte limit to reasoning parts', () => {
+    const onStream = vi.fn();
+    const state = createStreamTrackingState();
+    const repeatCount = Math.floor(OPENCODE_STREAM_TEXT_BYTE_LIMIT / 'Reasoning '.length) + 1;
+    const reasoning = 'Reasoning '.repeat(repeatCount);
+    const part: OpenCodeReasoningPart = { id: 'r1', type: 'reasoning', text: reasoning };
+
+    handlePartUpdated(part, reasoning, onStream, state);
+
+    expect(onStream).toHaveBeenCalledWith({
+      type: 'thinking',
+      data: { thinking: reasoning },
+    });
+    expect(state.textBytes).toBe(0);
+    expect(state.exhausted).toBe(false);
   });
 
   it('should handle reasoning part without delta using offset tracking', () => {

--- a/src/__tests__/opencode-stream-handler.test.ts
+++ b/src/__tests__/opencode-stream-handler.test.ts
@@ -498,7 +498,12 @@ describe('handlePartUpdated', () => {
     const state = createStreamTrackingState();
     const repeatCount = Math.floor(OPENCODE_STREAM_TEXT_BYTE_LIMIT / 'Reasoning '.length) + 1;
     const reasoning = 'Reasoning '.repeat(repeatCount);
-    const part: OpenCodeReasoningPart = { id: 'r1', type: 'reasoning', text: reasoning };
+    const part: OpenCodeReasoningPart = {
+      id: 'r1',
+      sessionID: 'session-1',
+      type: 'reasoning',
+      text: reasoning,
+    };
 
     handlePartUpdated(part, reasoning, onStream, state);
 

--- a/src/infra/opencode/OpenCodeStreamHandler.ts
+++ b/src/infra/opencode/OpenCodeStreamHandler.ts
@@ -57,6 +57,12 @@ export type OpenCodeToolState =
 
 export type OpenCodePart = OpenCodeTextPart | OpenCodeReasoningPart | OpenCodeToolPart | { id: string; type: string; sessionID?: string };
 
+export type OpenCodeStreamTrackingLimitReason =
+  | 'event_count'
+  | 'tracked_id_count'
+  | 'text_bytes'
+  | 'sensitive_sources';
+
 /** OpenCode SSE event types relevant for stream handling */
 export interface OpenCodeMessagePartUpdatedEvent {
   type: 'message.part.updated';
@@ -165,12 +171,14 @@ export interface StreamTrackingState {
   thinkingOffsets: Map<string, number>;
   textRedactors: Map<string, SensitiveTextStreamRedactor>;
   thinkingRedactors: Map<string, SensitiveTextStreamRedactor>;
+  partTypes: Map<string, string>;
   startedTools: Set<string>;
   latestToolInputs: Map<string, Record<string, unknown>>;
   sensitiveSources: BoundedSensitiveValues;
   eventCount: number;
   textBytes: number;
   trackedIds: Set<string>;
+  trackingLimitReason?: OpenCodeStreamTrackingLimitReason;
   exhausted: boolean;
 }
 
@@ -185,12 +193,14 @@ export function createStreamTrackingState(): StreamTrackingState {
     thinkingOffsets: new Map<string, number>(),
     textRedactors: new Map<string, SensitiveTextStreamRedactor>(),
     thinkingRedactors: new Map<string, SensitiveTextStreamRedactor>(),
+    partTypes: new Map<string, string>(),
     startedTools: new Set<string>(),
     latestToolInputs: new Map<string, Record<string, unknown>>(),
     sensitiveSources: createBoundedSensitiveValues(),
     eventCount: 0,
     textBytes: 0,
     trackedIds: new Set<string>(),
+    trackingLimitReason: undefined,
     exhausted: false,
   };
 }
@@ -201,18 +211,25 @@ export function trackOpenCodeTextBytes(state: StreamTrackingState, text: string)
   }
   const nextTextBytes = state.textBytes + Buffer.byteLength(text, 'utf8');
   if (nextTextBytes > OPENCODE_STREAM_TEXT_BYTE_LIMIT) {
-    exhaustStreamTrackingState(state);
+    exhaustStreamTrackingState(state, 'text_bytes');
     return false;
   }
   state.textBytes = nextTextBytes;
   return true;
 }
 
-function exhaustStreamTrackingState(state: StreamTrackingState): void {
+function exhaustStreamTrackingState(
+  state: StreamTrackingState,
+  reason?: OpenCodeStreamTrackingLimitReason,
+): void {
+  if (reason !== undefined && state.trackingLimitReason === undefined) {
+    state.trackingLimitReason = reason;
+  }
   state.textOffsets.clear();
   state.thinkingOffsets.clear();
   state.textRedactors.clear();
   state.thinkingRedactors.clear();
+  state.partTypes.clear();
   state.startedTools.clear();
   state.latestToolInputs.clear();
   state.trackedIds.clear();
@@ -228,11 +245,26 @@ function trackStreamId(state: StreamTrackingState, id: string): boolean {
     return true;
   }
   if (state.trackedIds.size >= OPENCODE_STREAM_ID_LIMIT) {
-    exhaustStreamTrackingState(state);
+    exhaustStreamTrackingState(state, 'tracked_id_count');
     return false;
   }
   state.trackedIds.add(id);
   return true;
+}
+
+function rememberPartType(state: StreamTrackingState, part: OpenCodePart): void {
+  const partId = part.type === 'tool'
+    ? ((part as OpenCodeToolPart).callID || part.id)
+    : part.id;
+  state.partTypes.set(partId, part.type);
+}
+
+export function describeOpenCodeStreamTrackingLimitFailure(
+  reason: OpenCodeStreamTrackingLimitReason | undefined,
+): string {
+  return reason === undefined
+    ? OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE
+    : `${OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE}: ${reason}`;
 }
 
 export function trackOpenCodeStreamEvent(
@@ -244,7 +276,7 @@ export function trackOpenCodeStreamEvent(
   }
   state.eventCount += 1;
   if (state.eventCount > OPENCODE_STREAM_EVENT_LIMIT) {
-    exhaustStreamTrackingState(state);
+    exhaustStreamTrackingState(state, 'event_count');
     return false;
   }
   if (event.type === 'message.part.updated') {
@@ -252,7 +284,11 @@ export function trackOpenCodeStreamEvent(
     const partId = part.type === 'tool'
       ? ((part as OpenCodeToolPart).callID || part.id)
       : part.id;
-    return trackStreamId(state, partId);
+    if (!trackStreamId(state, partId)) {
+      return false;
+    }
+    rememberPartType(state, part);
+    return true;
   }
   if (event.type === 'message.part.delta') {
     const partId = event.properties['partID'];
@@ -417,6 +453,7 @@ export function handlePartUpdated(
   if (!trackStreamId(state, partId)) {
     return false;
   }
+  rememberPartType(state, part);
   switch (part.type) {
     case 'text': {
       if (!onStream) return true;
@@ -428,6 +465,8 @@ export function handlePartUpdated(
           delta,
           state.sensitiveSources,
         ));
+        const previous = state.textOffsets.get(textPart.id) ?? 0;
+        state.textOffsets.set(textPart.id, previous + delta.length);
       } else {
         const prev = state.textOffsets.get(textPart.id) ?? 0;
         if (textPart.text.length > prev) {
@@ -455,6 +494,8 @@ export function handlePartUpdated(
           delta,
           state.sensitiveSources,
         ));
+        const previous = state.thinkingOffsets.get(reasoningPart.id) ?? 0;
+        state.thinkingOffsets.set(reasoningPart.id, previous + delta.length);
       } else {
         const prev = state.thinkingOffsets.get(reasoningPart.id) ?? 0;
         if (reasoningPart.text.length > prev) {
@@ -493,7 +534,7 @@ function handleToolPartUpdated(
   if (previousInput !== toolPart.state.input) {
     state.sensitiveSources.add(toolPart.state.input);
     if (state.sensitiveSources.exhausted) {
-      exhaustStreamTrackingState(state);
+      exhaustStreamTrackingState(state, 'sensitive_sources');
       return false;
     }
   }

--- a/src/infra/opencode/attempt-runner.ts
+++ b/src/infra/opencode/attempt-runner.ts
@@ -25,8 +25,10 @@ import {
   type OpenCodeTextPart,
   type OpenCodeToolPart,
   createStreamTrackingState,
+  describeOpenCodeStreamTrackingLimitFailure,
   emitInit,
   emitText,
+  emitThinking,
   emitPermissionAsked,
   emitPermissionSummary,
   emitResult,
@@ -743,8 +745,16 @@ export class OpenCodeAttemptRunner {
   for (const source of attemptSensitiveSources) {
     state.sensitiveSources.add(source);
   }
-  const sanitizeAttemptError = (message: string): string => (
+  const isTrackingLimitFailureMessage = (message: string): boolean => (
     message === OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE
+    || message === describeOpenCodeStreamTrackingLimitFailure('event_count')
+    || message === describeOpenCodeStreamTrackingLimitFailure('tracked_id_count')
+    || message === describeOpenCodeStreamTrackingLimitFailure('text_bytes')
+    || message === describeOpenCodeStreamTrackingLimitFailure('sensitive_sources')
+  );
+
+  const sanitizeAttemptError = (message: string): string => (
+    isTrackingLimitFailureMessage(message)
       ? message
       : sanitizeSensitiveTextWithKnownValues(message, state.sensitiveSources)
   );
@@ -1055,7 +1065,7 @@ export class OpenCodeAttemptRunner {
         textContentParts.clear();
         textOffsets.clear();
         success = false;
-        failureMessage = OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE;
+        failureMessage = describeOpenCodeStreamTrackingLimitFailure(state.trackingLimitReason);
         return;
       }
       const visibleDelta = stripPromptEcho(rawDelta, echoState);
@@ -1071,6 +1081,26 @@ export class OpenCodeAttemptRunner {
       }
       const prevOffset = textOffsets.get(partId) ?? 0;
       textOffsets.set(partId, prevOffset + rawDelta.length);
+    };
+
+    const consumeReasoningDelta = (partId: string, rawDelta: string): void => {
+      if (!rawDelta) return;
+      const fallbackRedactor = state.textRedactors.get(partId);
+      if (fallbackRedactor !== undefined) {
+        state.textRedactors.delete(partId);
+        if (!state.thinkingRedactors.has(partId)) {
+          state.thinkingRedactors.set(partId, fallbackRedactor);
+        }
+      }
+      const redactor = state.thinkingRedactors.get(partId) ?? createSensitiveTextStreamRedactor();
+      state.thinkingRedactors.set(partId, redactor);
+      emitThinking(
+        options.onStream,
+        redactor.write(rawDelta, state.sensitiveSources),
+      );
+      const prevOffset = state.thinkingOffsets.get(partId) ?? 0;
+      const nextOffset = prevOffset + rawDelta.length;
+      state.thinkingOffsets.set(partId, nextOffset);
     };
 
     // for-await 単体だと、タイマーが abort してもイベントが来るまで
@@ -1125,7 +1155,7 @@ export class OpenCodeAttemptRunner {
       }
       if (!trackOpenCodeStreamEvent(state, sseEvent)) {
         success = false;
-        failureMessage = OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE;
+        failureMessage = describeOpenCodeStreamTrackingLimitFailure(state.trackingLimitReason);
         diag.onStreamError(sseEvent.type, failureMessage);
         break;
       }
@@ -1144,6 +1174,23 @@ export class OpenCodeAttemptRunner {
           const rawDelta = delta
             ?? (textPart.text.length > prev ? textPart.text.slice(prev) : '');
           consumeTextDelta(textPart.id, rawDelta);
+          if (!success) {
+            diag.onStreamError(sseEvent.type, failureMessage);
+            break;
+          }
+          continue;
+        }
+
+        if (part.type === 'reasoning') {
+          toolGuard.noteTextActivity();
+          const reasoningPart = part as {
+            id: string;
+            text: string;
+          };
+          const prev = state.thinkingOffsets.get(reasoningPart.id) ?? 0;
+          const rawDelta = delta
+            ?? (reasoningPart.text.length > prev ? reasoningPart.text.slice(prev) : '');
+          consumeReasoningDelta(reasoningPart.id, rawDelta);
           if (!success) {
             diag.onStreamError(sseEvent.type, failureMessage);
             break;
@@ -1236,7 +1283,7 @@ export class OpenCodeAttemptRunner {
           }
           if (!handlePartUpdated(partForDownstream, delta, options.onStream, state)) {
             success = false;
-            failureMessage = OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE;
+            failureMessage = describeOpenCodeStreamTrackingLimitFailure(state.trackingLimitReason);
             diag.onStreamError(sseEvent.type, failureMessage);
             break;
           }
@@ -1251,7 +1298,7 @@ export class OpenCodeAttemptRunner {
 
         if (!handlePartUpdated(part, delta, options.onStream, state)) {
           success = false;
-          failureMessage = OPENCODE_STREAM_TRACKING_LIMIT_MESSAGE;
+          failureMessage = describeOpenCodeStreamTrackingLimitFailure(state.trackingLimitReason);
           diag.onStreamError(sseEvent.type, failureMessage);
           break;
         }
@@ -1267,7 +1314,16 @@ export class OpenCodeAttemptRunner {
         };
         if (deltaProps.field === 'text' && deltaProps.delta) {
           toolGuard.noteTextActivity();
-          consumeTextDelta(deltaProps.partID, deltaProps.delta);
+          const partType = state.partTypes.get(deltaProps.partID);
+          if (partType === 'reasoning') {
+            consumeReasoningDelta(deltaProps.partID, deltaProps.delta);
+          } else if (partType === 'text' || partType === undefined) {
+            consumeTextDelta(deltaProps.partID, deltaProps.delta);
+            if (partType === undefined) {
+              const prevOffset = state.thinkingOffsets.get(deltaProps.partID) ?? 0;
+              state.thinkingOffsets.set(deltaProps.partID, prevOffset + deltaProps.delta.length);
+            }
+          }
           if (!success) {
             diag.onStreamError(sseEvent.type, failureMessage);
             break;


### PR DESCRIPTION
## Summary

Closes #1130.

OpenCodeの`message.part.delta`について、先行する`message.part.updated`からpart typeを追跡し、reasoningとresponse textを分離して処理します。

これにより、reasoning deltaがresponse contentへ混入したり、本文用の64 KiB stream tracking limitを消費したりする問題を修正します。

## Changes

- stream tracking stateでpart IDとtypeの対応を保持
- reasoning deltaをthinking streamへ送信
- reasoningをresponse contentと本文用byte countから除外
- reasoning/textでoffsetとredactorを分離
- delta後のfull snapshotによる重複出力を防止
- type未確定deltaは後方互換のためtextとして処理
- unsupported part typeのdeltaは利用者向け出力へ含めない
- tracking limit超過理由を次の値で識別可能に変更
  - `event_count`
  - `tracked_id_count`
  - `text_bytes`
  - `sensitive_sources`

## Preserved Behavior

- response textには従来どおり64 KiB上限を適用
- event count、tracked ID、sensitive sourceの防護上限を維持
- retry、session lifecycle、tool handlingは変更しない
- type未確定deltaのtext fallbackを維持
- workflow、依存関係、lockfileは変更しない

## Validation

### Unit tests

```sh
npm test -- \
  src/__tests__/opencode-client-retry.test.ts \
  src/__tests__/opencode-client-tool-error-log-sanitize.test.ts \
  src/__tests__/opencode-client-cleanup.test.ts \
  src/__tests__/opencode-stream-handler.test.ts
```

Result: 4 files / 216 tests passed.

以下を確認しています。

- Issue #1130のreasoning/textイベント順序
- 64 KiBを超えるreasoningと短い本文の正常終了
- 64 KiBを超える本文の`text_bytes`エラー
- reasoning/textの相互混入防止
- deltaとfull snapshotの重複防止
- type未確定delta、unsupported part、各tracking limit
- transient stream error後のretry

### OpenCode CLI integration

OpenCode CLI 1.18.3とローカルのダミー上流を使用しました。

```sh
TAKT_OPENCODE_PARALLEL_INTEGRATION=1 \
  npx vitest run --config vitest.config.e2e.opencode-parallel.ts
```

初回確認では8 tests passedでしたが、最新の再実行では7 tests passed、1 test failedとなりました。

失敗するのは、Takt adapter経由で一方のsessionをabortした際に、別sessionのsurvivorが`Aborted`になるケースです。

```text
OpenCodeClient via Takt adapter (integration)
× should not let one call abort interrupt another concurrent call
```

同じ失敗は、本PRの差分を含まない`main`でもOpenCode CLI 1.18.3を使用して複数回再現しています。一方、OpenCode SDK直結のabort分離テストは成功しています。

したがって、本PRによる回帰ではなく、`main`とOpenCode CLI 1.18.3の組み合わせでも再現する問題として別途扱います。

### Real OpenCode provider E2E

OpenCode CLI 1.18.3と`opencode-go/deepseek-v4-pro`を使用しました。

```sh
TAKT_E2E_PROVIDER=opencode \
TAKT_E2E_MODEL=opencode-go/deepseek-v4-pro \
  npx vitest run --config vitest.config.e2e.provider.ts \
  e2e/specs/opencode-conversation.e2e.ts
```

Result: 1 file / 3 tests passed.

### Structured output E2E

```sh
TAKT_E2E_PROVIDER=opencode \
TAKT_E2E_MODEL=opencode-go/deepseek-v4-pro \
  npx vitest run --config vitest.config.e2e.structured-output.ts
```

Result: 1 file / 1 test passed.

### Regression checks

`npm run build`、`npm run lint -- --quiet`、`git diff --check`はすべて成功しました。

## Known Risks

- 64 KiBを超えるreasoningの境界値はunit testで検証しています。実providerではモデル出力量を決定的に制御できないため、この境界値自体は再現していません。
- `npm run test:e2e:smoke`は20 tests passed、1 skipped、1 failedでしたが、失敗はmock providerを使う`list-non-interactive.e2e.ts`のfixture commit処理で発生しており、今回変更したOpenCode stream処理と対象ファイルに関連する差分はありません。
- OpenCode CLI 1.18.3では、Takt adapter経由の並列sessionの一方をabortすると、別sessionが`Aborted`になるintegration test failureを確認しています。差分のない`main`でも再現しており、本PRによる回帰ではありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 推論（Thinking）とテキスト出力を分離し、別々にストリーミング表示できるようになりました。
  - ストリーム制限エラーで、イベント数・追跡ID数・テキスト量・機密情報など発生理由と詳細を確認できるようになりました。
- **バグ修正**
  - 推論（reasoning）が長くなってもテキストのバイト上限には影響せず、Thinking出力を途切れさせません。
  - 不明形式や空パート、更新順の違いがあっても出力の整合性を維持します。
  - エラー表示やログ/永続化データに機密情報が漏れないよう強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->