### PR TITLE
fix: Phase2ガードがopencodeの構造化出力疑似ツールを誤拒否しないようにする

### DIFF
--- a/src/__tests__/report-phase-retry.test.ts
+++ b/src/__tests__/report-phase-retry.test.ts
@@ -103,18 +103,22 @@ function createContext(
     lastResponse: currentLastResponse,
     resolveSessionKey: (step) => step.persona ?? step.name,
     getSessionId: (_persona: string) => currentSessionId,
-    buildResumeOptions: (_step, sessionId, overrides) => ({
+    // 本番の OptionsBuilder.buildResumeOptions / buildNewSessionReportOptions と同じく
+    // step の structuredOutput を Phase 2 の outputSchema として渡す。
+    buildResumeOptions: (step, sessionId, overrides) => ({
       cwd: reportDir,
       resolvedProvider: primaryProvider,
       sessionId,
       allowedTools: overrides.allowedTools,
       maxTurns: overrides.maxTurns,
+      outputSchema: step.structuredOutput?.schema,
     }),
-    buildNewSessionReportOptions: (_step, overrides) => ({
+    buildNewSessionReportOptions: (step, overrides) => ({
       cwd: reportDir,
       resolvedProvider: primaryProvider,
       allowedTools: overrides.allowedTools,
       maxTurns: overrides.maxTurns,
+      outputSchema: step.structuredOutput?.schema,
     }),
     buildFallbackReportOptions: (step, failedPrimaryOptions, overrides) => {
       if (
@@ -1086,6 +1090,106 @@ describe('runReportPhase retry with new session', () => {
       'Finding review publication reportContent is missing',
     );
     expect(vi.mocked(runAgent)).toHaveBeenCalledTimes(1);
+  });
+
+  it('should accept the provider-native StructuredOutput tool when phase 2 requested structured output', async () => {
+    // Given: OpenCode はネイティブ構造化出力を StructuredOutput 疑似ツールとして流す
+    const reportDir = join(tmpRoot, '.takt', 'runs', 'sample-run', 'reports');
+    const step = createFindingReviewStep('finding-review-structured-tool.md');
+    const ctx = createContext(reportDir, 'Phase 1 review draft', 'structured-tool-session');
+    queueRunAgentAttempts([{
+      streamEvents: [
+        {
+          type: 'tool_use',
+          data: { tool: 'StructuredOutput', input: {}, id: 'structured-output-1' },
+        },
+        {
+          type: 'tool_result',
+          data: { id: 'structured-output-1', content: 'Structured output captured successfully.', isError: false },
+        },
+      ],
+      response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: '',
+        structuredOutput: {
+          reportContent: '# Review\nNo findings.',
+          rawFindings: [],
+        },
+        sessionId: 'structured-tool-session',
+        timestamp: new Date('2026-02-11T00:02:00Z'),
+      },
+    }]);
+
+    // When
+    const result = await generateReportPhase(step, 1, ctx, {
+      reviewerOutputStrategy: { kind: 'structured', reportGeneration: 'structured', intake: 'reviewer_structured' },
+    });
+
+    // Then
+    if (!('reports' in result)) {
+      throw new Error('Expected generated reports');
+    }
+    expect(result.reports[0]?.reportContent).toBe('# Review\nNo findings.');
+    expect(vi.mocked(runAgent)).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still reject a real tool call when phase 2 requested structured output', async () => {
+    // Given
+    const reportDir = join(tmpRoot, '.takt', 'runs', 'sample-run', 'reports');
+    const step = createFindingReviewStep('finding-review-real-tool.md');
+    const ctx = createContext(reportDir, undefined, 'structured-real-tool-session');
+    queueRunAgentAttempts([{
+      streamEvents: [{
+        type: 'tool_use',
+        data: { tool: 'read', input: {}, id: 'tool-read-1' },
+      }],
+      response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: '',
+        structuredOutput: { reportContent: '# Review', rawFindings: [] },
+        timestamp: new Date('2026-02-11T00:02:01Z'),
+      },
+    }]);
+
+    // When
+    const error = await generateReportPhase(step, 1, ctx, {
+      reviewerOutputStrategy: { kind: 'structured', reportGeneration: 'structured', intake: 'reviewer_structured' },
+    }).catch((caught: unknown) => caught);
+
+    // Then
+    expect(error).toBeInstanceOf(ReportPhaseGenerationError);
+    expect(error).toMatchObject({ failureReason: 'tool_call' });
+    expect((error as Error).message).toContain('provider emitted tool "read"');
+  });
+
+  it('should reject the StructuredOutput tool when phase 2 did not request structured output', async () => {
+    // Given: schema を要求していない Phase 2 での StructuredOutput は汚染セッション由来の違反
+    const reportDir = join(tmpRoot, '.takt', 'runs', 'sample-run', 'reports');
+    const step = createStep('plain-report-structured-tool.md');
+    const ctx = createContext(reportDir, undefined, 'plain-structured-tool-session');
+    queueRunAgentAttempts([{
+      streamEvents: [{
+        type: 'tool_use',
+        data: { tool: 'StructuredOutput', input: {}, id: 'structured-output-stale' },
+      }],
+      response: {
+        persona: 'coder',
+        status: 'done',
+        content: '# Report\nMust not be accepted',
+        timestamp: new Date('2026-02-11T00:02:02Z'),
+      },
+    }]);
+
+    // When
+    const error = await generateReportPhase(step, 1, ctx)
+      .catch((caught: unknown) => caught);
+
+    // Then
+    expect(error).toBeInstanceOf(ReportPhaseGenerationError);
+    expect(error).toMatchObject({ failureReason: 'tool_call' });
+    expect((error as Error).message).toContain('provider emitted tool "StructuredOutput"');
   });
 
   it('should resume the next report file with the primary session after a fallback report succeeds', async () => {

--- a/src/core/workflow/report-phase-runner.ts
+++ b/src/core/workflow/report-phase-runner.ts
@@ -4,7 +4,10 @@ import type { RunAgentOptions } from '../../agents/runner.js';
 import { executeAgent } from '../../agents/agent-usecases.js';
 import { parseStructuredOutputObject } from '../../agents/structured-caller/shared.js';
 import { createLogger } from '../../shared/utils/index.js';
-import type { StreamEvent } from '../../shared/types/provider.js';
+import {
+  PROVIDER_NATIVE_STRUCTURED_OUTPUT_TOOL_NAME,
+  type StreamEvent,
+} from '../../shared/types/provider.js';
 import { buildPhaseExecutionId } from '../../shared/utils/phaseExecutionId.js';
 import { buildSessionKey } from './session-key.js';
 import { ReportInstructionBuilder } from './instruction/ReportInstructionBuilder.js';
@@ -445,16 +448,46 @@ function buildReportPhaseToolResultError(): ReportPhaseToolCallError {
   return new ReportPhaseToolCallError('Report phase does not allow tool results.');
 }
 
-function detectReportPhaseToolCall(event: StreamEvent): ReportPhaseToolCallError | undefined {
-  if (event.type === 'tool_use') {
-    return buildReportPhaseToolUseError(event.data.tool);
-  }
+/**
+ * Phase 2 のツール禁止ガード。
+ *
+ * outputSchema を渡した attempt では、provider がネイティブ構造化出力を
+ * 疑似ツール呼び出しとして表現することがある（OpenCode の StructuredOutput）。
+ * これはエンジン自身が要求した収集機構であり、エージェントのツール使用ではないので
+ * 拒否しない。codex は --output-schema、claude は SDK の outputFormat で扱うため
+ * そもそもツールイベントを出さない。
+ *
+ * 構造化出力を要求していない attempt での StructuredOutput 呼び出しは、
+ * 汚染セッション由来の本物の違反なので従来どおり拒否する。
+ */
+function createReportPhaseToolCallDetector(
+  allowsNativeStructuredOutputTool: boolean,
+): (event: StreamEvent) => ReportPhaseToolCallError | undefined {
+  const nativeStructuredOutputToolIds = new Set<string>();
+  return (event) => {
+    if (event.type === 'tool_use') {
+      if (
+        allowsNativeStructuredOutputTool
+        && event.data.tool === PROVIDER_NATIVE_STRUCTURED_OUTPUT_TOOL_NAME
+      ) {
+        nativeStructuredOutputToolIds.add(event.data.id);
+        return undefined;
+      }
+      return buildReportPhaseToolUseError(event.data.tool);
+    }
 
-  if (event.type === 'tool_result') {
-    return buildReportPhaseToolResultError();
-  }
+    if (event.type === 'tool_result') {
+      if (
+        event.data.id !== undefined
+        && nativeStructuredOutputToolIds.has(event.data.id)
+      ) {
+        return undefined;
+      }
+      return buildReportPhaseToolResultError();
+    }
 
-  return undefined;
+    return undefined;
+  };
 }
 
 type ReportAttemptResult =
@@ -511,6 +544,9 @@ async function runSingleReportAttempt(
   let didEmitPhaseStart = false;
   let resolvedPromptParts: PhasePromptParts | undefined;
   let reportToolCallError: ReportPhaseToolCallError | undefined;
+  const detectReportPhaseToolCall = createReportPhaseToolCallDetector(
+    options.outputSchema !== undefined,
+  );
   const callOptions: RunAgentOptions = {
     ...options,
     onPromptResolved: (promptParts) => {

--- a/src/infra/opencode/structured-output-recovery.ts
+++ b/src/infra/opencode/structured-output-recovery.ts
@@ -17,9 +17,10 @@
 
 import type { Language } from '../../core/models/types.js';
 import { buildStructuredJsonSchemaInstruction } from '../../shared/prompts/index.js';
+import { PROVIDER_NATIVE_STRUCTURED_OUTPUT_TOOL_NAME } from '../../shared/types/provider.js';
 
 /** OpenCode のネイティブ構造化出力ツールの名前。stale recovery の対象判定に使う。 */
-export const STRUCTURED_OUTPUT_TOOL_NAME = 'StructuredOutput';
+export const STRUCTURED_OUTPUT_TOOL_NAME = PROVIDER_NATIVE_STRUCTURED_OUTPUT_TOOL_NAME;
 
 export type OpenCodeStructuredOutputSessionMode = 'resume' | 'fresh';
 export type OpenCodeStructuredOutputMode = 'native' | 'formatless' | 'plain';

--- a/src/shared/types/provider.ts
+++ b/src/shared/types/provider.ts
@@ -33,6 +33,14 @@ export interface StreamInitEventData {
   sessionId: string;
 }
 
+/**
+ * ネイティブ構造化出力を疑似ツール呼び出しとして表現する provider（OpenCode）が
+ * 使うツール名。エンジン自身が outputSchema で要求した収集機構であり、
+ * エージェントによるツール使用ではない。ツール禁止フェーズはこれを一般ツールとして
+ * 拒否してはならない。
+ */
+export const PROVIDER_NATIVE_STRUCTURED_OUTPUT_TOOL_NAME = 'StructuredOutput';
+
 export interface StreamToolUseEventData {
   tool: string;
   input: Record<string, unknown>;


### PR DESCRIPTION
## 症状(実走 run-5)

FC レビュアー(opencode)の Phase 2 が「Report phase does not allow tool calls, but provider emitted tool "StructuredOutput"」で全滅。

## 根本原因

opencode はネイティブ構造化出力を疑似ツール `StructuredOutput` の tool_use として表現する(codex は --output-schema ファイル、claude は SDK outputFormat でツールイベントを出さない非対称)。エンジン自身が outputSchema を渡して要求した収集機構なのに、Phase 2 のツール禁止ガードが一般ツールとして拒否していた。

intake_normalize が該当レビュアーを対象にすると plain_text_normalized 戦略になり Phase 2 に schema が付かないため潜伏(run-4 までは未発火)。

## 修正

- `PROVIDER_NATIVE_STRUCTURED_OUTPUT_TOOL_NAME` を共有型に定義し、ガードを「構造化出力を要求した attempt に限りこの疑似ツールと対応 tool_result のみ許可」へ
- 要求していない attempt の同名ツール(汚染セッション由来)と実ツールは従来どおり拒否

## 検証
再現3件(許可/実ツール拒否/schema無し拒否)+許可条件を落とすと確実に失敗する変異確認。report-phase系64+関連81テスト、tsc/lint/build green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 構造化出力を要求したレポート処理で、プロバイダーのネイティブ構造化出力を正しく受け付けるようになりました。
  - 構造化出力を要求していない場合や通常のツール呼び出しでは、対象外の構造化出力イベントを適切に拒否するようになりました。
  - レポート生成時のツール呼び出し判定が、要求内容に応じてより正確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->