### PR TITLE
fix: envelope移行前のsession-stateを読めるようにしMark as failedの停止を解消する

### DIFF
--- a/src/__tests__/sessionState.test.ts
+++ b/src/__tests__/sessionState.test.ts
@@ -149,41 +149,61 @@ describe('session state envelope', () => {
     expect(readFileSync(getSessionStatePath(testDir), 'utf-8')).toBe(serialized);
   });
 
+  const validLegacyState: SessionState = {
+    status: 'error',
+    taskResult: 'partial result',
+    errorMessage: 'user_interrupted',
+    timestamp: '2026-07-28T00:00:00.000Z',
+    workflowName: 'coding',
+    taskContent: 'Interrupted task',
+    lastStep: 'implement',
+  };
+
   it.each([
-    ['status is missing', {
-      timestamp: '2026-07-28T00:00:00.000Z',
-      workflowName: 'coding',
-    }],
-    ['timestamp is missing', {
-      status: 'error',
-      workflowName: 'coding',
-    }],
-    ['workflowName is missing', {
-      status: 'error',
-      timestamp: '2026-07-28T00:00:00.000Z',
-    }],
-    ['status is invalid', {
-      status: 'failed',
-      timestamp: '2026-07-28T00:00:00.000Z',
-      workflowName: 'coding',
-    }],
-    ['timestamp is invalid', {
-      status: 'error',
-      timestamp: 'not-a-timestamp',
-      workflowName: 'coding',
-    }],
-    ['workflowName is empty', {
-      status: 'error',
-      timestamp: '2026-07-28T00:00:00.000Z',
-      workflowName: '',
-    }],
+    [
+      'status is missing',
+      ({ status: _status, ...legacyState }: SessionState) => legacyState,
+      'Session state status is invalid',
+    ],
+    [
+      'timestamp is missing',
+      ({ timestamp: _timestamp, ...legacyState }: SessionState) => legacyState,
+      'Session state timestamp must be a non-empty string',
+    ],
+    [
+      'workflowName is missing',
+      ({
+        workflowName: _workflowName,
+        ...legacyState
+      }: SessionState) => legacyState,
+      'Session state workflowName must be a non-empty string',
+    ],
+    [
+      'status is invalid',
+      (legacyState: SessionState) => ({ ...legacyState, status: 'failed' }),
+      'Session state status is invalid',
+    ],
+    [
+      'timestamp is invalid',
+      (legacyState: SessionState) => ({
+        ...legacyState,
+        timestamp: 'not-a-timestamp',
+      }),
+      'Session state timestamp is invalid: not-a-timestamp',
+    ],
+    [
+      'workflowName is empty',
+      (legacyState: SessionState) => ({ ...legacyState, workflowName: '' }),
+      'Session state workflowName must be a non-empty string',
+    ],
   ] as const)(
     'should reject a legacy session state when %s',
-    (_condition, legacyState) => {
+    (_condition, makeInvalidLegacyState, expectedError) => {
+      const legacyState = makeInvalidLegacyState(validLegacyState);
       const serialized = JSON.stringify(legacyState, null, 2);
       writeSerializedSessionState(serialized);
 
-      expect(() => takeSessionState(testDir)).toThrow(/Session state/);
+      expect(() => takeSessionState(testDir)).toThrow(expectedError);
       expect(readFileSync(getSessionStatePath(testDir), 'utf-8')).toBe(serialized);
     },
   );

--- a/src/__tests__/sessionState.test.ts
+++ b/src/__tests__/sessionState.test.ts
@@ -42,6 +42,11 @@ describe('session state envelope', () => {
     };
   }
 
+  function writeSerializedSessionState(serialized: string): void {
+    mkdirSync(join(testDir, '.takt'), { recursive: true });
+    writeFileSync(getSessionStatePath(testDir), serialized, 'utf-8');
+  }
+
   it('pending stateを一度だけ取得してconsumed envelopeを残す', () => {
     const saved = state('2026-07-28T00:00:00.000Z', 'done');
     saveSessionState(testDir, 'publication-a', saved);
@@ -98,7 +103,7 @@ describe('session state envelope', () => {
     expect(takeSessionState(testDir)).toMatchObject({ taskResult: 'second' });
   });
 
-  it('errorMessageを含む旧session stateを読み込みconsumed envelopeへ移行する', () => {
+  it('should migrate a legacy session state to a consumed envelope when it includes errorMessage', () => {
     const legacyState: SessionState = {
       status: 'error',
       errorMessage: 'user_interrupted',
@@ -128,14 +133,75 @@ describe('session state envelope', () => {
     expect(takeSessionState(testDir)).toBeNull();
   });
 
+  it('should reject a v1 envelope when it contains an unknown field', () => {
+    const serialized = JSON.stringify({
+      version: 1,
+      publicationId: 'publication-a',
+      status: 'pending',
+      state: state('2026-07-28T00:00:00.000Z', 'done'),
+      unknownField: true,
+    }, null, 2);
+    writeSerializedSessionState(serialized);
+
+    expect(() => takeSessionState(testDir)).toThrow(
+      'Session state envelope contains unknown field "unknownField"',
+    );
+    expect(readFileSync(getSessionStatePath(testDir), 'utf-8')).toBe(serialized);
+  });
+
+  it.each([
+    ['status is missing', {
+      timestamp: '2026-07-28T00:00:00.000Z',
+      workflowName: 'coding',
+    }],
+    ['timestamp is missing', {
+      status: 'error',
+      workflowName: 'coding',
+    }],
+    ['workflowName is missing', {
+      status: 'error',
+      timestamp: '2026-07-28T00:00:00.000Z',
+    }],
+    ['status is invalid', {
+      status: 'failed',
+      timestamp: '2026-07-28T00:00:00.000Z',
+      workflowName: 'coding',
+    }],
+    ['timestamp is invalid', {
+      status: 'error',
+      timestamp: 'not-a-timestamp',
+      workflowName: 'coding',
+    }],
+    ['workflowName is empty', {
+      status: 'error',
+      timestamp: '2026-07-28T00:00:00.000Z',
+      workflowName: '',
+    }],
+  ] as const)(
+    'should reject a legacy session state when %s',
+    (_condition, legacyState) => {
+      const serialized = JSON.stringify(legacyState, null, 2);
+      writeSerializedSessionState(serialized);
+
+      expect(() => takeSessionState(testDir)).toThrow(/Session state/);
+      expect(readFileSync(getSessionStatePath(testDir), 'utf-8')).toBe(serialized);
+    },
+  );
+
   it('malformed envelopeを通知なしとして握りつぶさない', () => {
     saveSessionState(
       testDir,
       'publication-a',
       state('2026-07-28T00:00:00.000Z', 'first'),
     );
-    writeFileSync(getSessionStatePath(testDir), '{"version":1}');
+    const malformedEnvelope = '{"version":1}';
+    writeFileSync(getSessionStatePath(testDir), malformedEnvelope);
 
-    expect(() => takeSessionState(testDir)).toThrow(/session state/i);
+    expect(() => takeSessionState(testDir)).toThrow(
+      'Session state envelope version or status is invalid',
+    );
+    expect(readFileSync(getSessionStatePath(testDir), 'utf-8')).toBe(
+      malformedEnvelope,
+    );
   });
 });

--- a/src/__tests__/sessionState.test.ts
+++ b/src/__tests__/sessionState.test.ts
@@ -7,6 +7,7 @@ import {
 } from 'vitest';
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -95,6 +96,36 @@ describe('session state envelope', () => {
     );
 
     expect(takeSessionState(testDir)).toMatchObject({ taskResult: 'second' });
+  });
+
+  it('errorMessageを含む旧session stateを読み込みconsumed envelopeへ移行する', () => {
+    const legacyState: SessionState = {
+      status: 'error',
+      errorMessage: 'user_interrupted',
+      timestamp: '2026-07-28T00:00:00.000Z',
+      workflowName: 'coding',
+      taskContent: 'Interrupted task',
+      lastStep: 'implement',
+    };
+    mkdirSync(join(testDir, '.takt'), { recursive: true });
+    writeFileSync(
+      getSessionStatePath(testDir),
+      JSON.stringify(legacyState, null, 2),
+      'utf-8',
+    );
+
+    expect(takeSessionState(testDir)).toEqual(legacyState);
+    expect(JSON.parse(readFileSync(
+      getSessionStatePath(testDir),
+      'utf-8',
+    ))).toMatchObject({
+      version: 1,
+      publicationId: 'legacy-session-state',
+      status: 'consumed',
+      state: legacyState,
+      consumedAt: expect.any(String),
+    });
+    expect(takeSessionState(testDir)).toBeNull();
   });
 
   it('malformed envelopeを通知なしとして握りつぶさない', () => {

--- a/src/__tests__/taskForceFailActions.test.ts
+++ b/src/__tests__/taskForceFailActions.test.ts
@@ -6,6 +6,7 @@ import type { TaskListItem } from '../infra/task/types.js';
 import { isStaleRunningTask } from '../infra/task/index.js';
 import { buildRunPaths } from '../core/workflow/run/run-paths.js';
 import { initNdjsonLog } from '../infra/fs/index.js';
+import { getSessionStatePath } from '../infra/config/project/sessionState.js';
 import { createUsageEventLogger } from '../core/logging/usageEventLogger.js';
 import {
   OTEL_SESSION_SHADOW_LOG_FILE_SUFFIX,
@@ -409,6 +410,56 @@ describe('forceFailRunningTask', () => {
       step: 'implement',
       error: 'Manually marked as failed',
     });
+    expect(mockSuccess).toHaveBeenCalled();
+  });
+
+  it('should mark an interrupted running task as failed with a legacy error session state', async () => {
+    mockConfirm.mockResolvedValue(true);
+    writeMeta(projectDir, '20260409-run-a', {
+      task: 'Interrupted task',
+      status: 'aborted',
+      currentStep: 'implement',
+      currentIteration: 2,
+      reason: 'user_interrupted',
+      endTime: '2026-04-09T00:01:00.000Z',
+    });
+    const sessionStatePath = getSessionStatePath(projectDir);
+    fs.writeFileSync(
+      sessionStatePath,
+      JSON.stringify({
+        status: 'error',
+        errorMessage: 'user_interrupted',
+        timestamp: '2026-04-09T00:01:00.000Z',
+        workflowName: 'default',
+        taskContent: 'Interrupted task',
+        lastStep: 'implement',
+      }, null, 2),
+      'utf-8',
+    );
+
+    const result = await forceFailRunningTask(
+      createRunningTask(projectDir),
+      projectDir,
+    );
+
+    expect(result).toBe(true);
+    expect(mockForceFailRunningTask).toHaveBeenCalledWith('running-task', {
+      step: undefined,
+      error: 'Manually marked as failed',
+    });
+    expect(JSON.parse(fs.readFileSync(
+      sessionStatePath,
+      'utf-8',
+    ))).toMatchObject({
+      version: 1,
+      status: 'pending',
+      state: {
+        status: 'error',
+        errorMessage: 'Manually marked as failed',
+        workflowName: 'default',
+      },
+    });
+    expect(mockLogError).not.toHaveBeenCalled();
     expect(mockSuccess).toHaveBeenCalled();
   });
 

--- a/src/infra/config/project/sessionState.ts
+++ b/src/infra/config/project/sessionState.ts
@@ -8,6 +8,7 @@ import {
 import { getProjectConfigDir, ensureDir } from '../paths.js';
 
 const SESSION_STATE_MODE = 0o600;
+const LEGACY_SESSION_STATE_PUBLICATION_ID = 'legacy-session-state';
 
 export interface SessionState {
   readonly status: 'success' | 'error' | 'user_stopped';
@@ -164,6 +165,12 @@ function parseSessionStateEnvelope(serialized: string): SessionStateEnvelope {
     });
   }
   const envelope = requireRecord(value, 'Session state envelope');
+  if (!Object.hasOwn(envelope, 'version')) {
+    return pendingEnvelope(
+      LEGACY_SESSION_STATE_PUBLICATION_ID,
+      parseSessionState(envelope),
+    );
+  }
   const expectedKeys = envelope.status === 'consumed'
     ? ['version', 'publicationId', 'status', 'state', 'consumedAt']
     : ['version', 'publicationId', 'status', 'state'];


### PR DESCRIPTION
## 症状(実発生)

SIGINTで中断されたrunningタスクに `takt list` の「Mark as failed」を実行すると
`Session state envelope contains unknown field "errorMessage"` で失敗する。

## 根本原因

#1128 で session-state.json をフラット形式から version 1 envelope へ変更した際、**旧フラット形式の読み込み移行が未実装**だった。旧形式の正規フィールド(`errorMessage` 等)が envelope 検証で未知フィールドと誤認される。`takt run` 起動時の正規化が無事だったのは session-state.json を読まない経路のため(terminal publication 経路だけが読む)。

## 修正

- 旧フラット形式を判別して v1 envelope へ読み替える(読み込みのみ。新規書き込みは常に v1)
- v1 envelope の未知フィールド拒否は維持(検証の弱化なし)
- 再現テスト: 旧形式 + errorMessage の読み込み、中断running→Mark as failed 成功

production 変更は `sessionState.ts` +7行のみ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 旧形式で保存されたセッション状態を自動的に読み込み、新しい形式へ移行できるようになりました。
  - 移行済みの状態が重複して取得されないよう改善しました。
  - 不明な項目、必須項目の欠落、不正な値、形式不正の状態を拒否し、元のファイルを保持します。
  - 中断済みタスクを強制終了する際、旧形式の状態でも正しく処理できるようになりました。
  - 強制終了後の状態、手動失敗メッセージ、実行ログが適切に反映されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->