### PR TITLE
fix: stop double-counting sensitive sources on repeated tool input updates

### DIFF
--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -543,6 +543,66 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(stream.returnSpy).toHaveBeenCalled();
   });
 
+  it('does not exhaust sensitive source tracking when the same tool input is updated repeatedly', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const sessionId = 'session-sensitive-same-tool';
+    const toolId = 'same-tool';
+    const updates = MAX_TRACKED_SENSITIVE_SOURCES + 10;
+    const events: unknown[] = [
+      sensitiveToolPartUpdated(sessionId, toolId, 'initial-secret'),
+    ];
+    for (let index = 1; index <= updates; index += 1) {
+      events.push({
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            id: toolId,
+            sessionID: sessionId,
+            type: 'tool',
+            callID: `call-${toolId}`,
+            tool: 'remote',
+            state: { status: 'running', input: { token: `secret-${index}` } },
+          },
+        },
+      });
+    }
+    events.push({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          id: toolId,
+          sessionID: sessionId,
+          type: 'tool',
+          callID: `call-${toolId}`,
+          tool: 'remote',
+          state: { status: 'completed', input: { token: 'final-secret' }, output: 'ok', title: 'done' },
+        },
+      },
+    });
+    events.push(sessionIdle(sessionId));
+    const stream = new MockEventStream(events, sessionId);
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: sessionId } }),
+          promptAsync: vi.fn().mockResolvedValue(undefined),
+          abort: successfulSessionAbort(),
+        },
+        event: { subscribe: vi.fn().mockResolvedValue({ stream }) },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn() },
+    });
+
+    const result = await new OpenCodeClient().call('interactive', 'hello', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+    });
+    expect(result.status).toBe('done');
+    expect(result.error ?? '').not.toContain('sensitive_sources');
+  });
+
   it('should consume stream events while promptAsync is still pending', async () => {
     // promptAsync を手動 resolve するまで宙吊りにするテストなので、pump が
     // fake 時間を進めると prompt 完了タイムアウトが先に発火してしまう。実時間で走らせる。

--- a/src/__tests__/opencode-stream-handler.test.ts
+++ b/src/__tests__/opencode-stream-handler.test.ts
@@ -52,7 +52,7 @@ describe('createStreamTrackingState', () => {
     expect(state.textOffsets.size).toBe(0);
     expect(state.thinkingOffsets.size).toBe(0);
     expect(state.startedTools.size).toBe(0);
-    expect(state.latestToolInputs.size).toBe(0);
+    expect(state.latestToolInputJson.size).toBe(0);
     expect(state.textBytes).toBe(0);
   });
 });
@@ -646,7 +646,7 @@ describe('handlePartUpdated', () => {
         expect(jsonl).not.toContain(secret);
         expect(jsonl).toContain('[REDACTED]');
         expect(jsonl.match(/"event_type":"tool_use"/g)).toHaveLength(1);
-        expect(state.latestToolInputs.get('call-late')).toEqual({ token: secret });
+        expect(state.latestToolInputJson.get('call-late')).toBe(JSON.stringify({ token: secret }));
       } finally {
         rmSync(logsDir, { recursive: true, force: true });
       }
@@ -795,9 +795,27 @@ describe('handlePartUpdated', () => {
     }
 
     expect(state.exhausted).toBe(true);
-    expect(state.latestToolInputs.size).toBe(0);
+    expect(state.latestToolInputJson.size).toBe(0);
     expect(state.sensitiveSources.values.size).toBe(0);
     expect(sanitizeSensitiveTextWithKnownValues('unknown-secret', state.sensitiveSources)).toBe('[REDACTED]');
+  });
+
+  it('collects secrets from later input revisions of the same tool without consuming source slots', () => {
+    const state = createStreamTrackingState();
+    const revisions = ['first-revision-secret', 'second-revision-secret'];
+    for (const token of revisions) {
+      expect(handlePartUpdated({
+        id: 'tool-part',
+        type: 'tool',
+        callID: 'call-1',
+        tool: 'remote',
+        state: { status: 'running', input: { token } },
+      }, undefined, undefined, state)).toBe(true);
+    }
+
+    expect(state.sensitiveSources.sourceCount).toBe(1);
+    expect(state.sensitiveSources.values.has('first-revision-secret')).toBe(true);
+    expect(state.sensitiveSources.values.has('second-revision-secret')).toBe(true);
   });
 });
 

--- a/src/infra/opencode/OpenCodeStreamHandler.ts
+++ b/src/infra/opencode/OpenCodeStreamHandler.ts
@@ -531,9 +531,10 @@ function handleToolPartUpdated(
   state: StreamTrackingState,
 ): boolean {
   const toolId = toolPart.callID || toolPart.id;
-  const previousInput = state.latestToolInputs.get(toolId);
+  const isNewTool = !state.startedTools.has(toolId);
   state.latestToolInputs.set(toolId, toolPart.state.input);
-  if (previousInput !== toolPart.state.input) {
+  if (isNewTool) {
+    state.startedTools.add(toolId);
     state.sensitiveSources.add(toolPart.state.input);
     if (state.sensitiveSources.exhausted) {
       exhaustStreamTrackingState(state, 'sensitive_sources');
@@ -543,9 +544,8 @@ function handleToolPartUpdated(
 
   if (!onStream) return true;
 
-  if (!state.startedTools.has(toolId)) {
+  if (isNewTool) {
     emitToolUse(onStream, toolPart.tool, toolPart.state.input, toolId);
-    state.startedTools.add(toolId);
   }
 
   switch (toolPart.state.status) {

--- a/src/infra/opencode/OpenCodeStreamHandler.ts
+++ b/src/infra/opencode/OpenCodeStreamHandler.ts
@@ -173,7 +173,7 @@ export interface StreamTrackingState {
   thinkingRedactors: Map<string, SensitiveTextStreamRedactor>;
   partTypes: Map<string, string>;
   startedTools: Set<string>;
-  latestToolInputs: Map<string, Record<string, unknown>>;
+  latestToolInputJson: Map<string, string>;
   sensitiveSources: BoundedSensitiveValues;
   eventCount: number;
   textBytes: number;
@@ -195,7 +195,7 @@ export function createStreamTrackingState(): StreamTrackingState {
     thinkingRedactors: new Map<string, SensitiveTextStreamRedactor>(),
     partTypes: new Map<string, string>(),
     startedTools: new Set<string>(),
-    latestToolInputs: new Map<string, Record<string, unknown>>(),
+    latestToolInputJson: new Map<string, string>(),
     sensitiveSources: createBoundedSensitiveValues(),
     eventCount: 0,
     textBytes: 0,
@@ -231,7 +231,7 @@ function exhaustStreamTrackingState(
   state.thinkingRedactors.clear();
   state.partTypes.clear();
   state.startedTools.clear();
-  state.latestToolInputs.clear();
+  state.latestToolInputJson.clear();
   state.trackedIds.clear();
   state.sensitiveSources.exhaust();
   state.exhausted = true;
@@ -532,14 +532,20 @@ function handleToolPartUpdated(
 ): boolean {
   const toolId = toolPart.callID || toolPart.id;
   const isNewTool = !state.startedTools.has(toolId);
-  state.latestToolInputs.set(toolId, toolPart.state.input);
+  const inputJson = JSON.stringify(toolPart.state.input);
+  const inputChanged = state.latestToolInputJson.get(toolId) !== inputJson;
+  state.latestToolInputJson.set(toolId, inputJson);
   if (isNewTool) {
+    // 新しいツールだけがソース枠（MAX_TRACKED_SENSITIVE_SOURCES）を消費する。
+    // 同一ツールの input 更新は枠を消費せず値収集のみ行い、バイト予算で有界化する。
     state.startedTools.add(toolId);
     state.sensitiveSources.add(toolPart.state.input);
-    if (state.sensitiveSources.exhausted) {
-      exhaustStreamTrackingState(state, 'sensitive_sources');
-      return false;
-    }
+  } else if (inputChanged) {
+    state.sensitiveSources.collect(toolPart.state.input);
+  }
+  if (state.sensitiveSources.exhausted) {
+    exhaustStreamTrackingState(state, 'sensitive_sources');
+    return false;
   }
 
   if (!onStream) return true;

--- a/src/shared/utils/sensitive-value.ts
+++ b/src/shared/utils/sensitive-value.ts
@@ -31,6 +31,14 @@ export class BoundedSensitiveValues {
       this.exhaust();
       return;
     }
+    this.collect(source);
+  }
+
+  /** Collect values without consuming a source slot; still bounded by the byte budget. */
+  collect(source: unknown): void {
+    if (this.exhausted) {
+      return;
+    }
     const collected = collectSensitiveStringValues(
       source,
       MAX_TRACKED_SENSITIVE_SOURCE_BYTES - this.inspectedBytes,


### PR DESCRIPTION
## 目的

OpenCode stream が一部の plan ステップで `OpenCode stream tracking limit exceeded: sensitive_sources` により異常終了していた問題を修正します。

## 原因

`handleToolPartUpdated` が参照の不一致 (`!==`) で tool 入力の変更有無を判定し、入力が変わるたびに `sensitiveSources.add()` を呼んでいました。OpenCode は tool 入力を細粒度な `message.part.updated` event で增量送信し、毎回新しいオブジェクト参照を渡すため、同一 tool call でも 256 回 (`MAX_TRACKED_SENSITIVE_SOURCES`) を超えると stream 全体が ABORT されていました。

## 修正

tool call ごとに初回観測時だけ `sensitiveSources.add()` を呼ぶように変更しました。`startedTools` Set で tool を既知か判定し、未知の tool のときだけ収集します。

## テスト

`does not exhaust sensitive source tracking when the same tool input is updated repeatedly` を追加。同一 tool ID に対し 266 回（上限 256 + 10）の入力更新 event を流しても `sensitive_sources` で失敗しないことを検証します。

既存の `fails an attempt when sensitive source tracking is exhausted` テスト（257 個のユニーク tool で上限到達を検証）も引き続き通過します。

## 関連

- #1183 は別のガード (`event_count`) に関する issue で、今回の修正とは独立しています


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 同じツールから入力更新を繰り返し受信した場合でも、機密情報源の追跡エラーを発生させず、セッションを正常に完了できるようになりました。

* **テスト**
  * 複数回のツール入力更新後に、セッションが正常終了することを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->