### PR TITLE
feat: Finding Contractのmanager/adjudicatorをワークフローから構成可能にする

### DIFF
--- a/builtins/en/facets/instructions/adjudicate-finding-contract.md
+++ b/builtins/en/facets/instructions/adjudicate-finding-contract.md
@@ -1,0 +1,7 @@
+# Finding Contract adjudication
+
+Judge only the supplied ledger subject and the engine-issued proofs and scope bindings.
+
+Do not dismiss or terminate without claim-specific verified evidence or a matching scope binding. Choose the undetermined outcome when evidence does not correspond byte-for-byte to the candidate, when the scope differs, or when the result cannot be determined.
+
+Do not perform a new review, edit code, or invent evidence, authority, or findings. Do not treat reviewer or coder confidence, or their silence, as evidence.

--- a/builtins/en/workflows/takt-default-fc.yaml
+++ b/builtins/en/workflows/takt-default-fc.yaml
@@ -5,6 +5,9 @@ finding_contract:
     persona: findings-manager
     instruction: findings-manager
     output_contract: findings-manager
+  adjudicator:
+    persona: supervisor
+    instruction: adjudicate-finding-contract
   stop_budget:
     max_rounds: 40
   review_budget:

--- a/builtins/ja/facets/instructions/adjudicate-finding-contract.md
+++ b/builtins/ja/facets/instructions/adjudicate-finding-contract.md
@@ -1,0 +1,7 @@
+# Finding Contract adjudication
+
+与えられた1件の ledger subject と、エンジンが発行した proof および scope binding だけを判断してください。
+
+claim 固有の検証済み evidence または適合する scope binding がない dismiss / terminate は認めません。evidence が候補に byte-exact で対応しない場合、scope が異なる場合、または判断できない場合は未確定を選んでください。
+
+新しいレビュー、コード編集、evidence・authority・finding の作成は行わないでください。reviewer や coder の確信度、または沈黙を evidence として扱わないでください。

--- a/builtins/ja/workflows/takt-default-fc.yaml
+++ b/builtins/ja/workflows/takt-default-fc.yaml
@@ -5,6 +5,9 @@ finding_contract:
     persona: findings-manager
     instruction: findings-manager
     output_contract: findings-manager
+  adjudicator:
+    persona: supervisor
+    instruction: adjudicate-finding-contract
   stop_budget:
     max_rounds: 40
   review_budget:

--- a/docs/builtin-catalog.ja.md
+++ b/docs/builtin-catalog.ja.md
@@ -150,7 +150,7 @@ finding_contract:
     model: <strong-model>
 ```
 
-実装上の優先順は、CLI/環境変数の明示 override → 実行時にマッチした promotion → step の provider/model（この直接指定を含む）→ `workflow_call` override → `provider_routing` の step/tag/persona → deprecated の `persona_providers` → auto routing → workflow → project → global → provider default です。`provider` だけを直接指定すると、下位優先度の model fallback は停止します。
+実装上、provider と model はフィールドごとに、CLI/環境変数の明示 override → 実行時にマッチした promotion（通常の agent step のみ）→ step または parallel sub-step の provider/model（この直接指定を含む）→ `workflow_call` override → `provider_routing` の step/tag/persona → deprecated の `persona_providers` → auto routing → workflow → project → global → provider default の順で解決されます。parallel sub-step は promotion をサポートしないため、その場合は CLI/環境変数の明示 override の次に sub-step の直接指定が優先されます。`provider` だけを直接指定すると、下位優先度の model fallback は停止します。
 
 `takt` を実行すると workflow をインタラクティブに選択できます。
 

--- a/docs/builtin-catalog.ja.md
+++ b/docs/builtin-catalog.ja.md
@@ -150,7 +150,7 @@ finding_contract:
     model: <strong-model>
 ```
 
-直接指定は `provider_routing`、deprecated の `persona_providers`、auto routing、workflow/project/global fallback より優先されます。CLI と環境変数の明示 override はさらに優先されます。`provider` だけを直接指定すると、下位優先度の model fallback は停止します。
+実装上の優先順は、CLI/環境変数の明示 override → 実行時にマッチした promotion → step の provider/model（この直接指定を含む）→ `workflow_call` override → `provider_routing` の step/tag/persona → deprecated の `persona_providers` → auto routing → workflow → project → global → provider default です。`provider` だけを直接指定すると、下位優先度の model fallback は停止します。
 
 `takt` を実行すると workflow をインタラクティブに選択できます。
 

--- a/docs/builtin-catalog.ja.md
+++ b/docs/builtin-catalog.ja.md
@@ -133,6 +133,25 @@ provider_routing:
 
 `final-gate` タグは `review` より後に適用されるため、通常レビューをローカルに保ったまま final gate を強いモデルへ戻せます。Finding Manager は `findings-manager`、loop judge は judge の persona 設定にかかわらず固定キー `loop-judge`、現行エンジンが自動導出する adjudicator は `supervisor` の persona routing を使います。`loop-judge` の routing がない場合、loop judge は cycle を発火させた step の解決済み provider/model を引き継ぎます。
 
+特定の custom workflow で Finding Manager と adjudicator を完全に固定する場合は、workflow YAML に直接指定できます。
+
+```yaml
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+    provider: codex
+    model: <strong-model>
+  adjudicator:
+    persona: supervisor
+    instruction: adjudicate-finding-contract
+    provider: codex
+    model: <strong-model>
+```
+
+直接指定は `provider_routing`、deprecated の `persona_providers`、auto routing、workflow/project/global fallback より優先されます。CLI と環境変数の明示 override はさらに優先されます。`provider` だけを直接指定すると、下位優先度の model fallback は停止します。
+
 `takt` を実行すると workflow をインタラクティブに選択できます。
 
 ## ビルトイン Persona 一覧

--- a/docs/builtin-catalog.md
+++ b/docs/builtin-catalog.md
@@ -133,6 +133,25 @@ provider_routing:
 
 The `final-gate` tag is applied after `review`, so final-gate steps return to the strong model while regular reviews remain local. The Finding Manager uses `findings-manager`; loop judges use the fixed `loop-judge` routing key regardless of the configured judge persona; and the adjudicator automatically derived by the current engine uses `supervisor`. Without a `loop-judge` route, a loop judge inherits the resolved provider and model of the step that triggered the cycle.
 
+To pin the Finding Manager and adjudicator for one custom workflow, specify them directly in the workflow YAML.
+
+```yaml
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+    provider: codex
+    model: <strong-model>
+  adjudicator:
+    persona: supervisor
+    instruction: adjudicate-finding-contract
+    provider: codex
+    model: <strong-model>
+```
+
+Direct values override `provider_routing`, deprecated `persona_providers`, auto routing, and workflow/project/global fallbacks. Explicit CLI and environment overrides remain higher priority. Specifying only `provider` stops lower-priority model fallback.
+
 Run `takt` to choose a workflow interactively.
 
 ## Builtin Personas

--- a/docs/builtin-catalog.md
+++ b/docs/builtin-catalog.md
@@ -150,7 +150,7 @@ finding_contract:
     model: <strong-model>
 ```
 
-The implementation order is explicit CLI/environment override → promotion matching the current execution → step provider/model (including these direct values) → `workflow_call` override → `provider_routing` step/tag/persona → deprecated `persona_providers` → auto routing → workflow → project → global → provider default. Specifying only `provider` stops lower-priority model fallback.
+At runtime, provider and model are resolved field by field in this order: explicit CLI/environment override → promotion matching the current execution (normal agent steps only) → step or parallel sub-step provider/model (including these direct values) → `workflow_call` override → `provider_routing` step/tag/persona → deprecated `persona_providers` → auto routing → workflow → project → global → provider default. Parallel sub-steps do not support promotion, so their direct values come immediately after an explicit CLI/environment override. Specifying only `provider` stops lower-priority model fallback.
 
 Run `takt` to choose a workflow interactively.
 

--- a/docs/builtin-catalog.md
+++ b/docs/builtin-catalog.md
@@ -150,7 +150,7 @@ finding_contract:
     model: <strong-model>
 ```
 
-Direct values override `provider_routing`, deprecated `persona_providers`, auto routing, and workflow/project/global fallbacks. Explicit CLI and environment overrides remain higher priority. Specifying only `provider` stops lower-priority model fallback.
+The implementation order is explicit CLI/environment override → promotion matching the current execution → step provider/model (including these direct values) → `workflow_call` override → `provider_routing` step/tag/persona → deprecated `persona_providers` → auto routing → workflow → project → global → provider default. Specifying only `provider` stops lower-priority model fallback.
 
 Run `takt` to choose a workflow interactively.
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -471,7 +471,7 @@ kiro_cli_path: /usr/local/bin/kiro-cli
 
 provider と model の選択には、[Provider Routing](#provider-routing) に記載した単一のフィールド別優先順位を使用します。同じ契約が通常 step、parallel sub-step、合成 step、workflow call に適用されます。
 
-Finding Contract workflow では、`finding_contract.manager.provider` / `model` と `finding_contract.adjudicator.provider` / `model` は、それぞれの合成 step の step レベル provider/model として扱われます。`provider_routing`、deprecated の `persona_providers`、auto routing、workflow/project/global の既定値より優先されますが、CLI と環境変数の明示 override はさらに高い優先順位を維持します。両方とも未指定の場合は通常の workflow step と同じ fallback chain を使います。`provider` だけを指定すると下位優先度の model fallback は停止し、明示 model が必須の provider では検証エラーになります。
+Finding Contract workflow では、`finding_contract.manager.provider` / `model` と `finding_contract.adjudicator.provider` / `model` は、それぞれの合成 step の step レベル provider/model として扱われます。実装上のフィールド別優先順は、CLI/環境変数の明示 override → 実行時にマッチした promotion → step の provider/model（これらの直接指定を含む）→ `workflow_call` override → `provider_routing` の step/tag/persona → deprecated の `persona_providers` → auto routing → workflow → project → global → provider default です。両方とも未指定の場合は通常の workflow step と同じ fallback chain を使います。`provider` だけを指定すると下位優先度の model fallback は停止し、明示 model が必須の provider では検証エラーになります。
 
 ```yaml
 finding_contract:

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -471,7 +471,22 @@ kiro_cli_path: /usr/local/bin/kiro-cli
 
 provider と model の選択には、[Provider Routing](#provider-routing) に記載した単一のフィールド別優先順位を使用します。同じ契約が通常 step、parallel sub-step、合成 step、workflow call に適用されます。
 
-Finding Contract workflow では、`finding_contract.manager.provider` と `finding_contract.manager.model` は合成 `findings-manager` step の step レベル provider/model として扱われます。`provider_routing`、deprecated の `persona_providers.findings-manager`、auto routing、workflow/project/global の既定値より優先されますが、CLI と環境変数の明示 override はさらに高い優先順位を維持します。両方とも未指定の場合、manager は通常の workflow step と同じ fallback chain を使います。`provider` だけを指定すると、下位優先度の model fallback は停止し、選択した provider 自身のデフォルトを使います。明示 model が必須の provider では検証エラーになります。
+Finding Contract workflow では、`finding_contract.manager.provider` / `model` と `finding_contract.adjudicator.provider` / `model` は、それぞれの合成 step の step レベル provider/model として扱われます。`provider_routing`、deprecated の `persona_providers`、auto routing、workflow/project/global の既定値より優先されますが、CLI と環境変数の明示 override はさらに高い優先順位を維持します。両方とも未指定の場合は通常の workflow step と同じ fallback chain を使います。`provider` だけを指定すると下位優先度の model fallback は停止し、明示 model が必須の provider では検証エラーになります。
+
+```yaml
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+    provider: codex
+    model: <strong-model>
+  adjudicator:
+    persona: supervisor
+    instruction: adjudicate-finding-contract
+    provider: codex
+    model: <strong-model>
+```
 
 workflow YAML では、通常 step、parallel sub-step、`loop_monitors.judge` の `model: null` は model の明示的な省略を表します。`model` 未指定とは異なります。未指定の場合は routing、workflow、loop monitor judge のトリガー元 step、入力由来の値など、適用可能な下位優先度のソースへフォールバックしますが、`model: null` はその entry で model 解決を止め、実効 model を未定義のままにします。解決済み provider に CLI または provider 側のデフォルトを使わせたい場合に指定します。明示 model が必須の provider では、model が供給されないため検証エラーになります。
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -469,9 +469,9 @@ kiro_cli_path: /usr/local/bin/kiro-cli
 
 ## モデル解決
 
-provider と model の選択には、[Provider Routing](#provider-routing) に記載した単一のフィールド別優先順位を使用します。同じ契約が通常 step、parallel sub-step、合成 step、workflow call に適用されます。
+provider と model の選択には、[Provider Routing](#provider-routing) に記載した単一のフィールド別優先順位を使用します。通常 step、parallel sub-step、合成 step、workflow call は、各種類で利用可能なレイヤーについて同じ契約に従います。parallel sub-step は promotion をサポートしません。
 
-Finding Contract workflow では、`finding_contract.manager.provider` / `model` と `finding_contract.adjudicator.provider` / `model` は、それぞれの合成 step の step レベル provider/model として扱われます。実装上のフィールド別優先順は、CLI/環境変数の明示 override → 実行時にマッチした promotion → step の provider/model（これらの直接指定を含む）→ `workflow_call` override → `provider_routing` の step/tag/persona → deprecated の `persona_providers` → auto routing → workflow → project → global → provider default です。両方とも未指定の場合は通常の workflow step と同じ fallback chain を使います。`provider` だけを指定すると下位優先度の model fallback は停止し、明示 model が必須の provider では検証エラーになります。
+Finding Contract workflow では、`finding_contract.manager.provider` / `model` と `finding_contract.adjudicator.provider` / `model` は、それぞれの合成 step の step レベル provider/model として扱われます。実装上のフィールド別優先順は、CLI/環境変数の明示 override → 実行時にマッチした promotion（通常の agent step のみ）→ step または parallel sub-step の provider/model（これらの直接指定を含む）→ `workflow_call` override → `provider_routing` の step/tag/persona → deprecated の `persona_providers` → auto routing → workflow → project → global → provider default です。両方とも未指定の場合は通常の workflow step と同じ fallback chain を使います。`provider` だけを指定すると下位優先度の model fallback は停止し、明示 model が必須の provider では検証エラーになります。
 
 ```yaml
 finding_contract:
@@ -750,7 +750,7 @@ workflow step での `provider` / `model` の完全な優先順位は次のと�
 
 ```text
 CLI / 環境変数の明示 override
-> 有効な promotion
+> 有効な promotion（通常の agent step のみ。parallel sub-step では非対応）
 > step または parallel sub-step YAML provider/model
 > workflow_call override
 > provider_routing.steps.<step.name>
@@ -766,7 +766,7 @@ CLI / 環境変数の明示 override
 
 provider と model は各レイヤーで個別に解決されます。provider だけの override によって、より高い優先順位の model override が失われることはありません。
 
-「有効な promotion」とは、step の `promotion` エントリのうち、実行回数条件（`at: <N>`）または `ai()` 条件が現在の実行にマッチしたものを指します。[Step レベルのプロバイダープロモーション](./workflows.ja.md#step-レベルのプロバイダープロモーション)を参照してください。
+「有効な promotion」とは、通常の agent step の `promotion` エントリのうち、実行回数条件（`at: <N>`）または `ai()` 条件が現在の実行にマッチしたものを指します。parallel sub-step では promotion を指定できないため、CLI/環境変数の明示 override の次に sub-step YAML の provider/model が優先されます。[Step レベルのプロバイダープロモーション](./workflows.ja.md#step-レベルのプロバイダープロモーション)を参照してください。
 
 Finding Contract manager では、`finding_contract.manager.provider` と `finding_contract.manager.model` が合成 `findings-manager` step の `step YAML provider/model` 位置に入ります。
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -471,9 +471,9 @@ Paths must be absolute paths to executable files. Environment variables take pre
 
 ## Model Resolution
 
-Provider and model selection uses the single, field-by-field precedence contract documented under [Provider Routing](#provider-routing). The same contract applies to normal steps, parallel sub-steps, synthetic steps, and workflow calls.
+Provider and model selection uses the single, field-by-field precedence contract documented under [Provider Routing](#provider-routing). Normal steps, parallel sub-steps, synthetic steps, and workflow calls follow that contract for the layers available to each kind. Parallel sub-steps do not support promotion.
 
-For Finding Contract workflows, `finding_contract.manager.provider` / `model` and `finding_contract.adjudicator.provider` / `model` are treated as step-level values for their synthetic steps. The implementation's field-by-field order is explicit CLI/environment override → promotion matching the current execution → step provider/model (including these direct values) → `workflow_call` override → `provider_routing` step/tag/persona → deprecated `persona_providers` → auto routing → workflow → project → global → provider default. When neither field is set, the role uses the normal workflow-step fallback chain. Setting only `provider` stops lower-priority model fallback; providers that require an explicit model fail validation.
+For Finding Contract workflows, `finding_contract.manager.provider` / `model` and `finding_contract.adjudicator.provider` / `model` are treated as step-level values for their synthetic steps. The implementation's field-by-field order is explicit CLI/environment override → promotion matching the current execution (normal agent steps only) → step or parallel sub-step provider/model (including these direct values) → `workflow_call` override → `provider_routing` step/tag/persona → deprecated `persona_providers` → auto routing → workflow → project → global → provider default. When neither field is set, the role uses the normal workflow-step fallback chain. Setting only `provider` stops lower-priority model fallback; providers that require an explicit model fail validation.
 
 ```yaml
 finding_contract:
@@ -752,7 +752,7 @@ For `provider` / `model`, the complete workflow-step resolution priority is:
 
 ```text
 explicit CLI / environment override
-> active promotion
+> active promotion (normal agent steps only; unsupported on parallel sub-steps)
 > step or parallel sub-step YAML provider/model
 > workflow_call override
 > provider_routing.steps.<step.name>
@@ -768,7 +768,7 @@ explicit CLI / environment override
 
 Provider and model are resolved independently at each layer. A provider-only override does not displace a higher-priority model override.
 
-`active promotion` means a step `promotion` entry whose execution-count (`at: <N>`) or `ai()` condition matched for the current execution; see [Step-level Provider Promotion](./workflows.md#step-level-provider-promotion).
+`active promotion` means a normal agent step `promotion` entry whose execution-count (`at: <N>`) or `ai()` condition matched for the current execution. Parallel sub-steps cannot specify promotion, so their YAML provider/model follows an explicit CLI/environment override directly; see [Step-level Provider Promotion](./workflows.md#step-level-provider-promotion).
 
 For the Finding Contract manager, `finding_contract.manager.provider` and `finding_contract.manager.model` occupy the `step YAML provider/model` position for the synthetic `findings-manager` step.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -473,7 +473,7 @@ Paths must be absolute paths to executable files. Environment variables take pre
 
 Provider and model selection uses the single, field-by-field precedence contract documented under [Provider Routing](#provider-routing). The same contract applies to normal steps, parallel sub-steps, synthetic steps, and workflow calls.
 
-For Finding Contract workflows, `finding_contract.manager.provider` / `model` and `finding_contract.adjudicator.provider` / `model` are treated as step-level values for their synthetic steps. They override `provider_routing`, deprecated `persona_providers`, auto routing, and workflow/project/global defaults, while explicit CLI and environment overrides remain higher priority. When neither field is set, the role uses the normal workflow-step fallback chain. Setting only `provider` stops lower-priority model fallback; providers that require an explicit model fail validation.
+For Finding Contract workflows, `finding_contract.manager.provider` / `model` and `finding_contract.adjudicator.provider` / `model` are treated as step-level values for their synthetic steps. The implementation's field-by-field order is explicit CLI/environment override → promotion matching the current execution → step provider/model (including these direct values) → `workflow_call` override → `provider_routing` step/tag/persona → deprecated `persona_providers` → auto routing → workflow → project → global → provider default. When neither field is set, the role uses the normal workflow-step fallback chain. Setting only `provider` stops lower-priority model fallback; providers that require an explicit model fail validation.
 
 ```yaml
 finding_contract:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -473,7 +473,22 @@ Paths must be absolute paths to executable files. Environment variables take pre
 
 Provider and model selection uses the single, field-by-field precedence contract documented under [Provider Routing](#provider-routing). The same contract applies to normal steps, parallel sub-steps, synthetic steps, and workflow calls.
 
-For Finding Contract workflows, `finding_contract.manager.provider` and `finding_contract.manager.model` are treated as step-level provider/model values for the synthetic `findings-manager` step. They override `provider_routing`, deprecated `persona_providers.findings-manager`, auto routing, and workflow/project/global defaults, while explicit CLI and environment overrides remain higher priority. When neither field is set, the manager uses the same fallback chain as any other workflow step. Setting only `provider` stops lower-priority model fallback, so the selected provider uses its own default; providers that require an explicit model fail validation.
+For Finding Contract workflows, `finding_contract.manager.provider` / `model` and `finding_contract.adjudicator.provider` / `model` are treated as step-level values for their synthetic steps. They override `provider_routing`, deprecated `persona_providers`, auto routing, and workflow/project/global defaults, while explicit CLI and environment overrides remain higher priority. When neither field is set, the role uses the normal workflow-step fallback chain. Setting only `provider` stops lower-priority model fallback; providers that require an explicit model fail validation.
+
+```yaml
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+    provider: codex
+    model: <strong-model>
+  adjudicator:
+    persona: supervisor
+    instruction: adjudicate-finding-contract
+    provider: codex
+    model: <strong-model>
+```
 
 In workflow YAML, `model: null` is an explicit model omission for a normal step, parallel sub-step, or `loop_monitors.judge`. It differs from leaving `model` unspecified: an unspecified model continues to applicable lower-priority sources such as routing, workflow, the triggering step for loop monitor judges, and input sources, while `model: null` stops model resolution at that entry and leaves the effective model undefined. Use it when the resolved provider should use its own CLI or provider default instead of inheriting another model source. Providers that require an explicit model still fail validation when no model is supplied.
 

--- a/src/__tests__/engine-workflow-call.test.ts
+++ b/src/__tests__/engine-workflow-call.test.ts
@@ -37,7 +37,7 @@ import { WorkflowCallRunner } from '../core/workflow/engine/WorkflowCallRunner.j
 import {
   applyWorkflowCallOverridesToPersonaProviders,
   applyWorkflowCallOverridesToProviderRouting,
-} from '../core/workflow/engine/WorkflowCallExecutor.js';
+} from '../core/workflow/workflow-call-provider-context.js';
 import {
   applyDefaultMocks,
   cleanupWorkflowEngine,

--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -155,7 +155,10 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     rmSync(cwd, { recursive: true, force: true });
   });
 
-  function runner() {
+  function runner(
+    guidance?: string,
+    store: FindingLedgerStore = ledgerStore,
+  ) {
     const step = buildFindingConflictAdjudicationStep({
       contract: contract(cwd),
       workflowProvider: 'claude',
@@ -163,7 +166,7 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     return {
       step,
       runner: createFindingConflictAdjudicationRunner({
-        ledgerStore,
+        ledgerStore: store,
         optionsBuilder: {
           buildAgentOptions: () => ({ provider: 'claude', cwd }),
           resolveStepProviderModel: () => ({ provider: 'claude', providerSource: 'workflow' }),
@@ -179,8 +182,41 @@ describe('finding-conflict-adjudication runner registry contract', () => {
         runId: 'run-1',
         refreshFindingsState: () => {},
         emitEvent: () => {},
+        guidance,
       }),
     };
+  }
+
+  function reopenStore(): FindingLedgerStore {
+    return createTestFindingLedgerStore({
+      projectCwd: cwd,
+      runId: 'run-1',
+      reportDir: join(cwd, '.takt', 'runs', 'run-1', 'reports'),
+      workflowName: 'runner-test',
+    });
+  }
+
+  function crashAfterConflictReservation(store: FindingLedgerStore): FindingLedgerStore {
+    let crashed = false;
+    return new Proxy(store, {
+      get(target, property, receiver) {
+        if (property === 'updateLedger') {
+          return async (...args: Parameters<FindingLedgerStore['updateLedger']>) => {
+            const mutation = await target.updateLedger(...args);
+            const hasReservation = mutation.ledger.findingManagerProviderCalls.some((call) => (
+              call.purpose === 'conflict_adjudication' && call.state === 'reserved'
+            ));
+            if (!crashed && hasReservation) {
+              crashed = true;
+              throw new Error('simulated crash after conflict WAL reservation');
+            }
+            return mutation;
+          };
+        }
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
   }
 
   it('records undetermined output in snapshots, episodes, attempts, and provider calls', async () => {
@@ -220,6 +256,33 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(ledger.findingManagerProviderCalls).toEqual([
       expect.objectContaining({ state: 'settled', purpose: 'conflict_adjudication' }),
     ]);
+  });
+
+  it('places configured guidance once before the engine-owned conflict instruction', async () => {
+    const snapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'undetermined',
+          subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+          rationale: 'No verified terminal authority is available.',
+        },
+      },
+      timestamp: new Date(),
+    });
+    const target = runner('Use only exact conflict evidence.');
+
+    await target.runner.run(target.step, state());
+
+    const prompt = executeAgentMock.mock.calls[0]?.[1];
+    expect(prompt).toContain('Use only exact conflict evidence.\n\n---\n\nAdjudicate the durable finding conflict snapshot below.');
+    expect(prompt?.match(/Use only exact conflict evidence\./g)).toHaveLength(1);
   });
 
   it('stores malformed output as a diagnostic attempt without a legacy adjudication record', async () => {
@@ -308,5 +371,123 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       }),
     ]);
     expect(applied.conflicts[0]).not.toHaveProperty('adjudications');
+  });
+
+  it('resumes the same real conflict WAL reservation after reopening the store', async () => {
+    const guidance = 'Use the configured conflict policy.';
+    const crashingTarget = runner(guidance, crashAfterConflictReservation(ledgerStore));
+    await expect(crashingTarget.runner.run(crashingTarget.step, state()))
+      .rejects.toThrow('simulated crash after conflict WAL reservation');
+    const reserved = ledgerStore.loadLedger().findingManagerProviderCalls[0]!;
+    expect(reserved.state).toBe('reserved');
+
+    ledgerStore = reopenStore();
+    const snapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'undetermined',
+          subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+          rationale: 'No authority.',
+        },
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+    const resumedTarget = runner(guidance, ledgerStore);
+    await resumedTarget.runner.run(resumedTarget.step, state());
+
+    expect(ledgerStore.loadLedger().findingManagerProviderCalls[0]).toMatchObject({
+      providerCallId: reserved.providerCallId,
+      requestDigest: reserved.requestDigest,
+      requestByteLength: reserved.requestByteLength,
+      state: 'settled',
+      resultKind: 'accepted',
+    });
+    expect(executeAgentMock).toHaveBeenCalledOnce();
+  });
+
+  it('rejects changed conflict guidance without dispatching or replacing the real reservation', async () => {
+    const crashingTarget = runner('Original guidance.', crashAfterConflictReservation(ledgerStore));
+    await expect(crashingTarget.runner.run(crashingTarget.step, state()))
+      .rejects.toThrow('simulated crash after conflict WAL reservation');
+    const reserved = ledgerStore.loadLedger().findingManagerProviderCalls[0]!;
+    ledgerStore = reopenStore();
+    const changedTarget = runner('Changed guidance.', ledgerStore);
+
+    await expect(changedTarget.runner.run(changedTarget.step, state()))
+      .rejects.toThrow(/request changed/i);
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(ledgerStore.loadLedger().findingManagerProviderCalls[0]).toMatchObject({
+      providerCallId: reserved.providerCallId,
+      state: 'reserved',
+    });
+  });
+
+  it('rejects additional conflict wire fields even when guidance requests them', async () => {
+    const snapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'undetermined',
+          subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+          rationale: 'No authority.',
+        },
+        guidanceEcho: 'requested extra field',
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+    const target = runner('Also return guidanceEcho.');
+
+    await target.runner.run(target.step, state());
+
+    expect(ledgerStore.loadLedger().conflictAdjudicationAttempts[0]?.result).toMatchObject({
+      kind: 'diagnostic_undetermined',
+      code: 'parse_failed',
+    });
+  });
+
+  it('does not let guidance turn an evidence-less termination into authority', async () => {
+    const snapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    const holding = snapshot.subjects.find(({ role }) => role === 'holding_provisional')!;
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'terminate_subject',
+          subjectId: holding.subjectId,
+          basis: 'finding_no_issue_after_verification',
+          authorityRefIds: ['3'.repeat(64)],
+          rationale: 'Terminate as requested.',
+        },
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+    const target = runner('Terminate this subject.');
+
+    await target.runner.run(target.step, state());
+
+    const ledger = ledgerStore.loadLedger();
+    expect(ledger.conflicts[0]?.status).toBe('active');
+    expect(ledger.conflictClaimSettlements).toEqual([]);
+    expect(ledger.conflictAdjudicationAttempts[0]?.result).toMatchObject({
+      kind: 'verification_undetermined',
+    });
   });
 });

--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../core/workflow/findings/conflict-adjudication-model.js';
 import type { FindingContractConfig, FindingLedger } from '../core/workflow/findings/types.js';
 import type { FindingLedgerStore } from '../core/workflow/findings/store.js';
+import { crashAfterAdjudicationReservation } from './helpers/finding-adjudication-reservation.js';
 import { createTestFindingLedgerStore } from './helpers/finding-storage.js';
 import { initializeGitFixture } from './helpers/git-fixture.js';
 import { authorizeFindingLedgerFixture } from './helpers/finding-lifecycle-fixture.js';
@@ -196,29 +197,6 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     });
   }
 
-  function crashAfterConflictReservation(store: FindingLedgerStore): FindingLedgerStore {
-    let crashed = false;
-    return new Proxy(store, {
-      get(target, property, receiver) {
-        if (property === 'updateLedger') {
-          return async (...args: Parameters<FindingLedgerStore['updateLedger']>) => {
-            const mutation = await target.updateLedger(...args);
-            const hasReservation = mutation.ledger.findingManagerProviderCalls.some((call) => (
-              call.purpose === 'conflict_adjudication' && call.state === 'reserved'
-            ));
-            if (!crashed && hasReservation) {
-              crashed = true;
-              throw new Error('simulated crash after conflict WAL reservation');
-            }
-            return mutation;
-          };
-        }
-        const value = Reflect.get(target, property, receiver) as unknown;
-        return typeof value === 'function' ? value.bind(target) : value;
-      },
-    });
-  }
-
   it('records undetermined output in snapshots, episodes, attempts, and provider calls', async () => {
     const snapshot = freshConflictAdjudicationSnapshot(
       ledgerStore.loadLedger(),
@@ -375,7 +353,12 @@ describe('finding-conflict-adjudication runner registry contract', () => {
 
   it('resumes the same real conflict WAL reservation after reopening the store', async () => {
     const guidance = 'Use the configured conflict policy.';
-    const crashingTarget = runner(guidance, crashAfterConflictReservation(ledgerStore));
+    const crashingStore = crashAfterAdjudicationReservation({
+      store: ledgerStore,
+      purpose: 'conflict_adjudication',
+      errorMessage: 'simulated crash after conflict WAL reservation',
+    });
+    const crashingTarget = runner(guidance, crashingStore);
     await expect(crashingTarget.runner.run(crashingTarget.step, state()))
       .rejects.toThrow('simulated crash after conflict WAL reservation');
     const reserved = ledgerStore.loadLedger().findingManagerProviderCalls[0]!;
@@ -413,7 +396,12 @@ describe('finding-conflict-adjudication runner registry contract', () => {
   });
 
   it('rejects changed conflict guidance without dispatching or replacing the real reservation', async () => {
-    const crashingTarget = runner('Original guidance.', crashAfterConflictReservation(ledgerStore));
+    const crashingStore = crashAfterAdjudicationReservation({
+      store: ledgerStore,
+      purpose: 'conflict_adjudication',
+      errorMessage: 'simulated crash after conflict WAL reservation',
+    });
+    const crashingTarget = runner('Original guidance.', crashingStore);
     await expect(crashingTarget.runner.run(crashingTarget.step, state()))
       .rejects.toThrow('simulated crash after conflict WAL reservation');
     const reserved = ledgerStore.loadLedger().findingManagerProviderCalls[0]!;

--- a/src/__tests__/finding-contract-workflow-schema.test.ts
+++ b/src/__tests__/finding-contract-workflow-schema.test.ts
@@ -916,7 +916,7 @@ describe('workflow finding_contract schema', () => {
     },
   );
 
-  it('should preserve omitted manager additions and reject invalid addition/adjudicator shapes', () => {
+  it('should preserve omitted manager additions', () => {
     const normalized = normalizeWorkflowConfig(
       makeWorkflowWithFindingContract({
         manager: {
@@ -929,31 +929,101 @@ describe('workflow finding_contract schema', () => {
     );
     expect(normalized.findingContract?.manager).not.toHaveProperty('policyContents');
     expect(normalized.findingContract?.manager).not.toHaveProperty('knowledgeContents');
+  });
 
-    const manager = {
-      persona: 'findings-manager',
-      instruction: 'findings-manager',
-      output_contract: 'findings-manager',
-    };
-    const invalidContracts = [
-      { manager: { ...manager, policy: [] } },
-      { manager: { ...manager, policy: [''] } },
-      { manager: { ...manager, knowledge: [] } },
-      { manager: { ...manager, knowledge: [''] } },
-      { manager, adjudicator: {} },
-      { manager, adjudicator: { persona: 'supervisor' } },
-      { manager, adjudicator: { instruction: 'adjudicate' } },
-      { manager, adjudicator: { persona: '', instruction: 'adjudicate' } },
-      { manager, adjudicator: { persona: 'supervisor', instruction: '' } },
-      { manager, adjudicator: { persona: 'supervisor', instruction: 'adjudicate', provider: 'auto' } },
-      { manager, adjudicator: { persona: 'supervisor', instruction: 'adjudicate', output_contract: 'forbidden' } },
-    ];
-    for (const findingContract of invalidContracts) {
-      expect(() => normalizeWorkflowConfig(
-        makeWorkflowWithFindingContract(findingContract),
-        '/tmp/project',
-      )).toThrow();
-    }
+  const validManager = {
+    persona: 'findings-manager',
+    instruction: 'findings-manager',
+    output_contract: 'findings-manager',
+  };
+
+  it.each([
+    {
+      label: 'empty manager policy list',
+      findingContract: { manager: { ...validManager, policy: [] } },
+      expectedError: /policy/,
+    },
+    {
+      label: 'empty manager policy ref',
+      findingContract: { manager: { ...validManager, policy: [''] } },
+      expectedError: /policy/,
+    },
+    {
+      label: 'empty manager knowledge list',
+      findingContract: { manager: { ...validManager, knowledge: [] } },
+      expectedError: /knowledge/,
+    },
+    {
+      label: 'empty manager knowledge ref',
+      findingContract: { manager: { ...validManager, knowledge: [''] } },
+      expectedError: /knowledge/,
+    },
+    {
+      label: 'adjudicator without persona and instruction',
+      findingContract: { manager: validManager, adjudicator: {} },
+      expectedError: /adjudicator.*persona|persona.*adjudicator/s,
+    },
+    {
+      label: 'adjudicator without instruction',
+      findingContract: { manager: validManager, adjudicator: { persona: 'supervisor' } },
+      expectedError: /adjudicator.*instruction|instruction.*adjudicator/s,
+    },
+    {
+      label: 'adjudicator without persona',
+      findingContract: { manager: validManager, adjudicator: { instruction: 'adjudicate' } },
+      expectedError: /adjudicator.*persona|persona.*adjudicator/s,
+    },
+    {
+      label: 'empty adjudicator persona',
+      findingContract: { manager: validManager, adjudicator: { persona: '', instruction: 'adjudicate' } },
+      expectedError: /adjudicator.*persona|persona.*adjudicator/s,
+    },
+    {
+      label: 'empty adjudicator instruction',
+      findingContract: { manager: validManager, adjudicator: { persona: 'supervisor', instruction: '' } },
+      expectedError: /adjudicator.*instruction|instruction.*adjudicator/s,
+    },
+    {
+      label: 'unsupported adjudicator provider',
+      findingContract: {
+        manager: validManager,
+        adjudicator: { persona: 'supervisor', instruction: 'adjudicate', provider: 'auto' },
+      },
+      expectedError: /adjudicator.*provider|provider.*adjudicator/s,
+    },
+    {
+      label: 'adjudicator output contract',
+      findingContract: {
+        manager: validManager,
+        adjudicator: {
+          persona: 'supervisor',
+          instruction: 'adjudicate',
+          output_contract: 'forbidden',
+        },
+      },
+      expectedError: /output_contract|unrecognized/i,
+    },
+  ])('should reject $label at its schema field', ({ findingContract, expectedError }) => {
+    expect(() => normalizeWorkflowConfig(
+      makeWorkflowWithFindingContract(findingContract),
+      '/tmp/project',
+    )).toThrow(expectedError);
+  });
+
+  it('should omit an empty adjudicator persona routing key after trimming', () => {
+    const normalized = normalizeWorkflowConfig(
+      makeWorkflowWithFindingContract({
+        manager: validManager,
+        adjudicator: {
+          persona: '   ',
+          instruction: 'adjudicate',
+        },
+      }),
+      '/tmp/project',
+    );
+
+    expect(normalized.findingContract?.adjudicator)
+      .not.toHaveProperty('providerRoutingPersonaKey');
   });
 
   it('should reject unresolved additions and explicit adjudicator facets with field paths', () => {

--- a/src/__tests__/finding-contract-workflow-schema.test.ts
+++ b/src/__tests__/finding-contract-workflow-schema.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -627,6 +627,393 @@ describe('workflow finding_contract schema', () => {
         ],
       }, '/tmp/project'),
     ).toThrow();
+  });
+
+  it('should resolve manager additions and an explicit adjudicator through normal facet lookup', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'takt-finding-contract-additions-'));
+    try {
+      const projectDir = join(tempDir, 'project');
+      const workflowDir = join(projectDir, '.takt', 'workflows');
+      for (const kind of ['personas', 'instructions', 'output-contracts', 'policies', 'knowledge']) {
+        mkdirSync(join(projectDir, '.takt', 'facets', kind), { recursive: true });
+      }
+      mkdirSync(workflowDir, { recursive: true });
+      writeFileSync(join(projectDir, '.takt', 'facets', 'personas', 'findings-manager.md'), 'Manager persona');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'personas', 'terminal-supervisor.md'), 'Supervisor persona');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'instructions', 'findings-manager.md'), 'Manager instruction');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'instructions', 'adjudicate.md'), 'Adjudication guidance');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'output-contracts', 'findings-manager.md'), 'Manager output');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'policies', 'first.md'), 'First policy');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'policies', 'second.md'), 'Second policy');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'knowledge', 'domain.md'), 'Domain knowledge');
+
+      const workflow = normalizeWorkflowConfig({
+        name: 'finding-contract-additions',
+        finding_contract: {
+          manager: {
+            persona: 'findings-manager',
+            instruction: 'findings-manager',
+            output_contract: 'findings-manager',
+            policy: ['first', 'second'],
+            knowledge: ['domain'],
+          },
+          adjudicator: {
+            persona: 'terminal-supervisor',
+            instruction: 'adjudicate',
+            provider: 'codex',
+            model: 'gpt-test',
+          },
+        },
+        initial_step: 'review',
+        max_steps: 2,
+        steps: [{
+          name: 'review',
+          persona: 'reviewer',
+          instruction: 'Review.',
+          rules: [{ condition: 'done', next: 'COMPLETE' }],
+        }],
+      }, workflowDir, { projectDir, workflowDir, lang: 'ja' });
+
+      expect(workflow.findingContract?.manager.policyContents).toEqual(['First policy', 'Second policy']);
+      expect(workflow.findingContract?.manager.knowledgeContents).toEqual(['Domain knowledge']);
+      expect(workflow.findingContract?.adjudicator).toMatchObject({
+        persona: 'terminal-supervisor',
+        providerRoutingPersonaKey: 'terminal-supervisor',
+        instruction: 'Adjudication guidance',
+        provider: 'codex',
+        model: 'gpt-test',
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the same project facet override layer for ordinary steps and both finding-contract roles', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'takt-finding-contract-project-override-'));
+    try {
+      const projectDir = join(tempDir, 'project');
+      const workflowDir = join(projectDir, '.takt', 'workflows');
+      for (const kind of ['personas', 'instructions', 'output-contracts', 'policies', 'knowledge']) {
+        mkdirSync(join(projectDir, '.takt', 'facets', kind), { recursive: true });
+      }
+      mkdirSync(workflowDir, { recursive: true });
+      writeFileSync(join(projectDir, '.takt', 'facets', 'personas', 'shared.md'), 'Project persona override');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'instructions', 'shared.md'), 'Project instruction override');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'output-contracts', 'shared.md'), 'Project output override');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'policies', 'shared.md'), 'Project policy override');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'knowledge', 'shared.md'), 'Project knowledge override');
+
+      const workflow = normalizeWorkflowConfig({
+        name: 'shared-project-overrides',
+        finding_contract: {
+          manager: {
+            persona: 'shared',
+            instruction: 'shared',
+            output_contract: 'shared',
+            policy: ['shared'],
+            knowledge: ['shared'],
+          },
+          adjudicator: { persona: 'shared', instruction: 'shared' },
+        },
+        initial_step: 'review',
+        max_steps: 2,
+        steps: [{
+          name: 'review',
+          persona: 'shared',
+          instruction: 'shared',
+          rules: [{ condition: 'done', next: 'COMPLETE' }],
+        }],
+      }, workflowDir, { projectDir, workflowDir, lang: 'ja' });
+
+      const expectedPersonaPath = join(projectDir, '.takt', 'facets', 'personas', 'shared.md');
+      expect(workflow.steps[0]).toMatchObject({
+        personaPath: expectedPersonaPath,
+        instruction: 'Project instruction override',
+      });
+      expect(workflow.findingContract?.manager).toMatchObject({
+        personaPath: expectedPersonaPath,
+        instruction: 'Project instruction override',
+        outputContract: 'Project output override',
+        policyContents: ['Project policy override'],
+        knowledgeContents: ['Project knowledge override'],
+      });
+      expect(workflow.findingContract?.adjudicator).toMatchObject({
+        personaPath: expectedPersonaPath,
+        instruction: 'Project instruction override',
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('gives package facets the same priority for ordinary steps and finding-contract roles', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'takt-finding-contract-package-override-'));
+    try {
+      const projectDir = join(tempDir, 'project');
+      const repertoireDir = join(tempDir, 'repertoire');
+      const packageRoot = join(repertoireDir, '@owner', 'repo');
+      const workflowDir = join(packageRoot, 'workflows');
+      for (const base of [join(projectDir, '.takt', 'facets'), join(packageRoot, 'facets')]) {
+        for (const kind of ['personas', 'instructions', 'output-contracts']) {
+          mkdirSync(join(base, kind), { recursive: true });
+          writeFileSync(join(base, kind, 'shared.md'), `${base === join(packageRoot, 'facets') ? 'Package' : 'Project'} ${kind}`);
+        }
+      }
+      mkdirSync(workflowDir, { recursive: true });
+
+      const workflow = normalizeWorkflowConfig({
+        name: 'shared-package-overrides',
+        finding_contract: {
+          manager: { persona: 'shared', instruction: 'shared', output_contract: 'shared' },
+          adjudicator: { persona: 'shared', instruction: 'shared' },
+        },
+        initial_step: 'review',
+        max_steps: 2,
+        steps: [{
+          name: 'review',
+          persona: 'shared',
+          instruction: 'shared',
+          rules: [{ condition: 'done', next: 'COMPLETE' }],
+        }],
+      }, workflowDir, { projectDir, workflowDir, repertoireDir, lang: 'ja' });
+
+      const packagePersonaPath = join(packageRoot, 'facets', 'personas', 'shared.md');
+      expect(workflow.steps[0]).toMatchObject({
+        personaPath: packagePersonaPath,
+        instruction: 'Package instructions',
+      });
+      expect(workflow.findingContract?.manager).toMatchObject({
+        personaPath: packagePersonaPath,
+        instruction: 'Package instructions',
+        outputContract: 'Package output-contracts',
+      });
+      expect(workflow.findingContract?.adjudicator).toMatchObject({
+        personaPath: packagePersonaPath,
+        instruction: 'Package instructions',
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each(['step', 'manager', 'adjudicator'] as const)(
+    'applies the same project symlink safety boundary to %s persona resolution',
+    (owner) => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'takt-finding-contract-symlink-safety-'));
+      try {
+        const projectDir = join(tempDir, 'project');
+        const workflowDir = join(projectDir, '.takt', 'workflows');
+        const personaDir = join(projectDir, '.takt', 'facets', 'personas');
+        mkdirSync(workflowDir, { recursive: true });
+        mkdirSync(personaDir, { recursive: true });
+        const outside = join(tempDir, 'outside.md');
+        writeFileSync(outside, 'Outside persona');
+        symlinkSync(outside, join(personaDir, 'unsafe.md'));
+        const personaFor = (candidate: typeof owner) => candidate === owner ? 'unsafe' : 'inline-safe-persona';
+
+        let thrown: unknown;
+        try {
+          normalizeWorkflowConfig({
+            name: `symlink-safety-${owner}`,
+            finding_contract: {
+              manager: {
+                persona: personaFor('manager'),
+                instruction: 'Inline manager instruction.',
+                output_contract: 'Inline output contract.',
+              },
+              adjudicator: {
+                persona: personaFor('adjudicator'),
+                instruction: 'Inline adjudicator instruction.',
+              },
+            },
+            initial_step: 'review',
+            max_steps: 2,
+            steps: [{
+              name: 'review',
+              persona: personaFor('step'),
+              instruction: 'Inline review instruction.',
+              rules: [{ condition: 'done', next: 'COMPLETE' }],
+            }],
+          }, workflowDir, { projectDir, workflowDir, lang: 'ja' });
+        } catch (error) {
+          thrown = error;
+        }
+        expect(thrown).toBeInstanceOf(Error);
+        const error = thrown as Error & { cause?: unknown };
+        const causeMessage = error.cause instanceof Error ? error.cause.message : '';
+        expect(`${error.message}\n${causeMessage}`).toMatch(
+          /Project facet file must stay inside the project|must not use symlinks/,
+        );
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    { field: 'ordinary step policy', facetKind: 'policies', target: 'step_policy' },
+    { field: 'manager policy', facetKind: 'policies', target: 'manager_policy' },
+    { field: 'manager knowledge', facetKind: 'knowledge', target: 'manager_knowledge' },
+    { field: 'adjudicator instruction', facetKind: 'instructions', target: 'adjudicator_instruction' },
+  ] as const)(
+    'applies facet symlink safety to $field',
+    ({ facetKind, target }) => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'takt-finding-contract-field-safety-'));
+      try {
+        const projectDir = join(tempDir, 'project');
+        const workflowDir = join(projectDir, '.takt', 'workflows');
+        const facetDir = join(projectDir, '.takt', 'facets', facetKind);
+        mkdirSync(workflowDir, { recursive: true });
+        mkdirSync(facetDir, { recursive: true });
+        const outside = join(tempDir, 'outside.md');
+        writeFileSync(outside, 'Outside facet');
+        symlinkSync(outside, join(facetDir, 'unsafe.md'));
+        let thrown: unknown;
+        try {
+          normalizeWorkflowConfig({
+            name: `field-safety-${target}`,
+            finding_contract: {
+              manager: {
+                persona: 'inline-manager',
+                instruction: 'Inline manager instruction.',
+                output_contract: 'Inline manager output.',
+                ...(target === 'manager_policy' ? { policy: ['unsafe'] } : {}),
+                ...(target === 'manager_knowledge' ? { knowledge: ['unsafe'] } : {}),
+              },
+              adjudicator: {
+                persona: 'inline-supervisor',
+                instruction: target === 'adjudicator_instruction'
+                  ? 'unsafe'
+                  : 'Inline adjudicator instruction.',
+              },
+            },
+            initial_step: 'review',
+            max_steps: 2,
+            steps: [{
+              name: 'review',
+              persona: 'inline-reviewer',
+              instruction: 'Inline review instruction.',
+              ...(target === 'step_policy' ? { policy: ['unsafe'] } : {}),
+              rules: [{ condition: 'done', next: 'COMPLETE' }],
+            }],
+          }, workflowDir, { projectDir, workflowDir, lang: 'ja' });
+        } catch (error) {
+          thrown = error;
+        }
+        expect(thrown).toBeInstanceOf(Error);
+        const messages: string[] = [];
+        let current: unknown = thrown;
+        while (current instanceof Error) {
+          messages.push(current.message);
+          current = (current as Error & { cause?: unknown }).cause;
+        }
+        expect(messages.join('\n')).toMatch(
+          /Project facet file must stay inside the project|must not use symlinks/,
+        );
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it('should preserve omitted manager additions and reject invalid addition/adjudicator shapes', () => {
+    const normalized = normalizeWorkflowConfig(
+      makeWorkflowWithFindingContract({
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          output_contract: 'findings-manager',
+        },
+      }),
+      '/tmp/project',
+    );
+    expect(normalized.findingContract?.manager).not.toHaveProperty('policyContents');
+    expect(normalized.findingContract?.manager).not.toHaveProperty('knowledgeContents');
+
+    const manager = {
+      persona: 'findings-manager',
+      instruction: 'findings-manager',
+      output_contract: 'findings-manager',
+    };
+    const invalidContracts = [
+      { manager: { ...manager, policy: [] } },
+      { manager: { ...manager, policy: [''] } },
+      { manager: { ...manager, knowledge: [] } },
+      { manager: { ...manager, knowledge: [''] } },
+      { manager, adjudicator: {} },
+      { manager, adjudicator: { persona: 'supervisor' } },
+      { manager, adjudicator: { instruction: 'adjudicate' } },
+      { manager, adjudicator: { persona: '', instruction: 'adjudicate' } },
+      { manager, adjudicator: { persona: 'supervisor', instruction: '' } },
+      { manager, adjudicator: { persona: 'supervisor', instruction: 'adjudicate', provider: 'auto' } },
+      { manager, adjudicator: { persona: 'supervisor', instruction: 'adjudicate', output_contract: 'forbidden' } },
+    ];
+    for (const findingContract of invalidContracts) {
+      expect(() => normalizeWorkflowConfig(
+        makeWorkflowWithFindingContract(findingContract),
+        '/tmp/project',
+      )).toThrow();
+    }
+  });
+
+  it('should reject unresolved additions and explicit adjudicator facets with field paths', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'takt-finding-contract-missing-facets-'));
+    try {
+      const projectDir = join(tempDir, 'project');
+      const workflowDir = join(projectDir, '.takt', 'workflows');
+      for (const kind of ['personas', 'instructions', 'output-contracts', 'policies']) {
+        mkdirSync(join(projectDir, '.takt', 'facets', kind), { recursive: true });
+      }
+      mkdirSync(workflowDir, { recursive: true });
+      writeFileSync(join(projectDir, '.takt', 'facets', 'personas', 'findings-manager.md'), 'Manager persona');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'personas', 'supervisor.md'), 'Supervisor persona');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'instructions', 'findings-manager.md'), 'Manager instruction');
+      writeFileSync(join(projectDir, '.takt', 'facets', 'output-contracts', 'findings-manager.md'), 'Manager output');
+      const context = {
+        projectDir,
+        workflowDir,
+        repertoireDir: join(tempDir, 'repertoire'),
+        lang: 'ja' as const,
+      };
+      const base = {
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          output_contract: 'findings-manager',
+        },
+      };
+      expect(() => normalizeWorkflowConfig(
+        makeWorkflowWithFindingContract({
+          manager: { ...base.manager, policy: ['@missing/package/policy'] },
+        }),
+        workflowDir,
+        context,
+      )).toThrow(/finding_contract\.manager\.policy\[0\].*@missing\/package\/policy/);
+      expect(() => normalizeWorkflowConfig(
+        makeWorkflowWithFindingContract({
+          ...base,
+          adjudicator: {
+            persona: '@missing/package/adjudicator',
+            instruction: 'findings-manager',
+          },
+        }),
+        workflowDir,
+        context,
+      )).toThrow(/finding_contract\.adjudicator\.persona.*@missing\/package\/adjudicator/);
+      expect(() => normalizeWorkflowConfig(
+        makeWorkflowWithFindingContract({
+          ...base,
+          adjudicator: {
+            persona: 'supervisor',
+            instruction: '@missing/package/adjudication-guidance',
+          },
+        }),
+        workflowDir,
+        context,
+      )).toThrow(/finding_contract\.adjudicator\.instruction.*@missing\/package\/adjudication-guidance/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('should reject invalid finding_contract raw shapes', () => {

--- a/src/__tests__/finding-interpretation-case-store.integration.test.ts
+++ b/src/__tests__/finding-interpretation-case-store.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { executeAgent } from '../agents/agent-usecases.js';
 import type { AgentResponse, WorkflowStep } from '../core/models/types.js';
 import { compareBinaryStrings } from '../shared/utils/binary-string-comparator.js';
@@ -32,6 +32,10 @@ import { applyFindingLedgerFixtureRevision } from './helpers/finding-lifecycle-f
 vi.mock('../agents/agent-usecases.js', () => ({ executeAgent: vi.fn() }));
 
 const executeAgentMock = vi.mocked(executeAgent);
+
+beforeEach(() => {
+  executeAgentMock.mockReset();
+});
 
 function interpretationDependencies() {
   return {

--- a/src/__tests__/finding-interpretation-case-store.integration.test.ts
+++ b/src/__tests__/finding-interpretation-case-store.integration.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { executeAgent } from '../agents/agent-usecases.js';
+import type { AgentResponse, WorkflowStep } from '../core/models/types.js';
 import { compareBinaryStrings } from '../shared/utils/binary-string-comparator.js';
 import { computeFindingManagerProviderCallId } from '../core/models/finding-contract-identity.js';
 import { computeInterpretationAttemptId } from '../core/models/finding-interpretation-identity.js';
@@ -9,6 +11,8 @@ import type {
 } from '../core/workflow/findings/types.js';
 import { parseFindingLedger } from '../core/workflow/findings/schemas.js';
 import { dispatchFindingManagerProviderCall } from '../core/workflow/findings/finding-manager-provider-call.js';
+import { runInterpretationCases } from '../core/workflow/findings/interpretation-case-runner.js';
+import { prepareInterpretationCaseProviderRequest } from '../core/workflow/findings/manager-interpretation-agent.js';
 import {
   baseLedger,
   addExactProductFinding,
@@ -21,8 +25,33 @@ import {
   response,
   seed,
   taintedItems,
+  verifiedEvidenceRecords,
 } from './helpers/finding-interpretation-case-store-fixture.js';
 import { applyFindingLedgerFixtureRevision } from './helpers/finding-lifecycle-fixture.js';
+
+vi.mock('../agents/agent-usecases.js', () => ({ executeAgent: vi.fn() }));
+
+const executeAgentMock = vi.mocked(executeAgent);
+
+function interpretationDependencies() {
+  return {
+    optionsBuilder: { buildAgentOptions: () => ({}) } as never,
+    stepExecutor: {
+      buildPhase1Instruction: (instruction: string) => instruction,
+      normalizeStructuredOutput: (_step: WorkflowStep, response: AgentResponse) => response,
+      recordSynthesizedAgentUsage: () => {},
+    },
+  };
+}
+
+function interpretationCasesFromInstruction(instruction: string): Array<{ caseId: string }> {
+  const section = instruction.split('## Cases\n')[1];
+  const match = section === undefined ? undefined : /^(`{3,})json\n([\s\S]*?)\n\1/m.exec(section);
+  if (match?.[2] === undefined) {
+    throw new Error('Expected interpretation cases in provider instruction');
+  }
+  return JSON.parse(match[2]) as Array<{ caseId: string }>;
+}
 
 afterEach(cleanupInterpretationCaseRoots);
 
@@ -649,6 +678,228 @@ describe('interpretation case SQLite begin transaction', () => {
     ]));
     harness.resolver.close();
   });
+
+  it.each([
+    { label: 'omitted additions', policyContents: undefined, knowledgeContents: undefined },
+    { label: 'configured additions', policyContents: ['Manager policy'], knowledgeContents: ['Manager knowledge'] },
+  ])('reconstructs and dispatches the persisted real provider request after reopen: $label', async ({
+    policyContents,
+    knowledgeContents,
+  }) => {
+    executeAgentMock.mockReset();
+    const dependencies = interpretationDependencies();
+    const contract = {
+      manager: {
+        persona: 'findings-manager',
+        ...(policyContents === undefined ? {} : { policyContents }),
+        ...(knowledgeContents === undefined ? {} : { knowledgeContents }),
+      },
+    };
+    const prepareProviderRequest = (current: FindingLedger, cases: Parameters<
+      NonNullable<Parameters<typeof openHarness>[0]['prepareProviderRequest']>
+    >[1]) => ({
+      requestBytes: prepareInterpretationCaseProviderRequest({
+        cases,
+        contract,
+        optionsBuilder: dependencies.optionsBuilder,
+        stepExecutor: dependencies.stepExecutor,
+        ledger: current,
+      }).requestBytes,
+      adapterSupportsUtf8ByteUpperBound: true,
+    });
+    let harness = openHarness({ prepareProviderRequest });
+    const ledger = baseLedger();
+    await seed(harness, ledger);
+    const items = taintedItems({ rawFindingIds: [`raw-real-wal-${policyContents?.length ?? 0}`], ledger });
+    await harness.beginInterpretationCases({
+      items,
+      provisionalOnlyRawFindingIds: new Set(),
+    });
+    const reserved = harness.store.loadLedger().findingManagerProviderCalls[0]!;
+    expect(reserved.state).toBe('reserved');
+    harness.resolver.close();
+
+    executeAgentMock.mockImplementation(async (_persona, instruction) => ({
+      persona: 'findings-manager',
+      status: 'done',
+      content: '',
+      timestamp: new Date(OBSERVATION.timestamp),
+      structuredOutput: {
+        decisions: interpretationCasesFromInstruction(instruction).map(({ caseId }) => ({
+          caseId,
+          decision: { kind: 'provisional', reason: 'WAL resume fixture' },
+        })),
+      },
+    }));
+    harness = openHarness({ root: harness.root, prepareProviderRequest });
+    await runInterpretationCases({
+      items,
+      provisionalOnlyRawFindingIds: new Set(),
+      ledgerStore: harness.store,
+      contract,
+      ...dependencies,
+      observation: OBSERVATION,
+      roundMarker: 'round-case-store',
+      scopeIdentity: '2'.repeat(64),
+      verifiedEvidenceRecordsByRawFindingId: verifiedEvidenceRecords(items),
+    });
+
+    const settled = harness.store.loadLedger().findingManagerProviderCalls[0]!;
+    expect(settled).toMatchObject({
+      providerCallId: reserved.providerCallId,
+      requestDigest: reserved.requestDigest,
+      requestByteLength: reserved.requestByteLength,
+      state: 'settled',
+      resultKind: 'accepted',
+    });
+    expect(executeAgentMock).toHaveBeenCalledOnce();
+    harness.resolver.close();
+  });
+
+  it('keeps a real reserved interpretation call untouched when manager guidance changes after reopen', async () => {
+    executeAgentMock.mockReset();
+    const dependencies = interpretationDependencies();
+    const originalContract = { manager: { persona: 'findings-manager', policyContents: ['Original policy'] } };
+    const prepareProviderRequest = (current: FindingLedger, cases: Parameters<
+      NonNullable<Parameters<typeof openHarness>[0]['prepareProviderRequest']>
+    >[1]) => ({
+      requestBytes: prepareInterpretationCaseProviderRequest({
+        cases,
+        contract: originalContract,
+        optionsBuilder: dependencies.optionsBuilder,
+        stepExecutor: dependencies.stepExecutor,
+        ledger: current,
+      }).requestBytes,
+      adapterSupportsUtf8ByteUpperBound: true,
+    });
+    let harness = openHarness({ prepareProviderRequest });
+    const ledger = baseLedger();
+    await seed(harness, ledger);
+    const items = taintedItems({ rawFindingIds: ['raw-real-wal-guidance-change'], ledger });
+    await harness.beginInterpretationCases({ items, provisionalOnlyRawFindingIds: new Set() });
+    const reserved = harness.store.loadLedger().findingManagerProviderCalls[0]!;
+    harness.resolver.close();
+
+    harness = openHarness({ root: harness.root, prepareProviderRequest });
+    await expect(runInterpretationCases({
+      items,
+      provisionalOnlyRawFindingIds: new Set(),
+      ledgerStore: harness.store,
+      contract: { manager: { persona: 'findings-manager', policyContents: ['Changed policy'] } },
+      ...dependencies,
+      observation: OBSERVATION,
+      roundMarker: 'round-case-store',
+      scopeIdentity: '2'.repeat(64),
+      verifiedEvidenceRecordsByRawFindingId: verifiedEvidenceRecords(items),
+    })).rejects.toThrow(/request changed after (lease )?reservation/i);
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(harness.store.loadLedger().findingManagerProviderCalls[0]).toMatchObject({
+      providerCallId: reserved.providerCallId,
+      state: 'reserved',
+    });
+    harness.resolver.close();
+  });
+
+  it.each([23_999, 24_000, 24_001])(
+    'enforces the fully serialized interpretation request at the exact %i-byte boundary',
+    async (targetBytes) => {
+      let padding = 0;
+      const dependencies = {
+        optionsBuilder: { buildAgentOptions: () => ({}) } as never,
+        stepExecutor: {
+          buildPhase1Instruction: (instruction: string) => `${instruction}${'x'.repeat(padding)}`,
+          normalizeStructuredOutput: (_step: WorkflowStep, response: AgentResponse) => response,
+          recordSynthesizedAgentUsage: () => {},
+        },
+      };
+      const contract = {
+        manager: {
+          persona: 'findings-manager',
+          policyContents: ['Boundary policy'],
+          knowledgeContents: ['Boundary knowledge'],
+        },
+      };
+      const prepareProviderRequest = (current: FindingLedger, cases: Parameters<
+        NonNullable<Parameters<typeof openHarness>[0]['prepareProviderRequest']>
+      >[1]) => {
+        padding = 0;
+        const base = prepareInterpretationCaseProviderRequest({
+          cases,
+          contract,
+          optionsBuilder: dependencies.optionsBuilder,
+          stepExecutor: dependencies.stepExecutor,
+          ledger: current,
+        });
+        padding = targetBytes - Buffer.byteLength(base.requestBytes, 'utf8');
+        if (padding < 0) {
+          throw new Error('Interpretation boundary fixture base request is too large');
+        }
+        const prepared = prepareInterpretationCaseProviderRequest({
+          cases,
+          contract,
+          optionsBuilder: dependencies.optionsBuilder,
+          stepExecutor: dependencies.stepExecutor,
+          ledger: current,
+        });
+        expect(Buffer.byteLength(prepared.requestBytes, 'utf8')).toBe(targetBytes);
+        return {
+          requestBytes: prepared.requestBytes,
+          adapterSupportsUtf8ByteUpperBound: true,
+        };
+      };
+      const harness = openHarness({
+        prepareProviderRequest,
+        budgetLimits: {
+          maxCallsPerRound: 4,
+          maxAdapterVisibleInputTokensPerCall: 24_000,
+          maxOutputTokensPerCall: 10_000,
+          maxChargedInputTokensPerRound: 96_000,
+          maxChargedOutputTokensPerRound: 40_000,
+        },
+      });
+      const ledger = baseLedger();
+      await seed(harness, ledger);
+      const items = taintedItems({ rawFindingIds: [`raw-interpretation-boundary-${targetBytes}`], ledger });
+
+      const begun = await harness.beginInterpretationCases({
+        items,
+        provisionalOnlyRawFindingIds: new Set(),
+      });
+      const stored = harness.store.loadLedger();
+
+      if (targetBytes <= 24_000) {
+        expect(begun.providerCases).toHaveLength(1);
+        expect(stored.interpretationAttempts).toHaveLength(1);
+        expect(stored.findingManagerProviderBudgetScopes).toHaveLength(1);
+        expect(stored.findingManagerProviderCalls).toEqual([
+          expect.objectContaining({
+            state: 'reserved',
+            requestByteLength: targetBytes,
+            inputMeasurementBasis: 'utf8_byte_upper_bound',
+          }),
+        ]);
+      } else {
+        expect(begun.providerCases).toEqual([]);
+        expect(begun.attempts).toEqual([]);
+        expect(begun.directPlans).toEqual([
+          expect.objectContaining({
+            decision: expect.objectContaining({
+              kind: 'provisional',
+              reason: expect.stringMatching(/input exceeded/i),
+            }),
+            unreservedAuthority: expect.objectContaining({
+              reason: 'manager-input-overflow',
+            }),
+          }),
+        ]);
+        expect(stored.interpretationAttempts).toEqual([]);
+        expect(stored.findingManagerProviderBudgetScopes).toEqual([]);
+        expect(stored.findingManagerProviderCalls).toEqual([]);
+      }
+      expect(executeAgentMock).not.toHaveBeenCalled();
+      harness.resolver.close();
+    },
+  );
 
   it('keeps persisted pending ownership ahead of a proof that becomes available later', async () => {
     let harness = openHarness();

--- a/src/__tests__/finding-manager-task-runner.test.ts
+++ b/src/__tests__/finding-manager-task-runner.test.ts
@@ -204,7 +204,11 @@ function successfulRawResponse(
   });
 }
 
-async function run(rawFindings: RawFinding[], previousLedger = emptyLedger()) {
+async function run(
+  rawFindings: RawFinding[],
+  previousLedger = emptyLedger(),
+  executionInput = runInput,
+) {
   return runMainManagerTasks({
     contract,
     previousLedger,
@@ -216,11 +220,33 @@ async function run(rawFindings: RawFinding[], previousLedger = emptyLedger()) {
     dismissCandidates: new Map(),
     evidenceRecordsByRawFindingId: new Map(),
     managerStep,
-    runInput,
+    runInput: executionInput,
     managerAuthority: 'standard',
     workflowTask: 'Review the requested implementation.',
     subResults: [],
   });
+}
+
+function exactRenderedBytesInput(
+  targetBytes: number,
+  includeFixedPrefix: boolean,
+): typeof runInput {
+  return {
+    ...runInput,
+    stepExecutor: {
+      ...runInput.stepExecutor,
+      buildPhase1Instruction: (instruction: string) => {
+        if (!includeFixedPrefix && instruction.includes('__manager-prefix-check__')) {
+          return instruction;
+        }
+        const bytes = Buffer.byteLength(instruction, 'utf8');
+        if (bytes > targetBytes) {
+          throw new Error(`Test fixture base instruction ${bytes} exceeds target ${targetBytes}`);
+        }
+        return `${instruction}${'x'.repeat(targetBytes - bytes)}`;
+      },
+    },
+  };
 }
 
 beforeEach(() => {
@@ -850,6 +876,54 @@ describe('main manager bounded task runner', () => {
     expect(result.taskAudits).toMatchObject([{ status: 'input_overflow' }]);
   });
 
+  it.each([23_999, 24_000, 24_001])(
+    'enforces the fixed manager prefix at the exact %i-byte boundary',
+    async (targetBytes) => {
+      const executionInput = exactRenderedBytesInput(targetBytes, true);
+      if (targetBytes <= MAIN_MANAGER_INPUT_MAX_BYTES) {
+        await expect(run([], emptyLedger(), executionInput)).resolves.toMatchObject({
+          taskAudits: [],
+        });
+      } else {
+        await expect(run([], emptyLedger(), executionInput)).rejects.toThrow(
+          `(${targetBytes})`,
+        );
+      }
+      expect(executeAgentMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([23_999, 24_000, 24_001])(
+    'enforces a single raw task at the exact %i-byte boundary',
+    async (targetBytes) => {
+      executeAgentMock.mockImplementation(async (_persona, instruction) => (
+        successfulRawResponse(instruction)
+      ));
+      const raw = rawFinding(1);
+      const result = await run(
+        [raw],
+        emptyLedger(),
+        exactRenderedBytesInput(targetBytes, false),
+      );
+
+      expect(result.taskAudits).toEqual([
+        expect.objectContaining({
+          taskKind: 'raw',
+          status: targetBytes <= MAIN_MANAGER_INPUT_MAX_BYTES
+            ? 'succeeded'
+            : 'input_overflow',
+          inputBytes: targetBytes,
+        }),
+      ]);
+      expect(executeAgentMock).toHaveBeenCalledTimes(
+        targetBytes <= MAIN_MANAGER_INPUT_MAX_BYTES ? 1 : 0,
+      );
+      expect(result.rawFailures.has(raw.rawFindingId)).toBe(
+        targetBytes > MAIN_MANAGER_INPUT_MAX_BYTES,
+      );
+    },
+  );
+
   it('creates the same finite manifest regardless of input order', () => {
     const raws = Array.from({ length: 20 }, (_, index) => rawFinding(index + 1));
     const forward = createMainManagerRawTaskManifest({
@@ -1252,6 +1326,53 @@ describe('main manager bounded task runner', () => {
       status: 'input_overflow',
     }]);
   });
+
+  it.each([23_999, 24_000, 24_001])(
+    'enforces a control task at the exact %i-byte boundary',
+    async (targetBytes) => {
+      executeAgentMock.mockImplementation(async (_persona, instruction) => {
+        const manifest = sectionJson<ControlManifestView>(instruction, '## Task manifest');
+        return response({
+          taskId: manifest.taskId,
+          evaluations: manifest.candidateIntents.map((intent) => ({
+            intentId: intent.intentId,
+            result: { kind: 'no_action', reason: 'No verified action.' },
+          })),
+          selectedIntentId: null,
+        });
+      });
+      const finding = ledgerFinding(1);
+      const result = await runMainManagerTasks({
+        contract,
+        previousLedger: emptyLedger({ findings: [finding] }),
+        reviewScopeSnapshotId: 'scope-test',
+        residualRawFindings: [],
+        mechanicallyClassifiedCount: 0,
+        priorStepResponseText: undefined,
+        invalidLocationCandidates: new Map([['F-0001', 'missing location']]),
+        dismissCandidates: new Map(),
+        evidenceRecordsByRawFindingId: new Map(),
+        managerStep,
+        runInput: exactRenderedBytesInput(targetBytes, false),
+        managerAuthority: 'standard',
+        workflowTask: 'Review the requested implementation.',
+        subResults: [],
+      });
+
+      expect(result.taskAudits).toEqual([
+        expect.objectContaining({
+          status: targetBytes <= MAIN_MANAGER_INPUT_MAX_BYTES
+            ? 'succeeded'
+            : 'input_overflow',
+          inputBytes: targetBytes,
+        }),
+      ]);
+      expect(executeAgentMock).toHaveBeenCalledTimes(
+        targetBytes <= MAIN_MANAGER_INPUT_MAX_BYTES ? 1 : 0,
+      );
+      expect(result.decisions.invalidateDecisions).toEqual([]);
+    },
+  );
 
   it('does not create fuzzy same-locus duplicate control tasks', () => {
     const findings = Array.from({ length: 17 }, (_, index) => ({

--- a/src/__tests__/finding-pre-admission-entity-binding.test.ts
+++ b/src/__tests__/finding-pre-admission-entity-binding.test.ts
@@ -215,14 +215,26 @@ async function bind(input: {
   intake: ReviewerIntakeResult;
   roundMarker?: string;
   options?: Record<string, unknown>;
+  exactInputBytes?: number;
 }) {
+  const executionInput = runInput(input.options);
+  if (input.exactInputBytes !== undefined) {
+    const targetBytes = input.exactInputBytes;
+    executionInput.stepExecutor.buildPhase1Instruction = (instruction: string) => {
+      const bytes = Buffer.byteLength(instruction, 'utf8');
+      if (bytes > targetBytes) {
+        throw new Error(`Test fixture base instruction ${bytes} exceeds target ${targetBytes}`);
+      }
+      return `${instruction}${'x'.repeat(targetBytes - bytes)}`;
+    };
+  }
   return bindPreAdmissionEntities({
     contract,
     previousLedger: input.ledger,
     intake: input.intake,
     managerStep,
     roundMarker: input.roundMarker ?? 'round-1',
-    runInput: runInput(input.options),
+    runInput: executionInput,
   });
 }
 
@@ -1600,6 +1612,52 @@ describe('pre-admission semantic entity binding', () => {
     expect(ledger.findings).toEqual([]);
     expect(ledger.nextId).toBe(1);
   });
+
+  it.each([23_999, 24_000, 24_001])(
+    'enforces entity binding at the exact %i-byte boundary without partial mutation',
+    async (targetBytes) => {
+      const ledger = emptyLedger();
+      const raws = [rawFinding({
+        rawFindingId: 'raw-exact-boundary',
+        title: 'Exact boundary entity',
+        description: 'Exercise the fully rendered entity-binding request.',
+      })];
+      mockGroupedDecision((rawFindingId) => ({
+        decision: 'new_entity',
+        groupRawFindingId: rawFindingId,
+      }));
+
+      const bound = await bind({
+        ledger,
+        intake: intakeFor(ledger, raws),
+        exactInputBytes: targetBytes,
+      });
+      const evaluation = evaluate(ledger, bound.intake);
+
+      expect(bound.taskAudits).toEqual([
+        expect.objectContaining({
+          status: targetBytes <= MAIN_MANAGER_INPUT_MAX_BYTES
+            ? 'succeeded'
+            : 'input_overflow',
+          inputBytes: targetBytes,
+        }),
+      ]);
+      expect(executeAgentMock).toHaveBeenCalledTimes(
+        targetBytes <= MAIN_MANAGER_INPUT_MAX_BYTES ? 1 : 0,
+      );
+      if (targetBytes <= MAIN_MANAGER_INPUT_MAX_BYTES) {
+        expect(bound.intake.overflowRawFindingIds).toEqual(new Set());
+        expect(evaluation.preAdmissionEntityMutations).toHaveLength(1);
+      } else {
+        expect(bound.intake.overflowRawFindingIds).toEqual(new Set(['raw-exact-boundary']));
+        expect(bound.intake.intakeAnomalySpecs).toHaveLength(1);
+        expect(evaluation.preAdmissionEntityMutations).toEqual([]);
+        expect(evaluation.admissionProvisionalSpecs).toEqual([]);
+        expect(ledger.findings).toEqual([]);
+        expect(ledger.nextId).toBe(1);
+      }
+    },
+  );
 
   it('scans every disjoint component across deterministic budget pages', async () => {
     const ledger = emptyLedger();

--- a/src/__tests__/finding-provisional-recovery.test.ts
+++ b/src/__tests__/finding-provisional-recovery.test.ts
@@ -336,15 +336,4 @@ describe('terminal adjudication durable contract', () => {
     });
   });
 
-  it('fails closed when the episode head is stale', () => {
-    const stale = findingHead(2);
-    const plan = resolveTerminalAdjudicationPlan({
-      ledger: ledger({ lifecycleEvents: [lifecycleEvent(stale)] }),
-      episode: episode(),
-      candidate: candidate(),
-      proposal: { kind: 'undetermined' },
-      ...VERIFIER_CONTEXT,
-    });
-    expect(plan).toEqual({ kind: 'undetermined', reasonCodes: ['head_not_fresh'] });
-  });
 });

--- a/src/__tests__/finding-review-integrity-gate.test.ts
+++ b/src/__tests__/finding-review-integrity-gate.test.ts
@@ -173,6 +173,7 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
       provider: 'claude',
       findingContract: {
         manager: { persona: 'findings-manager', instruction: 'findings-manager', outputContract: 'findings-manager' },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         reviewerStep([makeRule('when(findings.open.count == 0 && findings.conflicts.count == 0)', 'COMPLETE')]),
@@ -216,6 +217,7 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
       provider: 'claude',
       findingContract: {
         manager: { persona: 'findings-manager', instruction: 'findings-manager', outputContract: 'findings-manager' },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         reviewerStep([makeRule(
@@ -269,6 +271,7 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
       provider: 'claude',
       findingContract: {
         manager: { persona: 'findings-manager', instruction: 'findings-manager', outputContract: 'findings-manager' },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         {
@@ -343,6 +346,7 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
       }],
       findingContract: {
         manager: { persona: 'findings-manager', instruction: 'findings-manager', outputContract: 'findings-manager' },
+        adjudicator: { persona: 'supervisor' },
         reviewBudget: { maxReviewRounds: 2 },
       },
       steps: [
@@ -422,6 +426,7 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
       provider: 'claude',
       findingContract: {
         manager: { persona: 'findings-manager', instruction: 'findings-manager', outputContract: 'findings-manager' },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({

--- a/src/__tests__/finding-review-observability-wiring.test.ts
+++ b/src/__tests__/finding-review-observability-wiring.test.ts
@@ -62,6 +62,7 @@ function makeFindingContract() {
       instruction: 'Reconcile findings.',
       outputContract: 'Return manager decisions.',
     },
+    adjudicator: { persona: 'supervisor' },
   };
 }
 

--- a/src/__tests__/finding-terminal-adjudication-runner.test.ts
+++ b/src/__tests__/finding-terminal-adjudication-runner.test.ts
@@ -30,6 +30,7 @@ import {
   canonicalRawFindingFixture,
   rawCanonicalSnapshotFixture,
 } from './helpers/finding-lifecycle-fixture.js';
+import { crashAfterAdjudicationReservation } from './helpers/finding-adjudication-reservation.js';
 import { createTestFindingLedgerStore } from './helpers/finding-storage.js';
 
 vi.mock('../agents/agent-usecases.js', () => ({ executeAgent: vi.fn() }));
@@ -313,29 +314,6 @@ describe('terminal adjudication runner provider envelope', () => {
     });
   }
 
-  function crashAfterTerminalReservation(store: FindingLedgerStore): FindingLedgerStore {
-    let crashed = false;
-    return new Proxy(store, {
-      get(target, property, receiver) {
-        if (property === 'updateLedger') {
-          return async (...args: Parameters<FindingLedgerStore['updateLedger']>) => {
-            const mutation = await target.updateLedger(...args);
-            const hasReservation = mutation.ledger.findingManagerProviderCalls.some((call) => (
-              call.purpose === 'terminal_adjudication' && call.state === 'reserved'
-            ));
-            if (!crashed && hasReservation) {
-              crashed = true;
-              throw new Error('simulated crash after terminal WAL reservation');
-            }
-            return mutation;
-          };
-        }
-        const value = Reflect.get(target, property, receiver) as unknown;
-        return typeof value === 'function' ? value.bind(target) : value;
-      },
-    });
-  }
-
   it('preserves the omitted-adjudicator terminal prompt and reserved request digest', async () => {
     executeAgentMock.mockResolvedValue({
       persona: 'supervisor',
@@ -484,7 +462,12 @@ describe('terminal adjudication runner provider envelope', () => {
 
   it('resumes the same real terminal WAL reservation after reopening the store', async () => {
     const guidance = 'Use the configured terminal policy.';
-    await expect(run(guidance, crashAfterTerminalReservation(ledgerStore)))
+    const crashingStore = crashAfterAdjudicationReservation({
+      store: ledgerStore,
+      purpose: 'terminal_adjudication',
+      errorMessage: 'simulated crash after terminal WAL reservation',
+    });
+    await expect(run(guidance, crashingStore))
       .rejects.toThrow('simulated crash after terminal WAL reservation');
     const reserved = ledgerStore.loadLedger().findingManagerProviderCalls[0]!;
     expect(reserved.state).toBe('reserved');
@@ -510,7 +493,12 @@ describe('terminal adjudication runner provider envelope', () => {
   });
 
   it('rejects changed terminal guidance without dispatching or replacing the real reservation', async () => {
-    await expect(run('Original guidance.', crashAfterTerminalReservation(ledgerStore)))
+    const crashingStore = crashAfterAdjudicationReservation({
+      store: ledgerStore,
+      purpose: 'terminal_adjudication',
+      errorMessage: 'simulated crash after terminal WAL reservation',
+    });
+    await expect(run('Original guidance.', crashingStore))
       .rejects.toThrow('simulated crash after terminal WAL reservation');
     const reserved = ledgerStore.loadLedger().findingManagerProviderCalls[0]!;
     ledgerStore = reopenStore();

--- a/src/__tests__/finding-terminal-adjudication-runner.test.ts
+++ b/src/__tests__/finding-terminal-adjudication-runner.test.ts
@@ -1,11 +1,16 @@
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { executeAgent } from '../agents/agent-usecases.js';
 import { findingContentAddress } from '../core/models/finding-contract-identity.js';
 import { createEmptyFindingContractRegistries } from '../core/models/finding-contract-seed.js';
-import type { TerminalAdjudicationProposal } from '../core/models/finding-contract-types.js';
+import type {
+  TerminalAdjudicationCandidateSnapshot,
+  TerminalAdjudicationEpisode,
+  TerminalAdjudicationProposal,
+} from '../core/models/finding-contract-types.js';
 import { createEngineProofRecord } from '../core/models/finding-evidence-record.js';
 import type { OptionsBuilder } from '../core/workflow/engine/OptionsBuilder.js';
 import { responseUpperBound } from '../core/workflow/findings/finding-manager-provider-call.js';
@@ -13,8 +18,15 @@ import { applyFindingLifecycleCommands } from '../core/workflow/findings/lifecyc
 import type { RunFindingManagerForStepInput } from '../core/workflow/findings/manager-contracts.js';
 import type { FindingLedger, FindingLedgerEntry } from '../core/workflow/findings/types.js';
 import { runTerminalAdjudication } from '../core/workflow/findings/terminal-adjudication-runner.js';
+import { buildTerminalAdjudicationCandidateSnapshot } from '../core/workflow/findings/terminal-adjudication-candidates.js';
+import { resolveTerminalAdjudicationPlan } from '../core/workflow/findings/terminal-adjudication-verifier.js';
+import { runManagerDecisionStage } from '../core/workflow/findings/manager-decision.js';
+import type { RawAdmissionEvaluation } from '../core/workflow/findings/manager-admission.js';
+import { issueFindingScopeBindings } from '../core/workflow/findings/finding-scope-binding.js';
+import { captureFindingLifecycleHead } from '../core/workflow/findings/lifecycle-mutation.js';
 import type { FindingLedgerStore } from '../core/workflow/findings/store.js';
 import {
+  applyFindingLedgerFixtureRevision,
   canonicalRawFindingFixture,
   rawCanonicalSnapshotFixture,
 } from './helpers/finding-lifecycle-fixture.js';
@@ -22,6 +34,16 @@ import { createTestFindingLedgerStore } from './helpers/finding-storage.js';
 
 vi.mock('../agents/agent-usecases.js', () => ({ executeAgent: vi.fn() }));
 const executeAgentMock = vi.mocked(executeAgent);
+const TERMINAL_BASELINE = JSON.parse(readFileSync(join(
+  process.cwd(),
+  'src',
+  '__tests__',
+  'fixtures',
+  'takt-default-fc-terminal-compatibility-baseline.json',
+), 'utf8')) as {
+  prompt: { bytes: number; sha256: string };
+  requestDigest: string;
+};
 
 const OBSERVATION = {
   runId: 'run-terminal-runner',
@@ -224,7 +246,10 @@ describe('terminal adjudication runner provider envelope', () => {
     rmSync(cwd, { recursive: true, force: true });
   });
 
-  function runInput(): RunFindingManagerForStepInput {
+  function runInput(
+    guidance?: string,
+    store: FindingLedgerStore = ledgerStore,
+  ): RunFindingManagerForStepInput {
     return {
       contract: {
         manager: {
@@ -232,11 +257,14 @@ describe('terminal adjudication runner provider envelope', () => {
           instruction: 'Manage findings.',
           outputContract: 'Return structured findings.',
         },
-        adjudicator: { persona: 'supervisor' },
+        adjudicator: {
+          persona: 'supervisor',
+          ...(guidance === undefined ? {} : { instruction: guidance }),
+        },
       },
       cwd,
       workflowProvider: 'claude',
-      ledgerStore,
+      ledgerStore: store,
       optionsBuilder: {
         buildAgentOptions: () => ({ provider: 'claude', cwd }),
       } as unknown as OptionsBuilder,
@@ -263,15 +291,99 @@ describe('terminal adjudication runner provider envelope', () => {
     };
   }
 
-  async function run(): Promise<void> {
+  async function run(
+    guidance?: string,
+    store: FindingLedgerStore = ledgerStore,
+  ): Promise<void> {
     await runTerminalAdjudication({
-      runInput: runInput(),
+      runInput: runInput(guidance, store),
       observation: OBSERVATION,
       roundIdentity: findingContentAddress('terminal-runner-round', {}),
       scopeIdentity: findingContentAddress('terminal-runner-scope', {}),
       reviewScopeSnapshot: REVIEW_SCOPE_SNAPSHOT,
     });
   }
+
+  function reopenStore(): FindingLedgerStore {
+    return createTestFindingLedgerStore({
+      projectCwd: cwd,
+      runId: OBSERVATION.runId,
+      reportDir: join(cwd, '.takt', 'runs', OBSERVATION.runId, 'reports'),
+      workflowName: 'terminal-runner',
+    });
+  }
+
+  function crashAfterTerminalReservation(store: FindingLedgerStore): FindingLedgerStore {
+    let crashed = false;
+    return new Proxy(store, {
+      get(target, property, receiver) {
+        if (property === 'updateLedger') {
+          return async (...args: Parameters<FindingLedgerStore['updateLedger']>) => {
+            const mutation = await target.updateLedger(...args);
+            const hasReservation = mutation.ledger.findingManagerProviderCalls.some((call) => (
+              call.purpose === 'terminal_adjudication' && call.state === 'reserved'
+            ));
+            if (!crashed && hasReservation) {
+              crashed = true;
+              throw new Error('simulated crash after terminal WAL reservation');
+            }
+            return mutation;
+          };
+        }
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+  }
+
+  it('preserves the omitted-adjudicator terminal prompt and reserved request digest', async () => {
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'undetermined',
+          rationale: 'No exact authority is available.',
+        },
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+
+    await run();
+
+    const prompt = executeAgentMock.mock.calls[0]?.[1];
+    if (typeof prompt !== 'string') throw new Error('Terminal adjudication prompt was not captured');
+    const actual = {
+      prompt: {
+        bytes: Buffer.byteLength(prompt, 'utf8'),
+        sha256: createHash('sha256').update(prompt).digest('hex'),
+      },
+      requestDigest: ledgerStore.loadLedger().findingManagerProviderCalls[0]?.requestDigest,
+    };
+    expect(actual).toEqual(TERMINAL_BASELINE);
+  });
+
+  it('places configured guidance once before the engine-owned terminal instruction', async () => {
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'undetermined',
+          rationale: 'No exact authority is available.',
+        },
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+
+    await run('Use only verified evidence.');
+
+    const prompt = executeAgentMock.mock.calls[0]?.[1];
+    expect(prompt).toContain('Use only verified evidence.\n\n---\n\nAdjudicate the durable provisional finding below.');
+    expect(prompt?.match(/Use only verified evidence\./g)).toHaveLength(1);
+  });
 
   it.each(PROPOSALS)('accepts the $kind proposal envelope and digests the full response', async (proposal) => {
     const structuredOutput = { proposal };
@@ -369,4 +481,282 @@ describe('terminal adjudication runner provider envelope', () => {
     ]);
     expect(ledger.findingManagerProviderCalls[0]).not.toHaveProperty('responseDigest');
   });
+
+  it('resumes the same real terminal WAL reservation after reopening the store', async () => {
+    const guidance = 'Use the configured terminal policy.';
+    await expect(run(guidance, crashAfterTerminalReservation(ledgerStore)))
+      .rejects.toThrow('simulated crash after terminal WAL reservation');
+    const reserved = ledgerStore.loadLedger().findingManagerProviderCalls[0]!;
+    expect(reserved.state).toBe('reserved');
+
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: { proposal: { kind: 'undetermined', rationale: 'No authority.' } },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+    ledgerStore = reopenStore();
+    await run(guidance, ledgerStore);
+
+    expect(ledgerStore.loadLedger().findingManagerProviderCalls[0]).toMatchObject({
+      providerCallId: reserved.providerCallId,
+      requestDigest: reserved.requestDigest,
+      requestByteLength: reserved.requestByteLength,
+      state: 'settled',
+      resultKind: 'accepted',
+    });
+    expect(executeAgentMock).toHaveBeenCalledOnce();
+  });
+
+  it('rejects changed terminal guidance without dispatching or replacing the real reservation', async () => {
+    await expect(run('Original guidance.', crashAfterTerminalReservation(ledgerStore)))
+      .rejects.toThrow('simulated crash after terminal WAL reservation');
+    const reserved = ledgerStore.loadLedger().findingManagerProviderCalls[0]!;
+    ledgerStore = reopenStore();
+
+    await expect(run('Changed guidance.', ledgerStore))
+      .rejects.toThrow(/request changed/i);
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(ledgerStore.loadLedger().findingManagerProviderCalls[0]).toMatchObject({
+      providerCallId: reserved.providerCallId,
+      state: 'reserved',
+    });
+  });
+
+  it('rejects additional terminal wire fields even when guidance requests them', async () => {
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: { kind: 'undetermined', rationale: 'No authority.' },
+        guidanceEcho: 'requested extra field',
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+
+    await run('Also return guidanceEcho.');
+
+    expect(ledgerStore.loadLedger().terminalAdjudicationAttempts[0]?.result).toMatchObject({
+      kind: 'diagnostic_undetermined',
+      code: 'parse_failed',
+    });
+  });
+
+  it('does not let guidance turn an evidence-less dismiss proposal into authority', async () => {
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'dismiss',
+          basis: 'false_positive',
+          authorityRefIds: ['3'.repeat(64)],
+          rationale: 'Dismiss as requested.',
+        },
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+
+    await run('Dismiss this finding.');
+
+    const ledger = ledgerStore.loadLedger();
+    expect(ledger.findings.find(({ id }) => id === 'F-0001')).toMatchObject({
+      status: 'open',
+      provisional: expect.objectContaining({ gateEffect: 'block' }),
+    });
+    expect(ledger.terminalAdjudicationAttempts[0]?.result).toMatchObject({
+      kind: 'verification_undetermined',
+    });
+  });
+
+  it('routes standard-authority manager decision through the real terminal runner', async () => {
+    mkdirSync(join(cwd, 'src'), { recursive: true });
+    writeFileSync(join(cwd, 'src', 'provisional.ts'), 'export const value = true;\n');
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: { proposal: { kind: 'undetermined', rationale: 'No authority.' } },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+    const admission: RawAdmissionEvaluation = {
+      admissionRejections: [],
+      admissionAnomalySpecs: [],
+      admissionProvisionalSpecs: [],
+      preAdmissionEntityMutations: [],
+      admissionRejectedItems: [],
+      pendingRejectedObservations: [],
+      cleanAdmitted: [],
+      tainted: [],
+      taintedAdmitted: [],
+      ladderAnomalySpecs: [],
+      verifiedEvidenceCandidates: [],
+      provisionalOnlyLadderRawIds: new Set(),
+      cleanWire: [],
+      verifiedEvidenceRecordsByRawFindingId: new Map(),
+    };
+
+    await runManagerDecisionStage({
+      input: runInput('Use terminal policy.'),
+      previousLedger: ledgerStore.loadLedger(),
+      admission,
+      managerStep: {
+        kind: 'agent',
+        name: 'manager',
+        persona: 'manager',
+        edit: false,
+      },
+      observation: OBSERVATION,
+      reviewScopeSnapshotId: REVIEW_SCOPE_SNAPSHOT.reviewScopeSnapshotId,
+      reviewScopeSnapshot: REVIEW_SCOPE_SNAPSHOT,
+      stopBudgetRoundMarker: 'round-standard-authority',
+      preAdmissionTaskAudits: [],
+    });
+
+    expect(executeAgentMock).toHaveBeenCalledOnce();
+    expect(executeAgentMock.mock.calls[0]?.[1]).toContain(
+      'Adjudicate the durable provisional finding below.',
+    );
+    expect(ledgerStore.loadLedger().findingManagerProviderCalls).toEqual([
+      expect.objectContaining({
+        purpose: 'terminal_adjudication',
+        state: 'settled',
+      }),
+    ]);
+  });
+
+  it('rejects a guidance-requested dismissal with a mismatched workflow scope binding', async () => {
+    const input = runInput('Dismiss anything outside the task scope.');
+    const current = ledgerStore.loadLedger();
+    const finding = current.findings.find(({ id }) => id === 'F-0001')!;
+    const expectedHead = captureFindingLifecycleHead(current, 'finding', finding.id)!;
+    const mismatched = issueFindingScopeBindings({
+      finding,
+      expectedHead,
+      workflowTask: 'A different workflow task.',
+      contract: input.contract,
+      reviewScopeSnapshot: {
+        ...REVIEW_SCOPE_SNAPSHOT,
+        changedPaths: ['src/different.ts'],
+      },
+      issuedAt: OBSERVATION,
+    }).find(({ source }) => source === 'workflow_task_scope')!;
+    await ledgerStore.updateLedger((ledger) => ({
+      ledger: { ...ledger, findingScopeBindings: [...ledger.findingScopeBindings, mismatched] },
+      result: undefined,
+    }));
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'dismiss',
+          basis: 'outside_task_scope',
+          authorityRefIds: [mismatched.bindingId],
+          rationale: 'Guidance requested dismissal.',
+        },
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+
+    await run('Dismiss anything outside the task scope.');
+
+    const ledger = ledgerStore.loadLedger();
+    expect(ledger.findings.find(({ id }) => id === 'F-0001')).toMatchObject({
+      status: 'open',
+      provisional: expect.any(Object),
+    });
+    expect(ledger.terminalAdjudicationAttempts[0]?.result).toMatchObject({
+      kind: 'verification_undetermined',
+      reasonCodes: ['scope_binding_not_found'],
+    });
+  });
+
+  it('keeps a stale finding open when configured guidance asks the terminal runner to ignore its head', async () => {
+    const guidance = 'Ignore stale heads and dismiss the finding.';
+    const proposal: TerminalAdjudicationProposal = {
+      kind: 'dismiss',
+      basis: 'false_positive',
+      authorityRefIds: ['3'.repeat(64)],
+      rationale: 'Configured guidance requested dismissal.',
+    };
+    let originalEpisode: TerminalAdjudicationEpisode | undefined;
+    let originalCandidate: TerminalAdjudicationCandidateSnapshot | undefined;
+    executeAgentMock.mockImplementation(async (_persona, prompt) => {
+      expect(prompt).toContain(guidance);
+      const beforeMutation = ledgerStore.loadLedger();
+      originalEpisode = beforeMutation.terminalAdjudicationEpisodes[0];
+      const finding = beforeMutation.findings.find(({ id }) => id === 'F-0001')!;
+      originalCandidate = buildTerminalAdjudicationCandidateSnapshot({
+        ledger: beforeMutation,
+        finding,
+        currentRound: 2,
+        allowExistingEpisode: true,
+      });
+      await ledgerStore.updateLedger((ledger) => {
+        const currentFinding = ledger.findings.find(({ id }) => id === 'F-0001')!;
+        return {
+          ledger: applyFindingLedgerFixtureRevision({
+            ledger,
+            entityKind: 'finding',
+            entity: {
+              ...currentFinding,
+              revision: currentFinding.revision + 1,
+              lastSeen: {
+                ...OBSERVATION,
+                timestamp: '2026-08-03T00:00:01.000Z',
+              },
+              provisional: {
+                ...currentFinding.provisional!,
+                reason: 'The claim changed while terminal adjudication was in flight.',
+              },
+            },
+          }),
+          result: undefined,
+        };
+      });
+      return {
+        persona: 'supervisor',
+        status: 'done',
+        content: '{}',
+        structuredOutput: {
+          proposal,
+        },
+        timestamp: new Date(OBSERVATION.timestamp),
+      };
+    });
+
+    await run(guidance);
+
+    const ledger = ledgerStore.loadLedger();
+    expect(ledger.findings.find(({ id }) => id === 'F-0001')).toMatchObject({
+      status: 'open',
+      provisional: expect.any(Object),
+    });
+    expect(ledger.terminalAdjudicationAttempts[0]?.result).toMatchObject({
+      kind: 'stale_precondition',
+      actualHead: expect.objectContaining({ revision: 2 }),
+    });
+    expect(originalEpisode).toBeDefined();
+    expect(originalCandidate).toBeDefined();
+    expect(resolveTerminalAdjudicationPlan({
+      ledger,
+      episode: originalEpisode!,
+      candidate: originalCandidate!,
+      proposal,
+      workflowTask: WORKFLOW_TASK,
+      findingContractDigest: findingContentAddress(
+        'finding-contract-config',
+        runInput(guidance).contract,
+      ),
+      reviewScopeSnapshotId: REVIEW_SCOPE_SNAPSHOT.reviewScopeSnapshotId,
+      adjudicationTaskId: ledger.terminalAdjudicationAttempts[0]!.attemptId,
+    })).toEqual({ kind: 'undetermined', reasonCodes: ['head_not_fresh'] });
+    expect(ledger.lifecycleEvents).toHaveLength(2);
+  });
+
 });

--- a/src/__tests__/fixtures/takt-default-fc-compatibility-baseline.json
+++ b/src/__tests__/fixtures/takt-default-fc-compatibility-baseline.json
@@ -1,0 +1,43 @@
+{
+  "head": "3847cda1",
+  "normalizedFindingContract": {
+    "bytes": 10256,
+    "sha256": "63990ca46fb12f19825af25ff1d171262452f4659926854a9509a13f1b661b70"
+  },
+  "executionBundle": {
+    "rootOwned": "e11afd9ad63392d8f4285d2e001b0d3c217a15ac8a005e5ae1fb5f509f07dec1",
+    "inheritedChild": "6447d33727e95e909fc15c0ca79bf4a4ade04ef0b936f84723e49d1f19cb2eb2"
+  },
+  "adjudicatorPrompts": {
+    "conflict": {
+      "bytes": 2774,
+      "sha256": "1988df324b72fb7f161a12c4cb58b42d2d638bb30cdca178ab1b9e765c15d37c"
+    }
+  },
+  "managerPrompts": {
+    "raw": {
+      "bytes": 4694,
+      "sha256": "f241689dc0b5b128dc81a4c63371b7429930b020d718d415dafc889b65634b01"
+    },
+    "control": {
+      "bytes": 3364,
+      "sha256": "9d1aa4d303026b885e64ac32c4eae06fa8496237ab6ebd75de8660df32351148"
+    },
+    "entityBinding": {
+      "bytes": 1963,
+      "sha256": "71a866930ddf32fd8ca743887897d6977fcdc6204ddc16b32872dbe2cfdc50d9"
+    },
+    "legacy": {
+      "bytes": 10293,
+      "sha256": "bbf39da9343e6a3bef70cd250414c1b0259c4da388b50ec3e6a4cb4cb4d48ec7"
+    },
+    "interpretation": {
+      "bytes": 2269,
+      "sha256": "644fce40dc751d7d6a2793e6fbf89a4bc15f663e37542bcc847cd219be82874a"
+    }
+  },
+  "interpretationRequest": {
+    "bytes": 2071,
+    "sha256": "21c0b4ecfec03318f5ea5dab5af361a11b1a58ee77e8b5d1ba31bcb7937422e2"
+  }
+}

--- a/src/__tests__/fixtures/takt-default-fc-terminal-compatibility-baseline.json
+++ b/src/__tests__/fixtures/takt-default-fc-terminal-compatibility-baseline.json
@@ -1,0 +1,7 @@
+{
+  "prompt": {
+    "bytes": 1478,
+    "sha256": "de73df023d73494652eab509f2645b2fb27bafc00ec0b2066a117b83ca61e076"
+  },
+  "requestDigest": "63f9e28fc10a52182a31bb2bcf05efc92ed1f90bbe1423b35d4c97568ff99b21"
+}

--- a/src/__tests__/helpers/finding-adjudication-reservation.ts
+++ b/src/__tests__/helpers/finding-adjudication-reservation.ts
@@ -1,4 +1,6 @@
 import { processInterpretationLiveClaims } from '../../core/workflow/findings/interpretation-live-claims.js';
+import type { FindingManagerAttemptKind } from '../../core/models/finding-contract-types.js';
+import type { FindingLedgerStore } from '../../core/workflow/findings/store.js';
 
 type FindingInterpretationLiveClaimFixture = {
   interpretationLiveClaims: typeof processInterpretationLiveClaims;
@@ -8,4 +10,36 @@ export function createFindingAdjudicationReservation(): FindingInterpretationLiv
   return {
     interpretationLiveClaims: processInterpretationLiveClaims,
   };
+}
+
+type AdjudicationPurpose = Extract<
+  FindingManagerAttemptKind,
+  'terminal_adjudication' | 'conflict_adjudication'
+>;
+
+export function crashAfterAdjudicationReservation(input: {
+  store: FindingLedgerStore;
+  purpose: AdjudicationPurpose;
+  errorMessage: string;
+}): FindingLedgerStore {
+  let crashed = false;
+  return new Proxy(input.store, {
+    get(target, property, receiver) {
+      if (property === 'updateLedger') {
+        return async (...args: Parameters<FindingLedgerStore['updateLedger']>) => {
+          const mutation = await target.updateLedger(...args);
+          const hasReservation = mutation.ledger.findingManagerProviderCalls.some((call) => (
+            call.purpose === input.purpose && call.state === 'reserved'
+          ));
+          if (!crashed && hasReservation) {
+            crashed = true;
+            throw new Error(input.errorMessage);
+          }
+          return mutation;
+        };
+      }
+      const value = Reflect.get(target, property, receiver) as unknown;
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
 }

--- a/src/__tests__/helpers/finding-interpretation-case-store-fixture.ts
+++ b/src/__tests__/helpers/finding-interpretation-case-store-fixture.ts
@@ -21,6 +21,7 @@ import type {
   FindingObservation,
   FindingEvidenceRecord,
   InterpretationBatchReceipt,
+  InterpretationCase,
   InterpretationDecision,
 } from '../../core/workflow/findings/types.js';
 import {
@@ -183,7 +184,7 @@ export interface Harness {
   }) => ReturnType<typeof completeInterpretationCases>;
 }
 
-function verifiedEvidenceRecords(
+export function verifiedEvidenceRecords(
   items: readonly CanonicalIntakeItem[],
 ): ReadonlyMap<string, readonly FindingEvidenceRecord[]> {
   return new Map(items.map((item) => [
@@ -220,6 +221,13 @@ export function openHarness(input: {
   root?: string;
   maxEpochsPerLineage?: number;
   budgetLimits?: FindingManagerProviderBudgetLimits;
+  prepareProviderRequest?: (
+    ledger: FindingLedger,
+    cases: readonly Extract<InterpretationCase, { kind: 'provider_case' }>[],
+  ) => {
+    requestBytes: string;
+    adapterSupportsUtf8ByteUpperBound: boolean;
+  };
 } = {}): Harness {
   const root = input.root ?? tempRoot();
   const resolver = new FindingStorageResolver({
@@ -253,12 +261,12 @@ export function openHarness(input: {
         maxChargedOutputTokensPerRound: 40_000,
       },
       maxCasesPerProviderCall: 16,
-      prepareProviderRequest: (_ledger, cases) => ({
-        requestBytes: JSON.stringify(cases
-          .map((plannedCase) => plannedCase.caseId)
-          .sort()),
-        adapterSupportsUtf8ByteUpperBound: true,
-      }),
+      prepareProviderRequest: input.prepareProviderRequest ?? ((_ledger, cases) => ({
+          requestBytes: JSON.stringify(cases
+            .map((plannedCase) => plannedCase.caseId)
+            .sort()),
+          adapterSupportsUtf8ByteUpperBound: true,
+        })),
       verifiedEvidenceRecordsByRawFindingId: verifiedEvidenceRecords(request.items),
       ...request,
     }),

--- a/src/__tests__/previewPrompts.test.ts
+++ b/src/__tests__/previewPrompts.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MockInstance } from 'vitest';
 import type { CompiledProviderEnvironment } from '../infra/config/runtime-provider/environment.js';
+import { getProviderValidationErrorSource } from '../core/workflow/provider-validation-error.js';
+
+const VALID_ADJUDICATOR = {
+  persona: 'supervisor',
+  provider: 'codex' as const,
+  model: 'gpt-5',
+};
 
 const {
   mockLoadWorkflowByIdentifier,
   mockResolveWorkflowConfigValue,
   mockResolveWorkflowSelector,
   mockResolveAuxiliaryProviderEnvironment,
+  mockValidateWorkflowCallContracts,
   mockHeader,
   mockInfo,
   mockError,
@@ -20,6 +28,7 @@ const {
   mockResolveWorkflowConfigValue: vi.fn(),
   mockResolveWorkflowSelector: vi.fn(),
   mockResolveAuxiliaryProviderEnvironment: vi.fn(),
+  mockValidateWorkflowCallContracts: vi.fn(),
   mockHeader: vi.fn(),
   mockInfo: vi.fn(),
   mockError: vi.fn(),
@@ -41,6 +50,10 @@ vi.mock('../infra/config/index.js', () => ({
 // resolveAuxiliaryProviderEnvironment; here we drive its resolved output directly.
 vi.mock('../infra/config/runtime-provider/provider-environment.js', () => ({
   resolveAuxiliaryProviderEnvironment: mockResolveAuxiliaryProviderEnvironment,
+}));
+
+vi.mock('../infra/config/loaders/workflowResolver.js', () => ({
+  validateWorkflowCallContracts: mockValidateWorkflowCallContracts,
 }));
 
 function compiledEnvironment(
@@ -371,6 +384,12 @@ describe('previewPrompts', () => {
   });
 
   it('finding manager の設定済み provider/model を表示する', async () => {
+    mockResolveAuxiliaryProviderEnvironment.mockReturnValueOnce(compiledEnvironment({
+      provider: 'codex',
+      providerSource: 'project',
+      model: 'gpt-5.5',
+      modelSource: 'project',
+    }));
     mockLoadWorkflowByIdentifier.mockReturnValueOnce({
       name: 'finding-contract-preview',
       maxSteps: 1,
@@ -380,6 +399,12 @@ describe('previewPrompts', () => {
           personaDisplayName: 'Findings Manager',
           instruction: 'manager instruction',
           outputContract: 'manager output contract',
+          provider: 'codex',
+          model: 'gpt-5.5',
+        },
+        adjudicator: {
+          persona: 'supervisor',
+          personaDisplayName: 'Finding Adjudicator',
           provider: 'codex',
           model: 'gpt-5.5',
         },
@@ -398,6 +423,22 @@ describe('previewPrompts', () => {
     expect(mockInfo).toHaveBeenCalledWith('Finding manager: Findings Manager');
     expect(mockInfo).toHaveBeenCalledWith('Finding manager provider: codex');
     expect(mockInfo).toHaveBeenCalledWith('Finding manager model: gpt-5.5');
+    expect(mockInfo).toHaveBeenCalledWith('Finding adjudicator: Finding Adjudicator');
+    expect(mockInfo).toHaveBeenCalledWith('Finding adjudicator provider: codex');
+    expect(mockInfo).toHaveBeenCalledWith('Finding adjudicator model: gpt-5.5');
+    expect(mockValidateWorkflowCallContracts).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'finding-contract-preview' }),
+      '/project',
+      '/project',
+      {
+        providerValidationOptions: expect.objectContaining({
+          provider: 'codex',
+          providerSource: 'project',
+          model: 'gpt-5.5',
+          modelSource: 'project',
+        }),
+      },
+    );
   });
 
   it('finding manager の未設定 provider/model は未設定として表示する', async () => {
@@ -410,6 +451,7 @@ describe('previewPrompts', () => {
           instruction: 'manager instruction',
           outputContract: 'manager output contract',
         },
+        adjudicator: VALID_ADJUDICATOR,
       },
       steps: [
         {
@@ -446,6 +488,7 @@ describe('previewPrompts', () => {
           instruction: 'manager instruction',
           outputContract: 'manager output contract',
         },
+        adjudicator: VALID_ADJUDICATOR,
       },
       steps: [
         {
@@ -480,6 +523,7 @@ describe('previewPrompts', () => {
           provider: 'codex',
           model: 'step-model',
         },
+        adjudicator: VALID_ADJUDICATOR,
       },
       steps: [{ name: 'review', personaDisplayName: 'reviewer', outputContracts: [] }],
     });
@@ -510,6 +554,7 @@ describe('previewPrompts', () => {
           outputContract: 'manager output contract',
           provider: 'codex',
         },
+        adjudicator: VALID_ADJUDICATOR,
       },
       steps: [
         {
@@ -552,6 +597,7 @@ describe('previewPrompts', () => {
           instruction: 'manager instruction',
           outputContract: 'manager output contract',
         },
+        adjudicator: VALID_ADJUDICATOR,
       },
       steps: [{ name: 'review', personaDisplayName: 'reviewer', outputContracts: [] }],
     });
@@ -588,6 +634,7 @@ describe('previewPrompts', () => {
           instruction: 'manager instruction',
           outputContract: 'manager output contract',
         },
+        adjudicator: VALID_ADJUDICATOR,
       },
       steps: [{ name: 'review', personaDisplayName: 'reviewer', outputContracts: [] }],
     });
@@ -598,5 +645,72 @@ describe('previewPrompts', () => {
     // 候補へ決定的に解決される。preview も同じ値を表示する。
     expect(mockInfo).toHaveBeenCalledWith('Finding manager provider: codex');
     expect(mockInfo).toHaveBeenCalledWith('Finding manager model: gpt-5.5');
+  });
+
+  it.each([
+    {
+      role: 'manager',
+      environment: compiledEnvironment({
+        personaProviders: {
+          'Findings Manager': { provider: 'opencode' },
+        },
+      }),
+      contract: {
+        manager: {
+          persona: 'findings-manager',
+          personaDisplayName: 'Findings Manager',
+          instruction: 'manager instruction',
+          outputContract: 'manager output contract',
+        },
+        adjudicator: VALID_ADJUDICATOR,
+      },
+      source: 'persona_providers',
+    },
+    {
+      role: 'adjudicator',
+      environment: compiledEnvironment({
+        providerRouting: {
+          personas: { supervisor: { provider: 'opencode' } },
+        },
+      }),
+      contract: {
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'manager instruction',
+          outputContract: 'manager output contract',
+          provider: 'codex' as const,
+          model: 'gpt-5',
+        },
+        adjudicator: { persona: 'supervisor' },
+      },
+      source: 'provider_routing.personas',
+    },
+  ])('workflow_call のない root でも不正な finding $role provider を拒否する', async ({
+    environment,
+    contract,
+    source,
+  }) => {
+    mockResolveAuxiliaryProviderEnvironment.mockReturnValueOnce(environment);
+    mockLoadWorkflowByIdentifier.mockReturnValueOnce({
+      name: 'finding-contract-preview',
+      maxSteps: 1,
+      findingContract: contract,
+      steps: [{ name: 'review', personaDisplayName: 'reviewer', outputContracts: [] }],
+    });
+
+    let validationError: unknown;
+    try {
+      await previewPrompts('/project');
+    } catch (error) {
+      validationError = error;
+    }
+
+    expect(validationError).toBeInstanceOf(Error);
+    expect((validationError as Error).message).toContain("provider 'opencode' requires model");
+    expect(getProviderValidationErrorSource(validationError)).toMatchObject({
+      field: 'provider',
+      source,
+    });
+    expect(mockValidateWorkflowCallContracts).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/promptEvalProbeLifecycle.test.ts
+++ b/src/__tests__/promptEvalProbeLifecycle.test.ts
@@ -40,6 +40,8 @@ interface SmokeFixtureCase {
 // expire before the probe finishes starting (it then never spawns its
 // grandchild or prints its PIDs), so give each phase extra headroom there.
 const PROBE_PHASE_BUDGET_MS = process.platform === 'win32' ? 2_000 : 500;
+// The owned entrypoint adds a second Node process hop before worker cleanup.
+const OWNED_ENTRYPOINT_TIMEOUT_MS = process.platform === 'win32' ? 10_000 : 2_000;
 
 const smokeBatchFixture = fileURLToPath(
   new URL('../../prompt-evals/fixtures/run-smoke-batch.mjs', import.meta.url),
@@ -1069,7 +1071,9 @@ describe('prompt eval probe lifecycle', () => {
       "console.log(`PROBE_RESULT ${JSON.stringify({ workspace, temporaryRoot: tmpdir() })}`)",
     ].join('\n'), 'utf8');
 
-    const { stdout } = await runSmokeScript(script, [], process.env, { timeoutMs: 2_000 });
+    const { stdout } = await runSmokeScript(script, [], process.env, {
+      timeoutMs: OWNED_ENTRYPOINT_TIMEOUT_MS,
+    });
     const result = parseProbeResult(stdout) as { workspace: string; temporaryRoot: string };
     if (existsSync(result.workspace)) {
       temporaryDirectories.push(result.workspace);

--- a/src/__tests__/provider-resolution.test.ts
+++ b/src/__tests__/provider-resolution.test.ts
@@ -15,6 +15,10 @@ import {
   resolveNonWorkflowProviderModelFromConfig,
 } from '../core/config/provider-resolution.js';
 import { buildFindingManagerStep } from '../core/workflow/findings/manager-step.js';
+import {
+  buildFindingConflictAdjudicationStep,
+  buildFindingTerminalAdjudicationStep,
+} from '../core/workflow/findings/adjudication-step.js';
 import type { ProjectConfig } from '../core/models/config-types.js';
 
 describe('resolveProviderModelCandidates', () => {
@@ -216,6 +220,75 @@ describe('resolveStepProviderModel', () => {
       provider: 'codex',
       model: undefined,
     });
+  });
+
+  it('should resolve conflict and terminal adjudicators through the same direct provider/model rules', () => {
+    const input = {
+      contract: {
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          outputContract: 'findings-manager',
+        },
+        adjudicator: {
+          persona: 'terminal-supervisor',
+          providerRoutingPersonaKey: 'terminal-supervisor',
+          provider: 'codex' as const,
+        },
+      },
+      workflowProvider: 'claude' as const,
+      workflowModel: 'workflow-model',
+    };
+
+    for (const step of [
+      buildFindingConflictAdjudicationStep(input),
+      buildFindingTerminalAdjudicationStep(input),
+    ]) {
+      expect(resolveStepProviderModel({
+        step,
+        providerRouting: {
+          personas: {
+            'terminal-supervisor': { provider: 'opencode', model: 'persona-model' },
+          },
+        },
+      })).toMatchObject({
+        provider: 'codex',
+        model: undefined,
+      });
+    }
+  });
+
+  it('should resolve conflict and terminal adjudicators through the same persona routing fallback', () => {
+    const input = {
+      contract: {
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          outputContract: 'findings-manager',
+        },
+        adjudicator: {
+          persona: 'terminal-supervisor',
+          providerRoutingPersonaKey: 'terminal-supervisor',
+        },
+      },
+    };
+
+    for (const step of [
+      buildFindingConflictAdjudicationStep(input),
+      buildFindingTerminalAdjudicationStep(input),
+    ]) {
+      expect(resolveStepProviderModel({
+        step,
+        providerRouting: {
+          personas: {
+            'terminal-supervisor': { provider: 'codex', model: 'strong-model' },
+          },
+        },
+      })).toMatchObject({
+        provider: 'codex',
+        model: 'strong-model',
+      });
+    }
   });
 
   it('should prefer step.provider over personaProviders.provider when both are defined', () => {

--- a/src/__tests__/takt-default-fc-builtins.test.ts
+++ b/src/__tests__/takt-default-fc-builtins.test.ts
@@ -321,7 +321,10 @@ describe('takt-default-fc builtins', () => {
     const loaded = loadWorkflow(language, 'takt-default-fc');
     expect(loaded.findingContract).toMatchObject({
       manager: { providerRoutingPersonaKey: 'findings-manager' },
-      adjudicator: { providerRoutingPersonaKey: 'supervisor' },
+      adjudicator: {
+        providerRoutingPersonaKey: 'supervisor',
+        instruction: expect.stringContaining('ledger subject'),
+      },
       stopBudget: { maxRounds: 40 },
       reviewBudget: { maxReviewRounds: 6 },
     });

--- a/src/__tests__/takt-default-fc-compatibility-baseline.test.ts
+++ b/src/__tests__/takt-default-fc-compatibility-baseline.test.ts
@@ -1,0 +1,515 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { executeAgent } from '../agents/agent-usecases.js';
+import { createEmptyFindingContractRegistries } from '../core/models/finding-contract-seed.js';
+import type {
+  AgentResponse,
+  AgentWorkflowStep,
+  FindingContractConfig,
+  WorkflowConfig,
+  WorkflowStep,
+} from '../core/models/types.js';
+import { buildManagerInstruction } from '../core/workflow/findings/manager-agent.js';
+import { renderConflictAdjudicationInstruction } from '../core/workflow/findings/adjudication-evidence.js';
+import {
+  freshConflictAdjudicationSnapshot,
+  refreshActiveConflictAdjudicationSnapshots,
+} from '../core/workflow/findings/conflict-adjudication-model.js';
+import {
+  prepareInterpretationCaseProviderRequest,
+  requestInterpretationCases,
+} from '../core/workflow/findings/manager-interpretation-agent.js';
+import type { RunFindingManagerForStepInput } from '../core/workflow/findings/manager-contracts.js';
+import { runMainManagerTasks } from '../core/workflow/findings/manager-task-runner.js';
+import { bindPreAdmissionEntities } from '../core/workflow/findings/pre-admission-entity-binding.js';
+import {
+  candidateFromStoredRawFinding,
+  canonicalizeReviewerRawFinding,
+  toLedgerRawFinding,
+} from '../core/workflow/findings/raw-canonicalization.js';
+import type {
+  FindingLedger,
+  RawFinding,
+} from '../core/workflow/findings/types.js';
+import type { ReviewerIntakeResult } from '../core/workflow/findings/manager-admission.js';
+import { attachWorkflowOpaqueRef } from '../shared/workflowConfigMetadata.js';
+import { canonicalJson } from '../shared/utils/canonical-json.js';
+import { prepareWorkflowExecutionBundle } from '../features/tasks/execute/workflowExecutionBundle.js';
+import { loadWorkflowFromFile } from '../infra/config/loaders/workflowFileLoader.js';
+import { composeFindingManagerInstruction } from '../core/workflow/findings/manager-instruction-composer.js';
+import {
+  authorizeFindingLedgerFixture,
+  canonicalRawFindingFixture,
+  emptyFindingAuthorityProjection,
+  rawCanonicalSnapshotFixture,
+} from './helpers/finding-lifecycle-fixture.js';
+
+vi.mock('../agents/agent-usecases.js', () => ({ executeAgent: vi.fn() }));
+
+const executeAgentMock = vi.mocked(executeAgent);
+const REPO_ROOT = process.cwd();
+const BASELINE_PATH = join(
+  REPO_ROOT,
+  'src',
+  '__tests__',
+  'fixtures',
+  'takt-default-fc-compatibility-baseline.json',
+);
+
+const contract: FindingContractConfig = {
+  manager: {
+    persona: 'findings-manager',
+    instruction: 'Reconcile only the supplied task.',
+    outputContract: 'Return structured JSON.',
+  },
+};
+
+const managerStep: AgentWorkflowStep = {
+  kind: 'agent',
+  name: 'findings-manager',
+  persona: 'findings-manager',
+  edit: false,
+};
+
+function digest(bytes: string): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function byteGolden(bytes: string): { bytes: number; sha256: string } {
+  return { bytes: Buffer.byteLength(bytes, 'utf8'), sha256: digest(bytes) };
+}
+
+function normalizePaths(bytes: string): string {
+  return bytes.replaceAll(REPO_ROOT, '<REPO>');
+}
+
+function emptyLedger(overrides: Partial<FindingLedger> = {}): FindingLedger {
+  return {
+    workflowName: 'compatibility-baseline',
+    nextId: 1,
+    updatedAt: '2026-08-04T00:00:00.000Z',
+    findings: [],
+    evidenceRecords: [],
+    evidenceBindings: [],
+    lifecycleReservations: [],
+    lifecycleEvents: [],
+    rawFindings: [],
+    conflicts: [],
+    ...createEmptyFindingContractRegistries(),
+    ...overrides,
+  };
+}
+
+function rawFinding(): RawFinding {
+  return canonicalRawFindingFixture({
+    rawFindingId: 'raw-compatibility-001',
+    stepName: 'reviewer',
+    reviewer: 'reviewer',
+    familyTag: 'correctness',
+    severity: 'high',
+    title: 'Compatibility finding',
+    description: 'The compatibility fixture exercises every manager prompt path.',
+    suggestion: 'Preserve the prompt bytes.',
+    relation: 'new',
+    targetFindingId: null,
+    target: { kind: 'code', paths: ['src/compatibility.ts'] },
+    evidence: [],
+  });
+}
+
+function response(structuredOutput: Record<string, unknown>): AgentResponse {
+  return {
+    persona: 'findings-manager',
+    status: 'done',
+    content: '',
+    timestamp: new Date('2026-08-04T00:00:00.000Z'),
+    structuredOutput,
+  };
+}
+
+function sectionJson<T>(instruction: string, heading: string): T {
+  const start = instruction.indexOf(`${heading}\n`);
+  if (start < 0) throw new Error(`Missing section ${heading}`);
+  const rest = instruction.slice(start + heading.length + 1);
+  const match = /^(`{3,})json\n([\s\S]*?)\n\1/m.exec(rest);
+  if (match?.[2] === undefined) throw new Error(`Missing JSON block after ${heading}`);
+  return JSON.parse(match[2]) as T;
+}
+
+function runInput() {
+  return {
+    optionsBuilder: {
+      buildAgentOptions: () => ({}),
+    },
+    stepExecutor: {
+      buildPhase1Instruction: (instruction: string) => instruction,
+      normalizeStructuredOutput: (_step: WorkflowStep, agentResponse: AgentResponse) => agentResponse,
+      recordSynthesizedAgentUsage: () => {},
+    },
+  } as Pick<RunFindingManagerForStepInput, 'optionsBuilder' | 'stepExecutor'>;
+}
+
+function reviewerIntake(ledger: FindingLedger, raw: RawFinding): ReviewerIntakeResult {
+  const canonical = canonicalizeReviewerRawFinding(
+    candidateFromStoredRawFinding(raw, 'reviewer-stable-compatibility'),
+    { ledger },
+  ).canonical;
+  return {
+    items: [{ canonical, wire: toLedgerRawFinding(canonical) }],
+    entityBindings: new Map(),
+    overflowRawFindingIds: new Set(),
+    intakeProvisionalSpecs: [],
+    intakeAnomalySpecs: [],
+    overflowReports: [],
+    clarifications: [],
+    rawNormalizations: [],
+    healthyReviewerStableKeys: new Set(),
+  };
+}
+
+function bundleGolden(): { rootOwned: string; inheritedChild: string } {
+  const loadedBuiltin = loadWorkflowFromFile(
+    join(REPO_ROOT, 'builtins', 'en', 'workflows', 'takt-default-high.yaml'),
+    REPO_ROOT,
+  );
+  if (loadedBuiltin.findingContract === undefined) {
+    throw new Error('Expected takt-default-high to load its finding contract facets');
+  }
+  const child = attachWorkflowOpaqueRef({
+    name: 'compatibility-child',
+    subworkflow: { callable: true, visibility: 'internal', requiresFindingContract: true },
+    initialStep: 'review',
+    maxSteps: 2,
+    steps: [{
+      kind: 'agent',
+      name: 'review',
+      persona: 'reviewer',
+      personaDisplayName: 'reviewer',
+      instruction: 'Review.',
+      rules: [{ condition: { kind: 'semantic', label: 'COMPLETE' }, next: 'COMPLETE' }],
+    }],
+  } satisfies WorkflowConfig, `builtin:sha256:${'b'.repeat(64)}`);
+  const root = attachWorkflowOpaqueRef({
+    name: 'compatibility-root',
+    findingContract: loadedBuiltin.findingContract,
+    initialStep: 'review-call',
+    maxSteps: 2,
+    steps: [{
+      kind: 'workflow_call',
+      name: 'review-call',
+      call: 'compatibility-child',
+      personaDisplayName: 'review-call',
+      instruction: '',
+      rules: [{ condition: { kind: 'semantic', label: 'COMPLETE' }, next: 'COMPLETE' }],
+    }],
+  } satisfies WorkflowConfig, `builtin:sha256:${'a'.repeat(64)}`);
+  const prepared = prepareWorkflowExecutionBundle({
+    rootWorkflow: root,
+    workflowCallResolver: () => child,
+    projectCwd: REPO_ROOT,
+    lookupCwd: REPO_ROOT,
+  });
+  const objects = [...prepared.objects.values()].sort();
+  const rootObjectHash = prepared.manifest.nodes[prepared.manifest.root.nodeId];
+  const rootObject = prepared.objects.get(rootObjectHash!);
+  if (rootObject === undefined) throw new Error('Missing root bundle object');
+  const childObject = objects.find((value) => value !== rootObject);
+  if (childObject === undefined) throw new Error('Missing inherited child bundle object');
+  return {
+    rootOwned: digest(rootObject),
+    inheritedChild: digest(childObject),
+  };
+}
+
+function conflictPromptGolden(): { bytes: number; sha256: string } {
+  const raw = rawFinding();
+  const observation = {
+    runId: 'compatibility-run',
+    stepName: 'reviewer',
+    timestamp: '2026-08-04T00:00:00.000Z',
+  };
+  const ledger = refreshActiveConflictAdjudicationSnapshots({
+    ledger: authorizeFindingLedgerFixture(emptyLedger({
+        nextId: 2,
+        rawFindings: [raw],
+        rawCanonicalSnapshots: [rawCanonicalSnapshotFixture(raw, observation)],
+        findings: [{
+          id: 'F-0001',
+          status: 'open',
+          lifecycle: 'new',
+          revision: 1,
+          target: raw.target,
+          targetIdentityHash: raw.targetIdentityHash,
+          claimIdentityHash: raw.claimIdentityHash,
+          semanticClaimIdentityHash: raw.semanticClaimIdentityHash,
+          severity: raw.severity,
+          title: raw.title,
+          description: raw.description ?? undefined,
+          suggestion: raw.suggestion ?? undefined,
+          evidenceIds: [],
+          reviewers: ['reviewer'],
+          rawFindingIds: [raw.rawFindingId],
+          firstSeen: observation,
+          lastSeen: observation,
+        }],
+        conflicts: [{
+          id: 'C-FA2947446963',
+          status: 'active',
+          findingIds: ['F-0001'],
+          rawFindingIds: [raw.rawFindingId],
+          description: 'Compatibility conflict.',
+          firstSeen: observation,
+          lastSeen: observation,
+          revision: 1,
+        }],
+    })),
+    originStep: 'reviewer',
+    createdAt: observation,
+  });
+  const snapshot = freshConflictAdjudicationSnapshot(ledger, 'C-FA2947446963');
+  return byteGolden(renderConflictAdjudicationInstruction(snapshot));
+}
+
+async function collectManagerPrompts(
+  promptContract: FindingContractConfig,
+  promptManagerStep: AgentWorkflowStep,
+): Promise<Record<string, string>> {
+  const raw = rawFinding();
+  const ledger = emptyLedger({
+    nextId: 2,
+    findings: [{
+      id: 'F-0001',
+      status: 'open',
+      lifecycle: 'new',
+      revision: 1,
+      target: raw.target,
+      targetIdentityHash: raw.targetIdentityHash,
+      claimIdentityHash: raw.claimIdentityHash,
+      semanticClaimIdentityHash: raw.semanticClaimIdentityHash,
+      severity: raw.severity,
+      title: raw.title,
+      description: raw.description ?? undefined,
+      suggestion: raw.suggestion ?? undefined,
+      evidenceIds: [],
+      reviewers: ['reviewer'],
+      rawFindingIds: [],
+      firstSeen: {
+        runId: 'compatibility-run',
+        stepName: 'reviewer',
+        timestamp: '2026-08-04T00:00:00.000Z',
+      },
+      lastSeen: {
+        runId: 'compatibility-run',
+        stepName: 'reviewer',
+        timestamp: '2026-08-04T00:00:00.000Z',
+      },
+    }],
+  });
+  const prompts: Record<string, string> = {};
+  executeAgentMock.mockImplementation(async (_persona, instruction) => {
+    if (instruction.includes('## Control task output override')) {
+      const manifest = sectionJson<{
+        taskId: string;
+        candidateIntents: Array<{ intentId: string }>;
+      }>(instruction, '## Task manifest');
+      prompts.control = instruction;
+      return response({
+        taskId: manifest.taskId,
+        evaluations: manifest.candidateIntents.map(({ intentId }) => ({
+          intentId,
+          result: { kind: 'no_action', reason: 'No control action is authorized.' },
+        })),
+        selectedIntentId: null,
+      });
+    }
+    const manifest = sectionJson<{
+      taskId: string;
+      rawFindings: Array<{ rawFindingId: string; componentId: string }>;
+    }>(instruction, '## Task manifest');
+    prompts.raw = instruction;
+    return response({
+      taskId: manifest.taskId,
+      decisions: manifest.rawFindings.map(({ rawFindingId, componentId }) => ({
+        rawFindingId,
+        componentId,
+        decision: 'new',
+        findingId: '',
+        evidence: 'Compatibility baseline decision.',
+      })),
+    });
+  });
+  await runMainManagerTasks({
+    contract: promptContract,
+    previousLedger: ledger,
+    reviewScopeSnapshotId: 'scope-compatibility',
+    residualRawFindings: [raw],
+    mechanicallyClassifiedCount: 0,
+    priorStepResponseText: undefined,
+    invalidLocationCandidates: new Map(),
+    dismissCandidates: new Map([['F-0001', 'The finding is outside the requested scope.']]),
+    evidenceRecordsByRawFindingId: new Map(),
+    managerStep: promptManagerStep,
+    runInput: runInput(),
+    managerAuthority: 'standard',
+    workflowTask: 'Preserve compatibility.',
+    subResults: [],
+  });
+
+  executeAgentMock.mockImplementation(async (_persona, instruction) => {
+    const manifest = sectionJson<{
+      taskId: string;
+      ownedRawFindingIds: string[];
+    }>(instruction, '## Task manifest');
+    prompts.entityBinding = instruction;
+    return response({
+      taskId: manifest.taskId,
+      decisions: manifest.ownedRawFindingIds.map((rawFindingId) => ({
+        rawFindingId,
+        decision: 'new_entity',
+        findingId: '',
+        groupRawFindingId: rawFindingId,
+        reason: 'Compatibility baseline entity.',
+      })),
+    });
+  });
+  const entityLedger = emptyLedger();
+  await bindPreAdmissionEntities({
+    contract: promptContract,
+    previousLedger: entityLedger,
+    intake: reviewerIntake(entityLedger, raw),
+    managerStep: promptManagerStep,
+    roundMarker: 'round-compatibility',
+    runInput: runInput(),
+  });
+
+  prompts.legacy = buildManagerInstruction({
+    contract: promptContract,
+    previousLedger: ledger,
+    residualRawFindings: [raw],
+    mechanicallyClassifiedCount: 0,
+    priorStepResponseText: undefined,
+    invalidLocationCandidates: new Map(),
+    dismissCandidates: new Map(),
+    verifiedEvidenceRecordsByRawFindingId: new Map(),
+  });
+  const prepared = prepareInterpretationCaseProviderRequest({
+    cases: [],
+    contract: promptContract,
+    optionsBuilder: runInput().optionsBuilder as never,
+    stepExecutor: runInput().stepExecutor,
+    ledger,
+  });
+  prompts.interpretation = prepared.phase1Instruction;
+
+  executeAgentMock.mockResolvedValue(response({ decisions: [] }));
+  await requestInterpretationCases({
+    cases: [],
+    contract: promptContract,
+    optionsBuilder: runInput().optionsBuilder as never,
+    stepExecutor: runInput().stepExecutor,
+    ledger,
+    prepared,
+  });
+
+  return prompts;
+}
+
+async function collectBaseline() {
+  const loaded = loadWorkflowFromFile(
+    join(REPO_ROOT, 'builtins', 'en', 'workflows', 'takt-default-high.yaml'),
+    REPO_ROOT,
+  );
+  const normalizedContractBytes = normalizePaths(canonicalJson(loaded.findingContract));
+  const managerPromptBytes = await collectManagerPrompts(contract, managerStep);
+  const managerPrompts = Object.fromEntries(
+    Object.entries(managerPromptBytes).map(([name, prompt]) => [name, byteGolden(prompt)]),
+  );
+  const interpretationRequest = prepareInterpretationCaseProviderRequest({
+    cases: [],
+    contract,
+    optionsBuilder: runInput().optionsBuilder as never,
+    stepExecutor: runInput().stepExecutor,
+    ledger: emptyLedger(),
+  }).requestBytes;
+  return {
+    head: '3847cda1',
+    normalizedFindingContract: byteGolden(normalizedContractBytes),
+    executionBundle: bundleGolden(),
+    adjudicatorPrompts: {
+      conflict: conflictPromptGolden(),
+    },
+    managerPrompts,
+    interpretationRequest: byteGolden(interpretationRequest),
+  };
+}
+
+describe('takt-default-fc compatibility baseline', () => {
+  it('pins omitted manager additions and adjudicator configuration before production changes', async () => {
+    const expected = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as unknown;
+    const actual = await collectBaseline();
+    expect(actual).toEqual(expected);
+  });
+
+  it('prepends additions exactly once while preserving all five manager prompt suffixes', async () => {
+    const additionsContract: FindingContractConfig = {
+      manager: {
+        ...contract.manager,
+        knowledgeContents: ['Knowledge one', 'Knowledge two'],
+        policyContents: ['Policy one', 'Policy two'],
+      },
+    };
+    const additionsStep: AgentWorkflowStep = {
+      ...managerStep,
+      knowledgeContents: additionsContract.manager.knowledgeContents,
+      policyContents: additionsContract.manager.policyContents,
+    };
+    const basePrompts = await collectManagerPrompts(contract, managerStep);
+    const composedPrompts = await collectManagerPrompts(additionsContract, additionsStep);
+    const prefix = [
+      '## Knowledge additions',
+      'Knowledge one',
+      '---',
+      'Knowledge two',
+      '',
+      '## Policy additions',
+      'Policy one',
+      '---',
+      'Policy two',
+      '',
+      '',
+    ].join('\n');
+    expect(Object.keys(composedPrompts).sort()).toEqual(
+      ['control', 'entityBinding', 'interpretation', 'legacy', 'raw'],
+    );
+    for (const [name, basePrompt] of Object.entries(basePrompts)) {
+      expect(composedPrompts[name]).toBe(`${prefix}${basePrompt}`);
+    }
+  });
+
+  it('rejects defined-empty manager additions instead of treating them as omitted', () => {
+    for (const additions of [
+      { policyContents: [] },
+      { knowledgeContents: [] },
+      { policyContents: [], knowledgeContents: undefined },
+      { policyContents: undefined, knowledgeContents: [] },
+    ]) {
+      expect(() => composeFindingManagerInstruction({
+        baseInstruction: 'base',
+        ...additions,
+      })).toThrow('Finding Manager policy/knowledge additions must not be empty');
+    }
+  });
+
+  it('does not impose the new 24KB task ceiling on the legacy manager composer', () => {
+    const legacyBase = `Legacy manager input ${'x'.repeat(24_100)}`;
+
+    const composed = composeFindingManagerInstruction({
+      baseInstruction: legacyBase,
+    });
+
+    expect(composed).toBe(legacyBase);
+    expect(Buffer.byteLength(composed, 'utf8')).toBeGreaterThan(24_000);
+  });
+});

--- a/src/__tests__/takt-default-fc-compatibility-baseline.test.ts
+++ b/src/__tests__/takt-default-fc-compatibility-baseline.test.ts
@@ -138,7 +138,12 @@ function sectionJson<T>(instruction: string, heading: string): T {
   return JSON.parse(match[2]) as T;
 }
 
-function runInput() {
+type CompatibilityRunInput = {
+  optionsBuilder: Pick<RunFindingManagerForStepInput['optionsBuilder'], 'buildAgentOptions'>;
+  stepExecutor: RunFindingManagerForStepInput['stepExecutor'];
+};
+
+function runInput(): CompatibilityRunInput {
   return {
     optionsBuilder: {
       buildAgentOptions: () => ({}),
@@ -148,7 +153,7 @@ function runInput() {
       normalizeStructuredOutput: (_step: WorkflowStep, agentResponse: AgentResponse) => agentResponse,
       recordSynthesizedAgentUsage: () => {},
     },
-  } as Pick<RunFindingManagerForStepInput, 'optionsBuilder' | 'stepExecutor'>;
+  };
 }
 
 function reviewerIntake(ledger: FindingLedger, raw: RawFinding): ReviewerIntakeResult {
@@ -397,7 +402,7 @@ async function collectManagerPrompts(
   const prepared = prepareInterpretationCaseProviderRequest({
     cases: [],
     contract: promptContract,
-    optionsBuilder: runInput().optionsBuilder as never,
+    optionsBuilder: runInput().optionsBuilder,
     stepExecutor: runInput().stepExecutor,
     ledger,
   });
@@ -407,7 +412,7 @@ async function collectManagerPrompts(
   await requestInterpretationCases({
     cases: [],
     contract: promptContract,
-    optionsBuilder: runInput().optionsBuilder as never,
+    optionsBuilder: runInput().optionsBuilder,
     stepExecutor: runInput().stepExecutor,
     ledger,
     prepared,
@@ -429,12 +434,11 @@ async function collectBaseline() {
   const interpretationRequest = prepareInterpretationCaseProviderRequest({
     cases: [],
     contract,
-    optionsBuilder: runInput().optionsBuilder as never,
+    optionsBuilder: runInput().optionsBuilder,
     stepExecutor: runInput().stepExecutor,
     ledger: emptyLedger(),
   }).requestBytes;
   return {
-    head: '3847cda1',
     normalizedFindingContract: byteGolden(normalizedContractBytes),
     executionBundle: bundleGolden(),
     adjudicatorPrompts: {
@@ -447,7 +451,9 @@ async function collectBaseline() {
 
 describe('takt-default-fc compatibility baseline', () => {
   it('pins omitted manager additions and adjudicator configuration before production changes', async () => {
-    const expected = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as unknown;
+    const { head: _head, ...expected } = JSON.parse(
+      readFileSync(BASELINE_PATH, 'utf8'),
+    ) as Record<string, unknown>;
     const actual = await collectBaseline();
     expect(actual).toEqual(expected);
   });

--- a/src/__tests__/workflow-doctor.test.ts
+++ b/src/__tests__/workflow-doctor.test.ts
@@ -2486,8 +2486,8 @@ steps:
         worktreeDir,
         expect.objectContaining({
           providerValidationOptions: expect.objectContaining({
-            providerSource: expect.any(String),
-            modelSource: expect.any(String),
+            providerSource: 'default',
+            modelSource: 'default',
           }),
         }),
       );

--- a/src/__tests__/workflow-doctor.test.ts
+++ b/src/__tests__/workflow-doctor.test.ts
@@ -2480,6 +2480,17 @@ steps:
         worktreeDir,
         { allowPathBasedCalls: false },
       );
+      expect(validateContractsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'parent' }),
+        projectDir,
+        worktreeDir,
+        expect.objectContaining({
+          providerValidationOptions: expect.objectContaining({
+            providerSource: expect.any(String),
+            modelSource: expect.any(String),
+          }),
+        }),
+      );
     } finally {
       validateContractsSpy.mockRestore();
       rmSync(configuredRoot, { recursive: true, force: true });

--- a/src/__tests__/workflow-engine-finding-store-injection.test.ts
+++ b/src/__tests__/workflow-engine-finding-store-injection.test.ts
@@ -32,6 +32,7 @@ function workflow(): WorkflowConfig {
         instruction: 'manage',
         outputContract: 'findings-manager',
       },
+      adjudicator: { persona: 'supervisor' },
     },
     steps: [{
       name: 'review',

--- a/src/__tests__/workflow-engine-structured-caller.integration.test.ts
+++ b/src/__tests__/workflow-engine-structured-caller.integration.test.ts
@@ -482,6 +482,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -703,6 +704,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -845,6 +847,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -1014,6 +1017,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -1099,6 +1103,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [makeStep({
         name: 'review',
@@ -1217,6 +1222,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [makeStep({
         name: 'review',
@@ -1252,6 +1258,7 @@ describe('WorkflowEngine structured caller defaults', () => {
       initialStep: 'review',
       findingContract: {
         manager: { persona: 'findings-manager', instruction: 'findings-manager', outputContract: 'findings-manager' },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [makeStep({
         name: 'review',
@@ -1352,6 +1359,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -1433,6 +1441,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -1535,6 +1544,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -1634,6 +1644,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -1748,6 +1759,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -1862,6 +1874,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -1982,6 +1995,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -2125,6 +2139,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -2258,6 +2273,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -2450,6 +2466,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -2590,6 +2607,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -2821,6 +2839,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -3077,6 +3096,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -3271,6 +3291,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -3463,6 +3484,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -3553,6 +3575,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -3656,6 +3679,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           provider: 'codex',
           model: 'gpt-5.5',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -3749,6 +3773,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -3823,6 +3848,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -3949,6 +3975,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -4069,6 +4096,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         {
@@ -4149,6 +4177,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({
@@ -4305,6 +4334,7 @@ describe('WorkflowEngine structured caller defaults', () => {
           instruction: 'findings-manager',
           outputContract: 'findings-manager',
         },
+        adjudicator: { persona: 'supervisor' },
       },
       steps: [
         makeStep({

--- a/src/__tests__/workflow-execution-bundle.test.ts
+++ b/src/__tests__/workflow-execution-bundle.test.ts
@@ -15,6 +15,7 @@ import {
   publishWorkflowExecutionBundle,
 } from '../features/tasks/execute/workflowExecutionBundle.js';
 import { attachLegacyWorkflowExecutionBundle } from '../features/workflowAuthoring/attachExecutionBundle.js';
+import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
 
 const roots: string[] = [];
 
@@ -147,6 +148,85 @@ describe('workflow execution bundle', () => {
       instruction: 'Implement part 1',
     });
     expect(partStep.personaPath).toBe(partPersonaPath);
+  });
+
+  it('materializes and rebinds real facet personas for root-owned and inherited finding contracts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'takt-workflow-bundle-finding-contract-'));
+    roots.push(root);
+    const workflowDir = join(root, '.takt', 'workflows');
+    for (const kind of ['personas', 'instructions', 'output-contracts']) {
+      mkdirSync(join(root, '.takt', 'facets', kind), { recursive: true });
+    }
+    mkdirSync(workflowDir, { recursive: true });
+    writeFileSync(join(root, '.takt', 'facets', 'personas', 'manager.md'), 'Resolved manager persona');
+    writeFileSync(join(root, '.takt', 'facets', 'personas', 'supervisor.md'), 'Resolved adjudicator persona');
+    writeFileSync(join(root, '.takt', 'facets', 'instructions', 'manager.md'), 'Resolved manager instruction');
+    writeFileSync(join(root, '.takt', 'facets', 'instructions', 'adjudicate.md'), 'Resolved adjudication guidance');
+    writeFileSync(join(root, '.takt', 'facets', 'output-contracts', 'manager.md'), 'Resolved manager output');
+    const rawFindingContract = {
+      manager: { persona: 'manager', instruction: 'manager', output_contract: 'manager' },
+      adjudicator: { persona: 'supervisor', instruction: 'adjudicate' },
+    };
+    const context = { projectDir: root, workflowDir, lang: 'en' as const };
+    const child = attachWorkflowOpaqueRef(normalizeWorkflowConfig({
+      name: 'facet-child',
+      subworkflow: { callable: true, requires_finding_contract: true },
+      finding_contract: rawFindingContract,
+      initial_step: 'review',
+      max_steps: 2,
+      steps: [{
+        name: 'review',
+        persona: 'reviewer',
+        instruction: 'Review.',
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      }],
+    }, workflowDir, context), `project:sha256:${'c'.repeat(64)}`);
+    const parent = attachWorkflowOpaqueRef(normalizeWorkflowConfig({
+      name: 'facet-parent',
+      finding_contract: rawFindingContract,
+      initial_step: 'delegate',
+      max_steps: 2,
+      steps: [{
+        name: 'delegate',
+        kind: 'workflow_call',
+        call: 'facet-child',
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      }],
+    }, workflowDir, context), `project:sha256:${'p'.repeat(64)}`);
+    const paths = buildRunPaths(root, 'finding-contract-bundle-run');
+    const prepared = prepareWorkflowExecutionBundle({
+      rootWorkflow: parent,
+      workflowCallResolver: () => child,
+      projectCwd: root,
+      lookupCwd: root,
+    });
+    publishWorkflowExecutionBundle(paths, prepared);
+
+    const loaded = loadWorkflowExecutionBundle(paths);
+    const loadedChild = loaded.workflowCallResolver({
+      parentWorkflow: loaded.rootWorkflow,
+      step: loaded.rootWorkflow.steps[0] as never,
+      projectCwd: root,
+      lookupCwd: root,
+    });
+    for (const config of [loaded.rootWorkflow, loadedChild]) {
+      const managerPath = config?.findingContract?.manager.personaPath;
+      const adjudicatorPath = config?.findingContract?.adjudicator?.personaPath;
+      expect(dirname(managerPath!)).toBe(loaded.resourceRoot);
+      expect(dirname(adjudicatorPath!)).toBe(loaded.resourceRoot);
+      expect(readFileSync(managerPath!, 'utf8')).toBe('Resolved manager persona');
+      expect(readFileSync(adjudicatorPath!, 'utf8')).toBe('Resolved adjudicator persona');
+    }
+    expect(prepared.manifest.resources).toEqual(expect.objectContaining({
+      [createHash('sha256').update('Resolved manager persona').digest('hex')]: {
+        kind: 'prompt',
+        size: Buffer.byteLength('Resolved manager persona'),
+      },
+      [createHash('sha256').update('Resolved adjudicator persona').digest('hex')]: {
+        kind: 'prompt',
+        size: Buffer.byteLength('Resolved adjudicator persona'),
+      },
+    }));
   });
 
   it('attaches once without changing run metadata or Finding Contract SQLite bytes', () => {

--- a/src/__tests__/workflow-run-lifecycle-finding-source-ancestry.test.ts
+++ b/src/__tests__/workflow-run-lifecycle-finding-source-ancestry.test.ts
@@ -49,6 +49,7 @@ function workflow(name: string): WorkflowConfig {
         instruction: 'manage',
         outputContract: 'findings-manager',
       },
+      adjudicator: { persona: 'supervisor' },
     },
   };
 }

--- a/src/__tests__/workflow-run-lifecycle.test.ts
+++ b/src/__tests__/workflow-run-lifecycle.test.ts
@@ -51,6 +51,7 @@ function workflow(name: string, withFindingContract: boolean): WorkflowConfig {
               instruction: 'manage',
               outputContract: 'findings-manager',
             },
+            adjudicator: { persona: 'supervisor' },
           },
         }
       : {}),

--- a/src/__tests__/workflow-validator.test.ts
+++ b/src/__tests__/workflow-validator.test.ts
@@ -33,6 +33,12 @@ function createFakeLedgerStore(): FindingLedgerStore {
 }
 
 function createWorkflow(overrides: Partial<WorkflowConfig> = {}): WorkflowConfig {
+  const findingContract = overrides.findingContract === undefined
+    ? undefined
+    : {
+        ...overrides.findingContract,
+        adjudicator: overrides.findingContract.adjudicator ?? { persona: 'supervisor' },
+      };
   return {
     name: 'validator-test',
     description: 'validator test workflow',
@@ -50,6 +56,7 @@ function createWorkflow(overrides: Partial<WorkflowConfig> = {}): WorkflowConfig
       },
     ],
     ...overrides,
+    ...(findingContract === undefined ? {} : { findingContract }),
   };
 }
 
@@ -720,6 +727,78 @@ describe('validateWorkflowConfig', () => {
         'findings-manager': { provider: 'opencode' },
       },
     })).not.toThrow();
+  });
+
+  it.each(['standard', 'terminal_adjudication'] as const)(
+    'validates an inherited terminal adjudicator for %s authority',
+    (managerAuthority) => {
+      const workflow = createWorkflow();
+
+      expect(() => validateWorkflowConfig(workflow, {
+        projectCwd: process.cwd(),
+        provider: 'claude',
+        inheritedFindingContract: {
+          contract: {
+            manager: {
+              persona: 'findings-manager',
+              instruction: 'findings-manager',
+              outputContract: 'findings-manager',
+              provider: 'codex',
+              model: 'strong-manager',
+            },
+            adjudicator: {
+              persona: 'supervisor',
+              provider: 'opencode',
+            },
+          },
+          ledgerStore: createFakeLedgerStore(),
+          managerAuthority,
+        },
+      })).toThrow(/provider 'opencode' requires model/);
+    },
+  );
+
+  it.each(['standard', 'terminal_adjudication'] as const)(
+    'rejects an unresolved inherited adjudicator before execution for %s authority',
+    (managerAuthority) => {
+      const workflow = createWorkflow();
+
+      expect(() => validateWorkflowConfig(workflow, {
+        projectCwd: process.cwd(),
+        provider: 'claude',
+        inheritedFindingContract: {
+          contract: {
+            manager: {
+              persona: 'findings-manager',
+              instruction: 'findings-manager',
+              outputContract: 'findings-manager',
+              provider: 'codex',
+              model: 'strong-manager',
+            },
+          },
+          ledgerStore: createFakeLedgerStore(),
+          managerAuthority,
+        },
+      })).toThrow('Finding adjudication requires finding_contract.adjudicator');
+    },
+  );
+
+  it('rejects an unresolved programmatic root adjudicator before execution', () => {
+    const workflow = {
+      ...createWorkflow(),
+      findingContract: {
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          outputContract: 'findings-manager',
+        },
+      },
+    } satisfies WorkflowConfig;
+
+    expect(() => validateWorkflowConfig(workflow, {
+      projectCwd: process.cwd(),
+      provider: 'claude',
+    })).toThrow('Finding adjudication requires finding_contract.adjudicator');
   });
 
   it('findingContract の parallel parent に迂回ルール（invalid manager output rule）は要求しない', () => {
@@ -1702,6 +1781,7 @@ describe('validateWorkflowConfig', () => {
               instruction: 'findings-manager',
               outputContract: 'findings-manager',
             },
+            adjudicator: { persona: 'supervisor' },
           },
           ledgerStore: createFakeLedgerStore(),
           managerAuthority: 'standard',
@@ -1733,6 +1813,7 @@ describe('validateWorkflowConfig', () => {
               instruction: 'findings-manager',
               outputContract: 'findings-manager',
             },
+            adjudicator: { persona: 'supervisor' },
           },
           ledgerStore: createFakeLedgerStore(),
           managerAuthority: 'standard',
@@ -1768,6 +1849,7 @@ describe('validateWorkflowConfig', () => {
               instruction: 'findings-manager',
               outputContract: 'findings-manager',
             },
+            adjudicator: { persona: 'supervisor' },
           },
           ledgerStore: createFakeLedgerStore(),
           managerAuthority: 'standard',
@@ -1795,6 +1877,7 @@ describe('validateWorkflowConfig', () => {
               instruction: 'findings-manager',
               outputContract: 'findings-manager',
             },
+            adjudicator: { persona: 'supervisor' },
           },
           ledgerStore: createFakeLedgerStore(),
           managerAuthority: 'standard',
@@ -1816,6 +1899,7 @@ describe('validateWorkflowConfig', () => {
               outputContract: 'findings-manager',
               provider: 'opencode',
             },
+            adjudicator: { persona: 'supervisor' },
           },
           ledgerStore: createFakeLedgerStore(),
           managerAuthority: 'standard',
@@ -1838,6 +1922,7 @@ describe('validateWorkflowConfig', () => {
               provider: 'codex',
               model: 'gpt-5.5',
             },
+            adjudicator: { persona: 'supervisor' },
           },
           ledgerStore: createFakeLedgerStore(),
           managerAuthority: 'standard',

--- a/src/__tests__/workflowCallExecutor.test.ts
+++ b/src/__tests__/workflowCallExecutor.test.ts
@@ -88,6 +88,11 @@ const FAKE_FINDING_CONTRACT: FindingContractConfig = {
     instruction: 'findings-manager',
     outputContract: 'findings-manager',
   },
+  adjudicator: {
+    persona: 'supervisor',
+    provider: 'codex',
+    model: 'strong-adjudicator',
+  },
 };
 
 const FAKE_FINDING_CONTRACT_WITH_INVALID_MANAGER_PROVIDER: FindingContractConfig = {
@@ -98,6 +103,25 @@ const FAKE_FINDING_CONTRACT_WITH_INVALID_MANAGER_PROVIDER: FindingContractConfig
     // opencode は model 必須。manager.provider を直接指定すると workflow の
     // provider/model フォールバックが働かなくなる（buildFindingManagerStep 参照）
     // ため、この組み合わせは常に不正になる。
+    provider: 'opencode',
+  },
+  adjudicator: {
+    persona: 'supervisor',
+    provider: 'codex',
+    model: 'strong-adjudicator',
+  },
+};
+
+const FAKE_FINDING_CONTRACT_WITH_INVALID_ADJUDICATOR_PROVIDER: FindingContractConfig = {
+  manager: {
+    persona: 'findings-manager',
+    instruction: 'findings-manager',
+    outputContract: 'findings-manager',
+    provider: 'codex',
+    model: 'strong-manager',
+  },
+  adjudicator: {
+    persona: 'supervisor',
     provider: 'opencode',
   },
 };
@@ -797,7 +821,10 @@ describe('WorkflowCallExecutor', () => {
     expect(refreshFindingsState).toHaveBeenCalledTimes(1);
   });
 
-  it('子が継承した finding_contract.manager の provider/model が不正なとき、子 engine を作る前に fail-fast する', async () => {
+  it.each([
+    ['manager', FAKE_FINDING_CONTRACT_WITH_INVALID_MANAGER_PROVIDER],
+    ['adjudicator', FAKE_FINDING_CONTRACT_WITH_INVALID_ADJUDICATOR_PROVIDER],
+  ] as const)('子が継承した finding_contract.%s の provider/model が不正なとき、子 engine を作る前に fail-fast する', async (_role, findingContract) => {
     const parentConfig = {
       name: 'parent',
       initialStep: 'delegate',
@@ -843,7 +870,7 @@ describe('WorkflowCallExecutor', () => {
       state,
       setActiveResumePoint: vi.fn(),
       refreshFindingsState: vi.fn(),
-      findingContract: FAKE_FINDING_CONTRACT_WITH_INVALID_MANAGER_PROVIDER,
+      findingContract,
       findingLedgerStore: createFakeLedgerStore(),
     });
 
@@ -920,5 +947,9 @@ describe('WorkflowCallExecutor', () => {
 
     expect(result.status).toBe('completed');
     expect(createEngine).toHaveBeenCalledTimes(1);
+    expect(createEngine.mock.calls[0]?.[3]?.inheritedFindingContract).toMatchObject({
+      contract: FAKE_FINDING_CONTRACT,
+      managerAuthority: 'standard',
+    });
   });
 });

--- a/src/__tests__/workflowCallResolver.test.ts
+++ b/src/__tests__/workflowCallResolver.test.ts
@@ -11,6 +11,7 @@ import * as workflowResolver from '../infra/config/loaders/workflowResolver.js';
 import { getWorkflowSourcePath } from '../infra/config/loaders/workflowSourceMetadata.js';
 import { getWorkflowTrustInfo, resolveWorkflowTrustInfo } from '../infra/config/loaders/workflowTrustSource.js';
 import type { WorkflowConfig } from '../core/models/index.js';
+import type { AutoRoutingConfig } from '../core/models/config-types.js';
 import { findWorkflowCallStep } from './testUtils/workflowCallStepTestHelper.js';
 
 describe('workflowCallResolver module boundary', () => {
@@ -37,6 +38,95 @@ describe('workflowCallResolver module boundary', () => {
         lookupCwd: worktreeDir,
       }),
     });
+  }
+
+  function writeFindingContractCallFixture(
+    overridesYaml: string,
+    childAutoRoutingYaml = '',
+  ): void {
+    writeProjectWorkflow('root.yaml', `name: root
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+    provider: codex
+    model: gpt-5
+  adjudicator:
+    persona: supervisor
+    instruction: adjudicate
+initial_step: delegate
+steps:
+  - name: delegate
+    kind: workflow_call
+    call: child
+${overridesYaml}    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+`);
+    writeProjectWorkflow('child.yaml', `name: child
+subworkflow:
+  callable: true
+${childAutoRoutingYaml}initial_step: review
+steps:
+  - name: review
+    persona: reviewer
+    instruction: Review.
+    rules:
+      - condition: done
+        next: COMPLETE
+`);
+  }
+
+  function syntheticRoleAutoRouting(
+    provider: 'codex' | 'opencode',
+    strategy: AutoRoutingConfig['strategy'],
+  ): AutoRoutingConfig {
+    const candidateName = `${provider}-synthetic`;
+    return {
+      strategy,
+      router: { provider: 'claude-sdk', model: 'claude-haiku-4-5-20251001' },
+      candidates: [{
+        name: candidateName,
+        provider,
+        model: provider === 'opencode' ? 'opencode/good' : 'gpt-5',
+        routingTier: 'medium',
+      }],
+      defaultPool: 'synthetic',
+      candidatePools: {
+        synthetic: { candidates: [candidateName], fallback: candidateName },
+      },
+      rules: {
+        steps: { 'findings-terminal-adjudication': candidateName },
+      },
+    };
+  }
+
+  function childAutoRoutingYaml(
+    provider: 'codex' | 'opencode',
+    strategy: AutoRoutingConfig['strategy'],
+  ): string {
+    const candidateName = `${provider}-synthetic`;
+    const model = provider === 'opencode' ? 'opencode/good' : 'gpt-5';
+    return `auto_routing:
+  strategy: ${strategy}
+  router:
+    provider: claude-sdk
+    model: claude-haiku-4-5-20251001
+  candidates:
+    - name: ${candidateName}
+      provider: ${provider}
+      model: ${model}
+      routing_tier: medium
+  default_pool: synthetic
+  candidate_pools:
+    synthetic:
+      candidates: [${candidateName}]
+      fallback: ${candidateName}
+  rules:
+    steps:
+      findings-terminal-adjudication: ${candidateName}
+`;
   }
 
   beforeEach(() => {
@@ -885,6 +975,291 @@ steps:
     expect(() => workflowResolver.validateWorkflowCallContracts(root, projectDir)).toThrow(
       /workflow "required-review".*requires a finding_contract inherited from its caller/s,
     );
+  });
+
+  it.each([
+    { nested: false, terminalAuthority: false },
+    { nested: false, terminalAuthority: true },
+    { nested: true, terminalAuthority: false },
+    { nested: true, terminalAuthority: true },
+  ])(
+    'accepts routing that makes an inherited terminal role valid (nested=$nested, terminal=$terminalAuthority)',
+    ({ nested, terminalAuthority }) => {
+      const authorityLine = terminalAuthority
+        ? '    finding_contract_authority: terminal_adjudication\n'
+        : '';
+      writeProjectWorkflow('root.yaml', `name: root
+workflow_config:
+  provider: claude
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+    provider: codex
+    model: strong-manager
+initial_step: delegate
+steps:
+  - name: delegate
+    kind: workflow_call
+    call: ${nested ? 'outer' : 'inner'}
+${nested ? '' : authorityLine}    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+`);
+      if (nested) {
+        writeProjectWorkflow('outer.yaml', `name: outer
+workflow_config:
+  provider: claude
+subworkflow:
+  callable: true
+initial_step: delegate-inner
+steps:
+  - name: delegate-inner
+    kind: workflow_call
+    call: inner
+${authorityLine}    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+`);
+      }
+      writeProjectWorkflow('inner.yaml', `name: inner
+workflow_config:
+  provider: opencode
+subworkflow:
+  callable: true
+initial_step: review
+steps:
+  - name: review
+    persona: reviewer
+    instruction: Review.
+    rules:
+      - condition: done
+        next: COMPLETE
+`);
+
+      const root = loadProjectWorkflow('root.yaml');
+
+      expect(() => workflowResolver.validateWorkflowCallContracts(root, projectDir, projectDir, {
+        providerValidationOptions: {
+          provider: 'claude',
+          providerSource: 'project',
+          providerRouting: {
+            personas: {
+              supervisor: { provider: 'codex', model: 'strong-adjudicator' },
+            },
+          },
+        },
+      })).not.toThrow();
+    },
+  );
+
+  it('rejects an inherited role when workflow_call provider override invalidates valid base routing', () => {
+    writeFindingContractCallFixture(`    overrides:
+      provider: opencode
+`);
+    const root = loadProjectWorkflow('root.yaml');
+
+    expect(() => workflowResolver.validateWorkflowCallContracts(root, projectDir, projectDir, {
+      providerValidationOptions: {
+        providerRouting: {
+          personas: {
+            supervisor: { provider: 'codex', model: 'gpt-5' },
+          },
+        },
+      },
+    })).toThrow(/provider 'opencode' requires model/);
+  });
+
+  it('accepts an inherited role when workflow_call overrides repair invalid base routing', () => {
+    writeFindingContractCallFixture(`    overrides:
+      provider: codex
+      model: gpt-5
+`);
+    const root = loadProjectWorkflow('root.yaml');
+
+    expect(() => workflowResolver.validateWorkflowCallContracts(root, projectDir, projectDir, {
+      providerValidationOptions: {
+        providerRouting: {
+          personas: {
+            supervisor: { provider: 'opencode' },
+          },
+        },
+      },
+    })).not.toThrow();
+  });
+
+  it('rejects using child auto_routing instead of valid inherited auto routing', () => {
+    writeFindingContractCallFixture(`    overrides:
+      model: bare-model
+`, childAutoRoutingYaml('opencode', 'performance'));
+    const root = loadProjectWorkflow('root.yaml');
+
+    expect(() => workflowResolver.validateWorkflowCallContracts(root, projectDir, projectDir, {
+      providerValidationOptions: {
+        autoRouting: syntheticRoleAutoRouting('codex', 'cost'),
+      },
+    })).toThrow(/auto_routing resolved model.*provider\/model/);
+  });
+
+  it('accepts using child auto_routing instead of invalid inherited auto routing', () => {
+    writeFindingContractCallFixture(`    overrides:
+      model: bare-model
+`, childAutoRoutingYaml('codex', 'cost'));
+    const root = loadProjectWorkflow('root.yaml');
+
+    expect(() => workflowResolver.validateWorkflowCallContracts(root, projectDir, projectDir, {
+      providerValidationOptions: {
+        autoRouting: syntheticRoleAutoRouting('opencode', 'performance'),
+      },
+    })).not.toThrow();
+  });
+
+  it.each([
+    { nested: false, terminalAuthority: false },
+    { nested: false, terminalAuthority: true },
+    { nested: true, terminalAuthority: false },
+    { nested: true, terminalAuthority: true },
+  ])(
+    'rejects routing that makes an inherited terminal role invalid before execution (nested=$nested, terminal=$terminalAuthority)',
+    ({ nested, terminalAuthority }) => {
+      const authorityLine = terminalAuthority
+        ? '    finding_contract_authority: terminal_adjudication\n'
+        : '';
+      writeProjectWorkflow('root.yaml', `name: root
+workflow_config:
+  provider: claude
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+    provider: codex
+    model: strong-manager
+initial_step: delegate
+steps:
+  - name: delegate
+    kind: workflow_call
+    call: ${nested ? 'outer' : 'inner'}
+${nested ? '' : authorityLine}    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+`);
+      if (nested) {
+        writeProjectWorkflow('outer.yaml', `name: outer
+workflow_config:
+  provider: claude
+subworkflow:
+  callable: true
+initial_step: delegate-inner
+steps:
+  - name: delegate-inner
+    kind: workflow_call
+    call: inner
+${authorityLine}    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+`);
+      }
+      writeProjectWorkflow('inner.yaml', `name: inner
+workflow_config:
+  provider: claude
+subworkflow:
+  callable: true
+initial_step: review
+steps:
+  - name: review
+    persona: reviewer
+    instruction: Review.
+    rules:
+      - condition: done
+        next: COMPLETE
+`);
+
+      const root = loadProjectWorkflow('root.yaml');
+
+      expect(() => workflowResolver.validateWorkflowCallContracts(root, projectDir, projectDir, {
+        providerValidationOptions: {
+          provider: 'claude',
+          providerSource: 'project',
+          providerRouting: {
+            personas: {
+              supervisor: { provider: 'opencode' },
+            },
+          },
+        },
+      })).toThrow(/provider 'opencode' requires model/);
+    },
+  );
+
+  it('does not apply terminal validation to a sibling without an effective contract or conflict route', () => {
+    writeProjectWorkflow('root.yaml', `name: root
+workflow_config:
+  provider: claude
+initial_step: fc-child
+steps:
+  - name: fc-child
+    kind: workflow_call
+    call: local-fc
+    rules:
+      - condition: COMPLETE
+        next: plain-child
+  - name: plain-child
+    kind: workflow_call
+    call: plain
+    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+`);
+    writeProjectWorkflow('local-fc.yaml', `name: local-fc
+subworkflow:
+  callable: true
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+    provider: codex
+    model: strong-manager
+  adjudicator:
+    persona: supervisor
+    instruction: adjudicate
+    provider: codex
+    model: strong-adjudicator
+initial_step: review
+steps:
+  - name: review
+    persona: reviewer
+    instruction: Review.
+    rules:
+      - condition: done
+        next: COMPLETE
+`);
+    writeProjectWorkflow('plain.yaml', `name: plain
+subworkflow:
+  callable: true
+initial_step: review
+steps:
+  - name: review
+    persona: reviewer
+    instruction: Review.
+    rules:
+      - condition: done
+        next: COMPLETE
+`);
+
+    const root = loadProjectWorkflow('root.yaml');
+
+    expect(() => workflowResolver.validateWorkflowCallContracts(root, projectDir, projectDir, {
+      providerValidationOptions: {
+        provider: 'claude',
+        providerRouting: {
+          personas: {
+            supervisor: { provider: 'opencode' },
+          },
+        },
+      },
+    })).not.toThrow();
   });
 
   it('validates nested return routes for each expanded workflow_ref invocation', () => {

--- a/src/__tests__/workflowExecution-finding-storage.integration.test.ts
+++ b/src/__tests__/workflowExecution-finding-storage.integration.test.ts
@@ -92,6 +92,7 @@ function workflow(
               instruction: 'Manage findings',
               outputContract: 'findings-manager',
             },
+            adjudicator: { persona: 'supervisor' },
           },
         }
       : {}),

--- a/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
+++ b/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
@@ -16,6 +16,7 @@ const {
   mockEnsureWorktreeTaktRuntimeProtection,
   mockIsValidReportDirName,
   mockLogWarn,
+  mockValidateWorkflowCallContracts,
 } = vi.hoisted(() => ({
   mockWriteFileAtomic: vi.fn(),
   mockResolveWorkflowConfigValues: vi.fn(),
@@ -25,6 +26,7 @@ const {
   mockEnsureWorktreeTaktRuntimeProtection: vi.fn(),
   mockIsValidReportDirName: vi.fn((_slug: string) => true),
   mockLogWarn: vi.fn(),
+  mockValidateWorkflowCallContracts: vi.fn(),
 }));
 
 vi.mock('../infra/config/index.js', () => ({
@@ -136,6 +138,10 @@ vi.mock('../features/tasks/execute/sessionLogger.js', () => ({
 
 vi.mock('../core/runtime/runtime-environment.js', () => ({
   resolveRuntimeConfig: vi.fn(() => undefined),
+}));
+
+vi.mock('../infra/config/loaders/workflowResolver.js', () => ({
+  validateWorkflowCallContracts: mockValidateWorkflowCallContracts,
 }));
 
 import {
@@ -676,6 +682,20 @@ describe('createWorkflowExecutionBootstrap direct resume metadata', () => {
     expect(bootstrap.currentProviderSource).toBe('project');
     expect(bootstrap.configuredModel).toBe('project-model');
     expect(bootstrap.configuredModelSource).toBe('project');
+    expect(mockValidateWorkflowCallContracts).toHaveBeenCalledWith(
+      expect.objectContaining({ name: workflowConfig.name }),
+      '/project',
+      '/project',
+      {
+        providerValidationOptions: expect.objectContaining({
+          provider: 'codex',
+          providerSource: 'project',
+          model: 'project-model',
+          modelSource: 'project',
+          personaProviders: undefined,
+        }),
+      },
+    );
   });
 
   it('traced provider resolution の設定エラーを握りつぶさない', async () => {

--- a/src/core/models/finding-schemas.ts
+++ b/src/core/models/finding-schemas.ts
@@ -154,10 +154,21 @@ export const Rfc3339TimestampSchema = z.string().min(1).transform((timestamp, ct
   }
 });
 
+const FindingFacetRefListRawSchema = z.array(nonEmptyString).min(1);
+
 export const FindingContractManagerConfigRawSchema = z.object({
   persona: nonEmptyString,
   instruction: nonEmptyString,
   output_contract: nonEmptyString,
+  policy: FindingFacetRefListRawSchema.optional(),
+  knowledge: FindingFacetRefListRawSchema.optional(),
+  provider: z.enum(PROVIDER_TYPES).optional(),
+  model: nonEmptyString.optional(),
+}).strict();
+
+export const FindingContractAdjudicatorConfigRawSchema = z.object({
+  persona: nonEmptyString,
+  instruction: nonEmptyString,
   provider: z.enum(PROVIDER_TYPES).optional(),
   model: nonEmptyString.optional(),
 }).strict();
@@ -175,6 +186,7 @@ export const FindingContractReviewBudgetRawSchema = z.object({
 
 export const FindingContractConfigRawSchema = z.object({
   manager: FindingContractManagerConfigRawSchema,
+  adjudicator: FindingContractAdjudicatorConfigRawSchema.optional(),
   stop_budget: FindingContractStopBudgetRawSchema.optional(),
   review_budget: FindingContractReviewBudgetRawSchema.optional(),
 }).strict();

--- a/src/core/models/finding-types.ts
+++ b/src/core/models/finding-types.ts
@@ -286,23 +286,26 @@ export interface FindingContractManagerConfig {
   providerRoutingPersonaKey?: string;
   instruction: string;
   outputContract: string;
+  policyContents?: string[];
+  knowledgeContents?: string[];
   provider?: ProviderType;
   model?: string;
 }
 
 /**
- * The persona the engine-synthesized finding-conflict-adjudication step runs
- * as. Fixed to the "supervisor" facet — not user-selectable
- * like finding_contract.manager — but the loader must still resolve the facet
- * to a real file so its body reaches the system prompt (workflowParser
- * resolves it whenever the workflow wires `next: finding-conflict-adjudication`
- * and fails fast when the persona cannot be found).
+ * The persona and optional guidance/provider routing used by engine-synthesized
+ * conflict and terminal adjudication steps. The loader resolves explicit
+ * configuration eagerly; omitted configuration preserves the supervisor
+ * derivation used by existing workflows.
  */
 export interface FindingContractAdjudicatorConfig {
   persona: string;
   personaPath?: string;
   personaDisplayName?: string;
   providerRoutingPersonaKey?: string;
+  instruction?: string;
+  provider?: ProviderType;
+  model?: string;
 }
 
 /**

--- a/src/core/workflow/engine/WorkflowCallExecutor.ts
+++ b/src/core/workflow/engine/WorkflowCallExecutor.ts
@@ -9,15 +9,13 @@ import type {
   WorkflowResumePointEntry,
   WorkflowState,
 } from '../../models/types.js';
-import type {
-  PersonaProviderEntry,
-  ProviderRoutingConfig,
-  ProviderRoutingEntry,
-} from '../../models/config-types.js';
 import type { FindingLedgerStore } from '../findings/store.js';
 import type { RunPaths } from '../run/run-paths.js';
 import { trimResumePointStackForWorkflow } from '../run/resume-point.js';
-import { resolveEffectiveAutoRouting } from '../auto-routing/effective-auto-routing.js';
+import {
+  getWorkflowCallOverrideErrorPath,
+  resolveWorkflowCallChildAutoRouting,
+} from '../workflow-call-provider-context.js';
 import type { WorkRequirementEstimator } from '../auto-routing/contracts.js';
 import { RoutingRuntime } from '../auto-routing/runtime.js';
 import {
@@ -42,8 +40,7 @@ import type {
   WorkflowSharedRuntimeState,
   WorkflowStepFailureSummary,
 } from '../types.js';
-import { validateFindingContractManagerProviderModel } from './WorkflowValidator.js';
-import { getProviderValidationErrorSource } from '../provider-validation-error.js';
+import { validateFindingContractSyntheticProviderModels } from './WorkflowValidator.js';
 import { withWorkflowConfigErrorPath } from '../workflow-config-error.js';
 import { findWorkflowStepLocation } from '../workflow-step-location.js';
 import { translateWorkflowConfigError } from '../../../shared/workflowConfigMetadata.js';
@@ -109,87 +106,6 @@ interface ChildRoutingRuntime {
   estimator: WorkRequirementEstimator;
   runtime: RoutingRuntime;
   estimatorSource: Exclude<AutoRoutingEstimatorSource, 'absent'>;
-}
-
-function workflowCallOverrideErrorPath(
-  step: WorkflowCallStep,
-  error: unknown,
-): readonly PropertyKey[] | undefined {
-  if (!step.overrides) {
-    return undefined;
-  }
-  const validationSource = getProviderValidationErrorSource(error);
-  if (validationSource?.source !== 'workflow_call') {
-    return undefined;
-  }
-  if (validationSource.field === 'model' && step.overrides.model !== undefined) {
-    return ['overrides', 'model'];
-  }
-  if (validationSource.field === 'provider' && step.overrides.provider !== undefined) {
-    return ['overrides', 'provider'];
-  }
-  return undefined;
-}
-
-function applyWorkflowCallOverridesToProviderEntries<T extends PersonaProviderEntry>(
-  entries: Record<string, T> | undefined,
-  overrides: WorkflowCallStep['overrides'],
-): Record<string, T> | undefined {
-  if (!entries) {
-    return undefined;
-  }
-  if (overrides?.provider === undefined && overrides?.model === undefined) {
-    return entries;
-  }
-
-  const overrideProvider = overrides.provider;
-  return Object.fromEntries(
-    Object.entries(entries).map(([key, entry]) => {
-      const nextEntry: T = {
-        ...(overrideProvider !== undefined
-          ? { provider: overrideProvider }
-          : entry.provider !== undefined
-            ? { provider: entry.provider }
-            : {}),
-      } as T;
-
-      if (overrides.model !== undefined) {
-        nextEntry.model = overrides.model;
-      } else if (overrideProvider === undefined && entry.model !== undefined) {
-        nextEntry.model = entry.model;
-      }
-      if (entry.providerOptions !== undefined) {
-        nextEntry.providerOptions = entry.providerOptions;
-      }
-
-      return [key, nextEntry];
-    }),
-  );
-}
-
-export function applyWorkflowCallOverridesToPersonaProviders(
-  personaProviders: Record<string, PersonaProviderEntry> | undefined,
-  overrides: WorkflowCallStep['overrides'],
-): Record<string, PersonaProviderEntry> | undefined {
-  return applyWorkflowCallOverridesToProviderEntries(personaProviders, overrides);
-}
-
-export function applyWorkflowCallOverridesToProviderRouting(
-  providerRouting: ProviderRoutingConfig | undefined,
-  overrides: WorkflowCallStep['overrides'],
-): ProviderRoutingConfig | undefined {
-  if (!providerRouting) {
-    return undefined;
-  }
-  if (overrides?.provider === undefined && overrides?.model === undefined) {
-    return providerRouting;
-  }
-
-  return {
-    personas: applyWorkflowCallOverridesToProviderEntries<ProviderRoutingEntry>(providerRouting.personas, overrides),
-    tags: applyWorkflowCallOverridesToProviderEntries<ProviderRoutingEntry>(providerRouting.tags, overrides),
-    steps: applyWorkflowCallOverridesToProviderEntries<ProviderRoutingEntry>(providerRouting.steps, overrides),
-  };
 }
 
 interface WorkflowCallExecutorDeps {
@@ -276,7 +192,7 @@ export class WorkflowCallExecutor {
 
   private getChildRoutingRuntime(
     childWorkflow: WorkflowConfig,
-    childAutoRouting: NonNullable<ReturnType<typeof resolveEffectiveAutoRouting>>,
+    childAutoRouting: NonNullable<ReturnType<typeof resolveWorkflowCallChildAutoRouting>>,
     options: WorkflowEngineOptions,
     workflowCallStep: WorkflowCallStep,
   ): ChildRoutingRuntime {
@@ -662,7 +578,7 @@ export class WorkflowCallExecutor {
     });
     const inheritedSessions = new Map(this.deps.state.personaSessions);
     const sessionUpdates = new Map<string, WorkflowCallSessionUpdate>();
-    const childAutoRouting = resolveEffectiveAutoRouting(childWorkflow, options.autoRouting);
+    const childAutoRouting = resolveWorkflowCallChildAutoRouting(childWorkflow, options.autoRouting);
     const childRoutingRuntime = childAutoRouting === undefined
       ? undefined
       : this.getChildRoutingRuntime(childWorkflow, childAutoRouting, options, request.step);
@@ -749,10 +665,10 @@ export class WorkflowCallExecutor {
     // 検証済みの childOptions を再利用する）。
     let childEngine: WorkflowCallChildEngine;
     try {
-      validateFindingContractManagerProviderModel(childWorkflow, childOptions);
+      validateFindingContractSyntheticProviderModels(childWorkflow, childOptions);
       childEngine = this.deps.createEngine(childWorkflow, this.deps.getCwd(), this.deps.task, childOptions);
     } catch (error) {
-      const overridePath = workflowCallOverrideErrorPath(request.step, error);
+      const overridePath = getWorkflowCallOverrideErrorPath(request.step, error);
       const parentStepPath = findWorkflowStepLocation(parentConfig, request.step);
       if (!overridePath || !parentStepPath) {
         throw error;

--- a/src/core/workflow/engine/WorkflowCallRunner.ts
+++ b/src/core/workflow/engine/WorkflowCallRunner.ts
@@ -15,6 +15,11 @@ import {
   resolveWorkflowCallProviderModel,
 } from '../provider-resolution.js';
 import {
+  applyWorkflowCallOverridesToPersonaProviders,
+  applyWorkflowCallOverridesToProviderRouting,
+  resolveWorkflowCallChildProviderModel,
+} from '../workflow-call-provider-context.js';
+import {
   buildWorkflowResumePointEntry,
   getResumePointWorkflowReference,
   getWorkflowReference,
@@ -37,8 +42,6 @@ import type {
 import {
   WorkflowCallExecutor,
   preserveWorkflowCallChildExecutionState,
-  applyWorkflowCallOverridesToProviderRouting,
-  applyWorkflowCallOverridesToPersonaProviders,
   type WorkflowCallExecutionResult,
   type WorkflowCallIsolatedStateSync,
   type WorkflowCallSessionUpdates,
@@ -160,30 +163,11 @@ export class WorkflowCallRunner {
     step: WorkflowCallStep,
     childWorkflow: WorkflowConfig,
   ): StepProviderInfo {
-    const parentProviderInfo = this.resolveParentWorkflowProviderContext();
-    const childProviderInfo = resolveWorkflowCallProviderModel({
-      workflow: childWorkflow,
-      provider: parentProviderInfo.provider,
-      providerSource: parentProviderInfo.providerSource,
-      model: parentProviderInfo.model,
-      modelSource: parentProviderInfo.modelSource,
-    });
-    if (!step.overrides) {
-      return {
-        provider: childProviderInfo.provider,
-        providerSource: childProviderInfo.providerSource,
-        model: childProviderInfo.model,
-        modelSource: childProviderInfo.modelSource,
-      };
-    }
-
-    return applyProviderModelOverride(childProviderInfo, {
-      provider: step.overrides.provider,
-      providerSpecified: step.overrides.provider !== undefined,
-      model: step.overrides.model,
-      modelSpecified: step.overrides.model !== undefined,
-      source: 'workflow_call',
-    });
+    return resolveWorkflowCallChildProviderModel(
+      childWorkflow,
+      step.overrides,
+      this.resolveParentWorkflowProviderContext(),
+    );
   }
 
   resolveRuntime(step: WorkflowCallStep): RuntimeStepResolution {

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -421,6 +421,7 @@ export class WorkflowEngine extends EventEmitter {
           runId: this.runPaths.slug,
           refreshFindingsState: this.refreshFindingsState.bind(this),
           emitEvent: (event, ...args) => this.emitEvent(event, ...args),
+          guidance: this.findingContract.adjudicator?.instruction,
         })
         : undefined,
     });

--- a/src/core/workflow/engine/WorkflowValidator.ts
+++ b/src/core/workflow/engine/WorkflowValidator.ts
@@ -26,6 +26,7 @@ import { buildFindingInterpretationStep, buildFindingManagerStep } from '../find
 import {
   buildFindingConflictAdjudicationStep,
   buildFindingTerminalAdjudicationStep,
+  FINDING_TERMINAL_ADJUDICATION_STEP,
   workflowWiresFindingConflictAdjudication,
 } from '../findings/adjudication-step.js';
 import { findFindingContractFormat, hasFindingContractFormat } from '../findings/finding-contract-format.js';
@@ -324,9 +325,10 @@ export function validateFindingContractSyntheticProviderModels(
           currentProviderInfo: providerInfo,
         })
       : undefined;
-    const configurationPath = step.name === 'findings-manager' || step.name === 'findings-interpreter'
-      ? 'Configuration error: finding_contract.manager.model'
-      : 'Configuration error: finding_contract.adjudicator.model';
+    const configurationPath = step.name === FINDING_TERMINAL_ADJUDICATION_STEP
+      || step.name === FINDING_CONFLICT_ADJUDICATION_STEP
+      ? 'Configuration error: finding_contract.adjudicator.model'
+      : 'Configuration error: finding_contract.manager.model';
     validateResolvedProviderInfo(
       deterministicInfo ?? providerInfo,
       configurationPath,

--- a/src/core/workflow/engine/WorkflowValidator.ts
+++ b/src/core/workflow/engine/WorkflowValidator.ts
@@ -23,6 +23,11 @@ import {
   hasFindingsReference,
 } from '../../models/workflow-rule-condition.js';
 import { buildFindingInterpretationStep, buildFindingManagerStep } from '../findings/manager-step.js';
+import {
+  buildFindingConflictAdjudicationStep,
+  buildFindingTerminalAdjudicationStep,
+  workflowWiresFindingConflictAdjudication,
+} from '../findings/adjudication-step.js';
 import { findFindingContractFormat, hasFindingContractFormat } from '../findings/finding-contract-format.js';
 import {
   resolveAutoRoutingCandidateProviderInfo,
@@ -39,6 +44,22 @@ import { resolveFindingIntakeNormalizeConfig } from '../findings/intake-normaliz
 import { validateDynamicParallelContracts } from '../dynamic-parallel/validator.js';
 
 type ResolvedProviderInfo = ReturnType<typeof resolveStepProviderModel>;
+export type FindingContractSyntheticProviderValidationOptions = Pick<
+  WorkflowEngineOptions,
+  | 'provider'
+  | 'providerSource'
+  | 'model'
+  | 'modelSource'
+  | 'autoRouting'
+  | 'providerRouting'
+  | 'providerRoutingTagConflictPolicy'
+  | 'personaProviders'
+> & {
+  inheritedFindingContract?: Pick<
+    NonNullable<WorkflowEngineOptions['inheritedFindingContract']>,
+    'contract' | 'managerAuthority'
+  >;
+};
 const withWorkflowStepErrorPath = withWorkflowConfigErrorPath;
 
 function providerValidationField(error: unknown, fallback: 'provider' | 'model'): 'provider' | 'model' {
@@ -235,25 +256,27 @@ function validateFindingContractStructuredOutput(config: WorkflowConfig, finding
 }
 
 /**
- * findings-manager は実行時に合成されるステップで、config.steps の走査
- * （validateAgentStepProviderModel）に現れない。実行時（manager-runner.ts）と
- * 同じ buildFindingManagerStep で合成した形を同じ resolveStepProviderModel で
- * 解決し、provider/model の要件（例: opencode は model 必須）を実行前に検証する。
- * ここで検証しないと、validate は素通りしたのに manager 起動時に初めて落ちる。
+ * Finding Contract の manager / interpreter / adjudicator は実行時に合成される
+ * ステップで、config.steps の通常走査（validateAgentStepProviderModel）だけでは
+ * 網羅できない。各 runner と共通の builder で合成し、同じ
+ * resolveStepProviderModel で provider/model 要件を実行前に検証する。
  *
  * 対象の finding_contract は自前（config.findingContract）だけでなく
  * workflow_call 親からの継承（options.inheritedFindingContract）も含む
  * （WorkflowEngine が実際に使う有効な契約と同じ判定基準。findingContractEnabled
  * と同じ式）。継承分をここで見ないと、子の workflow provider/model では
- * manager が成立しない構成が validate を素通りし、manager 起動時に初めて落ちる。
+ * synthetic role が成立しない構成が validate を素通りし、起動時に初めて落ちる。
  *
  * WorkflowCallExecutor が子 engine を組み立てる際、この関数を子の config と
  * 継承契約入り options に対して明示的に呼び、子の実行前に fail-fast する
  * （createEngine は単体テストではモックされるため、子 WorkflowEngine の
  * コンストラクタが暗黙に行う検証には頼れない）。
  */
-export function validateFindingContractManagerProviderModel(config: WorkflowConfig, options: WorkflowEngineOptions): void {
-  const findingContract = config.findingContract ?? options.inheritedFindingContract?.contract;
+export function validateFindingContractSyntheticProviderModels(
+  config: WorkflowConfig,
+  options: FindingContractSyntheticProviderValidationOptions,
+): void {
+  const findingContract = options.inheritedFindingContract?.contract ?? config.findingContract;
   if (!findingContract) {
     return;
   }
@@ -262,7 +285,7 @@ export function validateFindingContractManagerProviderModel(config: WorkflowConf
     workflowProvider: config.provider,
     workflowModel: config.model,
   };
-  // findings-manager と findings-interpreter は実行ループの AI ルーターを
+  // synthetic roles は実行ループの AI ルーターを
   // 通らず、実行時は OptionsBuilder.resolveStepProviderModel が rules →
   // strategy デフォルトへ決定的に補完する。validator も同じ解決で検証しないと、
   // 実行時には到達しない候補の組み合わせを検証して有効な構成を拒否する
@@ -271,7 +294,18 @@ export function validateFindingContractManagerProviderModel(config: WorkflowConf
   // され得る — 片方だけの検証では他方の実行時エラーを素通しする。全候補を
   // 検証する expandAutoRoutingProviderInfos は AI ルーターがどの候補も選び得る
   // 通常ステップ専用。
-  for (const step of [buildFindingManagerStep(stepInput), buildFindingInterpretationStep(stepInput)]) {
+  const adjudicationSteps = [
+    buildFindingTerminalAdjudicationStep(stepInput),
+    ...(workflowWiresFindingConflictAdjudication(config.steps, config.loopMonitors)
+      ? [buildFindingConflictAdjudicationStep(stepInput)]
+      : []),
+  ];
+  const syntheticSteps = [
+    buildFindingManagerStep(stepInput),
+    buildFindingInterpretationStep(stepInput),
+    ...adjudicationSteps,
+  ];
+  for (const step of syntheticSteps) {
     const providerInfo = resolveStepProviderModel({
       step,
       provider: options.provider,
@@ -290,9 +324,12 @@ export function validateFindingContractManagerProviderModel(config: WorkflowConf
           currentProviderInfo: providerInfo,
         })
       : undefined;
+    const configurationPath = step.name === 'findings-manager' || step.name === 'findings-interpreter'
+      ? 'Configuration error: finding_contract.manager.model'
+      : 'Configuration error: finding_contract.adjudicator.model';
     validateResolvedProviderInfo(
       deterministicInfo ?? providerInfo,
-      'Configuration error: finding_contract.manager.model',
+      configurationPath,
       deterministicInfo !== undefined,
     );
   }
@@ -648,7 +685,7 @@ export function validateWorkflowConfig(config: WorkflowConfig, options: Workflow
     config.findingContract ?? options.inheritedFindingContract?.contract,
   );
   validateFindingContractStructuredOutput(config, findingContractEnabled);
-  validateFindingContractManagerProviderModel(config, options);
+  validateFindingContractSyntheticProviderModels(config, options);
   validateFindingConflictAdjudicationReservedName(config);
   validateWorkflowStepNamesUnique(config);
   validateRequiredInheritedFindingContract(config, options);

--- a/src/core/workflow/findings/adjudication-instruction.ts
+++ b/src/core/workflow/findings/adjudication-instruction.ts
@@ -1,0 +1,9 @@
+export function composeFindingAdjudicationInstruction(
+  guidance: string | undefined,
+  engineInstruction: string,
+): string {
+  if (guidance === undefined) {
+    return engineInstruction;
+  }
+  return `${guidance}\n\n---\n\n${engineInstruction}`;
+}

--- a/src/core/workflow/findings/adjudication-reservation.ts
+++ b/src/core/workflow/findings/adjudication-reservation.ts
@@ -72,9 +72,6 @@ export async function reserveFindingConflictAdjudication(input: {
     if (snapshot.conflictSnapshotId !== input.expectedSnapshotId) {
       return { ledger: fresh, result: { started: false } };
     }
-    if (isConflictSnapshotAdjudicated(fresh, snapshot)) {
-      return { ledger: fresh, result: { started: false } };
-    }
     const ensured = exactEpisode(
       fresh.conflictAdjudicationEpisodes,
       snapshot,
@@ -125,6 +122,9 @@ export async function reserveFindingConflictAdjudication(input: {
             : attempt
         )),
       };
+    }
+    if (isConflictSnapshotAdjudicated(fresh, snapshot)) {
+      return { ledger: fresh, result: { started: false } };
     }
     const used = fresh.conflictAdjudicationAttempts.filter(
       (attempt) => attempt.episodeId === ensured.episode.episodeId,

--- a/src/core/workflow/findings/adjudication-runner.ts
+++ b/src/core/workflow/findings/adjudication-runner.ts
@@ -26,6 +26,7 @@ import { FINDING_CONFLICT_ADJUDICATION_RULE_INDEX } from './adjudication-step.js
 import { parseConflictAdjudicationProviderOutput } from './schemas.js';
 import type { FindingAdjudicationStore } from './store.js';
 import type { FindingLedger, FindingObservation } from './types.js';
+import { composeFindingAdjudicationInstruction } from './adjudication-instruction.js';
 
 export interface FindingConflictAdjudicationRunnerDeps {
   ledgerStore: FindingAdjudicationStore;
@@ -38,6 +39,7 @@ export interface FindingConflictAdjudicationRunnerDeps {
   runId: string;
   refreshFindingsState: () => void;
   emitEvent: (event: string, ...args: unknown[]) => void;
+  guidance?: string;
 }
 
 const DISPOSITION_RULE_INDEX: Record<FindingConflictAdjudicationDisposition, number> = {
@@ -87,6 +89,19 @@ function requestBytes(input: {
   });
 }
 
+function hasReservedConflictAttempt(ledger: FindingLedger, conflictId: string): boolean {
+  return ledger.conflictAdjudicationAttempts.some((attempt) => (
+    attempt.conflictId === conflictId
+    && attempt.stage === 'started'
+    && ledger.findingManagerProviderCalls.some((call) => (
+      call.providerCallId === attempt.providerCallId
+      && call.ownerAttemptId === attempt.attemptId
+      && call.purpose === 'conflict_adjudication'
+      && call.state === 'reserved'
+    ))
+  ));
+}
+
 export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdjudicationRunnerDeps): {
   run: (step: WorkflowStep, state: WorkflowState, runtime?: RuntimeStepResolution) => Promise<StepRunResult>;
   getLastOriginStep: () => string | undefined;
@@ -114,7 +129,10 @@ export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdj
     const initial = deps.ledgerStore.loadLedger();
     const conflict = selectConflictForAdjudication(
       initial,
-      (candidate) => isActiveConflictUnadjudicated(initial, candidate.id),
+      (candidate) => (
+        hasReservedConflictAttempt(initial, candidate.id)
+        || isActiveConflictUnadjudicated(initial, candidate.id)
+      ),
     );
     const noTarget = (ledger: FindingLedger, reason: string): StepRunResult => {
       const active = ledger.conflicts.some((candidate) => candidate.status === 'active');
@@ -133,7 +151,10 @@ export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdj
     }
     const snapshot = freshConflictAdjudicationSnapshot(initial, conflict.id);
     const instruction = deps.stepExecutor.buildPhase1Instruction(
-      renderConflictAdjudicationInstruction(snapshot),
+      composeFindingAdjudicationInstruction(
+        deps.guidance,
+        renderConflictAdjudicationInstruction(snapshot),
+      ),
       step,
       runtime,
     );

--- a/src/core/workflow/findings/adjudication-runner.ts
+++ b/src/core/workflow/findings/adjudication-runner.ts
@@ -89,6 +89,8 @@ function requestBytes(input: {
   });
 }
 
+// A crash after WAL reservation leaves a started attempt that the normal
+// unadjudicated predicate excludes; selecting the reserved call resumes it.
 function hasReservedConflictAttempt(ledger: FindingLedger, conflictId: string): boolean {
   return ledger.conflictAdjudicationAttempts.some((attempt) => (
     attempt.conflictId === conflictId

--- a/src/core/workflow/findings/adjudication-step.ts
+++ b/src/core/workflow/findings/adjudication-step.ts
@@ -3,12 +3,16 @@ import type {
   FindingContractConfig,
   LoopMonitorConfig,
   WorkflowConfig,
+  WorkflowStructuredOutput,
   WorkflowStep,
 } from '../../models/types.js';
 import { getAllParallelSubSteps } from '../../models/types.js';
 import { parseWorkflowRuleCondition } from '../../models/workflow-rule-condition.js';
 import { FINDING_CONFLICT_ADJUDICATION_STEP } from '../constants.js';
-import { ConflictAdjudicationProviderOutputJsonSchema } from './schemas.js';
+import {
+  ConflictAdjudicationProviderOutputJsonSchema,
+  TerminalAdjudicationProviderOutputJsonSchema,
+} from './schemas.js';
 
 // Current output is a closed outcome plus optional actionableFix/rationale.
 // Finding transitions are engine-owned and derived from the outcome.
@@ -44,6 +48,58 @@ export const FINDING_CONFLICT_ADJUDICATION_RULE_INDEX = {
   UNRESOLVED: 2,
 } as const;
 
+function buildFindingAdjudicatorStep(input: {
+  contract: FindingContractConfig;
+  workflowProvider?: WorkflowConfig['provider'];
+  workflowModel?: WorkflowConfig['model'];
+  name: string;
+  instruction: string;
+  schemaRef: string;
+  schema: WorkflowStructuredOutput['schema'];
+}): AgentWorkflowStep {
+  const adjudicator = input.contract.adjudicator;
+  if (adjudicator === undefined) {
+    throw new Error('Finding adjudication requires finding_contract.adjudicator');
+  }
+  const providerIsDirect = adjudicator.provider !== undefined;
+  const modelIsDirect = adjudicator.model !== undefined;
+  return {
+    kind: 'agent',
+    name: input.name,
+    engineSynthesized: true,
+    persona: adjudicator.persona,
+    personaDisplayName: adjudicator.personaDisplayName ?? FINDING_CONFLICT_ADJUDICATION_PERSONA,
+    providerRoutingPersonaKey: adjudicator.providerRoutingPersonaKey ?? FINDING_CONFLICT_ADJUDICATION_PERSONA,
+    ...(adjudicator.personaPath !== undefined ? { personaPath: adjudicator.personaPath } : {}),
+    provider: providerIsDirect ? adjudicator.provider : input.workflowProvider,
+    providerSpecified: providerIsDirect,
+    model: modelIsDirect ? adjudicator.model : providerIsDirect ? undefined : input.workflowModel,
+    modelSpecified: modelIsDirect || providerIsDirect,
+    instruction: input.instruction,
+    session: 'refresh',
+    edit: false,
+    structuredOutput: {
+      schemaRef: input.schemaRef,
+      schema: input.schema,
+    },
+    rules: [],
+  };
+}
+
+export function buildFindingTerminalAdjudicationStep(input: {
+  contract: FindingContractConfig;
+  workflowProvider?: WorkflowConfig['provider'];
+  workflowModel?: WorkflowConfig['model'];
+}): AgentWorkflowStep {
+  return buildFindingAdjudicatorStep({
+    ...input,
+    name: 'findings-terminal-adjudication',
+    instruction: 'Adjudicate one durable provisional finding entity.',
+    schemaRef: 'takt.findings.terminal-adjudication',
+    schema: TerminalAdjudicationProviderOutputJsonSchema,
+  });
+}
+
 /**
  * Builds the finding-conflict-adjudication synthetic step. Unlike
  * findings-manager (which runs outside the step state machine), this is a REAL
@@ -62,33 +118,22 @@ export function buildFindingConflictAdjudicationStep(input: {
   workflowProvider?: WorkflowConfig['provider'];
   workflowModel?: WorkflowConfig['model'];
 }): AgentWorkflowStep {
-  const adjudicator = input.contract.adjudicator;
-  if (!adjudicator) {
+  if (!input.contract.adjudicator) {
     throw new Error(
       `Configuration error: persona "${FINDING_CONFLICT_ADJUDICATION_PERSONA}" is required for `
       + `next: ${FINDING_CONFLICT_ADJUDICATION_STEP} but finding_contract.adjudicator was not resolved `
       + '(the supervisor persona facet could not be found)',
     );
   }
-  return {
-    kind: 'agent',
+  const step = buildFindingAdjudicatorStep({
+    ...input,
     name: FINDING_CONFLICT_ADJUDICATION_STEP,
-    engineSynthesized: true,
-    persona: adjudicator.persona,
-    personaDisplayName: adjudicator.personaDisplayName ?? FINDING_CONFLICT_ADJUDICATION_PERSONA,
-    providerRoutingPersonaKey: adjudicator.providerRoutingPersonaKey ?? FINDING_CONFLICT_ADJUDICATION_PERSONA,
-    ...(adjudicator.personaPath !== undefined ? { personaPath: adjudicator.personaPath } : {}),
-    provider: input.workflowProvider,
-    providerSpecified: false,
-    model: input.workflowModel,
-    modelSpecified: false,
     instruction: 'Adjudicate one unresolved finding-contract conflict (engine-synthesized step; the conflict payload is assembled at execution time).',
-    session: 'refresh',
-    edit: false,
-    structuredOutput: {
-      schemaRef: FINDING_CONFLICT_ADJUDICATION_SCHEMA_REF,
-      schema: ConflictAdjudicationProviderOutputJsonSchema,
-    },
+    schemaRef: FINDING_CONFLICT_ADJUDICATION_SCHEMA_REF,
+    schema: ConflictAdjudicationProviderOutputJsonSchema,
+  });
+  return {
+    ...step,
     rules: [
       // Dynamic next (resolved from WorkflowState.previousStep) — see
       // FINDING_CONFLICT_ADJUDICATION_RULE_INDEX and

--- a/src/core/workflow/findings/adjudication-step.ts
+++ b/src/core/workflow/findings/adjudication-step.ts
@@ -17,9 +17,11 @@ import {
 // Current output is a closed outcome plus optional actionableFix/rationale.
 // Finding transitions are engine-owned and derived from the outcome.
 export const FINDING_CONFLICT_ADJUDICATION_SCHEMA_REF = 'takt.findings.adjudication';
+export const FINDING_TERMINAL_ADJUDICATION_SCHEMA_REF = 'takt.findings.terminal-adjudication';
+export const FINDING_TERMINAL_ADJUDICATION_STEP = 'findings-terminal-adjudication';
 
 /** The engine-owned adjudication step always uses the supervisor facet resolved into finding_contract.adjudicator. */
-export const FINDING_CONFLICT_ADJUDICATION_PERSONA = 'supervisor';
+export const FINDING_ADJUDICATION_PERSONA = 'supervisor';
 
 /**
  * Rule indexes of the synthesized step. The adjudication executor
@@ -68,8 +70,8 @@ function buildFindingAdjudicatorStep(input: {
     name: input.name,
     engineSynthesized: true,
     persona: adjudicator.persona,
-    personaDisplayName: adjudicator.personaDisplayName ?? FINDING_CONFLICT_ADJUDICATION_PERSONA,
-    providerRoutingPersonaKey: adjudicator.providerRoutingPersonaKey ?? FINDING_CONFLICT_ADJUDICATION_PERSONA,
+    personaDisplayName: adjudicator.personaDisplayName ?? FINDING_ADJUDICATION_PERSONA,
+    providerRoutingPersonaKey: adjudicator.providerRoutingPersonaKey ?? FINDING_ADJUDICATION_PERSONA,
     ...(adjudicator.personaPath !== undefined ? { personaPath: adjudicator.personaPath } : {}),
     provider: providerIsDirect ? adjudicator.provider : input.workflowProvider,
     providerSpecified: providerIsDirect,
@@ -93,9 +95,9 @@ export function buildFindingTerminalAdjudicationStep(input: {
 }): AgentWorkflowStep {
   return buildFindingAdjudicatorStep({
     ...input,
-    name: 'findings-terminal-adjudication',
+    name: FINDING_TERMINAL_ADJUDICATION_STEP,
     instruction: 'Adjudicate one durable provisional finding entity.',
-    schemaRef: 'takt.findings.terminal-adjudication',
+    schemaRef: FINDING_TERMINAL_ADJUDICATION_SCHEMA_REF,
     schema: TerminalAdjudicationProviderOutputJsonSchema,
   });
 }
@@ -120,7 +122,7 @@ export function buildFindingConflictAdjudicationStep(input: {
 }): AgentWorkflowStep {
   if (!input.contract.adjudicator) {
     throw new Error(
-      `Configuration error: persona "${FINDING_CONFLICT_ADJUDICATION_PERSONA}" is required for `
+      `Configuration error: persona "${FINDING_ADJUDICATION_PERSONA}" is required for `
       + `next: ${FINDING_CONFLICT_ADJUDICATION_STEP} but finding_contract.adjudicator was not resolved `
       + '(the supervisor persona facet could not be found)',
     );

--- a/src/core/workflow/findings/manager-agent.ts
+++ b/src/core/workflow/findings/manager-agent.ts
@@ -36,6 +36,7 @@ import {
 } from '../../../shared/utils/canonical-json.js';
 import { computeFindingLifecycleProjectionDigest } from '../../models/finding-lifecycle-identity.js';
 import { selectActionableFindingEntries } from './context.js';
+import { composeFindingManagerInstruction } from './manager-instruction-composer.js';
 
 export { RAW_FINDINGS_SCHEMA_REF };
 export { FINDING_MANAGER_SCHEMA_REF } from './manager-step.js';
@@ -438,7 +439,7 @@ export function buildManagerInstruction(input: {
       ...findings.map((finding) => `  - ${finding.id} [${finding.severity}] ${finding.title}`),
     ].join('\n'))
     .join('\n');
-  return loadTemplate('finding_manager_instruction', 'en', {
+  const baseInstruction = loadTemplate('finding_manager_instruction', 'en', {
     managerInstruction,
     outputContract: input.contract.manager.outputContract,
     anchorRelevanceInstruction: PROVIDER_ANCHOR_RELEVANCE_INSTRUCTION,
@@ -456,6 +457,11 @@ export function buildManagerInstruction(input: {
     hasDuplicateLocusGroups: duplicateLocusGroups.size > 0,
     duplicateLocusGroupsBlock,
     coderResponse: renderFencedTextBlock(input.priorStepResponseText ?? '(no prior step response)'),
+  });
+  return composeFindingManagerInstruction({
+    baseInstruction,
+    policyContents: input.contract.manager.policyContents,
+    knowledgeContents: input.contract.manager.knowledgeContents,
   });
 }
 

--- a/src/core/workflow/findings/manager-agent.ts
+++ b/src/core/workflow/findings/manager-agent.ts
@@ -38,6 +38,8 @@ import { computeFindingLifecycleProjectionDigest } from '../../models/finding-li
 import { selectActionableFindingEntries } from './context.js';
 import { composeFindingManagerInstruction } from './manager-instruction-composer.js';
 
+type ManagerOptionsBuilder = Pick<OptionsBuilder, 'buildAgentOptions'>;
+
 export { RAW_FINDINGS_SCHEMA_REF };
 export { FINDING_MANAGER_SCHEMA_REF } from './manager-step.js';
 
@@ -488,7 +490,7 @@ export function parseManagerDecisions(
 }
 
 export function buildManagerAgentOptions(
-  optionsBuilder: OptionsBuilder,
+  optionsBuilder: ManagerOptionsBuilder,
   managerStep: AgentWorkflowStep,
 ): ReturnType<OptionsBuilder['buildAgentOptions']> {
   const options = {
@@ -508,7 +510,7 @@ export function buildManagerAgentOptions(
 export async function runManagerAttempt(input: {
   managerStep: AgentWorkflowStep;
   instruction: string;
-  optionsBuilder: OptionsBuilder;
+  optionsBuilder: ManagerOptionsBuilder;
   stepExecutor: Pick<StepExecutor, 'buildPhase1Instruction' | 'normalizeStructuredOutput' | 'recordSynthesizedAgentUsage'>;
 }): Promise<AgentResponse> {
   const phase1Instruction = input.stepExecutor.buildPhase1Instruction(input.instruction, input.managerStep);
@@ -523,7 +525,7 @@ export async function runManagerAttempt(input: {
 export async function runPreparedManagerAttempt(input: {
   managerStep: AgentWorkflowStep;
   phase1Instruction: string;
-  optionsBuilder: OptionsBuilder;
+  optionsBuilder: ManagerOptionsBuilder;
   stepExecutor: Pick<StepExecutor, 'normalizeStructuredOutput' | 'recordSynthesizedAgentUsage'>;
 }): Promise<AgentResponse> {
   const agentOptions = buildManagerAgentOptions(input.optionsBuilder, input.managerStep);

--- a/src/core/workflow/findings/manager-instruction-composer.ts
+++ b/src/core/workflow/findings/manager-instruction-composer.ts
@@ -1,0 +1,21 @@
+export function composeFindingManagerInstruction(input: {
+  baseInstruction: string;
+  policyContents?: readonly string[];
+  knowledgeContents?: readonly string[];
+}): string {
+  if (input.policyContents?.length === 0 || input.knowledgeContents?.length === 0) {
+    throw new Error('Finding Manager policy/knowledge additions must not be empty');
+  }
+  if (input.policyContents === undefined && input.knowledgeContents === undefined) {
+    return input.baseInstruction;
+  }
+  const sections = [
+    input.knowledgeContents === undefined
+      ? undefined
+      : ['## Knowledge additions', input.knowledgeContents.join('\n---\n')].join('\n'),
+    input.policyContents === undefined
+      ? undefined
+      : ['## Policy additions', input.policyContents.join('\n---\n')].join('\n'),
+  ].filter((section): section is string => section !== undefined);
+  return `${sections.join('\n\n')}\n\n${input.baseInstruction}`;
+}

--- a/src/core/workflow/findings/manager-interpretation-agent.ts
+++ b/src/core/workflow/findings/manager-interpretation-agent.ts
@@ -12,6 +12,7 @@ import {
   runPreparedManagerAttempt,
 } from './manager-agent.js';
 import type { FindingLedger, InterpretationCase, InterpretationDecision } from './types.js';
+import { composeFindingManagerInstruction } from './manager-instruction-composer.js';
 
 export interface InterpretationCaseProviderResult {
   responses: Array<{ caseId: string; decision: InterpretationDecision }>;
@@ -68,7 +69,7 @@ export function prepareInterpretationCaseProviderRequest(input: {
   stepExecutor: Pick<StepExecutor, 'buildPhase1Instruction'>;
   ledger: FindingLedger;
 }): PreparedInterpretationCaseProviderRequest {
-  const instruction = buildInterpretationCaseInstruction({
+  const baseInstruction = buildInterpretationCaseInstruction({
     ledger: input.ledger,
     cases: input.cases,
   }).instruction;
@@ -77,7 +78,14 @@ export function prepareInterpretationCaseProviderRequest(input: {
     workflowProvider: input.workflowProvider,
     workflowModel: input.workflowModel,
   });
-  const phase1Instruction = input.stepExecutor.buildPhase1Instruction(instruction, managerStep);
+  const phase1Instruction = input.stepExecutor.buildPhase1Instruction(
+    composeFindingManagerInstruction({
+      baseInstruction,
+      policyContents: managerStep.policyContents,
+      knowledgeContents: managerStep.knowledgeContents,
+    }),
+    managerStep,
+  );
   const agentOptions = buildManagerAgentOptions(input.optionsBuilder, managerStep);
   return {
     managerStep,

--- a/src/core/workflow/findings/manager-interpretation-agent.ts
+++ b/src/core/workflow/findings/manager-interpretation-agent.ts
@@ -14,6 +14,8 @@ import {
 import type { FindingLedger, InterpretationCase, InterpretationDecision } from './types.js';
 import { composeFindingManagerInstruction } from './manager-instruction-composer.js';
 
+type ManagerOptionsBuilder = Pick<OptionsBuilder, 'buildAgentOptions'>;
+
 export interface InterpretationCaseProviderResult {
   responses: Array<{ caseId: string; decision: InterpretationDecision }>;
   omittedCaseIds: string[];
@@ -65,7 +67,7 @@ export function prepareInterpretationCaseProviderRequest(input: {
   contract: FindingContractConfig;
   workflowProvider?: WorkflowConfig['provider'];
   workflowModel?: WorkflowConfig['model'];
-  optionsBuilder: OptionsBuilder;
+  optionsBuilder: ManagerOptionsBuilder;
   stepExecutor: Pick<StepExecutor, 'buildPhase1Instruction'>;
   ledger: FindingLedger;
 }): PreparedInterpretationCaseProviderRequest {
@@ -116,7 +118,7 @@ export async function requestInterpretationCases(input: {
   contract: FindingContractConfig;
   workflowProvider?: WorkflowConfig['provider'];
   workflowModel?: WorkflowConfig['model'];
-  optionsBuilder: OptionsBuilder;
+  optionsBuilder: ManagerOptionsBuilder;
   stepExecutor: Pick<StepExecutor, 'buildPhase1Instruction' | 'normalizeStructuredOutput' | 'recordSynthesizedAgentUsage'>;
   ledger: FindingLedger;
   prepared: PreparedInterpretationCaseProviderRequest;

--- a/src/core/workflow/findings/manager-step.ts
+++ b/src/core/workflow/findings/manager-step.ts
@@ -49,6 +49,8 @@ export function buildFindingManagerStep(input: {
     model: modelIsDirect ? manager.model : providerIsDirect ? undefined : input.workflowModel,
     modelSpecified: modelIsDirect || providerIsDirect,
     instruction: manager.instruction,
+    ...(manager.policyContents === undefined ? {} : { policyContents: manager.policyContents }),
+    ...(manager.knowledgeContents === undefined ? {} : { knowledgeContents: manager.knowledgeContents }),
     session: 'refresh',
     edit: false,
     structuredOutput: {

--- a/src/core/workflow/findings/manager-step.ts
+++ b/src/core/workflow/findings/manager-step.ts
@@ -21,9 +21,10 @@ const FINDING_INTERPRETATION_INSTRUCTION =
  * 同じ形のステップを見ないと、検証やプレビューでは通る provider/model が
  * 実行時に別の値へ解決される食い違いが生まれるため、ここへ一本化する。
  *
- * provider/model の優先順位: finding_contract.manager の直接指定が最優先
- * （providerSpecified/modelSpecified を立てて persona_providers 等の後段解決を
- * 抑止する）。未指定時はワークフローの provider/model を fallback として載せる。
+ * finding_contract.manager の直接指定は workflow 構成層内で最優先とし、
+ * providerSpecified/modelSpecified を立てて persona_providers 等の後段解決を
+ * 抑止する。CLI/環境変数の実行時 override はこの直接指定より優先する。
+ * 未指定時はワークフローの provider/model を fallback として載せる。
  * provider だけが直接指定された場合、workflow model を引き継ぐと provider と
  * model の組み合わせが食い違うため model は載せない（modelSpecified は立てて
  * 後段の model 解決も抑止する）。

--- a/src/core/workflow/findings/manager-task-runner.ts
+++ b/src/core/workflow/findings/manager-task-runner.ts
@@ -46,6 +46,7 @@ import {
   PROVIDER_ANCHOR_RELEVANCE_INSTRUCTION,
 } from './manager-raw-decision-adapter.js';
 import { computeConflictEvidenceHash } from './adjudication-evidence.js';
+import { composeFindingManagerInstruction } from './manager-instruction-composer.js';
 import type {
   FindingEvidenceRecord,
   FindingLedger,
@@ -655,13 +656,14 @@ async function executeRawTasks(input: {
     let prepared:
       | { phase1Instruction: string; inputBytes: number }
       | undefined;
+    let renderedInputBytes: number | undefined;
     for (const candidateLimit of CONTEXT_CANDIDATE_LIMITS) {
       const context = rawTaskContext(
         input.previousLedger,
         item.rawFindings,
         candidateLimit,
       );
-      const instruction = buildRawTaskInstruction({
+      const baseInstruction = buildRawTaskInstruction({
         contract: input.contract,
         task: item.task,
         rawFindings: item.rawFindings,
@@ -670,10 +672,15 @@ async function executeRawTasks(input: {
         evidenceRecordsByRawFindingId: input.evidenceRecordsByRawFindingId,
       });
       const phase1Instruction = input.runInput.stepExecutor.buildPhase1Instruction(
-        instruction,
+        composeFindingManagerInstruction({
+          baseInstruction,
+          policyContents: input.managerStep.policyContents,
+          knowledgeContents: input.managerStep.knowledgeContents,
+        }),
         input.managerStep,
       );
       const inputBytes = Buffer.byteLength(phase1Instruction, 'utf8');
+      renderedInputBytes = inputBytes;
       if (inputBytes <= MAIN_MANAGER_INPUT_MAX_BYTES) {
         prepared = { phase1Instruction, inputBytes };
         break;
@@ -704,7 +711,7 @@ async function executeRawTasks(input: {
         taskKind: 'raw',
         ownedIds: [rawFindingId],
         status: 'input_overflow',
-        inputBytes: null,
+        inputBytes: renderedInputBytes ?? null,
         reason,
       });
       continue;
@@ -1243,13 +1250,17 @@ async function executeControlTasks(input: {
   const controlStep = buildFindingManagerControlTaskStep(input.managerStep);
   const tasks = createMainManagerControlTaskManifest(input);
   for (const item of tasks) {
-    const instruction = buildControlTaskInstruction({
+    const baseInstruction = buildControlTaskInstruction({
       contract: input.contract,
       previousLedger: input.previousLedger,
       task: item.task,
     });
     const phase1Instruction = input.runInput.stepExecutor.buildPhase1Instruction(
-      instruction,
+      composeFindingManagerInstruction({
+        baseInstruction,
+        policyContents: controlStep.policyContents,
+        knowledgeContents: controlStep.knowledgeContents,
+      }),
       controlStep,
     );
     const inputBytes = Buffer.byteLength(phase1Instruction, 'utf8');
@@ -1338,7 +1349,7 @@ function assertFixedPrefixFits(input: {
     rawFindings: [],
     conflicts: [],
   }, [], new Map(), []);
-  const instruction = buildRawTaskInstruction({
+  const baseInstruction = buildRawTaskInstruction({
     contract: input.contract,
     task: emptyTask.task,
     rawFindings: [],
@@ -1362,7 +1373,14 @@ function assertFixedPrefixFits(input: {
     mechanicallyClassifiedCount: 0,
     evidenceRecordsByRawFindingId: new Map(),
   });
-  const phase1 = input.stepExecutor.buildPhase1Instruction(instruction, input.managerStep);
+  const phase1 = input.stepExecutor.buildPhase1Instruction(
+    composeFindingManagerInstruction({
+      baseInstruction,
+      policyContents: input.managerStep.policyContents,
+      knowledgeContents: input.managerStep.knowledgeContents,
+    }),
+    input.managerStep,
+  );
   const bytes = Buffer.byteLength(phase1, 'utf8');
   if (bytes > MAIN_MANAGER_INPUT_MAX_BYTES) {
     throw new Error(

--- a/src/core/workflow/findings/pre-admission-entity-binding.ts
+++ b/src/core/workflow/findings/pre-admission-entity-binding.ts
@@ -33,6 +33,7 @@ import {
   createReviewerAnomalySpec,
   type ReviewerAnomalySpec,
 } from './reviewer-anomalies.js';
+import { composeFindingManagerInstruction } from './manager-instruction-composer.js';
 
 export interface PreAdmissionEntityBindingResult {
   intake: ReviewerIntakeResult;
@@ -156,7 +157,7 @@ function prepareBindingTask(input: {
     input.components,
   );
   const taskId = taskIdForCandidates(candidates, ledgerContext.projectionDigest);
-  const instruction = taskInstruction({
+  const baseInstruction = taskInstruction({
     contract: input.contract,
     taskId,
     candidates,
@@ -164,7 +165,11 @@ function prepareBindingTask(input: {
   });
   const bindingStep = buildFindingEntityBindingTaskStep(input.managerStep);
   const phase1Instruction = input.runInput.stepExecutor.buildPhase1Instruction(
-    instruction,
+    composeFindingManagerInstruction({
+      baseInstruction,
+      policyContents: bindingStep.policyContents,
+      knowledgeContents: bindingStep.knowledgeContents,
+    }),
     bindingStep,
   );
   return {

--- a/src/core/workflow/findings/terminal-adjudication-runner.ts
+++ b/src/core/workflow/findings/terminal-adjudication-runner.ts
@@ -28,7 +28,6 @@ import type { RunFindingManagerForStepInput } from './manager-contracts.js';
 import { MANAGER_INTERPRETATION_LIMITS } from './raw-finding-limits.js';
 import {
   parseTerminalAdjudicationProviderOutput,
-  TerminalAdjudicationProviderOutputJsonSchema,
 } from './schemas.js';
 import { applyResolvedTerminalAdjudication } from './terminal-adjudication-commit.js';
 import {
@@ -47,33 +46,15 @@ import type {
 } from './types.js';
 import { issueFindingScopeBindings } from './finding-scope-binding.js';
 import type { ReviewScopeProofSnapshot } from './snapshot.js';
+import { buildFindingTerminalAdjudicationStep } from './adjudication-step.js';
+import { composeFindingAdjudicationInstruction } from './adjudication-instruction.js';
 
 function terminalStep(input: RunFindingManagerForStepInput): AgentWorkflowStep {
-  const adjudicator = input.contract.adjudicator;
-  if (adjudicator === undefined) {
-    throw new Error('Terminal adjudication requires finding_contract.adjudicator');
-  }
-  return {
-    kind: 'agent',
-    name: 'findings-terminal-adjudication',
-    engineSynthesized: true,
-    persona: adjudicator.persona,
-    personaDisplayName: adjudicator.personaDisplayName ?? 'supervisor',
-    providerRoutingPersonaKey: adjudicator.providerRoutingPersonaKey ?? 'supervisor',
-    ...(adjudicator.personaPath === undefined ? {} : { personaPath: adjudicator.personaPath }),
-    provider: input.workflowProvider,
-    providerSpecified: false,
-    model: input.workflowModel,
-    modelSpecified: false,
-    instruction: 'Adjudicate one durable provisional finding entity.',
-    session: 'refresh',
-    edit: false,
-    structuredOutput: {
-      schemaRef: 'takt.findings.terminal-adjudication',
-      schema: TerminalAdjudicationProviderOutputJsonSchema,
-    },
-    rules: [],
-  };
+  return buildFindingTerminalAdjudicationStep({
+    contract: input.contract,
+    workflowProvider: input.workflowProvider,
+    workflowModel: input.workflowModel,
+  });
 }
 
 function instruction(
@@ -501,7 +482,10 @@ export async function runTerminalAdjudication(input: {
   );
   const step = terminalStep(input.runInput);
   const phase1Instruction = input.runInput.stepExecutor.buildPhase1Instruction(
-    instruction(candidate, candidateScopeBindings),
+    composeFindingAdjudicationInstruction(
+      input.runInput.contract.adjudicator?.instruction,
+      instruction(candidate, candidateScopeBindings),
+    ),
     step,
   );
   const agentOptions = buildManagerAgentOptions(input.runInput.optionsBuilder, step);

--- a/src/core/workflow/workflow-call-provider-context.ts
+++ b/src/core/workflow/workflow-call-provider-context.ts
@@ -1,0 +1,165 @@
+import type {
+  PersonaProviderEntry,
+  ProviderRoutingConfig,
+  ProviderRoutingEntry,
+} from '../models/config-types.js';
+import type { WorkflowConfig, WorkflowCallStep } from '../models/types.js';
+import { resolveEffectiveAutoRouting } from './auto-routing/effective-auto-routing.js';
+import {
+  applyProviderModelOverride,
+  resolveWorkflowCallProviderModel,
+} from './provider-resolution.js';
+import { getProviderValidationErrorSource } from './provider-validation-error.js';
+import type { WorkflowEngineOptions } from './types.js';
+
+export type WorkflowCallProviderContext = Pick<
+  WorkflowEngineOptions,
+  | 'provider'
+  | 'providerSource'
+  | 'model'
+  | 'modelSource'
+  | 'autoRouting'
+  | 'personaProviders'
+  | 'providerRouting'
+>;
+
+type WorkflowCallProviderModel = {
+  provider: WorkflowEngineOptions['provider'];
+  providerSource: WorkflowEngineOptions['providerSource'];
+  model: WorkflowEngineOptions['model'];
+  modelSource: WorkflowEngineOptions['modelSource'];
+};
+
+export function getWorkflowCallOverrideErrorPath(
+  step: WorkflowCallStep,
+  error: unknown,
+): readonly PropertyKey[] | undefined {
+  if (!step.overrides) {
+    return undefined;
+  }
+  const validationSource = getProviderValidationErrorSource(error);
+  if (validationSource?.source !== 'workflow_call') {
+    return undefined;
+  }
+  if (validationSource.field === 'model' && step.overrides.model !== undefined) {
+    return ['overrides', 'model'];
+  }
+  if (validationSource.field === 'provider' && step.overrides.provider !== undefined) {
+    return ['overrides', 'provider'];
+  }
+  return undefined;
+}
+
+function applyWorkflowCallOverridesToProviderEntries<T extends PersonaProviderEntry>(
+  entries: Record<string, T> | undefined,
+  overrides: WorkflowCallStep['overrides'],
+): Record<string, T> | undefined {
+  if (!entries) {
+    return undefined;
+  }
+  if (overrides?.provider === undefined && overrides?.model === undefined) {
+    return entries;
+  }
+
+  const overrideProvider = overrides.provider;
+  return Object.fromEntries(
+    Object.entries(entries).map(([key, entry]) => {
+      const nextEntry: T = {
+        ...(overrideProvider !== undefined
+          ? { provider: overrideProvider }
+          : entry.provider !== undefined
+            ? { provider: entry.provider }
+            : {}),
+      } as T;
+
+      if (overrides.model !== undefined) {
+        nextEntry.model = overrides.model;
+      } else if (overrideProvider === undefined && entry.model !== undefined) {
+        nextEntry.model = entry.model;
+      }
+      if (entry.providerOptions !== undefined) {
+        nextEntry.providerOptions = entry.providerOptions;
+      }
+
+      return [key, nextEntry];
+    }),
+  );
+}
+
+export function applyWorkflowCallOverridesToPersonaProviders(
+  personaProviders: Record<string, PersonaProviderEntry> | undefined,
+  overrides: WorkflowCallStep['overrides'],
+): Record<string, PersonaProviderEntry> | undefined {
+  return applyWorkflowCallOverridesToProviderEntries(personaProviders, overrides);
+}
+
+export function applyWorkflowCallOverridesToProviderRouting(
+  providerRouting: ProviderRoutingConfig | undefined,
+  overrides: WorkflowCallStep['overrides'],
+): ProviderRoutingConfig | undefined {
+  if (!providerRouting) {
+    return undefined;
+  }
+  if (overrides?.provider === undefined && overrides?.model === undefined) {
+    return providerRouting;
+  }
+
+  return {
+    personas: applyWorkflowCallOverridesToProviderEntries<ProviderRoutingEntry>(providerRouting.personas, overrides),
+    tags: applyWorkflowCallOverridesToProviderEntries<ProviderRoutingEntry>(providerRouting.tags, overrides),
+    steps: applyWorkflowCallOverridesToProviderEntries<ProviderRoutingEntry>(providerRouting.steps, overrides),
+  };
+}
+
+export function resolveWorkflowCallChildProviderModel(
+  childWorkflow: WorkflowConfig,
+  overrides: WorkflowCallStep['overrides'],
+  parentContext: Pick<WorkflowCallProviderContext, 'provider' | 'providerSource' | 'model' | 'modelSource'>,
+): WorkflowCallProviderModel {
+  const childProviderInfo = resolveWorkflowCallProviderModel({
+    workflow: childWorkflow,
+    provider: parentContext.provider,
+    providerSource: parentContext.providerSource,
+    model: parentContext.model,
+    modelSource: parentContext.modelSource,
+  });
+  const resolved = applyProviderModelOverride(childProviderInfo, {
+    provider: overrides?.provider,
+    providerSpecified: overrides?.provider !== undefined,
+    model: overrides?.model,
+    modelSpecified: overrides?.model !== undefined,
+    source: 'workflow_call',
+  });
+  return {
+    provider: resolved.provider,
+    providerSource: resolved.providerSource,
+    model: resolved.model,
+    modelSource: resolved.modelSource,
+  };
+}
+
+export function resolveWorkflowCallChildAutoRouting(
+  childWorkflow: WorkflowConfig,
+  inheritedAutoRouting: WorkflowCallProviderContext['autoRouting'],
+): WorkflowCallProviderContext['autoRouting'] {
+  return resolveEffectiveAutoRouting(childWorkflow, inheritedAutoRouting);
+}
+
+export function resolveWorkflowCallChildProviderContext(
+  childWorkflow: WorkflowConfig,
+  step: WorkflowCallStep,
+  parentContext: WorkflowCallProviderContext,
+): WorkflowCallProviderContext {
+  return {
+    ...resolveWorkflowCallChildProviderModel(childWorkflow, step.overrides, parentContext),
+    autoRouting: resolveWorkflowCallChildAutoRouting(childWorkflow, parentContext.autoRouting),
+    personaProviders: applyWorkflowCallOverridesToPersonaProviders(
+      parentContext.personaProviders,
+      step.overrides,
+    ),
+    providerRouting: applyWorkflowCallOverridesToProviderRouting(
+      parentContext.providerRouting,
+      step.overrides,
+    ),
+  };
+}

--- a/src/features/prompt/preview.ts
+++ b/src/features/prompt/preview.ts
@@ -11,6 +11,7 @@ import {
   resolveWorkflowSelector,
   type SelectorProviderOverrides,
 } from '../../infra/config/index.js';
+import { validateWorkflowCallContracts } from '../../infra/config/loaders/workflowResolver.js';
 import { resolveAuxiliaryProviderEnvironment } from '../../infra/config/runtime-provider/provider-environment.js';
 import { InstructionBuilder } from '../../core/workflow/instruction/InstructionBuilder.js';
 import { ReportInstructionBuilder } from '../../core/workflow/instruction/ReportInstructionBuilder.js';
@@ -22,6 +23,11 @@ import {
 } from '../../core/workflow/provider-resolution.js';
 import { resolveDeterministicAutoRoutingProviderInfo, toAutoRoutingStepMetadata } from '../../core/workflow/auto-routing/resolver.js';
 import { buildFindingManagerStep } from '../../core/workflow/findings/manager-step.js';
+import { buildFindingTerminalAdjudicationStep } from '../../core/workflow/findings/adjudication-step.js';
+import {
+  validateFindingContractSyntheticProviderModels,
+  type FindingContractSyntheticProviderValidationOptions,
+} from '../../core/workflow/engine/WorkflowValidator.js';
 import type { InstructionContext } from '../../core/workflow/instruction/instruction-context.js';
 import type { WorkflowConfig, WorkflowStep } from '../../core/models/index.js';
 import type { TagRoutingConflictPolicy } from '../../core/models/config-types.js';
@@ -33,6 +39,7 @@ import { redactProviderOptions } from '../../core/workflow/providerOptionsRedact
 import { header, info, error, blankLine } from '../../shared/ui/index.js';
 import { DEFAULT_WORKFLOW_NAME } from '../../shared/constants.js';
 import { sanitizeTerminalText } from '../../shared/utils/text.js';
+import { translateWorkflowConfigError } from '../../shared/workflowConfigMetadata.js';
 
 function printStepExecutionMetadata(step: WorkflowStep): void {
   if (step.sessionKey) {
@@ -109,18 +116,10 @@ function resolvePreviewProviderResolution(
   };
 }
 
-function resolveFindingManagerProviderModel(
-  config: WorkflowConfig,
+function resolveSyntheticProviderModel(
+  step: WorkflowStep,
   resolution: PreviewProviderResolution,
-): ReturnType<typeof resolveStepProviderModel> | undefined {
-  if (!config.findingContract) {
-    return undefined;
-  }
-  const step = buildFindingManagerStep({
-    contract: config.findingContract,
-    workflowProvider: config.provider,
-    workflowModel: config.model,
-  });
+): ReturnType<typeof resolveStepProviderModel> {
   const currentProviderInfo = resolveStepProviderModel({
     step,
     provider: resolution.provider,
@@ -135,7 +134,7 @@ function resolveFindingManagerProviderModel(
   if (resolution.autoRouting === undefined) {
     return currentProviderInfo;
   }
-  // findings-manager は AI ルーターを通らないため、実行時（OptionsBuilder）と
+  // synthetic roles は AI ルーターを通らないため、実行時（OptionsBuilder）と
   // 同じ rules → strategy デフォルトの決定的解決で表示する。
   return resolveDeterministicAutoRoutingProviderInfo({
     autoRouting: resolution.autoRouting,
@@ -148,15 +147,34 @@ function printFindingContractMetadata(
   config: WorkflowConfig,
   resolution: PreviewProviderResolution,
 ): void {
-  const manager = config.findingContract?.manager;
-  if (!manager) {
+  const contract = config.findingContract;
+  if (contract === undefined) {
     return;
   }
-  const providerInfo = resolveFindingManagerProviderModel(config, resolution);
+  const manager = contract.manager;
+  const managerStep = buildFindingManagerStep({
+    contract,
+    workflowProvider: config.provider,
+    workflowModel: config.model,
+  });
+  const providerInfo = resolveSyntheticProviderModel(managerStep, resolution);
 
   info(`Finding manager: ${sanitizeTerminalText(manager.personaDisplayName ?? manager.persona)}`);
   info(`Finding manager provider: ${formatConfiguredValue(providerInfo?.provider)}`);
   info(`Finding manager model: ${formatConfiguredValue(providerInfo?.model)}`);
+  const adjudicator = contract.adjudicator;
+  if (adjudicator === undefined) {
+    return;
+  }
+  const adjudicatorStep = buildFindingTerminalAdjudicationStep({
+    contract,
+    workflowProvider: config.provider,
+    workflowModel: config.model,
+  });
+  const adjudicatorProviderInfo = resolveSyntheticProviderModel(adjudicatorStep, resolution);
+  info(`Finding adjudicator: ${sanitizeTerminalText(adjudicator.personaDisplayName ?? adjudicator.persona)}`);
+  info(`Finding adjudicator provider: ${formatConfiguredValue(adjudicatorProviderInfo.provider)}`);
+  info(`Finding adjudicator model: ${formatConfiguredValue(adjudicatorProviderInfo.model)}`);
 }
 
 function buildInstructionContext(
@@ -239,6 +257,24 @@ export async function previewPrompts(
 
   const language = resolveWorkflowConfigValue(cwd, 'language') as Language;
   const providerResolution = resolvePreviewProviderResolution(cwd, config);
+  const providerValidationOptions: FindingContractSyntheticProviderValidationOptions = {
+    provider: providerResolution.provider,
+    providerSource: providerResolution.providerSource,
+    model: providerResolution.model,
+    modelSource: providerResolution.modelSource,
+    autoRouting: providerResolution.autoRouting,
+    personaProviders: providerResolution.personaProviders,
+    providerRouting: providerResolution.providerRouting,
+    providerRoutingTagConflictPolicy: providerResolution.tagConflictPolicy,
+  };
+  try {
+    validateFindingContractSyntheticProviderModels(config, providerValidationOptions);
+  } catch (validationError) {
+    throw translateWorkflowConfigError(config, validationError);
+  }
+  validateWorkflowCallContracts(config, cwd, cwd, {
+    providerValidationOptions,
+  });
   const selectorResolution = resolveWorkflowSelector(config, {
     projectCwd: cwd,
     lookupCwd: cwd,

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -79,6 +79,7 @@ import type { LegacyProviderEnvironmentInput } from '../../../infra/config/runti
 import { assertTaskPrefixPair, detectStepType } from './workflowExecutionUtils.js';
 import type { WorkflowRunBootstrap } from './workflowRunLifecycle.js';
 import { inheritWorkflowConfigMetadata } from '../../../shared/workflowConfigMetadata.js';
+import { validateWorkflowCallContracts } from '../../../infra/config/loaders/workflowResolver.js';
 
 const log = createLogger('workflow');
 
@@ -572,6 +573,18 @@ export async function createWorkflowExecutionBootstrap(
     maxSteps: effectiveMaxSteps,
   };
   inheritWorkflowConfigMetadata(workflowConfig, effectiveWorkflowConfig);
+  validateWorkflowCallContracts(effectiveWorkflowConfig, projectCwd, cwd, {
+    providerValidationOptions: {
+      provider: currentProvider,
+      providerSource: currentProviderSource,
+      model: configuredModel,
+      modelSource: configuredModelSource,
+      autoRouting: providerEnvironment.autoRouting,
+      personaProviders: effectivePersonaProviders,
+      providerRouting: effectiveProviderRouting,
+      providerRoutingTagConflictPolicy,
+    },
+  });
   const providerEventLogger = createProviderEventLogger({
     logsDir: runPaths.logsAbs,
     sessionId: workflowSessionId,

--- a/src/features/workflowAuthoring/doctor.ts
+++ b/src/features/workflowAuthoring/doctor.ts
@@ -31,6 +31,7 @@ import type { WorkflowConfig, WorkflowRule, WorkflowState, WorkflowStep } from '
 import { getAllParallelSubSteps } from '../../core/models/types.js';
 import type { WorkflowDoctorReport, WorkflowDoctorTarget } from '../../infra/config/loaders/workflowDoctor.js';
 import { translateWorkflowConfigError } from '../../shared/workflowConfigMetadata.js';
+import { validateWorkflowCallContracts } from '../../infra/config/loaders/workflowResolver.js';
 
 function reportHasErrors(report: WorkflowDoctorReport): boolean {
   return report.diagnostics.some((diagnostic) => diagnostic.level === 'error');
@@ -84,6 +85,18 @@ function validateWorkflowRuntimeContract(
     // findingContract is not a provider setting, so it keeps the plain config resolution.
     const env = resolveAuxiliaryProviderEnvironment(projectDir, workflow);
     const config = resolveWorkflowConfigValues(projectDir, ['findingContract']);
+    validateWorkflowCallContracts(workflow, projectDir, target.lookupCwd ?? projectDir, {
+      providerValidationOptions: {
+        provider: env.provider,
+        providerSource: env.providerSource,
+        model: env.model,
+        modelSource: env.modelSource,
+        personaProviders: env.personaProviders,
+        providerRouting: env.providerRouting,
+        autoRouting: env.autoRouting,
+        providerRoutingTagConflictPolicy: env.tagConflictPolicy,
+      },
+    });
     validateWorkflowConfig(workflow, {
       projectCwd: projectDir,
       provider: env.provider,

--- a/src/infra/config/loaders/workflowCallContractValidator.ts
+++ b/src/infra/config/loaders/workflowCallContractValidator.ts
@@ -1,5 +1,9 @@
 import { dirname } from 'node:path';
-import type { WorkflowConfig } from '../../../core/models/index.js';
+import type {
+  FindingContractConfig,
+  WorkflowConfig,
+} from '../../../core/models/index.js';
+import type { FindingManagerAuthority } from '../../../core/models/finding-types.js';
 import { canonicalJson } from '../../../shared/utils/canonical-json.js';
 import { validateWorkflowCallRulesAgainstChildReturns } from './workflowCallContracts.js';
 import { getWorkflowSourcePath } from './workflowSourceMetadata.js';
@@ -8,6 +12,14 @@ import { withWorkflowConfigErrorPath as withWorkflowStepErrorPath } from '../../
 import { findWorkflowStepLocation } from '../../../core/workflow/workflow-step-location.js';
 import { annotateWorkflowConfigFragmentError } from './workflowRawParser.js';
 import { collectWorkflowCallSteps } from './workflowParallelTraversal.js';
+import {
+  validateFindingContractSyntheticProviderModels,
+  type FindingContractSyntheticProviderValidationOptions,
+} from '../../../core/workflow/engine/WorkflowValidator.js';
+import {
+  getWorkflowCallOverrideErrorPath,
+  resolveWorkflowCallChildProviderContext,
+} from '../../../core/workflow/workflow-call-provider-context.js';
 
 interface WorkflowCallValidationLookupOptions {
   basePath?: string;
@@ -29,11 +41,19 @@ interface ValidateWorkflowCallContractsDeps {
 interface WorkflowCallContractValidationOptions {
   allowPathBasedCalls?: boolean;
   lookupCwd?: string;
+  providerValidationOptions?: FindingContractSyntheticProviderValidationOptions;
 }
 
 interface WorkflowCallContractValidationTraversal {
   active: Set<string>;
   completed: Set<string>;
+}
+
+interface FindingContractTraversalContext {
+  available: boolean;
+  effectiveContract?: FindingContractConfig;
+  effectiveManagerAuthority: FindingManagerAuthority;
+  providerValidationOptions?: FindingContractSyntheticProviderValidationOptions;
 }
 
 function getWorkflowCallInvocationIdentity(
@@ -43,16 +63,33 @@ function getWorkflowCallInvocationIdentity(
   return canonicalJson({ call, args: args ?? {} });
 }
 
+function getProviderValidationIdentity(
+  options: FindingContractSyntheticProviderValidationOptions,
+): string {
+  return canonicalJson(JSON.parse(JSON.stringify(options)) as unknown);
+}
+
 function getWorkflowCallValidationKey(
   workflow: WorkflowConfig,
   lookupCwd: string,
-  inheritedFindingContractAvailable: boolean,
+  findingContractContext: FindingContractTraversalContext,
   invocationIdentity: string,
 ): string {
   const sourcePath = getWorkflowSourcePath(workflow);
   const workflowKey = sourcePath ?? `${lookupCwd}:${workflow.name}`;
   return canonicalJson({
-    findingContractAvailable: inheritedFindingContractAvailable,
+    findingContractAvailable: findingContractContext.available,
+    ...(findingContractContext.effectiveContract === undefined
+      ? {}
+      : { effectiveContract: findingContractContext.effectiveContract }),
+    effectiveManagerAuthority: findingContractContext.effectiveManagerAuthority,
+    ...(findingContractContext.providerValidationOptions === undefined
+      ? {}
+      : {
+          providerValidationIdentity: getProviderValidationIdentity(
+            findingContractContext.providerValidationOptions,
+          ),
+        }),
     invocation: invocationIdentity,
     workflow: workflowKey,
   });
@@ -65,13 +102,13 @@ function validateWorkflowCallContractsRecursive(
   traversal: WorkflowCallContractValidationTraversal,
   deps: ValidateWorkflowCallContractsDeps,
   allowPathBasedCalls: boolean,
-  inheritedFindingContractAvailable: boolean,
+  findingContractContext: FindingContractTraversalContext,
   invocationIdentity: string,
 ): void {
   const validationKey = getWorkflowCallValidationKey(
     workflow,
     lookupCwd,
-    inheritedFindingContractAvailable,
+    findingContractContext,
     invocationIdentity,
   );
   if (traversal.completed.has(validationKey)) {
@@ -107,7 +144,7 @@ function validateWorkflowCallContractsRecursive(
         continue;
       }
 
-      const parentProvidesFindingContract = inheritedFindingContractAvailable
+      const parentProvidesFindingContract = findingContractContext.available
         || workflow.findingContract !== undefined
         || workflow.subworkflow?.requiresFindingContract === true;
       if (childWorkflow.subworkflow?.requiresFindingContract === true && !parentProvidesFindingContract) {
@@ -121,6 +158,48 @@ function validateWorkflowCallContractsRecursive(
         );
       }
 
+      const childInheritedContract = findingContractContext.effectiveContract;
+      const childEffectiveContract = childInheritedContract ?? childWorkflow.findingContract;
+      const childManagerAuthority = childInheritedContract === undefined
+        ? 'standard'
+        : step.findingContractAuthority ?? 'standard';
+      const parentProviderValidationOptions = findingContractContext.providerValidationOptions;
+      const childProviderValidationOptions = parentProviderValidationOptions === undefined
+        ? undefined
+        : {
+            ...resolveWorkflowCallChildProviderContext(
+              childWorkflow,
+              step,
+              parentProviderValidationOptions,
+            ),
+            providerRoutingTagConflictPolicy:
+              parentProviderValidationOptions.providerRoutingTagConflictPolicy,
+          };
+      if (childProviderValidationOptions !== undefined) {
+        try {
+          validateFindingContractSyntheticProviderModels(childWorkflow, {
+            ...childProviderValidationOptions,
+            ...(childInheritedContract === undefined
+              ? {}
+              : {
+                  inheritedFindingContract: {
+                    contract: childInheritedContract,
+                    managerAuthority: childManagerAuthority,
+                  },
+                }),
+          });
+        } catch (error) {
+          const overridePath = getWorkflowCallOverrideErrorPath(step, error);
+          if (overridePath !== undefined && stepPath !== undefined) {
+            throw annotateWorkflowConfigFragmentError(
+              withWorkflowStepErrorPath(error, [...stepPath, ...overridePath]),
+              workflow,
+            );
+          }
+          throw annotateWorkflowConfigFragmentError(error, childWorkflow);
+        }
+      }
+
       validateWorkflowCallContractsRecursive(
         childWorkflow,
         projectCwd,
@@ -128,7 +207,12 @@ function validateWorkflowCallContractsRecursive(
         traversal,
         deps,
         allowPathBasedCalls,
-        parentProvidesFindingContract,
+        {
+          available: parentProvidesFindingContract || childWorkflow.findingContract !== undefined,
+          ...(childEffectiveContract === undefined ? {} : { effectiveContract: childEffectiveContract }),
+          effectiveManagerAuthority: childManagerAuthority,
+          providerValidationOptions: childProviderValidationOptions,
+        },
         getWorkflowCallInvocationIdentity(step.call, step.args),
       );
       try {
@@ -156,7 +240,14 @@ export function validateWorkflowCallContracts(
     { active: new Set<string>(), completed: new Set<string>() },
     deps,
     options?.allowPathBasedCalls !== false,
-    false,
+    {
+      available: workflow.findingContract !== undefined,
+      ...(workflow.findingContract === undefined
+        ? {}
+        : { effectiveContract: workflow.findingContract }),
+      effectiveManagerAuthority: 'standard',
+      providerValidationOptions: options?.providerValidationOptions,
+    },
     canonicalJson({ root: true }),
   );
 }

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -22,7 +22,11 @@ import {
 } from '../../../core/workflow/findings/adjudication-step.js';
 import { FINDING_CONFLICT_ADJUDICATION_STEP } from '../../../core/workflow/constants.js';
 import { normalizeAutoRoutingConfig, normalizeRateLimitFallback, normalizeRuntime } from '../configNormalizers.js';
-import type { FacetResolutionContext, WorkflowSections } from './resource-resolver.js';
+import type {
+  FacetResolutionContext,
+  ResolvedSectionMap,
+  WorkflowSections,
+} from './resource-resolver.js';
 import {
   extractPersonaDisplayName,
   resolvePersona,
@@ -49,6 +53,7 @@ import {
 import type { WorkflowTrustInfo } from './workflowTrustSource.js';
 import { withWorkflowConfigErrorPath as withWorkflowStepErrorPath } from '../../../core/workflow/workflow-config-error.js';
 import { validateDynamicParallelContracts } from '../../../core/workflow/dynamic-parallel/validator.js';
+import { isScopeRef } from 'faceted-prompting';
 
 function normalizeSubworkflowConfig(
   raw: ReturnType<typeof WorkflowConfigRawSchema.parse>['subworkflow'],
@@ -80,6 +85,40 @@ function normalizeSubworkflowConfig(
       )
       : undefined,
   };
+}
+
+function resolveFindingManagerAdditions(input: {
+  refs: readonly string[] | undefined;
+  resolved: Record<string, string> | ResolvedSectionMap | undefined;
+  workflowDir: string;
+  kind: 'policies' | 'knowledge';
+  field: 'policy' | 'knowledge';
+  context?: FacetResolutionContext;
+}): string[] | undefined {
+  return input.refs?.map((ref, index) => {
+    const fieldPath = `finding_contract.manager.${input.field}[${index}]`;
+    let content: string | undefined;
+    try {
+      content = resolveRefToContent(
+        ref,
+        input.resolved,
+        input.workflowDir,
+        input.kind,
+        input.context,
+      );
+    } catch (error) {
+      throw new Error(
+        `Configuration error: failed to resolve ${fieldPath} "${ref}"`,
+        { cause: error },
+      );
+    }
+    if (content === undefined) {
+      throw new Error(
+        `Configuration error: failed to resolve ${fieldPath} "${ref}"`,
+      );
+    }
+    return content;
+  });
 }
 
 function normalizeFindingContractConfig(
@@ -117,6 +156,80 @@ function normalizeFindingContractConfig(
     throw new Error(`Configuration error: failed to resolve finding_contract.manager.output_contract "${raw.manager.output_contract}"`);
   }
   const providerRoutingPersonaKey = raw.manager.persona.trim();
+  const policyContents = resolveFindingManagerAdditions({
+    refs: raw.manager.policy,
+    resolved: sections.resolvedPoliciesWithSource ?? sections.resolvedPolicies,
+    workflowDir,
+    kind: 'policies',
+    field: 'policy',
+    context,
+  });
+  const knowledgeContents = resolveFindingManagerAdditions({
+    refs: raw.manager.knowledge,
+    resolved: sections.resolvedKnowledgeWithSource ?? sections.resolvedKnowledge,
+    workflowDir,
+    kind: 'knowledge',
+    field: 'knowledge',
+    context,
+  });
+  const adjudicator = raw.adjudicator === undefined
+    ? undefined
+    : (() => {
+        let resolvedPersona: ReturnType<typeof resolvePersona>;
+        try {
+          resolvedPersona = resolvePersona(
+            raw.adjudicator.persona,
+            sections,
+            workflowDir,
+            context,
+          );
+        } catch (error) {
+          throw new Error(
+            `Configuration error: failed to resolve finding_contract.adjudicator.persona "${raw.adjudicator.persona}"`,
+            { cause: error },
+          );
+        }
+        let resolvedInstruction: string | undefined;
+        try {
+          resolvedInstruction = resolveRefToContent(
+            raw.adjudicator.instruction,
+            sections.resolvedInstructionsWithSource ?? sections.resolvedInstructions,
+            workflowDir,
+            'instructions',
+            context,
+          );
+        } catch (error) {
+          throw new Error(
+            `Configuration error: failed to resolve finding_contract.adjudicator.instruction "${raw.adjudicator.instruction}"`,
+            { cause: error },
+          );
+        }
+        if (
+          resolvedPersona.personaSpec === undefined
+          || (isScopeRef(raw.adjudicator.persona) && resolvedPersona.personaPath === undefined)
+        ) {
+          throw new Error(
+            `Configuration error: failed to resolve finding_contract.adjudicator.persona "${raw.adjudicator.persona}"`,
+          );
+        }
+        if (resolvedInstruction === undefined) {
+          throw new Error(
+            `Configuration error: failed to resolve finding_contract.adjudicator.instruction "${raw.adjudicator.instruction}"`,
+          );
+        }
+        const routingKey = raw.adjudicator.persona.trim();
+        return {
+          persona: resolvedPersona.personaSpec,
+          personaDisplayName: resolvedPersona.personaPath
+            ? extractPersonaDisplayName(resolvedPersona.personaPath)
+            : resolvedPersona.personaSpec,
+          providerRoutingPersonaKey: routingKey,
+          ...(resolvedPersona.personaPath ? { personaPath: resolvedPersona.personaPath } : {}),
+          instruction: resolvedInstruction,
+          ...(raw.adjudicator.provider ? { provider: raw.adjudicator.provider } : {}),
+          ...(raw.adjudicator.model ? { model: raw.adjudicator.model } : {}),
+        };
+      })();
 
   return {
     manager: {
@@ -126,9 +239,12 @@ function normalizeFindingContractConfig(
       ...(personaPath ? { personaPath } : {}),
       instruction,
       outputContract,
+      ...(policyContents === undefined ? {} : { policyContents }),
+      ...(knowledgeContents === undefined ? {} : { knowledgeContents }),
       ...(raw.manager.provider ? { provider: raw.manager.provider } : {}),
       ...(raw.manager.model ? { model: raw.manager.model } : {}),
     },
+    ...(adjudicator === undefined ? {} : { adjudicator }),
     // 有限停止予算（Finding Contract・対策バッチ B1 の拡張）: ここでは YAML に
     // 書かれた値だけをそのまま写す（未指定フィールドの穴埋めはしない）。
     // max_rounds の既定値適用は stop-budget.ts の resolveStopBudgetLimits が唯一の
@@ -172,6 +288,9 @@ function resolveFindingConflictAdjudicator(
   context?: FacetResolutionContext,
 ): void {
   if (!findingContract) {
+    return;
+  }
+  if (findingContract.adjudicator !== undefined) {
     return;
   }
   const wires = workflowWiresFindingConflictAdjudication(steps, loopMonitors);

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -17,7 +17,7 @@ import {
   parseWorkflowRuleCondition,
 } from '../../../core/models/workflow-rule-condition.js';
 import {
-  FINDING_CONFLICT_ADJUDICATION_PERSONA,
+  FINDING_ADJUDICATION_PERSONA,
   workflowWiresFindingConflictAdjudication,
 } from '../../../core/workflow/findings/adjudication-step.js';
 import { FINDING_CONFLICT_ADJUDICATION_STEP } from '../../../core/workflow/constants.js';
@@ -121,6 +121,71 @@ function resolveFindingManagerAdditions(input: {
   });
 }
 
+type RawFindingContractAdjudicator = NonNullable<
+  NonNullable<ReturnType<typeof WorkflowConfigRawSchema.parse>['finding_contract']>['adjudicator']
+>;
+
+function findingContractAdjudicatorResolutionError(
+  field: 'persona' | 'instruction',
+  ref: string,
+  options?: ErrorOptions,
+): Error {
+  return new Error(
+    `Configuration error: failed to resolve finding_contract.adjudicator.${field} "${ref}"`,
+    options,
+  );
+}
+
+function resolveFindingContractAdjudicator(
+  raw: RawFindingContractAdjudicator,
+  sections: WorkflowSections,
+  workflowDir: string,
+  context?: FacetResolutionContext,
+): NonNullable<FindingContractConfig['adjudicator']> {
+  let resolvedPersona: ReturnType<typeof resolvePersona>;
+  try {
+    resolvedPersona = resolvePersona(raw.persona, sections, workflowDir, context);
+  } catch (error) {
+    throw findingContractAdjudicatorResolutionError('persona', raw.persona, { cause: error });
+  }
+
+  let resolvedInstruction: string | undefined;
+  try {
+    resolvedInstruction = resolveRefToContent(
+      raw.instruction,
+      sections.resolvedInstructionsWithSource ?? sections.resolvedInstructions,
+      workflowDir,
+      'instructions',
+      context,
+    );
+  } catch (error) {
+    throw findingContractAdjudicatorResolutionError('instruction', raw.instruction, { cause: error });
+  }
+
+  if (
+    resolvedPersona.personaSpec === undefined
+    || (isScopeRef(raw.persona) && resolvedPersona.personaPath === undefined)
+  ) {
+    throw findingContractAdjudicatorResolutionError('persona', raw.persona);
+  }
+  if (resolvedInstruction === undefined) {
+    throw findingContractAdjudicatorResolutionError('instruction', raw.instruction);
+  }
+
+  const routingKey = raw.persona.trim();
+  return {
+    persona: resolvedPersona.personaSpec,
+    personaDisplayName: resolvedPersona.personaPath
+      ? extractPersonaDisplayName(resolvedPersona.personaPath)
+      : resolvedPersona.personaSpec,
+    ...(routingKey ? { providerRoutingPersonaKey: routingKey } : {}),
+    ...(resolvedPersona.personaPath ? { personaPath: resolvedPersona.personaPath } : {}),
+    instruction: resolvedInstruction,
+    ...(raw.provider ? { provider: raw.provider } : {}),
+    ...(raw.model ? { model: raw.model } : {}),
+  };
+}
+
 function normalizeFindingContractConfig(
   raw: ReturnType<typeof WorkflowConfigRawSchema.parse>['finding_contract'],
   workflowDir: string,
@@ -174,62 +239,7 @@ function normalizeFindingContractConfig(
   });
   const adjudicator = raw.adjudicator === undefined
     ? undefined
-    : (() => {
-        let resolvedPersona: ReturnType<typeof resolvePersona>;
-        try {
-          resolvedPersona = resolvePersona(
-            raw.adjudicator.persona,
-            sections,
-            workflowDir,
-            context,
-          );
-        } catch (error) {
-          throw new Error(
-            `Configuration error: failed to resolve finding_contract.adjudicator.persona "${raw.adjudicator.persona}"`,
-            { cause: error },
-          );
-        }
-        let resolvedInstruction: string | undefined;
-        try {
-          resolvedInstruction = resolveRefToContent(
-            raw.adjudicator.instruction,
-            sections.resolvedInstructionsWithSource ?? sections.resolvedInstructions,
-            workflowDir,
-            'instructions',
-            context,
-          );
-        } catch (error) {
-          throw new Error(
-            `Configuration error: failed to resolve finding_contract.adjudicator.instruction "${raw.adjudicator.instruction}"`,
-            { cause: error },
-          );
-        }
-        if (
-          resolvedPersona.personaSpec === undefined
-          || (isScopeRef(raw.adjudicator.persona) && resolvedPersona.personaPath === undefined)
-        ) {
-          throw new Error(
-            `Configuration error: failed to resolve finding_contract.adjudicator.persona "${raw.adjudicator.persona}"`,
-          );
-        }
-        if (resolvedInstruction === undefined) {
-          throw new Error(
-            `Configuration error: failed to resolve finding_contract.adjudicator.instruction "${raw.adjudicator.instruction}"`,
-          );
-        }
-        const routingKey = raw.adjudicator.persona.trim();
-        return {
-          persona: resolvedPersona.personaSpec,
-          personaDisplayName: resolvedPersona.personaPath
-            ? extractPersonaDisplayName(resolvedPersona.personaPath)
-            : resolvedPersona.personaSpec,
-          providerRoutingPersonaKey: routingKey,
-          ...(resolvedPersona.personaPath ? { personaPath: resolvedPersona.personaPath } : {}),
-          instruction: resolvedInstruction,
-          ...(raw.adjudicator.provider ? { provider: raw.adjudicator.provider } : {}),
-          ...(raw.adjudicator.model ? { model: raw.adjudicator.model } : {}),
-        };
-      })();
+    : resolveFindingContractAdjudicator(raw.adjudicator, sections, workflowDir, context);
 
   return {
     manager: {
@@ -295,7 +305,7 @@ function resolveFindingConflictAdjudicator(
   }
   const wires = workflowWiresFindingConflictAdjudication(steps, loopMonitors);
   const { personaSpec, personaPath } = resolvePersona(
-    FINDING_CONFLICT_ADJUDICATION_PERSONA,
+    FINDING_ADJUDICATION_PERSONA,
     sections,
     workflowDir,
     context,
@@ -305,13 +315,13 @@ function resolveFindingConflictAdjudicator(
       persona: personaSpec,
       personaPath,
       personaDisplayName: extractPersonaDisplayName(personaPath),
-      providerRoutingPersonaKey: FINDING_CONFLICT_ADJUDICATION_PERSONA,
+      providerRoutingPersonaKey: FINDING_ADJUDICATION_PERSONA,
     };
     return;
   }
   if (wires) {
     throw new Error(
-      `Configuration error: persona "${FINDING_CONFLICT_ADJUDICATION_PERSONA}" is required for `
+      `Configuration error: persona "${FINDING_ADJUDICATION_PERSONA}" is required for `
       + `next: ${FINDING_CONFLICT_ADJUDICATION_STEP} but could not be resolved`,
     );
   }

--- a/src/infra/config/loaders/workflowResolver.ts
+++ b/src/infra/config/loaders/workflowResolver.ts
@@ -7,6 +7,7 @@ import { homedir } from 'node:os';
 import { isAbsolute, join, resolve } from 'node:path';
 import { isScopeRef, parseScopeRef } from 'faceted-prompting';
 import type { WorkflowConfig } from '../../../core/models/index.js';
+import type { FindingContractSyntheticProviderValidationOptions } from '../../../core/workflow/engine/WorkflowValidator.js';
 import { validateWorkflowCallContracts as validateWorkflowCallContractsImpl } from './workflowCallContractValidator.js';
 import { buildWorkflowDiscoveryConfig, loadValidatedWorkflowDiscoveryEntry } from './workflowDiscoveryLoader.js';
 import {
@@ -247,7 +248,10 @@ export function validateWorkflowCallContracts(
   workflow: WorkflowConfig,
   projectCwd: string,
   lookupCwd = projectCwd,
-  options?: { allowPathBasedCalls?: boolean },
+  options?: {
+    allowPathBasedCalls?: boolean;
+    providerValidationOptions?: FindingContractSyntheticProviderValidationOptions;
+  },
 ): void {
   validateWorkflowCallContractsImpl(workflow, projectCwd, {
     isWorkflowPath,
@@ -255,6 +259,7 @@ export function validateWorkflowCallContracts(
   }, {
     lookupCwd,
     allowPathBasedCalls: options?.allowPathBasedCalls,
+    providerValidationOptions: options?.providerValidationOptions,
   });
 }
 


### PR DESCRIPTION
## 概要

#1187 の後続。FC の2つの合成ロール(findings manager / adjudicator)をワークフロー YAML から構成可能にするエンジン拡張。

## 変更

### finding_contract.adjudicator の指定化
```yaml
finding_contract:
  adjudicator:            # 省略時は現行どおりsupervisor自動導出
    persona: supervisor
    instruction: adjudicate-finding-contract   # 判断基準の指導のみ
    provider: codex        # 任意。裁定だけ強いモデルへ
    model: gpt-5.6-sol
```
- 注入できるのは判断基準まで。却下のワイヤ形式(構造化出力スキーマ・byte一致証拠要求)はエンジン所有のままで、facetから緩められないことをテストで固定
- conflict/terminal 両ランナーが同一の解決(persona key・direct provider/model)を共有

### finding_contract.manager への policy/knowledge additions
- 通常ステップと同じ facet_ref[] 形式。5経路(raw/control/entity-binding/interpretation/legacy)の共通composerで注入
- 両省略時は既存プロンプトへバイト単位で恒等(identity分岐)

### 検証の一致性
- workflow_call 境界の routing 変換(overrides適用・child auto_routing)を共通helperへ抽出し、load-time再帰検証・preview・runtimeが同じ解決を使う
- terminal role の事前検証は authority を継承して実際に runner が走る側の文脈で実施(sibling への誤適用なし)

## 互換性

省略時の不変を実装前採取の baseline golden で固定:
- manager 5経路のプロンプト bytes/SHA-256、conflict/terminal 裁定プロンプト、request digest、normalized config digest、execution bundle(root-owned/inherited)
- 実WAL予約経由の reserved-call resume で保存時・再構築時 digest 一致

## 検証
設計3ラウンド(敵対レビューでGO)+実装への敵対レビュー3ラウンド(BLOCK計6件を解消)。schema/parser/runner/provider validation/24KB境界/authority非緩和のテスト追加。ローカルは対象テスト個別実行のみ、フル検証はCI。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Finding Contract に判定担当（adjudicator）を設定できるようになりました。
  - ポリシーやナレッジを判定・管理用の指示に追加できます。
  - ワークフローごとに persona、instruction、provider、model を指定できます。
  - 子ワークフローへの設定継承と上書きに対応しました。

- **改善**
  - 証拠の一致・スコープを検証し、判断不能な場合は未確定として扱います。
  - プロンプトプレビューで判定担当の設定を確認できます。
  - 入力サイズ超過時の処理とエラー表示を改善しました。

- **ドキュメント**
  - カスタム設定例と provider・model の優先順位を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->