### PR TITLE
docs: CLAUDE.mdを現行アーキテクチャへ全面書き直しする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,214 +6,155 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-TAKT (TAKT Agent Koordination Topology) is a multi-agent orchestration CLI. It runs AI agents (Claude, Codex, OpenCode, Cursor, Copilot) through YAML-defined workflows: a state machine of steps with rule-based routing, parallel review sub-steps, dynamic task decomposition, and worktree-isolated execution. TAKT is dogfooded — this repository uses TAKT itself for review and development.
+TAKT (TAKT Agent Koordination Topology) is a multi-agent orchestration CLI. It runs AI agents (Claude, Codex, OpenCode, Cursor, Copilot) through YAML-defined workflows: a state machine of steps with rule-based routing, parallel review sub-steps, dynamic task decomposition, worktree-isolated execution, and an optional Finding Contract subsystem that tracks review findings in a per-run SQLite ledger. TAKT is dogfooded — this repository uses TAKT itself for review and development.
 
 ## Development Commands
 
 | Command | Notes |
 |---------|-------|
-| `npm run build` | `tsc` plus copy of `src/shared/prompts/{en,ja}/*.md`, `src/shared/i18n/*.yaml`, and `src/core/runtime/presets/*.sh` into `dist/`. Skipping any of these copies breaks runtime resolution. |
+| `npm run build` | `tsc` (+ prompt-evals tsconfig) plus copies of `src/shared/prompts/{en,ja}/**/*.md`, `src/shared/i18n/*.yaml`, and `src/core/runtime/presets/*.sh` into `dist/`. Skipping any copy breaks runtime resolution. |
 | `npm run watch` | TypeScript incremental build (no asset copy). |
 | `npm run lint` | ESLint on `src/`. `no-explicit-any` is error; unused vars must be prefixed `_`. |
-| `npm test` | Fast unit gate. Excludes integration/regression/performance tests. |
-| `npm run test:unit:parallel` | Parallel unit slice (`vitest.config.unit.parallel.ts`). |
-| `npm run test:it` | Integration/regression/performance gate. Runs the parallel IT slice, then the serial group of fsync/spawnSync-storm tests. |
-| `npm run test:it:parallel` | Parallel IT slice (`vitest.config.it.parallel.ts`). Excludes files listed in the serial escape-hatch groups. |
-| `npm run test:it:serial` | Serial group (`scripts/test-classification.mjs`). Membership is about measured IO behavior, not correctness: a 2026-08 audit found every file mkdtemp-isolated, but fsync/spawnSync-storm tests serialize at the device level and can block a parallel worker past the 60s vitest RPC timeout. Add files only with a measured interference reason. |
-| `npm run test:prompt-evals` | Deterministic OpenCode prompt-eval smoke gate. Included in `check:release`. |
-| `npm test -- src/__tests__/<file>.test.ts` | Route a single file to the unit or parallel-IT runner (or a serial runner if listed). Multiple routed runners execute sequentially and return the first failing child exit code. |
+| `npm test` | Fast unit gate: type-contracts tsc, then 4 shards launched **concurrently** (`Promise.all` in `scripts/run-npm-test.mjs`, each shard `--maxWorkers=1`). Excludes integration/regression/performance tests. |
+| `npm run test:it` | Integration gate: parallel IT slice (`it-*`, `*.integration/regression/performance.test.ts`), then the serial group. |
+| `npm test -- src/__tests__/<file>.test.ts` | Route a single file to the correct runner (unit, parallel-IT, or serial). Multiple routed runners execute sequentially and return the first failing exit code. |
 | `npm test -- -t "<pattern>"` | Run unit tests whose name matches `<pattern>`. |
-| `npm run test:e2e:smoke` | Fast mock-provider E2E smoke check for targeted local iteration. |
-| `npm run test:e2e:mock` | Full mock-provider E2E suite split into parallel shards. This is the TAKT quality gate. Use `test:e2e:mock:serial` for the legacy single-process run. |
-| `npm run test:e2e` | Wrapper around `test:e2e:mock` that also fails on `error connecting to api.github.com` in the output and emits a macOS notification. |
+| `npm run test:prompt-evals` | Deterministic OpenCode prompt-eval smoke gate (11 cases, no API cost). Part of `check:release`; not part of routine gates. |
+| `npm run test:e2e:mock` | Full mock-provider E2E suite (parallel shards). Single spec: `npx vitest run --config vitest.config.e2e.mock.ts e2e/specs/<file>.e2e.ts`. |
 | `npm run test:e2e:provider:{claude,claude-sdk,codex,opencode,cursor}` | E2E against a real provider (slow, costs API credits). |
-| `npm run check:release` | Full pre-release gate: `build` + `lint` + `test` + `test:it` + `test:prompt-evals` + `test:e2e:all`. |
+| `npm run check:release` | Full pre-release gate: build + lint + test + test:it + prompt-evals + e2e. |
 
-### Local quality gates
+### Test pool behavior (worth knowing before "fixing" flakes)
 
-`.takt/config.yaml` gives implementation and fix steps explicit build, lint, test, integration, and mock-E2E verification instructions. The builtin merge-readiness final gate evaluates the reported verification results and routes failures through `needs_fix`; it does not execute command gates itself. Run `npm run check:release` when validating the full release path.
+- Serial-group membership lives in `scripts/test-classification.mjs` (`serialGitTestFiles`). Membership is about **measured IO interference** (fsync/spawnSync storms that block a worker past vitest's 60s birpc deadline), not correctness. Add files only with a measured reason; `releaseVerificationWiring.test.ts` fails if a listed file does not exist.
+- `dangerouslyIgnoreUnhandledErrors: !process.env.CI` (vitest.config.shared.ts): the spurious `[vitest-worker]: Timeout calling "onTaskUpdate"` error is tolerated locally (4 concurrent shards on one machine) but **fatal on CI**. The parallel IT slice runs single-worker on CI (`maxWorkers: process.env.CI ? 1 : 4`) for the same reason.
+- `src/__tests__/test-setup.ts` clears `TAKT_CONFIG_DIR` / `TAKT_NOTIFY_WEBHOOK` per test and provides an isolated config root — don't add per-suite env overrides that fight it.
 
 ## CLI Surface
 
-Entry point: `bin/takt` → `dist/app/cli/index.js` (`src/app/cli/index.ts`). Subcommand definitions live in `src/app/cli/commands.ts`; argumentless/slash-fallback routing is in `src/app/cli/routing.ts`.
+Entry point: `bin/takt` → `dist/app/cli/index.js` (`src/app/cli/index.ts`). Subcommand definitions live in `src/app/cli/commands.ts`; argumentless/slash-fallback routing is in `src/app/cli/routing.ts`. See `commands.ts` for the full list rather than maintaining a copy here.
 
-Most-used subcommands: `takt` (interactive planning), `takt {task}` (one-shot), `takt run` / `takt watch`, `takt add [task]`, `takt list`, `takt #N` (GitHub issue), `takt workflow {init,doctor}`, `takt eject [--global]`, `takt prompt`, `takt catalog`, `takt repertoire {add,remove,list}`, `takt export-cc` / `export-codex`. See `src/app/cli/commands.ts` for the full list and option flags rather than maintaining a copy here.
-
-Two execution modes share the same engine:
-
-- **Interactive** (`src/features/interactive/`): four sub-modes — `assistant` (default), `passthrough`, `quiet`, `persona`. `/go` executes, `/cancel` aborts.
-- **Pipeline** (`src/features/pipeline/`, `--pipeline`): non-interactive. Auto-branch, commit, push; `--auto-pr` for PR creation; `--skip-git` for workflow-only.
+Two execution modes share the same engine: **Interactive** (`src/features/interactive/`; `/go` executes, `/cancel` aborts) and **Pipeline** (`src/features/pipeline/`, `--pipeline`; auto-branch/commit/push, `--auto-pr`, `--skip-git`).
 
 ## Architecture
 
 ### Layered layout (`src/`)
 
 ```
-app/cli/        CLI entrypoint, command wiring, routing
-core/           Engine internals — no IO providers here
-  workflow/    Engine, step executors, rule evaluation, instruction builder
+app/cli/       CLI entrypoint, command wiring, routing
+core/          Engine internals — no IO providers here
+  workflow/    Engine, step executors, rule evaluation, instruction builder,
+               findings/ (Finding Contract engine)
   config/      Workflow/global/project config models
-  models/      Shared domain types + Zod schemas
+  models/      Shared domain types + Zod schemas (schemas.ts, finding-*.ts)
   runtime/     Runtime environment & shell presets
-  logging/     Structured logging
-features/      User-facing feature modules (interactive, pipeline, tasks,
-              catalog, prompt, repertoire, analytics, workflowAuthoring,
-              workflowSelection)
-infra/        Adapters — providers, fs, git/github/gitlab, observability,
-              rate-limit, resources, config loaders
-shared/       Constants, i18n, ui, utils, prompt templates
-agents/       agent-usecases (executeAgent, generateReport, judgeStatus, etc.)
+features/      User-facing feature modules (interactive, pipeline, tasks, ...)
+infra/         Adapters — providers, fs, git/github/gitlab, finding-storage,
+               observability, config loaders
+shared/        Constants, i18n, ui, utils, prompt templates
+agents/        agent-usecases (executeAgent, generateReport, judgeStatus, ...)
 ```
-
-Public programmatic API is re-exported from `src/index.ts`.
 
 ### Workflow execution
 
-`WorkflowEngine` (`src/core/workflow/engine/WorkflowEngine.ts`) is an EventEmitter-driven state machine. For each step it dispatches to one of four runners under `src/core/workflow/engine/`:
-
-| Runner | When | Notes |
-|---|---|---|
-| `StepExecutor` | Normal step | 3-phase execution model. |
-| `ParallelRunner` | `parallel:` block | `Promise.allSettled()` over sub-steps; parent aggregates with `all()`/`any()`. |
-| `ArpeggioRunner` | `arpeggio:` block | Data-driven batch (CSV/JSON → template → LLM) with bounded concurrency. |
-| `TeamLeaderRunner` | `team_leader:` block | Leader decomposes the task into parts at runtime, dispatches each to a worker agent. |
-| `WorkflowCallExecutor` | `workflow_call:` block | Invokes a subworkflow in the same run; parent rules consume the child outcome. |
-
-Engine emits: `step:start`, `step:complete`, `step:blocked`, `step:report`, `step:user_input`, `step:loop_detected`, `step:cycle_detected`, `phase:start`, `phase:complete`, `workflow:complete`, `workflow:abort`, `iteration:limit`. `LoopDetector` catches consecutive same-step repeats; `CycleDetector` + `loop_monitors` catch cyclic patterns (e.g. `review ↔ fix`).
+`WorkflowEngine` (`src/core/workflow/engine/WorkflowEngine.ts`) is an EventEmitter-driven state machine. Per-step dispatch: `StepExecutor` (normal, 3-phase), `ParallelRunner` (`parallel:`, Promise.allSettled + `all()`/`any()` aggregation), `ArpeggioRunner` (`arpeggio:` data-driven batch), `TeamLeaderRunner` (`team_leader:` runtime decomposition), `WorkflowCallExecutor` (`workflow_call:` subworkflow in the same run). `LoopDetector` catches consecutive same-step repeats; `CycleDetector` + `loop_monitors` catch cyclic patterns (judge personas routed under the fixed persona key **`loop-judge`**, not `supervisor`).
 
 ### Three-phase step model
 
-Each normal step runs up to three phases on the same provider session (resumed across phases):
+Each normal step runs up to three phases on the same provider session: Phase 1 main work (step's `allowed_tools`; `Write` excluded when a report is defined), Phase 2 report output (`Write` only, when `output_contracts` defined), Phase 3 status judgment (no tools, when tag-based rules exist). Implemented in `phase-runner.ts` / `report-phase-runner.ts` / `status-judgment-phase.ts`.
 
-| Phase | Purpose | Tool set | When |
-|---|---|---|---|
-| 1 | Main work | Step's `allowed_tools` (`Write` excluded if a report is defined) | Always |
-| 2 | Report output | `Write` only | If `output_contracts` is defined |
-| 3 | Status judgment | None (judgment only) | If the step has tag-based rules |
+### Rule evaluation (5-stage fallback)
 
-Implemented in `src/core/workflow/phase-runner.ts` / `report-phase-runner.ts` / `status-judgment-phase.ts`.
-
-### Rule evaluation (staged fallback)
-
-`src/core/workflow/evaluation/` + `src/agents/judge-status-usecase.ts` — first match wins, in this order:
-
-1. **Aggregate** — `all("…")` / `any("…")` for parallel parents (`AggregateEvaluator`)
-2. **Structured output** — native provider structured output selects a candidate index (stage 1)
-3. **Phase 3 tag** — `[STEP:N]` emitted during status judgment (stage 2)
-4. **AI judge** — provider evaluates the candidates as a last resort (stage 3)
-
-`auto_select` short-circuits the judge when only one semantic candidate exists (`post-execution-rule-evaluator.ts`).
-
-Quirks that matter:
-
-- Tag rules match by array **index** (0-based), not by condition text.
-- When multiple `[STEP:N]` tags appear, **last match wins**.
-- If rules exist but nothing matches, the workflow **fails fast** (abort) — silently picking a default is a bug.
+`src/core/workflow/evaluation/` — first match wins: (1) aggregate `all()`/`any()` for parallel parents, (2) Phase 3 `[STEP:N]` tag, (3) Phase 1 tag, (4) AI judge for `ai("...")` conditions, (5) AI judge over every condition. Deterministic `when(...)` expressions (e.g. `findings.*`) are evaluated before tags. Quirks: tag rules match by array **index**; multiple tags → last match wins; if rules exist but nothing matches the workflow **fails fast** — silently picking a default is a bug.
 
 ### Instruction assembly
 
-`InstructionBuilder` (`src/core/workflow/instruction/`) auto-injects execution context, workflow context, `{task}`, `{previous_response}`, `{user_inputs}`, and status output rules into every instruction. **Templates should contain only step-specific content** — don't repeat boilerplate the builder already adds.
+`InstructionBuilder` (`src/core/workflow/instruction/`) auto-injects execution context, workflow context, `{task}`, `{previous_response}`, `{user_inputs}`, and status output rules. **Templates contain only step-specific content** — never repeat what the builder injects. Facet markdown may include partials via `{{include:instructions/<name>}}` (resolved from `facets/partials/`).
 
 ### Provider integration
 
-`src/infra/providers/` exposes a unified `Provider` interface (`setup(AgentSetup) → ProviderAgent`, `ProviderAgent.call(prompt, options) → AgentResponse`). Registered providers: `claude-sdk` (Anthropic Agent SDK), `claude` (headless CLI, `src/infra/claude-headless/`), `codex` (`@openai/codex-sdk`), `opencode` (`@opencode-ai/sdk`, shared server pool), `cursor`, `copilot`, `mock`.
+`src/infra/providers/` exposes a unified `Provider` interface. Registered: `claude-sdk`, `claude` (headless CLI), `codex`, `opencode` (shared server pool), `cursor`, `copilot`, `mock`. **Provider errors must surface through `AgentResponse.error`** — otherwise SDK failures appear as empty `blocked` output and are nearly impossible to debug. Use `--provider mock` to exercise the engine without a real API.
 
-**Provider errors must surface through `AgentResponse.error`.** If they don't, SDK failures appear as empty `blocked` status and are nearly impossible to debug.
+### Provider/model resolution priority
 
-**Model/provider resolution priority** (highest first):
+Verified against `resolveStepProviderModel` / `PROVIDER_MODEL_SOURCE_PRIORITY` and runtime tests (2026-08). Provider and model resolve independently; highest first:
 
-1. Step `promotion` entry that matches current execution count or `ai()` condition
-2. Step `provider` / `model`
-3. Persona-level `persona_providers.<persona>`
-4. CLI/task override (`--provider` / `--model`)
-5. `.takt/config.yaml` then `~/.takt/config.yaml` (when provider matches)
-6. Provider default
+1. CLI / environment explicit override
+2. Matching `promotion` (normal agent steps only — parallel sub-steps **reject** `promotion` at schema level)
+3. Step / parallel sub-step direct `provider` / `model`
+4. `workflow_call` override
+5. `provider_routing.steps` → `provider_routing.tags` → `provider_routing.personas`
+6. `persona_providers` (deprecated)
+7. Auto routing (`auto.rules` / `auto.dynamic` / `auto.fallback`)
+8. Workflow → project (`.takt/config.yaml`) → global (`~/.takt/config.yaml`) → provider default
 
-`promotion` is **not** supported on parallel sub-steps.
+Synthetic Finding Contract roles route by persona key: `findings-manager`, `supervisor` (adjudication), `loop-judge` (loop monitors).
+
+### Finding Contract (FC)
+
+Optional per-run SQLite ledger (`finding-contract.sqlite`) that makes review findings durable and machine-verified. **Activates only when a workflow defines `finding_contract:`** — non-FC workflows are unaffected. Core pieces (`src/core/workflow/findings/`, storage in `src/infra/finding-storage/`):
+
+- Reviewers emit structured raw findings via `*-finding-contract` output contracts; the engine verifies quotes/anchors byte-exact against files.
+- The **manager** (persona `findings-manager`) runs after each FC review step: admission, same/new identity judgment (dedup merge), rejected-observation recording. It **cannot** dismiss findings.
+- **Terminal/conflict adjudication** (adjudicator, default derived from `supervisor` persona) dismisses or settles findings — every dismissal basis requires machine-verifiable evidence (byte-exact quotes or task-scope quotes). Terminal authority is granted only via `finding_contract_authority: terminal_adjudication` on a workflow call, never by configuration alone.
+- Lifecycle identity across rounds: `new` / `persists` / `reopened` / `resolved`; resolution is lifecycle-continuity based and needs verified confirmation — "I fixed it" alone never resolves.
+- Provider calls run under persistent leases (reserved→dispatched→settled) with input/output/call budgets in the ledger; `stop_budget.max_rounds` guarantees finite termination.
+- `finding_contract.manager` accepts `persona/instruction/output_contract`, optional `policy`/`knowledge` additions, and `provider`/`model`. `finding_contract.adjudicator` (optional) accepts `persona/instruction/provider/model`; when omitted the supervisor auto-derivation keeps prompts byte-identical (guarded by golden-baseline tests — do not regenerate goldens to make a change pass).
+- Manager/adjudicator prompt wire formats (structured output schemas, allowed actions, evidence requirements) are **engine-owned**; facets add judgment guidance only.
+
+Workflows: `takt-default` (non-FC, prompt-adjudication step) and `takt-default-fc` (FC; no adjudication step — manager + terminal adjudication replace it). The FC fix/plan/monitor instructions treat the engine-injected live ledger state as the single source of truth; report files are not authoritative there.
 
 ### Config & workflow loading
 
-`src/infra/config/loaders/`. Workflow resolution is **3-layer with project taking priority**: `.takt/workflows/` → `~/.takt/workflows/` → bundled `builtins/{lang}/workflows/`. Repertoire packages use `@{owner}/{repo}/{workflow-name}`. YAML parsing + step/rule normalization runs through Zod schemas in `src/core/models/schemas.ts`.
+`src/infra/config/loaders/`. Workflow resolution is 3-layer with project priority: `.takt/workflows/` → `~/.takt/workflows/` → bundled `builtins/{lang}/workflows/`. Zod schemas in `src/core/models/schemas.ts` (Zod v4). Load-time provider validation for workflow_call chains uses the same routing transformation helpers as runtime (`workflow-call-provider-context.ts`) — keep them shared; divergence between load-time and runtime resolution is a bug class we have shipped before.
 
 ### Worktree-isolated execution
 
-When a task sets `worktree: true`, TAKT runs it in a `git clone --reference <main repo> --dissociate` (an independent clone with its own `.git`; plain `git clone` when the reference repo is shallow), not a real git worktree. The field name is retained for back-compat; the implementation uses `git clone` because Claude Code follows `.git`-file `gitdir:` pointers back to the main repo, which breaks isolation.
-
-- Clones are ephemeral: created pre-run, auto-committed + pushed on success, deleted afterward.
-- Sessions can't be resumed inside the clone (`cwd !== projectCwd`); session resume is skipped there.
-- Clones contain only tracked files — no `node_modules`. Runtime presets under `src/core/runtime/presets/` handle setup.
-- `cwd` = clone path, `projectCwd` = repo root; reports go to `cwd/.takt/runs/{slug}/reports/`.
+`worktree: true` runs a task in a `git clone --shared` (not a real git worktree — Claude Code follows `.git`-file `gitdir:` pointers back to the main repo, which breaks isolation). Clones are ephemeral (auto-commit + push on success, deleted after), contain only tracked files, and cannot resume sessions (`cwd !== projectCwd`). `cwd` = clone path, `projectCwd` = repo root; reports go to `cwd/.takt/runs/{slug}/reports/`.
 
 ## Faceted Prompting
 
-Prompts are split into four facet kinds — keep additions in the right bucket or reviewers will lose track:
+Prompts are split into facet kinds — keep additions in the right bucket:
 
-| Facet | Lives in | Holds |
-|---|---|---|
-| `personas/` | `builtins/{lang}/facets/personas/` | WHO — identity, expertise, behavioral habits. Must be reusable across workflows; never put workflow-specific procedures here. |
-| `policies/` | `builtins/{lang}/facets/policies/` | HOW — REJECT/APPROVE criteria. **Reviewers only enforce what's in policy**; knowledge alone does not trigger enforcement. |
-| `knowledge/` | `builtins/{lang}/facets/knowledge/` | WHAT TO KNOW — domain patterns, anti-patterns, examples, reasoning. |
-| `instructions/` | `builtins/{lang}/facets/instructions/` | WHAT TO DO NOW — step-bound procedures and checklists. |
+| Facet | Holds |
+|---|---|
+| `personas/` | WHO — identity, expertise. Reusable across workflows; no workflow-specific procedures. |
+| `policies/` | HOW — REJECT/APPROVE criteria. **Reviewers only enforce what's in policy.** |
+| `knowledge/` | WHAT TO KNOW — domain patterns, anti-patterns, examples. |
+| `instructions/` | WHAT TO DO NOW — step-bound procedures. |
+| `partials/instructions/` | Shared fragments injected via `{{include:...}}`. Headless (no H1) by design. |
 
-Output contracts live under `builtins/{lang}/facets/output-contracts/`. User overrides go under `~/.takt/facets/<type>/` or `.takt/facets/<type>/`.
+Output contracts live under `facets/output-contracts/`. User overrides: `~/.takt/facets/<type>/` or `.takt/facets/<type>/`.
+
+**No FC conditionals in shared facets.** Never write "if Finding Contract state exists, …" branches into a shared instruction. The pattern is: a standard variant (report-based, zero FC vocabulary), an FC variant (`*-finding-contract`, live-ledger-based), and shared body extracted to partials. Workflows wire the right variant. Structural tests pin that standard facets stay FC-free after partial expansion.
 
 ## Runtime directory layout
 
 ```
-~/.takt/                Global user config
-  config.yaml           provider / model / language / log level
-  workflows/            user workflow overrides
-  facets/               user facets (personas/, policies/, knowledge/, instructions/, output-contracts/)
-  repertoire/           installed @{owner}/{repo}/ packages
-
+~/.takt/                Global user config (config.yaml, workflows/, facets/, repertoire/)
 .takt/                  Project config (highest priority)
-  config.yaml           project overrides (quality_gates, workflow_overrides, etc.)
+  config.yaml           provider / provider_routing / quality gates / overrides
   workflows/, facets/   project-level overrides
   tasks.yaml, tasks/    queued task specs
-  runs/{slug}/reports/  per-run reports
-  logs/                 NDJSON session logs (gitignored)
-  events/               analytics events (NDJSON)
-
-builtins/               Bundled defaults (read from dist/ at runtime)
-  {en,ja}/              language-scoped facets + workflows
-  project/              project-template assets
-  schemas/              JSON schemas
-  skill/, skill-codex/  exported Claude Code / Codex skill bundles
+  runs/{slug}/          per-run reports + finding-contract.sqlite
+  logs/, events/        NDJSON session logs / analytics (gitignored)
+builtins/{en,ja}/       Bundled facets + workflows (read from dist/ at runtime)
 ```
 
 ## TypeScript / testing
 
-- ESM (`"type": "module"`). Import paths use `.js` extensions in `.ts` sources.
-- Strict TS with `noUncheckedIndexedAccess`. Node ≥ 18.19.
-- Zod v4 for runtime schemas (`src/core/models/schemas.ts`).
-- Unit and integration tests live under `src/__tests__/` (Vitest). The default `npm test` is the fast unit gate; `npm run test:it` runs `it-*`, `*.integration.test.ts`, `*.regression.test.ts`, and `*.performance.test.ts`, mostly in one parallel slice; only measured fsync/spawnSync-storm files stay serial. E2E specs live under `e2e/`, with a smoke config plus one config per provider (`vitest.config.e2e.*.ts`).
-- `src/__tests__/test-setup.ts` clears `TAKT_CONFIG_DIR` and `TAKT_NOTIFY_WEBHOOK` per test — don't rely on inherited env in tests.
+- ESM (`"type": "module"`); import paths use `.js` extensions in `.ts` sources. Strict TS with `noUncheckedIndexedAccess`. Node ≥ 18.19.
+- Unit and integration tests live under `src/__tests__/` (Vitest); E2E specs under `e2e/` with per-provider configs.
+- Tests that hand-build normalized `WorkflowConfig` objects with a finding contract must include an `adjudicator` — engine construction pre-validates all synthetic FC roles.
 
 ## Debugging
 
-- Set `logging.debug: true` in `~/.takt/config.yaml` for debug logs under `.takt/runs/debug-{timestamp}/logs/`.
-- `TAKT_VERBOSE=true` or `verbose: true` for verbose console output.
-- Session logs at `.takt/logs/{sessionId}.jsonl`.
-- Use `--provider mock` to exercise the engine without calling a real API.
-
-### Observing what OpenCode actually sends
-
-OpenCode's default system prompt is not readable from the binary, and neither `session.messages()` nor `opencode debug agent <name>` exposes the prompt that reaches the model. The only reliable way is to point OpenCode at a local OpenAI-compatible endpoint and record the request body. `prompt-evals/sdk-prompt-capture.mjs` does this: it defines a `probe` provider via `config.provider.<id>.options.baseURL`, sends one prompt, and writes every captured request to JSON.
-
-Facts established with it (re-verify before relying on them — OpenCode changes):
-
-- The composed system prompt is `agent.prompt` (or OpenCode's default when `prompt` is omitted) **plus** the user's `~/.claude/CLAUDE.md`, **plus** the skills section, **plus** `config.instructions` files. All four are concatenated into a single `system` message.
-- `~/.claude/CLAUDE.md` is injected whether or not `agent.prompt` is set. For benchmarks this means the operator's personal config is part of the measured conditions.
-- `config.instructions: string[]` (typed on `Config` in `@opencode-ai/sdk/v2`) appends file contents near the end, after the CLAUDE.md block. It is a supported way to add guidance without replacing OpenCode's default prompt.
-- Each prompt triggers **two** provider requests: a thread-title generation call using `small_model`, then the real one. Capture tooling that grabs the first request measures the title generator.
-- TAKT's `opencode_agent_prompt.md` (~8.5k chars) is OpenCode's default (~9k chars, excluding injections) with two removals: the `ls`-tool few-shot examples become `{{listFilesMethod}}`, and the line recommending the `Task` tool is dropped. #892 originally deleted the whole `# Proactiveness` and `# Tool usage policy` sections to eliminate those references, which starved weak models of OpenCode's own tool guidance; both sections are restored. The prompt is English-only — `client.ts` always loads `'en'`, so there is no `ja` copy.
-
-Do not use `opencode run` (the CLI) as a measurement instrument. It intermittently hangs before session creation with no log output. TAKT uses `createOpencode` from the SDK, so the CLI's behavior says nothing about production.
+- `logging.debug: true` in `~/.takt/config.yaml` → debug logs under `.takt/runs/debug-{timestamp}/logs/`. `TAKT_VERBOSE=true` for verbose console. Session logs at `.takt/logs/{sessionId}.jsonl`.
+- OpenCode's composed system prompt cannot be read from the binary or SDK; `prompt-evals/sdk-prompt-capture.mjs` points OpenCode at a local OpenAI-compatible probe endpoint and records real request bodies. Facts established with it (re-verify — OpenCode changes): the system prompt concatenates `agent.prompt` + the user's `~/.claude/CLAUDE.md` + skills + `config.instructions`; every prompt triggers a thread-title call on `small_model` before the real one (capture tooling that grabs the first request measures the title generator). Do not use `opencode run` (CLI) as a measurement instrument — it intermittently hangs; production uses `createOpencode` from the SDK.
 
 ## House conventions (from AGENTS.md / CONTRIBUTING.md)
 
-- Prefer simple code over defensive fallback-heavy logic.
-- Filenames mostly `kebab-case`, focused module names like `workflowLoader.ts`.
-- Conventional Commit style with occasional `(#issue)` suffix.
+- Prefer simple code over defensive fallback-heavy logic. TAKT is a local tool: no audit trails, tamper-resistance, or security theater — the threat model is provider output and engine wiring mistakes, not hostile users editing their own files.
+- Filenames mostly `kebab-case`. Conventional Commit style with occasional `(#issue)` suffix.
 - Don't commit secrets; provider keys live in env vars or `~/.takt/config.yaml`.
-- A TAKT review pass is recommended (not required) before a PR: `takt -t "#<PR>" -w review-takt-default` (or branch/current-diff variants); pasting `.takt/runs/*/reports/review-summary.md` into the PR helps reviewers. For CodeRabbit comments, judge whether each should be addressed, act on those that should, and resolve every thread.
+- A TAKT review pass is recommended before a PR: `takt -t "#<PR>" -w review-takt-default`. For CodeRabbit comments: judge each, act on the valid ones, resolve every thread; don't post replies.


### PR DESCRIPTION
## 概要

CLAUDE.md をいちから書き直し。#1128 / #1180 / #1187 / #1188 で変わった実態に追随する。

## 主な修正
- **provider/model 解決優先順位を実測値へ修正**(旧記載は実装と不一致だった。CLI/env が最上位、parallel sub-step は promotion をスキーマ拒否)
- **Finding Contract 節を新設**: SQLite台帳、manager(却下不可)/adjudicator(証拠必須)の役割分担、terminal authority の付与条件、golden baseline の扱い、loop-judge routing キー
- テストプール実挙動(ローカル4シャード並列、serial グループの計測要件、CI との unhandled error 差)
- faceted prompting に「共有facetへのFC条件分岐禁止」原則を明文化
- 古い記載(dual final gate 等)と実装から乖離した情報を削除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * TAKTの概要、アーキテクチャ、CLI、設定、ワークフロー実行、ルール評価に関する開発者向けドキュメントを現行仕様に合わせて更新しました。
  * テスト方法、CI設定、デバッグ手順、プロバイダー解決、隔離実行、Finding Contractの説明を追加しました。
  * 古い実装や未使用機能に関する記述を整理・削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->