### PR TITLE
docs: CLAUDE.md書き直しのCodeRabbit指摘対応とtakt.md knowledgeの優先順位修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Two execution modes share the same engine: **Interactive** (`src/features/intera
 
 ### Layered layout (`src/`)
 
-```
+```text
 app/cli/       CLI entrypoint, command wiring, routing
 core/          Engine internals — no IO providers here
   workflow/    Engine, step executors, rule evaluation, instruction builder,
@@ -97,7 +97,7 @@ Optional per-run SQLite ledger (`finding-contract.sqlite`) that makes review fin
 - Reviewers emit structured raw findings via `*-finding-contract` output contracts; the engine verifies quotes/anchors byte-exact against files.
 - The **manager** (persona `findings-manager`) runs after each FC review step: admission, same/new identity judgment (dedup merge), rejected-observation recording. It **cannot** dismiss findings.
 - **Terminal/conflict adjudication** (adjudicator, default derived from `supervisor` persona) dismisses or settles findings — every dismissal basis requires machine-verifiable evidence (byte-exact quotes or task-scope quotes). Terminal authority is granted only via `finding_contract_authority: terminal_adjudication` on a workflow call, never by configuration alone.
-- Lifecycle identity across rounds: `new` / `persists` / `reopened` / `resolved`; resolution is lifecycle-continuity based and needs verified confirmation — "I fixed it" alone never resolves.
+- Lifecycle identity across rounds: `new` / `persists` / `reopened` / `resolved`; resolution is lifecycle-continuity based and requires verified confirmation — "I fixed it" alone never resolves.
 - Provider calls run under persistent leases (reserved→dispatched→settled) with input/output/call budgets in the ledger; `stop_budget.max_rounds` guarantees finite termination.
 - `finding_contract.manager` accepts `persona/instruction/output_contract`, optional `policy`/`knowledge` additions, and `provider`/`model`. `finding_contract.adjudicator` (optional) accepts `persona/instruction/provider/model`; when omitted the supervisor auto-derivation keeps prompts byte-identical (guarded by golden-baseline tests — do not regenerate goldens to make a change pass).
 - Manager/adjudicator prompt wire formats (structured output schemas, allowed actions, evidence requirements) are **engine-owned**; facets add judgment guidance only.
@@ -130,7 +130,7 @@ Output contracts live under `facets/output-contracts/`. User overrides: `~/.takt
 
 ## Runtime directory layout
 
-```
+```text
 ~/.takt/                Global user config (config.yaml, workflows/, facets/, repertoire/)
 .takt/                  Project config (highest priority)
   config.yaml           provider / provider_routing / quality gates / overrides

--- a/builtins/en/facets/knowledge/takt.md
+++ b/builtins/en/facets/knowledge/takt.md
@@ -63,13 +63,16 @@ ProviderAgent.call(prompt, options) → AgentResponse
 
 ### Model Resolution
 
-Models resolve through 5-level priority. Higher takes precedence.
+Provider and model resolve independently per field. Higher takes precedence.
 
-1. persona_providers model specification
-2. Step model field
-3. CLI `--model` override
-4. config.yaml (when resolved provider matches)
-5. Provider default
+1. CLI / environment explicit override
+2. Matching promotion (normal agent steps only; parallel sub-steps reject `promotion` at the schema level)
+3. Step / parallel sub-step direct provider / model
+4. workflow_call override
+5. provider_routing (steps → tags → personas)
+6. persona_providers (deprecated)
+7. Auto routing
+8. Workflow → project config.yaml → global config.yaml → provider default
 
 ## Auxiliary Entry Contracts
 

--- a/builtins/ja/facets/knowledge/takt.md
+++ b/builtins/ja/facets/knowledge/takt.md
@@ -63,13 +63,16 @@ ProviderAgent.call(prompt, options) → AgentResponse
 
 ### モデル解決
 
-5段階の優先順位でモデルを解決する。上位が優先。
+provider と model はフィールドごとに独立して解決される。上位が優先。
 
-1. persona_providers のモデル指定
-2. step の model フィールド
-3. CLI `--model` オーバーライド
-4. config.yaml（プロバイダー一致時）
-5. プロバイダーデフォルト
+1. CLI / 環境変数の明示オーバーライド
+2. 現在の実行にマッチした promotion（通常の agent step のみ。parallel sub-step では指定自体がスキーマで拒否される）
+3. step / parallel sub-step の直接 provider / model
+4. workflow_call のオーバーライド
+5. provider_routing（steps → tags → personas の順）
+6. persona_providers（非推奨）
+7. auto routing
+8. workflow → プロジェクト config.yaml → グローバル config.yaml → プロバイダーデフォルト
 
 ## 補助入口の契約
 


### PR DESCRIPTION
## 概要

#1189(マージ済み)への CodeRabbit 指摘3件のフォローアップ。

- CLAUDE.md: コードフェンスに言語指定(MD040)、英文法修正(needs verified → requires verified)
- **builtins/{ja,en}/facets/knowledge/takt.md: モデル解決優先順位を実測済みの実装契約へ更新** — 旧記載(persona_providers最上位の5段階)は実装と不一致で、TAKTのレビュアー自身が誤った知識で審査する状態だった。#1188 の実測(CLI/env → promotion → step直接 → workflow_call → provider_routing → persona_providers → auto → workflow/project/global/default、parallel sub-stepはpromotionをスキーマ拒否)に統一

CodeRabbitの元指摘は「takt.mdに合わせろ」だったが、takt.md側が実装と乖離していたため逆方向に修正した。

## 検証
- it-workflow-loader.test.ts 94/94(facet変更後のロード確認)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * モデルおよびプロバイダーの解決優先順位を、より詳細な8段階に更新しました。
  * CLI、環境変数、ステップ指定、ワークフロー、ルーティング、設定ファイル、既定値などの適用順序を明記しました。
  * プロバイダーとモデルを個別に解決する動作を説明しました。
  * 並列サブステップでのプロモーション制限を明記しました。
  * Finding Contract のライフサイクル説明を、検証済み確認が必要な表現に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->