### PR TITLE
feat: FC escalation reviewerを実装し言い直し最終枠を強モデル再レビューへ格上げする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Verified against `resolveStepProviderModel` / `PROVIDER_MODEL_SOURCE_PRIORITY` a
 7. Auto routing (`auto.rules` / `auto.dynamic` / `auto.fallback`)
 8. Workflow → project (`.takt/config.yaml`) → global (`~/.takt/config.yaml`) → provider default
 
-Synthetic Finding Contract roles route by persona key: `findings-manager`, `supervisor` (adjudication), `loop-judge` (loop monitors).
+Synthetic Finding Contract roles route by persona key: `findings-manager`, `supervisor` (adjudication), `escalation-reviewer` (escalated restatement review), `loop-judge` (loop monitors).
 
 ### Finding Contract (FC)
 
@@ -100,6 +100,7 @@ Optional per-run SQLite ledger (`finding-contract.sqlite`) that makes review fin
 - Lifecycle identity across rounds: `new` / `persists` / `reopened` / `resolved`; resolution is lifecycle-continuity based and requires verified confirmation — "I fixed it" alone never resolves.
 - Provider calls run under persistent leases (reserved→dispatched→settled) with input/output/call budgets in the ledger; `stop_budget.max_rounds` guarantees finite termination.
 - `finding_contract.manager` accepts `persona/instruction/output_contract`, optional `policy`/`knowledge` additions, and `provider`/`model`. `finding_contract.adjudicator` (optional) accepts `persona/instruction/provider/model`; when omitted the supervisor auto-derivation keeps prompts byte-identical (guarded by golden-baseline tests — do not regenerate goldens to make a change pass).
+- `finding_contract.escalation_reviewer` (optional) accepts `persona`, optional `instruction`/`output_contract`/`provider`/`model`. When set, the **last** restatement presentation of each intake anomaly (`presentationOrdinal === presentationLimit`) goes to an engine-synthesized escalation reviewer instead of the owning reviewer — a direct provider call like `findings-manager`, never a workflow step. Its reviewer key is the fixed string `escalation-reviewer` (also its provider-routing persona key and its reserved step name); omit the field and behaviour is unchanged.
 - Manager/adjudicator prompt wire formats (structured output schemas, allowed actions, evidence requirements) are **engine-owned**; facets add judgment guidance only.
 
 Workflows: `takt-default` (non-FC, prompt-adjudication step) and `takt-default-fc` (FC; no adjudication step — manager + terminal adjudication replace it). The FC fix/plan/monitor instructions treat the engine-injected live ledger state as the single source of truth; report files are not authoritative there.

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -509,7 +509,7 @@ kiro_cli_path: /usr/local/bin/kiro-cli
 
 provider と model の選択には、[Provider Routing](#provider-routing) に記載した単一のフィールド別優先順位を使用します。通常 step、parallel sub-step、合成 step、workflow call は、各種類で利用可能なレイヤーについて同じ契約に従います。parallel sub-step は promotion をサポートしません。
 
-Finding Contract workflow では、`finding_contract.manager.provider` / `model` と `finding_contract.adjudicator.provider` / `model` は、それぞれの合成 step の step レベル provider/model として扱われます。実装上のフィールド別優先順は、CLI/環境変数の明示 override → 実行時にマッチした promotion（通常の agent step のみ）→ step または parallel sub-step の provider/model（これらの直接指定を含む）→ `workflow_call` override → `provider_routing` の step/tag/persona → deprecated の `persona_providers` → auto routing → workflow → project → global → provider default です。両方とも未指定の場合は通常の workflow step と同じ fallback chain を使います。`provider` だけを指定すると下位優先度の model fallback は停止し、明示 model が必須の provider では検証エラーになります。
+Finding Contract workflow では、`finding_contract.manager.provider` / `model`、`finding_contract.adjudicator.provider` / `model`、`finding_contract.escalation_reviewer.provider` / `model` は、それぞれの合成 step の step レベル provider/model として扱われます。実装上のフィールド別優先順は、CLI/環境変数の明示 override → 実行時にマッチした promotion（通常の agent step のみ）→ step または parallel sub-step の provider/model（これらの直接指定を含む）→ `workflow_call` override → `provider_routing` の step/tag/persona → deprecated の `persona_providers` → auto routing → workflow → project → global → provider default です。両方とも未指定の場合は通常の workflow step と同じ fallback chain を使います。`provider` だけを指定すると下位優先度の model fallback は停止し、明示 model が必須の provider では検証エラーになります。
 
 ```yaml
 finding_contract:
@@ -522,6 +522,10 @@ finding_contract:
   adjudicator:
     persona: supervisor
     instruction: adjudicate-finding-contract
+    provider: codex
+    model: <strong-model>
+  escalation_reviewer:
+    persona: escalation-supervisor
     provider: codex
     model: <strong-model>
 ```
@@ -807,6 +811,8 @@ provider と model は各レイヤーで個別に解決されます。provider �
 「有効な promotion」とは、通常の agent step の `promotion` エントリのうち、実行回数条件（`at: <N>`）または `ai()` 条件が現在の実行にマッチしたものを指します。parallel sub-step では promotion を指定できないため、CLI/環境変数の明示 override の次に sub-step YAML の provider/model が優先されます。[Step レベルのプロバイダープロモーション](./workflows.ja.md#step-レベルのプロバイダープロモーション)を参照してください。
 
 Finding Contract manager では、`finding_contract.manager.provider` と `finding_contract.manager.model` が合成 `findings-manager` step の `step YAML provider/model` 位置に入ります。
+
+合成された Finding Contract ロールは、設定した persona 名ではなく固定の persona キーで `provider_routing.personas` を解決します。`findings-manager`（manager）、`supervisor`（conflict / terminal adjudication）、`escalation-reviewer`（格上げ言い直しレビュー）、`loop-judge`（loop monitor の judge）です。`finding_contract.escalation_reviewer.provider` / `model` は合成 `escalation-reviewer` step の `step YAML provider/model` 位置に入ります。`finding_contract.escalation_reviewer` を設定している間、`escalation-reviewer` は workflow の予約 step 名にもなります。
 
 ### Auto Routing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -513,7 +513,7 @@ Paths must be absolute paths to executable files. Environment variables take pre
 
 Provider and model selection uses the single, field-by-field precedence contract documented under [Provider Routing](#provider-routing). Normal steps, parallel sub-steps, synthetic steps, and workflow calls follow that contract for the layers available to each kind. Parallel sub-steps do not support promotion.
 
-For Finding Contract workflows, `finding_contract.manager.provider` / `model` and `finding_contract.adjudicator.provider` / `model` are treated as step-level values for their synthetic steps. The implementation's field-by-field order is explicit CLI/environment override → promotion matching the current execution (normal agent steps only) → step or parallel sub-step provider/model (including these direct values) → `workflow_call` override → `provider_routing` step/tag/persona → deprecated `persona_providers` → auto routing → workflow → project → global → provider default. When neither field is set, the role uses the normal workflow-step fallback chain. Setting only `provider` stops lower-priority model fallback; providers that require an explicit model fail validation.
+For Finding Contract workflows, `finding_contract.manager.provider` / `model`, `finding_contract.adjudicator.provider` / `model`, and `finding_contract.escalation_reviewer.provider` / `model` are treated as step-level values for their synthetic steps. The implementation's field-by-field order is explicit CLI/environment override → promotion matching the current execution (normal agent steps only) → step or parallel sub-step provider/model (including these direct values) → `workflow_call` override → `provider_routing` step/tag/persona → deprecated `persona_providers` → auto routing → workflow → project → global → provider default. When neither field is set, the role uses the normal workflow-step fallback chain. Setting only `provider` stops lower-priority model fallback; providers that require an explicit model fail validation.
 
 ```yaml
 finding_contract:
@@ -526,6 +526,10 @@ finding_contract:
   adjudicator:
     persona: supervisor
     instruction: adjudicate-finding-contract
+    provider: codex
+    model: <strong-model>
+  escalation_reviewer:
+    persona: escalation-supervisor
     provider: codex
     model: <strong-model>
 ```
@@ -811,6 +815,8 @@ Provider and model are resolved independently at each layer. A provider-only ove
 `active promotion` means a normal agent step `promotion` entry whose execution-count (`at: <N>`) or `ai()` condition matched for the current execution. Parallel sub-steps cannot specify promotion, so their YAML provider/model follows an explicit CLI/environment override directly; see [Step-level Provider Promotion](./workflows.md#step-level-provider-promotion).
 
 For the Finding Contract manager, `finding_contract.manager.provider` and `finding_contract.manager.model` occupy the `step YAML provider/model` position for the synthetic `findings-manager` step.
+
+Synthetic Finding Contract roles resolve `provider_routing.personas` by a fixed persona key rather than the configured persona name: `findings-manager` (manager), `supervisor` (conflict and terminal adjudication), `escalation-reviewer` (escalated restatement review), and `loop-judge` (loop monitor judges). `finding_contract.escalation_reviewer.provider` / `model` occupy the `step YAML provider/model` position for the synthetic `escalation-reviewer` step. While `finding_contract.escalation_reviewer` is set, `escalation-reviewer` is also a reserved workflow step name.
 
 ### Auto Routing
 

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -865,6 +865,34 @@ finding_contract:
     max_rounds: 40
 ```
 
+### `finding_contract.escalation_reviewer`
+
+任意。各 intake anomaly の**最後の1回**の言い直し提示（`review_budget.max_review_rounds` から決まる `presentationLimit` と同じ ordinal の提示）を、元のレビュアーへもう一度返すのではなく、専用の格上げレビュアーへ回します。
+
+```yaml
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+  escalation_reviewer:
+    persona: escalation-supervisor
+    instruction: escalation-finding-contract      # 任意。省略時は persona 本体を使う
+    output_contract: escalation-finding-contract  # 任意。省略時は元レビュアーの report 形式を継承
+    provider: codex
+    model: gpt-5.5
+  review_budget:
+    max_review_rounds: 6
+```
+
+- `persona` は必須で、`instruction` / `output_contract` / `provider` / `model` は任意です。未知のフィールドは拒否されます。
+- escalation reviewer は workflow の step では**ありません**。`findings-manager` や terminal adjudication と同じくエンジンが合成して直接 provider call を発行し、その出力を通常の取り込み経路（正規化、canonical publication、byte 一致検証、昇格の対応づけ）へ流します。実行はレビューラウンドごとに1回で、全レビュアーの publication が揃ったあと・manager の取り込み前です。
+- reviewer キーは固定文字列 `escalation-reviewer` です。この値が raw finding の `reviewer`、publication identity、レポート名（`escalation-reviewer.md`）、provider routing の persona キーになります。`provider_routing.personas.escalation-reviewer` は、設定した persona 名にかかわらずこのロールへ効きます。
+- Phase 1 は読み取り専用で動きます。escalation reviewer はリポジトリを自分で読んで byte 一致の引用を作れますが、書き込みはできません。
+- `escalation_reviewer` を設定している間、`escalation-reviewer` は**予約 step 名**です。同名の step（parallel sub-step を含む）を持つ workflow は読み込みに失敗します。
+- `presentationLimit == 1` の場合、最初で最後の1回がそのまま格上げ提示になります。`escalation_reviewer` を省略すれば最後の1回も従来どおり元のレビュアーへ戻ります。
+- 格上げレビューが publication 成立前に失敗した場合は何も計上せず、次のラウンドで同じ escalation request を再発行します。有限停止は従来どおり workflow の `max_steps` が保証します。
+
 ### `interactive_mode`
 
 `takt` を引数なしで起動したときのデフォルト interactive mode。`assistant`（デフォルト） / `passthrough` / `quiet` / `persona` のいずれか。

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -866,6 +866,34 @@ finding_contract:
     max_rounds: 40
 ```
 
+### `finding_contract.escalation_reviewer`
+
+Optional. Re-routes the **last** restatement presentation of each intake anomaly (the presentation whose ordinal equals the anomaly's `presentationLimit`, derived from `review_budget.max_review_rounds`) to a dedicated escalation reviewer instead of asking the original reviewer once more.
+
+```yaml
+finding_contract:
+  manager:
+    persona: findings-manager
+    instruction: findings-manager
+    output_contract: findings-manager
+  escalation_reviewer:
+    persona: escalation-supervisor
+    instruction: escalation-finding-contract      # optional; falls back to the persona body
+    output_contract: escalation-finding-contract  # optional; inherits the owning reviewer's report format
+    provider: codex
+    model: gpt-5.5
+  review_budget:
+    max_review_rounds: 6
+```
+
+- `persona` is required; `instruction`, `output_contract`, `provider`, and `model` are optional. Unknown fields are rejected.
+- The escalation reviewer is **not** a workflow step. Like `findings-manager` and terminal adjudication, the engine synthesizes it and issues the provider call directly, then feeds its output through the ordinary intake pipeline (normalization, canonical publication, byte-exact verification, promotion matching). It runs once per review round, after every owning reviewer's publication has landed and before the manager ingests them.
+- Its reviewer key is the fixed string `escalation-reviewer`. That key is the raw findings' `reviewer` value, the publication identity, the report name (`escalation-reviewer.md`), and the provider-routing persona key — `provider_routing.personas.escalation-reviewer` targets it regardless of the configured persona name.
+- Phase 1 runs read-only: the escalation reviewer can read the repository to produce byte-exact quotes, but cannot write.
+- While `escalation_reviewer` is set, `escalation-reviewer` is a **reserved step name**; a workflow that also declares a step (or parallel sub-step) with that name fails to load.
+- With `presentationLimit == 1`, the first and only presentation is already the escalated one. Omit `escalation_reviewer` and the final presentation stays with the original reviewer, exactly as before.
+- When the escalated review fails before its publication lands, nothing is counted and the same escalation request is re-issued next round; the workflow's `max_steps` still bounds the run.
+
 ### `interactive_mode`
 
 Default interactive mode used when `takt` is invoked without arguments. One of `assistant` (default), `passthrough`, `quiet`, `persona`.

--- a/src/__tests__/finding-fc-escalation-reviewer.test.ts
+++ b/src/__tests__/finding-fc-escalation-reviewer.test.ts
@@ -1,0 +1,1127 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { AgentResponse, AgentWorkflowStep, FindingContractConfig } from '../core/models/types.js';
+import { FINDING_ESCALATION_REVIEWER_ROUTING_KEY } from '../core/models/finding-types.js';
+import {
+  buildFindingEscalationReviewerStep,
+  requireEscalationOwnerOutputContractFormat,
+  FINDING_ESCALATION_REVIEWER_REPORT_NAME,
+} from '../core/workflow/findings/escalation-reviewer-step.js';
+import { resolveRestatementPresentationPhase } from '../core/workflow/findings/restatement-presentation-phase.js';
+import {
+  computeRestatementRequestId,
+  createFindingReviewPresentationContextV2,
+  createFindingReviewPublication,
+  listFindingReviewPublications,
+  persistFindingReviewPublication,
+  STRUCTURED_FINDING_REVIEW_PUBLICATION_PROTOCOL,
+} from '../core/workflow/findings/review-publication.js';
+import {
+  buildFindingContractInstruction,
+  buildFindingContractReportInstruction,
+} from '../core/workflow/instruction/finding-contract-instruction.js';
+import { resolveStepProviderModel } from '../core/workflow/provider-resolution.js';
+import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
+import { FindingContractConfigRawSchema } from '../core/models/finding-schemas.js';
+import type { WorkflowStep } from '../core/models/types.js';
+import { ParallelRunner, type ParallelRunnerDeps } from '../core/workflow/engine/ParallelRunner.js';
+import { makeRule, makeStep } from './test-helpers.js';
+import type { FindingLedger } from '../core/workflow/findings/types.js';
+import {
+  createSharedRuntime,
+  createWorkflowEngineServices,
+} from '../core/workflow/engine/WorkflowEngineSetup.js';
+import { createStructuredOutputNormalizerRegistry } from '../core/workflow/engine/structured-output-normalizer.js';
+import { buildRunPaths } from '../core/workflow/run/run-paths.js';
+import { createEmptyFindingContractRegistries } from '../core/models/finding-contract-seed.js';
+import {
+  applyReviewerAnomalySpecsToLedger,
+  createReviewerAnomalySpec,
+} from '../core/workflow/findings/reviewer-anomalies.js';
+import {
+  candidateFromStoredRawFinding,
+  canonicalizeReviewerRawFinding,
+} from '../core/workflow/findings/raw-canonicalization.js';
+import { canonicalRawFindingFixture } from './helpers/finding-lifecycle-fixture.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('../agents/agent-usecases.js', () => ({
+  executeAgent: vi.fn(),
+}));
+
+vi.mock('../core/workflow/findings/contract-intake.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../core/workflow/findings/contract-intake.js')>();
+  return {
+    ...actual,
+    ingestFindingContractResults: vi.fn().mockResolvedValue({ status: 'unchanged' }),
+  };
+});
+
+const { executeAgent } = await import('../agents/agent-usecases.js');
+const executeAgentMock = vi.mocked(executeAgent);
+
+const { runFindingEscalationReviewer } = await import(
+  '../core/workflow/findings/escalation-reviewer-runner.js'
+);
+
+function contractWithEscalationReviewer(
+  overrides: Partial<NonNullable<FindingContractConfig['escalationReviewer']>> = {},
+): FindingContractConfig {
+  return {
+    manager: {
+      persona: 'findings-manager',
+      instruction: 'Manage findings.',
+      outputContract: 'Manager output contract.',
+    },
+    escalationReviewer: {
+      persona: 'escalation-supervisor',
+      providerRoutingPersonaKey: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+      ...overrides,
+    },
+  };
+}
+
+describe('FC escalation reviewer — presentation phase', () => {
+  it('spends the restatement budget on the owner and the last presentation on escalation', () => {
+    const phases = [0, 1, 2, 3].map((presentedCount) => resolveRestatementPresentationPhase({
+      presentedCount,
+      presentationLimit: 3,
+      escalationReviewerConfigured: true,
+    }));
+
+    expect(phases).toEqual(['restatement', 'restatement', 'escalation', 'exhausted']);
+  });
+
+  it('escalates the first and only presentation when presentationLimit is 1', () => {
+    expect(resolveRestatementPresentationPhase({
+      presentedCount: 0,
+      presentationLimit: 1,
+      escalationReviewerConfigured: true,
+    })).toBe('escalation');
+  });
+
+  it('keeps every presentation on the owner reviewer when no escalation reviewer is configured', () => {
+    const phases = [0, 1, 2, 3].map((presentedCount) => resolveRestatementPresentationPhase({
+      presentedCount,
+      presentationLimit: 3,
+      escalationReviewerConfigured: false,
+    }));
+
+    expect(phases).toEqual(['restatement', 'restatement', 'restatement', 'exhausted']);
+  });
+
+  it('stays in the escalation phase while a publication never lands', () => {
+    // publication 成立前の失敗は presentedCount を増やさないため、次ラウンドも
+    // 同じ presentationOrdinal の escalation request を再発行する。
+    const beforeFailedRound = resolveRestatementPresentationPhase({
+      presentedCount: 1,
+      presentationLimit: 2,
+      escalationReviewerConfigured: true,
+    });
+    const afterFailedRound = resolveRestatementPresentationPhase({
+      presentedCount: 1,
+      presentationLimit: 2,
+      escalationReviewerConfigured: true,
+    });
+
+    expect([beforeFailedRound, afterFailedRound]).toEqual(['escalation', 'escalation']);
+  });
+
+  it('gives the owner request and the escalation request different identities without changing the digest contract', () => {
+    const requestWithoutId = {
+      anomalyId: 'RA-ESCALATION',
+      presentationOrdinal: 2,
+      reviewScopeSnapshotId: '3'.repeat(64),
+      sourceExcerptDigest: '4'.repeat(64),
+      claimedExcerpt: 'A bounded reviewer claim.',
+      targetPaths: ['src/example.ts'],
+      missingRequirements: ['description'] as const,
+      expectedRelation: 'new' as const,
+      expectedTargetFindingId: null,
+      expectedTargetPreconditionClass: 'absent' as const,
+    };
+    const ownerRequestId = computeRestatementRequestId({
+      ...requestWithoutId,
+      reviewer: 'architecture-review',
+    });
+    const escalationRequestId = computeRestatementRequestId({
+      ...requestWithoutId,
+      reviewer: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+    });
+
+    expect(escalationRequestId).not.toBe(ownerRequestId);
+    expect(computeRestatementRequestId({
+      ...requestWithoutId,
+      reviewer: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+    })).toBe(escalationRequestId);
+  });
+});
+
+describe('FC escalation reviewer — synthetic step', () => {
+  it('builds a read-only reviewer step with a fixed name, routing key and report name', () => {
+    const step = buildFindingEscalationReviewerStep({
+      contract: contractWithEscalationReviewer(),
+      ownerOutputContractFormat: 'Owner report format.',
+    });
+
+    expect(step).toMatchObject({
+      kind: 'agent',
+      name: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+      engineSynthesized: true,
+      providerRoutingPersonaKey: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+      sessionKey: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+      session: 'refresh',
+      edit: false,
+      rules: [],
+    });
+    expect(step.outputContracts).toEqual([{
+      name: FINDING_ESCALATION_REVIEWER_REPORT_NAME,
+      format: 'Owner report format.',
+    }]);
+    expect(step.structuredOutput).toBeUndefined();
+  });
+
+  it('falls back to the persona body as instruction and keeps a configured output contract', () => {
+    const inherited = buildFindingEscalationReviewerStep({
+      contract: contractWithEscalationReviewer(),
+      ownerOutputContractFormat: 'Owner report format.',
+    });
+    const configured = buildFindingEscalationReviewerStep({
+      contract: contractWithEscalationReviewer({
+        instruction: 'Restate the escalated claims.',
+        outputContract: 'Escalation report format.',
+      }),
+      ownerOutputContractFormat: 'Owner report format.',
+    });
+
+    expect(inherited.instruction).toBe('escalation-supervisor');
+    expect(configured.instruction).toBe('Restate the escalated claims.');
+    expect(configured.outputContracts).toEqual([{
+      name: FINDING_ESCALATION_REVIEWER_REPORT_NAME,
+      format: 'Escalation report format.',
+    }]);
+  });
+
+  it('prefers the direct provider/model over the workflow defaults', () => {
+    const direct = buildFindingEscalationReviewerStep({
+      contract: contractWithEscalationReviewer({ provider: 'codex', model: 'gpt-test' }),
+      workflowProvider: 'claude',
+      workflowModel: 'workflow-model',
+      ownerOutputContractFormat: 'Owner report format.',
+    });
+    const inherited = buildFindingEscalationReviewerStep({
+      contract: contractWithEscalationReviewer(),
+      workflowProvider: 'claude',
+      workflowModel: 'workflow-model',
+      ownerOutputContractFormat: 'Owner report format.',
+    });
+
+    expect(direct).toMatchObject({
+      provider: 'codex',
+      providerSpecified: true,
+      model: 'gpt-test',
+      modelSpecified: true,
+    });
+    expect(inherited).toMatchObject({
+      provider: 'claude',
+      providerSpecified: false,
+      model: 'workflow-model',
+      modelSpecified: false,
+    });
+  });
+
+  it('refuses to build a step when no escalation reviewer is configured', () => {
+    expect(() => buildFindingEscalationReviewerStep({
+      contract: { manager: contractWithEscalationReviewer().manager },
+      ownerOutputContractFormat: 'Owner report format.',
+    })).toThrow(/finding_contract\.escalation_reviewer/);
+  });
+
+  it('fails loudly when no owner output contract can be inherited', () => {
+    expect(() => requireEscalationOwnerOutputContractFormat([
+      { kind: 'agent', name: 'review', instruction: 'Review.' } as AgentWorkflowStep,
+    ])).toThrow(/output contract/);
+  });
+
+  it('routes provider/model through the escalation-reviewer persona key', () => {
+    const step = buildFindingEscalationReviewerStep({
+      contract: contractWithEscalationReviewer(),
+      ownerOutputContractFormat: 'Owner report format.',
+    });
+
+    expect(resolveStepProviderModel({
+      step,
+      provider: 'mock',
+      model: 'project-model',
+      providerRouting: {
+        personas: {
+          [FINDING_ESCALATION_REVIEWER_ROUTING_KEY]: { provider: 'codex', model: 'gpt-5' },
+          'escalation-supervisor': { provider: 'cursor', model: 'persona-name-model' },
+        },
+      },
+    } as Parameters<typeof resolveStepProviderModel>[0])).toMatchObject({
+      provider: 'codex',
+      model: 'gpt-5',
+      providerSource: 'provider_routing.personas',
+      modelSource: 'provider_routing.personas',
+    });
+  });
+});
+
+describe('FC escalation reviewer — configuration schema', () => {
+  it('requires only the persona and rejects unknown fields', () => {
+    expect(FindingContractConfigRawSchema.safeParse({
+      manager: { persona: 'm', instruction: 'i', output_contract: 'o' },
+      escalation_reviewer: { persona: 'escalation-supervisor' },
+    }).success).toBe(true);
+    expect(FindingContractConfigRawSchema.safeParse({
+      manager: { persona: 'm', instruction: 'i', output_contract: 'o' },
+      escalation_reviewer: {},
+    }).success).toBe(false);
+    expect(FindingContractConfigRawSchema.safeParse({
+      manager: { persona: 'm', instruction: 'i', output_contract: 'o' },
+      escalation_reviewer: { persona: 'escalation-supervisor', unknown_field: true },
+    }).success).toBe(false);
+  });
+
+  it('normalizes the routing key to escalation-reviewer regardless of the persona name', () => {
+    const workflow = normalizeWorkflowConfig({
+      name: 'escalation-workflow',
+      finding_contract: {
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          output_contract: 'findings-manager',
+        },
+        escalation_reviewer: {
+          persona: 'terminal-supervisor',
+          provider: 'codex',
+          model: 'gpt-test',
+        },
+      },
+      initial_step: 'review',
+      max_steps: 2,
+      steps: [{
+        name: 'review',
+        persona: 'reviewer',
+        instruction: 'Review.',
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      }],
+    }, '/tmp/project');
+
+    expect(workflow.findingContract?.escalationReviewer).toEqual({
+      persona: 'terminal-supervisor',
+      personaDisplayName: 'terminal-supervisor',
+      providerRoutingPersonaKey: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+      provider: 'codex',
+      model: 'gpt-test',
+    });
+  });
+
+  it('leaves escalationReviewer undefined when the workflow omits it', () => {
+    const workflow = normalizeWorkflowConfig({
+      name: 'plain-fc-workflow',
+      finding_contract: {
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          output_contract: 'findings-manager',
+        },
+      },
+      initial_step: 'review',
+      max_steps: 2,
+      steps: [{
+        name: 'review',
+        persona: 'reviewer',
+        instruction: 'Review.',
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      }],
+    }, '/tmp/project');
+
+    expect(workflow.findingContract?.escalationReviewer).toBeUndefined();
+  });
+
+  it('reserves the escalation-reviewer step name only while the role is configured', () => {
+    const workflowRaw = (withEscalationReviewer: boolean) => ({
+      name: 'reserved-name-workflow',
+      finding_contract: {
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          output_contract: 'findings-manager',
+        },
+        ...(withEscalationReviewer
+          ? { escalation_reviewer: { persona: 'terminal-supervisor' } }
+          : {}),
+      },
+      initial_step: 'review',
+      max_steps: 2,
+      steps: [
+        {
+          name: 'review',
+          persona: 'reviewer',
+          instruction: 'Review.',
+          rules: [{ condition: 'done', next: 'escalation-reviewer' }],
+        },
+        {
+          name: 'escalation-reviewer',
+          persona: 'reviewer',
+          instruction: 'Review again.',
+          rules: [{ condition: 'done', next: 'COMPLETE' }],
+        },
+      ],
+    });
+
+    expect(() => normalizeWorkflowConfig(workflowRaw(true), '/tmp/project'))
+      .toThrow(/step name "escalation-reviewer" is reserved/);
+    expect(() => normalizeWorkflowConfig(workflowRaw(false), '/tmp/project')).not.toThrow();
+  });
+
+  it('reserves the escalation-reviewer name for parallel sub-steps too', () => {
+    expect(() => normalizeWorkflowConfig({
+      name: 'reserved-parallel-workflow',
+      finding_contract: {
+        manager: {
+          persona: 'findings-manager',
+          instruction: 'findings-manager',
+          output_contract: 'findings-manager',
+        },
+        escalation_reviewer: { persona: 'terminal-supervisor' },
+      },
+      initial_step: 'reviewers',
+      max_steps: 2,
+      steps: [{
+        name: 'reviewers',
+        parallel: [
+          {
+            name: 'escalation-reviewer',
+            persona: 'reviewer',
+            instruction: 'Review.',
+            rules: [{ condition: 'done', next: 'COMPLETE' }],
+          },
+        ],
+        rules: [{ condition: 'all(done)', next: 'COMPLETE' }],
+      }],
+    }, '/tmp/project')).toThrow(/step name "escalation-reviewer" is reserved/);
+  });
+});
+
+describe('FC escalation reviewer — restatement instruction', () => {
+  it.each(['en', 'ja'] as const)(
+    'tells the %s restatement reviewer to read the target files and request quotes from them',
+    (language) => {
+      const requestWithoutId = {
+        anomalyId: 'RA-ESCALATION',
+        reviewer: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+        presentationOrdinal: 2,
+        reviewScopeSnapshotId: '7'.repeat(64),
+        sourceExcerptDigest: '8'.repeat(64),
+        claimedExcerpt: 'A bounded reviewer claim.',
+        targetPaths: ['src/example.ts'],
+        missingRequirements: [] as const,
+        expectedRelation: 'new' as const,
+        expectedTargetFindingId: null,
+        expectedTargetPreconditionClass: 'absent' as const,
+      };
+      const context = createFindingReviewPresentationContextV2({
+        reviewScopeSnapshotId: requestWithoutId.reviewScopeSnapshotId,
+        restatementRequests: [{
+          ...requestWithoutId,
+          restatementRequestId: computeRestatementRequestId(requestWithoutId),
+        }],
+      });
+      const instruction = buildFindingContractInstruction({
+        contract: {
+          ledgerSummary: { findings: [] },
+          hasOpenFindings: false,
+          hasWaivedFindings: false,
+          hasDismissedFindings: false,
+          reviewer: {
+            mode: 'structured',
+            rawFindingsStructuredOutput: { schemaRef: 'test', schema: { type: 'object' } },
+            reviewScopeSnapshotId: context.reviewScopeSnapshotId,
+            presentationContext: context,
+          },
+        },
+        language,
+        renderFencedJsonBlock: (value) => `\`\`\`json\n${JSON.stringify(value)}\n\`\`\``,
+      });
+
+      expect(instruction).toContain('file_quote');
+      expect(instruction).toContain('verbatimExcerpt');
+      expect(instruction).toMatch(language === 'en' ? /Read the request's target files/ : /対象ファイルをリポジトリで実際に読/);
+    },
+  );
+
+  it('keeps phase 2 restatement-only for the escalation context and loses it for a rebuilt empty one', () => {
+    const requestWithoutId = {
+      anomalyId: 'RA-PHASE2',
+      reviewer: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+      presentationOrdinal: 1,
+      reviewScopeSnapshotId: '9'.repeat(64),
+      sourceExcerptDigest: 'a'.repeat(64),
+      claimedExcerpt: 'A bounded reviewer claim.',
+      targetPaths: [] as const,
+      missingRequirements: [] as const,
+      expectedRelation: 'new' as const,
+      expectedTargetFindingId: null,
+      expectedTargetPreconditionClass: 'absent' as const,
+    };
+    const escalationPresentationContext = createFindingReviewPresentationContextV2({
+      reviewScopeSnapshotId: requestWithoutId.reviewScopeSnapshotId,
+      restatementRequests: [{
+        ...requestWithoutId,
+        restatementRequestId: computeRestatementRequestId(requestWithoutId),
+      }],
+    });
+    const reportInstruction = (
+      presentationContext: ReturnType<typeof createFindingReviewPresentationContextV2>,
+    ) => buildFindingContractReportInstruction({
+      contract: {
+        ledgerSummary: { findings: [] },
+        reportLedgerSummary: { findings: [] },
+        hasOpenFindings: false,
+        hasWaivedFindings: false,
+        hasDismissedFindings: false,
+        reviewer: {
+          mode: 'structured',
+          rawFindingsStructuredOutput: { schemaRef: 'test', schema: { type: 'object' } },
+          reviewScopeSnapshotId: presentationContext.reviewScopeSnapshotId,
+          presentationContext,
+        },
+      },
+      language: 'en',
+      renderFencedJsonBlock: (value) => `\`\`\`json\n${JSON.stringify(value)}\n\`\`\``,
+    });
+
+    // Phase 1 と同じ context を渡した Phase 2 は restatement-only のまま。
+    const escalationReportInstruction = reportInstruction(escalationPresentationContext);
+    expect(escalationReportInstruction).toContain('restatement-only review');
+    expect(escalationReportInstruction).toContain('RA-PHASE2');
+    // reviewer 名から組み直した context（request 0件）は通常レビュー契約へ化ける。
+    const rebuiltReportInstruction = reportInstruction(createFindingReviewPresentationContextV2({
+      reviewScopeSnapshotId: requestWithoutId.reviewScopeSnapshotId,
+    }));
+    expect(rebuiltReportInstruction).not.toContain('restatement-only review');
+    expect(rebuiltReportInstruction).toContain('Report every fresh issue you observe');
+  });
+});
+
+describe('FC escalation reviewer — presentation freeze', () => {
+  const reviewerStep: WorkflowStep = {
+    name: 'architecture-review',
+    persona: 'reviewer',
+    instruction: 'Review.',
+    outputContracts: [{ name: 'architecture-review', format: 'Owner report format.' }],
+    rules: [],
+  };
+  const reviewScopeSnapshotId = 'b'.repeat(64);
+  const structuredStrategy = {
+    kind: 'structured',
+    reportGeneration: 'structured',
+    intake: 'reviewer_structured',
+  } as const;
+
+  function makeServices(presentationLimit: number) {
+    const cwd = process.cwd();
+    const runPaths = buildRunPaths(cwd, `escalation-freeze-${presentationLimit}`);
+    // 提示回数の正本は report dir の canonical publication。凍結が効いているかを
+    // 見るため、実際に publication を書き込める隔離ディレクトリを使う。
+    const reportDir = mkdtempSync(join(tmpdir(), 'takt-fc-escalation-freeze-'));
+    const raw = canonicalRawFindingFixture({
+      rawFindingId: 'raw-freeze',
+      stepName: reviewerStep.name,
+      reviewer: reviewerStep.name,
+      familyTag: null,
+      severity: null,
+      title: null,
+      description: null,
+      suggestion: null,
+      relation: 'new',
+      targetFindingId: null,
+      target: { kind: 'code', paths: ['src/example.ts'] },
+      rawExcerpt: 'The reviewer claim must be restated.',
+      evidence: [],
+    });
+    const observedAt = {
+      runId: 'run-escalation-freeze',
+      stepName: reviewerStep.name,
+      timestamp: '2026-08-07T00:00:00.000Z',
+    };
+    const emptyLedger: FindingLedger = {
+      workflowName: 'peer-review',
+      nextId: 1,
+      updatedAt: observedAt.timestamp,
+      findings: [],
+      evidenceRecords: [],
+      rawFindings: [raw],
+      conflicts: [],
+      lifecycleReservations: [],
+      lifecycleEvents: [],
+      ...createEmptyFindingContractRegistries(),
+    };
+    const ledger = applyReviewerAnomalySpecsToLedger(emptyLedger, [createReviewerAnomalySpec({
+      wire: raw,
+      canonical: canonicalizeReviewerRawFinding(
+        candidateFromStoredRawFinding(raw, 'reviewer-stable-key'),
+        { ledger: emptyLedger },
+      ).canonical,
+      anomalyKind: 'intake-contract-incomplete',
+      reason: 'The normalized claim omitted product identity.',
+      intakeContract: {
+        observationClass: 'claim-bearing',
+        classificationAuthorityId: 'system/intake_observation_classification_v1',
+        reasonCodes: ['product-identity-incomplete'],
+        missingRequirements: ['title'],
+        presentationOwnerReviewer: reviewerStep.name,
+        presentationLimit,
+      },
+    })], {
+      workflowName: 'peer-review',
+      stepName: observedAt.stepName,
+      runId: observedAt.runId,
+      timestamp: observedAt.timestamp,
+    }, new Set());
+
+    const services = createWorkflowEngineServices({
+      config: {
+        name: 'test-workflow',
+        initialStep: reviewerStep.name,
+        maxSteps: 10,
+        steps: [reviewerStep],
+      },
+      state: {
+        workflowName: 'test-workflow',
+        currentStep: reviewerStep.name,
+        iteration: 1,
+        stepOutputs: new Map(),
+        structuredOutputs: new Map(),
+        systemContexts: new Map(),
+        effectResults: new Map(),
+        userInputs: [],
+        personaSessions: new Map(),
+        stepIterations: new Map(),
+        restoredStepIterationNames: new Set(),
+        dynamicParallelSelections: new Map(),
+        resumedDynamicParallelSteps: new Set(),
+        status: 'running',
+      },
+      task: 'test task',
+      projectCwd: cwd,
+      getCwd: () => cwd,
+      getReportDir: () => reportDir,
+      getRunPaths: () => runPaths,
+      getMaxSteps: () => 10,
+      options: {
+        projectCwd: cwd,
+        structuredOutputNormalizers: createStructuredOutputNormalizerRegistry([]),
+      },
+      structuredCaller: {
+        evaluateCondition: vi.fn(),
+        judgeStatus: vi.fn(),
+        decomposeTask: vi.fn(),
+        requestMoreParts: vi.fn(),
+      },
+      sharedRuntime: createSharedRuntime(undefined, 10),
+      resumeStackPrefix: [],
+      runPaths,
+      updateMaxSteps: vi.fn(),
+      setActiveResumePoint: vi.fn(),
+      persistDynamicParallelSelection: vi.fn(),
+      refreshFindingsState: vi.fn(),
+      findingContract: contractWithEscalationReviewer() as never,
+      findingLedgerStore: { loadLedger: () => ledger } as never,
+      updatePersonaSession: vi.fn(),
+      resolveNextStepFromDone: vi.fn(),
+      resetCycleDetector: vi.fn(),
+      emitEvent: vi.fn(),
+      createEngine: vi.fn(),
+    });
+    return {
+      services,
+      reportDir,
+      anomalyId: ledger.reviewerAnomalies![0]!.id,
+      cleanup: () => rmSync(reportDir, { recursive: true, force: true }),
+    };
+  }
+
+  /** owner reviewer がその anomaly を提示した canonical publication を報告先へ実際に書き込む。 */
+  function persistOwnerPresentation(input: {
+    reportDir: string;
+    anomalyId: string;
+    presentationOrdinal: number;
+  }): void {
+    const requestWithoutId = {
+      anomalyId: input.anomalyId,
+      reviewer: reviewerStep.name,
+      presentationOrdinal: input.presentationOrdinal,
+      reviewScopeSnapshotId,
+      sourceExcerptDigest: 'c'.repeat(64),
+      claimedExcerpt: 'The reviewer claim must be restated.',
+      targetPaths: ['src/example.ts'],
+      missingRequirements: ['title'] as const,
+      expectedRelation: 'new' as const,
+      expectedTargetFindingId: null,
+      expectedTargetPreconditionClass: 'absent' as const,
+    };
+    const presentationContext = createFindingReviewPresentationContextV2({
+      reviewScopeSnapshotId,
+      restatementRequests: [{
+        ...requestWithoutId,
+        restatementRequestId: computeRestatementRequestId(requestWithoutId),
+      }],
+    });
+    expect(presentationContext.presentedReviewerAnomalyIds).toEqual([input.anomalyId]);
+    persistFindingReviewPublication(input.reportDir, {
+      publication: createFindingReviewPublication({
+        identity: {
+          scopeIdentity: 'scope-fc-escalation-freeze',
+          callNamespace: '',
+          parentStepName: reviewerStep.name,
+          stepIteration: 1,
+          reviewerStepName: reviewerStep.name,
+          reportName: 'architecture-review.md',
+        },
+        protocol: STRUCTURED_FINDING_REVIEW_PUBLICATION_PROTOCOL,
+        reportContent: 'Owner restatement report.',
+        rawFindings: [],
+        presentationContext,
+      }),
+      reviewerExecutionIdentity: { provider: 'codex' },
+    });
+  }
+
+  it('does not escalate in the same round the owner reviewer spends its (limit-1) presentation', () => {
+    const { services, reportDir, anomalyId, cleanup } = makeServices(2);
+    try {
+      const freezeKey = 'freeze-limit-2';
+
+      const ownerContext = services.optionsBuilder.buildFindingContractInstructionContext(
+        reviewerStep,
+        structuredStrategy,
+        reviewScopeSnapshotId,
+        freezeKey,
+      );
+      const ownerPresentation = ownerContext?.reviewer?.presentationContext;
+      // owner が limit-1 回目（ordinal 1）を提示するラウンド。
+      expect(ownerPresentation?.revision === 2 && ownerPresentation.restatementRequests).toMatchObject([
+        { reviewer: reviewerStep.name, presentationOrdinal: 1 },
+      ]);
+
+      // owner の canonical publication が実際に成立した状態を作る。ここで
+      // presentation counts を数え直すと presentedCount=1 → ordinal 2 =
+      // escalation になり、同じ iteration で二重提示になる。
+      persistOwnerPresentation({ reportDir, anomalyId, presentationOrdinal: 1 });
+      expect(listFindingReviewPublications(reportDir)[0]!.presentationContext.presentedReviewerAnomalyIds)
+        .toEqual([anomalyId]);
+
+      // 凍結した presentation counts を使う限り、同じラウンドでは発火しない。
+      expect(services.optionsBuilder.buildFindingEscalationInstructionContext({
+        ownerStepNames: [reviewerStep.name],
+        reviewScopeSnapshotId,
+        findingContractFreezeKey: freezeKey,
+      })).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('escalates the only presentation when presentationLimit is 1 and leaves the owner batch empty', () => {
+    const { services, cleanup } = makeServices(1);
+    try {
+      const freezeKey = 'freeze-limit-1';
+
+      const ownerContext = services.optionsBuilder.buildFindingContractInstructionContext(
+        reviewerStep,
+        structuredStrategy,
+        reviewScopeSnapshotId,
+        freezeKey,
+      );
+      const ownerPresentation = ownerContext?.reviewer?.presentationContext;
+      expect(ownerPresentation?.revision === 2 && ownerPresentation.restatementRequests).toEqual([]);
+
+      const escalationContext = services.optionsBuilder.buildFindingEscalationInstructionContext({
+        ownerStepNames: [reviewerStep.name],
+        reviewScopeSnapshotId,
+        findingContractFreezeKey: freezeKey,
+      });
+      const escalationPresentation = escalationContext?.reviewer?.presentationContext;
+      expect(escalationPresentation?.revision === 2 && escalationPresentation.restatementRequests)
+        .toMatchObject([
+          { reviewer: FINDING_ESCALATION_REVIEWER_ROUTING_KEY, presentationOrdinal: 1 },
+        ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('refuses to build an escalation batch from anything but the frozen input of the same round', () => {
+    const { services, cleanup } = makeServices(1);
+    try {
+      services.optionsBuilder.buildFindingContractInstructionContext(
+        reviewerStep,
+        structuredStrategy,
+        reviewScopeSnapshotId,
+        'freeze-current-round',
+      );
+
+      expect(() => services.optionsBuilder.buildFindingEscalationInstructionContext({
+        ownerStepNames: [reviewerStep.name],
+        reviewScopeSnapshotId,
+        findingContractFreezeKey: 'freeze-other-round',
+      })).toThrow(/frozen reviewer input of the same review round/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('FC escalation reviewer — direct provider call wiring', () => {
+  const escalationContext = {
+    ledgerSummary: { findings: [] },
+    reportLedgerSummary: { findings: [] },
+    hasOpenFindings: false,
+    hasWaivedFindings: false,
+    hasDismissedFindings: false,
+    reviewer: {
+      mode: 'structured' as const,
+      rawFindingsStructuredOutput: { schemaRef: 'takt.findings.raw', schema: { type: 'object' } },
+      reviewScopeSnapshotId: '5'.repeat(64),
+      presentationContext: {
+        revision: 2 as const,
+        reviewScopeSnapshotId: '5'.repeat(64),
+        restatementRequests: [],
+        presentedReviewerAnomalyIds: [],
+        contextDigest: '6'.repeat(64),
+      },
+    },
+  };
+
+  const ownerReviewerStep = {
+    kind: 'agent' as const,
+    name: 'architecture-review',
+    instruction: 'Review.',
+    outputContracts: [{ name: 'architecture-review', format: 'Owner report format.' }],
+  };
+
+  function createRunnerInput(overrides: {
+    resumeResult?: unknown;
+    prepareResult?: unknown;
+    withoutEscalationContext?: boolean;
+  } = {}) {
+    const recordSynthesizedAgentUsage = vi.fn();
+    const prepareFindingReviewPublication = vi.fn().mockResolvedValue(
+      overrides.prepareResult ?? { publication: { publicationId: 'pub-escalation' } },
+    );
+    const stepExecutor = {
+      recordSynthesizedAgentUsage,
+      resumeFindingReviewPublication: vi.fn().mockResolvedValue(overrides.resumeResult),
+      buildInstruction: vi.fn().mockReturnValue('escalation instruction'),
+      buildPhase1Instruction: vi.fn((instruction: string) => instruction),
+      prepareFindingReviewPublication,
+    };
+    const optionsBuilder = {
+      // 通常レビュアーの Phase 1 と同じ形。allowedTools は provider 既定
+      // （undefined）で、permission は profile 解決に委ねられている。
+      buildAgentOptions: vi.fn().mockReturnValue({
+        cwd: '/repo',
+        allowedTools: undefined,
+        sessionId: undefined,
+        permissionResolution: {
+          stepName: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+          requiredPermissionMode: undefined,
+          providerProfiles: { mock: { defaultPermissionMode: 'edit' } },
+        },
+      }),
+      resolveStepProviderModel: vi.fn().mockReturnValue({ provider: 'mock', model: 'mock-model' }),
+    };
+    return {
+      input: {
+        contract: contractWithEscalationReviewer(),
+        ...(overrides.withoutEscalationContext === true ? {} : { escalationContext }),
+        ownerReviewerSteps: [ownerReviewerStep],
+        parentStepName: 'reviewers',
+        stepIteration: 1,
+        state: { iteration: 1 },
+        task: 'Improve the code.',
+        maxSteps: 20,
+        optionsBuilder,
+        stepExecutor,
+        updatePersonaSession: vi.fn(),
+      } as unknown as Parameters<typeof runFindingEscalationReviewer>[0],
+      stepExecutor,
+      optionsBuilder,
+    };
+  }
+
+  beforeEach(() => {
+    executeAgentMock.mockReset();
+  });
+
+  it('publishes through the ordinary intake pipeline and records synthesized usage', async () => {
+    const doneResponse: AgentResponse = {
+      persona: 'escalation-supervisor',
+      status: 'done',
+      content: '{}',
+      sessionId: 'session-escalation',
+      timestamp: new Date(),
+    };
+    executeAgentMock.mockResolvedValue(doneResponse);
+    const { input, stepExecutor } = createRunnerInput();
+
+    const outcome = await runFindingEscalationReviewer(input);
+
+    expect(outcome).toMatchObject({
+      kind: 'published',
+      publication: { publicationId: 'pub-escalation' },
+    });
+    expect(outcome!.step.name).toBe(FINDING_ESCALATION_REVIEWER_ROUTING_KEY);
+    expect(outcome!.step.structuredOutput).toBe(
+      escalationContext.reviewer.rawFindingsStructuredOutput,
+    );
+    // 実際に走った attempt の provider/model をそのまま計上する。
+    expect(stepExecutor.recordSynthesizedAgentUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ name: FINDING_ESCALATION_REVIEWER_ROUTING_KEY }),
+      true,
+      undefined,
+      { provider: 'mock', model: 'mock-model' },
+    );
+    expect(stepExecutor.prepareFindingReviewPublication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentStepName: 'reviewers',
+        stepIteration: 1,
+        presentationContext: escalationContext.reviewer.presentationContext,
+        // Phase 2 が step 名から context を組み直すと restatement-only 契約が
+        // 消えるため、Phase 1 と同じ context を明示的に渡す。
+        findingContractContext: escalationContext,
+        reviewerOutputStrategy: {
+          kind: 'structured',
+          reportGeneration: 'structured',
+          intake: 'reviewer_structured',
+        },
+      }),
+    );
+  });
+
+  it('runs phase 1 with read-only tools so it can read the code it must quote', async () => {
+    executeAgentMock.mockResolvedValue({
+      persona: 'escalation-supervisor',
+      status: 'done',
+      content: '{}',
+      timestamp: new Date(),
+    } satisfies AgentResponse);
+    const { input, optionsBuilder } = createRunnerInput();
+
+    await runFindingEscalationReviewer(input);
+
+    expect(optionsBuilder.buildAgentOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+        edit: false,
+        session: 'refresh',
+      }),
+      undefined,
+    );
+    const agentOptions = executeAgentMock.mock.calls[0]![2]!;
+    // findings-manager の allowedTools: [] は流用しない。読み取りツールが
+    // 塞がれると新規の byte-exact 証拠を自作できない。
+    expect(agentOptions.allowedTools).toBeUndefined();
+    // provider profile が edit を既定にしていても書き込みへ昇格させない。
+    expect(agentOptions.permissionMode).toBe('readonly');
+    expect(agentOptions).not.toHaveProperty('permissionResolution');
+    expect(agentOptions.sessionId).toBeUndefined();
+  });
+
+  it('maps a failed phase 1 to a terminal outcome without preparing a publication', async () => {
+    executeAgentMock.mockResolvedValue({
+      persona: 'escalation-supervisor',
+      status: 'error',
+      content: '',
+      error: 'provider exploded',
+      timestamp: new Date(),
+    } satisfies AgentResponse);
+    const { input, stepExecutor } = createRunnerInput();
+
+    const outcome = await runFindingEscalationReviewer(input);
+
+    expect(outcome).toMatchObject({ kind: 'terminal', response: { status: 'error' } });
+    expect(stepExecutor.prepareFindingReviewPublication).not.toHaveBeenCalled();
+  });
+
+  it('resumes a stored escalation publication without issuing a provider call', async () => {
+    const { input, stepExecutor } = createRunnerInput({
+      resumeResult: { publication: { publicationId: 'pub-resumed' }, response: { status: 'done' } },
+    });
+
+    const outcome = await runFindingEscalationReviewer(input);
+
+    expect(outcome).toMatchObject({
+      kind: 'published',
+      publication: { publicationId: 'pub-resumed' },
+    });
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(stepExecutor.prepareFindingReviewPublication).not.toHaveBeenCalled();
+  });
+
+  it('hands a stored escalation publication to the manager even when the budget is spent', async () => {
+    // 前ラウンドで publication が成立していれば提示は計上済みで、今ラウンドの
+    // escalation request は0件になる。それでも raw findings がまだ intake されて
+    // いない可能性があるため、request の有無より先に stored publication を引く。
+    const { input, stepExecutor } = createRunnerInput({
+      withoutEscalationContext: true,
+      resumeResult: { publication: { publicationId: 'pub-carried-over' }, response: { status: 'done' } },
+    });
+
+    const outcome = await runFindingEscalationReviewer(input);
+
+    expect(outcome).toMatchObject({
+      kind: 'published',
+      publication: { publicationId: 'pub-carried-over' },
+    });
+    expect(stepExecutor.resumeFindingReviewPublication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentStepName: 'reviewers',
+        stepIteration: 1,
+        step: expect.objectContaining({ name: FINDING_ESCALATION_REVIEWER_ROUTING_KEY }),
+      }),
+    );
+    expect(executeAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is neither an escalation request nor a stored publication', async () => {
+    const { input, stepExecutor } = createRunnerInput({ withoutEscalationContext: true });
+
+    expect(await runFindingEscalationReviewer(input)).toBeUndefined();
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(stepExecutor.prepareFindingReviewPublication).not.toHaveBeenCalled();
+  });
+});
+
+describe('FC escalation reviewer — caller reaches the runner without a request batch', () => {
+  const reviewerSubStep = {
+    kind: 'agent' as const,
+    name: 'architecture-review',
+    persona: 'reviewer',
+    instruction: 'Review.',
+    outputContracts: [
+      { name: 'architecture-review.md', format: 'Owner report format.', formatRef: 'review-finding-contract' },
+    ],
+    rules: [makeRule('approved', 'COMPLETE')],
+  };
+
+  it('calls the escalation runner even when this round has no escalation request', async () => {
+    const publication = { publicationId: 'pub-owner', rawFindings: [] };
+    const resumeFindingReviewPublication = vi.fn().mockResolvedValue({
+      publication,
+      response: {
+        persona: reviewerSubStep.name,
+        status: 'done',
+        content: '[STEP:1] approved',
+        timestamp: new Date('2026-08-07T00:00:00.000Z'),
+      },
+    });
+    const findingContractContext = {
+      ledgerSummary: '{"findings":[]}',
+      reportLedgerSummary: '{"ids":[]}',
+      hasOpenFindings: false,
+      hasWaivedFindings: false,
+      hasDismissedFindings: false,
+      reviewer: {
+        mode: 'structured' as const,
+        rawFindingsStructuredOutput: { schemaRef: 'takt.findings.raw', schema: { type: 'object' } },
+        reviewScopeSnapshotId: 'd'.repeat(64),
+      },
+    };
+    // 今ラウンドは格上げ対象の anomaly が0件 = escalation context は undefined。
+    const buildFindingEscalationInstructionContext = vi.fn().mockReturnValue(undefined);
+    const deps = {
+      optionsBuilder: {
+        buildAgentOptions: vi.fn().mockReturnValue({}),
+        buildPhaseRunnerContext: vi.fn().mockReturnValue({}),
+        resolveStepProviderModelBeforeAutoRouting: vi.fn().mockReturnValue({ provider: 'mock', model: 'mock-model' }),
+        resolveStepProviderModel: vi.fn().mockReturnValue({ provider: 'mock', model: 'mock-model' }),
+        buildFindingContractInstructionContext: vi.fn().mockReturnValue(findingContractContext),
+        buildFindingEscalationInstructionContext,
+      },
+      stepExecutor: {
+        buildInstruction: vi.fn((step: { name: string }) => `instruction:${step.name}`),
+        buildPhase1Instruction: vi.fn((instruction: string) => instruction),
+        emitStepReports: vi.fn(),
+        persistPreviousResponseSnapshot: vi.fn(),
+        applyPostExecutionRulesOnly: vi.fn(async (_step, _state, response) => ({
+          ...response,
+          matchedRuleIndex: 0,
+        })),
+        recordSynthesizedAgentUsage: vi.fn(),
+        resumeFindingReviewPublication,
+        prepareFindingReviewPublication: vi.fn(),
+      },
+      engineOptions: { projectCwd: '/tmp/project' },
+      getCwd: () => '/tmp/project',
+      getReportDir: () => '.takt/runs/test/reports',
+      getWorkflowName: () => 'test-workflow',
+      getTask: () => 'test task',
+      getInteractive: () => false,
+      getRunId: () => 'test-run',
+      getFindingCallNamespace: () => '',
+      reviewPublicationDir: '/tmp/project/reports',
+      findingManagerAuthority: 'standard',
+      findingContract: contractWithEscalationReviewer(),
+      findingLedgerStore: {
+        ledgerIdentity: 'scope-escalation-caller',
+        workflowName: 'test-workflow',
+        runId: 'test-run',
+        loadLedger: () => ({ findings: [] }),
+      },
+      observabilityEnabled: false,
+      refreshFindingsState: vi.fn(),
+      emitEvent: vi.fn(),
+      runQualityGates: vi.fn().mockResolvedValue({ ok: true }),
+      claimStepOccurrence: vi.fn().mockReturnValue(1),
+      updateMaxSteps: vi.fn(),
+      setActiveResumePoint: vi.fn(),
+      dynamicParallelSelector: { selectParticipants: vi.fn() },
+    } as unknown as ParallelRunnerDeps;
+
+    await new ParallelRunner(deps).runParallelStep(
+      makeStep({
+        name: 'reviewers',
+        instruction: 'Run reviewers',
+        parallel: [reviewerSubStep as unknown as WorkflowStep],
+        rules: [makeRule('all("approved")', 'COMPLETE')],
+      }),
+      {
+        workflowName: 'test-workflow',
+        currentStep: 'reviewers',
+        iteration: 1,
+        stepOutputs: new Map(),
+        structuredOutputs: new Map(),
+        systemContexts: new Map(),
+        effectResults: new Map(),
+        userInputs: [],
+        personaSessions: new Map(),
+        stepIterations: new Map(),
+        status: 'running',
+      } as unknown as Parameters<ParallelRunner['runParallelStep']>[1],
+      'test task',
+      10,
+      vi.fn(),
+    );
+
+    expect(buildFindingEscalationInstructionContext).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerStepNames: [reviewerSubStep.name] }),
+    );
+    // request が0件でも runner へ到達し、未取り込みの stored escalation publication を
+    // resume で引き当てにいく。ここで早期 return すると raw findings が永久に
+    // intake されない。
+    const escalationResumeCalls = resumeFindingReviewPublication.mock.calls.filter(
+      ([call]) => call.step.name === FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+    );
+    expect(escalationResumeCalls).toHaveLength(1);
+    expect(escalationResumeCalls[0]![0]).toMatchObject({
+      parentStepName: 'reviewers',
+      stepIteration: 1,
+    });
+  });
+});

--- a/src/__tests__/finding-fc-escalation-reviewer.test.ts
+++ b/src/__tests__/finding-fc-escalation-reviewer.test.ts
@@ -74,6 +74,10 @@ function contractWithEscalationReviewer(
       instruction: 'Manage findings.',
       outputContract: 'Manager output contract.',
     },
+    adjudicator: {
+      persona: 'supervisor',
+      instruction: 'Adjudicate findings.',
+    },
     escalationReviewer: {
       persona: 'escalation-supervisor',
       providerRoutingPersonaKey: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
@@ -109,23 +113,6 @@ describe('FC escalation reviewer — presentation phase', () => {
     }));
 
     expect(phases).toEqual(['restatement', 'restatement', 'restatement', 'exhausted']);
-  });
-
-  it('stays in the escalation phase while a publication never lands', () => {
-    // publication 成立前の失敗は presentedCount を増やさないため、次ラウンドも
-    // 同じ presentationOrdinal の escalation request を再発行する。
-    const beforeFailedRound = resolveRestatementPresentationPhase({
-      presentedCount: 1,
-      presentationLimit: 2,
-      escalationReviewerConfigured: true,
-    });
-    const afterFailedRound = resolveRestatementPresentationPhase({
-      presentedCount: 1,
-      presentationLimit: 2,
-      escalationReviewerConfigured: true,
-    });
-
-    expect([beforeFailedRound, afterFailedRound]).toEqual(['escalation', 'escalation']);
   });
 
   it('gives the owner request and the escalation request different identities without changing the digest contract', () => {
@@ -294,6 +281,13 @@ describe('FC escalation reviewer — configuration schema', () => {
           instruction: 'findings-manager',
           output_contract: 'findings-manager',
         },
+        // 正規化済み WorkflowConfig を engine が組み立てる際、合成 FC ロールは
+        // 事前検証される（CLAUDE.md）。adjudicator を欠くと検証を素通りする
+        // 構成をテストが作ってしまう。
+        adjudicator: {
+          persona: 'supervisor',
+          instruction: 'adjudicate-finding-contract',
+        },
         escalation_reviewer: {
           persona: 'terminal-supervisor',
           provider: 'codex',
@@ -328,6 +322,13 @@ describe('FC escalation reviewer — configuration schema', () => {
           instruction: 'findings-manager',
           output_contract: 'findings-manager',
         },
+        // 正規化済み WorkflowConfig を engine が組み立てる際、合成 FC ロールは
+        // 事前検証される（CLAUDE.md）。adjudicator を欠くと検証を素通りする
+        // 構成をテストが作ってしまう。
+        adjudicator: {
+          persona: 'supervisor',
+          instruction: 'adjudicate-finding-contract',
+        },
       },
       initial_step: 'review',
       max_steps: 2,
@@ -350,6 +351,13 @@ describe('FC escalation reviewer — configuration schema', () => {
           persona: 'findings-manager',
           instruction: 'findings-manager',
           output_contract: 'findings-manager',
+        },
+        // 正規化済み WorkflowConfig を engine が組み立てる際、合成 FC ロールは
+        // 事前検証される（CLAUDE.md）。adjudicator を欠くと検証を素通りする
+        // 構成をテストが作ってしまう。
+        adjudicator: {
+          persona: 'supervisor',
+          instruction: 'adjudicate-finding-contract',
         },
         ...(withEscalationReviewer
           ? { escalation_reviewer: { persona: 'terminal-supervisor' } }
@@ -386,6 +394,13 @@ describe('FC escalation reviewer — configuration schema', () => {
           persona: 'findings-manager',
           instruction: 'findings-manager',
           output_contract: 'findings-manager',
+        },
+        // 正規化済み WorkflowConfig を engine が組み立てる際、合成 FC ロールは
+        // 事前検証される（CLAUDE.md）。adjudicator を欠くと検証を素通りする
+        // 構成をテストが作ってしまう。
+        adjudicator: {
+          persona: 'supervisor',
+          instruction: 'adjudicate-finding-contract',
         },
         escalation_reviewer: { persona: 'terminal-supervisor' },
       },
@@ -646,15 +661,17 @@ describe('FC escalation reviewer — presentation freeze', () => {
     };
   }
 
-  /** owner reviewer がその anomaly を提示した canonical publication を報告先へ実際に書き込む。 */
-  function persistOwnerPresentation(input: {
+  /** 指定 reviewer がその anomaly を提示した canonical publication を報告先へ実際に書き込む。 */
+  function persistPresentation(input: {
     reportDir: string;
     anomalyId: string;
     presentationOrdinal: number;
+    reviewerStepName: string;
+    reportName: string;
   }): void {
     const requestWithoutId = {
       anomalyId: input.anomalyId,
-      reviewer: reviewerStep.name,
+      reviewer: input.reviewerStepName,
       presentationOrdinal: input.presentationOrdinal,
       reviewScopeSnapshotId,
       sourceExcerptDigest: 'c'.repeat(64),
@@ -680,15 +697,39 @@ describe('FC escalation reviewer — presentation freeze', () => {
           callNamespace: '',
           parentStepName: reviewerStep.name,
           stepIteration: 1,
-          reviewerStepName: reviewerStep.name,
-          reportName: 'architecture-review.md',
+          reviewerStepName: input.reviewerStepName,
+          reportName: input.reportName,
         },
         protocol: STRUCTURED_FINDING_REVIEW_PUBLICATION_PROTOCOL,
-        reportContent: 'Owner restatement report.',
+        reportContent: `${input.reviewerStepName} restatement report.`,
         rawFindings: [],
         presentationContext,
       }),
       reviewerExecutionIdentity: { provider: 'codex' },
+    });
+  }
+
+  function persistOwnerPresentation(input: {
+    reportDir: string;
+    anomalyId: string;
+    presentationOrdinal: number;
+  }): void {
+    persistPresentation({
+      ...input,
+      reviewerStepName: reviewerStep.name,
+      reportName: 'architecture-review.md',
+    });
+  }
+
+  function persistEscalationPresentation(input: {
+    reportDir: string;
+    anomalyId: string;
+    presentationOrdinal: number;
+  }): void {
+    persistPresentation({
+      ...input,
+      reviewerStepName: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+      reportName: `${FINDING_ESCALATION_REVIEWER_REPORT_NAME}.md`,
     });
   }
 
@@ -751,6 +792,68 @@ describe('FC escalation reviewer — presentation freeze', () => {
         .toMatchObject([
           { reviewer: FINDING_ESCALATION_REVIEWER_ROUTING_KEY, presentationOrdinal: 1 },
         ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('re-issues the same escalation request after a round whose publication never landed', () => {
+    const { services, reportDir, anomalyId, cleanup } = makeServices(2);
+    try {
+      // owner が limit-1 回目を提示し、その publication だけが成立している状態。
+      persistOwnerPresentation({ reportDir, anomalyId, presentationOrdinal: 1 });
+
+      const escalationRequestsForRound = (freezeKey: string) => {
+        services.optionsBuilder.buildFindingContractInstructionContext(
+          reviewerStep,
+          structuredStrategy,
+          reviewScopeSnapshotId,
+          freezeKey,
+        );
+        const context = services.optionsBuilder.buildFindingEscalationInstructionContext({
+          ownerStepNames: [reviewerStep.name],
+          reviewScopeSnapshotId,
+          findingContractFreezeKey: freezeKey,
+        });
+        const presentation = context?.reviewer?.presentationContext;
+        return presentation?.revision === 2 ? presentation.restatementRequests : undefined;
+      };
+
+      const firstRound = escalationRequestsForRound('freeze-escalation-round-1');
+      expect(firstRound).toMatchObject([
+        { reviewer: FINDING_ESCALATION_REVIEWER_ROUTING_KEY, presentationOrdinal: 2 },
+      ]);
+
+      // このラウンドは escalation publication を成立させずに失敗した想定。
+      // report dir には owner の publication しか無いままにする。
+      expect(listFindingReviewPublications(reportDir)).toHaveLength(1);
+
+      // 次ラウンドは同じ ordinal・同じ request ID の escalation request を再発行する。
+      const secondRound = escalationRequestsForRound('freeze-escalation-round-2');
+      expect(secondRound).toEqual(firstRound);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('stops issuing escalation requests once the escalation publication lands', () => {
+    const { services, reportDir, anomalyId, cleanup } = makeServices(2);
+    try {
+      persistOwnerPresentation({ reportDir, anomalyId, presentationOrdinal: 1 });
+      persistEscalationPresentation({ reportDir, anomalyId, presentationOrdinal: 2 });
+
+      services.optionsBuilder.buildFindingContractInstructionContext(
+        reviewerStep,
+        structuredStrategy,
+        reviewScopeSnapshotId,
+        'freeze-after-escalation',
+      );
+
+      expect(services.optionsBuilder.buildFindingEscalationInstructionContext({
+        ownerStepNames: [reviewerStep.name],
+        reviewScopeSnapshotId,
+        findingContractFreezeKey: 'freeze-after-escalation',
+      })).toBeUndefined();
     } finally {
       cleanup();
     }

--- a/src/__tests__/finding-fc-intake-contract.test.ts
+++ b/src/__tests__/finding-fc-intake-contract.test.ts
@@ -336,6 +336,120 @@ describe('FC intake contract', () => {
     expect(linked.reviewerAnomalies![0]!.promotedFindingId).toBe('F-0001');
   });
 
+  describe('escalation restatement correspondence', () => {
+    const escalationCase = (admittedReviewer: string, requestReviewer: string) => {
+      const sourceExcerpt = 'The escalated defect remains observable.';
+      const source = incompleteRaw('raw-escalation-source', {
+        rawExcerpt: sourceExcerpt,
+        sourceBinding: {
+          reportDigest: 'f'.repeat(64),
+          startByte: 0,
+          endByte: Buffer.byteLength(sourceExcerpt),
+          excerptDigest: '8'.repeat(64),
+        },
+      });
+      const admitted = canonicalRawFindingFixture({
+        rawFindingId: 'raw-escalation-admitted',
+        stepName: source.stepName,
+        reviewer: admittedReviewer,
+        familyTag: 'bug',
+        severity: 'high',
+        title: 'Escalated issue',
+        description: sourceExcerpt,
+        suggestion: null,
+        relation: 'new',
+        targetFindingId: null,
+        target: source.target,
+        sourceBinding: {
+          ...source.sourceBinding,
+          reportDigest: 'e'.repeat(64),
+          excerptDigest: '9'.repeat(64),
+        },
+        evidence: [],
+      });
+      const sourceItem = canonicalItem(source);
+      const spec = createReviewerAnomalySpec({
+        wire: source,
+        canonical: sourceItem.canonical,
+        anomalyKind: 'intake-contract-incomplete',
+        reason: 'The owner reviewer never restated a complete claim',
+        intakeContract: {
+          observationClass: 'claim-bearing' as const,
+          classificationAuthorityId: 'system/intake_observation_classification_v1',
+          reasonCodes: ['product-identity-incomplete'] as const,
+          missingRequirements: ['title'] as const,
+          presentationOwnerReviewer: source.reviewer,
+          presentationLimit: 2,
+        },
+      });
+      const withAnomaly = applyReviewerAnomalySpecsToLedger(emptyLedger(), [spec], {
+        workflowName: 'peer-review',
+        stepName: observedAt.stepName,
+        runId: observedAt.runId,
+        timestamp: observedAt.timestamp,
+      }, new Set());
+      const anomaly = withAnomaly.reviewerAnomalies![0]!;
+      const requestWithoutId = {
+        anomalyId: anomaly.id,
+        reviewer: requestReviewer,
+        presentationOrdinal: 2,
+        reviewScopeSnapshotId: 'a'.repeat(64),
+        sourceExcerptDigest: source.sourceBinding.excerptDigest,
+        claimedExcerpt: sourceExcerpt,
+        targetPaths: ['src/example.ts'] as const,
+        missingRequirements: ['title'] as const,
+        expectedRelation: 'new' as const,
+        expectedTargetFindingId: null,
+        expectedTargetPreconditionClass: 'absent' as const,
+      };
+      return linkPromotedReviewerAnomalies({
+        ...withAnomaly,
+        rawFindings: [source, admitted],
+        findings: [{
+          id: 'F-0001',
+          status: 'open',
+          lifecycle: 'new',
+          target: admitted.target,
+          targetIdentityHash: admitted.targetIdentityHash,
+          claimIdentityHash: admitted.claimIdentityHash,
+          semanticClaimIdentityHash: admitted.semanticClaimIdentityHash,
+          severity: admitted.severity!,
+          title: admitted.title!,
+          description: admitted.description!,
+          evidenceIds: [],
+          reviewers: [admitted.reviewer],
+          rawFindingIds: [admitted.rawFindingId],
+          firstSeen: observedAt,
+          lastSeen: observedAt,
+          revision: 1,
+        }],
+      }, [{
+        lineageKey: 'not-authoritative',
+        rawFindingId: admitted.rawFindingId,
+        restatementRequestBindings: [{
+          request: {
+            ...requestWithoutId,
+            restatementRequestId: computeRestatementRequestId(requestWithoutId),
+          },
+          publicationId: 'publication-escalation',
+          reportDigest: admitted.sourceBinding.reportDigest,
+        }],
+      }]);
+    };
+
+    it('promotes when the escalation reviewer restates an owner reviewer observation', () => {
+      const linked = escalationCase('escalation-reviewer', 'escalation-reviewer');
+
+      expect(linked.reviewerAnomalies![0]!.promotedFindingId).toBe('F-0001');
+    });
+
+    it('does not promote when a non-escalation request comes from a different reviewer', () => {
+      const linked = escalationCase('escalation-reviewer', 'architecture-review');
+
+      expect(linked.reviewerAnomalies![0]!.promotedFindingId).toBeUndefined();
+    });
+  });
+
   describe('restatement batch promotion (correspondence edges)', () => {
     const batchReportDigest = 'e'.repeat(64);
     const buildBatchCase = (

--- a/src/__tests__/step-executor.test.ts
+++ b/src/__tests__/step-executor.test.ts
@@ -42,6 +42,8 @@ import { initializeGitFixture } from './helpers/git-fixture.js';
 import { verifiedSourceQuoteFields } from './helpers/finding-evidence.js';
 import { authorizeFindingLedgerFixture } from './helpers/finding-lifecycle-fixture.js';
 import {
+  computeRestatementRequestId,
+  createFindingReviewPresentationContextV2,
   createPendingFindingReviewNormalization,
   createFindingReviewPublication,
   loadPendingFindingReviewNormalization,
@@ -486,6 +488,91 @@ describe('StepExecutor', () => {
         model: 'normalizer-model',
       });
     }
+  });
+
+  it('Phase 2 は明示指定された finding contract context を使い restatement-only 契約を保つ', async () => {
+    const rawFinding = {
+      rawExcerpt: 'Issue: src/example.ts still bypasses the required boundary.',
+      candidate: {
+        rawFindingId: null,
+        familyTag: null,
+        severity: null,
+        title: null,
+        description: 'src/example.ts still bypasses the required boundary.',
+        suggestion: null,
+        relation: null,
+        targetFindingIds: [],
+        target: null,
+        evidenceRequests: [],
+      },
+    };
+    const harness = createPlainTextPublicationHarness([{
+      persona: 'default',
+      status: 'done',
+      content: '{"rawFindings":[]}',
+      structuredOutput: { rawFindings: [rawFinding] },
+      timestamp: new Date('2026-08-07T00:00:01.000Z'),
+    }]);
+    const requestWithoutId = {
+      anomalyId: 'RA-PHASE2-OVERRIDE',
+      reviewer: 'escalation-reviewer',
+      presentationOrdinal: 1,
+      reviewScopeSnapshotId: '7'.repeat(64),
+      sourceExcerptDigest: '8'.repeat(64),
+      claimedExcerpt: 'A bounded reviewer claim.',
+      targetPaths: [] as const,
+      missingRequirements: [] as const,
+      expectedRelation: 'new' as const,
+      expectedTargetFindingId: null,
+      expectedTargetPreconditionClass: 'absent' as const,
+    };
+    const presentationContext = createFindingReviewPresentationContextV2({
+      reviewScopeSnapshotId: requestWithoutId.reviewScopeSnapshotId,
+      restatementRequests: [{
+        ...requestWithoutId,
+        restatementRequestId: computeRestatementRequestId(requestWithoutId),
+      }],
+    });
+    // Phase 2 の既定経路（reviewer step 名から context を組み直す）は、この
+    // harness の phase context に buildFindingContractInstructionContext が無いため
+    // Finding Contract ブロックを一切出さない。明示 override が届いて初めて
+    // restatement-only 契約が Phase 2 の指示に残る。
+    const explicitContext = {
+      ledgerSummary: '{"findings":[]}',
+      reportLedgerSummary: '{"ids":[]}',
+      hasOpenFindings: false,
+      hasWaivedFindings: false,
+      hasDismissedFindings: false,
+      reviewer: {
+        mode: 'plain_text_normalized' as const,
+        reviewScopeSnapshotId: requestWithoutId.reviewScopeSnapshotId,
+        presentationContext,
+      },
+    };
+
+    await harness.executor.prepareFindingReviewPublication({
+      step: harness.step,
+      executableStep: harness.step,
+      reviewerOutputStrategy: PLAIN_TEXT_NORMALIZED_STRATEGY,
+      parentStepName: 'reviewers',
+      stepIteration: 1,
+      state: harness.state,
+      phase1Response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: 'phase 1 investigation',
+        sessionId: 'reviewer-phase1-session',
+        timestamp: new Date('2026-08-07T00:00:00.000Z'),
+      },
+      agentOptions: { resolvedProvider: 'mock' },
+      onProviderAttempt: vi.fn(),
+      updatePersonaSession: harness.updatePersonaSession,
+      findingContractContext: explicitContext,
+    });
+
+    const reportInstruction = vi.mocked(executeAgent).mock.calls[0]?.[1] ?? '';
+    expect(reportInstruction).toContain('restatement-only review');
+    expect(reportInstruction).toContain('RA-PHASE2-OVERRIDE');
   });
 
   it('plain-text normalizerはmodel output不正時だけ新規抽出を1回訂正する', async () => {
@@ -2272,7 +2359,14 @@ describe('StepExecutor', () => {
     );
 
     expect(buildFindingContractInstructionContext)
-      .toHaveBeenCalledWith(step, { kind: 'structured', reportGeneration: 'structured', intake: 'reviewer_structured' });
+      .toHaveBeenCalledWith(
+        step,
+        { kind: 'structured', reportGeneration: 'structured', intake: 'reviewer_structured' },
+        undefined,
+        // owner context と escalation slot が同じ ledger / presentation counts を
+        // 見るための凍結キー。
+        expect.stringMatching(new RegExp(`^${step.name}\\u0000\\d+\\u0000\\d+$`)),
+      );
     expect(buildAgentOptions).toHaveBeenCalledWith(expect.objectContaining({
       structuredOutput,
     }), undefined);

--- a/src/__tests__/step-executor.test.ts
+++ b/src/__tests__/step-executor.test.ts
@@ -2364,9 +2364,15 @@ describe('StepExecutor', () => {
         { kind: 'structured', reportGeneration: 'structured', intake: 'reviewer_structured' },
         undefined,
         // owner context と escalation slot が同じ ledger / presentation counts を
-        // 見るための凍結キー。
-        expect.stringMatching(new RegExp(`^${step.name}\\u0000\\d+\\u0000\\d+$`)),
+        // 見るための凍結キー。区切りは固定なので分解して検証する。
+        expect.any(String),
       );
+    const freezeKey = String(buildFindingContractInstructionContext.mock.calls[0]![3]);
+    const freezeKeyParts = freezeKey.split('\u0000');
+    expect(freezeKeyParts).toHaveLength(3);
+    expect(freezeKeyParts[0]).toBe(step.name);
+    expect(Number(freezeKeyParts[1])).toBeGreaterThan(0);
+    expect(Number(freezeKeyParts[2])).toBeGreaterThan(0);
     expect(buildAgentOptions).toHaveBeenCalledWith(expect.objectContaining({
       structuredOutput,
     }), undefined);

--- a/src/core/models/finding-schemas.ts
+++ b/src/core/models/finding-schemas.ts
@@ -176,6 +176,18 @@ export const FindingContractAdjudicatorConfigRawSchema = z.object({
   model: nonEmptyString.optional(),
 }).strict();
 
+/**
+ * 言い直し予算の最終1回を担う格上げレビュアー。省略可 — 省略時は escalation を
+ * 発火させず、最終1回も元レビュアーへの restatement になる。
+ */
+export const FindingContractEscalationReviewerConfigRawSchema = z.object({
+  persona: nonEmptyString,
+  instruction: nonEmptyString.optional(),
+  output_contract: nonEmptyString.optional(),
+  provider: z.enum(PROVIDER_TYPES).optional(),
+  model: nonEmptyString.optional(),
+}).strict();
+
 /** 有限停止予算。両方省略可 — max_rounds は省略時に既定値 40、max_minutes は省略時は時間上限なし（opt-in）。 */
 export const FindingContractStopBudgetRawSchema = z.object({
   max_rounds: z.number().int().positive().optional(),
@@ -190,6 +202,7 @@ export const FindingContractReviewBudgetRawSchema = z.object({
 export const FindingContractConfigRawSchema = z.object({
   manager: FindingContractManagerConfigRawSchema,
   adjudicator: FindingContractAdjudicatorConfigRawSchema.optional(),
+  escalation_reviewer: FindingContractEscalationReviewerConfigRawSchema.optional(),
   stop_budget: FindingContractStopBudgetRawSchema.optional(),
   review_budget: FindingContractReviewBudgetRawSchema.optional(),
 }).strict();

--- a/src/core/models/finding-types.ts
+++ b/src/core/models/finding-types.ts
@@ -303,6 +303,36 @@ export interface FindingContractAdjudicatorConfig {
 }
 
 /**
+ * escalation reviewer の provider routing persona key。ユーザーが設定した
+ * persona 名ではなくこの固定キーで routing を解決し、publication identity の
+ * reviewer キーもこの値になる（restatement request との識別子はこれだけ）。
+ */
+export const FINDING_ESCALATION_REVIEWER_ROUTING_KEY = 'escalation-reviewer';
+
+/**
+ * 言い直し予算の最終1回を元レビュアーではなく格上げレビュアーへ回すための設定。
+ * workflow が finding_contract.escalation_reviewer を書いたときだけ解決され、
+ * 省略時は最終1回も元レビュアーへの restatement のままになる。
+ */
+export interface FindingContractEscalationReviewerConfig {
+  persona: string;
+  personaPath?: string;
+  personaDisplayName?: string;
+  /** 常に 'escalation-reviewer'。persona 名と routing key を混同させない。 */
+  providerRoutingPersonaKey: typeof FINDING_ESCALATION_REVIEWER_ROUTING_KEY;
+  /** 省略時は persona 本体を instruction として使う（adjudicator と同形）。 */
+  instruction?: string;
+  /**
+   * 解決済みの report 形式。省略時は owner reviewer step の report 形式を継承する。
+   * 出力 strategy は owner step によらず常に structured raw findings で、
+   * ここで変わるのは report 本文の形式だけ。
+   */
+  outputContract?: string;
+  provider?: ProviderType;
+  model?: string;
+}
+
+/**
  * 有限停止予算の
  * per-workflow 設定。fixpoint 判定だけでは、レビュアーが毎ラウンド
  * 別の架空 provisional を1件でも生成し続けると provisional 集合が毎回変わり
@@ -338,6 +368,8 @@ export interface FindingContractConfig {
   manager: FindingContractManagerConfig;
   /** Present when the supervisor persona was resolved for the finding-conflict-adjudication synthetic step. */
   adjudicator?: FindingContractAdjudicatorConfig;
+  /** Present only when the workflow declares finding_contract.escalation_reviewer; see FindingContractEscalationReviewerConfig. */
+  escalationReviewer?: FindingContractEscalationReviewerConfig;
   /** Optional per-workflow override of the bounded stop budget; see FindingContractStopBudgetConfig. */
   stopBudget?: FindingContractStopBudgetConfig;
   /** Optional per-workflow override of the review-integrity re-review budget; see FindingContractReviewBudgetConfig. */

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -85,9 +85,14 @@ export class OptionsBuilder {
       step: WorkflowStep,
       reviewerOutputStrategy: FindingContractReviewerOutputStrategy | undefined,
       reviewScopeSnapshotId?: string,
-      parallelContextKey?: string,
+      findingContractFreezeKey?: string,
     ) => FindingContractInstructionContext | undefined,
     private readonly getTask?: () => string,
+    private readonly getFindingEscalationInstructionContext?: (input: {
+      ownerStepNames: readonly string[];
+      reviewScopeSnapshotId: string;
+      findingContractFreezeKey: string;
+    }) => FindingContractInstructionContext | undefined,
   ) {}
 
   /**
@@ -389,14 +394,26 @@ export class OptionsBuilder {
     step: WorkflowStep,
     reviewerOutputStrategy: FindingContractReviewerOutputStrategy | undefined,
     reviewScopeSnapshotId?: string,
-    parallelContextKey?: string,
+    findingContractFreezeKey?: string,
   ): FindingContractInstructionContext | undefined {
     return this.getFindingContractInstructionContext?.(
       step,
       reviewerOutputStrategy,
       reviewScopeSnapshotId,
-      parallelContextKey,
+      findingContractFreezeKey,
     );
+  }
+
+  /**
+   * escalation slot（提示予算の最終1回）用の reviewer context。escalation reviewer が
+   * 未設定、または今ラウンドに格上げ対象の anomaly が無い場合は undefined。
+   */
+  buildFindingEscalationInstructionContext(input: {
+    ownerStepNames: readonly string[];
+    reviewScopeSnapshotId: string;
+    findingContractFreezeKey: string;
+  }): FindingContractInstructionContext | undefined {
+    return this.getFindingEscalationInstructionContext?.(input);
   }
 
   private resolveSupportedMaxTurns(

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -39,8 +39,11 @@ import type { FindingLedgerStore } from '../findings/store.js';
 import type { FindingManagerRunResult } from '../findings/manager-runner.js';
 import {
   ingestFindingContractResults,
+  resolveFindingContractIntakeStep,
   withFindingContractStructuredOutput,
 } from '../findings/contract-intake.js';
+import type { FindingManagerSubStepResult } from '../findings/manager-runner.js';
+import { runFindingEscalationReviewer } from '../findings/escalation-reviewer-runner.js';
 import type { ReviewerRelationClarification } from '../findings/relation-coherence.js';
 import type { CanonicalFindingReviewPublication } from '../findings/review-publication.js';
 import type { WorkflowCallRunner } from './WorkflowCallRunner.js';
@@ -233,7 +236,7 @@ export interface ParallelRunnerDeps {
 }
 
 export class ParallelRunner {
-  private parallelContextSequence = 0;
+  private findingContractFreezeSequence = 0;
 
   constructor(
     private readonly deps: ParallelRunnerDeps,
@@ -347,14 +350,14 @@ export class ParallelRunner {
       reportGeneration: 'structured',
       intake: 'reviewer_structured',
     };
-    const parallelContextKey = `${step.name}\0${stepIteration}\0${++this.parallelContextSequence}`;
+    const findingContractFreezeKey = `${step.name}\0${stepIteration}\0${++this.findingContractFreezeSequence}`;
     const baseFindingContractContext = this.deps.findingContract
       && agentSubSteps[0] !== undefined
         ? this.deps.optionsBuilder.buildFindingContractInstructionContext(
           agentSubSteps[0],
           structuredReviewerStrategy,
           undefined,
-          parallelContextKey,
+          findingContractFreezeKey,
         )
       : undefined;
     const sharedReviewerContext = baseFindingContractContext?.reviewer;
@@ -458,7 +461,7 @@ export class ParallelRunner {
                   subStep,
                   structuredReviewerStrategy,
                   sharedReviewerContext?.reviewScopeSnapshotId,
-                  parallelContextKey,
+                  findingContractFreezeKey,
                 ),
                 reviewerOutputStrategy,
               )
@@ -1045,6 +1048,34 @@ export class ParallelRunner {
       };
     }
 
+    // 提示予算の最終1回は escalation reviewer へ格上げする。owner の
+    // publication が揃った後・manager の取り込み前に一度だけ実行し、その
+    // publication を owner の集合へ足してから intake へ渡す。
+    const sharedReviewScopeSnapshotId = sharedReviewerContext?.reviewScopeSnapshotId;
+    const escalation = sharedReviewScopeSnapshotId === undefined
+      ? undefined
+      : await this.runEscalationReviewer({
+        step,
+        state,
+        task,
+        maxSteps,
+        stepIteration,
+        subResults,
+        // report 形式の継承元と owner 名の両方を、実際に FC 台帳へ寄稿する
+        // reviewer sub-step だけに絞る（通常 agent sub-step が混在する構成で
+        // 誤継承・不当 throw を起こさない）。
+        ownerReviewerSteps: agentSubSteps.filter(
+          (subStep) => resolveFindingContractIntakeStep(subStep, this.deps.findingContract) !== undefined,
+        ),
+        findingContractFreezeKey,
+        reviewScopeSnapshotId: sharedReviewScopeSnapshotId,
+        updatePersonaSession,
+        runtime,
+      });
+    if (escalation !== undefined && 'terminalResult' in escalation) {
+      return escalation.terminalResult;
+    }
+
     // 全 reviewer の canonical publication が揃った後に一度だけ取り込む。
     // ここより前の失敗では ledger と rules のどちらも動かさない。
     await this.runFindingContractManager(
@@ -1053,6 +1084,7 @@ export class ParallelRunner {
       state.iteration,
       subResults,
       priorStepResponseText,
+      escalation?.reviewerResult,
     );
 
     const postExecutionRuntime = runtime?.fallback === undefined
@@ -1308,12 +1340,108 @@ export class ParallelRunner {
     }
   }
 
+  /**
+   * escalation slot の直接 provider call。escalation reviewer が未設定、または
+   * 今ラウンドに格上げ対象の anomaly も未取り込みの stored publication も無い
+   * 場合は undefined を返して何もしない（§2.5 — 最終1回も owner reviewer への
+   * restatement のままになる）。
+   *
+   * escalation の失敗は既存の step failure 写像に従い、owner publication を
+   * 巻き込まずに parent step を terminal にする。publication 成立前の失敗なので
+   * 提示回数は増えず、次ラウンドで同じ escalation request を再発行する。
+   */
+  private async runEscalationReviewer(input: {
+    step: WorkflowStep;
+    state: WorkflowState;
+    task: string;
+    maxSteps: WorkflowMaxSteps;
+    stepIteration: number;
+    subResults: ParallelSubStepResult[];
+    ownerReviewerSteps: AgentWorkflowStep[];
+    findingContractFreezeKey: string;
+    reviewScopeSnapshotId: string;
+    updatePersonaSession: (persona: string, sessionId: string | undefined) => void;
+    runtime?: RuntimeStepResolution;
+  }): Promise<
+    | { reviewerResult: FindingManagerSubStepResult }
+    | { terminalResult: StepRunResult }
+    | undefined
+  > {
+    const contract = this.deps.findingContract;
+    if (contract?.escalationReviewer === undefined || input.ownerReviewerSteps.length === 0) {
+      return undefined;
+    }
+    const escalationContext = this.deps.optionsBuilder.buildFindingEscalationInstructionContext({
+      ownerStepNames: input.ownerReviewerSteps.map((subStep) => subStep.name),
+      reviewScopeSnapshotId: input.reviewScopeSnapshotId,
+      findingContractFreezeKey: input.findingContractFreezeKey,
+    });
+    const outcome = await runFindingEscalationReviewer({
+      contract,
+      workflowProvider: this.deps.workflowProvider,
+      workflowModel: this.deps.workflowModel,
+      ...(escalationContext === undefined ? {} : { escalationContext }),
+      ownerReviewerSteps: input.ownerReviewerSteps,
+      parentStepName: input.step.name,
+      stepIteration: input.stepIteration,
+      state: input.state,
+      task: input.task,
+      maxSteps: input.maxSteps,
+      optionsBuilder: this.deps.optionsBuilder,
+      stepExecutor: this.deps.stepExecutor,
+      updatePersonaSession: input.updatePersonaSession,
+      runtime: input.runtime,
+    });
+    if (outcome === undefined) {
+      return undefined;
+    }
+    if (outcome.kind === 'published') {
+      return {
+        reviewerResult: {
+          subStep: outcome.step,
+          publication: outcome.publication,
+          ...(outcome.relationClarification === undefined
+            ? {}
+            : { relationClarification: outcome.relationClarification }),
+        },
+      };
+    }
+    const terminalResult: ParallelSubStepResult = {
+      subStep: outcome.step,
+      response: outcome.response,
+      instruction: '',
+      providerInfo: outcome.providerInfo,
+      ...(outcome.terminalOperation === undefined
+        ? {}
+        : { terminalOperation: outcome.terminalOperation }),
+    };
+    return {
+      terminalResult: this.createTerminalParentResult({
+        step: input.step,
+        state: input.state,
+        stepIteration: input.stepIteration,
+        subResults: input.subResults,
+        terminalResults: [terminalResult],
+        status: outcome.response.status === 'blocked'
+          ? 'blocked'
+          : outcome.response.status === 'rate_limited'
+            ? 'rate_limited'
+            : 'error',
+        providerInfo: outcome.providerInfo,
+        ...(outcome.terminalOperation === undefined
+          ? {}
+          : { terminalOperation: outcome.terminalOperation }),
+      }),
+    };
+  }
+
   private async runFindingContractManager(
     step: WorkflowStep,
     stepIteration: number,
     iteration: number,
     subResults: ParallelSubStepResult[],
     priorStepResponseText: string | undefined,
+    escalationResult?: FindingManagerSubStepResult,
   ): Promise<FindingManagerRunResult | undefined> {
     if (!this.deps.findingContract) {
       return undefined;
@@ -1339,6 +1467,9 @@ export class ParallelRunner {
           : {}),
       }];
     });
+    if (escalationResult !== undefined) {
+      reviewerResults.push(escalationResult);
+    }
     if (reviewerResults.length === 0) {
       return undefined;
     }

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -21,6 +21,7 @@ import type {
   NormalAgentWorkflowStep,
   ResolvedFacetPool,
   ResolvedFacetContent,
+  WorkflowMaxSteps,
 } from '../../models/types.js';
 import { isNormalAgentWorkflowStep } from '../../models/types.js';
 import type { FindingIntakeNormalizeConfig } from '../../models/config-types.js';
@@ -80,8 +81,12 @@ import type {
 } from '../instruction/instruction-context.js';
 import { compactSessionBeforePhase1 } from './session-compaction.js';
 import type { FindingLedgerStore } from '../findings/store.js';
-import type { FindingManagerRunResult } from '../findings/manager-runner.js';
+import type {
+  FindingManagerRunResult,
+  FindingManagerSubStepResult,
+} from '../findings/manager-runner.js';
 import { createRawFindingsStructuredOutput } from '../findings/manager-runner.js';
+import { runFindingEscalationReviewer } from '../findings/escalation-reviewer-runner.js';
 import {
   ingestFindingContractResults,
   resolveFindingContractIntakeStep,
@@ -274,6 +279,8 @@ export interface StepExecutorDeps {
 export interface PreparedNormalStepExecution {
   readonly executableStep: AgentWorkflowStep;
   readonly findingContractContext?: FindingContractInstructionContext;
+  /** owner context を組んだときの ledger / presentation counts 凍結キー（escalation slot と共有する）。 */
+  readonly findingContractFreezeKey?: string;
   readonly reviewerOutputStrategy?: FindingContractReviewerOutputStrategy;
   readonly phase1Instruction: string;
   readonly priorStepResponseText?: string;
@@ -282,6 +289,8 @@ export interface PreparedNormalStepExecution {
 
 export class StepExecutor {
   private readonly structuredOutputNormalizers: StructuredOutputNormalizerRegistry;
+
+  private findingContractFreezeSequence = 0;
 
   constructor(
     private readonly deps: StepExecutorDeps,
@@ -332,6 +341,122 @@ export class StepExecutor {
     return resolveFindingContractIntakeStep(step, this.deps.findingContract);
   }
 
+  /**
+   * 単独 FC reviewer step の escalation slot。owner publication 成立後・manager
+   * 取り込み前に一度だけ実行する（parallel 経路と同型）。escalation reviewer が
+   * 未設定、または今ラウンドに格上げ対象の anomaly も未取り込みの stored
+   * publication も無い場合は undefined。
+   *
+   * 提示回数の判定は owner context を組んだ時点で凍結した ledger /
+   * presentation counts を使う。owner publication 永続化後に数え直すと、
+   * 同じ iteration で owner の (limit-1) 回目と escalation が二重に走る。
+   */
+  private async runEscalationReviewerForNormalStep(input: {
+    parentStepName: string;
+    ownerReviewerStep: AgentWorkflowStep;
+    findingContractContext: FindingContractInstructionContext | undefined;
+    findingContractFreezeKey: string | undefined;
+    stepIteration: number;
+    state: WorkflowState;
+    task: string;
+    maxSteps: WorkflowMaxSteps;
+    updatePersonaSession: (persona: string, sessionId: string | undefined) => void;
+    runtime?: RuntimeStepResolution;
+  }): Promise<
+    | { reviewerResult: FindingManagerSubStepResult }
+    | {
+        terminalResponse: AgentResponse;
+        providerInfo?: StepProviderInfo;
+        terminalOperation?: NonNullable<StepRunResult['terminalOperation']>;
+      }
+    | undefined
+  > {
+    const contract = this.deps.findingContract;
+    const ownerReviewer = input.findingContractContext?.reviewer;
+    if (
+      contract?.escalationReviewer === undefined
+      || ownerReviewer === undefined
+      || input.findingContractFreezeKey === undefined
+    ) {
+      return undefined;
+    }
+    const escalationContext = this.deps.optionsBuilder.buildFindingEscalationInstructionContext({
+      ownerStepNames: [input.parentStepName],
+      reviewScopeSnapshotId: ownerReviewer.reviewScopeSnapshotId,
+      findingContractFreezeKey: input.findingContractFreezeKey,
+    });
+    const outcome = await runFindingEscalationReviewer({
+      contract,
+      workflowProvider: this.deps.workflowProvider,
+      workflowModel: this.deps.workflowModel,
+      ...(escalationContext === undefined ? {} : { escalationContext }),
+      ownerReviewerSteps: [input.ownerReviewerStep],
+      parentStepName: input.parentStepName,
+      stepIteration: input.stepIteration,
+      state: input.state,
+      task: input.task,
+      maxSteps: input.maxSteps,
+      optionsBuilder: this.deps.optionsBuilder,
+      stepExecutor: this,
+      updatePersonaSession: input.updatePersonaSession,
+      runtime: input.runtime,
+    });
+    if (outcome === undefined) {
+      return undefined;
+    }
+    if (outcome.kind === 'published') {
+      return {
+        reviewerResult: {
+          subStep: outcome.step,
+          publication: outcome.publication,
+          ...(outcome.relationClarification === undefined
+            ? {}
+            : { relationClarification: outcome.relationClarification }),
+        },
+      };
+    }
+    return {
+      terminalResponse: outcome.response,
+      ...(outcome.providerInfo === undefined ? {} : { providerInfo: outcome.providerInfo }),
+      ...(outcome.terminalOperation === undefined
+        ? {}
+        : { terminalOperation: outcome.terminalOperation }),
+    };
+  }
+
+  private escalationTerminalStepResult(input: {
+    step: WorkflowStep;
+    state: WorkflowState;
+    stepIteration: number;
+    instruction: string;
+    fallbackProviderInfo: StepProviderInfo;
+    escalation: {
+      terminalResponse: AgentResponse;
+      providerInfo?: StepProviderInfo;
+      terminalOperation?: NonNullable<StepRunResult['terminalOperation']>;
+    };
+  }): StepRunResult {
+    const response = input.escalation.terminalResponse;
+    input.state.stepOutputs.set(input.step.name, response);
+    input.state.lastOutput = response;
+    if (response.status === 'blocked') {
+      this.persistPreviousResponseSnapshot(
+        input.state,
+        input.step.name,
+        input.stepIteration,
+        response.content,
+      );
+    }
+    return {
+      response,
+      instruction: input.instruction,
+      providerInfo: input.escalation.providerInfo ?? input.fallbackProviderInfo,
+      ...(input.escalation.terminalOperation === undefined
+        ? {}
+        : { terminalOperation: input.escalation.terminalOperation }),
+    };
+  }
+
   private async ingestFindingContractForNormalStep(input: {
     step: AgentWorkflowStep;
     stepIteration: number;
@@ -339,6 +464,7 @@ export class StepExecutor {
     publication: CanonicalFindingReviewPublication;
     priorStepResponseText: string | undefined;
     relationClarification?: ReviewerRelationClarification;
+    escalationResult?: FindingManagerSubStepResult;
   }): Promise<FindingManagerRunResult> {
     if (!this.deps.findingLedgerStore) {
       throw new Error('Finding contract is configured but finding ledger store is not available');
@@ -356,11 +482,14 @@ export class StepExecutor {
       iteration: input.iteration,
       // 単独ステップでは「レビュアー1件」を自分自身として渡す
       // （manager-runner.ts の subResults は並列・単独どちらも同じ形で扱う）。
-      subResults: [{
-        subStep: input.step,
-        publication: input.publication,
-        ...(input.relationClarification !== undefined ? { relationClarification: input.relationClarification } : {}),
-      }],
+      subResults: [
+        {
+          subStep: input.step,
+          publication: input.publication,
+          ...(input.relationClarification !== undefined ? { relationClarification: input.relationClarification } : {}),
+        },
+        ...(input.escalationResult === undefined ? [] : [input.escalationResult]),
+      ],
       // 台帳の workflowName スタンプは店（ledgerStore）が束縛する正準名を使う。
       // workflow_call の子が親の台帳を継承した場合、この engine 自身の
       // getWorkflowName()（子のワークフロー名）を使うと reconcile 後の
@@ -493,10 +622,17 @@ export class StepExecutor {
           reviewerRuntime,
         )
       : undefined;
+    // owner context と escalation slot が同じ ledger / presentation counts を
+    // 見るよう、ここで一度だけ凍結する（parallel の共有 freeze と同じ役割）。
+    const findingContractFreezeKey = findingContractIntakeStep === undefined
+      ? undefined
+      : `${step.name}\0${stepIteration}\0${++this.findingContractFreezeSequence}`;
     const findingContractContext = findingContractIntakeStep
       ? this.deps.optionsBuilder.buildFindingContractInstructionContext(
           findingContractIntakeStep,
           reviewerOutputStrategy,
+          undefined,
+          findingContractFreezeKey,
         )
       : this.buildFindingContractInstructionContext(step, undefined);
     let executableStep = findingContractIntakeStep
@@ -551,6 +687,7 @@ export class StepExecutor {
     return {
       executableStep,
       ...(findingContractContext !== undefined ? { findingContractContext } : {}),
+      ...(findingContractFreezeKey !== undefined ? { findingContractFreezeKey } : {}),
       ...(reviewerOutputStrategy !== undefined ? { reviewerOutputStrategy } : {}),
       phase1Instruction: this.buildPhase1Instruction(
         instruction,
@@ -568,11 +705,21 @@ export class StepExecutor {
    * イベント経由、parallel / team_leader は recordDelegatedAgentUsage 経由で
    * 記録されるが、合成ステップの executeAgent 直呼びはどちらの経路にも
    * 乗らず、トークン集計の死角になっていた。
+   *
+   * `attemptProviderInfo` は、その呼び出しが実際に使った provider/model。
+   * report phase の fallback のように attempt ごとに provider が変わる経路では
+   * これを渡さないと、fallback で走った試行を primary として計上してしまう。
+   * 単発呼び出し（findings-manager 等）は省略でき、ステップ解決結果を使う。
    */
-  recordSynthesizedAgentUsage(step: WorkflowStep, success: boolean, usage: ProviderUsageSnapshot | undefined): void {
+  recordSynthesizedAgentUsage(
+    step: WorkflowStep,
+    success: boolean,
+    usage: ProviderUsageSnapshot | undefined,
+    attemptProviderInfo?: StepProviderInfo,
+  ): void {
     this.deps.recordSynthesizedAgentUsage(
       step.name,
-      this.deps.optionsBuilder.resolveStepProviderModel(step),
+      attemptProviderInfo ?? this.deps.optionsBuilder.resolveStepProviderModel(step),
       success,
       usage,
     );
@@ -1086,6 +1233,14 @@ export class StepExecutor {
     readonly updatePersonaSession: (persona: string, sessionId: string | undefined) => void;
     readonly runtime?: RuntimeStepResolution;
     readonly presentationContext?: FindingReviewPresentationContext;
+    /**
+     * Phase 2 で使う Finding Contract context の明示指定。省略時は Phase 2 が
+     * reviewer step 名から context を組み直す（通常レビュアーの既存挙動）。
+     * escalation slot のように「step 名では引けない reviewer 契約」で走る
+     * publication は、Phase 1 と同じ context をここから渡さないと Phase 2 の
+     * restatement-only 契約が消える。
+     */
+    readonly findingContractContext?: FindingContractInstructionContext;
   }): Promise<
     | {
         readonly publication: CanonicalFindingReviewPublication;
@@ -1114,8 +1269,9 @@ export class StepExecutor {
           structuredOutput: createFindingReviewPublicationStructuredOutput(),
         }
       : input.step;
-    const buildPhaseContext = (phase1Response: AgentResponse) => (
-      this.deps.optionsBuilder.buildPhaseRunnerContext(
+    const explicitFindingContractContext = input.findingContractContext;
+    const buildPhaseContext = (phase1Response: AgentResponse) => {
+      const phaseContext = this.deps.optionsBuilder.buildPhaseRunnerContext(
         reportStep,
         input.state,
         phase1Response.content,
@@ -1126,8 +1282,14 @@ export class StepExecutor {
         input.state.iteration,
         input.runtime,
         input.onProviderAttempt,
-      )
-    );
+      );
+      return explicitFindingContractContext === undefined
+        ? phaseContext
+        : {
+            ...phaseContext,
+            buildFindingContractInstructionContext: () => explicitFindingContractContext,
+          };
+    };
     const phaseContext = buildPhaseContext(input.phase1Response);
     const reportFiles = input.step.outputContracts?.map((entry) => entry.name) ?? [];
     if (reportFiles.length !== 1) {
@@ -1993,6 +2155,28 @@ export class StepExecutor {
             terminalOperation: resumedPublication.terminalOperation,
           };
         }
+        const resumedEscalation = await this.runEscalationReviewerForNormalStep({
+          parentStepName: step.name,
+          ownerReviewerStep: findingContractIntakeStep,
+          findingContractContext,
+          findingContractFreezeKey: preparedExecution?.findingContractFreezeKey,
+          stepIteration,
+          state,
+          task,
+          maxSteps,
+          updatePersonaSession,
+          runtime: executionRuntime,
+        });
+        if (resumedEscalation !== undefined && 'terminalResponse' in resumedEscalation) {
+          return this.escalationTerminalStepResult({
+            step,
+            state,
+            stepIteration,
+            instruction: phase1Instruction,
+            fallbackProviderInfo: resumedPublication.reviewerProviderInfo ?? providerInfo,
+            escalation: resumedEscalation,
+          });
+        }
         await this.ingestFindingContractForNormalStep({
           step: findingContractIntakeStep,
           stepIteration,
@@ -2002,6 +2186,7 @@ export class StepExecutor {
           ...(resumedPublication.relationClarification !== undefined
             ? { relationClarification: resumedPublication.relationClarification }
             : {}),
+          ...(resumedEscalation === undefined ? {} : { escalationResult: resumedEscalation.reviewerResult }),
         });
         const response = await this.applyPostExecutionRulesOnly(
           step,
@@ -2248,6 +2433,28 @@ export class StepExecutor {
         prepared.response,
         phase1ProviderUsage,
       );
+      const escalation = await this.runEscalationReviewerForNormalStep({
+        parentStepName: step.name,
+        ownerReviewerStep: findingContractIntakeStep,
+        findingContractContext,
+        findingContractFreezeKey: preparedExecution?.findingContractFreezeKey,
+        stepIteration,
+        state,
+        task,
+        maxSteps,
+        updatePersonaSession,
+        runtime: executionRuntime,
+      });
+      if (escalation !== undefined && 'terminalResponse' in escalation) {
+        return this.escalationTerminalStepResult({
+          step,
+          state,
+          stepIteration,
+          instruction: phase1Instruction,
+          fallbackProviderInfo: completedReviewerProviderInfo,
+          escalation,
+        });
+      }
       await this.ingestFindingContractForNormalStep({
         step: findingContractIntakeStep,
         stepIteration,
@@ -2255,6 +2462,7 @@ export class StepExecutor {
         publication: prepared.publication,
         priorStepResponseText,
         relationClarification: prepared.relationClarification,
+        ...(escalation === undefined ? {} : { escalationResult: escalation.reviewerResult }),
       });
     }
 

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -381,7 +381,10 @@ export class StepExecutor {
       return undefined;
     }
     const escalationContext = this.deps.optionsBuilder.buildFindingEscalationInstructionContext({
-      ownerStepNames: [input.parentStepName],
+      // owner 名は publication identity の reviewerStepName（= anomaly の
+      // presentationOwnerReviewer）と同じ値でなければならない。単独ステップでは
+      // parent step 名と一致するが、意味が違う値なので reviewer step から取る。
+      ownerStepNames: [input.ownerReviewerStep.name],
       reviewScopeSnapshotId: ownerReviewer.reviewScopeSnapshotId,
       findingContractFreezeKey: input.findingContractFreezeKey,
     });

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -257,22 +257,20 @@ export function assertFindingReviewPresentationCapacity(input: {
   currentIteration: number;
   stepName: string;
 }): void {
-  const unpresented = (input.ledger.reviewerAnomalies ?? []).filter((anomaly) => {
-    const defect = anomaly.intakeContract;
-    const presentedCount = input.presentationCounts.get(anomaly.id) ?? 0;
-    return anomaly.kind === 'intake-contract-incomplete'
-      && defect !== undefined
-      && anomaly.promotedFindingId === undefined
+  const unpresented = (input.ledger.reviewerAnomalies ?? [])
+    .filter(hasIntakeContract)
+    .filter((anomaly) => (
+      anomaly.promotedFindingId === undefined
       && anomaly.settlement === undefined
-      && defect.terminalDisposition === undefined
-      && presentedCount === 0;
-  });
+      && anomaly.intakeContract.terminalDisposition === undefined
+      && (input.presentationCounts.get(anomaly.id) ?? 0) === 0
+    ));
   if (unpresented.length === 0) {
     return;
   }
   const countsByOwner = new Map<string, number>();
   for (const anomaly of unpresented) {
-    const owner = anomaly.intakeContract!.presentationOwnerReviewer;
+    const owner = anomaly.intakeContract.presentationOwnerReviewer;
     countsByOwner.set(owner, (countsByOwner.get(owner) ?? 0) + 1);
   }
   const total = unpresented.length;
@@ -290,7 +288,7 @@ export function assertFindingReviewPresentationCapacity(input: {
     stepName: input.stepName,
     anomalyIds: unpresented.map(({ id }) => id),
     classificationAuthorityIds: unpresented.map(
-      ({ intakeContract }) => intakeContract!.classificationAuthorityId,
+      ({ intakeContract }) => intakeContract.classificationAuthorityId,
     ),
     requiredInvocations,
     remainingCapacity,
@@ -335,8 +333,17 @@ function collectFindingReviewPresentationCounts(reportDir: string): Map<string, 
 type LoadedFindingLedger = ReturnType<FindingLedgerStore['loadLedger']>;
 type LoadedReviewerAnomaly = NonNullable<LoadedFindingLedger['reviewerAnomalies']>[number];
 
+/** `intake-contract-incomplete` の anomaly は intakeContract を必ず持つ（台帳 invariant）。 */
+type IntakeContractAnomaly = LoadedReviewerAnomaly & {
+  readonly intakeContract: NonNullable<LoadedReviewerAnomaly['intakeContract']>;
+};
+
+function hasIntakeContract(anomaly: LoadedReviewerAnomaly): anomaly is IntakeContractAnomaly {
+  return anomaly.kind === 'intake-contract-incomplete' && anomaly.intakeContract !== undefined;
+}
+
 interface OutstandingIntakeAnomaly {
-  readonly anomaly: LoadedReviewerAnomaly;
+  readonly anomaly: IntakeContractAnomaly;
   readonly presentedCount: number;
 }
 
@@ -354,10 +361,9 @@ function collectOutstandingIntakeAnomalies(input: {
   escalationReviewerConfigured: boolean;
 }): OutstandingIntakeAnomaly[] {
   return (input.ledger.reviewerAnomalies ?? [])
+    .filter(hasIntakeContract)
     .filter((anomaly) => (
-      anomaly.kind === 'intake-contract-incomplete'
-      && anomaly.intakeContract !== undefined
-      && input.ownerStepNames.has(anomaly.intakeContract.presentationOwnerReviewer)
+      input.ownerStepNames.has(anomaly.intakeContract.presentationOwnerReviewer)
       && anomaly.promotedFindingId === undefined
       && anomaly.settlement === undefined
     ))
@@ -368,7 +374,7 @@ function collectOutstandingIntakeAnomalies(input: {
     .filter(({ anomaly, presentedCount }) => (
       resolveRestatementPresentationPhase({
         presentedCount,
-        presentationLimit: anomaly.intakeContract!.presentationLimit,
+        presentationLimit: anomaly.intakeContract.presentationLimit,
         escalationReviewerConfigured: input.escalationReviewerConfigured,
       }) === input.phase
     ))
@@ -400,7 +406,7 @@ function buildRestatementRequests(input: {
       sourceExcerptDigest: raw.sourceBinding.excerptDigest,
       claimedExcerpt: boundedRestatementClaimExcerpt(anomaly, raw),
       targetPaths: targetPathsForRestatementRequest(raw.target),
-      missingRequirements: anomaly.intakeContract!.missingRequirements,
+      missingRequirements: anomaly.intakeContract.missingRequirements,
       expectedRelation: 'new' as const,
       expectedTargetFindingId: null,
       expectedTargetPreconditionClass: 'absent' as const,

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -56,7 +56,12 @@ import {
   type RestatementRequestV1,
 } from '../findings/review-publication.js';
 import { RAW_FINDING_LIMITS } from '../findings/raw-finding-limits.js';
+import {
+  resolveRestatementPresentationPhase,
+  type RestatementPresentationPhase,
+} from '../findings/restatement-presentation-phase.js';
 import type { FindingTarget } from '../../models/finding-types.js';
+import { FINDING_ESCALATION_REVIEWER_ROUTING_KEY } from '../../models/finding-types.js';
 import type {
   FindingContractInstructionContext,
   FindingContractReviewerOutputStrategy,
@@ -310,9 +315,114 @@ function targetPathsForRestatementRequest(target: FindingTarget): string[] {
   }
 }
 
+/**
+ * 提示回数の正本は canonical review publication だけ。V2 context を持つ
+ * publication の `presentedReviewerAnomalyIds` を publication ID 単位で数える。
+ */
+function collectFindingReviewPresentationCounts(reportDir: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const publication of listFindingReviewPublications(reportDir)) {
+    if (publication.presentationContext?.revision !== 2) {
+      continue;
+    }
+    for (const anomalyId of publication.presentationContext.presentedReviewerAnomalyIds) {
+      counts.set(anomalyId, (counts.get(anomalyId) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+type LoadedFindingLedger = ReturnType<FindingLedgerStore['loadLedger']>;
+type LoadedReviewerAnomaly = NonNullable<LoadedFindingLedger['reviewerAnomalies']>[number];
+
+interface OutstandingIntakeAnomaly {
+  readonly anomaly: LoadedReviewerAnomaly;
+  readonly presentedCount: number;
+}
+
+/**
+ * 未消化の intake anomaly を、指定した提示フェーズと owner に限って
+ * 決定的な順序（未提示優先 → 最初の観測時刻 → anomaly ID）で列挙する。
+ * owner batch と escalation batch はこの1関数を共有し、同じ anomaly が
+ * 両方の batch に入ることがない。
+ */
+function collectOutstandingIntakeAnomalies(input: {
+  ledger: LoadedFindingLedger;
+  presentationCounts: ReadonlyMap<string, number>;
+  ownerStepNames: ReadonlySet<string>;
+  phase: RestatementPresentationPhase;
+  escalationReviewerConfigured: boolean;
+}): OutstandingIntakeAnomaly[] {
+  return (input.ledger.reviewerAnomalies ?? [])
+    .filter((anomaly) => (
+      anomaly.kind === 'intake-contract-incomplete'
+      && anomaly.intakeContract !== undefined
+      && input.ownerStepNames.has(anomaly.intakeContract.presentationOwnerReviewer)
+      && anomaly.promotedFindingId === undefined
+      && anomaly.settlement === undefined
+    ))
+    .map((anomaly) => ({
+      anomaly,
+      presentedCount: input.presentationCounts.get(anomaly.id) ?? 0,
+    }))
+    .filter(({ anomaly, presentedCount }) => (
+      resolveRestatementPresentationPhase({
+        presentedCount,
+        presentationLimit: anomaly.intakeContract!.presentationLimit,
+        escalationReviewerConfigured: input.escalationReviewerConfigured,
+      }) === input.phase
+    ))
+    .sort((left, right) => (
+      left.presentedCount - right.presentedCount
+      || compareBinaryStrings(left.anomaly.firstObserved.timestamp, right.anomaly.firstObserved.timestamp)
+      || compareBinaryStrings(left.anomaly.id, right.anomaly.id)
+    ));
+}
+
+function buildRestatementRequests(input: {
+  ledger: LoadedFindingLedger;
+  entries: readonly OutstandingIntakeAnomaly[];
+  reviewer: string;
+  reviewScopeSnapshotId: string;
+}): RestatementRequestV1[] {
+  return input.entries.flatMap(({ anomaly, presentedCount }) => {
+    const raw = anomaly.sourceRawFindingIds
+      .map((rawId) => input.ledger.rawFindings.find((candidate) => candidate.rawFindingId === rawId))
+      .find((candidate) => candidate !== undefined);
+    if (raw === undefined) {
+      return [];
+    }
+    const requestWithoutId = {
+      anomalyId: anomaly.id,
+      reviewer: input.reviewer,
+      presentationOrdinal: presentedCount + 1,
+      reviewScopeSnapshotId: input.reviewScopeSnapshotId,
+      sourceExcerptDigest: raw.sourceBinding.excerptDigest,
+      claimedExcerpt: boundedRestatementClaimExcerpt(anomaly, raw),
+      targetPaths: targetPathsForRestatementRequest(raw.target),
+      missingRequirements: anomaly.intakeContract!.missingRequirements,
+      expectedRelation: 'new' as const,
+      expectedTargetFindingId: null,
+      expectedTargetPreconditionClass: 'absent' as const,
+    };
+    return [{
+      ...requestWithoutId,
+      restatementRequestId: computeRestatementRequestId(requestWithoutId),
+    }];
+  });
+}
+
+/** owner batch と escalation batch の合計を 1 step あたりの raw finding 上限内に収める。 */
+function remainingRestatementSlots(allocatedRequestCount: number): number {
+  return Math.min(
+    RAW_FINDING_LIMITS.maxRawFindingsPerReviewer,
+    Math.max(0, RAW_FINDING_LIMITS.maxRawFindingsPerStep - allocatedRequestCount),
+  );
+}
+
 function boundedRestatementClaimExcerpt(
-  anomaly: NonNullable<ReturnType<FindingLedgerStore['loadLedger']>['reviewerAnomalies']>[number],
-  raw: NonNullable<ReturnType<FindingLedgerStore['loadLedger']>['rawFindings']>[number],
+  anomaly: LoadedReviewerAnomaly,
+  raw: NonNullable<LoadedFindingLedger['rawFindings']>[number],
 ): string {
   // フォールバックは「非 blank な最初の候補」を選ぶ。`??` だけだと空白のみの
   // claimedExcerpt が後続の description / rawExcerpt を遮って title まで飛ぶ。
@@ -334,7 +444,8 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     params.options.findingContractConfig?.intakeNormalize,
     params.findingContract,
   );
-  let frozenParallelFindingContractInput: {
+  const escalationReviewerConfigured = params.findingContract?.escalationReviewer !== undefined;
+  let frozenFindingContractInput: {
     contextKey: string;
     ledger: ReturnType<FindingLedgerStore['loadLedger']>;
     presentationCounts: Map<string, number>;
@@ -345,7 +456,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     step: WorkflowStep,
     strategy: FindingContractReviewerOutputStrategy | undefined,
     sharedReviewScopeSnapshotId?: string,
-    parallelContextKey?: string,
+    findingContractFreezeKey?: string,
   ): FindingContractInstructionContext | undefined => {
     if (!params.findingContract) {
       return undefined;
@@ -360,30 +471,22 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     let allocatedRequestCount = 0;
     if (
       sharedReviewScopeSnapshotId !== undefined
-      && parallelContextKey !== undefined
-      && frozenParallelFindingContractInput?.contextKey === parallelContextKey
+      && findingContractFreezeKey !== undefined
+      && frozenFindingContractInput?.contextKey === findingContractFreezeKey
     ) {
-      ({ ledger, presentationCounts, contexts: frozenContexts, allocatedRequestCount } = frozenParallelFindingContractInput);
+      ({ ledger, presentationCounts, contexts: frozenContexts, allocatedRequestCount } = frozenFindingContractInput);
     } else {
       ledger = params.findingLedgerStore.loadLedger();
-      presentationCounts = new Map<string, number>();
-      for (const publication of listFindingReviewPublications(params.getReportDir())) {
-        if (publication.presentationContext?.revision !== 2) {
-          continue;
-        }
-        for (const anomalyId of publication.presentationContext.presentedReviewerAnomalyIds) {
-          presentationCounts.set(anomalyId, (presentationCounts.get(anomalyId) ?? 0) + 1);
-        }
-      }
-      if (parallelContextKey !== undefined) {
-        frozenParallelFindingContractInput = {
-          contextKey: parallelContextKey,
+      presentationCounts = collectFindingReviewPresentationCounts(params.getReportDir());
+      if (findingContractFreezeKey !== undefined) {
+        frozenFindingContractInput = {
+          contextKey: findingContractFreezeKey,
           ledger,
           presentationCounts,
           contexts: new Map(),
           allocatedRequestCount: 0,
         };
-        frozenContexts = frozenParallelFindingContractInput.contexts;
+        frozenContexts = frozenFindingContractInput.contexts;
       }
     }
     if (frozenContexts !== undefined && strategy !== undefined) {
@@ -403,51 +506,17 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
         currentIteration: params.state.iteration,
         stepName: step.name,
       });
-      const requests = (ledger.reviewerAnomalies ?? [])
-        .filter((anomaly) => (
-          anomaly.kind === 'intake-contract-incomplete'
-          && anomaly.intakeContract !== undefined
-          && anomaly.intakeContract.presentationOwnerReviewer === step.name
-          && anomaly.promotedFindingId === undefined
-          && anomaly.settlement === undefined
-        ))
-        .map((anomaly) => ({
-          anomaly,
-          presentedCount: presentationCounts.get(anomaly.id) ?? 0,
-        }))
-        .filter(({ anomaly, presentedCount }) => (
-          presentedCount < anomaly.intakeContract!.presentationLimit
-        ))
-        .sort((left, right) => (
-          left.presentedCount - right.presentedCount
-          || compareBinaryStrings(left.anomaly.firstObserved.timestamp, right.anomaly.firstObserved.timestamp)
-          || compareBinaryStrings(left.anomaly.id, right.anomaly.id)
-        ))
-        .slice(0, Math.min(64, Math.max(0, 128 - allocatedRequestCount)));
-      const restatementRequests: RestatementRequestV1[] = requests.flatMap(({ anomaly, presentedCount }) => {
-        const raw = anomaly.sourceRawFindingIds
-          .map((rawId) => ledger.rawFindings.find((candidate) => candidate.rawFindingId === rawId))
-          .find((candidate) => candidate !== undefined);
-        if (raw === undefined) {
-          return [];
-        }
-        const requestWithoutId = {
-          anomalyId: anomaly.id,
-          reviewer: step.name,
-          presentationOrdinal: presentedCount + 1,
-          reviewScopeSnapshotId,
-          sourceExcerptDigest: raw.sourceBinding.excerptDigest,
-          claimedExcerpt: boundedRestatementClaimExcerpt(anomaly, raw),
-          targetPaths: targetPathsForRestatementRequest(raw.target),
-          missingRequirements: anomaly.intakeContract!.missingRequirements,
-          expectedRelation: 'new' as const,
-          expectedTargetFindingId: null,
-          expectedTargetPreconditionClass: 'absent' as const,
-        };
-        return [{
-          ...requestWithoutId,
-          restatementRequestId: computeRestatementRequestId(requestWithoutId),
-        }];
+      const restatementRequests = buildRestatementRequests({
+        ledger,
+        entries: collectOutstandingIntakeAnomalies({
+          ledger,
+          presentationCounts,
+          ownerStepNames: new Set([step.name]),
+          phase: 'restatement',
+          escalationReviewerConfigured,
+        }).slice(0, remainingRestatementSlots(allocatedRequestCount)),
+        reviewer: step.name,
+        reviewScopeSnapshotId,
       });
       const presentationContext = createFindingReviewPresentationContextV2({
         reviewScopeSnapshotId,
@@ -465,7 +534,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
             reviewScopeSnapshotId,
             presentationContext,
           };
-      if (frozenContexts !== undefined && parallelContextKey !== undefined) {
+      if (frozenContexts !== undefined && findingContractFreezeKey !== undefined) {
         frozenContexts.set(step.name, {
           ledgerSummary: renderFindingLedgerInstructionSummary(ledger),
           reportLedgerSummary: renderFindingLedgerReportSummary(ledger),
@@ -474,8 +543,8 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
           hasDismissedFindings: ledgerHasDismissedFindings(ledger),
           ...(reviewer !== undefined ? { reviewer } : {}),
         });
-        frozenParallelFindingContractInput = {
-          contextKey: parallelContextKey,
+        frozenFindingContractInput = {
+          contextKey: findingContractFreezeKey,
           ledger,
           presentationCounts,
           contexts: frozenContexts,
@@ -494,6 +563,63 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     return context;
   };
 
+  /**
+   * escalation slot（提示予算の最終1回）用の reviewer context を組み立てる。
+   *
+   * owner batch を組んだときに凍結した ledger / presentation counts をそのまま
+   * 使い、owner が使い切った残り枠だけを escalation batch へ割り当てる。
+   * owner publication 永続化後に数え直すと、同じ iteration で owner の
+   * (limit-1) 回目の提示と escalation が二重に走る。
+   *
+   * escalation 対象の anomaly が1件も無い場合は undefined を返す。
+   */
+  const buildFindingEscalationInstructionContext = (input: {
+    ownerStepNames: readonly string[];
+    reviewScopeSnapshotId: string;
+    findingContractFreezeKey: string;
+  }): FindingContractInstructionContext | undefined => {
+    if (!escalationReviewerConfigured) {
+      return undefined;
+    }
+    if (frozenFindingContractInput?.contextKey !== input.findingContractFreezeKey) {
+      throw new Error(
+        'Finding escalation reviewer context requires the frozen reviewer input of the same review round',
+      );
+    }
+    const { ledger, presentationCounts, allocatedRequestCount } = frozenFindingContractInput;
+    const restatementRequests = buildRestatementRequests({
+      ledger,
+      entries: collectOutstandingIntakeAnomalies({
+        ledger,
+        presentationCounts,
+        ownerStepNames: new Set(input.ownerStepNames),
+        phase: 'escalation',
+        escalationReviewerConfigured,
+      }).slice(0, remainingRestatementSlots(allocatedRequestCount)),
+      reviewer: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+      reviewScopeSnapshotId: input.reviewScopeSnapshotId,
+    });
+    if (restatementRequests.length === 0) {
+      return undefined;
+    }
+    return {
+      ledgerSummary: renderFindingLedgerInstructionSummary(ledger),
+      reportLedgerSummary: renderFindingLedgerReportSummary(ledger),
+      hasOpenFindings: ledgerHasOpenFindings(ledger),
+      hasWaivedFindings: ledgerHasWaivedFindings(ledger),
+      hasDismissedFindings: ledgerHasDismissedFindings(ledger),
+      reviewer: {
+        mode: 'structured',
+        rawFindingsStructuredOutput: createRawFindingsStructuredOutput(),
+        reviewScopeSnapshotId: input.reviewScopeSnapshotId,
+        presentationContext: createFindingReviewPresentationContextV2({
+          reviewScopeSnapshotId: input.reviewScopeSnapshotId,
+          restatementRequests,
+        }),
+      },
+    };
+  };
+
   const optionsBuilder = new OptionsBuilder(
     params.options,
     params.getCwd,
@@ -507,6 +633,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     params.getCurrentWorkflowStack,
     buildFindingContractInstructionContext,
     () => params.task,
+    buildFindingEscalationInstructionContext,
   );
 
   const dynamicFacetSelector = new DynamicFacetSelectorCoordinator({

--- a/src/core/workflow/engine/WorkflowValidator.ts
+++ b/src/core/workflow/engine/WorkflowValidator.ts
@@ -29,6 +29,8 @@ import {
   FINDING_TERMINAL_ADJUDICATION_STEP,
   workflowWiresFindingConflictAdjudication,
 } from '../findings/adjudication-step.js';
+import { buildFindingEscalationReviewerPreflightStep } from '../findings/escalation-reviewer-step.js';
+import { FINDING_ESCALATION_REVIEWER_ROUTING_KEY } from '../../models/finding-types.js';
 import { findFindingContractFormat, hasFindingContractFormat } from '../findings/finding-contract-format.js';
 import {
   resolveAutoRoutingCandidateProviderInfo,
@@ -305,6 +307,11 @@ export function validateFindingContractSyntheticProviderModels(
     buildFindingManagerStep(stepInput),
     buildFindingInterpretationStep(stepInput),
     ...adjudicationSteps,
+    // escalation reviewer は report 形式だけを実行時に owner から継承するため、
+    // provider/model 検証は output contract を持たない preflight 用ステップで足りる。
+    ...(findingContract.escalationReviewer === undefined
+      ? []
+      : [buildFindingEscalationReviewerPreflightStep(stepInput)]),
   ];
   for (const step of syntheticSteps) {
     const providerInfo = resolveStepProviderModel({
@@ -325,10 +332,12 @@ export function validateFindingContractSyntheticProviderModels(
           currentProviderInfo: providerInfo,
         })
       : undefined;
-    const configurationPath = step.name === FINDING_TERMINAL_ADJUDICATION_STEP
-      || step.name === FINDING_CONFLICT_ADJUDICATION_STEP
-      ? 'Configuration error: finding_contract.adjudicator.model'
-      : 'Configuration error: finding_contract.manager.model';
+    const configurationPath = step.name === FINDING_ESCALATION_REVIEWER_ROUTING_KEY
+      ? 'Configuration error: finding_contract.escalation_reviewer.model'
+      : step.name === FINDING_TERMINAL_ADJUDICATION_STEP
+        || step.name === FINDING_CONFLICT_ADJUDICATION_STEP
+        ? 'Configuration error: finding_contract.adjudicator.model'
+        : 'Configuration error: finding_contract.manager.model';
     validateResolvedProviderInfo(
       deterministicInfo ?? providerInfo,
       configurationPath,

--- a/src/core/workflow/findings/escalation-reviewer-runner.ts
+++ b/src/core/workflow/findings/escalation-reviewer-runner.ts
@@ -1,0 +1,320 @@
+/**
+ * escalation reviewer の実行。findings-manager / terminal adjudication と同じく、
+ * workflow の step としてではなく engine が合成ステップ経由で直接 provider call を
+ * 発行し、その出力を通常の intake pipeline
+ * （StepExecutor.prepareFindingReviewPublication → canonical publication →
+ * findings-manager の取り込み）へ載せる。
+ *
+ * 呼び出しタイミングは「全 owner reviewer の canonical publication が揃った後、
+ * findings-manager の取り込み前」。owner publication は既に成立しているため、
+ * escalation の失敗だけで owner の計上を巻き込まない。
+ */
+import type {
+  AgentResponse,
+  AgentWorkflowStep,
+  FindingContractConfig,
+  WorkflowConfig,
+  WorkflowMaxSteps,
+  WorkflowState,
+} from '../../models/types.js';
+import { executeAgent } from '../../../agents/agent-usecases.js';
+import { FINDING_ESCALATION_REVIEWER_ROUTING_KEY } from '../../models/finding-types.js';
+import type { OptionsBuilder } from '../engine/OptionsBuilder.js';
+import type { StepExecutor } from '../engine/StepExecutor.js';
+import { reviewerOperationOrigin, runtimeForOperation } from '../engine/fallback-operation.js';
+import type { RuntimeStepResolution, StepProviderInfo, StepRunResult } from '../types.js';
+import { buildSessionKey } from '../session-key.js';
+import type { FindingContractInstructionContext } from '../instruction/instruction-context.js';
+import { withFindingContractStructuredOutput } from './contract-intake.js';
+import {
+  buildFindingEscalationReviewerStep,
+  requireEscalationOwnerOutputContractFormat,
+} from './escalation-reviewer-step.js';
+import type { CanonicalFindingReviewPublication } from './review-publication.js';
+import type { ReviewerRelationClarification } from './relation-coherence.js';
+import type { RunAgentOptions } from '../../../agents/runner.js';
+
+/** escalation reviewer の出力 strategy は owner step によらず structured raw findings で固定。 */
+const ESCALATION_REVIEWER_OUTPUT_STRATEGY = Object.freeze({
+  kind: 'structured',
+  reportGeneration: 'structured',
+  intake: 'reviewer_structured',
+} as const);
+
+/**
+ * escalation reviewer は「レビュアー」であって manager ではない。対象コードを
+ * 自分で読み、新規の byte-exact な引用証拠を作れなければ格上げの意味がないため、
+ * 通常レビュアーの Phase 1 と同じ読み取り専用ツールセットを与える
+ * （2026-08-07 裁定。findings-manager の allowedTools: [] は流用しない）。
+ *
+ * permission mode だけは provider profile の既定に委ねず readonly で固定する。
+ * 合成ステップは `edit: false` なので profile が edit を既定にしていても
+ * 書き込み権限へ昇格させない。
+ */
+function buildEscalationReviewerAgentOptions(
+  optionsBuilder: OptionsBuilder,
+  escalationStep: AgentWorkflowStep,
+  runtime: RuntimeStepResolution | undefined,
+): RunAgentOptions {
+  const options = {
+    ...optionsBuilder.buildAgentOptions(escalationStep, runtime),
+  } as RunAgentOptions & { permissionResolution?: unknown };
+  delete options.permissionResolution;
+  return {
+    ...options,
+    permissionMode: 'readonly',
+  };
+}
+
+/**
+ * 親ステップの runtime から escalation slot 用の runtime を導く。
+ *
+ * provider/model は escalation reviewer の routing persona key で解決させたいので、
+ * 親（owner reviewer / parallel 親）が持つ `providerInfo` の上書きは引き継がない。
+ * 一方 rate-limit fallback は透過させる — escalation reviewer 自身の operation を
+ * 対象とする fallback だけが `runtimeForOperation` によって providerInfo へ反映され、
+ * 他 operation 向けの fallback はここで落ちる。
+ */
+function escalationReviewerRuntime(
+  runtime: RuntimeStepResolution | undefined,
+): RuntimeStepResolution | undefined {
+  return runtimeForOperation(
+    runtime === undefined ? undefined : { ...runtime, providerInfo: undefined },
+    reviewerOperationOrigin(FINDING_ESCALATION_REVIEWER_ROUTING_KEY),
+  );
+}
+
+export type FindingEscalationReviewerOutcome =
+  | {
+      readonly kind: 'published';
+      readonly step: AgentWorkflowStep;
+      readonly publication: CanonicalFindingReviewPublication;
+      readonly relationClarification?: ReviewerRelationClarification;
+    }
+  | {
+      readonly kind: 'terminal';
+      readonly step: AgentWorkflowStep;
+      readonly response: AgentResponse;
+      readonly providerInfo?: StepProviderInfo;
+      readonly terminalOperation?: NonNullable<StepRunResult['terminalOperation']>;
+    };
+
+export interface FindingEscalationReviewerInput {
+  readonly contract: FindingContractConfig;
+  readonly workflowProvider?: WorkflowConfig['provider'];
+  readonly workflowModel?: WorkflowConfig['model'];
+  /**
+   * buildFindingEscalationInstructionContext が返した escalation slot 専用 context。
+   * 今ラウンドに格上げ対象の anomaly が無ければ undefined。その場合でも、
+   * 前ラウンドで永続化済みの escalation publication があれば resume して返す
+   * （提示は計上済みなので request は作られないが、raw findings はまだ
+   * manager へ渡っていない）。
+   */
+  readonly escalationContext?: FindingContractInstructionContext;
+  /** owner reviewer step。escalation_reviewer.output_contract 未設定時に report 形式を継承する。 */
+  readonly ownerReviewerSteps: readonly AgentWorkflowStep[];
+  readonly parentStepName: string;
+  readonly stepIteration: number;
+  readonly state: WorkflowState;
+  readonly task: string;
+  readonly maxSteps: WorkflowMaxSteps;
+  readonly optionsBuilder: OptionsBuilder;
+  readonly stepExecutor: StepExecutor;
+  readonly updatePersonaSession: (persona: string, sessionId: string | undefined) => void;
+  readonly runtime?: RuntimeStepResolution;
+}
+
+/**
+ * runPreparedManagerAttempt と同形の直接 provider call。usage 計上も manager と
+ * 揃えて、合成ステップの LLM 呼び出しをトークン集計の死角にしない。
+ */
+export async function runEscalationReviewerAttempt(input: {
+  readonly escalationStep: AgentWorkflowStep;
+  readonly phase1Instruction: string;
+  /** この呼び出しが実際に使う provider/model。usage event へそのまま計上する。 */
+  readonly providerInfo: StepProviderInfo;
+  readonly optionsBuilder: OptionsBuilder;
+  readonly stepExecutor: Pick<StepExecutor, 'recordSynthesizedAgentUsage'>;
+  readonly runtime?: RuntimeStepResolution;
+}): Promise<AgentResponse> {
+  const agentOptions = buildEscalationReviewerAgentOptions(
+    input.optionsBuilder,
+    input.escalationStep,
+    input.runtime,
+  );
+  let response: AgentResponse;
+  try {
+    response = await executeAgent(
+      input.escalationStep.persona,
+      input.phase1Instruction,
+      agentOptions,
+    );
+  } catch (error) {
+    input.stepExecutor.recordSynthesizedAgentUsage(
+      input.escalationStep,
+      false,
+      undefined,
+      input.providerInfo,
+    );
+    throw error;
+  }
+  input.stepExecutor.recordSynthesizedAgentUsage(
+    input.escalationStep,
+    response.status === 'done',
+    response.providerUsage,
+    input.providerInfo,
+  );
+  return response;
+}
+
+export async function runFindingEscalationReviewer(
+  input: FindingEscalationReviewerInput,
+): Promise<FindingEscalationReviewerOutcome | undefined> {
+  const baseStep = buildFindingEscalationReviewerStep({
+    contract: input.contract,
+    workflowProvider: input.workflowProvider,
+    workflowModel: input.workflowModel,
+    ownerOutputContractFormat: requireEscalationOwnerOutputContractFormat(input.ownerReviewerSteps),
+  });
+  const runtime = escalationReviewerRuntime(input.runtime);
+
+  // 提示予算を使い切った anomaly でも、前ラウンドの escalation publication が
+  // 未取り込みのまま残ることがある（publication 成立後 / manager commit 前の crash）。
+  // request の有無より先に stored publication を引き当てないと、
+  // 「予算は消費済みなのに証拠は一度も intake されない」状態で終端する。
+  const resumed = await input.stepExecutor.resumeFindingReviewPublication({
+    step: baseStep,
+    parentStepName: input.parentStepName,
+    stepIteration: input.stepIteration,
+    state: input.state,
+    runtime,
+    ...(input.escalationContext?.reviewer?.presentationContext === undefined
+      ? {}
+      : { presentationContext: input.escalationContext.reviewer.presentationContext }),
+  });
+  if (resumed !== undefined) {
+    return 'terminalResponse' in resumed
+      ? {
+          kind: 'terminal',
+          step: baseStep,
+          response: resumed.terminalResponse,
+          ...(resumed.reviewerProviderInfo === undefined
+            ? {}
+            : { providerInfo: resumed.reviewerProviderInfo }),
+          terminalOperation: resumed.terminalOperation,
+        }
+      : {
+          kind: 'published',
+          step: baseStep,
+          publication: resumed.publication,
+          ...(resumed.relationClarification === undefined
+            ? {}
+            : { relationClarification: resumed.relationClarification }),
+        };
+  }
+  if (input.escalationContext === undefined) {
+    return undefined;
+  }
+
+  const escalationContext = input.escalationContext;
+  const escalationStep = withFindingContractStructuredOutput(baseStep, escalationContext);
+  const presentationContext = escalationContext.reviewer?.presentationContext;
+  const instruction = input.stepExecutor.buildInstruction(
+    escalationStep,
+    input.stepIteration,
+    input.state,
+    input.task,
+    input.maxSteps,
+    undefined,
+    { mode: 'explicit', context: escalationContext },
+  );
+  const phase1Instruction = input.stepExecutor.buildPhase1Instruction(
+    instruction,
+    escalationStep,
+    runtime,
+  );
+  const providerInfo = input.optionsBuilder.resolveStepProviderModel(escalationStep, runtime);
+  const phase1Response = await runEscalationReviewerAttempt({
+    escalationStep,
+    phase1Instruction,
+    providerInfo,
+    optionsBuilder: input.optionsBuilder,
+    stepExecutor: input.stepExecutor,
+    runtime,
+  });
+  // Phase 1 は sessionId を渡さず必ず新規セッションで開始するため、Phase 2 が
+  // 同じセッションを再開できるようここで登録する。
+  if (phase1Response.sessionId !== undefined) {
+    input.updatePersonaSession(
+      buildSessionKey(escalationStep, {
+        provider: providerInfo.provider,
+        model: providerInfo.model,
+      }),
+      phase1Response.sessionId,
+    );
+  }
+  if (phase1Response.status !== 'done') {
+    return {
+      kind: 'terminal',
+      step: escalationStep,
+      response: phase1Response,
+      providerInfo,
+      // blocked / rate_limited は既存の継続・fallback 経路が operation 単位で扱う。
+      ...(phase1Response.status === 'blocked' || phase1Response.status === 'rate_limited'
+        ? {
+            terminalOperation: {
+              origin: reviewerOperationOrigin(escalationStep.name),
+              providerInfo,
+            },
+          }
+        : {}),
+    };
+  }
+
+  const prepared = await input.stepExecutor.prepareFindingReviewPublication({
+    step: escalationStep,
+    executableStep: escalationStep,
+    reviewerOutputStrategy: ESCALATION_REVIEWER_OUTPUT_STRATEGY,
+    parentStepName: input.parentStepName,
+    stepIteration: input.stepIteration,
+    state: input.state,
+    phase1Response,
+    agentOptions: buildEscalationReviewerAgentOptions(input.optionsBuilder, escalationStep, runtime),
+    // Phase 2 も escalation slot の restatement-only 契約で動かす。既定の
+    // context 再構築（reviewer 名でフィルタ）では request が0件になり、
+    // Phase 2 の指示が通常レビュー契約へ化ける。
+    findingContractContext: escalationContext,
+    // report phase の fallback で provider が切り替わっても、実際に走った
+    // attempt の provider/model をそのまま計上する。
+    onProviderAttempt: (attemptProviderInfo, success, usage) => {
+      input.stepExecutor.recordSynthesizedAgentUsage(
+        escalationStep,
+        success,
+        usage,
+        attemptProviderInfo,
+      );
+    },
+    updatePersonaSession: input.updatePersonaSession,
+    runtime,
+    presentationContext,
+  });
+  if ('terminalResponse' in prepared) {
+    return {
+      kind: 'terminal',
+      step: escalationStep,
+      response: prepared.terminalResponse,
+      providerInfo: prepared.reviewerProviderInfo ?? providerInfo,
+      ...(prepared.terminalOperation === undefined
+        ? {}
+        : { terminalOperation: prepared.terminalOperation }),
+    };
+  }
+  return {
+    kind: 'published',
+    step: escalationStep,
+    publication: prepared.publication,
+    ...(prepared.relationClarification === undefined
+      ? {}
+      : { relationClarification: prepared.relationClarification }),
+  };
+}

--- a/src/core/workflow/findings/escalation-reviewer-step.ts
+++ b/src/core/workflow/findings/escalation-reviewer-step.ts
@@ -1,0 +1,102 @@
+import type {
+  AgentWorkflowStep,
+  FindingContractConfig,
+  WorkflowConfig,
+} from '../../models/types.js';
+import { FINDING_ESCALATION_REVIEWER_ROUTING_KEY } from '../../models/finding-types.js';
+
+/**
+ * escalation reviewer が公開する report 名。owner reviewer の report 名を
+ * 継承すると、別 identity の publication が同じ report ファイルへ別内容を
+ * 公開して衝突する。escalation_reviewer.output_contract の有無によらず固定する。
+ */
+export const FINDING_ESCALATION_REVIEWER_REPORT_NAME = FINDING_ESCALATION_REVIEWER_ROUTING_KEY;
+
+interface FindingEscalationReviewerStepInput {
+  contract: FindingContractConfig;
+  workflowProvider?: WorkflowConfig['provider'];
+  workflowModel?: WorkflowConfig['model'];
+}
+
+/**
+ * escalation_reviewer.output_contract を省略したときに継承する report 形式。
+ * FC reviewer step は必ず1件の output contract を持つ（publication 準備の前提）
+ * ため、先頭の owner reviewer から決定的に取る。
+ */
+export function requireEscalationOwnerOutputContractFormat(
+  ownerReviewerSteps: readonly AgentWorkflowStep[],
+): string {
+  const format = ownerReviewerSteps[0]?.outputContracts?.[0]?.format;
+  if (format === undefined) {
+    throw new Error(
+      'Finding contract reviewer has no output contract to inherit for escalation review',
+    );
+  }
+  return format;
+}
+
+/**
+ * provider/model 解決の検証だけに使う escalation reviewer ステップ。
+ * report 形式は実行時に owner step から継承するため検証には不要で、
+ * 検証のためだけの空ダミー契約を実行用 builder へ持ち込まないよう分けている。
+ *
+ * provider/model の優先順位は adjudicator と同形（直接指定 > workflow）。
+ * routing key は persona 名ではなく固定の 'escalation-reviewer' で、
+ * provider_routing.personas はこのキーで解決する。
+ */
+export function buildFindingEscalationReviewerPreflightStep(
+  input: FindingEscalationReviewerStepInput,
+): AgentWorkflowStep {
+  const escalationReviewer = input.contract.escalationReviewer;
+  if (escalationReviewer === undefined) {
+    throw new Error('Finding escalation review requires finding_contract.escalation_reviewer');
+  }
+  const providerIsDirect = escalationReviewer.provider !== undefined;
+  const modelIsDirect = escalationReviewer.model !== undefined;
+  return {
+    kind: 'agent',
+    name: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+    engineSynthesized: true,
+    persona: escalationReviewer.persona,
+    personaDisplayName: escalationReviewer.personaDisplayName ?? FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+    providerRoutingPersonaKey: escalationReviewer.providerRoutingPersonaKey,
+    // owner reviewer と persona を共有していてもセッションを混ぜない。
+    sessionKey: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+    ...(escalationReviewer.personaPath !== undefined ? { personaPath: escalationReviewer.personaPath } : {}),
+    provider: providerIsDirect ? escalationReviewer.provider : input.workflowProvider,
+    providerSpecified: providerIsDirect,
+    model: modelIsDirect ? escalationReviewer.model : providerIsDirect ? undefined : input.workflowModel,
+    modelSpecified: modelIsDirect || providerIsDirect,
+    instruction: escalationReviewer.instruction ?? escalationReviewer.persona,
+    session: 'refresh',
+    edit: false,
+    rules: [],
+  };
+}
+
+/**
+ * escalation reviewer の実行用合成ステップ。workflow の step ではなく、
+ * findings-manager / terminal adjudication と同じく engine が直接 provider call を
+ * 発行するための AgentWorkflowStep で、config.steps へは注入しない。
+ *
+ * report 形式（outputContracts[].format）だけは owner reviewer step から継承でき、
+ * report 名は衝突回避のため常に FINDING_ESCALATION_REVIEWER_REPORT_NAME。
+ * 出力 strategy は owner step によらず常に structured raw findings
+ * （呼び出し側が withFindingContractStructuredOutput で付与する）。
+ */
+export function buildFindingEscalationReviewerStep(
+  input: FindingEscalationReviewerStepInput & {
+    /** owner reviewer step の report 形式。escalation_reviewer.output_contract 未設定時に継承する。 */
+    ownerOutputContractFormat: string;
+  },
+): AgentWorkflowStep {
+  const step = buildFindingEscalationReviewerPreflightStep(input);
+  const configuredOutputContract = input.contract.escalationReviewer?.outputContract;
+  return {
+    ...step,
+    outputContracts: [{
+      name: FINDING_ESCALATION_REVIEWER_REPORT_NAME,
+      format: configuredOutputContract ?? input.ownerOutputContractFormat,
+    }],
+  };
+}

--- a/src/core/workflow/findings/restatement-presentation-phase.ts
+++ b/src/core/workflow/findings/restatement-presentation-phase.ts
@@ -1,0 +1,31 @@
+/**
+ * intake anomaly の言い直し提示1回分の宛先を決める判定。
+ *
+ * owner reviewer への通常 restatement と escalation reviewer への格上げ再レビューは
+ * 同じ提示予算を分け合うため、判定はこの1関数に集約する。owner batch と
+ * escalation batch の両方がここを通ることで、同じ anomaly が両方の batch に
+ * 入ることがない。
+ */
+export type RestatementPresentationPhase = 'restatement' | 'escalation' | 'exhausted';
+
+/**
+ * - `presentedCount < presentationLimit - 1`: 元レビュアーへの通常 restatement
+ * - `presentedCount === presentationLimit - 1`: 最終1回。escalation reviewer が
+ *   設定されていれば格上げ、未設定なら従来どおり元レビュアーへ戻す
+ * - `presentedCount >= presentationLimit`: 新しい request を作らない
+ *
+ * `presentationLimit === 1` のときは最初の提示がそのまま最終1回になる。
+ */
+export function resolveRestatementPresentationPhase(input: {
+  presentedCount: number;
+  presentationLimit: number;
+  escalationReviewerConfigured: boolean;
+}): RestatementPresentationPhase {
+  if (input.presentedCount >= input.presentationLimit) {
+    return 'exhausted';
+  }
+  return input.escalationReviewerConfigured
+    && input.presentedCount === input.presentationLimit - 1
+    ? 'escalation'
+    : 'restatement';
+}

--- a/src/core/workflow/findings/reviewer-anomalies.ts
+++ b/src/core/workflow/findings/reviewer-anomalies.ts
@@ -29,6 +29,7 @@ import type {
 } from './types.js';
 import { computeReviewerAnomalyStableKey } from './raw-canonicalization.js';
 import type { RestatementRequestBinding, RestatementRequestV1 } from './review-publication.js';
+import { FINDING_ESCALATION_REVIEWER_ROUTING_KEY } from '../../models/finding-types.js';
 
 export interface ReviewerAnomalySpec {
   kind: ReviewerAnomalyKind;
@@ -150,16 +151,27 @@ function hasRestatementCorrespondence(input: {
   )));
 }
 
+/**
+ * escalation phase では、元の不完全な観測の所有者（owner reviewer）と、格上げで
+ * clean な claim を出した reviewer が異なる。これが reviewer 一致要件の唯一の
+ * 緩和点で、判別子は request.reviewer === 'escalation-reviewer' だけ。
+ * escalation reviewer 未設定のワークフローでは escalation request が作られないため
+ * この分岐は発火せず、従来の条件式と等価になる。
+ */
 function hasRestatementCandidateShape(
   request: RestatementRequestV1,
   anomaly: ReviewerAnomalyEntry,
   sourceRaw: RawFinding,
   admittedRaw: RawFinding,
 ): boolean {
+  const ownerReviewer = anomaly.intakeContract?.presentationOwnerReviewer;
+  const reviewersMatch = request.reviewer === FINDING_ESCALATION_REVIEWER_ROUTING_KEY
+    ? sourceRaw.reviewer === ownerReviewer && admittedRaw.reviewer === request.reviewer
+    : request.reviewer === ownerReviewer
+      && sourceRaw.reviewer === request.reviewer
+      && admittedRaw.reviewer === request.reviewer;
   return request.anomalyId === anomaly.id
-    && request.reviewer === anomaly.intakeContract?.presentationOwnerReviewer
-    && sourceRaw.reviewer === request.reviewer
-    && admittedRaw.reviewer === request.reviewer
+    && reviewersMatch
     && admittedRaw.relation === 'new'
     && admittedRaw.targetFindingId === null
     && admittedRaw.targetPrecondition === undefined;

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -21,6 +21,7 @@ import {
   workflowWiresFindingConflictAdjudication,
 } from '../../../core/workflow/findings/adjudication-step.js';
 import { FINDING_CONFLICT_ADJUDICATION_STEP } from '../../../core/workflow/constants.js';
+import { FINDING_ESCALATION_REVIEWER_ROUTING_KEY } from '../../../core/models/finding-types.js';
 import { normalizeAutoRoutingConfig, normalizeRateLimitFallback, normalizeRuntime } from '../configNormalizers.js';
 import type {
   FacetResolutionContext,
@@ -193,6 +194,118 @@ function resolveFindingContractAdjudicator(
   };
 }
 
+type RawFindingContractEscalationReviewer = NonNullable<
+  NonNullable<ReturnType<typeof WorkflowConfigRawSchema.parse>['finding_contract']>['escalation_reviewer']
+>;
+
+function findingContractEscalationReviewerResolutionError(
+  field: 'persona' | 'instruction' | 'output_contract',
+  ref: string,
+  options?: ErrorOptions,
+): Error {
+  return new Error(
+    `Configuration error: failed to resolve finding_contract.escalation_reviewer.${field} "${ref}"`,
+    options,
+  );
+}
+
+function resolveFindingContractEscalationReviewer(
+  raw: RawFindingContractEscalationReviewer,
+  sections: WorkflowSections,
+  workflowDir: string,
+  context?: FacetResolutionContext,
+): NonNullable<FindingContractConfig['escalationReviewer']> {
+  let resolvedPersona: ReturnType<typeof resolvePersona>;
+  try {
+    resolvedPersona = resolvePersona(raw.persona, sections, workflowDir, context);
+  } catch (error) {
+    throw findingContractEscalationReviewerResolutionError('persona', raw.persona, { cause: error });
+  }
+  if (
+    resolvedPersona.personaSpec === undefined
+    || (isScopeRef(raw.persona) && resolvedPersona.personaPath === undefined)
+  ) {
+    throw findingContractEscalationReviewerResolutionError('persona', raw.persona);
+  }
+
+  const resolveOptionalRef = (
+    field: 'instruction' | 'output_contract',
+    ref: string | undefined,
+    resolved: Record<string, string> | ResolvedSectionMap | undefined,
+    kind: 'instructions' | 'output-contracts',
+  ): string | undefined => {
+    if (ref === undefined) {
+      return undefined;
+    }
+    let content: string | undefined;
+    try {
+      content = resolveRefToContent(ref, resolved, workflowDir, kind, context);
+    } catch (error) {
+      throw findingContractEscalationReviewerResolutionError(field, ref, { cause: error });
+    }
+    if (content === undefined) {
+      throw findingContractEscalationReviewerResolutionError(field, ref);
+    }
+    return content;
+  };
+
+  const instruction = resolveOptionalRef(
+    'instruction',
+    raw.instruction,
+    sections.resolvedInstructionsWithSource ?? sections.resolvedInstructions,
+    'instructions',
+  );
+  const outputContract = resolveOptionalRef(
+    'output_contract',
+    raw.output_contract,
+    sections.resolvedReportFormatsWithSource ?? sections.resolvedReportFormats,
+    'output-contracts',
+  );
+
+  return {
+    persona: resolvedPersona.personaSpec,
+    personaDisplayName: resolvedPersona.personaPath
+      ? extractPersonaDisplayName(resolvedPersona.personaPath)
+      : resolvedPersona.personaSpec,
+    // persona 名ではなく固定キー。escalation_reviewer を書いた時点で
+    // provider_routing.personas['escalation-reviewer'] が唯一の routing 入口になる。
+    providerRoutingPersonaKey: FINDING_ESCALATION_REVIEWER_ROUTING_KEY,
+    ...(resolvedPersona.personaPath ? { personaPath: resolvedPersona.personaPath } : {}),
+    ...(instruction === undefined ? {} : { instruction }),
+    ...(outputContract === undefined ? {} : { outputContract }),
+    ...(raw.provider ? { provider: raw.provider } : {}),
+    ...(raw.model ? { model: raw.model } : {}),
+  };
+}
+
+/**
+ * escalation reviewer の publication identity は reviewerStepName
+ * 'escalation-reviewer' で owner publication と分かれる。同名の実 step が
+ * 存在すると publication identity が衝突し、提示計上が混線する。
+ * escalation_reviewer を設定したワークフローに限り予約語として拒否する。
+ */
+function validateFindingContractEscalationReviewerReservedStepName(
+  findingContract: FindingContractConfig | undefined,
+  steps: readonly WorkflowStep[],
+): void {
+  if (findingContract?.escalationReviewer === undefined) {
+    return;
+  }
+  const collectNames = (candidates: readonly WorkflowStep[]): string[] => (
+    candidates.flatMap((step) => [
+      step.name,
+      ...(step.parallel === undefined
+        ? []
+        : collectNames(enumerateParallelSubSteps(step.parallel, []).map(({ subStep }) => subStep))),
+    ])
+  );
+  if (collectNames(steps).includes(FINDING_ESCALATION_REVIEWER_ROUTING_KEY)) {
+    throw new Error(
+      `Configuration error: step name "${FINDING_ESCALATION_REVIEWER_ROUTING_KEY}" is reserved for finding_contract.escalation_reviewer`,
+    );
+  }
+}
+
 function normalizeFindingContractConfig(
   raw: ReturnType<typeof WorkflowConfigRawSchema.parse>['finding_contract'],
   workflowDir: string,
@@ -247,6 +360,9 @@ function normalizeFindingContractConfig(
   const adjudicator = raw.adjudicator === undefined
     ? undefined
     : resolveFindingContractAdjudicator(raw.adjudicator, sections, workflowDir, context);
+  const escalationReviewer = raw.escalation_reviewer === undefined
+    ? undefined
+    : resolveFindingContractEscalationReviewer(raw.escalation_reviewer, sections, workflowDir, context);
 
   return {
     manager: {
@@ -262,6 +378,7 @@ function normalizeFindingContractConfig(
       ...(raw.manager.model ? { model: raw.manager.model } : {}),
     },
     ...(adjudicator === undefined ? {} : { adjudicator }),
+    ...(escalationReviewer === undefined ? {} : { escalationReviewer }),
     // 有限停止予算（Finding Contract・対策バッチ B1 の拡張）: ここでは YAML に
     // 書かれた値だけをそのまま写す（未指定フィールドの穴埋めはしない）。
     // max_rounds の既定値適用は stop-budget.ts の resolveStopBudgetLimits が唯一の
@@ -489,6 +606,7 @@ export function normalizeWorkflowConfig(
     parsed.subworkflow?.requires_finding_contract === true,
   );
   resolveFindingConflictAdjudicator(findingContract, steps, loopMonitors, workflowDir, sections, context);
+  validateFindingContractEscalationReviewerReservedStepName(findingContract, steps);
 
   const config: WorkflowConfig = {
     name: parsed.name,

--- a/src/shared/prompts/en/parts/finding_contract_instruction.md
+++ b/src/shared/prompts/en/parts/finding_contract_instruction.md
@@ -9,6 +9,7 @@
 
 {{#if restatementOnly}}## Restatement requests
 This is a restatement-only review. Address only the requests below. Preserve each request's source claim atom and return a complete product claim only when the repository evidence supports every required field. Do not invent missing fields, lifecycle relations, targets, or evidence. Each request may produce at most one `new` claim, and any claim must keep relation `new`, have no targetFindingId or target precondition, and may echo the request's anomaly ID in `reassertsReviewerAnomalyId`.
+Read the request's target files in the repository before restating. Derive every path and bounded 1-based line range from the current file contents, not from the request excerpt, and request a `file_quote` for each code target with that path and line range only — do not supply source text or verbatimExcerpt, because the engine reads and byte-matches the actual file. If the current file no longer supports the claim, return no claim for that request.
 {{restatementRequestsJson}}
 {{/if}}
 

--- a/src/shared/prompts/ja/parts/finding_contract_instruction.md
+++ b/src/shared/prompts/ja/parts/finding_contract_instruction.md
@@ -9,6 +9,7 @@
 
 {{#if restatementOnly}}## Restatement requests
 これは再提示専用レビューです。以下の request だけを処理してください。各 request の元の claim atom を保ち、リポジトリの証拠からすべての必須項目を裏づけられる場合だけ完全な product claim を返してください。欠けた項目、lifecycle relation、target、evidence を補作しないでください。各 request は最大1件の `new` claim とし、relation は `new`、targetFindingId と target precondition は空にしてください。可能なら request の anomaly ID を `reassertsReviewerAnomalyId` に echo してください。
+言い直す前に、request が指す対象ファイルをリポジトリで実際に読んでください。path と 1-based の行範囲は request の抜粋ではなく現在のファイル内容から取り、code target には その path と行範囲だけを指定した `file_quote` を request してください。engine が現物を読んで byte 一致を検証するため、ソース本文や verbatimExcerpt は自分で書かないでください。現在のファイルが claim を裏づけない場合は、その request に対して claim を返さないでください。
 {{restatementRequestsJson}}
 {{/if}}
 


### PR DESCRIPTION
## 概要

intake anomaly の言い直し(restatement)提示予算の最終1回を、元レビュアーへの再要求ではなく `finding_contract.escalation_reviewer` 設定のモデルへの格上げ再レビューに差し替える。弱いレビュアーが「主張はあるが形式が壊れていて台帳に載らない」出力を繰り返すケースの救済装置。LLM コール回数は増えない(既存予算の最終1回のモデルが変わるだけ)。省略時は完全に現行挙動。

## 実行モデル

- escalation reviewer は workflow step ではなく、findings-manager / terminal adjudication と同列の synthetic ロール(engine が設定から合成し direct provider call)。reviewer key は固定文字列 `escalation-reviewer`
- provider/model は synthetic FC ロールの persona key routing で解決(`provider_routing.personas['escalation-reviewer']`)
- 出力は通常の intake pipeline(pending normalization / canonical publication / 冪等計上)をそのまま通る。digest 契約不変
- Phase 1 は read-only ツール許可(裁定: 対象コードを現物で読んで path+行範囲の引用を自作できる。ただし provider profile が edit 既定でも readonly 固定で昇格しない)
- 発火判定は単一の純関数(restatement / escalation / exhausted)。owner への言い直しと escalation は同じ判定を通るため二重提示は構造的に不可能(parallel/normal 両経路とも step 開始時凍結の presentation counts を共有)
- resume 時は stored publication を identity で引き当て、言い直し request が無くても manager へ届ける(予算消費済み・証拠未取込の取りこぼし防止)

## 品質過程

独立 Opus レビュー2巡(初回 BLOCK 4件 → 全件 RESOLVED 確認、最終 APPROVE with SHOULD → 全対応)。BLOCK はいずれも「escalation が予算を消費するのに成果が台帳へ届かない」系(Phase 2 の restatement-only 契約消失 / resume 取りこぼし / normal 経路の同一ラウンド二重提示 / phase 1 が証拠採取不能)。回帰テストは修正を revert すると落ちることを個別に実証済み。

## 同梱の共有プロンプト変更(意図的)

`finding_contract_instruction.md` の restatement ブロックに「言い直し前に対象ファイルを現物で読み、path と行範囲は現物から導出せよ。現物が主張を支えないなら claim を返すな」を追加(ja/en)。owner レビュアーの言い直しにも適用される — 両者とも読み取り権限を持ち、equally correct な指示のため専用分岐にしていない。

## テスト

新規 finding-fc-escalation-reviewer.test.ts(29件): フェーズ遷移(limit=3/limit=1/未設定/publication失敗時の据え置き)、request identity 分離、synthetic step 属性、read-only 権限(profile edit 既定でも昇格しない)、provider 解決、凍結機構(publication 永続化を挟んだ実 closure 検証)、resume 起点の manager 受け渡し、caller 境界。既存追随含め対象 21 ファイル 513 テスト green、tsc/lint クリーン。golden/compatibility-baseline 不変。

## ドキュメント

docs/workflows{,.ja}.md に finding_contract.escalation_reviewer 節、docs/configuration{,.ja}.md の provider/model 解決へ synthetic ロール(persona key `escalation-reviewer`)と予約 step 名を追記。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Finding Contract に専用のエスカレーションレビュアーを設定できるようになりました。
  * 最終回の再提示を専用レビュアーへ委譲し、結果を通常の取り込み処理へ反映します。
  * ペルソナ、指示、出力形式、プロバイダー、モデルを設定できます。
  * レビュー失敗時は結果を計上せず、次回ラウンドで再試行します。

* **ドキュメント**
  * 設定方法、動作仕様、予約済みキー、モデル解決規則を追加しました。

* **品質改善**
  * エスカレーション処理、再提示、設定検証、失敗時の復旧を包括的に検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->