### PR TITLE
fix: exclude content deltas from the structural event-count limit

### DIFF
--- a/src/__tests__/opencode-stream-handler.test.ts
+++ b/src/__tests__/opencode-stream-handler.test.ts
@@ -815,6 +815,34 @@ describe('trackOpenCodeStreamEvent', () => {
     expect(trackOpenCodeStreamEvent(state, event)).toBe(false);
     expect(state.exhausted).toBe(true);
   });
+
+  it('does not count message.part.delta toward the structural event limit', () => {
+    const state = createStreamTrackingState();
+    const deltaEvent: OpenCodeStreamEvent = {
+      type: 'message.part.delta',
+      properties: { sessionID: 'session-1', partID: 'part-1', field: 'text', delta: 'x' },
+    };
+    for (let index = 0; index < OPENCODE_STREAM_EVENT_LIMIT + 100; index += 1) {
+      expect(trackOpenCodeStreamEvent(state, deltaEvent)).toBe(true);
+    }
+    expect(state.exhausted).toBe(false);
+    expect(state.eventCount).toBe(0);
+  });
+
+  it('does not count message.part.updated toward the structural event limit', () => {
+    const state = createStreamTrackingState();
+    const partUpdatedEvent: OpenCodeStreamEvent = {
+      type: 'message.part.updated',
+      properties: {
+        part: { id: 'part-1', sessionID: 'session-1', type: 'text', text: 'x' },
+      },
+    };
+    for (let index = 0; index < OPENCODE_STREAM_EVENT_LIMIT + 100; index += 1) {
+      expect(trackOpenCodeStreamEvent(state, partUpdatedEvent)).toBe(true);
+    }
+    expect(state.exhausted).toBe(false);
+    expect(state.eventCount).toBe(0);
+  });
 });
 
 describe('trackOpenCodeTextBytes', () => {

--- a/src/infra/opencode/OpenCodeStreamHandler.ts
+++ b/src/infra/opencode/OpenCodeStreamHandler.ts
@@ -274,10 +274,12 @@ export function trackOpenCodeStreamEvent(
   if (state.exhausted) {
     return false;
   }
-  state.eventCount += 1;
-  if (state.eventCount > OPENCODE_STREAM_EVENT_LIMIT) {
-    exhaustStreamTrackingState(state, 'event_count');
-    return false;
+  if (event.type !== 'message.part.delta' && event.type !== 'message.part.updated') {
+    state.eventCount += 1;
+    if (state.eventCount > OPENCODE_STREAM_EVENT_LIMIT) {
+      exhaustStreamTrackingState(state, 'event_count');
+      return false;
+    }
   }
   if (event.type === 'message.part.updated') {
     const part = event.properties['part'] as OpenCodePart;


### PR DESCRIPTION
## 目的

#1183 の対応です。OpenCode プロバイダーで推論量の多いエージェント処理を実行すると `OpenCode stream tracking limit exceeded: event_count` で stream が中断される問題を修正します。

## 原因

`trackOpenCodeStreamEvent` がすべての event を同一の `eventCount` に加算し、10,000 件を超えると stream 全体を ABORT していました。`message.part.delta` と `message.part.updated` は content delta（text・reasoning・tool 入力）を運ぶ event で、プロバイダーの分割粒度に依存して数万件に達することがあります。deepseek-v4-flash は推論を非常に細かい delta として送るため、約 37,000 文字の推論で 10,000 件を超える event が発生し、正常な応答が拒否されていました。

## 修正

`message.part.delta` と `message.part.updated` を `eventCount` の加算対象から除外しました。これらは content delta であり、構造 event の反復ループとは性質が異なります。構造 event（`session.status`, `permission.asked`, `message.updated` 等）だけが `OPENCODE_STREAM_EVENT_LIMIT` (10,000) を消費します。

content の異常増加は既存の別ガードで保護します:
- text: `text_bytes` (64KB)
- tool: `tracked_id_count` (1,024 IDs) および `sensitive_sources` (256 sources)

## テスト

`trackOpenCodeStreamEvent` describe block に2つの回帰テストを追加:
- `message.part.delta` が event_count を消費しないこと（10,100 件流しても exhausted にならない）
- `message.part.updated` が event_count を消費しないこと（同上）

既存の構造 event flood テスト（`session.idle` で 10,001 件 → 失敗）はそのまま維持され、通過します。

## 関連

- Closes #1183
- #1184 は別のガード（`sensitive_sources`）の修正で、本 PR とは独立しています


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * メッセージ内容の差分・更新イベントがイベント数の上限に誤ってカウントされないよう修正しました。
  * 上限到達後も、対象イベントの処理が継続されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->