### PR TITLE
feat: isolated structured executionをProvider必須メソッド化しopencodeを対応させる

### DIFF
--- a/src/__tests__/codex-isolated-structured.test.ts
+++ b/src/__tests__/codex-isolated-structured.test.ts
@@ -163,14 +163,16 @@ describe('Codex strict isolated structured execution', () => {
       invalidateGlobalConfigCache();
       invalidateAllResolvedConfigCache();
 
-      await expect(runAgent(undefined, 'normalize', {
+      const response = await runAgent(undefined, 'normalize', {
         cwd: projectDir,
         executionProfile: 'isolated-structured',
         resolvedProvider: 'copilot',
         resolvedModel: 'test-model',
         resolvedProviderOptions: null,
         outputSchema: { type: 'object' },
-      })).rejects.toThrow(
+      });
+      expect(response.status).toBe('error');
+      expect(response.error).toBe(
         'Provider "copilot" does not support isolated structured execution',
       );
     } finally {

--- a/src/__tests__/codex-isolated-structured.test.ts
+++ b/src/__tests__/codex-isolated-structured.test.ts
@@ -153,7 +153,7 @@ describe('Codex strict isolated structured execution', () => {
     }
   });
 
-  it('rejects an unsupported provider before invoking it', async () => {
+  it('rejects an unsupported provider when invoked', async () => {
     const projectDir = mkdtempSync(join(tmpdir(), 'takt-isolated-provider-project-'));
     const globalDir = mkdtempSync(join(tmpdir(), 'takt-isolated-provider-global-'));
     const originalConfigDir = process.env.TAKT_CONFIG_DIR;
@@ -166,12 +166,12 @@ describe('Codex strict isolated structured execution', () => {
       await expect(runAgent(undefined, 'normalize', {
         cwd: projectDir,
         executionProfile: 'isolated-structured',
-        resolvedProvider: 'opencode',
+        resolvedProvider: 'copilot',
         resolvedModel: 'test-model',
         resolvedProviderOptions: null,
         outputSchema: { type: 'object' },
       })).rejects.toThrow(
-        'Provider "opencode" does not support strict isolated structured execution',
+        'Provider "copilot" does not support isolated structured execution',
       );
     } finally {
       if (originalConfigDir === undefined) {

--- a/src/__tests__/finding-intake-normalize.test.ts
+++ b/src/__tests__/finding-intake-normalize.test.ts
@@ -194,15 +194,22 @@ describe('reviewer output strategy', () => {
     )?.kind).toBe('structured');
   });
 
-  it('validates the isolated normalizer provider independently of targets', () => {
+  it('accepts providers that implement isolated structured execution', () => {
     expect(resolveFindingIntakeNormalizeConfig(
       { provider: 'codex', model: 'gpt-5.6-terra' },
       findingContract,
     )).toBeDefined();
-    expect(() => resolveFindingIntakeNormalizeConfig(
-      { provider: 'claude', model: 'sonnet' },
+    expect(resolveFindingIntakeNormalizeConfig(
+      { provider: 'opencode', model: 'ollama-cloud/glm-5.2' },
       findingContract,
-    )).toThrow(/finding_contract\.intake_normalize/);
+    )).toBeDefined();
+  });
+
+  it('rejects providers without isolated structured execution at load time', () => {
+    expect(() => resolveFindingIntakeNormalizeConfig(
+      { provider: 'cursor', model: 'auto' },
+      findingContract,
+    )).toThrow('does not support isolated structured execution');
   });
 });
 

--- a/src/__tests__/finding-intake-normalizer-usecase.test.ts
+++ b/src/__tests__/finding-intake-normalizer-usecase.test.ts
@@ -1,24 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync } from 'node:fs';
 
-const { runAgent } = vi.hoisted(() => ({
-  runAgent: vi.fn(),
+const { setupIsolatedStructured, getProvider } = vi.hoisted(() => ({
+  setupIsolatedStructured: vi.fn(),
+  getProvider: vi.fn(),
 }));
 
-vi.mock('../agents/runner.js', () => ({ runAgent }));
+vi.mock('../infra/providers/index.js', () => ({ getProvider }));
 
 import { normalizeFindingIntake } from '../agents/finding-intake-normalizer-usecase.js';
 
 describe('normalizeFindingIntake', () => {
   beforeEach(() => {
-    runAgent.mockReset();
-    runAgent.mockResolvedValue({
-      persona: 'default',
-      status: 'done',
-      content: '{}',
-      sessionId: 'discard-me',
-      structuredOutput: { rawFindings: [] },
+    setupIsolatedStructured.mockReset();
+    getProvider.mockReset();
+    setupIsolatedStructured.mockReturnValue({
+      call: vi.fn().mockResolvedValue({
+        persona: 'default',
+        status: 'done',
+        content: '{}',
+        sessionId: 'discard-me',
+        structuredOutput: { rawFindings: [] },
+      }),
     });
+    getProvider.mockReturnValue({ setupIsolatedStructured });
   });
 
   it('uses one fresh read-only configured call with no tools, session, or MCP inheritance', async () => {
@@ -30,40 +35,41 @@ describe('normalizeFindingIntake', () => {
       },
     });
 
-    expect(runAgent).toHaveBeenCalledOnce();
-    const [persona, prompt, options] = runAgent.mock.calls[0]!;
-    expect(persona).toBeUndefined();
-    expect(prompt).toContain('normal Markdown report');
-    expect(options).toMatchObject({
-      executionProfile: 'isolated-structured',
-      resolvedProvider: 'codex',
-      resolvedModel: 'gpt-5.6-terra',
-      resolvedProviderOptions: {
+    expect(getProvider).toHaveBeenCalledWith('codex');
+    expect(setupIsolatedStructured).toHaveBeenCalledOnce();
+    const [setupConfig] = setupIsolatedStructured.mock.calls[0]!;
+    expect(setupConfig).toMatchObject({
+      name: 'finding-intake-normalizer',
+      systemPrompt: '',
+    });
+  });
+
+  it('passes provider options through to the isolated call', async () => {
+    await normalizeFindingIntake('report', {
+      provider: 'codex',
+      model: 'gpt-5.6-terra',
+      providerOptions: {
         codex: { reasoningEffort: 'high' },
       },
+    });
+
+    const callFn = setupIsolatedStructured.mock.results[0]!.value.call;
+    const [prompt, options] = callFn.mock.calls[0]!;
+    expect(prompt).toContain('report');
+    expect(options).toMatchObject({
+      model: 'gpt-5.6-terra',
       permissionMode: 'readonly',
       allowedTools: [],
+      providerOptions: {
+        codex: { reasoningEffort: 'high' },
+      },
     });
     expect(options).not.toHaveProperty('childProcessEnv');
-    expect(options.cwd).not.toBe('/repo');
     expect(options.cwd).toContain('takt-finding-intake-');
     expect(existsSync(options.cwd)).toBe(false);
     expect(options.sessionId).toBeUndefined();
     expect(options.mcpServers).toBeUndefined();
-    expect(options.provider).toBeUndefined();
-    expect(options.model).toBeUndefined();
     expect(options.outputSchema).toBeDefined();
-  });
-
-  it('explicitly suppresses project/global provider option fallback when none are configured', async () => {
-    await normalizeFindingIntake('report', {
-      provider: 'codex',
-      model: 'gpt-5.6-terra',
-    });
-
-    expect(runAgent.mock.calls[0]?.[2]).toMatchObject({
-      resolvedProviderOptions: null,
-    });
   });
 
   it('uses the correction extractor with the same report and no prior output, ledger, or repository context', async () => {
@@ -73,12 +79,13 @@ describe('normalizeFindingIntake', () => {
       mode: 'correction',
     });
 
-    const prompt = runAgent.mock.calls[0]?.[1];
+    const callFn = setupIsolatedStructured.mock.results[0]!.value.call;
+    const [prompt] = callFn.mock.calls[0]!;
     expect(prompt).toContain('previous extraction failed');
     expect(prompt).toContain('## Review report\n\nauthoritative report');
     expect(prompt.match(/authoritative report/g)).toHaveLength(1);
-    expect(runAgent.mock.calls[0]?.[2]).toMatchObject({
-      executionProfile: 'isolated-structured',
+    const [, options] = callFn.mock.calls[0]!;
+    expect(options).toMatchObject({
       permissionMode: 'readonly',
       allowedTools: [],
     });
@@ -89,16 +96,20 @@ describe('normalizeFindingIntake', () => {
       mode: 'correction',
       extractionFidelityCorrection: true,
     });
-    expect(runAgent.mock.calls[1]?.[1]).toContain(
+    const secondCallFn = setupIsolatedStructured.mock.results[1]!.value.call;
+    const [secondPrompt] = secondCallFn.mock.calls[0]!;
+    expect(secondPrompt).toContain(
       'this exception overrides rule 3 for `candidate.description` alone',
     );
   });
 
   it('removes the isolated working directory when the provider call throws', async () => {
     let isolatedCwd: string | undefined;
-    runAgent.mockImplementationOnce(async (_persona, _prompt, options) => {
-      isolatedCwd = options.cwd;
-      throw new Error('provider failed');
+    setupIsolatedStructured.mockReturnValueOnce({
+      call: vi.fn(async (_prompt: string, options: { cwd: string }) => {
+        isolatedCwd = options.cwd;
+        throw new Error('provider failed');
+      }),
     });
 
     await expect(normalizeFindingIntake('report', {

--- a/src/__tests__/provider-structured-output.test.ts
+++ b/src/__tests__/provider-structured-output.test.ts
@@ -306,18 +306,17 @@ describe('CodexProvider — structured output', () => {
     expect(mockCallCodexIsolatedStructured).not.toHaveBeenCalled();
   });
 
-  it('isolated-structured profileだけをhardened direct CLI経路へ渡す', async () => {
+  it('setupIsolatedStructuredがhardened direct CLI経路を使う', async () => {
     mockCallCodexIsolatedStructured.mockResolvedValue(
       doneResponse('normalizer', { rawFindings: [] }),
     );
 
-    const agent = new CodexProvider().setup({
+    const agent = new CodexProvider().setupIsolatedStructured({
       name: 'normalizer',
       systemPrompt: 'system',
     });
     await agent.call('report', {
       cwd: '/tmp/isolated',
-      executionProfile: 'isolated-structured',
       outputSchema: SCHEMA,
     });
 

--- a/src/__tests__/step-executor.test.ts
+++ b/src/__tests__/step-executor.test.ts
@@ -1164,69 +1164,6 @@ describe('StepExecutor', () => {
     });
   });
 
-  it('pending normalizerのfallback providerが隔離structured実行に非対応ならreviewerを再実行せず拒否する', async () => {
-    const harness = createPlainTextPublicationHarness([]);
-    persistPendingFindingReviewNormalization(
-      runPaths.reportsAbs,
-      createPendingFindingReviewNormalization({
-        identity: {
-          scopeIdentity: 'scope-plain-text',
-          callNamespace: '',
-          parentStepName: 'review',
-          stepIteration: 1,
-          reviewerStepName: 'review',
-          reportName: 'review.md',
-        },
-        workflowName: 'test-workflow',
-        reportContent: harness.reportContent,
-        reviewerExecutionIdentity: {
-          provider: 'mock',
-          model: 'reviewer-model',
-        },
-      }),
-    );
-    const fallbackRuntime = {
-      providerInfo: {
-        provider: 'opencode' as const,
-        model: 'unsupported-normalizer-model',
-      },
-      fallback: {
-        reason: 'rate_limited' as const,
-        reasonDetail: 'normalizer rate limited',
-        originalIteration: 3,
-        previousProvider: 'mock' as const,
-        previousModel: 'normalizer-model',
-        currentProvider: 'opencode' as const,
-        currentModel: 'unsupported-normalizer-model',
-        stepName: 'review',
-        reportDir: runPaths.reportsRel,
-        origin: {
-          stage: 'finding_intake_normalizer' as const,
-          reviewerStepName: 'review',
-        },
-      },
-    };
-
-    await expect(harness.executor.runNormalStep(
-      harness.step,
-      harness.state,
-      'test task',
-      5,
-      harness.updatePersonaSession,
-      undefined,
-      fallbackRuntime,
-      {
-        executableStep: harness.step,
-        findingContractContext: harness.findingContractContext,
-        reviewerOutputStrategy: PLAIN_TEXT_NORMALIZED_STRATEGY,
-        phase1Instruction: 'Review.',
-        stepIteration: 1,
-      },
-    )).rejects.toThrow(/does not support isolated structured execution/u);
-    expect(executeAgent).not.toHaveBeenCalled();
-    expect(harness.normalizeFindingIntake).not.toHaveBeenCalled();
-  });
-
   it('runNormalStepの正式resumeはpending本文をnormalizerだけで再開する', async () => {
     const rawFinding = {
       rawExcerpt: 'Issue: src/example.ts still bypasses the required boundary.',

--- a/src/agents/finding-intake-normalizer-usecase.ts
+++ b/src/agents/finding-intake-normalizer-usecase.ts
@@ -8,7 +8,7 @@ import {
   buildFindingIntakeCorrectionPrompt,
   buildFindingIntakeExtractionPrompt,
 } from '../shared/prompts/finding-intake-extraction.js';
-import { runAgent } from './runner.js';
+import { getProvider } from '../infra/providers/index.js';
 
 export interface NormalizeFindingIntakeOptions {
   provider: ProviderType;
@@ -37,19 +37,26 @@ export async function normalizeFindingIntake(
           options.extractionFidelityCorrection ?? false,
         )
       : buildFindingIntakeExtractionPrompt(report, options.language ?? 'en');
-    return await runAgent(undefined, instruction, {
+    const provider = getProvider(options.provider);
+    const callOptions = {
       cwd: isolatedCwd,
-      executionProfile: 'isolated-structured',
-      resolvedProvider: options.provider,
-      resolvedModel: options.model,
-      resolvedProviderOptions: options.providerOptions ?? null,
-      permissionMode: 'readonly',
-      allowedTools: [],
+      abortSignal: options.abortSignal,
+      model: options.model,
+      permissionMode: 'readonly' as const,
+      allowedTools: [] as string[],
       outputSchema: createRawFindingsOutputJsonSchema(),
       language: options.language,
-      abortSignal: options.abortSignal,
-      onPromptResolved: options.onPromptResolved,
+      providerOptions: options.providerOptions,
+    };
+    const agent = provider.setupIsolatedStructured({
+      name: 'finding-intake-normalizer',
+      systemPrompt: '',
     });
+    options.onPromptResolved?.({
+      systemPrompt: '',
+      userInstruction: instruction,
+    });
+    return await agent.call(instruction, callOptions);
   } finally {
     rmSync(isolatedCwd, { recursive: true, force: true });
   }

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -13,7 +13,7 @@ import {
   resolveEffectiveProviderOptions,
   resolvePersonaProviderOptions,
 } from '../infra/config/providerOptions.js';
-import { getProvider, type ProviderType, type ProviderCallOptions } from '../infra/providers/index.js';
+import { getProvider, type ProviderType, type ProviderCallOptions, type ProviderAgent, type AgentSetup } from '../infra/providers/index.js';
 import type { AgentResponse, CustomAgentConfig } from '../core/models/index.js';
 import { resolveAgentProviderModel } from '../core/workflow/provider-resolution.js';
 import { mergeGlobalPermissionProfiles, resolveStepPermissionMode } from '../core/workflow/permission-profile-resolution.js';
@@ -168,7 +168,6 @@ export class AgentRunner {
   ): ProviderCallOptions {
     return {
       cwd: options.cwd,
-      executionProfile: options.executionProfile,
       abortSignal: options.abortSignal,
       sessionId: options.sessionId,
       internalAgentIsolation: options.internalAgentIsolation,
@@ -222,14 +221,6 @@ export class AgentRunner {
       customOptions,
     );
     const provider = getProvider(resolution.provider);
-    if (
-      options.executionProfile === 'isolated-structured'
-      && provider.supportsIsolatedStructuredExecution !== true
-    ) {
-      throw new Error(
-        `Provider "${resolution.provider}" does not support strict isolated structured execution`,
-      );
-    }
     const resolvedSystemPrompt = loadAgentPrompt(agentConfig, options.cwd);
     const callOptions = AgentRunner.buildCallOptions(resolution, customOptions);
     const providerRuntimeInstructions = provider.getRuntimeInstructions(customOptions.allowedTools, callOptions.permissionMode, callOptions.providerOptions?.opencode?.networkAccess);
@@ -243,10 +234,15 @@ export class AgentRunner {
       userInstruction: task,
     });
 
-    const agent = provider.setup({
-      name: agentConfig.name,
-      systemPrompt,
-    });
+    const agent = options.executionProfile === 'isolated-structured'
+      ? provider.setupIsolatedStructured({
+          name: agentConfig.name,
+          systemPrompt,
+        })
+      : provider.setup({
+          name: agentConfig.name,
+          systemPrompt,
+        });
 
     options.onDispatch?.(resolution.permissionMode);
     return agent.call(task, callOptions);
@@ -272,15 +268,12 @@ export class AgentRunner {
 
     const resolution = AgentRunner.resolveExecution(options.cwd, personaName, options);
     const provider = getProvider(resolution.provider);
-    if (
-      options.executionProfile === 'isolated-structured'
-      && provider.supportsIsolatedStructuredExecution !== true
-    ) {
-      throw new Error(
-        `Provider "${resolution.provider}" does not support strict isolated structured execution`,
-      );
-    }
     const callOptions = AgentRunner.buildCallOptions(resolution, options);
+    const useIsolatedStructured = options.executionProfile === 'isolated-structured';
+    const setupAgent = (agentSetup: AgentSetup): ProviderAgent =>
+      useIsolatedStructured
+        ? provider.setupIsolatedStructured(agentSetup)
+        : provider.setup(agentSetup);
 
     if (options.internalSystemPrompt !== undefined) {
       const systemPrompt = buildWrappedSystemPrompt(options.internalSystemPrompt, {
@@ -291,7 +284,7 @@ export class AgentRunner {
         systemPrompt,
         userInstruction: task,
       });
-      const agent = provider.setup({ name: 'takt-internal', systemPrompt });
+      const agent = setupAgent({ name: 'takt-internal', systemPrompt });
       options.onDispatch?.(resolution.permissionMode);
       return agent.call(task, callOptions);
     }
@@ -310,7 +303,7 @@ export class AgentRunner {
         systemPrompt,
         userInstruction: task,
       });
-      const agent = provider.setup({ name: personaName, systemPrompt });
+      const agent = setupAgent({ name: personaName, systemPrompt });
       options.onDispatch?.(resolution.permissionMode);
       return agent.call(task, callOptions);
     }
@@ -331,7 +324,7 @@ export class AgentRunner {
         systemPrompt,
         userInstruction: task,
       });
-      const agent = provider.setup({ name: personaName, systemPrompt });
+      const agent = setupAgent({ name: personaName, systemPrompt });
       options.onDispatch?.(resolution.permissionMode);
       return agent.call(task, callOptions);
     }
@@ -347,7 +340,7 @@ export class AgentRunner {
     const agentSetup = systemPrompt
       ? { name: personaName, systemPrompt }
       : { name: personaName };
-    const agent = provider.setup(agentSetup);
+    const agent = setupAgent(agentSetup);
     options.onDispatch?.(resolution.permissionMode);
     return agent.call(task, callOptions);
   }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -11,7 +11,6 @@ import type {
   ProviderPermissionProfiles,
 } from '../core/models/index.js';
 import type { InternalAgentIsolation, ProviderType } from '../shared/types/provider.js';
-import type { ProviderExecutionProfile } from '../infra/providers/types.js';
 
 export type { StreamCallback };
 
@@ -38,7 +37,7 @@ export interface ResolvedAgentExecution {
 /** Common options for running agents */
 export interface RunAgentOptions {
   cwd: string;
-  executionProfile?: ProviderExecutionProfile;
+  executionProfile?: 'isolated-structured';
   projectCwd?: string;
   abortSignal?: AbortSignal;
   sessionId?: string;

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -60,7 +60,6 @@ import {
   validateStructuredOutputAgainstSchema,
 } from './structured-output-schema-validator.js';
 import {
-  providerSupportsIsolatedStructuredExecution,
   providerSupportsStructuredOutput,
 } from '../../../infra/providers/provider-capabilities.js';
 import { AGENT_FAILURE_CATEGORIES } from '../../../shared/types/agent-failure.js';
@@ -680,13 +679,9 @@ export class StepExecutor {
       ...resolvedProviderInfo,
       providerOptions: config.providerOptions,
     };
-    if (
-      providerInfo.provider === undefined
-      || providerSupportsIsolatedStructuredExecution(providerInfo.provider) !== true
-    ) {
+    if (providerInfo.provider === undefined) {
       throw new Error(
-        `Finding intake normalizer provider "${providerInfo.provider ?? '(unresolved)'}" `
-        + 'does not support isolated structured execution',
+        'Finding intake normalizer provider could not be resolved',
       );
     }
     const normalizerProvider = providerInfo.provider;

--- a/src/infra/providers/claude-headless.ts
+++ b/src/infra/providers/claude-headless.ts
@@ -35,7 +35,7 @@ function toHeadlessOptions(options: ProviderCallOptions): ClaudeHeadlessCallOpti
 
 export class ClaudeHeadlessProvider implements Provider {
   readonly supportsStructuredOutput = true;
-  readonly supportsIsolatedStructuredExecution = false;
+  readonly supportsIsolatedStructuredExecution = true;
   readonly supportsNativeImageInput = false;
   readonly supportsStrictInternalAgentIsolation = true;
 

--- a/src/infra/providers/claude-headless.ts
+++ b/src/infra/providers/claude-headless.ts
@@ -4,6 +4,7 @@ import { resolveAnthropicApiKey, resolveClaudeCliPath } from '../config/index.js
 import type { AgentResponse } from '../../core/models/index.js';
 import { keepsAllowedToolWithoutEdit as keepsClaudeAllowedToolWithoutEdit } from './allowed-tool-edit-policy.js';
 import type { AgentSetup, Provider, ProviderAgent, ProviderCallOptions } from './types.js';
+import { assertOutputSchema } from './types.js';
 
 function toHeadlessOptions(options: ProviderCallOptions): ClaudeHeadlessCallOptions {
   const claudeOptions = options.providerOptions?.claude;
@@ -34,6 +35,7 @@ function toHeadlessOptions(options: ProviderCallOptions): ClaudeHeadlessCallOpti
 
 export class ClaudeHeadlessProvider implements Provider {
   readonly supportsStructuredOutput = true;
+  readonly supportsIsolatedStructuredExecution = false;
   readonly supportsNativeImageInput = false;
   readonly supportsStrictInternalAgentIsolation = true;
 
@@ -55,5 +57,26 @@ export class ClaudeHeadlessProvider implements Provider {
           systemPrompt: systemPrompt ?? undefined,
         }),
     };
+  }
+
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent {
+    const { name, systemPrompt } = config;
+    const call = (prompt: string, options: ProviderCallOptions): Promise<AgentResponse> => {
+      const isolatedOptions: ProviderCallOptions = {
+        ...options,
+        sessionId: undefined,
+        internalAgentIsolation: 'strict-readonly',
+        allowedTools: [],
+        mcpServers: undefined,
+        imageAttachments: undefined,
+        outputSchema: assertOutputSchema(options.outputSchema, 'claude-headless'),
+      };
+      const fullPrompt = systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
+      return callClaudeHeadless(name, fullPrompt, {
+        ...toHeadlessOptions(isolatedOptions),
+        systemPrompt: '',
+      });
+    };
+    return { call };
   }
 }

--- a/src/infra/providers/claude-terminal.ts
+++ b/src/infra/providers/claude-terminal.ts
@@ -7,6 +7,7 @@ import { AGENT_FAILURE_CATEGORIES } from '../../shared/types/agent-failure.js';
 import { getErrorMessage } from '../../shared/utils/index.js';
 import { keepsAllowedToolWithoutEdit as keepsClaudeAllowedToolWithoutEdit } from './allowed-tool-edit-policy.js';
 import type { AgentSetup, Provider, ProviderAgent, ProviderCallOptions } from './types.js';
+import { assertOutputSchema } from './types.js';
 
 function createProviderErrorResponse(
   agentName: string,
@@ -74,6 +75,7 @@ function toTerminalOptions(options: ProviderCallOptions): ClaudeTerminalCallOpti
 
 export class ClaudeTerminalProvider implements Provider {
   readonly supportsStructuredOutput = true;
+  readonly supportsIsolatedStructuredExecution = false;
   readonly supportsNativeImageInput = false;
   readonly supportsStrictInternalAgentIsolation = true;
 
@@ -100,5 +102,30 @@ export class ClaudeTerminalProvider implements Provider {
         }
       },
     };
+  }
+
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent {
+    const { name, systemPrompt } = config;
+    const call = async (prompt: string, options: ProviderCallOptions): Promise<AgentResponse> => {
+      try {
+        const isolatedOptions: ProviderCallOptions = {
+          ...options,
+          sessionId: undefined,
+          internalAgentIsolation: 'strict-readonly',
+          allowedTools: [],
+          mcpServers: undefined,
+          imageAttachments: undefined,
+          outputSchema: assertOutputSchema(options.outputSchema, 'claude-terminal'),
+        };
+        const fullPrompt = systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
+        return await callClaudeTerminal(name, fullPrompt, {
+          ...toTerminalOptions(isolatedOptions),
+          systemPrompt: '',
+        });
+      } catch (error) {
+        return createCaughtProviderErrorResponse(name, options, error);
+      }
+    };
+    return { call };
   }
 }

--- a/src/infra/providers/claude-terminal.ts
+++ b/src/infra/providers/claude-terminal.ts
@@ -75,7 +75,7 @@ function toTerminalOptions(options: ProviderCallOptions): ClaudeTerminalCallOpti
 
 export class ClaudeTerminalProvider implements Provider {
   readonly supportsStructuredOutput = true;
-  readonly supportsIsolatedStructuredExecution = false;
+  readonly supportsIsolatedStructuredExecution = true;
   readonly supportsNativeImageInput = false;
   readonly supportsStrictInternalAgentIsolation = true;
 

--- a/src/infra/providers/claude.ts
+++ b/src/infra/providers/claude.ts
@@ -4,6 +4,7 @@ import { resolveAnthropicApiKey, resolveClaudeCliPath } from '../config/index.js
 import type { AgentResponse } from '../../core/models/index.js';
 import { keepsAllowedToolWithoutEdit as keepsClaudeAllowedToolWithoutEdit } from './allowed-tool-edit-policy.js';
 import type { AgentSetup, Provider, ProviderAgent, ProviderCallOptions } from './types.js';
+import { assertOutputSchema } from './types.js';
 
 function toClaudeOptions(options: ProviderCallOptions): ClaudeCallOptions {
   const claudeSandbox = options.providerOptions?.claude?.sandbox;
@@ -42,6 +43,7 @@ function toClaudeOptions(options: ProviderCallOptions): ClaudeCallOptions {
 
 export class ClaudeProvider implements Provider {
   readonly supportsStructuredOutput = true;
+  readonly supportsIsolatedStructuredExecution = false;
   readonly supportsNativeImageInput = true;
   readonly supportsStrictInternalAgentIsolation = true;
 
@@ -66,5 +68,23 @@ export class ClaudeProvider implements Provider {
       call: (prompt: string, options: ProviderCallOptions): Promise<AgentResponse> =>
         callClaude(name, prompt, toClaudeOptions(options)),
     };
+  }
+
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent {
+    const { name, systemPrompt } = config;
+    const call = (prompt: string, options: ProviderCallOptions): Promise<AgentResponse> => {
+      const isolatedOptions: ProviderCallOptions = {
+        ...options,
+        sessionId: undefined,
+        internalAgentIsolation: 'strict-readonly',
+        allowedTools: [],
+        mcpServers: undefined,
+        imageAttachments: undefined,
+        outputSchema: assertOutputSchema(options.outputSchema, 'claude'),
+      };
+      const fullPrompt = systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
+      return callClaudeCustom(name, fullPrompt, '', toClaudeOptions(isolatedOptions));
+    };
+    return { call };
   }
 }

--- a/src/infra/providers/claude.ts
+++ b/src/infra/providers/claude.ts
@@ -43,7 +43,7 @@ function toClaudeOptions(options: ProviderCallOptions): ClaudeCallOptions {
 
 export class ClaudeProvider implements Provider {
   readonly supportsStructuredOutput = true;
-  readonly supportsIsolatedStructuredExecution = false;
+  readonly supportsIsolatedStructuredExecution = true;
   readonly supportsNativeImageInput = true;
   readonly supportsStrictInternalAgentIsolation = true;
 

--- a/src/infra/providers/codex.ts
+++ b/src/infra/providers/codex.ts
@@ -39,8 +39,8 @@ function toCodexOptions(options: ProviderCallOptions): CodexCallOptions {
 /** Codex provider — delegates to OpenAI Codex SDK */
 export class CodexProvider implements Provider {
   readonly supportsStructuredOutput = true;
-  readonly supportsNativeImageInput = true;
   readonly supportsIsolatedStructuredExecution = true;
+  readonly supportsNativeImageInput = true;
   readonly supportsStrictInternalAgentIsolation = true;
 
   getRuntimeInstructions(_allowedTools?: string[]): string | null {
@@ -58,21 +58,26 @@ export class CodexProvider implements Provider {
       options: ProviderCallOptions,
     ): Promise<AgentResponse> => {
       const codexOptions = toCodexOptions(options);
-      if (options.executionProfile === 'isolated-structured') {
-        return callCodexIsolatedStructured(
-          name,
-          systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt,
-          codexOptions,
-        );
-      }
       return systemPrompt
         ? callCodexCustom(name, prompt, systemPrompt, codexOptions)
         : callCodex(name, prompt, codexOptions);
     };
-    if (systemPrompt) {
-      return { call };
-    }
+    return { call };
+  }
 
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent {
+    const { name, systemPrompt } = config;
+    const call = async (
+      prompt: string,
+      options: ProviderCallOptions,
+    ): Promise<AgentResponse> => {
+      const codexOptions = toCodexOptions(options);
+      return callCodexIsolatedStructured(
+        name,
+        systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt,
+        codexOptions,
+      );
+    };
     return { call };
   }
 }

--- a/src/infra/providers/copilot.ts
+++ b/src/infra/providers/copilot.ts
@@ -45,6 +45,7 @@ function toCopilotOptions(options: ProviderCallOptions): CopilotCallOptions {
 /** Copilot provider — delegates to GitHub Copilot CLI */
 export class CopilotProvider implements Provider {
   readonly supportsStructuredOutput = false;
+  readonly supportsIsolatedStructuredExecution = false;
   readonly supportsNativeImageInput = false;
   readonly supportsStrictInternalAgentIsolation = false;
 
@@ -71,5 +72,12 @@ export class CopilotProvider implements Provider {
         return callCopilot(name, prompt, toCopilotOptions(options));
       },
     };
+  }
+
+  setupIsolatedStructured(_config: AgentSetup): ProviderAgent {
+    const call = async (): Promise<AgentResponse> => {
+      throw new Error('Provider "copilot" does not support isolated structured execution');
+    };
+    return { call };
   }
 }

--- a/src/infra/providers/copilot.ts
+++ b/src/infra/providers/copilot.ts
@@ -74,10 +74,15 @@ export class CopilotProvider implements Provider {
     };
   }
 
-  setupIsolatedStructured(_config: AgentSetup): ProviderAgent {
-    const call = async (): Promise<AgentResponse> => {
-      throw new Error('Provider "copilot" does not support isolated structured execution');
-    };
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent {
+    const call = async (_prompt: string, options: ProviderCallOptions): Promise<AgentResponse> => ({
+      persona: config.name,
+      status: 'error',
+      content: 'Provider "copilot" does not support isolated structured execution',
+      timestamp: new Date(),
+      sessionId: options.sessionId,
+      error: 'Provider "copilot" does not support isolated structured execution',
+    });
     return { call };
   }
 }

--- a/src/infra/providers/cursor.ts
+++ b/src/infra/providers/cursor.ts
@@ -40,6 +40,7 @@ function toCursorOptions(options: ProviderCallOptions): CursorCallOptions {
 /** Cursor provider — delegates to Cursor Agent CLI */
 export class CursorProvider implements Provider {
   readonly supportsStructuredOutput = false;
+  readonly supportsIsolatedStructuredExecution = false;
   readonly supportsNativeImageInput = false;
   readonly supportsStrictInternalAgentIsolation = false;
 
@@ -66,5 +67,12 @@ export class CursorProvider implements Provider {
         return callCursor(name, prompt, toCursorOptions(options));
       },
     };
+  }
+
+  setupIsolatedStructured(_config: AgentSetup): ProviderAgent {
+    const call = async (): Promise<AgentResponse> => {
+      throw new Error('Provider "cursor" does not support isolated structured execution');
+    };
+    return { call };
   }
 }

--- a/src/infra/providers/cursor.ts
+++ b/src/infra/providers/cursor.ts
@@ -69,10 +69,15 @@ export class CursorProvider implements Provider {
     };
   }
 
-  setupIsolatedStructured(_config: AgentSetup): ProviderAgent {
-    const call = async (): Promise<AgentResponse> => {
-      throw new Error('Provider "cursor" does not support isolated structured execution');
-    };
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent {
+    const call = async (_prompt: string, options: ProviderCallOptions): Promise<AgentResponse> => ({
+      persona: config.name,
+      status: 'error',
+      content: 'Provider "cursor" does not support isolated structured execution',
+      timestamp: new Date(),
+      sessionId: options.sessionId,
+      error: 'Provider "cursor" does not support isolated structured execution',
+    });
     return { call };
   }
 }

--- a/src/infra/providers/index.ts
+++ b/src/infra/providers/index.ts
@@ -12,7 +12,6 @@ import type { Provider, ProviderType } from './types.js';
 export type {
   AgentSetup,
   ProviderCallOptions,
-  ProviderExecutionProfile,
   ProviderCompactSessionOptions,
   ProviderAgent,
   Provider,

--- a/src/infra/providers/kiro.ts
+++ b/src/infra/providers/kiro.ts
@@ -62,10 +62,15 @@ export class KiroProvider implements Provider {
     };
   }
 
-  setupIsolatedStructured(_config: AgentSetup): ProviderAgent {
-    const call = async (): Promise<AgentResponse> => {
-      throw new Error('Provider "kiro" does not support isolated structured execution');
-    };
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent {
+    const call = async (_prompt: string, options: ProviderCallOptions): Promise<AgentResponse> => ({
+      persona: config.name,
+      status: 'error',
+      content: 'Provider "kiro" does not support isolated structured execution',
+      timestamp: new Date(),
+      sessionId: options.sessionId,
+      error: 'Provider "kiro" does not support isolated structured execution',
+    });
     return { call };
   }
 }

--- a/src/infra/providers/kiro.ts
+++ b/src/infra/providers/kiro.ts
@@ -40,6 +40,7 @@ function toKiroOptions(options: ProviderCallOptions, systemPrompt?: string): Kir
 
 export class KiroProvider implements Provider {
   readonly supportsStructuredOutput = false;
+  readonly supportsIsolatedStructuredExecution = false;
   readonly supportsNativeImageInput = false;
   readonly supportsStrictInternalAgentIsolation = false;
 
@@ -59,5 +60,12 @@ export class KiroProvider implements Provider {
         return callKiro(name, prompt, toKiroOptions(options, systemPrompt));
       },
     };
+  }
+
+  setupIsolatedStructured(_config: AgentSetup): ProviderAgent {
+    const call = async (): Promise<AgentResponse> => {
+      throw new Error('Provider "kiro" does not support isolated structured execution');
+    };
+    return { call };
   }
 }

--- a/src/infra/providers/mock.ts
+++ b/src/infra/providers/mock.ts
@@ -7,6 +7,7 @@ import type { AgentResponse } from '../../core/models/index.js';
 import { keepsAllowedToolWithoutEdit as keepsClaudeAllowedToolWithoutEdit } from './allowed-tool-edit-policy.js';
 import { createLogger } from '../../shared/utils/index.js';
 import type { AgentSetup, Provider, ProviderAgent, ProviderCallOptions } from './types.js';
+import { assertOutputSchema } from './types.js';
 
 const log = createLogger('mock-provider');
 
@@ -28,8 +29,8 @@ function toMockOptions(options: ProviderCallOptions): MockCallOptions {
 /** Mock provider — deterministic responses for testing */
 export class MockProvider implements Provider {
   readonly supportsStructuredOutput = true;
-  readonly supportsNativeImageInput = false;
   readonly supportsIsolatedStructuredExecution = true;
+  readonly supportsNativeImageInput = false;
   readonly supportsStrictInternalAgentIsolation = true;
 
   getRuntimeInstructions(_allowedTools?: string[]): string | null {
@@ -53,5 +54,22 @@ export class MockProvider implements Provider {
       call: (prompt: string, options: ProviderCallOptions): Promise<AgentResponse> =>
         callMock(name, prompt, toMockOptions(options)),
     };
+  }
+
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent {
+    const { name, systemPrompt } = config;
+    const call = (prompt: string, options: ProviderCallOptions): Promise<AgentResponse> => {
+      const isolatedOptions: ProviderCallOptions = {
+        ...options,
+        sessionId: undefined,
+        allowedTools: [],
+        mcpServers: undefined,
+        imageAttachments: undefined,
+        outputSchema: assertOutputSchema(options.outputSchema, 'mock'),
+      };
+      const fullPrompt = systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
+      return callMockCustom(name, fullPrompt, '', toMockOptions(isolatedOptions));
+    };
+    return { call };
   }
 }

--- a/src/infra/providers/mock.ts
+++ b/src/infra/providers/mock.ts
@@ -62,6 +62,8 @@ export class MockProvider implements Provider {
       const isolatedOptions: ProviderCallOptions = {
         ...options,
         sessionId: undefined,
+        internalAgentIsolation: 'strict-readonly',
+        permissionMode: 'readonly',
         allowedTools: [],
         mcpServers: undefined,
         imageAttachments: undefined,

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -16,6 +16,7 @@ import type { AgentResponse } from '../../core/models/index.js';
 import type { PermissionMode } from '../../core/models/index.js';
 import { createLogger } from '../../shared/utils/index.js';
 import type { AgentSetup, Provider, ProviderAgent, ProviderCallOptions, ProviderCompactSessionOptions } from './types.js';
+import { assertOutputSchema } from './types.js';
 
 const log = createLogger('opencode-provider');
 
@@ -87,6 +88,7 @@ function requireOpenCodeModel(model: string | undefined): string {
 /** OpenCode provider — delegates to OpenCode SDK */
 export class OpenCodeProvider implements Provider {
   readonly supportsStructuredOutput = true;
+  readonly supportsIsolatedStructuredExecution = true;
   readonly supportsNativeImageInput = false;
   readonly supportsStrictInternalAgentIsolation = false;
 
@@ -123,5 +125,22 @@ export class OpenCodeProvider implements Provider {
         return callOpenCode(name, prompt, toOpenCodeOptions(options));
       },
     };
+  }
+
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent {
+    const { name, systemPrompt } = config;
+    const call = async (prompt: string, options: ProviderCallOptions): Promise<AgentResponse> => {
+      const isolatedOptions: ProviderCallOptions = {
+        ...options,
+        sessionId: undefined,
+        allowedTools: [],
+        mcpServers: undefined,
+        imageAttachments: undefined,
+        outputSchema: assertOutputSchema(options.outputSchema, 'opencode'),
+      };
+      const fullPrompt = systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
+      return callOpenCodeCustom(name, fullPrompt, '', toOpenCodeOptions(isolatedOptions));
+    };
+    return { call };
   }
 }

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -133,6 +133,8 @@ export class OpenCodeProvider implements Provider {
       const isolatedOptions: ProviderCallOptions = {
         ...options,
         sessionId: undefined,
+        internalAgentIsolation: 'strict-readonly',
+        permissionMode: 'readonly',
         allowedTools: [],
         mcpServers: undefined,
         imageAttachments: undefined,

--- a/src/infra/providers/provider-capabilities.ts
+++ b/src/infra/providers/provider-capabilities.ts
@@ -67,8 +67,7 @@ function resolveProviderCapabilities(
 
   return {
     supportsStructuredOutput: providerImpl.supportsStructuredOutput,
-    supportsIsolatedStructuredExecution:
-      providerImpl.supportsIsolatedStructuredExecution === true,
+    supportsIsolatedStructuredExecution: providerImpl.supportsIsolatedStructuredExecution,
     supportsNativeImageInput: providerImpl.supportsNativeImageInput,
     supportsMcpServers: MCP_SERVER_PROVIDERS.has(provider),
     supportsAllowedTools: ALLOWED_TOOLS_PROVIDERS.has(provider),

--- a/src/infra/providers/types.ts
+++ b/src/infra/providers/types.ts
@@ -13,11 +13,8 @@ export interface ProviderImageAttachment {
   path: string;
 }
 
-export type ProviderExecutionProfile = 'isolated-structured';
-
 export interface ProviderCallOptions {
   cwd: string;
-  executionProfile?: ProviderExecutionProfile;
   abortSignal?: AbortSignal;
   sessionId?: string;
   internalAgentIsolation?: InternalAgentIsolation;
@@ -57,13 +54,27 @@ export interface ProviderAgent {
 
 export interface Provider {
   supportsStructuredOutput: boolean;
+  /** Pre-check flag for isolated structured execution; the implementation itself lives in setupIsolatedStructured. */
+  supportsIsolatedStructuredExecution: boolean;
   supportsNativeImageInput: boolean;
-  supportsIsolatedStructuredExecution?: boolean;
   supportsStrictInternalAgentIsolation: boolean;
   getRuntimeInstructions(allowedTools?: string[], permissionMode?: import('../../core/models/index.js').PermissionMode, networkAccess?: boolean): string | null;
   keepsAllowedToolWithoutEdit(tool: string): boolean;
   setup(config: AgentSetup): ProviderAgent;
+  setupIsolatedStructured(config: AgentSetup): ProviderAgent;
   compactSession?(options: ProviderCompactSessionOptions): Promise<void>;
 }
 
 export type ProviderType = SharedProviderType;
+
+export function assertOutputSchema(
+  schema: Record<string, unknown> | undefined,
+  provider: string,
+): Record<string, unknown> {
+  if (schema === undefined) {
+    throw new Error(
+      `Provider "${provider}" cannot run isolated structured execution without an output schema`,
+    );
+  }
+  return schema;
+}


### PR DESCRIPTION
## 概要

`finding_contract.intake_normalize` が codex 専用だった制約を解消し、opencode(ローカルモデル)で構成可能にする。

## 設計

- **実行は必須メソッド**: `Provider.setupIsolatedStructured` を interface の必須メソッドにし、executionProfile による呼び出し側分岐を廃止。対応プロバイダ(codex/opencode/mock)は隔離実行を実装、非対応プロバイダは自身の実装内で明示的に throw
- **opencode の隔離実行**: セッション再利用なし・ツール/MCP/画像無効・出力スキーマ必須の純粋JSON呼び出し(既存の構造化出力機構を再利用)
- **事前チェックはフラグ**: `supportsIsolatedStructuredExecution` により intake_normalize のロード時 fail-fast を維持(実行中に初めて落ちる退行を防止)

## 検証
対象テスト4ファイル(76件)・lint・tsc 全緑。codex の既存挙動は等価維持。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Claude、Codex、OpenCodeなどで、隔離された構造化実行と出力検証に対応しました。
  * 実行時に不要なツール、セッション、MCP、画像添付を無効化し、安全性を高めました。
* **バグ修正**
  * 未対応プロバイダー利用時に、明確なエラー応答を返すよう改善しました。
  * プロバイダー呼び出し失敗時の一時データ削除を確実にしました。
* **テスト**
  * 対応状況、権限、設定、出力形式に関する検証を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->