### PR TITLE
feat: development-coreにreplanステップを追加しneed_replanのフル再走を解消する

### DIFF
--- a/builtins/en/workflows/development-core.yaml
+++ b/builtins/en/workflows/development-core.yaml
@@ -16,6 +16,10 @@ subworkflow:
       type: facet_ref
       facet_kind: instruction
       default: plan
+    replan_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: replan-implementation
     testing_policy:
       type: facet_ref[]
       facet_kind: policy
@@ -84,6 +88,31 @@ steps:
       - condition: Requirements are unclear or information is insufficient
         next: ABORT
 
+  - name: replan
+    tags: [plan]
+    edit: false
+    persona: planner
+    policy:
+      - contract-change
+      - $param: plan_policy
+    knowledge:
+      $param: plan_knowledge
+    provider_options:
+      extends: review-readonly
+    instruction:
+      $param: replan_instruction
+    output_contracts:
+      report:
+        - name: plan.md
+          format: plan
+    rules:
+      - condition: An actionable, untried project-scoped change or investigation and its verification steps were defined
+        next: implement
+      - condition: The current implementation meets the requirements and acceptance criteria, required project-scoped verification is complete, and no untried change or investigation remains
+        next: peer-review
+      - condition: Confirmed evidence shows that project-scoped changes or investigation cannot resolve the issue, leaving only external action or mutually unsatisfiable requirements
+        next: ABORT
+
   - name: write_tests
     uses: development-core-write-tests
     with:
@@ -120,7 +149,7 @@ steps:
       - condition: Implementation not started (report only)
         next: peer-review
       - condition: Unable to proceed with implementation
-        next: plan
+        next: replan
       - condition: User input is required
         next: implement
         requires_user_input: true
@@ -149,6 +178,6 @@ steps:
       - condition: COMPLETE
         next: COMPLETE
       - condition: need_replan
-        next: plan
+        next: replan
       - condition: ABORT
         next: ABORT

--- a/builtins/en/workflows/takt-default-fc.yaml
+++ b/builtins/en/workflows/takt-default-fc.yaml
@@ -26,6 +26,7 @@ steps:
       development_policy: [coding, testing]
       development_knowledge: [takt, architecture, task-decomposition]
       implementation_instruction: implement
+      replan_instruction: replan-implementation-finding-contract
       reviewer_suite: peer-review-suite-finding-contract-base
       peer_review_workflow: peer-review-finding-contract
       review_policy: [coding, testing, review]

--- a/builtins/en/workflows/takt-default-localllm.yaml
+++ b/builtins/en/workflows/takt-default-localllm.yaml
@@ -19,6 +19,7 @@ steps:
       development_policy: [coding, testing]
       development_knowledge: [takt, architecture, task-decomposition]
       implementation_instruction: team-leader-implement
+      replan_instruction: replan-implementation-finding-contract
       peer_review_workflow: peer-review-finding-contract-localllm
       review_policy: [coding, testing, review]
       review_knowledge: [takt, architecture, implementation-semantics, unit-testing, e2e-testing]

--- a/builtins/ja/workflows/development-core.yaml
+++ b/builtins/ja/workflows/development-core.yaml
@@ -16,6 +16,10 @@ subworkflow:
       type: facet_ref
       facet_kind: instruction
       default: plan
+    replan_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: replan-implementation
     testing_policy:
       type: facet_ref[]
       facet_kind: policy
@@ -84,6 +88,31 @@ steps:
       - condition: 要件が不明確、情報不足
         next: ABORT
 
+  - name: replan
+    tags: [plan]
+    edit: false
+    persona: planner
+    policy:
+      - contract-change
+      - $param: plan_policy
+    knowledge:
+      $param: plan_knowledge
+    provider_options:
+      extends: review-readonly
+    instruction:
+      $param: replan_instruction
+    output_contracts:
+      report:
+        - name: plan.md
+          format: plan
+    rules:
+      - condition: プロジェクト内で実行可能な未試行の変更または原因調査と、その検証手順を具体化した
+        next: implement
+      - condition: 現行実装が要件・受入条件を満たし、必要なプロジェクト内検証が完了し、未試行の変更・調査が残っていない
+        next: peer-review
+      - condition: 確認済みの根拠により、プロジェクト内の変更や調査では解消できず、外部操作だけが残るか要件が両立不能である
+        next: ABORT
+
   - name: write_tests
     uses: development-core-write-tests
     with:
@@ -120,7 +149,7 @@ steps:
       - condition: 実装未着手（レポートのみ）
         next: peer-review
       - condition: 実装を進行できない
-        next: plan
+        next: replan
       - condition: ユーザー入力が必要
         next: implement
         requires_user_input: true
@@ -149,6 +178,6 @@ steps:
       - condition: COMPLETE
         next: COMPLETE
       - condition: need_replan
-        next: plan
+        next: replan
       - condition: ABORT
         next: ABORT

--- a/builtins/ja/workflows/takt-default-fc.yaml
+++ b/builtins/ja/workflows/takt-default-fc.yaml
@@ -26,6 +26,7 @@ steps:
       development_policy: [coding, testing]
       development_knowledge: [takt, architecture, task-decomposition]
       implementation_instruction: implement
+      replan_instruction: replan-implementation-finding-contract
       reviewer_suite: peer-review-suite-finding-contract-base
       peer_review_workflow: peer-review-finding-contract
       review_policy: [coding, testing, review]

--- a/builtins/ja/workflows/takt-default-localllm.yaml
+++ b/builtins/ja/workflows/takt-default-localllm.yaml
@@ -19,6 +19,7 @@ steps:
       development_policy: [coding, testing]
       development_knowledge: [takt, architecture, task-decomposition]
       implementation_instruction: team-leader-implement
+      replan_instruction: replan-implementation-finding-contract
       peer_review_workflow: peer-review-finding-contract-localllm
       review_policy: [coding, testing, review]
       review_knowledge: [takt, architecture, implementation-semantics, unit-testing, e2e-testing]

--- a/src/__tests__/takt-default-fc-builtins.test.ts
+++ b/src/__tests__/takt-default-fc-builtins.test.ts
@@ -340,11 +340,12 @@ afterEach(() => {
 });
 
 describe('takt-default-fc builtins', () => {
-  it.each(LANGUAGES)('%s root owns FC and changes only peer-review call arguments', (language) => {
+  it.each(LANGUAGES)('%s root owns FC and changes only FC-specialized call arguments', (language) => {
     const standard = rawStep(readWorkflow(language, 'takt-default'), 'develop');
     const fc = rawStep(readWorkflow(language, 'takt-default-fc'), 'develop');
     expect(fc.args).toEqual({
       ...standard.args,
+      replan_instruction: 'replan-implementation-finding-contract',
       reviewer_suite: 'peer-review-suite-finding-contract-base',
       peer_review_workflow: 'peer-review-finding-contract',
     });

--- a/src/__tests__/workflow-step-fragment-builtin-runtime.test.ts
+++ b/src/__tests__/workflow-step-fragment-builtin-runtime.test.ts
@@ -803,6 +803,52 @@ describe('builtin workflow step fragment migration', () => {
     }
   });
 
+  it.each(LANGUAGES)('routes %s development-core rework through replan instead of a full replan-from-plan', (lang) => {
+    mkdirSync(join(projectDir, '.takt'), { recursive: true });
+    writeFileSync(join(projectDir, '.takt', 'config.yaml'), 'language: ' + lang + '\n', 'utf-8');
+    invalidateAllResolvedConfigCache();
+
+    const raw = readBuiltinWorkflow(lang, 'development-core');
+    const replan = getStep(raw, 'replan');
+    // Defined inline: the subworkflow param type system cannot parameterize `uses:`,
+    // so the FC instruction variant is selected through the instruction facet_ref param.
+    expect(replan.uses).toBeUndefined();
+    expect(replan).toMatchObject({
+      persona: 'planner',
+      edit: false,
+      instruction: { $param: 'replan_instruction' },
+      knowledge: { $param: 'plan_knowledge' },
+      output_contracts: { report: [{ name: 'plan.md', format: 'plan' }] },
+    });
+    expect(replan.policy).toEqual(['contract-change', { $param: 'plan_policy' }]);
+    expect((replan.rules as RawRule[]).map((rule) => rule.next))
+      .toEqual(['implement', 'peer-review', 'ABORT']);
+
+    const nextTargets = (stepName: string): (string | undefined)[] =>
+      (getStep(raw, stepName).rules as RawRule[]).map((rule) => rule.next);
+    expect(nextTargets('implement')).toContain('replan');
+    expect(nextTargets('implement')).not.toContain('plan');
+    expect(nextTargets('peer-review')).toContain('replan');
+    expect(nextTargets('peer-review')).not.toContain('plan');
+    // write_tests keeps its escalation to the full plan step.
+    expect(nextTargets('write_tests')).toContain('plan');
+
+    const workflowPath = join(getBuiltinWorkflowsDir(lang), 'development-core.yaml');
+    const loaded = loadWorkflowFromFile(workflowPath, projectDir);
+    const loadedReplan = loaded.steps.find((step) => step.name === 'replan');
+    expect(loadedReplan).toMatchObject({ persona: 'planner', edit: false });
+    expect(loadedReplan?.outputContracts?.[0]).toMatchObject({ name: 'plan.md', formatRef: 'plan' });
+    expect(loadedReplan?.instruction?.trim().length ?? 0).toBeGreaterThan(0);
+
+    invalidateAllResolvedConfigCache();
+    const fcLoaded = loadWorkflowFromFile(workflowPath, projectDir, {
+      callableArgs: { replan_instruction: 'replan-implementation-finding-contract' },
+    });
+    const fcReplan = fcLoaded.steps.find((step) => step.name === 'replan');
+    expect(fcReplan?.instruction).not.toBe(loadedReplan?.instruction);
+    expect(fcReplan?.instruction?.trim().length ?? 0).toBeGreaterThan(0);
+  });
+
   it.each(LANGUAGES)('loads %s lightweight development routines with resolved runtime report contracts', (lang) => {
     mkdirSync(join(projectDir, '.takt'), { recursive: true });
     writeFileSync(join(projectDir, '.takt', 'config.yaml'), 'language: ' + lang + '\n', 'utf-8');


### PR DESCRIPTION
## 背景

development-core (takt-default / takt-default-fc / takt-default-localllm の共通中核) には replan ステップがなく、peer-review が need_replan を返すたびに plan→write_tests→implement をフル再走していた。実走行(takt-default-fc ベンチ)で plan/write_tests/implement が11周する事象を確認。takt-default-high 系には replan ステップが既に存在する。

## 変更内容

- development-core (ja/en) に replan ステップを**インライン定義**で追加
  - subworkflow param 型は facet_ref / facet_ref[] / workflow_ref のみで `uses:` はパラメータ化できないため、ステップ断片の新設ではなくインライン定義とし、FC変種の選択は instruction の facet_ref param (`replan_instruction`, default: `replan-implementation`) で行う
  - ルール: 未試行の変更・調査を具体化→implement / 現行実装が要件充足・検証済み→peer-review 直行 / プロジェクト内で解消不能→ABORT
- `peer-review: need_replan → replan`、`implement: 進行できない → replan` に付け替え (write_tests→plan は維持)
- takt-default-fc / takt-default-localllm (ja/en) は `replan_instruction: replan-implementation-finding-contract` を渡す (facet は既存の標準/FC変種ペアをそのまま使用、新規facetなし)

## テスト

- workflow-step-fragment-builtin-runtime に構造テスト追加: インライン定義 ($param配線・uses不在)、implement/peer-review が plan でなく replan へ行くこと、FC変種引数で別インストラクションが解決されること (ja/en)
- takt-default-fc-builtins の args 厳密比較へ `replan_instruction` を追加
- 影響対象テスト group 実行 all green (unit/IT)、lint クリーン

## 備考

- development-core には loop_monitors が元々ないため replan⇄implement の往復監視は CycleDetector / max_steps 任せ。monitor 追加は別途判断

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 開発ワークフローに、実装やレビューで問題が発生した際の再計画ステップを追加しました。
  * 再計画後に、実装、ピアレビュー、または中止へ適切に進めるようになりました。
  * Finding Contract向けの再計画指示に対応しました。
* **テスト**
  * 再計画時の遷移と指示の解決を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->