### PR TITLE
fix: extend requeued max steps linearly

### DIFF
--- a/src/__tests__/workflowExecution-ask-user-question.test.ts
+++ b/src/__tests__/workflowExecution-ask-user-question.test.ts
@@ -358,6 +358,19 @@ describe('executeWorkflow AskUserQuestion deny handler wiring', () => {
     });
   });
 
+  it('should reject the next max steps when an infinite workflow override would exceed the safe integer range', async () => {
+    MockWorkflowEngine.triggerIterationLimit = true;
+    const maxStepsOverride = Math.floor(Number.MAX_SAFE_INTEGER / 2) + 1;
+
+    await expect(executeWorkflow({
+      ...makeConfig(),
+      maxSteps: 'infinite',
+    }, 'task', '/tmp/project', {
+      projectCwd: '/tmp/project',
+      maxStepsOverride,
+    })).rejects.toThrow('safe integer range');
+  });
+
   it('should use engine getResumePoint when currentStep cannot be rebuilt in exceeded handling', async () => {
     MockWorkflowEngine.triggerIterationLimit = true;
     MockWorkflowEngine.iterationLimitCurrentStep = 'fix';

--- a/src/__tests__/workflowExecution-ask-user-question.test.ts
+++ b/src/__tests__/workflowExecution-ask-user-question.test.ts
@@ -338,6 +338,26 @@ describe('executeWorkflow AskUserQuestion deny handler wiring', () => {
     });
   });
 
+  it('should add the latest workflow max steps when a resumed workflow exceeds again', async () => {
+    MockWorkflowEngine.triggerIterationLimit = true;
+
+    const result = await executeWorkflow({
+      ...makeConfig(),
+      maxSteps: 51,
+    }, 'task', '/tmp/project', {
+      projectCwd: '/tmp/project',
+      maxStepsOverride: 102,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.exceeded).toBe(true);
+    expect(result.exceededInfo).toEqual({
+      currentStep: 'implement',
+      newMaxSteps: 153,
+      currentIteration: 1,
+    });
+  });
+
   it('should use engine getResumePoint when currentStep cannot be rebuilt in exceeded handling', async () => {
     MockWorkflowEngine.triggerIterationLimit = true;
     MockWorkflowEngine.iterationLimitCurrentStep = 'fix';

--- a/src/__tests__/workflowExecution-ask-user-question.test.ts
+++ b/src/__tests__/workflowExecution-ask-user-question.test.ts
@@ -358,6 +358,38 @@ describe('executeWorkflow AskUserQuestion deny handler wiring', () => {
     });
   });
 
+  it('should allow the next max steps when a finite workflow reaches the safe integer boundary', async () => {
+    MockWorkflowEngine.triggerIterationLimit = true;
+
+    const result = await executeWorkflow({
+      ...makeConfig(),
+      maxSteps: 51,
+    }, 'task', '/tmp/project', {
+      projectCwd: '/tmp/project',
+      maxStepsOverride: Number.MAX_SAFE_INTEGER - 51,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.exceeded).toBe(true);
+    expect(result.exceededInfo).toEqual({
+      currentStep: 'implement',
+      newMaxSteps: Number.MAX_SAFE_INTEGER,
+      currentIteration: 1,
+    });
+  });
+
+  it('should reject the next max steps when a finite workflow would exceed the safe integer range', async () => {
+    MockWorkflowEngine.triggerIterationLimit = true;
+
+    await expect(executeWorkflow({
+      ...makeConfig(),
+      maxSteps: 51,
+    }, 'task', '/tmp/project', {
+      projectCwd: '/tmp/project',
+      maxStepsOverride: Number.MAX_SAFE_INTEGER - 50,
+    })).rejects.toThrow('safe integer range');
+  });
+
   it('should reject the next max steps when an infinite workflow override would exceed the safe integer range', async () => {
     MockWorkflowEngine.triggerIterationLimit = true;
     const maxStepsOverride = Math.floor(Number.MAX_SAFE_INTEGER / 2) + 1;

--- a/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
+++ b/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
@@ -304,8 +304,8 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     { initialIterationOverride: 50, maxStepsOverride: undefined, expectedMaxSteps: 51 },
     { initialIterationOverride: 56, maxStepsOverride: undefined, expectedMaxSteps: 102 },
     { initialIterationOverride: 56, maxStepsOverride: 102, expectedMaxSteps: 102 },
-    { initialIterationOverride: 102, maxStepsOverride: 102, expectedMaxSteps: 204 },
-    { initialIterationOverride: 205, maxStepsOverride: undefined, expectedMaxSteps: 408 },
+    { initialIterationOverride: 102, maxStepsOverride: 102, expectedMaxSteps: 153 },
+    { initialIterationOverride: 205, maxStepsOverride: undefined, expectedMaxSteps: 255 },
   ])(
     'resolves max steps to $expectedMaxSteps for restored iteration $initialIterationOverride',
     async ({ initialIterationOverride, maxStepsOverride, expectedMaxSteps }) => {
@@ -326,6 +326,41 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     },
   );
 
+  it('uses the latest workflow max steps as the increment after the workflow definition changes', async () => {
+    const projectDir = createTempProject();
+    const bootstrap = await createWorkflowExecutionBootstrap(
+      { ...workflowConfig, maxSteps: 60 },
+      'Resume changed workflow iteration',
+      projectDir,
+      {
+        projectCwd: projectDir,
+        provider: 'mock',
+        initialIterationOverride: 102,
+        maxStepsOverride: 102,
+      },
+    );
+
+    expect(bootstrap.effectiveWorkflowConfig.maxSteps).toBe(162);
+  });
+
+  it('allows an additive extension exactly to the safe integer boundary', async () => {
+    const projectDir = createTempProject();
+    const maxStepsOverride = Number.MAX_SAFE_INTEGER - 51;
+    const bootstrap = await createWorkflowExecutionBootstrap(
+      { ...workflowConfig, maxSteps: 51 },
+      'Resume workflow at safe integer boundary',
+      projectDir,
+      {
+        projectCwd: projectDir,
+        provider: 'mock',
+        initialIterationOverride: maxStepsOverride,
+        maxStepsOverride,
+      },
+    );
+
+    expect(bootstrap.effectiveWorkflowConfig.maxSteps).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
   it('keeps an infinite max steps limit when restoring an iteration', async () => {
     const projectDir = createTempProject();
     const bootstrap = await createWorkflowExecutionBootstrap(
@@ -342,17 +377,61 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     expect(bootstrap.effectiveWorkflowConfig.maxSteps).toBe('infinite');
   });
 
-  it('rejects a restored iteration when the next finite limit is not safely representable', async () => {
+  it.each([
+    { initialIterationOverride: 7, expectedMaxSteps: 12 },
+    { initialIterationOverride: 12, expectedMaxSteps: 24 },
+  ])(
+    'doubles a finite override to $expectedMaxSteps for an infinite workflow restored at $initialIterationOverride',
+    async ({ initialIterationOverride, expectedMaxSteps }) => {
+      const projectDir = createTempProject();
+      const bootstrap = await createWorkflowExecutionBootstrap(
+        { ...workflowConfig, maxSteps: 'infinite' },
+        'Resume infinite workflow iteration',
+        projectDir,
+        {
+          projectCwd: projectDir,
+          provider: 'mock',
+          initialIterationOverride,
+          maxStepsOverride: 3,
+        },
+      );
+
+      expect(bootstrap.effectiveWorkflowConfig.maxSteps).toBe(expectedMaxSteps);
+    },
+  );
+
+  it('rejects an infinite workflow override when doubling exceeds the safe integer range', async () => {
     const projectDir = createTempProject();
+    const maxStepsOverride = Math.floor(Number.MAX_SAFE_INTEGER / 2) + 1;
 
     await expect(createWorkflowExecutionBootstrap(
-      { ...workflowConfig, maxSteps: Number.MAX_SAFE_INTEGER },
+      { ...workflowConfig, maxSteps: 'infinite' },
+      'Resume infinite workflow beyond safe integer range',
+      projectDir,
+      {
+        projectCwd: projectDir,
+        provider: 'mock',
+        initialIterationOverride: maxStepsOverride,
+        maxStepsOverride,
+      },
+    )).rejects.toThrow();
+    expect(mockWriteFileAtomic).not.toHaveBeenCalled();
+    expect(mockCreateOutputFns).not.toHaveBeenCalled();
+  });
+
+  it('rejects a restored iteration when the next finite limit is not safely representable', async () => {
+    const projectDir = createTempProject();
+    const maxStepsOverride = Number.MAX_SAFE_INTEGER - 50;
+
+    await expect(createWorkflowExecutionBootstrap(
+      { ...workflowConfig, maxSteps: 51 },
       'Resume workflow iteration',
       projectDir,
       {
         projectCwd: projectDir,
         provider: 'mock',
-        initialIterationOverride: Number.MAX_SAFE_INTEGER,
+        initialIterationOverride: maxStepsOverride,
+        maxStepsOverride,
       },
     )).rejects.toThrow();
     expect(mockWriteFileAtomic).not.toHaveBeenCalled();

--- a/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
+++ b/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
@@ -326,7 +326,7 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     },
   );
 
-  it('uses the latest workflow max steps as the increment after the workflow definition changes', async () => {
+  it('should use the latest workflow max steps when the workflow definition changes', async () => {
     const projectDir = createTempProject();
     const bootstrap = await createWorkflowExecutionBootstrap(
       { ...workflowConfig, maxSteps: 60 },
@@ -343,7 +343,7 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     expect(bootstrap.effectiveWorkflowConfig.maxSteps).toBe(162);
   });
 
-  it('allows an additive extension exactly to the safe integer boundary', async () => {
+  it('should allow an additive extension when it reaches the safe integer boundary exactly', async () => {
     const projectDir = createTempProject();
     const maxStepsOverride = Number.MAX_SAFE_INTEGER - 51;
     const bootstrap = await createWorkflowExecutionBootstrap(
@@ -381,7 +381,7 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     { initialIterationOverride: 7, expectedMaxSteps: 12 },
     { initialIterationOverride: 12, expectedMaxSteps: 24 },
   ])(
-    'doubles a finite override to $expectedMaxSteps for an infinite workflow restored at $initialIterationOverride',
+    'should double a finite override to $expectedMaxSteps when an infinite workflow is restored at $initialIterationOverride',
     async ({ initialIterationOverride, expectedMaxSteps }) => {
       const projectDir = createTempProject();
       const bootstrap = await createWorkflowExecutionBootstrap(
@@ -400,7 +400,7 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     },
   );
 
-  it('rejects an infinite workflow override when doubling exceeds the safe integer range', async () => {
+  it('should reject an infinite workflow override when doubling exceeds the safe integer range', async () => {
     const projectDir = createTempProject();
     const maxStepsOverride = Math.floor(Number.MAX_SAFE_INTEGER / 2) + 1;
 
@@ -419,7 +419,7 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     expect(mockCreateOutputFns).not.toHaveBeenCalled();
   });
 
-  it('rejects a restored iteration when the next finite limit is not safely representable', async () => {
+  it('should reject a restored iteration when the next finite limit is not safely representable', async () => {
     const projectDir = createTempProject();
     const maxStepsOverride = Number.MAX_SAFE_INTEGER - 50;
 

--- a/src/features/tasks/execute/workflowExecution.ts
+++ b/src/features/tasks/execute/workflowExecution.ts
@@ -175,12 +175,16 @@ async function executeWorkflowInternal(
       const workflowMaxSteps = workflowConfig.maxSteps === 'infinite'
         ? requireFiniteWorkflowMaxSteps(bootstrap.effectiveWorkflowConfig)
         : workflowConfig.maxSteps;
+      const newMaxSteps = request.maxSteps + workflowMaxSteps;
+      if (!Number.isSafeInteger(newMaxSteps)) {
+        throw new Error('Cannot continue workflow because the next max steps limit exceeds the safe integer range');
+      }
       const resumePoint = getLatestResumePoint()
         ?? buildResumePointForStep(request.currentStep)
         ?? eventBridge?.state.lastResumePoint;
       eventBridge!.state.exceededInfo = {
         currentStep: request.currentStep,
-        newMaxSteps: request.maxSteps + workflowMaxSteps,
+        newMaxSteps,
         currentIteration: request.currentIteration,
         ...(resumePoint ? { resumePoint } : {}),
       };

--- a/src/features/tasks/execute/workflowExecution.ts
+++ b/src/features/tasks/execute/workflowExecution.ts
@@ -172,7 +172,9 @@ async function executeWorkflowInternal(
     bootstrap.displayRef,
     bootstrap.shouldNotifyIterationLimit,
     (request) => {
-      const workflowMaxSteps = requireFiniteWorkflowMaxSteps(bootstrap.effectiveWorkflowConfig);
+      const workflowMaxSteps = workflowConfig.maxSteps === 'infinite'
+        ? requireFiniteWorkflowMaxSteps(bootstrap.effectiveWorkflowConfig)
+        : workflowConfig.maxSteps;
       const resumePoint = getLatestResumePoint()
         ?? buildResumePointForStep(request.currentStep)
         ?? eventBridge?.state.lastResumePoint;

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -114,20 +114,36 @@ class AutoRoutingReachTracker {
 }
 
 function resolveMaxStepsForRestoredIteration(
-  maxSteps: WorkflowConfig['maxSteps'],
+  currentMaxSteps: WorkflowConfig['maxSteps'],
+  workflowMaxSteps: WorkflowConfig['maxSteps'],
   initialIteration: number | undefined,
 ): WorkflowConfig['maxSteps'] {
-  if (maxSteps === 'infinite' || initialIteration === undefined || initialIteration < maxSteps) {
-    return maxSteps;
+  if (
+    currentMaxSteps === 'infinite'
+    || initialIteration === undefined
+    || initialIteration < currentMaxSteps
+  ) {
+    return currentMaxSteps;
   }
 
-  let resumedMaxSteps = maxSteps;
-  while (initialIteration >= resumedMaxSteps) {
-    const nextMaxSteps = resumedMaxSteps * 2;
-    if (!Number.isSafeInteger(nextMaxSteps)) {
-      throw new Error('Cannot resume workflow because the next max steps limit exceeds the safe integer range');
+  if (workflowMaxSteps === 'infinite') {
+    let resumedMaxSteps = currentMaxSteps;
+    while (initialIteration >= resumedMaxSteps) {
+      const nextMaxSteps = resumedMaxSteps * 2;
+      if (!Number.isSafeInteger(nextMaxSteps)) {
+        throw new Error('Cannot resume workflow because the next max steps limit exceeds the safe integer range');
+      }
+      resumedMaxSteps = nextMaxSteps;
     }
-    resumedMaxSteps = nextMaxSteps;
+    return resumedMaxSteps;
+  }
+
+  const requiredIncrements = Math.floor(
+    (initialIteration - currentMaxSteps) / workflowMaxSteps,
+  ) + 1;
+  const resumedMaxSteps = currentMaxSteps + requiredIncrements * workflowMaxSteps;
+  if (!Number.isSafeInteger(resumedMaxSteps)) {
+    throw new Error('Cannot resume workflow because the next max steps limit exceeds the safe integer range');
   }
   return resumedMaxSteps;
 }
@@ -140,6 +156,7 @@ export async function createWorkflowExecutionBootstrap(
 ): Promise<WorkflowExecutionBootstrap> {
   const effectiveMaxSteps = resolveMaxStepsForRestoredIteration(
     options.maxStepsOverride ?? workflowConfig.maxSteps,
+    workflowConfig.maxSteps,
     options.initialIterationOverride,
   );
   const { headerPrefix = 'Running Workflow:', interactiveUserInput = false, outputMode = 'terminal' } = options;


### PR DESCRIPTION
## 目的

requeue後に上限を再度超えた場合、有限workflowの最新の `max_steps` を現在上限へ加算し、上限を線形に延長します。

例: `51 → 102 → 153`

## 変更

- 有限workflowの復元時上限を、最新workflow定義の `max_steps` 単位で延長
- workflow定義変更後も最新値を増分として使用
- `max_steps: infinite` と有限overrideの既存progressive doublingを維持
- 安全整数境界とoverflow拒否を追加検証

## 検証

- `npm test -- src/__tests__/workflowExecution-ask-user-question.test.ts src/__tests__/workflowExecutionBootstrapDirectResume.test.ts` (58 tests passed)
- `npm run build`
- `npm run lint`
- `git diff --check`
- 別Codexレビュー: APPROVE（新規findingなし）

## 成果物確認

- 実行ログ・レポート・絶対パスを差分に含めていません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - ワークフロー再開後、現在の実行状況と最新設定に基づいてステップ上限を正しく拡張するよう改善しました。
  - 無限実行では上限を適切に倍増し、有限設定では必要な範囲だけ追加します。
  - 上限が安全な数値範囲を超える場合、エラーを通知するようになりました。
  - 再開後の実行状態と反復回数が正しく引き継がれるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->