### PR TITLE
fix: opencode隔離構造化実行の空応答をerrorへ表面化する

### DIFF
--- a/src/__tests__/opencode-isolated-structured.test.ts
+++ b/src/__tests__/opencode-isolated-structured.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentResponse } from '../core/models/index.js';
+import type { ProviderCallOptions } from '../infra/providers/types.js';
+
+const openCodeMocks = vi.hoisted(() => ({
+  callOpenCode: vi.fn(),
+  callOpenCodeCustom: vi.fn(),
+  compactOpenCodeSession: vi.fn(),
+}));
+
+vi.mock('../infra/opencode/index.js', () => ({
+  callOpenCode: openCodeMocks.callOpenCode,
+  callOpenCodeCustom: openCodeMocks.callOpenCodeCustom,
+  compactOpenCodeSession: openCodeMocks.compactOpenCodeSession,
+}));
+
+const callOptions: ProviderCallOptions = {
+  cwd: '/tmp/takt-isolated-structured',
+  model: 'ollama-cloud/glm-5.2',
+  permissionMode: 'readonly',
+  allowedTools: [],
+  outputSchema: {
+    type: 'object',
+    required: ['rawFindings'],
+    properties: { rawFindings: { type: 'array' } },
+  },
+};
+
+async function callIsolated(response: AgentResponse): Promise<AgentResponse> {
+  openCodeMocks.callOpenCodeCustom.mockResolvedValue(response);
+  const { OpenCodeProvider } = await import('../infra/providers/opencode.js');
+  const agent = new OpenCodeProvider().setupIsolatedStructured({
+    name: 'finding-intake-normalizer',
+    systemPrompt: '',
+  });
+  return agent.call('extract raw findings', callOptions);
+}
+
+describe('OpenCodeProvider.setupIsolatedStructured response contract', () => {
+  beforeEach(() => {
+    openCodeMocks.callOpenCodeCustom.mockReset();
+  });
+
+  it('accepts a structured payload delivered outside the message body', async () => {
+    const structuredOutput = { rawFindings: [{ rawExcerpt: 'claim', candidate: null }] };
+    const response = await callIsolated({
+      persona: 'finding-intake-normalizer',
+      status: 'done',
+      // OpenCode の native structured output はモデルが本文を出さないことがあり、
+      // 構造化ペイロードだけが assistant message の structured で返る。
+      content: '',
+      structuredOutput,
+      timestamp: new Date(),
+    });
+
+    expect(response.status).toBe('done');
+    expect(response.structuredOutput).toEqual(structuredOutput);
+    expect(response.error).toBeUndefined();
+    expect(response.failureCategory).toBeUndefined();
+  });
+
+  it('turns a fully empty response into a provider error instead of a success', async () => {
+    const response = await callIsolated({
+      persona: 'finding-intake-normalizer',
+      status: 'done',
+      content: '',
+      timestamp: new Date(),
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.failureCategory).toBe('provider_error');
+    expect(response.error).toContain('empty response');
+    expect(response.structuredOutput).toBeUndefined();
+  });
+
+  it('turns an unparsable non-empty response into a provider error', async () => {
+    const response = await callIsolated({
+      persona: 'finding-intake-normalizer',
+      status: 'done',
+      content: 'I could not extract anything from this report.',
+      timestamp: new Date(),
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.failureCategory).toBe('provider_error');
+    expect(response.error).toContain('no structured output');
+    expect(response.error).toContain('I could not extract anything');
+  });
+
+  it('passes a provider-side failure through untouched', async () => {
+    const response = await callIsolated({
+      persona: 'finding-intake-normalizer',
+      status: 'error',
+      content: 'upstream request failed',
+      error: 'upstream request failed',
+      failureCategory: 'provider_error',
+      timestamp: new Date(),
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.error).toBe('upstream request failed');
+  });
+});

--- a/src/__tests__/opencode-isolated-structured.test.ts
+++ b/src/__tests__/opencode-isolated-structured.test.ts
@@ -26,6 +26,8 @@ const callOptions: ProviderCallOptions = {
   },
 };
 
+const providerTimestamp = new Date('2026-08-06T00:00:00.000Z');
+
 async function callIsolated(response: AgentResponse): Promise<AgentResponse> {
   openCodeMocks.callOpenCodeCustom.mockResolvedValue(response);
   const { OpenCodeProvider } = await import('../infra/providers/opencode.js');
@@ -41,7 +43,7 @@ describe('OpenCodeProvider.setupIsolatedStructured response contract', () => {
     openCodeMocks.callOpenCodeCustom.mockReset();
   });
 
-  it('accepts a structured payload delivered outside the message body', async () => {
+  it('should keep the response successful when the structured payload arrives outside the message body', async () => {
     const structuredOutput = { rawFindings: [{ rawExcerpt: 'claim', candidate: null }] };
     const response = await callIsolated({
       persona: 'finding-intake-normalizer',
@@ -50,54 +52,83 @@ describe('OpenCodeProvider.setupIsolatedStructured response contract', () => {
       // 構造化ペイロードだけが assistant message の structured で返る。
       content: '',
       structuredOutput,
-      timestamp: new Date(),
+      sessionId: 'isolated-session',
+      timestamp: providerTimestamp,
     });
 
-    expect(response.status).toBe('done');
-    expect(response.structuredOutput).toEqual(structuredOutput);
-    expect(response.error).toBeUndefined();
-    expect(response.failureCategory).toBeUndefined();
+    expect(response).toEqual({
+      persona: 'finding-intake-normalizer',
+      status: 'done',
+      content: '',
+      structuredOutput,
+      sessionId: 'isolated-session',
+      timestamp: providerTimestamp,
+    });
   });
 
-  it('turns a fully empty response into a provider error instead of a success', async () => {
+  it('should report a provider error when the response is fully empty', async () => {
     const response = await callIsolated({
       persona: 'finding-intake-normalizer',
       status: 'done',
       content: '',
-      timestamp: new Date(),
+      sessionId: 'isolated-session',
+      timestamp: providerTimestamp,
     });
 
-    expect(response.status).toBe('error');
-    expect(response.failureCategory).toBe('provider_error');
-    expect(response.error).toContain('empty response');
-    expect(response.structuredOutput).toBeUndefined();
+    const expectedError =
+      'OpenCode isolated structured execution returned an empty response with no structured output';
+    expect(response).toEqual({
+      persona: 'finding-intake-normalizer',
+      status: 'error',
+      content: expectedError,
+      error: expectedError,
+      failureCategory: 'provider_error',
+      sessionId: 'isolated-session',
+      timestamp: providerTimestamp,
+    });
   });
 
-  it('turns an unparsable non-empty response into a provider error', async () => {
+  it('should report a provider error when the response body is not parsable structured output', async () => {
     const response = await callIsolated({
       persona: 'finding-intake-normalizer',
       status: 'done',
-      content: 'I could not extract anything from this report.',
-      timestamp: new Date(),
+      content: '  I could not extract anything from this report.  ',
+      sessionId: 'isolated-session',
+      timestamp: providerTimestamp,
     });
 
-    expect(response.status).toBe('error');
-    expect(response.failureCategory).toBe('provider_error');
-    expect(response.error).toContain('no structured output');
-    expect(response.error).toContain('I could not extract anything');
+    const expectedError = 'OpenCode isolated structured execution returned no structured output: '
+      + 'I could not extract anything from this report.';
+    expect(response).toEqual({
+      persona: 'finding-intake-normalizer',
+      status: 'error',
+      content: expectedError,
+      error: expectedError,
+      failureCategory: 'provider_error',
+      sessionId: 'isolated-session',
+      timestamp: providerTimestamp,
+    });
   });
 
-  it('passes a provider-side failure through untouched', async () => {
+  it('should pass the response through unchanged when the provider already reported a failure', async () => {
     const response = await callIsolated({
       persona: 'finding-intake-normalizer',
       status: 'error',
       content: 'upstream request failed',
       error: 'upstream request failed',
       failureCategory: 'provider_error',
-      timestamp: new Date(),
+      sessionId: 'isolated-session',
+      timestamp: providerTimestamp,
     });
 
-    expect(response.status).toBe('error');
-    expect(response.error).toBe('upstream request failed');
+    expect(response).toEqual({
+      persona: 'finding-intake-normalizer',
+      status: 'error',
+      content: 'upstream request failed',
+      error: 'upstream request failed',
+      failureCategory: 'provider_error',
+      sessionId: 'isolated-session',
+      timestamp: providerTimestamp,
+    });
   });
 });

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -14,6 +14,10 @@ import { resolveOpenCodeAllowedPermissions } from '../opencode/types.js';
 import { resolveOpencodeApiKey } from '../config/index.js';
 import type { AgentResponse } from '../../core/models/index.js';
 import type { PermissionMode } from '../../core/models/index.js';
+import {
+  createProviderErrorFailure,
+  formatAgentFailure,
+} from '../../shared/types/agent-failure.js';
 import { createLogger } from '../../shared/utils/index.js';
 import type { AgentSetup, Provider, ProviderAgent, ProviderCallOptions, ProviderCompactSessionOptions } from './types.js';
 import { assertOutputSchema } from './types.js';
@@ -75,6 +79,50 @@ function toOpenCodeCompactSessionOptions(options: ProviderCompactSessionOptions)
     abortSignal: options.abortSignal,
     opencodeApiKey: resolveOpencodeApiKey(),
     childProcessEnv: options.childProcessEnv,
+  };
+}
+
+const ISOLATED_STRUCTURED_ERROR_EXCERPT_CHARS = 200;
+
+/**
+ * 隔離構造化実行の応答契約を守らせる。
+ *
+ * 通常経路（OpenCodeAttemptRunner）は構造化出力を2系統で採取する。
+ * assistant message の `structured` フィールドと、それが無いときの本文パース
+ * （outputSchema があるときだけ動く fallback）である。隔離実行は
+ * assertOutputSchema で outputSchema を必須にしているため、両系統とも必ず通る。
+ * つまりここで structuredOutput が無いということは「どちらでも採れなかった」
+ * ＝空応答か JSON として読めない応答であり、成功として返してはならない。
+ *
+ * 本文が空でも `structured` が採れていれば正常（構造化チャンネルだけで返す
+ * モデルがある）ので、判定は本文ではなく structuredOutput の有無で行う。
+ */
+function requireIsolatedStructuredOutput(
+  agentType: string,
+  response: AgentResponse,
+): AgentResponse {
+  if (response.status !== 'done' || response.structuredOutput !== undefined) {
+    return response;
+  }
+  const excerpt = response.content.trim();
+  const failure = createProviderErrorFailure(
+    excerpt === ''
+      ? 'OpenCode isolated structured execution returned an empty response with no structured output'
+      : `OpenCode isolated structured execution returned no structured output: ${
+          excerpt.slice(0, ISOLATED_STRUCTURED_ERROR_EXCERPT_CHARS)
+        }`,
+  );
+  const content = formatAgentFailure(failure);
+  log.warn('OpenCode isolated structured execution produced no structured output', {
+    agentType,
+    contentLength: response.content.length,
+  });
+  return {
+    ...response,
+    status: 'error',
+    content,
+    error: content,
+    failureCategory: failure.category,
   };
 }
 
@@ -141,7 +189,13 @@ export class OpenCodeProvider implements Provider {
         outputSchema: assertOutputSchema(options.outputSchema, 'opencode'),
       };
       const fullPrompt = systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
-      return callOpenCodeCustom(name, fullPrompt, '', toOpenCodeOptions(isolatedOptions));
+      const response = await callOpenCodeCustom(
+        name,
+        fullPrompt,
+        '',
+        toOpenCodeOptions(isolatedOptions),
+      );
+      return requireIsolatedStructuredOutput(name, response);
     };
     return { call };
   }


### PR DESCRIPTION
## 症状(実走 run-4)

intake_normalize(opencode/glm-5.2)の隔離構造化呼び出しが空応答を返しても `status: done` で受理され、全レビュー主張が「Normalizer extraction candidate is null」の protocol-anomaly になった。

## 根本原因

OpenCodeAttemptRunner は構造化出力を SSE `structured` フィールドと本文パースの2系統で採取するが、**schema 要求済みで両系統とも空**の場合に done・error なしを返し、隔離実行がそのまま素通ししていた。codex の隔離実行は同条件で throw→error であり非対称だった(家訓「Provider errors must surface through AgentResponse.error」違反)。

## 修正

- 隔離実行の応答が done かつ structuredOutput 未取得なら `createProviderErrorFailure`(provider_error)で error 化
- 判定は本文ではなく structuredOutput の有無(本文空でも structured チャンネルで返すモデルは成功のまま)
- 抽出は既存2系統に委ね再実装なし

## 検証
新規テスト4件(別フィールド構造化payload成功/完全空error/非JSON本文error/provider error素通し)+関連242テスト green。tsc/lint/build green。

## 補足(スコープ外の所見)
実走38回中37回は構造化出力の取得自体は成功しており、中身が「スキーマ妥当な空/null候補」だった。これは glm-5.2 のモデル品質問題で provider seam では判別不能(ベンチ側は正規化モデルの変更で対処)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 隔離構造化実行で構造化出力を取得できなかった場合、処理が成功扱いにならず、明確なプロバイダーエラーとして報告されるよう改善しました。
  - 空の応答や解析できない応答でも、原因を確認しやすいエラー情報が表示されます。

- **テスト**
  - 正常応答、空応答、解析不能な応答、プロバイダーエラーの各ケースを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->