### PR TITLE
fix: finding-review-observability テストのシャード並列時タイムアウトを解消する

### DIFF
--- a/src/__tests__/finding-review-observability-wiring.test.ts
+++ b/src/__tests__/finding-review-observability-wiring.test.ts
@@ -22,6 +22,8 @@ vi.mock('../agents/runner.js', () => ({
   runAgent: vi.fn(),
 }));
 
+const SLOW_ENGINE_TEST_TIMEOUT_MS = 60_000;
+
 class CapturingSpanExporter implements SpanExporter {
   readonly spans: ReadableSpan[] = [];
 
@@ -344,7 +346,7 @@ describe('finding reviewer observability wiring', () => {
     const ledger = readFindingLedger(cwd, config.name);
     expect(ledger.findings).toHaveLength(1);
     expect(ledger.reviewerAnomalies ?? []).toHaveLength(0);
-  });
+  }, SLOW_ENGINE_TEST_TIMEOUT_MS);
 
   it('parallel reviewers share the request-only provider schema and expose matching real phase spans', async () => {
     const config = makeParallelReviewerConfig();
@@ -395,7 +397,7 @@ describe('finding reviewer observability wiring', () => {
     ]);
     expect(new Set(ledger.findings.flatMap((finding) => finding.evidenceIds)).size).toBe(4);
     expect(ledger.reviewerAnomalies ?? []).toHaveLength(0);
-  });
+  }, SLOW_ENGINE_TEST_TIMEOUT_MS);
 
   it('reviewer 実行中に source が変わっても engine snapshot から quote を発行する', async () => {
     vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
@@ -438,5 +440,5 @@ describe('finding reviewer observability wiring', () => {
     const ledger = readFindingLedger(cwd, config.name);
     expect(ledger.findings).toHaveLength(1);
     expect(ledger.reviewerAnomalies ?? []).toHaveLength(0);
-  });
+  }, SLOW_ENGINE_TEST_TIMEOUT_MS);
 });


### PR DESCRIPTION
## 背景

`npm run check:release` で `npm test` が落ちた。

```
FAIL src/__tests__/finding-review-observability-wiring.test.ts
Error: Test timed out in 15000ms.
```

## 原因

このファイルの各ケースは実 git fixture と SQLite 台帳を張って WorkflowEngine を通しで動かす。単独実行では 1 ケース約 7 秒だが、`npm test` は 4 シャードを同時起動するため、デバイスレベルの IO 競合で共通の `testTimeout: 15000` を超える。

- 修正前に 2 回連続で再現
- 単独実行（`npm test -- src/__tests__/finding-review-observability-wiring.test.ts`）では 4 ケースとも常に成功

機能の不具合ではなく、上限の見積もり不足による負荷依存の不安定テスト。

## 対応

serial ランナーと同じ 60 秒をケース単位で与える。カバレッジは削っていない。既存の `finding-evidence-protocol.integration.test.ts` と同じ手法。

## 確認

- `npm run build` / `npm run lint` / `npm test` / `npm run test:it` / `npm run test:prompt-evals` / `npm run test:e2e:mock` すべて green
- 実プロバイダ E2E は claude / claude-sdk / opencode で green。codex はレートリミットのため未実行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 非同期エンジンテストのタイムアウトを60秒に設定し、処理に時間がかかる環境でもテストが安定して実行されるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->