### PR TITLE
fix: withdrawal settlementへ全観測者のpublicationを記録し監査完全性を担保する

### DIFF
--- a/src/__tests__/finding-contract-phase1.test.ts
+++ b/src/__tests__/finding-contract-phase1.test.ts
@@ -8,6 +8,7 @@ import { createEmptyFindingContractRegistries } from '../core/models/finding-con
 import { collectFindingLedgerProjectionInvariantViolations } from '../core/models/finding-ledger-invariants.js';
 import { canonicalJson } from '../shared/utils/canonical-json.js';
 import { FindingLedgerSchema } from '../core/models/finding-schemas.js';
+import { assertFindingLedgerAppendOnlyTransition } from '../core/workflow/findings/finding-integrity.js';
 import {
   dispatchFindingManagerProviderCall,
   reserveFindingManagerProviderCall,
@@ -36,6 +37,57 @@ function emptyLedger() {
   };
 }
 
+function withdrawnAnomaly(
+  supersedingPublications: Array<{ reviewer: string; publicationId: string }>,
+  reviewers = ['arch-review', 'security-review'],
+) {
+  return {
+    id: 'RA-000000000001',
+    kind: 'quote-mismatch' as const,
+    stableKey: 'a'.repeat(64),
+    lineageKey: 'b'.repeat(64),
+    sourceRawFindingIds: [],
+    sourceIntakeIds: ['intake-1'],
+    reviewers,
+    title: 'Unverifiable reviewer claim',
+    mismatchReason: 'the quoted excerpt does not exist',
+    firstObserved: observedAt,
+    lastObserved: observedAt,
+    occurrences: 1,
+    settlement: {
+      kind: 'withdrawn_by_subsequent_review' as const,
+      supersedingPublications,
+      decidedAt: observedAt,
+    },
+  };
+}
+
+/** 観測者 arch-review / security-review 全員分の根拠（binary 順）。 */
+function completeWithdrawalPublications(): Array<{ reviewer: string; publicationId: string }> {
+  return [
+    { reviewer: 'arch-review', publicationId: 'c'.repeat(64) },
+    { reviewer: 'security-review', publicationId: 'd'.repeat(64) },
+  ];
+}
+
+/** 決着前（未決着）の台帳。append-only 遷移検証の起点に使う。 */
+function outstandingWithdrawalLedger() {
+  const { settlement: _settlement, ...withoutSettlement } = withdrawnAnomaly(
+    completeWithdrawalPublications(),
+  );
+  return { ...emptyLedger(), reviewerAnomalies: [withoutSettlement] };
+}
+
+function withdrawalInvariantMessages(
+  supersedingPublications: Array<{ reviewer: string; publicationId: string }>,
+  reviewers?: string[],
+): string[] {
+  return collectFindingLedgerProjectionInvariantViolations({
+    ...emptyLedger(),
+    reviewerAnomalies: [withdrawnAnomaly(supersedingPublications, reviewers)],
+  } as never).map(({ message }) => message);
+}
+
 describe('Finding Contract phase 1', () => {
   it('requires every contract registry without defaults', () => {
     const ledger = emptyLedger();
@@ -57,67 +109,92 @@ describe('Finding Contract phase 1', () => {
       .toContain('Interpretation outcome for "raw-unknown" has an unknown kind');
   });
 
-  it('取り下げ settlement は観測者全員分の根拠を要求する（部分集合・過剰・空・重複を拒否）', () => {
-    const withdrawnAnomaly = (
-      supersedingPublications: Array<{ reviewer: string; publicationId: string }>,
-      reviewers = ['arch-review', 'security-review'],
-    ) => ({
-      id: 'RA-000000000001',
-      kind: 'quote-mismatch' as const,
-      stableKey: 'a'.repeat(64),
-      lineageKey: 'b'.repeat(64),
-      sourceRawFindingIds: [],
-      sourceIntakeIds: ['intake-1'],
-      reviewers,
-      title: 'Unverifiable reviewer claim',
-      mismatchReason: 'the quoted excerpt does not exist',
-      firstObserved: observedAt,
-      lastObserved: observedAt,
-      occurrences: 1,
-      settlement: {
-        kind: 'withdrawn_by_subsequent_review' as const,
-        supersedingPublications,
-        decidedAt: observedAt,
-      },
-    });
-    const invariantMessages = (anomaly: ReturnType<typeof withdrawnAnomaly>) => (
-      collectFindingLedgerProjectionInvariantViolations({
-        ...emptyLedger(),
-        reviewerAnomalies: [anomaly],
-      } as never).map(({ message }) => message)
-    );
-    const complete = [
-      { reviewer: 'arch-review', publicationId: 'c'.repeat(64) },
-      { reviewer: 'security-review', publicationId: 'd'.repeat(64) },
-    ];
-
-    // 観測者全員分が揃っていれば適格。
-    expect(invariantMessages(withdrawnAnomaly(complete))).toEqual([]);
+  it('取り下げ settlement は観測者全員分の根拠が揃えば適格', () => {
+    expect(withdrawalInvariantMessages(completeWithdrawalPublications())).toEqual([]);
     expect(() => FindingLedgerSchema.parse({
       ...emptyLedger(),
-      reviewerAnomalies: [withdrawnAnomaly(complete)],
+      reviewerAnomalies: [withdrawnAnomaly(completeWithdrawalPublications())],
     })).not.toThrow();
+  });
 
-    // 部分集合（1人分だけ）は不変条件違反。
-    expect(invariantMessages(withdrawnAnomaly([complete[0]!]))).toContainEqual(
+  it('取り下げ settlement は観測者の部分集合しか記録しない根拠を拒否する', () => {
+    expect(withdrawalInvariantMessages([completeWithdrawalPublications()[0]!])).toContainEqual(
       expect.stringContaining('every reviewer that observed the anomaly'),
     );
-    // 観測者でないレビュアーの混入（過剰）も違反。
-    expect(invariantMessages(withdrawnAnomaly([
-      ...complete,
+  });
+
+  it('取り下げ settlement は観測者でないレビュアーを含む根拠を拒否する', () => {
+    expect(withdrawalInvariantMessages([
+      ...completeWithdrawalPublications(),
       { reviewer: 'testing-review', publicationId: 'e'.repeat(64) },
-    ]))).toContainEqual(
+    ])).toContainEqual(
       expect.stringContaining('every reviewer that observed the anomaly'),
     );
+  });
 
-    // スキーマ側: 空配列と reviewer 重複を拒否する。
-    for (const invalid of [
+  it('取り下げ settlement は同一レビュアーの重複記録を拒否する（不変条件経路）', () => {
+    // 重複を先に潰してから集合比較すると、1人分を二重計上して別の観測者の根拠を
+    // 欠いた記録が完全一致として通ってしまう。スキーマを経由しない不変条件経路でも
+    // 弾けることを固定する。
+    const duplicated = [
+      completeWithdrawalPublications()[0]!,
+      { reviewer: 'arch-review', publicationId: 'f'.repeat(64) },
+    ];
+    expect(withdrawalInvariantMessages(duplicated, ['arch-review', 'security-review']))
+      .toContainEqual(
+        expect.stringContaining('exactly one superseding review per reviewer'),
+      );
+  });
+
+  it('取り下げ settlement の重複記録は台帳の append-only 遷移検証でも拒否される', () => {
+    const duplicated = {
+      ...emptyLedger(),
+      reviewerAnomalies: [withdrawnAnomaly([
+        completeWithdrawalPublications()[0]!,
+        { reviewer: 'arch-review', publicationId: 'f'.repeat(64) },
+      ])],
+    };
+    expect(() => assertFindingLedgerAppendOnlyTransition(
+      outstandingWithdrawalLedger() as never,
+      duplicated as never,
+    )).toThrow(/exactly one superseding review per reviewer/u);
+  });
+
+  it('観測者2人分の根拠を binary 順で持つ取り下げは append-only 遷移検証を通る', () => {
+    const settled = {
+      ...emptyLedger(),
+      reviewerAnomalies: [withdrawnAnomaly(completeWithdrawalPublications())],
+    };
+    expect(() => assertFindingLedgerAppendOnlyTransition(
+      outstandingWithdrawalLedger() as never,
+      settled as never,
+    )).not.toThrow();
+    // 受理された記録には両観測者の {reviewer, publicationId} が binary 順で残る。
+    expect(settled.reviewerAnomalies[0]!.settlement.supersedingPublications).toEqual([
+      { reviewer: 'arch-review', publicationId: 'c'.repeat(64) },
+      { reviewer: 'security-review', publicationId: 'd'.repeat(64) },
+    ]);
+  });
+
+  it('取り下げ settlement のスキーマは空配列・重複 reviewer・binary 順違反を拒否する', () => {
+    const invalidPublications = [
+      // 空配列: 根拠のない取り下げ。
       [],
-      [complete[0]!, { reviewer: 'arch-review', publicationId: 'f'.repeat(64) }],
-    ]) {
+      // 同一 reviewer の重複。
+      [
+        { reviewer: 'arch-review', publicationId: 'c'.repeat(64) },
+        { reviewer: 'arch-review', publicationId: 'f'.repeat(64) },
+      ],
+      // binary 順違反（security-review が arch-review より前）。
+      [
+        { reviewer: 'security-review', publicationId: 'd'.repeat(64) },
+        { reviewer: 'arch-review', publicationId: 'c'.repeat(64) },
+      ],
+    ];
+    for (const publications of invalidPublications) {
       expect(() => FindingLedgerSchema.parse({
         ...emptyLedger(),
-        reviewerAnomalies: [withdrawnAnomaly(invalid, ['arch-review'])],
+        reviewerAnomalies: [withdrawnAnomaly(publications, ['arch-review', 'security-review'])],
       })).toThrow();
     }
   });

--- a/src/__tests__/finding-contract-phase1.test.ts
+++ b/src/__tests__/finding-contract-phase1.test.ts
@@ -57,6 +57,71 @@ describe('Finding Contract phase 1', () => {
       .toContain('Interpretation outcome for "raw-unknown" has an unknown kind');
   });
 
+  it('取り下げ settlement は観測者全員分の根拠を要求する（部分集合・過剰・空・重複を拒否）', () => {
+    const withdrawnAnomaly = (
+      supersedingPublications: Array<{ reviewer: string; publicationId: string }>,
+      reviewers = ['arch-review', 'security-review'],
+    ) => ({
+      id: 'RA-000000000001',
+      kind: 'quote-mismatch' as const,
+      stableKey: 'a'.repeat(64),
+      lineageKey: 'b'.repeat(64),
+      sourceRawFindingIds: [],
+      sourceIntakeIds: ['intake-1'],
+      reviewers,
+      title: 'Unverifiable reviewer claim',
+      mismatchReason: 'the quoted excerpt does not exist',
+      firstObserved: observedAt,
+      lastObserved: observedAt,
+      occurrences: 1,
+      settlement: {
+        kind: 'withdrawn_by_subsequent_review' as const,
+        supersedingPublications,
+        decidedAt: observedAt,
+      },
+    });
+    const invariantMessages = (anomaly: ReturnType<typeof withdrawnAnomaly>) => (
+      collectFindingLedgerProjectionInvariantViolations({
+        ...emptyLedger(),
+        reviewerAnomalies: [anomaly],
+      } as never).map(({ message }) => message)
+    );
+    const complete = [
+      { reviewer: 'arch-review', publicationId: 'c'.repeat(64) },
+      { reviewer: 'security-review', publicationId: 'd'.repeat(64) },
+    ];
+
+    // 観測者全員分が揃っていれば適格。
+    expect(invariantMessages(withdrawnAnomaly(complete))).toEqual([]);
+    expect(() => FindingLedgerSchema.parse({
+      ...emptyLedger(),
+      reviewerAnomalies: [withdrawnAnomaly(complete)],
+    })).not.toThrow();
+
+    // 部分集合（1人分だけ）は不変条件違反。
+    expect(invariantMessages(withdrawnAnomaly([complete[0]!]))).toContainEqual(
+      expect.stringContaining('every reviewer that observed the anomaly'),
+    );
+    // 観測者でないレビュアーの混入（過剰）も違反。
+    expect(invariantMessages(withdrawnAnomaly([
+      ...complete,
+      { reviewer: 'testing-review', publicationId: 'e'.repeat(64) },
+    ]))).toContainEqual(
+      expect.stringContaining('every reviewer that observed the anomaly'),
+    );
+
+    // スキーマ側: 空配列と reviewer 重複を拒否する。
+    for (const invalid of [
+      [],
+      [complete[0]!, { reviewer: 'arch-review', publicationId: 'f'.repeat(64) }],
+    ]) {
+      expect(() => FindingLedgerSchema.parse({
+        ...emptyLedger(),
+        reviewerAnomalies: [withdrawnAnomaly(invalid, ['arch-review'])],
+      })).toThrow();
+    }
+  });
+
   it('uses domain-separated content addresses and rejects undefined or duplicate sets', () => {
     expect(findingContentAddress('domain-a', { value: 'x' })).toBe(
       createHash('sha256').update(canonicalJson({ domain: 'domain-a', value: 'x' })).digest('hex'),

--- a/src/__tests__/finding-evidence-protocol-units.test.ts
+++ b/src/__tests__/finding-evidence-protocol-units.test.ts
@@ -276,8 +276,8 @@ describe('applyReviewerAnomalySpecsToLedger / linkPromotedReviewerAnomalies (rev
     const anomaly = second.reviewerAnomalies![0]!;
     expect(anomaly.id).toBe(first.reviewerAnomalies![0]!.id);
     expect(anomaly.occurrences).toBe(2);
-    expect(anomaly.sourceRawFindingIds.sort()).toEqual(['raw-1', 'raw-2']);
-    expect(anomaly.reviewers.sort()).toEqual(['ai-antipattern-reviewer', 'another-reviewer']);
+    expect([...anomaly.sourceRawFindingIds].sort()).toEqual(['raw-1', 'raw-2']);
+    expect([...anomaly.reviewers].sort()).toEqual(['ai-antipattern-reviewer', 'another-reviewer']);
     // 最新の主張だけが監査値として残る（過去の主張を消したことにはならない —
     // firstObserved は変わらず保持されるため、いつ最初に観測されたかは失われない）。
     expect(anomaly.mismatchReason).toBe('the location changed but still does not exist');
@@ -625,8 +625,9 @@ describe('後続レビュー登録による reviewer anomaly の決着ライフ�
     expect(anomaly.promotedFindingId).toBeUndefined();
     expect(anomaly.settlement).toEqual({
       kind: 'withdrawn_by_subsequent_review',
-      reviewer: 'arch-review',
-      supersedingPublicationId: publicationFor('arch-review').publicationId,
+      supersedingPublications: [
+        { reviewer: 'arch-review', publicationId: publicationFor('arch-review').publicationId },
+      ],
       decidedAt: observation,
     });
     expect(isOutstandingReviewerAnomaly(anomaly)).toBe(false);
@@ -660,17 +661,22 @@ describe('後続レビュー登録による reviewer anomaly の決着ライフ�
       },
       new Set(),
     );
-    expect(seeded.reviewerAnomalies![0]!.reviewers.sort()).toEqual(['arch-review', 'security-review']);
+    expect([...seeded.reviewerAnomalies![0]!.reviewers].sort()).toEqual(['arch-review', 'security-review']);
 
     // 片方だけが再レビューした状態では取り下げない（ゲートを緩めない安全側）。
     const partial = commit({ ledger: seeded, reviewers: ['arch-review'] });
     expect(partial.reviewerAnomalies![0]!.settlement).toBeUndefined();
 
-    // 全観測者の後続レビューが揃って初めて決着し、記録する reviewer は binary 順の先頭。
+    // 全観測者の後続レビューが揃って初めて決着する。根拠は観測者全員分を
+    // binary 順で記録し、1人分に間引かない。
     const complete = commit({ ledger: seeded, reviewers: ['arch-review', 'security-review'] });
-    expect(complete.reviewerAnomalies![0]!.settlement).toMatchObject({
+    expect(complete.reviewerAnomalies![0]!.settlement).toEqual({
       kind: 'withdrawn_by_subsequent_review',
-      reviewer: 'arch-review',
+      supersedingPublications: [
+        { reviewer: 'arch-review', publicationId: publicationFor('arch-review').publicationId },
+        { reviewer: 'security-review', publicationId: publicationFor('security-review').publicationId },
+      ],
+      decidedAt: observation,
     });
   });
 
@@ -732,12 +738,13 @@ describe('後続レビュー登録による reviewer anomaly の決着ライフ�
     expect(isOutstandingReviewerAnomaly(anomaly)).toBe(true);
   });
 
-  it('決着の適格性判定は観測したレビュアーと言い直し契約の有無だけで決まる', () => {
+  it('決着の適格性判定は観測者集合の完全一致と言い直し契約の有無だけで決まる', () => {
     const anomaly = seededLedger().reviewerAnomalies![0]!;
     const settlement = {
       kind: 'withdrawn_by_subsequent_review' as const,
-      reviewer: 'arch-review',
-      supersedingPublicationId: 'a'.repeat(64),
+      supersedingPublications: [
+        { reviewer: 'arch-review', publicationId: 'a'.repeat(64) },
+      ],
       decidedAt: observation,
     };
     const projection = {
@@ -757,13 +764,26 @@ describe('後続レビュー登録による reviewer anomaly の決着ライフ�
       workflowTaskDigest: null,
     })).toBeUndefined();
 
+    // 観測者でないレビュアーの根拠（過剰）は無効。
     expect(reviewerAnomalySettlementEligibilityViolation({
       projection,
       anomaly,
-      settlement: { ...settlement, reviewer: 'security-review' },
+      settlement: {
+        ...settlement,
+        supersedingPublications: [{ reviewer: 'security-review', publicationId: 'a'.repeat(64) }],
+      },
       sourceHead: { kind: 'projection' },
       workflowTaskDigest: null,
-    })).toContain('observed the anomaly');
+    })).toContain('every reviewer that observed the anomaly');
+
+    // 観測者が2人いるのに1人分しか根拠が無い（部分集合）も無効。
+    expect(reviewerAnomalySettlementEligibilityViolation({
+      projection,
+      anomaly: { ...anomaly, reviewers: ['arch-review', 'security-review'] },
+      settlement,
+      sourceHead: { kind: 'projection' },
+      workflowTaskDigest: null,
+    })).toContain('every reviewer that observed the anomaly');
 
     expect(reviewerAnomalySettlementEligibilityViolation({
       projection,

--- a/src/__tests__/finding-review-integrity-gate.test.ts
+++ b/src/__tests__/finding-review-integrity-gate.test.ts
@@ -406,8 +406,12 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
       findings: unknown[];
       reviewerAnomalies?: Array<{
         occurrences: number;
+        reviewers: string[];
         promotedFindingId?: string;
-        settlement?: { kind: string; reviewer: string };
+        settlement?: {
+          kind: string;
+          supersedingPublications?: Array<{ reviewer: string; publicationId: string }>;
+        };
       }>;
       reviewIntegrity?: { roundMarkers: string[]; exhausted: boolean };
     };
@@ -425,7 +429,9 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
     expect(outstanding).toHaveLength(1);
     for (const settled of anomalies.filter((anomaly) => anomaly.settlement !== undefined)) {
       expect(settled.settlement?.kind).toBe('withdrawn_by_subsequent_review');
-      expect(settled.settlement?.reviewer).toBe('reviewers');
+      // 決着根拠は観測者全員分（この構成では単一レビュアー "reviewers"）。
+      expect(settled.settlement?.supersedingPublications?.map(({ reviewer }) => reviewer))
+        .toEqual([...settled.reviewers].sort());
     }
   }, 30_000);
 

--- a/src/__tests__/finding-review-integrity-gate.test.ts
+++ b/src/__tests__/finding-review-integrity-gate.test.ts
@@ -429,9 +429,16 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
     expect(outstanding).toHaveLength(1);
     for (const settled of anomalies.filter((anomaly) => anomaly.settlement !== undefined)) {
       expect(settled.settlement?.kind).toBe('withdrawn_by_subsequent_review');
-      // 決着根拠は観測者全員分（この構成では単一レビュアー "reviewers"）。
-      expect(settled.settlement?.supersedingPublications?.map(({ reviewer }) => reviewer))
+      // 決着根拠は観測者全員分（この構成では単一レビュアー "reviewers"）。観測者が
+      // 複数の場合の遷移検証は finding-contract-phase1.test.ts が持つ。
+      const publications = settled.settlement?.supersedingPublications ?? [];
+      expect(publications.map(({ reviewer }) => reviewer))
         .toEqual([...settled.reviewers].sort());
+      // 記録は reviewer の binary 順で、各件が実在の publication id を持つ。
+      expect(publications.map(({ reviewer }) => reviewer))
+        .toEqual([...publications.map(({ reviewer }) => reviewer)].sort());
+      expect(publications.every(({ publicationId }) => /^[0-9a-f]{64}$/u.test(publicationId)))
+        .toBe(true);
     }
   }, 30_000);
 

--- a/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
+++ b/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
@@ -1,4 +1,5 @@
 import { canonicalJson } from '../../shared/utils/canonical-json.js';
+import { compareBinaryStrings } from '../../shared/utils/binary-string-comparator.js';
 import {
   captureFindingMutationPrecondition,
   sameFindingMutationPrecondition,
@@ -251,12 +252,16 @@ function hasTerminalDismissalAuthority(input: {
 
 /**
  * 「同じレビュアー枠の次の完全なレビューが台帳へ登録された」ことによる決着は
- * product finding を根拠に持たない。成立条件は機械判定できる2点だけ:
+ * product finding を根拠に持たない。成立条件は機械判定できる3点だけ:
  *   - その anomaly をまだ誰も決着させていない(昇格済みは昇格側が決着)
- *   - 決着を記録したレビュアーがその anomaly の観測者である
- * intake-contract anomaly は言い直し(restatement)契約という固有の決着経路を
- * 持つため、この経路では決着させない — presentation / terminalDisposition と
- * 二重に決着すると監査記録が矛盾する。
+ *   - intake-contract anomaly ではない(あちらは言い直し契約という固有の決着経路を
+ *     持ち、presentation / terminalDisposition と二重に決着すると監査記録が矛盾する)
+ *   - 決着根拠として記録されたレビュアー集合が anomaly の観測者集合と完全一致する
+ *
+ * 完全一致を要求するのは、取り下げの成立条件が「全観測者の後続レビュー成立」
+ * (collectReviewSupersededReviewerAnomalyIds の every 判定)だからで、部分集合を
+ * 許すと再提示の機会を得ていない観測者の主張ごとゲートが緩む。過剰(観測者でない
+ * レビュアーの混入)も根拠として無効なので拒否する。
  */
 function reviewWithdrawalEligibilityViolation(
   anomaly: ReviewerAnomalyEntry,
@@ -268,9 +273,11 @@ function reviewWithdrawalEligibilityViolation(
   if (anomaly.intakeContract !== undefined) {
     return 'intake-contract anomalies settle through their restatement contract';
   }
-  return anomaly.reviewers.includes(settlement.reviewer)
+  const recorded = settlement.supersedingPublications.map(({ reviewer }) => reviewer);
+  return canonicalJson([...new Set(recorded)].sort(compareBinaryStrings))
+    === canonicalJson([...new Set(anomaly.reviewers)].sort(compareBinaryStrings))
     ? undefined
-    : 'withdrawal must be recorded by a reviewer that observed the anomaly';
+    : 'withdrawal must record a superseding review for every reviewer that observed the anomaly';
 }
 
 export function reviewerAnomalySettlementEligibilityViolation(input: {

--- a/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
+++ b/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
@@ -256,12 +256,16 @@ function hasTerminalDismissalAuthority(input: {
  *   - その anomaly をまだ誰も決着させていない(昇格済みは昇格側が決着)
  *   - intake-contract anomaly ではない(あちらは言い直し契約という固有の決着経路を
  *     持ち、presentation / terminalDisposition と二重に決着すると監査記録が矛盾する)
- *   - 決着根拠として記録されたレビュアー集合が anomaly の観測者集合と完全一致する
+ *   - 決着根拠が観測者ごとに1件ずつで、その集合が anomaly の観測者集合と完全一致する
  *
  * 完全一致を要求するのは、取り下げの成立条件が「全観測者の後続レビュー成立」
  * (collectReviewSupersededReviewerAnomalyIds の every 判定)だからで、部分集合を
  * 許すと再提示の機会を得ていない観測者の主張ごとゲートが緩む。過剰(観測者でない
  * レビュアーの混入)も根拠として無効なので拒否する。
+ *
+ * 重複は集合比較の前に弾く。先に重複を潰してから比較すると、同一レビュアーを
+ * 2件記録して別の観測者の1件を欠いた根拠(例: [a, a, b] と観測者 [a, b, c])が
+ * 完全一致として通ってしまい、欠けた観測者の主張ごとゲートが緩む。
  */
 function reviewWithdrawalEligibilityViolation(
   anomaly: ReviewerAnomalyEntry,
@@ -274,7 +278,10 @@ function reviewWithdrawalEligibilityViolation(
     return 'intake-contract anomalies settle through their restatement contract';
   }
   const recorded = settlement.supersedingPublications.map(({ reviewer }) => reviewer);
-  return canonicalJson([...new Set(recorded)].sort(compareBinaryStrings))
+  if (new Set(recorded).size !== recorded.length) {
+    return 'withdrawal must record exactly one superseding review per reviewer';
+  }
+  return canonicalJson([...recorded].sort(compareBinaryStrings))
     === canonicalJson([...new Set(anomaly.reviewers)].sort(compareBinaryStrings))
     ? undefined
     : 'withdrawal must record a superseding review for every reviewer that observed the anomaly';

--- a/src/core/models/finding-schemas.ts
+++ b/src/core/models/finding-schemas.ts
@@ -759,8 +759,16 @@ export const ReviewerAnomalyEntrySchema = z.object({
     }).strict(),
     z.object({
       kind: z.literal('withdrawn_by_subsequent_review'),
-      reviewer: nonEmptyString,
-      supersedingPublicationId: Sha256Schema,
+      supersedingPublications: z.array(z.object({
+        reviewer: nonEmptyString,
+        publicationId: Sha256Schema,
+      }).strict())
+        .min(1)
+        .superRefine((publications, ctx) => validateBinarySortedUniqueSet(
+          publications.map(({ reviewer }) => reviewer),
+          ctx,
+          'superseding publication reviewer',
+        )),
       decidedAt: FindingObservationSchema,
     }).strict(),
   ]).optional(),

--- a/src/core/models/finding-types.ts
+++ b/src/core/models/finding-types.ts
@@ -1601,10 +1601,18 @@ export interface ReviewerAnomalyTargetSettlement {
  */
 export interface ReviewerAnomalyReviewWithdrawalSettlement {
   kind: 'withdrawn_by_subsequent_review';
-  /** 後続レビューを登録したレビュアー(= anomaly の reviewers に含まれるステップ名)。 */
-  reviewer: string;
-  /** 決着の根拠になった後続レビューの publication id。 */
-  supersedingPublicationId: string;
+  /**
+   * 決着の根拠になった後続レビューの全件。取り下げは「その anomaly の観測者
+   * 全員が後続レビューを登録した」ときにだけ成立するため、記録も観測者全員分を
+   * 持つ(reviewer で binary 順ソート済み・重複なし・非空)。監査時に
+   * anomaly.reviewers と突き合わせるだけで根拠の網羅性を検証できる。
+   */
+  supersedingPublications: readonly {
+    /** 後続レビューを登録したレビュアー(= anomaly.reviewers の要素)。 */
+    reviewer: string;
+    /** そのレビュアーの後続レビュー publication id。 */
+    publicationId: string;
+  }[];
   decidedAt: FindingObservation;
 }
 

--- a/src/core/workflow/findings/reviewer-anomalies.ts
+++ b/src/core/workflow/findings/reviewer-anomalies.ts
@@ -526,16 +526,21 @@ export function withdrawReviewerAnomaliesSupersededByReview(input: {
       return anomaly;
     }
     // 候補は「全観測者が今ラウンドの publication を持つ」もののみ（collect 側の
-    // every 判定）。settlement に記録する reviewer は binary 順の先頭で決定的に選ぶ。
-    const reviewer = [...anomaly.reviewers].sort(compareBinaryStrings)[0]!;
-    const supersedingPublicationId = input.publicationIdByReviewer.get(reviewer)!;
+    // every 判定）。取り下げ根拠は観測者全員分を記録する — 1人分だけ残すと
+    // 「誰の後続レビューで決着したのか」を監査で再構成できない。順序は reviewer の
+    // binary 順で決定的にする。
+    const supersedingPublications = [...anomaly.reviewers]
+      .sort(compareBinaryStrings)
+      .map((reviewer) => ({
+        reviewer,
+        publicationId: input.publicationIdByReviewer.get(reviewer)!,
+      }));
     changed = true;
     return {
       ...anomaly,
       settlement: {
         kind: 'withdrawn_by_subsequent_review' as const,
-        reviewer,
-        supersedingPublicationId,
+        supersedingPublications,
         decidedAt: input.observation,
       },
     };


### PR DESCRIPTION
## 背景

#1209 のフォローアップ(CodeRabbit 指摘のうち妥当と判定した2件)。

## 変更内容

- withdrawal settlement の記録を単一 reviewer + publication から `supersedingPublications`(全観測者分の `{reviewer, publicationId}`、binary 順・重複なし・非空)へ変更。取り下げ判定は every(全観測者の後続レビュー成立)なので、記録も判定根拠を自己完結で証明する形にする
- eligibility 検証を「記録された reviewer が観測者に含まれるか」(部分集合チェック)から「記録の reviewer 集合が anomaly.reviewers と完全一致」(部分集合・過剰集合とも拒否)へ強化。invariant collector と integrity transition は既存の委譲経由で同ルールを自動的に適用(委譲をテストで固定)
- スキーマで非空・reviewer 重複なし・binary 順を検証
- 後方互換なし(裁定どおり)。旧形式への言及ゼロを grep で確認済み
- テスト fixture の in-place `sort()` による共有 fixture 破壊を修正(指摘の1箇所 + 既存2箇所)

## テスト

多観測者の全員分記録、部分集合/過剰集合 settlement の invariant 違反、空配列・重複 reviewer のスキーマ拒否を新規に固定。tsc / lint / 対象 unit・IT 全 green。FC prompt golden baseline 不変。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * 取り下げレビューの決着記録が、異常を確認した全レビュアーと各後続レビューの根拠を保持する形式になりました。
  * 根拠は重複なく一意に管理され、レビュアーの順序も一貫して記録されます。
  * 観測者の一部のみ、または無関係なレビュアーの根拠による決着は受け付けられません。

* **テスト**
  * 根拠の不足・重複・不正なレビュアー・順序違反を検出する検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->