### PR TITLE
fix: Windowsのテストタイムアウトを60秒へ引き上げる

### DIFF
--- a/vitest.config.shared.ts
+++ b/vitest.config.shared.ts
@@ -24,6 +24,12 @@ export const itSerialTestGlobs = [
   ...itSerialWorkflowLoaderTestGlobs,
 ];
 
+// Windows runners spawn processes and touch the filesystem an order of
+// magnitude slower than the Linux/macOS ones, so tests that pass everywhere
+// else hit the shared 15s ceiling there. Three of the four windows job
+// failures in the last 100 CI runs were "Test timed out in 15000ms".
+const testTimeout = process.platform === 'win32' ? 60_000 : 15_000;
+
 export const commonSrcTestConfig = {
   env: {
     TAKT_CONFIG_DIR: '',
@@ -40,7 +46,7 @@ export const commonSrcTestConfig = {
   globals: false,
   reporters: ['dot'],
   setupFiles: ['src/__tests__/test-setup.ts'],
-  testTimeout: 15000,
+  testTimeout,
   teardownTimeout: 5000,
   coverage: {
     provider: 'v8',


### PR DESCRIPTION
## 背景

`windows-private-artifacts` ジョブが断続的に落ちる。

```
FAIL src/__tests__/promptEvalProbeLifecycle.test.ts
  > should stop the timed-out child and grandchild before removing the parent-owned workspace
Error: Test timed out in 15000ms.
```

直近100 CI run の windows ジョブ失敗は4件、うち3件が `Test timed out in 15000ms` だった。

| run | 内容 |
|---|---|
| 31111363283 | `promptEvalProbeLifecycle` timeout 15000ms |
| 30958226601 | timeout 15000ms |
| 30903981972 | timeout 15000ms |
| 30933818354 | 別要因 |

## 原因

Windows ランナーはプロセス生成とファイル IO が Linux/macOS より桁で遅い。他プラットフォームで通るテストが、共通の `testTimeout: 15000` に収まらない。落ちるテストは毎回同じではなく、そのとき一番重いものが上限に当たる。個別テストへの対症療法ではプラットフォーム差という原因に届かない。

## 対応

`vitest.config.shared.ts` の `testTimeout` を Windows でのみ60秒にする。serial ランナーは元から60秒なので実質変化なし。他プラットフォームの15秒は据え置きで、そちらの検出力は落とさない。

## 確認

- ローカルでの設定読み込みとテスト実行を確認
- Windows での効果は CI の windows ジョブで確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * Windows環境でのテストタイムアウトを60秒に延長しました。
  * その他の環境では、従来どおり15秒のタイムアウトを使用します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->