### PR TITLE
fix: peer-review の reviewers サイクル loop monitor しきい値を 5 から 3 へ下げる

### DIFF
--- a/builtins/en/workflows/peer-review.yaml
+++ b/builtins/en/workflows/peer-review.yaml
@@ -61,7 +61,7 @@ loop_monitors:
     ignore_steps:
       - fix-verifier
       - fix-retry
-    threshold: 5
+    threshold: 3
     judge:
       persona: supervisor
       instruction: loop-monitor-reviewers-fix
@@ -83,7 +83,7 @@ loop_monitors:
     ignore_steps:
       - fix-verifier
       - fix-retry
-    threshold: 5
+    threshold: 3
     judge:
       persona: supervisor
       instruction: loop-monitor-reviewers-fix

--- a/builtins/ja/workflows/peer-review.yaml
+++ b/builtins/ja/workflows/peer-review.yaml
@@ -61,7 +61,7 @@ loop_monitors:
     ignore_steps:
       - fix-verifier
       - fix-retry
-    threshold: 5
+    threshold: 3
     judge:
       persona: supervisor
       instruction: loop-monitor-reviewers-fix
@@ -83,7 +83,7 @@ loop_monitors:
     ignore_steps:
       - fix-verifier
       - fix-retry
-    threshold: 5
+    threshold: 3
     judge:
       persona: supervisor
       instruction: loop-monitor-reviewers-fix


### PR DESCRIPTION
## 変更

`builtins/{en,ja}/workflows/peer-review.yaml` の loop_monitors のうち、reviewers サイクル2本の `threshold` を 5 → 3 にする。

- `[reviewers, review-adjudication, fix-plan, fix]`（L64）
- `[reviewers, review-adjudication, final-gate, fix-plan, fix]`（L86）

## 理由

このサイクルは1周のコストが高い。実測（#1137 の run、provider 呼び出し136件）で reviewers 単体が最大 23.6 分、coder が最大 14.4 分、1周でおおよそ 30〜60 分かかる。しきい値5では監視 judge が初めて呼ばれるまで 3〜5 時間かかり、発散検知器としては粗すぎる。

実際に #1137 の run では judge が一度も呼ばれなかった。中断時点で `ignore_steps` 除外後の履歴は17エントリ、完全サイクル4回で、`cycle-detector.ts:96-99` の `requiredLen = threshold * cycleLen = 20` に届いていない。

加えて `CycleDetector` は `WorkflowEngine.ts:248` でコンストラクタ時に生成され、resume で復元されない（`finding-types.ts:665` に既知として明記）。中断・再開を挟む運用ではしきい値5に到達しにくい。

## 変更しないもの

- `fix-plan/fix` と `fix-retry/fix-verifier` の `threshold: 4` — サイクル長が短く1周も短いため現状維持
- `peer-review-finding-contract{,-localllm}.yaml` の `threshold: 5` — FC 側は `stop_budget.max_rounds` が別途終端を保証するため判断が異なる

## 検証

`npx vitest run src/__tests__/workflow-step-fragment-builtin-runtime.test.ts` → 44 passed。

同ファイルの `detects every %s peer-review remediation cycle at its configured threshold` が en/ja 両方の `peer-review.yaml` を実際にロードし、設定値どおりに `CycleDetector` が発火することを検証している（しきい値をハードコードしていないため、値の変更に追随する）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ピアレビュー時の修正処理におけるループ検知を強化し、再試行回数のしきい値を5回から3回に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->