### PR TITLE
fix: follow @agentclientprotocol/sdk 1.3.0 contract changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.54.1",
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^1.0.0",
+        "@agentclientprotocol/sdk": "^1.3.0",
         "@anthropic-ai/claude-agent-sdk": "^0.3.206",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openai/codex-sdk": "^0.144.1",
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.0.0.tgz",
-      "integrity": "sha512-5FHgLbLZhSAq9F+9SU7AOCXTDzaw/IYx/AvMjrZDs/YFZ9ZPxkdn9ti3fSkny0huHfj2hrqF6pqdns9gN5/Fig==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "builtins/"
   ],
   "dependencies": {
-    "@agentclientprotocol/sdk": "^1.0.0",
+    "@agentclientprotocol/sdk": "^1.3.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.206",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/codex-sdk": "^0.144.1",

--- a/src/__tests__/acp-entrypoint.test.ts
+++ b/src/__tests__/acp-entrypoint.test.ts
@@ -600,6 +600,62 @@ describe('ACP package entrypoint', () => {
     expect(saveTaskFile).not.toHaveBeenCalled();
   });
 
+  it('should route ACP-transport MCP servers with serverId to the transport rejection over the SDK stream transport', async () => {
+    const clientToAgent = new TransformStream<Uint8Array>();
+    const agentToClient = new TransformStream<Uint8Array>();
+    const createConversationSession = vi.fn();
+    const app = createTaktAcpAgentApp({
+      createConversationSession,
+    });
+    app.connect(ndJsonStream(agentToClient.writable, clientToAgent.readable));
+
+    await expect(client({ name: 'takt-acp-transport-server-id-test-client' })
+      .connectWith(ndJsonStream(clientToAgent.writable, agentToClient.readable), async (agent) => {
+        await agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {},
+        });
+        return agent.request(methods.agent.session.new, {
+          cwd: '/repo',
+          mcpServers: [{
+            type: 'acp',
+            name: 'proxy',
+            serverId: 'srv-1',
+          }],
+        });
+      })).rejects.toMatchObject({
+        data: { details: 'Unsupported ACP MCP server transport: acp' },
+      });
+    expect(createConversationSession).not.toHaveBeenCalled();
+  });
+
+  it('should reject legacy id on ACP-transport MCP servers as invalid params over the SDK stream transport', async () => {
+    const clientToAgent = new TransformStream<Uint8Array>();
+    const agentToClient = new TransformStream<Uint8Array>();
+    const createConversationSession = vi.fn();
+    const app = createTaktAcpAgentApp({
+      createConversationSession,
+    });
+    app.connect(ndJsonStream(agentToClient.writable, clientToAgent.readable));
+
+    await expect(client({ name: 'takt-acp-transport-legacy-id-test-client' })
+      .connectWith(ndJsonStream(clientToAgent.writable, agentToClient.readable), async (agent) => {
+        await agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {},
+        });
+        return agent.request(methods.agent.session.new, {
+          cwd: '/repo',
+          mcpServers: [{
+            type: 'acp',
+            name: 'proxy',
+            id: 'srv-1',
+          }],
+        });
+      })).rejects.toThrow('Invalid params');
+    expect(createConversationSession).not.toHaveBeenCalled();
+  });
+
   it('should reject Git option session/new taskContext branch over the SDK stream transport', async () => {
     const clientToAgent = new TransformStream<Uint8Array>();
     const agentToClient = new TransformStream<Uint8Array>();

--- a/src/__tests__/acpAgent.test.ts
+++ b/src/__tests__/acpAgent.test.ts
@@ -2507,9 +2507,12 @@ describe('TAKT ACP agent adapter', () => {
     });
   });
 
-  it('should deny workflow AskUserQuestion when ACP elicitation is cancelled', async () => {
+  it.each([
+    { action: 'cancel' },
+    { action: 'decline' },
+  ])('should deny workflow AskUserQuestion when ACP elicitation responds with $action', async ({ action }) => {
     const sendSessionUpdate = vi.fn();
-    const createElicitation = vi.fn().mockResolvedValue({ action: 'cancel' });
+    const createElicitation = vi.fn().mockResolvedValue({ action });
     const runWorkflowExecution = vi.fn(async (request) => {
       await expect(request.onAskUserQuestion?.({
         questions: [{ question: 'Proceed?' }],
@@ -2551,7 +2554,7 @@ describe('TAKT ACP agent adapter', () => {
       event: {
         type: 'tool_completed',
         toolCallId: 'confirmation-1',
-        message: 'Confirmation cancel',
+        message: `Confirmation ${action}`,
         isError: true,
       },
     });

--- a/src/__tests__/acpAgent.test.ts
+++ b/src/__tests__/acpAgent.test.ts
@@ -2557,6 +2557,68 @@ describe('TAKT ACP agent adapter', () => {
     });
   });
 
+  it.each([
+    {
+      title: 'accept response with a malformed payload',
+      response: { action: 'accept', content: 'not-an-object' },
+      error: /invalid or unsupported response: accept/i,
+      message: 'ACP elicitation returned an invalid or unsupported response: accept',
+    },
+    {
+      title: 'custom elicitation action',
+      response: { action: '_defer' },
+      error: /invalid or unsupported response: _defer/i,
+      message: 'ACP elicitation returned an invalid or unsupported response: _defer',
+    },
+  ])('should surface an error for ACP elicitation $title instead of a denial', async ({ response, error, message }) => {
+    const sendSessionUpdate = vi.fn();
+    const createElicitation = vi.fn().mockResolvedValue(response);
+    const runWorkflowExecution = vi.fn(async (request) => {
+      await expect(request.onAskUserQuestion?.({
+        questions: [{ question: 'Proceed?' }],
+      })).rejects.toThrow(error);
+      return {
+        success: false,
+        reason: 'invalid elicitation response',
+      };
+    });
+    const agent = createTaktAcpAgent({
+      createConversationSession: vi.fn(() => ({
+        handleUserMessage: vi.fn().mockResolvedValue({
+          kind: 'workflow_execution_requested',
+          task: 'Implement ACP support',
+        }),
+      })),
+      runWorkflowExecution,
+      sendSessionUpdate,
+      createElicitation,
+    });
+    await agent.handleInitialize({
+      protocolVersion: 1,
+      clientCapabilities: {
+        elicitation: {
+          form: {},
+        },
+      },
+    });
+    const { sessionId } = await agent.handleSessionNew(newSessionParams());
+
+    await agent.handleSessionPrompt({
+      sessionId,
+      prompt: [{ type: 'text', text: '/play Implement ACP support' }],
+    });
+
+    expect(sendSessionUpdate).toHaveBeenCalledWith(sessionId, {
+      kind: 'workflow_event',
+      event: {
+        type: 'tool_completed',
+        toolCallId: 'confirmation-1',
+        message,
+        isError: true,
+      },
+    });
+  });
+
   it('should deny AskUserQuestion without sending elicitation when client lacks form capability', async () => {
     const sendSessionUpdate = vi.fn();
     const createElicitation = vi.fn();

--- a/src/app/acp/confirmationBridge.ts
+++ b/src/app/acp/confirmationBridge.ts
@@ -1,4 +1,4 @@
-import { methods, type ElicitationSchema } from '@agentclientprotocol/sdk';
+import { CreateElicitationResponse, methods, type ElicitationSchema } from '@agentclientprotocol/sdk';
 import { AskUserQuestionDeniedError } from '../../core/workflow/ask-user-question-error.js';
 import type { AskUserQuestionInput } from '../../core/workflow/types.js';
 import type {
@@ -185,7 +185,7 @@ export async function askUserQuestionViaAcp(
         requestedSchema: buildQuestionSchema(question),
       });
       const response = await waitForElicitationResponse(elicitation, abortSignal);
-      if (response.action !== 'accept') {
+      if (CreateElicitationResponse.isDecline(response) || CreateElicitationResponse.isCancel(response)) {
         await sendSessionUpdate?.(sessionId, {
           kind: 'workflow_event',
           event: {
@@ -196,6 +196,9 @@ export async function askUserQuestionViaAcp(
           },
         });
         throw new AskUserQuestionDeniedError();
+      }
+      if (!CreateElicitationResponse.isAccept(response)) {
+        throw new Error(`ACP elicitation returned an invalid or unsupported response: ${response.action}`);
       }
       answers[question.question] = formatElicitationAnswer(question, response.content?.[ANSWER_FIELD]);
       await sendSessionUpdate?.(sessionId, {

--- a/src/app/acp/index.ts
+++ b/src/app/acp/index.ts
@@ -58,7 +58,7 @@ const acpMcpServerSchema = z.union([
   z.object({
     type: z.literal('acp'),
     name: z.string(),
-    id: z.string(),
+    serverId: z.string(),
     _meta: acpMetadataSchema,
   }),
   z.object({


### PR DESCRIPTION
## 背景

スケジュール実行の Dependency Health Check（lockfile なしインストール）が失敗していました（https://github.com/nrslib/takt/actions/runs/30781606118）。`@agentclientprotocol/sdk` の range が `^1.0.0` のため最新 1.3.0 が入り、SDK の型変更でビルドが落ちる状態でした。

- `McpServerAcp` のフィールドが `id` から `serverId` にリネーム（1.2.0）
- `CreateElicitationResponse` にキャッチオールバリアント `{ action: string }` が追加（1.2.0）

## 変更内容

- range を `^1.3.0` に更新。lockfile は SDK エントリのみを更新（`npm install` に任せると mongoose 配下の optional peer `gcp-metadata@7.0.1` の nested エントリが刈り込まれ `npm ls` が壊れるため、最小差分に留めた）
- ACP MCP サーバーの zod スキーマで `id` を `serverId` にリネーム。下流の `normalizeAcpMcpServers` は `type` 付きトランスポートを全て拒否するため利用側の影響なし。旧 `id` の互換受理は追加しない（ACP transport は unstable 扱いで、受理しても機能しないため）
- elicitation 応答の分類を SDK の検証付き型ガードに変更。decline/cancel は従来どおり拒否（`AskUserQuestionDeniedError`）、payload が契約外の accept とカスタム action は「ユーザー拒否」ではなくプロトコルエラーとして伝播するように修正

## テスト

回帰テストを 4 件追加。

- accept + 不正 payload がエラーになる（拒否に誤分類されない）
- カスタム action がエラーになる
- `{type:'acp', serverId}` が parse を通過し transport 拒否に到達する
- 旧 `{type:'acp', id}` は Invalid params で拒否される

## 検証

- `npx tsc --noEmit` / `npm run lint` / `npm test`（全スライス）/ `npm run test -- src/__tests__/it-acp-workflow-bridge.test.ts` / `npm run build` すべてパス
- `npm ls --package-lock-only` exit 0、`npm ci --dry-run` exit 0
- SDK 1.1.0〜1.3.0 の変更を調査し、TAKT が使用するメソッド名・SessionUpdate shape・PROTOCOL_VERSION に他の非互換がないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **機能改善**
  - ACP MCPサーバー設定で、サーバー識別子に`serverId`を使用するようになりました。
  - 不正なACP応答を検出し、具体的なエラーとして通知するようになりました。

- **バグ修正**
  - 無効なサーバー指定によるセッション作成を防止し、適切なエラーを返すよう改善しました。
  - 不正な応答時に、処理完了通知がエラー状態で送信されるようになりました。
  - 拒否・キャンセルされた確認要求が、正しく拒否結果として処理されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->