### PR TITLE
fix: 並行CASテストが敗北経路を決め打ちするフレークを解消する

### DIFF
--- a/src/__tests__/it-operation-journal-store.test.ts
+++ b/src/__tests__/it-operation-journal-store.test.ts
@@ -269,6 +269,22 @@ function parseChildError(result: ChildProcessResult): {
   return JSON.parse(result.stderr) as { readonly name: string; readonly message: string };
 }
 
+const LOCK_SWAP_CONFLICT = 'Operation journal lock identity changed while reading';
+
+// 敗者は、勝者の書き込み後の状態を読んで負けることも、読み取り中にロックを
+// 差し替えられて負けることもある。どちらになるかはタイミングで決まる。
+function expectConcurrentLoss(
+  result: ChildProcessResult,
+  expectedDetail: string,
+): void {
+  const { name, message } = parseChildError(result);
+  expect(name).toBe('OperationJournalConflictError');
+  if (message.includes(LOCK_SWAP_CONFLICT)) {
+    return;
+  }
+  expect(message).toContain(expectedDetail);
+}
+
 describe('operation journal store', () => {
   let tempDir: string;
   let journalPath: string;
@@ -870,10 +886,7 @@ describe('operation journal store', () => {
     if (loser === undefined) {
       throw new Error('Concurrent claim did not produce a losing process');
     }
-    expect(parseChildError(loser)).toMatchObject({
-      name: 'OperationJournalConflictError',
-      message: expect.stringContaining('owner changed'),
-    });
+    expectConcurrentLoss(loser, 'owner changed');
     const finalParent = store.getParent('parent-1');
     expect(finalParent.revision).toBe(1);
     expect(finalParent.owner.generation).toBe(1);
@@ -929,10 +942,7 @@ describe('operation journal store', () => {
     if (loser === undefined) {
       throw new Error('Concurrent child CAS did not produce a losing process');
     }
-    expect(parseChildError(loser)).toMatchObject({
-      name: 'OperationJournalConflictError',
-      message: expect.stringContaining('Operation "parent-1" changed'),
-    });
+    expectConcurrentLoss(loser, 'Operation "parent-1" changed');
     expect(store.getParent('parent-1').revision).toBe(2);
     expect(store.getChild('parent-1', 'child-1').revision).toBe(1);
   });


### PR DESCRIPTION
## 症状

`it` ジョブが稀に落ちる。

```
FAIL src/__tests__/it-operation-journal-store.test.ts
  > allows exactly one concurrent process to update the same parent and child revisions

- "message": StringContaining "Operation \"parent-1\" changed"
+ "message": "Operation journal lock identity changed while reading: .../operation-journal.json.lock"
    "name": "OperationJournalConflictError"
```

## 原因

競合の敗者には2つの経路がある。

1. 勝者の書き込み後の状態を読んで、リビジョン不一致で負ける
2. `readLockSnapshot` の読み取り中に勝者がロックを差し替え、identity 不一致で負ける（`operation-journal-store.ts:999`）

どちらも `OperationJournalConflictError` で「ちょうど1プロセスだけが勝つ」という不変条件は満たしているが、テストは 1 の文言だけを期待していた。どちらの経路になるかはタイミング次第なので、負荷の高い CI で 2 を引くと落ちる。

## 対応

`expectConcurrentLoss` ヘルパーを追加し、ロック差し替え経路も正当な敗北として受け入れる。「ちょうど1プロセスだけが成功する」ことを検証する `exitCode` の assertion は変更していないので、テストの本来の意図は維持される。

同じ決め打ちが `allows exactly one concurrent process to claim the same parent generation`（`owner changed`）にもあったため、両方まとめて直した。

## 確認

- `npm test -- src/__tests__/it-operation-journal-store.test.ts` 23 passed
- `npm run lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 並行処理における競合や同時更新のテストを改善しました。
  * 更新競合が発生した際の敗者側のエラー判定を、複数の有効な状態に対応できるよう強化しました。
  * 親子データの同時更新に関する検証の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->