### PR TITLE
fix: candidate null逃げを訂正機構へ載せプロンプト条件分岐の漏れを直す

### DIFF
--- a/src/__tests__/finding-extraction-fidelity.test.ts
+++ b/src/__tests__/finding-extraction-fidelity.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { hasRawFindingExtractionFidelityFailure } from '../core/workflow/findings/extraction-fidelity.js';
+import { projectReviewerRawStructuredOutputWithEnvelope } from '../core/workflow/findings/raw-canonicalization.js';
+
+const CLAIM_EXCERPT = 'Issue: src/example.ts still bypasses the required boundary.';
+const COMPLETE_CANDIDATE = {
+  rawFindingId: null,
+  familyTag: null,
+  severity: null,
+  title: null,
+  description: 'src/example.ts still bypasses the required boundary.',
+  suggestion: null,
+  relation: null,
+  targetFindingIds: [],
+  target: null,
+  evidenceRequests: [],
+};
+
+describe('hasRawFindingExtractionFidelityFailure', () => {
+  it('should report a failure when an item has a non-empty rawExcerpt and a null candidate', () => {
+    expect(hasRawFindingExtractionFidelityFailure({
+      rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: null }],
+    })).toBe(true);
+  });
+
+  it('should report a failure when an item has a non-empty rawExcerpt and no candidate key', () => {
+    expect(hasRawFindingExtractionFidelityFailure({
+      rawFindings: [{ rawExcerpt: CLAIM_EXCERPT }],
+    })).toBe(true);
+  });
+
+  it('should report a failure when the candidate description is null', () => {
+    expect(hasRawFindingExtractionFidelityFailure({
+      rawFindings: [{
+        rawExcerpt: CLAIM_EXCERPT,
+        candidate: { ...COMPLETE_CANDIDATE, description: null },
+      }],
+    })).toBe(true);
+  });
+
+  it('should report a failure when only one item among several lost its claim', () => {
+    expect(hasRawFindingExtractionFidelityFailure({
+      rawFindings: [
+        { rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE },
+        { rawExcerpt: 'Another stated problem.', candidate: null },
+      ],
+    })).toBe(true);
+  });
+
+  it('should report no failure for a complete candidate, an empty list, or a non-publication value', () => {
+    expect(hasRawFindingExtractionFidelityFailure({
+      rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE }],
+    })).toBe(false);
+    expect(hasRawFindingExtractionFidelityFailure({ rawFindings: [] })).toBe(false);
+    expect(hasRawFindingExtractionFidelityFailure({ rawFindings: 'invalid' })).toBe(false);
+    expect(hasRawFindingExtractionFidelityFailure(undefined)).toBe(false);
+    expect(hasRawFindingExtractionFidelityFailure(null)).toBe(false);
+  });
+
+  it('should report a failure for an incomplete candidate once the reviewer projection collapses it to null', () => {
+    // 実運用で検出に使うのは projection 後の形。必須フィールドを欠く candidate は
+    // projection で null へ畳まれるため、全欠けと同じ経路で検出される。
+    const projected = projectReviewerRawStructuredOutputWithEnvelope({
+      rawFindings: [{
+        rawExcerpt: CLAIM_EXCERPT,
+        candidate: { description: 'partial only' },
+      }],
+    }).structuredOutput;
+
+    expect(projected.rawFindings).toEqual([{ rawExcerpt: CLAIM_EXCERPT, candidate: null }]);
+    expect(hasRawFindingExtractionFidelityFailure(projected)).toBe(true);
+  });
+});

--- a/src/__tests__/finding-intake-normalizer-usecase.test.ts
+++ b/src/__tests__/finding-intake-normalizer-usecase.test.ts
@@ -96,11 +96,17 @@ describe('normalizeFindingIntake', () => {
       mode: 'correction',
       extractionFidelityCorrection: true,
     });
+    // setupIsolatedStructured は beforeEach で同じ agent を返すため、2回目の呼び出しは
+    // 同じ call モックの calls[1] に入る。
     const secondCallFn = setupIsolatedStructured.mock.results[1]!.value.call;
-    const [secondPrompt] = secondCallFn.mock.calls[0]!;
+    const [secondPrompt] = secondCallFn.mock.calls[1]!;
     expect(secondPrompt).toContain(
-      'this exception overrides rule 3 for `candidate.description` alone',
+      'this exception overrides rule 3 for the candidate itself',
     );
+    expect(secondPrompt).toContain('`candidate: null` and a candidate missing any required field are both');
+    // 入れ子 {{#if}} は未対応なので、条件分岐は兄弟条件として展開される。
+    expect(secondPrompt).not.toContain('{{#if');
+    expect(prompt).not.toContain('extraction-fidelity case only');
   });
 
   it('removes the isolated working directory when the provider call throws', async () => {

--- a/src/__tests__/step-executor.test.ts
+++ b/src/__tests__/step-executor.test.ts
@@ -110,6 +110,10 @@ describe('StepExecutor', () => {
     reportContentOverride?: string,
     intakeNormalizeOverride?: FindingIntakeNormalizeConfig,
     structuredOutputNormalizersOverride?: StructuredOutputNormalizerRegistry,
+    reviewerOverrides?: {
+      readonly mode?: 'structured' | 'plain_text_normalized';
+      readonly agentResponses?: readonly AgentResponse[];
+    },
   ) {
     const reportContent = reportContentOverride ?? [
       '# Architecture Review',
@@ -118,11 +122,16 @@ describe('StepExecutor', () => {
       '',
       'Issue: src/example.ts still bypasses the required boundary.',
     ].join('\n');
+    const remainingAgentResponses = [...(reviewerOverrides?.agentResponses ?? [])];
     vi.mocked(executeAgent).mockImplementation(async (_persona, prompt, options) => {
       options?.onPromptResolved?.({
         systemPrompt: 'reviewer system',
         userInstruction: prompt,
       });
+      const queued = remainingAgentResponses.shift();
+      if (queued !== undefined) {
+        return queued;
+      }
       return {
         persona: 'reviewer',
         status: 'done',
@@ -160,7 +169,7 @@ describe('StepExecutor', () => {
       hasWaivedFindings: false,
       hasDismissedFindings: false,
       reviewer: {
-        mode: 'plain_text_normalized' as const,
+        mode: reviewerOverrides?.mode ?? ('plain_text_normalized' as const),
         reviewScopeSnapshotId: 'snapshot-plain-text',
       },
     };
@@ -651,6 +660,242 @@ describe('StepExecutor', () => {
       updatePersonaSession: harness.updatePersonaSession,
     })).rejects.toThrow(/extraction-fidelity correction failed/u);
     expect(harness.normalizeFindingIntake).toHaveBeenCalledTimes(2);
+  });
+
+  const PLAIN_TEXT_REPORT_CONTENT = [
+    '# Architecture Review',
+    '',
+    '## Result: REJECT',
+    '',
+    'Issue: src/example.ts still bypasses the required boundary.',
+  ].join('\n');
+  const CLAIM_EXCERPT = 'Issue: src/example.ts still bypasses the required boundary.';
+  const COMPLETE_CANDIDATE = {
+    rawFindingId: null,
+    familyTag: null,
+    severity: null,
+    title: null,
+    description: 'src/example.ts still bypasses the required boundary.',
+    suggestion: null,
+    relation: null,
+    targetFindingIds: [],
+    target: null,
+    evidenceRequests: [],
+  };
+  const STRUCTURED_STRATEGY = {
+    kind: 'structured',
+    reportGeneration: 'structured',
+    intake: 'reviewer_structured',
+  } as const;
+
+  it('should fire the extraction-fidelity correction when the normalizer returns a null candidate', async () => {
+    // Given: rawExcerpt はあるのに candidate ごと null（実走 run-4 の退行形）
+    const harness = createPlainTextPublicationHarness([
+      {
+        persona: 'default',
+        status: 'done',
+        content: '{}',
+        structuredOutput: { rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: null }] },
+        timestamp: new Date('2026-07-31T00:00:01.000Z'),
+      },
+      {
+        persona: 'default',
+        status: 'done',
+        content: '{}',
+        structuredOutput: {
+          rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE }],
+        },
+        timestamp: new Date('2026-07-31T00:00:02.000Z'),
+      },
+    ]);
+
+    // When
+    const result = await harness.executor.prepareFindingReviewPublication({
+      step: harness.step,
+      executableStep: harness.step,
+      reviewerOutputStrategy: PLAIN_TEXT_NORMALIZED_STRATEGY,
+      parentStepName: 'reviewers',
+      stepIteration: 1,
+      state: harness.state,
+      phase1Response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: 'phase 1 investigation',
+        timestamp: new Date('2026-07-31T00:00:00.000Z'),
+      },
+      agentOptions: { resolvedProvider: 'mock' },
+      onProviderAttempt: vi.fn(),
+      updatePersonaSession: harness.updatePersonaSession,
+    });
+
+    // Then
+    expect('publication' in result).toBe(true);
+    if (!('publication' in result)) {
+      throw new Error('Expected publication');
+    }
+    expect(result.publication.rawFindings).toEqual([
+      { rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE },
+    ]);
+    expect(harness.normalizeFindingIntake.mock.calls.map(([, options]) => {
+      const typed = options as { mode: string; extractionFidelityCorrection?: boolean };
+      return { mode: typed.mode, extractionFidelityCorrection: typed.extractionFidelityCorrection };
+    })).toEqual([
+      { mode: 'initial', extractionFidelityCorrection: false },
+      { mode: 'correction', extractionFidelityCorrection: true },
+    ]);
+  });
+
+  it('should not publish when the normalizer keeps returning a null candidate after the correction', async () => {
+    // Given
+    const nullCandidateFinding = { rawExcerpt: CLAIM_EXCERPT, candidate: null };
+    const harness = createPlainTextPublicationHarness([
+      {
+        persona: 'default',
+        status: 'done',
+        content: '{}',
+        structuredOutput: { rawFindings: [nullCandidateFinding] },
+        timestamp: new Date('2026-07-31T00:00:01.000Z'),
+      },
+      {
+        persona: 'default',
+        status: 'done',
+        content: '{}',
+        structuredOutput: { rawFindings: [nullCandidateFinding] },
+        timestamp: new Date('2026-07-31T00:00:02.000Z'),
+      },
+    ]);
+
+    // When / Then
+    await expect(harness.executor.prepareFindingReviewPublication({
+      step: harness.step,
+      executableStep: harness.step,
+      reviewerOutputStrategy: PLAIN_TEXT_NORMALIZED_STRATEGY,
+      parentStepName: 'reviewers',
+      stepIteration: 1,
+      state: harness.state,
+      phase1Response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: 'phase 1 investigation',
+        timestamp: new Date('2026-07-31T00:00:00.000Z'),
+      },
+      agentOptions: { resolvedProvider: 'mock' },
+      onProviderAttempt: vi.fn(),
+      updatePersonaSession: harness.updatePersonaSession,
+    })).rejects.toThrow('extraction-fidelity correction failed');
+    expect(harness.normalizeFindingIntake).toHaveBeenCalledTimes(2);
+  });
+
+  it('should correct a structured reviewer publication once when its candidate is null', async () => {
+    // Given: structured 戦略（normalizer なし）でも同じ退行を1回訂正へ載せる
+    const harness = createPlainTextPublicationHarness(
+      [],
+      PLAIN_TEXT_REPORT_CONTENT,
+      undefined,
+      undefined,
+      {
+        mode: 'structured',
+        agentResponses: [
+          {
+            persona: 'reviewer',
+            status: 'done',
+            content: '',
+            sessionId: 'reviewer-report-session',
+            structuredOutput: {
+              reportContent: PLAIN_TEXT_REPORT_CONTENT,
+              rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: null }],
+            },
+            timestamp: new Date('2026-07-31T00:00:00.000Z'),
+          },
+          {
+            persona: 'reviewer',
+            status: 'done',
+            content: '',
+            sessionId: 'reviewer-report-session',
+            structuredOutput: {
+              reportContent: PLAIN_TEXT_REPORT_CONTENT,
+              rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE }],
+            },
+            timestamp: new Date('2026-07-31T00:00:01.000Z'),
+          },
+        ],
+      },
+    );
+
+    // When
+    const result = await harness.executor.prepareFindingReviewPublication({
+      step: harness.step,
+      executableStep: harness.step,
+      reviewerOutputStrategy: STRUCTURED_STRATEGY,
+      parentStepName: 'reviewers',
+      stepIteration: 1,
+      state: harness.state,
+      phase1Response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: 'phase 1 investigation',
+        timestamp: new Date('2026-07-31T00:00:00.000Z'),
+      },
+      agentOptions: { resolvedProvider: 'mock' },
+      onProviderAttempt: vi.fn(),
+      updatePersonaSession: harness.updatePersonaSession,
+    });
+
+    // Then
+    expect('publication' in result).toBe(true);
+    if (!('publication' in result)) {
+      throw new Error('Expected publication');
+    }
+    expect(result.publication.rawFindings).toEqual([
+      { rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE },
+    ]);
+    expect(vi.mocked(executeAgent)).toHaveBeenCalledTimes(2);
+    expect(harness.normalizeFindingIntake).not.toHaveBeenCalled();
+  });
+
+  it('should fail loudly when a structured reviewer publication keeps a null candidate after the correction', async () => {
+    // Given
+    const publicationResponse = {
+      persona: 'reviewer',
+      status: 'done' as const,
+      content: '',
+      sessionId: 'reviewer-report-session',
+      structuredOutput: {
+        reportContent: PLAIN_TEXT_REPORT_CONTENT,
+        rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: null }],
+      },
+      timestamp: new Date('2026-07-31T00:00:00.000Z'),
+    };
+    const harness = createPlainTextPublicationHarness(
+      [],
+      PLAIN_TEXT_REPORT_CONTENT,
+      undefined,
+      undefined,
+      {
+        mode: 'structured',
+        agentResponses: [publicationResponse, publicationResponse],
+      },
+    );
+
+    // When / Then
+    await expect(harness.executor.prepareFindingReviewPublication({
+      step: harness.step,
+      executableStep: harness.step,
+      reviewerOutputStrategy: STRUCTURED_STRATEGY,
+      parentStepName: 'reviewers',
+      stepIteration: 1,
+      state: harness.state,
+      phase1Response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: 'phase 1 investigation',
+        timestamp: new Date('2026-07-31T00:00:00.000Z'),
+      },
+      agentOptions: { resolvedProvider: 'mock' },
+      onProviderAttempt: vi.fn(),
+      updatePersonaSession: harness.updatePersonaSession,
+    })).rejects.toThrow(/remained invalid after one correction/u);
+    expect(vi.mocked(executeAgent)).toHaveBeenCalledTimes(2);
   });
 
   it('plain-text normalizerの65件出力はcorrectionを消費せず64件とoverflow記録へ着地する', async () => {
@@ -1359,7 +1604,7 @@ describe('StepExecutor', () => {
   }) => {
     const corrected = {
       rawExcerpt: 'Issue: src/example.ts still bypasses the required boundary.',
-      candidate: null,
+      candidate: COMPLETE_CANDIDATE,
     };
     const harness = createPlainTextPublicationHarness([
       {
@@ -1429,7 +1674,7 @@ describe('StepExecutor', () => {
         structuredOutput: {
           rawFindings: [{
             rawExcerpt: 'Issue: src/example.ts still bypasses the required boundary.',
-            candidate: null,
+            candidate: COMPLETE_CANDIDATE,
           }],
         },
         timestamp: new Date('2026-07-31T00:00:02.000Z'),

--- a/src/__tests__/step-executor.test.ts
+++ b/src/__tests__/step-executor.test.ts
@@ -745,6 +745,68 @@ describe('StepExecutor', () => {
     ]);
   });
 
+  it('should fire the extraction-fidelity correction when the normalizer returns an incomplete candidate', async () => {
+    // Given: candidate object はあるが必須項目を欠く（reviewer projection が null へ畳む形）
+    const harness = createPlainTextPublicationHarness([
+      {
+        persona: 'default',
+        status: 'done',
+        content: '{}',
+        structuredOutput: {
+          rawFindings: [{
+            rawExcerpt: CLAIM_EXCERPT,
+            candidate: { description: 'src/example.ts still bypasses the required boundary.' },
+          }],
+        },
+        timestamp: new Date('2026-07-31T00:00:01.000Z'),
+      },
+      {
+        persona: 'default',
+        status: 'done',
+        content: '{}',
+        structuredOutput: {
+          rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE }],
+        },
+        timestamp: new Date('2026-07-31T00:00:02.000Z'),
+      },
+    ]);
+
+    // When
+    const result = await harness.executor.prepareFindingReviewPublication({
+      step: harness.step,
+      executableStep: harness.step,
+      reviewerOutputStrategy: PLAIN_TEXT_NORMALIZED_STRATEGY,
+      parentStepName: 'reviewers',
+      stepIteration: 1,
+      state: harness.state,
+      phase1Response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: 'phase 1 investigation',
+        timestamp: new Date('2026-07-31T00:00:00.000Z'),
+      },
+      agentOptions: { resolvedProvider: 'mock' },
+      onProviderAttempt: vi.fn(),
+      updatePersonaSession: harness.updatePersonaSession,
+    });
+
+    // Then
+    expect('publication' in result).toBe(true);
+    if (!('publication' in result)) {
+      throw new Error('Expected publication');
+    }
+    expect(result.publication.rawFindings).toEqual([
+      { rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE },
+    ]);
+    expect(harness.normalizeFindingIntake.mock.calls.map(([, options]) => {
+      const typed = options as { mode: string; extractionFidelityCorrection?: boolean };
+      return { mode: typed.mode, extractionFidelityCorrection: typed.extractionFidelityCorrection };
+    })).toEqual([
+      { mode: 'initial', extractionFidelityCorrection: false },
+      { mode: 'correction', extractionFidelityCorrection: true },
+    ]);
+  });
+
   it('should not publish when the normalizer keeps returning a null candidate after the correction', async () => {
     // Given
     const nullCandidateFinding = { rawExcerpt: CLAIM_EXCERPT, candidate: null };
@@ -851,6 +913,75 @@ describe('StepExecutor', () => {
     ]);
     expect(vi.mocked(executeAgent)).toHaveBeenCalledTimes(2);
     expect(harness.normalizeFindingIntake).not.toHaveBeenCalled();
+  });
+
+  it('should correct a structured reviewer publication once when its candidate is incomplete', async () => {
+    // Given
+    const harness = createPlainTextPublicationHarness(
+      [],
+      PLAIN_TEXT_REPORT_CONTENT,
+      undefined,
+      undefined,
+      {
+        mode: 'structured',
+        agentResponses: [
+          {
+            persona: 'reviewer',
+            status: 'done',
+            content: '',
+            sessionId: 'reviewer-report-session',
+            structuredOutput: {
+              reportContent: PLAIN_TEXT_REPORT_CONTENT,
+              rawFindings: [{
+                rawExcerpt: CLAIM_EXCERPT,
+                candidate: { description: 'src/example.ts still bypasses the required boundary.' },
+              }],
+            },
+            timestamp: new Date('2026-07-31T00:00:00.000Z'),
+          },
+          {
+            persona: 'reviewer',
+            status: 'done',
+            content: '',
+            sessionId: 'reviewer-report-session',
+            structuredOutput: {
+              reportContent: PLAIN_TEXT_REPORT_CONTENT,
+              rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE }],
+            },
+            timestamp: new Date('2026-07-31T00:00:01.000Z'),
+          },
+        ],
+      },
+    );
+
+    // When
+    const result = await harness.executor.prepareFindingReviewPublication({
+      step: harness.step,
+      executableStep: harness.step,
+      reviewerOutputStrategy: STRUCTURED_STRATEGY,
+      parentStepName: 'reviewers',
+      stepIteration: 1,
+      state: harness.state,
+      phase1Response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: 'phase 1 investigation',
+        timestamp: new Date('2026-07-31T00:00:00.000Z'),
+      },
+      agentOptions: { resolvedProvider: 'mock' },
+      onProviderAttempt: vi.fn(),
+      updatePersonaSession: harness.updatePersonaSession,
+    });
+
+    // Then
+    expect('publication' in result).toBe(true);
+    if (!('publication' in result)) {
+      throw new Error('Expected publication');
+    }
+    expect(result.publication.rawFindings).toEqual([
+      { rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE },
+    ]);
+    expect(vi.mocked(executeAgent)).toHaveBeenCalledTimes(2);
   });
 
   it('should fail loudly when a structured reviewer publication keeps a null candidate after the correction', async () => {

--- a/src/core/models/finding-schemas.ts
+++ b/src/core/models/finding-schemas.ts
@@ -3089,7 +3089,10 @@ const RawFindingsOutputIntakeJsonSchema = {
           },
           candidate: {
             anyOf: [
-              { type: 'null' },
+              {
+                type: 'null',
+                description: 'Use null ONLY when the rawExcerpt does not state a problem or lifecycle claim. Whenever the rawExcerpt states a claim, emit the candidate object instead: leave unstated scalars null and unstated lists empty. A null candidate discards the claim entirely and is rejected.',
+              },
               {
                 type: 'object',
                 additionalProperties: false,

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -88,6 +88,10 @@ import {
   withFindingContractStructuredOutput,
 } from '../findings/contract-intake.js';
 import { resolveFindingContractReviewerOutputStrategy } from '../findings/reviewer-output-strategy.js';
+import {
+  EXTRACTION_FIDELITY_INVALID_DETAIL,
+  hasRawFindingExtractionFidelityFailure,
+} from '../findings/extraction-fidelity.js';
 import { clarifyAmbiguousRawRelationsOnce, type ReviewerRelationClarification } from '../findings/relation-coherence.js';
 import {
   RAW_FINDINGS_SCHEMA_REF,
@@ -826,30 +830,8 @@ export class StepExecutor {
       }
     };
 
-    const hasExtractionFidelityFailure = (response: AgentResponse): boolean => {
-      const rawFindings = response.structuredOutput;
-      if (
-        typeof rawFindings !== 'object'
-        || rawFindings === null
-        || Array.isArray(rawFindings)
-        || !Array.isArray(Reflect.get(rawFindings, 'rawFindings'))
-      ) {
-        return false;
-      }
-      return (Reflect.get(rawFindings, 'rawFindings') as unknown[]).some((item) => {
-        if (typeof item !== 'object' || item === null || Array.isArray(item)) {
-          return false;
-        }
-        const rawExcerpt = Reflect.get(item, 'rawExcerpt');
-        const candidate = Reflect.get(item, 'candidate');
-        return typeof rawExcerpt === 'string'
-          && rawExcerpt.length > 0
-          && typeof candidate === 'object'
-          && candidate !== null
-          && !Array.isArray(candidate)
-          && Reflect.get(candidate, 'description') === null;
-      });
-    };
+    const hasExtractionFidelityFailure = (response: AgentResponse): boolean =>
+      hasRawFindingExtractionFidelityFailure(response.structuredOutput);
 
     const initial = await execute('initial');
     const extractionFidelityFailure = initial.invalidDetail === undefined
@@ -1281,7 +1263,7 @@ export class StepExecutor {
       normalizerProviderInfo = plainNormalization.providerInfo;
       normalizedPlainPublication = plainNormalization.publication;
     } else {
-      normalized = this.normalizeStructuredOutputWithDiagnostics(
+      normalized = this.normalizeStructuredOutputWithExtractionFidelity(
         reportStep,
         reportResponse,
         reportRuntime,
@@ -1309,7 +1291,7 @@ export class StepExecutor {
             sessionId: report.attemptIdentity.sessionId,
           },
         ),
-        normalize: (candidate) => this.normalizeStructuredOutputWithDiagnostics(
+        normalize: (candidate) => this.normalizeStructuredOutputWithExtractionFidelity(
           reportStep,
           candidate,
           reportRuntime,
@@ -1476,6 +1458,33 @@ export class StepExecutor {
       );
     }
     return result.response;
+  }
+
+  /**
+   * structured reviewer 経路（reviewer が publication を直接返す）用。schema 検証を
+   * 通ったあとに抽出忠実性の退行（非空 rawExcerpt に対して candidate が使えない）を
+   * model_output の不正として立てる。これで isolated normalizer 経路と同じく既存の
+   * 1回訂正が発火し、訂正後もなお退行していれば呼び出し側の fail-loud 契約
+   * （invalidDetail での throw / "remained invalid after one correction"）へ載る。
+   */
+  private normalizeStructuredOutputWithExtractionFidelity(
+    step: WorkflowStep,
+    response: AgentResponse,
+    runtime?: RuntimeStepResolution,
+  ): StructuredOutputNormalizationResult {
+    const result = this.normalizeStructuredOutputWithDiagnostics(step, response, runtime);
+    if (
+      result.invalidDetail !== undefined
+      || result.response.status !== 'done'
+      || !hasRawFindingExtractionFidelityFailure(result.response.structuredOutput)
+    ) {
+      return result;
+    }
+    return {
+      ...result,
+      invalidDetail: EXTRACTION_FIDELITY_INVALID_DETAIL,
+      invalidKind: 'model_output',
+    };
   }
 
   /**

--- a/src/core/workflow/findings/extraction-fidelity.ts
+++ b/src/core/workflow/findings/extraction-fidelity.ts
@@ -1,0 +1,62 @@
+/**
+ * 抽出忠実性（extraction fidelity）の退行検出。
+ *
+ * 非空の `rawExcerpt` は claim 本文が抽出できたことを意味するのに、同じ item の
+ * `candidate` 側が claim を失っている状態を「モデル出力の退行」として扱う。
+ * schema は candidate の null を許すため post-hoc 検証では捕まらず、canonicalization
+ * まで進んだあと `Normalizer extraction candidate is null or has no canonicalizable
+ * target` として protocol anomaly に落ちる — つまり訂正も fail-loud もないまま
+ * レビュー主張が黙って消える。ここで検出して既存の1回訂正へ載せる。
+ *
+ * 検出対象は projection 後の item 形（`{ rawExcerpt, candidate }`）で判定する。
+ * `projectReviewerRawStructuredOutputWithEnvelope` は不完全・不正な candidate を
+ * すべて `candidate: null` へ畳むため、次の2形態がまとめて対象になる。
+ *
+ * - candidate 自体が null（全欠け）
+ * - candidate object が必須フィールドを欠く／形が不正（projection で null へ畳まれる）
+ *
+ * candidate は完全だが `description` だけ null という半欠けも、同じく claim 本文を
+ * 失っているので対象に含める。
+ */
+
+export const EXTRACTION_FIDELITY_INVALID_DETAIL =
+  'Reviewer raw finding intake lost the claim: an item has a non-empty rawExcerpt but no usable candidate';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function itemLostTheClaim(item: unknown): boolean {
+  if (!isPlainObject(item)) {
+    return false;
+  }
+  const rawExcerpt = Reflect.get(item, 'rawExcerpt');
+  if (typeof rawExcerpt !== 'string' || rawExcerpt.length === 0) {
+    return false;
+  }
+  const candidate = Reflect.get(item, 'candidate');
+  if (candidate === null || candidate === undefined) {
+    return true;
+  }
+  if (!isPlainObject(candidate)) {
+    return false;
+  }
+  return Reflect.get(candidate, 'description') === null;
+}
+
+/**
+ * `{ rawFindings: [...] }` を含む構造化出力（raw findings / publication のどちらでも
+ * 同じ形）を受け取り、抽出忠実性の退行が1件でもあれば true を返す。
+ */
+export function hasRawFindingExtractionFidelityFailure(
+  structuredOutput: unknown,
+): boolean {
+  if (!isPlainObject(structuredOutput)) {
+    return false;
+  }
+  const rawFindings = Reflect.get(structuredOutput, 'rawFindings');
+  if (!Array.isArray(rawFindings)) {
+    return false;
+  }
+  return rawFindings.some(itemLostTheClaim);
+}

--- a/src/shared/prompts/en/parts/finding_intake_normalization.md
+++ b/src/shared/prompts/en/parts/finding_intake_normalization.md
@@ -54,9 +54,12 @@ Extraction rules:
 
 {{#if correction}}The previous extraction failed schema or mechanical intake validation, or lost the
 claim text while `rawExcerpt` was available. Perform one fresh extraction from the same report.
-{{#if extractionFidelityCorrection}}For the extraction-fidelity case only, this exception overrides rule 3 for `candidate.description` alone: when a non-empty `rawExcerpt` states a claim and the candidate
-has `description: null`, copy that exact `rawExcerpt` into `candidate.description`. Rule 3 still applies to every other field.
-{{/if}}Do not generate or improve any other field. Do not reuse, discuss, or repair the previous output.
+{{/if}}{{#if extractionFidelityCorrection}}For the extraction-fidelity case only, this exception overrides rule 3 for the candidate itself: whenever a non-empty `rawExcerpt` states a claim, that item MUST carry a
+complete `candidate` object. `candidate: null` and a candidate missing any required field are both
+rejected. If the previous candidate was `null` or incomplete, rebuild it from that same `rawExcerpt`
+alone, leaving unstated scalars `null` and unstated lists `[]`. When the candidate has
+`description: null`, copy that exact `rawExcerpt` into `candidate.description`. Rule 3 still applies to every other field.
+{{/if}}{{#if correction}}Do not generate or improve any other field. Do not reuse, discuss, or repair the previous output.
 
 {{/if}}## Review report
 

--- a/src/shared/prompts/ja/parts/finding_intake_normalization.md
+++ b/src/shared/prompts/ja/parts/finding_intake_normalization.md
@@ -47,11 +47,15 @@ schema に一致する JSON object を1つだけ返してください。説明�
 
 {{#if correction}}前回の抽出は schema または機械 intake 検証に失敗したか、`rawExcerpt` があるのに
 claim本文を失いました。同じ報告から新規に1回だけ抽出してください。
-{{#if extractionFidelityCorrection}}extraction-fidelity の場合に限り、この例外は規則3を
-`candidate.description` だけについて上書きします。非空の `rawExcerpt` が claim を記述し candidate の
-`description: null` になっているときは、その `rawExcerpt` 全体を `candidate.description` にそのままコピーしてください。
+{{/if}}{{#if extractionFidelityCorrection}}extraction-fidelity の場合に限り、この例外は規則3を
+candidate 自体について上書きします。非空の `rawExcerpt` が claim を記述している item は、必ず
+完全な `candidate` object を持たなければなりません。`candidate: null` も、必須フィールドを欠いた
+candidate も拒否されます。前回の candidate が `null` または不完全だった場合は、その同じ
+`rawExcerpt` だけを根拠に candidate を組み直し、明示されていない scalar は `null`、明示されていない
+list は `[]` にしてください。candidate の `description: null` になっているときは、その
+`rawExcerpt` 全体を `candidate.description` にそのままコピーしてください。
 規則3は他のすべての項目に適用されます。
-{{/if}}他の項目の生成・改善は
+{{/if}}{{#if correction}}他の項目の生成・改善は
 禁止です。前回出力の再利用、議論、修復は禁止です。
 
 {{/if}}## レビュー報告


### PR DESCRIPTION
## 症状(実走 run-4/6)

弱いモデル(gemma/glm)のレビュー抽出が「実クレーム入り rawExcerpt + candidate: null」を返し、全claimが protocol-anomaly 化して findings 0 になる。

## 根本原因

- スキーマの candidate null 枝が説明なしの無コスト合法解で、object 枝は11フィールド必須 — 弱いモデルは合理的に null へ逃げる
- candidate 全 null は extraction-fidelity 検出(description のみ null しか見ない)に掛からず、1回訂正も fail-loud もなく素通り
- 加えてプロンプトの入れ子 {{#if}} が faceted-prompting 非対応で literal が漏れ、訂正例外文が常時付与されていた

## 修正

- 共有判定器 extraction-fidelity.ts: 「非空 rawExcerpt + candidate null/不完全」を model_output 不正として normalizer/structured 両経路で既存1回訂正へ。訂正後も残れば既存契約どおり fail-loud
- プロンプト条件分岐を兄弟条件へ組み替え(en/ja)、schema null 枝へ使用条件の description 追記

## 検証
新規6+再現4テスト、finding-* 非IT 62ファイル970テスト green、tsc/lint/build green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 抽出元の記載（rawExcerpt）があるにもかかわらず、候補情報が欠落・不完全になるケースを検出するよう改善しました。
  - 不完全または空の候補を、抽出元の記載をもとに必須項目まで補完・再構築します。
  - 補正後も不正な出力が続く場合は公開を拒否し、品質を維持します。
  - 構造化されたレビュー結果にも同じ検証と自動補正を適用しました。

- **ドキュメント**
  - 候補を空にできる条件と、抽出元の記載を保持するルールを明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->