### PR TITLE
fix: preserve workflow progress across task requeues

### DIFF
--- a/src/__tests__/engine-workflow-call.test.ts
+++ b/src/__tests__/engine-workflow-call.test.ts
@@ -3927,6 +3927,95 @@ steps:
     expect(capturedResumePoint?.iteration).toBe(2);
   });
 
+  it('再開した子 workflow が最初の step 前に max_steps へ達しても child checkpoint を保持する', async () => {
+    writeWorkflow(tmpDir, 'takt/coding.yaml', `name: takt/coding
+subworkflow:
+  callable: true
+initial_step: review
+max_steps: 5
+steps:
+  - name: review
+    persona: reviewer
+    instruction: "Review child workflow"
+    rules:
+      - condition: done
+        next: fix
+  - name: fix
+    persona: fixer
+    instruction: "Fix child workflow"
+    rules:
+      - condition: done
+        next: COMPLETE
+`);
+
+    const config = createParentWorkflow(tmpDir, {
+      name: 'parent',
+      initial_step: 'delegate',
+      max_steps: 2,
+      steps: [
+        {
+          name: 'delegate',
+          kind: 'workflow_call',
+          call: 'takt/coding',
+          rules: [
+            {
+              condition: 'COMPLETE',
+              next: 'COMPLETE',
+            },
+            {
+              condition: 'ABORT',
+              next: 'ABORT',
+            },
+          ],
+        },
+      ],
+    });
+    const resumePoint = {
+      version: 2 as const,
+      stack: [
+        { workflow: 'parent', step: 'delegate', kind: 'workflow_call' as const, call_instance: 1 },
+        { workflow: 'takt/coding', step: 'fix', kind: 'agent' as const },
+      ],
+      iteration: 1,
+      elapsed_ms: 183245,
+      workflow_call_invocations: {
+        '{"workflow":"parent","step":"delegate","calls":[]}': {
+          call_instance: 1,
+          report_namespace_segment: 'iteration-1--step-delegate--workflow-takt%2Fcoding',
+        },
+      },
+      workflow_step_participations: {},
+    };
+    let capturedResumePoint: ReturnType<WorkflowEngine['getResumePoint']>;
+    engine = new WorkflowEngine(config, tmpDir, 'Resume child at iteration limit', createWorkflowCallOptions(tmpDir, {
+      initialIteration: 1,
+      resumePoint,
+      onIterationLimit: vi.fn().mockImplementation(async () => {
+        capturedResumePoint = engine?.getResumePoint();
+        return null;
+      }),
+    }));
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('aborted');
+    expect(runAgent).not.toHaveBeenCalled();
+    expect(capturedResumePoint?.stack).toEqual([
+      expect.objectContaining({
+        workflow: 'parent',
+        step: 'delegate',
+        kind: 'workflow_call',
+      }),
+      expect.objectContaining({
+        workflow: 'takt/coding',
+        step: 'fix',
+        kind: 'agent',
+      }),
+    ]);
+    expect(capturedResumePoint?.iteration).toBe(2);
+    expect(capturedResumePoint?.elapsed_ms).toBeGreaterThanOrEqual(resumePoint.elapsed_ms);
+  });
+
   it('resolveWorkflowCallTarget は child workflow の max_steps を書き換えない', () => {
     writeWorkflow(tmpDir, 'takt/coding.yaml', `name: takt/coding
 subworkflow:

--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -288,6 +288,17 @@ describe('TaskRunner (tasks.yaml)', () => {
   });
 
   it('should fail interrupted running tasks with start_movement from run meta', () => {
+    const latestResumePoint = {
+      version: 2 as const,
+      stack: [
+        { workflow: 'default', step: 'delegate', kind: 'workflow_call' as const, call_instance: 1 },
+        { workflow: 'takt/coding', step: 'review', kind: 'agent' as const },
+      ],
+      iteration: 7,
+      elapsed_ms: 183245,
+      workflow_call_invocations: {},
+      workflow_step_participations: {},
+    };
     runner.addTask('Task A', {
       workflow: 'default',
       start_step: 'draft',
@@ -320,17 +331,7 @@ describe('TaskRunner (tasks.yaml)', () => {
       startTime: '2026-04-13T00:00:00.000Z',
       currentStep: 'delegate',
       currentIteration: 7,
-      resume_point: {
-        version: 2,
-        stack: [
-          { workflow: 'default', step: 'delegate', kind: 'workflow_call', call_instance: 1 },
-          { workflow: 'takt/coding', step: 'review', kind: 'agent' },
-        ],
-        iteration: 7,
-        elapsed_ms: 183245,
-        workflow_call_invocations: {},
-        workflow_step_participations: {},
-      },
+      resume_point: latestResumePoint,
     });
 
     const current = loadTasksFile(testDir);
@@ -347,8 +348,8 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(file.tasks[0]?.run_slug).toBe('20260413-task-a');
     expect(file.tasks[0]?.start_movement).toBe('delegate');
     expect(file.tasks[0]?.start_step).toBeUndefined();
-    expect(file.tasks[0]?.resume_point).toBeUndefined();
-    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
+    expect(file.tasks[0]?.resume_point).toEqual(latestResumePoint);
+    expect(file.tasks[0]?.exceeded_current_iteration).toBe(7);
     expect(file.tasks[0]?.failure).toEqual({
       error: 'Task was interrupted before this TAKT run started. Requeue it explicitly to run again.',
     });
@@ -435,6 +436,114 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
     expect(file.tasks[0]?.exceeded_max_steps).toBeUndefined();
     expect(file.tasks[0]?.resume_point).toBeUndefined();
+  });
+
+  it('should preserve an inherited retry checkpoint when the new run has no checkpoint yet', () => {
+    const inheritedResumePoint = {
+      version: 2 as const,
+      stack: [
+        { workflow: 'default', step: 'develop', kind: 'workflow_call' as const, call_instance: 1 },
+        { workflow: 'development-core', step: 'peer-review', kind: 'workflow_call' as const, call_instance: 1 },
+        { workflow: 'peer-review', step: 'fix', kind: 'agent' as const },
+      ],
+      iteration: 59,
+      elapsed_ms: 183245,
+      workflow_call_invocations: {},
+      workflow_step_participations: {},
+    };
+    runner.addTask('Task A', {
+      workflow: 'default',
+      start_step: 'develop',
+      exceeded_max_steps: 90,
+      exceeded_current_iteration: 59,
+      resume_point: inheritedResumePoint,
+      resume_mode: 'requeue',
+      source_run_slug: '20260413-source',
+    });
+    const task = runner.claimNextTasks(1)[0]!;
+    runner.updateRunningTaskExecution(task.name, {
+      runSlug: '20260413-empty-run',
+    });
+    writeRunMeta(testDir, '20260413-empty-run', {
+      task: 'Task A',
+      workflow: 'default',
+      runSlug: '20260413-empty-run',
+      runRoot: '.takt/runs/20260413-empty-run',
+      reportDirectory: '.takt/runs/20260413-empty-run/reports',
+      contextDirectory: '.takt/runs/20260413-empty-run/context',
+      logsDirectory: '.takt/runs/20260413-empty-run/logs',
+      status: 'aborted',
+      startTime: '2026-04-13T00:00:00.000Z',
+    });
+
+    const current = loadTasksFile(testDir);
+    const running = current.tasks[0] as Record<string, unknown>;
+    running.owner_pid = 999999999;
+    writeFileSync(join(testDir, '.takt', 'tasks.yaml'), stringifyYaml(current), 'utf-8');
+
+    expect(runner.failInterruptedRunningTasks()).toBe(1);
+
+    const failedTask = loadTasksFile(testDir).tasks[0];
+    expectRetryMetadataPreserved(failedTask, {
+      startStep: 'develop',
+      currentIteration: 59,
+      maxSteps: 90,
+      resumePoint: inheritedResumePoint,
+    });
+  });
+
+  it('should prefer a checkpoint produced by the new run over an inherited checkpoint', () => {
+    const inheritedResumePoint = {
+      version: 2 as const,
+      stack: [
+        { workflow: 'default', step: 'develop', kind: 'workflow_call' as const, call_instance: 1 },
+        { workflow: 'development-core', step: 'peer-review', kind: 'workflow_call' as const, call_instance: 1 },
+        { workflow: 'peer-review', step: 'fix', kind: 'agent' as const },
+      ],
+      iteration: 59,
+      elapsed_ms: 183245,
+      workflow_call_invocations: {},
+      workflow_step_participations: {},
+    };
+    runner.addTask('Task A', {
+      workflow: 'default',
+      start_step: 'develop',
+      exceeded_max_steps: 90,
+      exceeded_current_iteration: 59,
+      resume_point: inheritedResumePoint,
+      resume_mode: 'requeue',
+      source_run_slug: '20260413-source',
+    });
+    const task = runner.claimNextTasks(1)[0]!;
+    runner.updateRunningTaskExecution(task.name, {
+      runSlug: '20260413-progressed-run',
+    });
+    writeRunMeta(testDir, '20260413-progressed-run', {
+      task: 'Task A',
+      workflow: 'default',
+      runSlug: '20260413-progressed-run',
+      runRoot: '.takt/runs/20260413-progressed-run',
+      reportDirectory: '.takt/runs/20260413-progressed-run/reports',
+      contextDirectory: '.takt/runs/20260413-progressed-run/context',
+      logsDirectory: '.takt/runs/20260413-progressed-run/logs',
+      status: 'aborted',
+      startTime: '2026-04-13T00:00:00.000Z',
+      currentStep: 'final-review',
+      currentIteration: 60,
+    });
+
+    const current = loadTasksFile(testDir);
+    const running = current.tasks[0] as Record<string, unknown>;
+    running.owner_pid = 999999999;
+    writeFileSync(join(testDir, '.takt', 'tasks.yaml'), stringifyYaml(current), 'utf-8');
+
+    expect(runner.failInterruptedRunningTasks()).toBe(1);
+
+    const failedTask = loadTasksFile(testDir).tasks[0];
+    expect(failedTask?.start_movement).toBe('final-review');
+    expect(failedTask?.resume_point).toBeUndefined();
+    expect(failedTask?.exceeded_current_iteration).toBeUndefined();
+    expect(failedTask?.exceeded_max_steps).toBeUndefined();
   });
 
   it('should keep running tasks owned by a live process', () => {
@@ -1308,7 +1417,7 @@ describe('TaskRunner (tasks.yaml)', () => {
     expect(file.tasks[0]?.resume_point).toEqual(resumePoint);
   });
 
-  it('should keep only start_movement when a re-executed task fails with run meta', () => {
+  it('should keep the latest checkpoint when a re-executed task fails with run meta', () => {
     const latestResumePoint = {
       version: 2 as const,
       stack: [
@@ -1368,12 +1477,12 @@ describe('TaskRunner (tasks.yaml)', () => {
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.start_movement).toBe('final-review');
     expect(file.tasks[0]?.start_step).toBeUndefined();
-    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
-    expect(file.tasks[0]?.resume_point).toBeUndefined();
+    expect(file.tasks[0]?.exceeded_current_iteration).toBe(9);
+    expect(file.tasks[0]?.resume_point).toEqual(latestResumePoint);
     expect(file.tasks[0]?.exceeded_max_steps).toBeUndefined();
   });
 
-  it('should keep only start_movement when terminal failure happens after the child completes', () => {
+  it('should keep the parent checkpoint when terminal failure happens after the child completes', () => {
     const workflowCallResumePoint = {
       version: 2 as const,
       stack: [
@@ -1432,8 +1541,8 @@ describe('TaskRunner (tasks.yaml)', () => {
     const file = loadTasksFile(testDir);
     expect(file.tasks[0]?.start_movement).toBe('delegate');
     expect(file.tasks[0]?.start_step).toBeUndefined();
-    expect(file.tasks[0]?.exceeded_current_iteration).toBeUndefined();
-    expect(file.tasks[0]?.resume_point).toBeUndefined();
+    expect(file.tasks[0]?.exceeded_current_iteration).toBe(7);
+    expect(file.tasks[0]?.resume_point).toEqual(workflowCallResumePoint);
   });
 
   it('should clear stale retry metadata when a re-executed task completes without run meta', () => {

--- a/src/__tests__/task.test.ts
+++ b/src/__tests__/task.test.ts
@@ -542,7 +542,7 @@ describe('TaskRunner (tasks.yaml)', () => {
     const failedTask = loadTasksFile(testDir).tasks[0];
     expect(failedTask?.start_movement).toBe('final-review');
     expect(failedTask?.resume_point).toBeUndefined();
-    expect(failedTask?.exceeded_current_iteration).toBeUndefined();
+    expect(failedTask?.exceeded_current_iteration).toBe(60);
     expect(failedTask?.exceeded_max_steps).toBeUndefined();
   });
 

--- a/src/__tests__/workflowExecution-ask-user-question.test.ts
+++ b/src/__tests__/workflowExecution-ask-user-question.test.ts
@@ -34,7 +34,8 @@ const { disabledObservability, MockWorkflowEngine } = vi.hoisted(() => {
     abort(): void {}
 
     getResumePoint(): WorkflowResumePoint | undefined {
-      return MockWorkflowEngine.activeResumePoint;
+      return MockWorkflowEngine.activeResumePoint
+        ?? this.receivedOptions.resumePoint as WorkflowResumePoint | undefined;
     }
 
     buildResumePointForStepName(stepName: string): WorkflowResumePoint | undefined {
@@ -288,6 +289,33 @@ describe('executeWorkflow AskUserQuestion deny handler wiring', () => {
       newMaxSteps: 10,
       currentIteration: 1,
     });
+  });
+
+  it('should preserve a nested checkpoint when a resumed run exceeds before its first step', async () => {
+    const resumePoint = {
+      version: 2 as const,
+      stack: [
+        { workflow: 'default', step: 'develop', kind: 'workflow_call' as const, call_instance: 1 },
+        { workflow: 'development-core', step: 'peer-review', kind: 'workflow_call' as const, call_instance: 1 },
+        { workflow: 'peer-review', step: 'fix', kind: 'agent' as const },
+      ],
+      iteration: 59,
+      elapsed_ms: 183245,
+      workflow_call_invocations: {},
+      workflow_step_participations: {},
+    };
+    MockWorkflowEngine.triggerIterationLimit = true;
+    MockWorkflowEngine.iterationLimitCurrentStep = 'develop';
+    MockWorkflowEngine.iterationLimitCurrentIteration = 59;
+
+    const result = await executeWorkflow(makeConfig(), 'task', '/tmp/project', {
+      projectCwd: '/tmp/project',
+      startStep: 'develop',
+      resumePoint,
+      initialIterationOverride: 59,
+    });
+
+    expect(result.exceededInfo?.resumePoint).toEqual(resumePoint);
   });
 
   it('should use maxStepsOverride when exceeded handling runs for an infinite workflow', async () => {

--- a/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
+++ b/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
@@ -300,6 +300,65 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     expect(getAttachedWorkflowOpaqueRef(bootstrap.effectiveWorkflowConfig)).toBeUndefined();
   });
 
+  it.each([
+    { initialIterationOverride: 50, maxStepsOverride: undefined, expectedMaxSteps: 51 },
+    { initialIterationOverride: 56, maxStepsOverride: undefined, expectedMaxSteps: 102 },
+    { initialIterationOverride: 56, maxStepsOverride: 102, expectedMaxSteps: 102 },
+    { initialIterationOverride: 102, maxStepsOverride: 102, expectedMaxSteps: 204 },
+    { initialIterationOverride: 205, maxStepsOverride: undefined, expectedMaxSteps: 408 },
+  ])(
+    'resolves max steps to $expectedMaxSteps for restored iteration $initialIterationOverride',
+    async ({ initialIterationOverride, maxStepsOverride, expectedMaxSteps }) => {
+      const projectDir = createTempProject();
+      const bootstrap = await createWorkflowExecutionBootstrap(
+        { ...workflowConfig, maxSteps: 51 },
+        'Resume workflow iteration',
+        projectDir,
+        {
+          projectCwd: projectDir,
+          provider: 'mock',
+          initialIterationOverride,
+          ...(maxStepsOverride === undefined ? {} : { maxStepsOverride }),
+        },
+      );
+
+      expect(bootstrap.effectiveWorkflowConfig.maxSteps).toBe(expectedMaxSteps);
+    },
+  );
+
+  it('keeps an infinite max steps limit when restoring an iteration', async () => {
+    const projectDir = createTempProject();
+    const bootstrap = await createWorkflowExecutionBootstrap(
+      { ...workflowConfig, maxSteps: 'infinite' },
+      'Resume workflow iteration',
+      projectDir,
+      {
+        projectCwd: projectDir,
+        provider: 'mock',
+        initialIterationOverride: 56,
+      },
+    );
+
+    expect(bootstrap.effectiveWorkflowConfig.maxSteps).toBe('infinite');
+  });
+
+  it('rejects a restored iteration when the next finite limit is not safely representable', async () => {
+    const projectDir = createTempProject();
+
+    await expect(createWorkflowExecutionBootstrap(
+      { ...workflowConfig, maxSteps: Number.MAX_SAFE_INTEGER },
+      'Resume workflow iteration',
+      projectDir,
+      {
+        projectCwd: projectDir,
+        provider: 'mock',
+        initialIterationOverride: Number.MAX_SAFE_INTEGER,
+      },
+    )).rejects.toThrow();
+    expect(mockWriteFileAtomic).not.toHaveBeenCalled();
+    expect(mockCreateOutputFns).not.toHaveBeenCalled();
+  });
+
   it('does not replace metadata already attached to the inheritance target', () => {
     const source = attachWorkflowSourcePath({}, '/source/workflow.yaml');
     const target = attachWorkflowSourcePath({}, '/target/workflow.yaml');

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -231,6 +231,11 @@ export class WorkflowEngine extends EventEmitter {
       restoreWorkflowCallInvocationEvidence(this.options.resumePoint);
     this.sharedRuntime.workflowStepParticipationIndex ??=
       restoreWorkflowStepParticipationIndex(this.options.resumePoint);
+    restoreActiveResumePoint(
+      this.sharedRuntime,
+      this.options.resumePoint,
+      this.options.initialIteration,
+    );
     this.sharedRuntime.workflowCallInvocationEvidence.index.validateResumePoint(this.options.resumePoint);
     this.sharedRuntime.maxSteps ??= initialMaxSteps;
     this.maxSteps = this.sharedRuntime.maxSteps;
@@ -926,4 +931,37 @@ export class WorkflowEngine extends EventEmitter {
       (result, error) => error !== undefined || result?.isComplete === true || this.state.status !== 'running',
     );
   }
+}
+
+function restoreActiveResumePoint(
+  sharedRuntime: WorkflowSharedRuntimeState,
+  resumePoint: WorkflowResumePoint | undefined,
+  initialIteration: number | undefined,
+): void {
+  if (resumePoint === undefined) {
+    return;
+  }
+
+  const restored = cloneWorkflowResumePoint(resumePoint);
+  const current = sharedRuntime.activeResumePoint === undefined
+    ? undefined
+    : cloneWorkflowResumePoint(sharedRuntime.activeResumePoint);
+  restored.iteration = Math.max(
+    restored.iteration,
+    initialIteration ?? restored.iteration,
+    current?.iteration ?? restored.iteration,
+  );
+  restored.elapsed_ms = Math.max(restored.elapsed_ms, current?.elapsed_ms ?? restored.elapsed_ms);
+
+  if (current !== undefined) {
+    restored.workflow_call_invocations = current.workflow_call_invocations;
+    restored.workflow_step_participations = current.workflow_step_participations;
+    if (current.dynamic_parallel_selections === undefined) {
+      delete restored.dynamic_parallel_selections;
+    } else {
+      restored.dynamic_parallel_selections = current.dynamic_parallel_selections;
+    }
+  }
+
+  sharedRuntime.activeResumePoint = restored;
 }

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -942,6 +942,8 @@ function restoreActiveResumePoint(
     return;
   }
 
+  // The persisted stack identifies where to resume. Keep the current runtime-owned
+  // evidence indexes and selection snapshot so restoration does not discard newer state.
   const restored = cloneWorkflowResumePoint(resumePoint);
   const current = sharedRuntime.activeResumePoint === undefined
     ? undefined

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -113,12 +113,35 @@ class AutoRoutingReachTracker {
   }
 }
 
+function resolveMaxStepsForRestoredIteration(
+  maxSteps: WorkflowConfig['maxSteps'],
+  initialIteration: number | undefined,
+): WorkflowConfig['maxSteps'] {
+  if (maxSteps === 'infinite' || initialIteration === undefined || initialIteration < maxSteps) {
+    return maxSteps;
+  }
+
+  let resumedMaxSteps = maxSteps;
+  while (initialIteration >= resumedMaxSteps) {
+    const nextMaxSteps = resumedMaxSteps * 2;
+    if (!Number.isSafeInteger(nextMaxSteps)) {
+      throw new Error('Cannot resume workflow because the next max steps limit exceeds the safe integer range');
+    }
+    resumedMaxSteps = nextMaxSteps;
+  }
+  return resumedMaxSteps;
+}
+
 export async function createWorkflowExecutionBootstrap(
   workflowConfig: WorkflowConfig,
   task: string,
   cwd: string,
   options: WorkflowExecutionOptions,
 ): Promise<WorkflowExecutionBootstrap> {
+  const effectiveMaxSteps = resolveMaxStepsForRestoredIteration(
+    options.maxStepsOverride ?? workflowConfig.maxSteps,
+    options.initialIterationOverride,
+  );
   const { headerPrefix = 'Running Workflow:', interactiveUserInput = false, outputMode = 'terminal' } = options;
   const projectCwd = options.projectCwd;
   const safeWorkflowName = sanitizeTerminalText(workflowConfig.name);
@@ -340,7 +363,7 @@ export async function createWorkflowExecutionBootstrap(
     autoRouting: inheritedAutoRouting,
     rateLimitFallback: workflowConfig.rateLimitFallback ?? globalConfig.rateLimitFallback,
     runtime: resolveRuntimeConfig(globalConfig.runtime, workflowConfig.runtime),
-    ...(options.maxStepsOverride !== undefined ? { maxSteps: options.maxStepsOverride } : {}),
+    maxSteps: effectiveMaxSteps,
   };
   inheritWorkflowConfigMetadata(workflowConfig, effectiveWorkflowConfig);
   const providerEventLogger = createProviderEventLogger({

--- a/src/infra/task/taskLifecycleService.ts
+++ b/src/infra/task/taskLifecycleService.ts
@@ -127,7 +127,12 @@ export class TaskLifecycleService {
     }
 
     if (retryMetadata.startStep) {
-      return { startStep: retryMetadata.startStep };
+      return {
+        startStep: retryMetadata.startStep,
+        ...(retryMetadata.currentIteration !== undefined
+          ? { currentIteration: retryMetadata.currentIteration }
+          : {}),
+      };
     }
 
     if (hasInheritedRetryCheckpoint(task)) {

--- a/src/infra/task/taskLifecycleService.ts
+++ b/src/infra/task/taskLifecycleService.ts
@@ -110,7 +110,7 @@ export class TaskLifecycleService {
 
   private readTerminalRetryMetadata(task: TaskRecord): ResolvedTaskRetryMetadata {
     if (!task.run_slug) {
-      return {};
+      return hasInheritedRetryCheckpoint(task) ? { preserveExisting: true } : {};
     }
 
     const retryMetadata = readRetryMetadataByRunSlug(
@@ -122,9 +122,19 @@ export class TaskLifecycleService {
       return retryMetadata;
     }
 
-    return retryMetadata.startStep
-      ? { startStep: retryMetadata.startStep }
-      : {};
+    if (retryMetadata.resumePoint) {
+      return retryMetadata;
+    }
+
+    if (retryMetadata.startStep) {
+      return { startStep: retryMetadata.startStep };
+    }
+
+    if (hasInheritedRetryCheckpoint(task)) {
+      return { preserveExisting: true };
+    }
+
+    return {};
   }
 
   completeTask(result: TaskResult): string {
@@ -281,4 +291,12 @@ export class TaskLifecycleService {
   private isRunningTaskStale(task: TaskRecord): boolean {
     return isStaleRunningTask(task.owner_pid ?? undefined);
   }
+}
+
+function hasInheritedRetryCheckpoint(task: TaskRecord): boolean {
+  return task.resume_mode !== undefined
+    && (
+      task.start_step !== undefined
+      || task.resume_point !== undefined
+    );
 }


### PR DESCRIPTION
## Summary

- preserve the latest nested workflow resume checkpoint when an interrupted or failed task is requeued
- prefer a checkpoint produced by the new run while retaining an inherited checkpoint before new progress exists
- expand a resumed finite step limit until it contains the restored iteration, so iteration 56 with max 51 continues to max 102
- fail before creating run artifacts when the next finite limit cannot be represented safely

## Verification

- npm run build
- npm run lint
- npm test
- npm run test:it
- focused resume and requeue tests: 128 passed
- independent Codex review: APPROVE after resolving all blocking findings

## E2E note

npm run test:e2e:mock passed all but the existing dynamic parallel selector resume assertion named should resume with the saved selection without invoking the selector again. The same failure was reproduced on clean main, so it is not introduced by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 中断・失敗したタスクの再試行時に、チェックポイント、反復回数、再開位置を正しく引き継ぐよう改善しました。
  - 子ワークフローを含む処理の再開時も、親子の進行状態を保持できるようになりました。
  - 再開時にステップ上限へ到達した場合でも、保存済みの再開情報が失われないよう修正しました。
  - 復元した反復回数に応じてステップ上限を安全に調整し、無効な上限値を適切に拒否します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->