### PR TITLE
fix: use direct implementation in shared development workflows

### DIFF
--- a/builtins/en/steps/development-core-implement.yaml
+++ b/builtins/en/steps/development-core-implement.yaml
@@ -10,7 +10,6 @@ params:
     facet_kind: instruction
 name: implement
 tags:
-  - leader
   - coding
 edit: true
 persona: coder
@@ -21,22 +20,6 @@ knowledge:
 provider_options:
   extends: edit
 required_permission_mode: edit
-team_leader:
-  max_parts: 2
-  part_tags:
-    - coding
-  part_persona: coder
-  part_edit: true
-  part_permission_mode: edit
-  part_allowed_tools:
-    - Read
-    - Glob
-    - Grep
-    - Edit
-    - Write
-    - Bash
-    - WebSearch
-    - WebFetch
 instruction:
   $param: implementation_instruction
 output_contracts:

--- a/builtins/en/workflows/cli.yaml
+++ b/builtins/en/workflows/cli.yaml
@@ -13,7 +13,7 @@ steps:
       testing_knowledge: [architecture, unit-testing, e2e-testing]
       development_policy: [coding, testing]
       development_knowledge: [architecture, task-decomposition]
-      implementation_instruction: team-leader-implement
+      implementation_instruction: implement
       review_policy: [coding, testing, review]
       review_knowledge: [architecture, unit-testing, e2e-testing]
       supervisor_persona: supervisor

--- a/builtins/en/workflows/default-high.yaml
+++ b/builtins/en/workflows/default-high.yaml
@@ -1,5 +1,5 @@
 name: default-high
-description: Full-spec workflow that runs the shared development flow with team-leader implementation facets.
+description: Full-spec workflow that runs the shared development flow with direct implementation and convergent remediation.
 max_steps: 51
 initial_step: develop
 steps:
@@ -13,7 +13,7 @@ steps:
       testing_knowledge: [architecture, unit-testing, e2e-testing]
       development_policy: [coding, testing]
       development_knowledge: [architecture]
-      implementation_instruction: team-leader-implement
+      implementation_instruction: implement
       review_policy: [coding, testing, review]
       review_knowledge: [architecture, unit-testing, e2e-testing]
       supervisor_persona: supervisor

--- a/builtins/en/workflows/development-core.yaml
+++ b/builtins/en/workflows/development-core.yaml
@@ -1,5 +1,5 @@
 name: development-core
-description: Shared development flow that injects domain facets into planning, testing, delegated implementation, peer review, and convergent remediation.
+description: Shared development flow that injects domain facets into planning, testing, direct implementation, peer review, and convergent remediation.
 subworkflow:
   callable: true
   visibility: internal

--- a/builtins/en/workflows/review-fix-takt-default.yaml
+++ b/builtins/en/workflows/review-fix-takt-default.yaml
@@ -24,7 +24,7 @@ steps:
       testing_knowledge: [takt, architecture, unit-testing, e2e-testing]
       development_policy: [coding, testing]
       development_knowledge: [takt, architecture, task-decomposition]
-      implementation_instruction: team-leader-implement
+      implementation_instruction: implement
       review_policy: [coding, testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
       supervisor_persona: supervisor

--- a/builtins/en/workflows/takt-default.yaml
+++ b/builtins/en/workflows/takt-default.yaml
@@ -13,7 +13,7 @@ steps:
       testing_knowledge: [takt, architecture, unit-testing, e2e-testing]
       development_policy: [coding, testing]
       development_knowledge: [takt, architecture, task-decomposition]
-      implementation_instruction: team-leader-implement
+      implementation_instruction: implement
       review_policy: [coding, testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
       supervisor_persona: supervisor

--- a/builtins/ja/steps/development-core-implement.yaml
+++ b/builtins/ja/steps/development-core-implement.yaml
@@ -10,7 +10,6 @@ params:
     facet_kind: instruction
 name: implement
 tags:
-  - leader
   - coding
 edit: true
 persona: coder
@@ -21,22 +20,6 @@ knowledge:
 provider_options:
   extends: edit
 required_permission_mode: edit
-team_leader:
-  max_parts: 2
-  part_tags:
-    - coding
-  part_persona: coder
-  part_edit: true
-  part_permission_mode: edit
-  part_allowed_tools:
-    - Read
-    - Glob
-    - Grep
-    - Edit
-    - Write
-    - Bash
-    - WebSearch
-    - WebFetch
 instruction:
   $param: implementation_instruction
 output_contracts:

--- a/builtins/ja/workflows/cli.yaml
+++ b/builtins/ja/workflows/cli.yaml
@@ -13,7 +13,7 @@ steps:
       testing_knowledge: [architecture, unit-testing, e2e-testing]
       development_policy: [coding, testing]
       development_knowledge: [architecture, task-decomposition]
-      implementation_instruction: team-leader-implement
+      implementation_instruction: implement
       review_policy: [coding, testing, review]
       review_knowledge: [architecture, unit-testing, e2e-testing]
       supervisor_persona: supervisor

--- a/builtins/ja/workflows/default-high.yaml
+++ b/builtins/ja/workflows/default-high.yaml
@@ -1,5 +1,5 @@
 name: default-high
-description: 共通開発フローをチームリーダー実装向けファセットで実行するフルスペックワークフロー。
+description: 共通開発フローを直接実装と収束修正で実行するフルスペックワークフロー。
 max_steps: 51
 initial_step: develop
 steps:
@@ -13,7 +13,7 @@ steps:
       testing_knowledge: [architecture, unit-testing, e2e-testing]
       development_policy: [coding, testing]
       development_knowledge: [architecture]
-      implementation_instruction: team-leader-implement
+      implementation_instruction: implement
       review_policy: [coding, testing, review]
       review_knowledge: [architecture, unit-testing, e2e-testing]
       supervisor_persona: supervisor

--- a/builtins/ja/workflows/development-core.yaml
+++ b/builtins/ja/workflows/development-core.yaml
@@ -1,5 +1,5 @@
 name: development-core
-description: ドメイン固有ファセットを注入して、計画、テスト、分割実装、ピアレビューと収束修正を実行する共通開発フロー。
+description: ドメイン固有ファセットを注入して、計画、テスト、直接実装、ピアレビューと収束修正を実行する共通開発フロー。
 subworkflow:
   callable: true
   visibility: internal

--- a/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -24,7 +24,7 @@ steps:
       testing_knowledge: [takt, architecture, unit-testing, e2e-testing]
       development_policy: [coding, testing]
       development_knowledge: [takt, architecture, task-decomposition]
-      implementation_instruction: team-leader-implement
+      implementation_instruction: implement
       review_policy: [coding, testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
       supervisor_persona: supervisor

--- a/builtins/ja/workflows/takt-default.yaml
+++ b/builtins/ja/workflows/takt-default.yaml
@@ -13,7 +13,7 @@ steps:
       testing_knowledge: [takt, architecture, unit-testing, e2e-testing]
       development_policy: [coding, testing]
       development_knowledge: [takt, architecture, task-decomposition]
-      implementation_instruction: team-leader-implement
+      implementation_instruction: implement
       review_policy: [coding, testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
       supervisor_persona: supervisor

--- a/docs/builtin-catalog.ja.md
+++ b/docs/builtin-catalog.ja.md
@@ -12,10 +12,10 @@ TAKT に同梱されているすべてのビルトイン workflow と persona �
 | `simple-mini` | 強いモデルの判断力を信頼する軽量版です。独立したテスト作成と最終監督を省き、計画 → 実装 → コードレビュー → 修正ループ → 完了。 |
 | `default` | 共通開発コアを使う標準テスト先行 workflow です。計画 → テスト作成 → 実装 → 専門ピアレビュー → 修正計画 → 修正 → 検証 → merge-readiness・監督 → 完了。 |
 | `default-mini` | テストなしのミニ開発 workflow です。`default` から `write_tests` を抜き、軽量に回したいタスク向けの構成です。計画 → 実装 → AIアンチパターンレビュー → 並列レビュー → 完了。 |
-| `default-high` | 共通開発コアをチームリーダー実装で使い、専門ピアレビュー、収束修正、merge-readiness、監督まで行うフルスペック workflow です。 |
+| `default-high` | 共通開発コアを直接実装で使い、専門ピアレビュー、収束修正、merge-readiness、監督まで行うフルスペック workflow です。 |
 | `frontend` | フロントエンド特化開発 workflow。React/Next.js に焦点を当てたレビューとナレッジ注入付き。 |
 | `backend` | バックエンド特化開発 workflow。バックエンド、セキュリティ、QA エキスパートレビュー付き。 |
-| `dual` | フロントエンド＋バックエンド開発 workflow。チームリーダー実装、architecture、frontend、security、QA レビューと修正ループ付き。 |
+| `dual` | フロントエンド＋バックエンド開発 workflow。直接実装、architecture、frontend、security、QA レビューと修正ループ付き。 |
 
 ## 全ビルトイン Workflow 一覧
 
@@ -26,7 +26,7 @@ TAKT に同梱されているすべてのビルトイン workflow と persona �
 | 🚀 クイックスタート | `simple` | 強いモデルの判断力を信頼するシンプルな開発 workflow。モデル自身が関連 SKILL を選び、計画 → テスト作成 → 実装 → コードレビュー → 修正ループ → 最終監督 → 完了。 |
 | | `default` | 共通開発コアを使い、専門ピアレビュー、収束修正、merge-readiness、監督まで行う標準テスト先行 workflow です。 |
 | | `default-mini` | テストなしのミニ開発 workflow。`default` から `write_tests` を抜いた軽量版。計画 → 実装 → AIアンチパターンレビュー → 並列レビュー → 完了。 |
-| | `default-high` | 共通開発コアをチームリーダー実装で使い、専門ピアレビュー、収束修正、merge-readiness、監督まで行うフルスペック workflow です。 |
+| | `default-high` | 共通開発コアを直接実装で使い、専門ピアレビュー、収束修正、merge-readiness、監督まで行うフルスペック workflow です。 |
 | | `frontend` | フロントエンド特化開発 workflow。React/Next.js に焦点を当てたレビューとナレッジ注入付き。 |
 | | `backend` | バックエンド特化開発 workflow。バックエンド、セキュリティ、QA エキスパートレビュー付き。 |
 | | `dual` | フロントエンド＋バックエンド開発 workflow: architecture、frontend、security、QA レビューと修正ループ付き。 |

--- a/docs/builtin-catalog.md
+++ b/docs/builtin-catalog.md
@@ -12,10 +12,10 @@ A comprehensive catalog of all builtin workflows and personas included with TAKT
 | `simple-mini` | A lightweight variant that trusts a capable model's judgment. Omits dedicated test writing and final supervision: plan → implement → code review → fix loop → complete. |
 | `default` | Standard test-first development workflow using the shared development core: plan → write tests → implement → specialist peer review → fix planning → fix → verification → merge-readiness and supervision → complete. |
 | `default-mini` | Mini development workflow without tests. A lightweight variant of `default` with `write_tests` removed. plan → implement → AI antipattern review → parallel review → complete. |
-| `default-high` | Full-spec workflow using the shared development core with team-leader implementation, specialist peer review, convergent remediation, merge-readiness, and supervision. |
+| `default-high` | Full-spec workflow using the shared development core with direct implementation, specialist peer review, convergent remediation, merge-readiness, and supervision. |
 | `frontend` | Frontend-specialized development workflow with React/Next.js focused reviews and knowledge injection. |
 | `backend` | Backend-specialized development workflow with backend, security, and QA expert reviews. |
-| `dual` | Frontend + backend development workflow with team-leader implementation, architecture, frontend, security, QA reviews with fix loops. |
+| `dual` | Frontend + backend development workflow with direct implementation, architecture, frontend, security, QA reviews with fix loops. |
 
 ## All Builtin Workflows
 
@@ -26,7 +26,7 @@ Organized by category.
 | 🚀 Quick Start | `simple` | A simple development workflow that trusts a capable model's judgment. The model selects relevant available skills for plan → write tests → implement → code review → fix loop → final supervision → complete. |
 | | `default` | Standard test-first workflow using the shared development core, specialist peer review, convergent remediation, merge-readiness, and supervision. |
 | | `default-mini` | Mini development workflow without tests. A lightweight variant of `default` with `write_tests` removed. plan → implement → AI antipattern review → parallel review → complete. |
-| | `default-high` | Full-spec workflow using the shared development core with team-leader implementation, specialist peer review, convergent remediation, merge-readiness, and supervision. |
+| | `default-high` | Full-spec workflow using the shared development core with direct implementation, specialist peer review, convergent remediation, merge-readiness, and supervision. |
 | | `frontend` | Frontend-specialized development workflow with React/Next.js focused reviews and knowledge injection. |
 | | `backend` | Backend-specialized development workflow with backend, security, and QA expert reviews. |
 | | `dual` | Frontend + backend development workflow: architecture, frontend, security, QA reviews with fix loops. |

--- a/src/__tests__/it-pipeline.test.ts
+++ b/src/__tests__/it-pipeline.test.ts
@@ -361,21 +361,7 @@ describe('Pipeline Integration Tests', () => {
     setMockScenario([
       { persona: 'planner', status: 'done', content: '[PLAN:1]\n\nRequirements are clear and implementable' },
       { persona: 'coder', status: 'done', content: '[WRITE_TESTS:1]\n\nTests written successfully' },
-      {
-        persona: 'coder',
-        status: 'done',
-        content: 'Implementation work decomposed.',
-        structuredOutput: {
-          parts: [{ id: 'implementation', title: 'Implement', instruction: 'Implement the planned change.' }],
-        },
-      },
       { persona: 'coder', status: 'done', content: '[IMPLEMENT:1]\n\nImplementation complete' },
-      {
-        persona: 'coder',
-        status: 'done',
-        content: 'No additional work is needed.',
-        structuredOutput: { done: true, reasoning: 'Implementation is complete.', cancelPartIds: [], parts: [] },
-      },
       { persona: 'architecture-reviewer', status: 'done', content: '[ARCH-REVIEW:1]\n\napproved' },
       { persona: 'security-reviewer', status: 'done', content: '[SECURITY-REVIEW:1]\n\napproved' },
       { persona: 'qa-reviewer', status: 'done', content: '[QA-REVIEW:1]\n\napproved' },
@@ -403,21 +389,7 @@ describe('Pipeline Integration Tests', () => {
     setMockScenario([
       { persona: 'planner', status: 'done', content: '[PLAN:1]\n\nPlan completed.' },
       { persona: 'coder', status: 'done', content: '[WRITE_TESTS:1]\n\nTests created.' },
-      {
-        persona: 'coder',
-        status: 'done',
-        content: 'Implementation work decomposed.',
-        structuredOutput: {
-          parts: [{ id: 'implementation', title: 'Implement', instruction: 'Implement the planned change.' }],
-        },
-      },
       { persona: 'coder', status: 'done', content: '[IMPLEMENT:1]\n\nImplementation completed.' },
-      {
-        persona: 'coder',
-        status: 'done',
-        content: 'No additional work is needed.',
-        structuredOutput: { done: true, reasoning: 'Implementation is complete.', cancelPartIds: [], parts: [] },
-      },
       { persona: 'architecture-reviewer', status: 'done', content: '[ARCH-REVIEW:2]\n\nA fix is required.' },
       { persona: 'security-reviewer', status: 'done', content: '[SECURITY-REVIEW:1]\n\nApproved.' },
       { persona: 'qa-reviewer', status: 'done', content: '[QA-REVIEW:1]\n\nApproved.' },

--- a/src/__tests__/private-path-identity.test.ts
+++ b/src/__tests__/private-path-identity.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const injectedRootAlias = vi.hoisted(() => ({
+  path: '',
+  fixturePath: '',
+  targetPath: '',
+}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    lstatSync(...args: Parameters<typeof actual.lstatSync>) {
+      if (String(args[0]) === injectedRootAlias.path) {
+        return actual.lstatSync(injectedRootAlias.fixturePath);
+      }
+      return actual.lstatSync(...args);
+    },
+    realpathSync(...args: Parameters<typeof actual.realpathSync>) {
+      if (String(args[0]) === injectedRootAlias.path) {
+        return injectedRootAlias.targetPath;
+      }
+      return actual.realpathSync(...args);
+    },
+  };
+});
+
+import { assertSafePath } from '../shared/utils/private-path-identity.js';
+
+describe('private artifact path identity', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    injectedRootAlias.path = '';
+    injectedRootAlias.fixturePath = '';
+    injectedRootAlias.targetPath = '';
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('should accept a filesystem root alias while still rejecting a symlink below it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'takt-private-root-alias-'));
+    roots.push(root);
+    const targetRoot = join(root, 'target');
+    const aliasFixture = join(root, 'alias');
+    const safeDirectory = join(targetRoot, 'safe');
+    const outsideDirectory = join(root, 'outside');
+    mkdirSync(safeDirectory, { recursive: true });
+    mkdirSync(outsideDirectory);
+    symlinkSync(targetRoot, aliasFixture, 'dir');
+    symlinkSync(outsideDirectory, join(targetRoot, 'linked'), 'dir');
+
+    injectedRootAlias.path = '/takt-private-root-alias';
+    injectedRootAlias.fixturePath = aliasFixture;
+    injectedRootAlias.targetPath = targetRoot;
+
+    expect(() => assertSafePath('/takt-private-root-alias/safe', true)).not.toThrow();
+    expect(() => assertSafePath('/takt-private-root-alias/linked', true)).toThrow(/symlink/);
+  });
+});

--- a/src/shared/utils/private-file.ts
+++ b/src/shared/utils/private-file.ts
@@ -93,8 +93,7 @@ function createPrivateArtifact(
 
 
 export function ensurePrivateDirectory(directoryPath: string): void {
-  const absolute = resolve(directoryPath);
-  const { trustedRoot } = artifactBoundary(absolute);
+  const { targetPath: absolute, trustedRoot } = artifactBoundary(directoryPath);
   assertSafePath(absolute, true);
   let current = trustedRoot;
   for (const component of relative(trustedRoot, absolute).split(sep).filter(Boolean)) {

--- a/src/shared/utils/private-path-identity.ts
+++ b/src/shared/utils/private-path-identity.ts
@@ -1,5 +1,5 @@
-import { lstatSync, statSync, type Stats } from 'node:fs';
-import { isAbsolute, join, parse, relative, resolve, sep } from 'node:path';
+import { lstatSync, realpathSync, statSync, type Stats } from 'node:fs';
+import { join, parse, relative, resolve, sep } from 'node:path';
 
 export interface DirectoryIdentity {
   path: string;
@@ -24,28 +24,40 @@ export function lstatOrUndefined(path: string): Stats | undefined {
   }
 }
 
+function resolveFilesystemRootAlias(targetPath: string): string {
+  const absolute = resolve(targetPath);
+  const { root } = parse(absolute);
+  const [rootEntry, ...remainingComponents] = relative(root, absolute).split(sep).filter(Boolean);
+  if (rootEntry === undefined) return absolute;
+
+  const rootEntryPath = join(root, rootEntry);
+  if (!lstatOrUndefined(rootEntryPath)?.isSymbolicLink()) return absolute;
+  return join(realpathSync(rootEntryPath), ...remainingComponents);
+}
+
 export function artifactBoundary(targetPath: string): {
+  targetPath: string;
   trustedRoot: string;
   rejectTrustedRootSymlink: boolean;
 } {
-  const absolute = resolve(targetPath);
+  const absolute = resolveFilesystemRootAlias(targetPath);
   const { root } = parse(absolute);
   const components = relative(root, absolute).split(sep).filter(Boolean);
   const taktIndex = components.indexOf('.takt');
   if (taktIndex >= 0) {
     return {
+      targetPath: absolute,
       trustedRoot: join(root, ...components.slice(0, taktIndex)),
       rejectTrustedRootSymlink: false,
     };
   }
-  return { trustedRoot: root, rejectTrustedRootSymlink: true };
+  return { targetPath: absolute, trustedRoot: root, rejectTrustedRootSymlink: true };
 }
 
 export function assertSafePath(targetPath: string, targetIsDirectory: boolean): void {
-  if (!isAbsolute(targetPath)) {
-    targetPath = resolve(targetPath);
-  }
-  const { trustedRoot, rejectTrustedRootSymlink } = artifactBoundary(targetPath);
+  const boundary = artifactBoundary(targetPath);
+  targetPath = boundary.targetPath;
+  const { trustedRoot, rejectTrustedRootSymlink } = boundary;
   const rootLinkStat = lstatSync(trustedRoot);
   if (rejectTrustedRootSymlink && rootLinkStat.isSymbolicLink()) {
     throw new Error(`Private artifact trusted root is a symlink: ${trustedRoot}`);
@@ -77,8 +89,7 @@ export function inspectPrivateArtifactPath(
   targetPath: string,
   targetKind: 'file' | 'directory',
 ): PrivateFileInspection {
-  const absolute = resolve(targetPath);
-  const { trustedRoot, rejectTrustedRootSymlink } = artifactBoundary(absolute);
+  const { targetPath: absolute, trustedRoot, rejectTrustedRootSymlink } = artifactBoundary(targetPath);
   const rootLinkStat = lstatSync(trustedRoot) as Stats;
   if (rejectTrustedRootSymlink && rootLinkStat.isSymbolicLink()) {
     throw new Error(`Private artifact trusted root is a symlink: ${trustedRoot}`);


### PR DESCRIPTION
## Summary

- Remove Team Leader execution from the shared development-core implementation step.
- Use direct implement instructions in the affected English and Japanese workflows.
- Preserve explicit Team Leader workflows such as takt-default-team-high and audit/research workflows.
- Normalize filesystem-root path aliases before private artifact validation while continuing to reject symlinks below that trusted boundary.
- Update pipeline scenarios and add a root-alias regression test.

## Verification

- npm run build
- npm run lint
- Private path and private file unit tests: 55 passed.
- Pipeline integration tests: 18 passed.
- Workflow fragment tests: 23 passed.
- Workflow loader tests: 106 passed.
- Targeted mock E2E: runtime provider tests passed, Team Leader batch barrier passed, and the previously failing symlink paths passed.

## Known separate test result

The dynamic selector resume scenario now proceeds past private artifact validation but separately fails its provider-call expectation: takt-internal is observed instead of the two expected reviewer calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ファイルシステムのルート直下にあるシンボリックリンクを適切に解決し、安全なプライベートパス判定を強化しました。
  * ルート配下の危険なシンボリックリンクを拒否する検証を追加しました。

* **改善**
  * 各ビルトインワークフローの実装処理を、チームリーダー経由ではなく直接実行する構成に統一しました。
  * 英語・日本語のワークフロー説明とカタログを更新しました。
  * 実装フェーズの処理を簡素化し、完了までの進行を安定化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->