### PR TITLE
fix: 旧start_movementキーを読めるようにしtasks.yaml全損を解消する

### DIFF
--- a/src/__tests__/task-schema.test.ts
+++ b/src/__tests__/task-schema.test.ts
@@ -146,6 +146,25 @@ describe('TaskExecutionConfigSchema', () => {
     expect(config.start_step).toBe('plan');
   });
 
+  it('should read the legacy start_movement key as start_step', () => {
+    const config = TaskExecutionConfigSchema.parse({
+      start_movement: 'develop',
+    }) as Record<string, unknown>;
+
+    expect(config.start_step).toBe('develop');
+    expect(config.start_movement).toBeUndefined();
+  });
+
+  it('should prefer start_step when the legacy start_movement key is also present', () => {
+    const config = TaskExecutionConfigSchema.parse({
+      start_step: 'plan',
+      start_movement: 'develop',
+    }) as Record<string, unknown>;
+
+    expect(config.start_step).toBe('plan');
+    expect(config.start_movement).toBeUndefined();
+  });
+
   it('should require occurrence and accept omitted or positive integer step iterations', () => {
     const baseResumePoint = {
       version: 2,

--- a/src/__tests__/task-schema.test.ts
+++ b/src/__tests__/task-schema.test.ts
@@ -165,6 +165,13 @@ describe('TaskExecutionConfigSchema', () => {
     expect(config.start_movement).toBeUndefined();
   });
 
+  it('should not let the legacy start_movement key mask a non-string start_step', () => {
+    expect(() => TaskExecutionConfigSchema.parse({
+      start_step: 123,
+      start_movement: 'develop',
+    })).toThrow();
+  });
+
   it('should require occurrence and accept omitted or positive integer step iterations', () => {
     const baseResumePoint = {
       version: 2,

--- a/src/infra/task/taskConfigSerialization.ts
+++ b/src/infra/task/taskConfigSerialization.ts
@@ -58,7 +58,7 @@ export function normalizeTaskConfig(input: unknown): unknown {
   }
   if (legacyStartStep !== undefined) {
     delete next.start_movement;
-    if (resolveTaskStartStepValue(record) === undefined) {
+    if (record.start_step === undefined) {
       next.start_step = legacyStartStep;
     }
   }

--- a/src/infra/task/taskConfigSerialization.ts
+++ b/src/infra/task/taskConfigSerialization.ts
@@ -45,6 +45,9 @@ export function normalizeTaskConfig(input: unknown): unknown {
 
   const exceededMax = resolveExceededMaxValue(record);
   const resumePoint = resolveResumePointValue(record);
+  // v0.55.1 までの serializeTaskConfig が start_step を start_movement という
+  // キー名で書き出していたため、既存の tasks.yaml を読めるようにする。
+  const legacyStartStep = getStringField(record, 'start_movement');
 
   const next: Record<string, unknown> = { ...record };
   if (exceededMax !== undefined) {
@@ -52,6 +55,12 @@ export function normalizeTaskConfig(input: unknown): unknown {
   }
   if (resumePoint !== undefined) {
     next.resume_point = resumePoint;
+  }
+  if (legacyStartStep !== undefined) {
+    delete next.start_movement;
+    if (resolveTaskStartStepValue(record) === undefined) {
+      next.start_step = legacyStartStep;
+    }
   }
 
   return next;


### PR DESCRIPTION
## 症状

既存の `.takt/tasks.yaml` が読めなくなる。`takt list` すら通らない。

```
[ERROR] Invalid tasks.yaml: .takt/tasks.yaml. Please fix the file and retry.
Cause: [{ "code": "unrecognized_keys", "keys": ["start_movement"], "path": ["tasks", 0] }]
```

tasks.yaml は全タスクが1ファイルなので、`start_movement` を持つタスクが1件あるだけで無関係なタスクも含めて全滅する。

## 原因

`c4bd7ca2`（2026-04-25）以降の `serializeTaskConfig` は、`start_step` を **`start_movement` というキー名で書き出していた**。

```ts
if (startStep !== undefined) {
  serialized.start_movement = startStep;   // v0.55.1 まで
}
```

読む側が両方を受け付けていたため表面化していなかった。#1207 がこの書き込みと読み込みを同時に削除したので、v0.39.0〜v0.55.1 の19リリース、約3か月半のあいだに TAKT 自身が書いたファイルが読めなくなる。

## 対応

`normalizeTaskConfig` で旧キーを `start_step` へ読み替え、キー自体を落とす。Zod の strict 検証に到達しないので `unrecognized_keys` にならない。両方ある場合は新キーを優先する。

書き込みは `start_step` のまま。`serializeTasksFileData` は保存時に全タスクを書き直すので、タスク操作が一度走ればファイルは新キーへ移行する。アップグレードのみで放置されたファイルは変換されないため、この読み替えは数リリース残す。

`serializeTaskConfig` は検証済みの `TaskRecord` しか受け取らないので、書き込み側には手を入れていない。

## 確認

- 実際に壊れていた `.takt/tasks.yaml`（3タスク、うち2件が `start_movement` 保持）で `takt list` の復旧を確認
- `task-schema.test.ts` に2件追加（旧キー単独の読み替え、両方あるときの優先順位）
- `npm run lint` / `npm test` / `npm run test:it` すべて green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 旧形式のタスク設定で使用されていた `start_movement` を自動的に読み替え、現在の `start_step` として扱えるようになりました。
  * 両方のキーが指定されている場合は、`start_step` の設定が優先されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->