### PR TITLE
feat: エンジン算出のレビュースコープをreview_scope変数としてレビュアー指示へ注入する

### DIFF
--- a/builtins/en/facets/partials/instructions/review-round-scope.md
+++ b/builtins/en/facets/partials/instructions/review-round-scope.md
@@ -1,3 +1,5 @@
+{review_scope}
+
 When a Finding Contract is present, follow `reviewMode` in the ledger summary. Otherwise, follow the review mode inherited from the caller: `{var:review_mode}`. For `initial`, cover the entire cumulative diff and report every location in the same family in this round. For `follow_up`, apply every Policy / Knowledge criterion to open findings, their fixes, and directly affected paths without restarting untouched-area discovery from scratch. Only when the review mode is `unspecified`, treat a directly executed reviewer step with `{step_iteration}` equal to `1` as `initial` and `2` or greater as `follow_up`.
 
 If a focused follow-up check would return APPROVE, first perform a final review of the entire cumulative diff. On follow-up reviews, always record the scope checked and supporting evidence in the existing verification or evidence fields defined by the output contract, including when approving.

--- a/builtins/ja/facets/partials/instructions/review-round-scope.md
+++ b/builtins/ja/facets/partials/instructions/review-round-scope.md
@@ -1,3 +1,5 @@
+{review_scope}
+
 レビューの走査範囲は、Finding Contract がある場合は台帳サマリの `reviewMode` に従ってください。ない場合は、呼び出し元から継承したレビュー区分 `{var:review_mode}` に従ってください。`initial` なら累積差分全体を網羅し、同じ family の問題を同じ回で出し切ってください。`follow_up` なら open findings、その修正箇所、直接影響する経路を Policy / Knowledge の全基準で確認し、未変更領域を毎回ゼロから再探索しないでください。レビュー区分が `unspecified` の場合に限り、直接実行される reviewer step の `{step_iteration}` が `1` なら `initial`、`2` 以上なら `follow_up` としてください。
 
 継続レビューの重点確認で blocking finding がなく APPROVE を出す場合は、その直前に累積差分全体を最終レビューしてください。継続レビューでは、確認した範囲と根拠を、出力契約が定める既存の検証・根拠欄へ必ず記録してください（APPROVE でも省略不可）。

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -164,6 +164,18 @@ steps:
 | `{user_inputs}` | workflow 中に追加で得たユーザー入力（テンプレートに無ければ自動注入） |
 | `{report_dir}` | レポートディレクトリのパス (例: `.takt/runs/20250126-143052-task-summary/reports`) |
 | `{report:filename}` | `{report_dir}/filename` の内容を埋め込む |
+| `{review_scope}` | TAKT が算出した、このタスクの変更ファイル一覧 |
+
+`{review_scope}` は実行の由来によって対象が変わります。
+
+- 作業ツリー計算（常に行われます）: base コミット以降のコミット済み変更、未コミット変更、未追跡ファイル（ignored を除く）の和集合。タスクの変更が既にブランチへコミット済みで working tree 差分が空になる構成でも一覧に出ます
+- PR 由来の実行（`takt --pr N` 等で PR context を持つ実行）: 上の作業ツリー計算に PR の diff range `base...head` を**加えた**和集合になります。`--pr` は PR のレビューコメントを取り込んで修正するフローで、同じ実行の中で作業ツリーが変わるため、両方を対象にします。diff range がローカルに用意されていない場合はその旨を述べ、ローカル変更だけを一覧にします
+
+Finding Contract の証拠検証は上の作業ツリー計算と同じ結果を使います。PR diff range の合成はレビュアーへの指示注入だけの拡張で、証拠検証側には入りません（証拠検証は cwd の実体に対する byte-exact 照合のため）。
+
+作業ディレクトリが Git リポジトリでない場合や変更が検出されない場合も、その事実を述べる文言に解決されます（空文字にはなりません）。ファイル数が 200 件を超える場合は残件数を明示して打ち切ります。組み込みの汎用レビュアーは partial `instructions/review-round-scope` 経由でこの変数を自動的に受け取ります。
+
+base コミットは `refs/takt/pr-base/<branch>` → `refs/takt/base/<branch>` → 検出した default branch の順で最初に存在する ref との merge-base、およびブランチ reflog の分岐点から、より新しい方を採ります。既存ブランチをそのまま clone した resume 実行のように、どの base ref も残らず reflog も分岐点を持たない環境では base を特定できず、コミット済み変更が一覧から外れます。その場合はその旨が文言に明示されます。
 
 > **補足**: `{task}` / `{previous_response}` / `{user_inputs}` は instruction に自動注入されます。テンプレート内の位置を制御したいときだけ明示的なプレースホルダを置いてください。
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -165,6 +165,18 @@ String `quality_gates` remain AI completion directives and are injected into age
 | `{user_inputs}` | Additional user inputs during workflow (auto-injected if not in template) |
 | `{report_dir}` | Report directory path (e.g., `.takt/runs/20250126-143052-task-summary/reports`) |
 | `{report:filename}` | Inline the content of `{report_dir}/filename` |
+| `{review_scope}` | TAKT-computed list of files changed by this task |
+
+What `{review_scope}` covers depends on where the run came from.
+
+- The working-tree computation (always performed): the union of committed changes since the base commit, uncommitted working-tree changes, and untracked files (ignored files excluded). It therefore still lists the changes when the task changes are already committed to the branch and the working-tree diff is empty.
+- PR-derived runs (a run carrying a PR context, e.g. `takt --pr N`): the PR diff range `base...head` is added **on top of** the working-tree computation. `--pr` pulls in PR review comments and fixes them, so the working tree changes within the same run and both belong to the review scope. If the diff range is not available locally, the text says so and lists the local changes only.
+
+The Finding Contract uses the same working-tree computation for evidence verification. Composing in the PR diff range is an instruction-injection-only extension; it does not enter evidence verification, which byte-exactly matches against what exists in the working directory.
+
+When the working directory is not a Git repository, or no change is detected, it resolves to text stating that fact rather than to an empty string. Lists longer than 200 files are truncated with the remaining count stated. Builtin general-purpose reviewers receive this variable automatically through the `instructions/review-round-scope` partial.
+
+The base commit is taken from the merge-base against the first existing ref among `refs/takt/pr-base/<branch>`, `refs/takt/base/<branch>`, and the detected default branch, combined with the branch entry point recorded in the reflog; the newer of the two is used. In environments where no base ref survives and the reflog holds no branch entry point — for example a resume run that clones an existing branch directly — the base cannot be determined and committed changes are left out of the list. That limitation is stated explicitly in the rendered text.
 
 > **Note**: `{task}`, `{previous_response}`, and `{user_inputs}` are auto-injected into instructions. You only need explicit placeholders if you want to control their position in the template.
 

--- a/src/__tests__/instruction-review-scope.test.ts
+++ b/src/__tests__/instruction-review-scope.test.ts
@@ -1,0 +1,273 @@
+/**
+ * {review_scope} の解決と、共有 partial `review-round-scope` 経由での供給。
+ *
+ * 全汎用レビュアーはこの partial を include するので、エンジンが算出した
+ * 変更ファイル一覧はレビュアー指示へ自動で届く。
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { replaceTemplatePlaceholders } from '../core/workflow/instruction/escape.js';
+import { ReportInstructionBuilder } from '../core/workflow/instruction/ReportInstructionBuilder.js';
+import {
+  REVIEW_SCOPE_MAX_LISTED_PATHS,
+  renderTaskReviewScope,
+  type TaskReviewScope,
+} from '../core/workflow/review-scope.js';
+import { resolveRefToContent } from '../infra/config/loaders/resource-resolver.js';
+import { makeInstructionContext, makeStep } from './test-helpers.js';
+
+const REVIEWER_INSTRUCTIONS = [
+  'review-arch',
+  'review-coding',
+  'ai-antipattern-review',
+  'review-test',
+  'review-security',
+  'review-frontend',
+  'review-cqrs-es',
+  'robustness-review',
+  'contract-lifecycle-review',
+  'review-implementation-semantics',
+] as const;
+
+function collected(paths: readonly string[]): TaskReviewScope {
+  return {
+    kind: 'collected',
+    paths,
+    source: { kind: 'working_tree', baseRange: { kind: 'branch_base', baseCommit: 'abcdef1234567890' } },
+  };
+}
+
+describe('{review_scope} resolution', () => {
+  it('lists the engine-computed changed files', () => {
+    const context = makeInstructionContext({
+      language: 'ja',
+      reviewScope: collected(['src/a.ts', 'src/b.ts']),
+    });
+
+    const resolved = replaceTemplatePlaceholders('{review_scope}', makeStep(), context);
+
+    expect(resolved).toContain('- src/a.ts');
+    expect(resolved).toContain('- src/b.ts');
+    expect(resolved).toContain('2 件');
+    expect(resolved).toContain('abcdef123456');
+  });
+
+  it.each(['en', 'ja'] as const)('reports no detected change without asserting it as a premise in %s', (language) => {
+    const resolved = renderTaskReviewScope(
+      {
+        kind: 'collected',
+        paths: [],
+        source: { kind: 'working_tree', baseRange: { kind: 'base_branch_head' } },
+      },
+      language,
+    );
+
+    expect(resolved.length).toBeGreaterThan(0);
+    expect(resolved).toContain(
+      language === 'ja' ? 'この作業ディレクトリで変更を検出しませんでした' : 'detected no changes in this working directory',
+    );
+    expect(resolved).not.toContain(language === 'ja' ? '前提にしてください' : 'established fact');
+  });
+
+  it.each(['en', 'ja'] as const)('uses the PR diff range for PR-derived runs in %s', (language) => {
+    const resolved = renderTaskReviewScope(
+      {
+        kind: 'collected',
+        paths: ['src/pr.ts'],
+        source: {
+          kind: 'pull_request',
+          prNumber: 42,
+          diffRange: {
+            baseDiffRef: 'refs/takt/pr-base/feature',
+            headDiffRef: 'refs/heads/feature',
+          },
+          includesWorkingTree: false,
+          baseRange: { kind: 'base_branch_head' },
+        },
+      },
+      language,
+    );
+
+    expect(resolved).toContain('- src/pr.ts');
+    expect(resolved).toContain('refs/takt/pr-base/feature...refs/heads/feature');
+    expect(resolved).toContain('#42');
+    expect(resolved).toContain(
+      language === 'ja' ? 'ローカルに追加の変更がない' : 'added no local changes',
+    );
+  });
+
+  // `--pr` は修正フロー。ローカル変更があるのに「作業ツリーは対象外」と言ってはならない。
+  it.each(['en', 'ja'] as const)('states that local changes are included for PR runs in %s', (language) => {
+    const resolved = renderTaskReviewScope(
+      {
+        kind: 'collected',
+        paths: ['src/fix.ts', 'src/pr.ts'],
+        source: {
+          kind: 'pull_request',
+          prNumber: 42,
+          diffRange: {
+            baseDiffRef: 'refs/takt/pr-base/feature',
+            headDiffRef: 'refs/heads/feature',
+          },
+          includesWorkingTree: true,
+          baseRange: { kind: 'base_branch_head' },
+        },
+      },
+      language,
+    );
+
+    expect(resolved).toContain('- src/fix.ts');
+    expect(resolved).toContain('- src/pr.ts');
+    expect(resolved).toContain(
+      language === 'ja' ? 'この実行のローカル変更' : 'plus the local changes of this run',
+    );
+    expect(resolved).not.toContain(
+      language === 'ja' ? 'レビュー対象は PR 側の差分だけ' : 'review target is the PR-side diff only',
+    );
+  });
+
+  // PR 経路のローカル分は作業ツリー計算そのもの。base が unresolved ならコミット済み
+  // 変更が一覧から抜けている事実を、非 PR 経路と同じく開示しなければならない。
+  it.each(['en', 'ja'] as const)('discloses an unresolved base on the PR path in %s', (language) => {
+    const resolved = renderTaskReviewScope(
+      {
+        kind: 'collected',
+        paths: ['src/fix.ts', 'src/pr.ts'],
+        source: {
+          kind: 'pull_request',
+          prNumber: 42,
+          diffRange: {
+            baseDiffRef: 'refs/takt/pr-base/feature',
+            headDiffRef: 'refs/heads/feature',
+          },
+          includesWorkingTree: true,
+          baseRange: { kind: 'unresolved', reason: 'HEAD is detached' },
+        },
+      },
+      language,
+    );
+
+    expect(resolved).toContain('#42');
+    expect(resolved).toContain('HEAD is detached');
+    expect(resolved).toContain(
+      language === 'ja' ? 'base コミットを特定できなかった' : 'base commit could not be determined',
+    );
+  });
+
+  it.each(['en', 'ja'] as const)('names the PR as the target when its diff range is missing in %s', (language) => {
+    const resolved = renderTaskReviewScope(
+      {
+        kind: 'collected',
+        paths: ['src/fix.ts'],
+        source: {
+          kind: 'pull_request',
+          prNumber: 42,
+          includesWorkingTree: true,
+          baseRange: { kind: 'base_branch_head' },
+        },
+      },
+      language,
+    );
+
+    expect(resolved).toContain('#42');
+    expect(resolved).toContain('- src/fix.ts');
+    expect(resolved).toContain(
+      language === 'ja' ? 'diff range がローカルに用意されていない' : 'diff range is not available locally',
+    );
+    expect(resolved).not.toContain(language === 'ja' ? '変更を検出しませんでした' : 'detected no changes');
+  });
+
+  it.each(['en', 'ja'] as const)('states that the directory is not a git repository in %s', (language) => {
+    const resolved = renderTaskReviewScope({ kind: 'not_a_git_repository' }, language);
+
+    expect(resolved).toContain(language === 'ja' ? 'Git リポジトリではありません' : 'not a Git repository');
+  });
+
+  it.each(['en', 'ja'] as const)('states that the scope was not computed in %s', (language) => {
+    const resolved = renderTaskReviewScope(undefined, language);
+
+    expect(resolved.length).toBeGreaterThan(0);
+    expect(resolved).toContain(language === 'ja' ? '算出していません' : 'did not compute');
+  });
+
+  it.each(['en', 'ja'] as const)('warns that committed changes are missing when the base is unresolved in %s', (language) => {
+    const resolved = renderTaskReviewScope(
+      {
+        kind: 'collected',
+        paths: ['src/a.ts'],
+        source: { kind: 'working_tree', baseRange: { kind: 'unresolved', reason: 'HEAD is detached' } },
+      },
+      language,
+    );
+
+    expect(resolved).toContain('HEAD is detached');
+    expect(resolved).toContain(language === 'ja' ? 'base コミットを特定できなかった' : 'base commit could not be determined');
+  });
+
+  it('truncates long lists and states the omitted count instead of dropping it silently', () => {
+    const paths = Array.from({ length: REVIEW_SCOPE_MAX_LISTED_PATHS + 7 }, (_, index) => `src/file-${index}.ts`);
+
+    const resolved = renderTaskReviewScope(collected(paths), 'ja');
+
+    expect(resolved).toContain(`- ${paths[REVIEW_SCOPE_MAX_LISTED_PATHS - 1]}`);
+    expect(resolved).not.toContain(`- ${paths[REVIEW_SCOPE_MAX_LISTED_PATHS]}`);
+    expect(resolved).toContain(String(paths.length));
+    expect(resolved).toContain('残り 7 件');
+  });
+
+  it('resolves {review_scope} in Phase 2 output contracts', () => {
+    const step = makeStep({
+      outputContracts: [{
+        name: 'review.md',
+        format: 'Scope under review:\n\n{review_scope}',
+      }],
+    });
+
+    const instruction = new ReportInstructionBuilder(step, {
+      cwd: '/tmp/test',
+      reportDir: '/tmp/test/reports',
+      stepIteration: 1,
+      language: 'ja',
+      targetFile: 'review.md',
+      reviewScope: collected(['src/phase2.ts']),
+    }).build();
+
+    expect(instruction).not.toContain('{review_scope}');
+    expect(instruction).toContain('- src/phase2.ts');
+  });
+});
+
+describe('review-round-scope partial supplies the scope to reviewers', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'takt-review-scope-facet-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it.each(['en', 'ja'] as const)('renders the changed file list in every builtin reviewer instruction (%s)', (lang) => {
+    const context = makeInstructionContext({
+      language: lang,
+      reviewScope: collected(['src/core/workflow/review-scope.ts']),
+    });
+
+    for (const name of REVIEWER_INSTRUCTIONS) {
+      const instruction = resolveRefToContent(name, undefined, projectDir, 'instructions', {
+        projectDir,
+        lang,
+      });
+      expect(instruction, `missing builtin instruction: ${name}`).toBeDefined();
+      expect(instruction).toContain('{review_scope}');
+
+      const resolved = replaceTemplatePlaceholders(instruction!, makeStep(), context);
+
+      expect(resolved).not.toContain('{review_scope}');
+      expect(resolved).toContain('- src/core/workflow/review-scope.ts');
+    }
+  });
+});

--- a/src/__tests__/previewPrompts.test.ts
+++ b/src/__tests__/previewPrompts.test.ts
@@ -23,6 +23,8 @@ const {
   mockReportBuild,
   mockJudgmentBuild,
   mockNeedsStatusJudgmentPhase,
+  mockResolveReviewScopeBaseRange,
+  mockCollectTaskReviewScope,
 } = vi.hoisted(() => ({
   mockLoadWorkflowByIdentifier: vi.fn(),
   mockResolveWorkflowConfigValue: vi.fn(),
@@ -37,6 +39,8 @@ const {
   mockReportBuild: vi.fn(() => 'phase2'),
   mockJudgmentBuild: vi.fn(() => 'phase3'),
   mockNeedsStatusJudgmentPhase: vi.fn(() => false),
+  mockResolveReviewScopeBaseRange: vi.fn(),
+  mockCollectTaskReviewScope: vi.fn(),
 }));
 
 vi.mock('../infra/config/index.js', () => ({
@@ -96,6 +100,11 @@ vi.mock('../core/workflow/index.js', () => ({
   needsStatusJudgmentPhase: mockNeedsStatusJudgmentPhase,
 }));
 
+vi.mock('../core/workflow/review-scope.js', () => ({
+  resolveReviewScopeBaseRange: mockResolveReviewScopeBaseRange,
+  collectTaskReviewScope: mockCollectTaskReviewScope,
+}));
+
 vi.mock('../shared/ui/index.js', () => ({
   header: mockHeader,
   info: mockInfo,
@@ -119,6 +128,12 @@ describe('previewPrompts', () => {
       return undefined;
     });
     mockResolveAuxiliaryProviderEnvironment.mockReturnValue(compiledEnvironment());
+    mockResolveReviewScopeBaseRange.mockReturnValue({ kind: 'base_branch_head' });
+    mockCollectTaskReviewScope.mockReturnValue({
+      kind: 'collected',
+      paths: [],
+      source: { kind: 'working_tree', baseRange: { kind: 'base_branch_head' } },
+    });
     mockResolveWorkflowSelector.mockImplementation((workflow: {
       steps?: Array<{ parallel?: { kind?: string } }>;
     }) => workflow.steps?.some((step) => step.parallel?.kind === 'dynamic')
@@ -160,6 +175,20 @@ describe('previewPrompts', () => {
       '/project',
       expect.objectContaining({ name: 'default' }),
     );
+  });
+
+  // takt prompt は診断ツール。レビュー範囲を解決できなくてもプロンプト本体の
+  // プレビューは出す（実行時の fail-fast は変えない）。
+  it('スコープ解決が失敗してもプレビューを継続し理由を表示する', async () => {
+    mockResolveReviewScopeBaseRange.mockImplementationOnce(() => {
+      throw new Error('spawnSync git ENOENT');
+    });
+
+    await expect(previewPrompts('/project', undefined, undefined)).resolves.toBeUndefined();
+
+    expect(mockInfo).toHaveBeenCalledWith('Review scope unavailable: spawnSync git ENOENT');
+    expect(console.log).toHaveBeenCalledWith('Step 1: implement (persona: coder)');
+    expect(console.log).toHaveBeenCalledWith('phase1');
   });
 
   it('step番号の見出しを表示する', async () => {

--- a/src/__tests__/previewPrompts.test.ts
+++ b/src/__tests__/previewPrompts.test.ts
@@ -191,6 +191,21 @@ describe('previewPrompts', () => {
     expect(console.log).toHaveBeenCalledWith('phase1');
   });
 
+  it('パス収集が失敗してもプレビューを継続し理由を表示する', async () => {
+    mockCollectTaskReviewScope.mockImplementationOnce(() => {
+      throw new Error('git ls-files --others: repository path is not reversibly UTF-8 encoded');
+    });
+
+    await expect(previewPrompts('/project', undefined, undefined)).resolves.toBeUndefined();
+
+    expect(mockResolveReviewScopeBaseRange).toHaveBeenCalledWith('/project');
+    expect(mockInfo).toHaveBeenCalledWith(
+      'Review scope unavailable: git ls-files --others: repository path is not reversibly UTF-8 encoded',
+    );
+    expect(console.log).toHaveBeenCalledWith('Step 1: implement (persona: coder)');
+    expect(console.log).toHaveBeenCalledWith('phase1');
+  });
+
   it('step番号の見出しを表示する', async () => {
     await previewPrompts('/project', undefined, undefined);
 

--- a/src/__tests__/report-phase-soft-error.test.ts
+++ b/src/__tests__/report-phase-soft-error.test.ts
@@ -101,6 +101,7 @@ function makeStepExecutor(): StepExecutor {
     getWorkflowName: () => 'test-workflow',
     getWorkflowDescription: () => undefined,
     getRetryNote: () => undefined,
+    getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
     structuredCaller: {
       evaluateCondition: vi.fn(),
       judgeStatus: vi.fn(),

--- a/src/__tests__/session-compaction-wiring.test.ts
+++ b/src/__tests__/session-compaction-wiring.test.ts
@@ -204,6 +204,7 @@ function makeNormalDeps(
     getTask: () => 'task',
     getWorkflowDescription: () => undefined,
     getRetryNote: () => undefined,
+    getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
     structuredCaller: {
       evaluateCondition: vi.fn(),
       judgeStatus: vi.fn(),
@@ -269,6 +270,7 @@ describe('session compaction Phase 1 wiring', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),
@@ -315,6 +317,7 @@ describe('session compaction Phase 1 wiring', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(), judgeStatus: vi.fn(), decomposeTask: vi.fn(), requestMoreParts: vi.fn(),
       },
@@ -447,6 +450,7 @@ describe('session compaction Phase 1 wiring', () => {
       ],
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(), judgeStatus: vi.fn(), decomposeTask: vi.fn(), requestMoreParts: vi.fn(),
       },
@@ -615,6 +619,7 @@ describe('session compaction Phase 1 wiring', () => {
       ],
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),

--- a/src/__tests__/step-executor.test.ts
+++ b/src/__tests__/step-executor.test.ts
@@ -2012,6 +2012,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),
@@ -2243,6 +2244,7 @@ describe('StepExecutor', () => {
       ],
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredOutputNormalizers: createStructuredOutputNormalizerRegistry([]),
       reviewerOutputStrategy: { kind: 'structured', reportGeneration: 'structured', intake: 'reviewer_structured' },
       findingContract: {
@@ -2454,6 +2456,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),
@@ -2529,6 +2532,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(), judgeStatus: vi.fn(), decomposeTask: vi.fn(), requestMoreParts: vi.fn(),
       },
@@ -2569,6 +2573,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(), judgeStatus: vi.fn(), decomposeTask: vi.fn(), requestMoreParts: vi.fn(),
       },
@@ -2639,6 +2644,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),
@@ -2711,6 +2717,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),
@@ -2790,6 +2797,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),
@@ -2864,6 +2872,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),
@@ -2937,6 +2946,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),
@@ -3013,6 +3023,7 @@ describe('StepExecutor', () => {
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
       getRetryNote: () => undefined,
+      getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
         evaluateCondition: vi.fn(),
         judgeStatus: vi.fn(),
@@ -3104,6 +3115,7 @@ describe('StepExecutor dynamic facet integration', () => {
         getTask: () => 'task',
         getWorkflowDescription: () => undefined,
         getRetryNote: () => undefined,
+        getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
         structuredCaller: {
           evaluateCondition: vi.fn(),
           judgeStatus: vi.fn(),

--- a/src/__tests__/task-review-scope.test.ts
+++ b/src/__tests__/task-review-scope.test.ts
@@ -1,0 +1,447 @@
+/**
+ * レビュースコープ（変更対象ファイル集合）の算出。
+ *
+ * レビュー時点でタスクの変更が既にコミット済みの構成（PR / ブランチレビュー、
+ * エージェント自身がコミットするワークフロー、ベンチのチェックポイント
+ * コミット、worktree クローンの自動コミット後の再レビュー）では HEAD との
+ * 差分が空になり、コミット済み範囲を含めないと変更が不可視になる。
+ *
+ * PR 由来の実行は対象が作業ツリーではなく PR の diff range である。クリーンな
+ * base ブランチ上で PR をレビューする構成へ「変更 0 件」を注入しないこと。
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  collectTaskReviewScope,
+  createTaskReviewScopeResolver,
+  resolveReviewScopeBaseRange,
+  type TaskReviewScope,
+} from '../core/workflow/review-scope.js';
+import { createPullRequestContext } from '../core/workflow/pr-context.js';
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'TAKT test',
+      GIT_AUTHOR_EMAIL: 'takt-test@example.invalid',
+      GIT_COMMITTER_NAME: 'TAKT test',
+      GIT_COMMITTER_EMAIL: 'takt-test@example.invalid',
+    },
+  }).trim();
+}
+
+function commitAll(cwd: string, message: string): void {
+  git(cwd, 'add', '-A');
+  git(cwd, 'commit', '--quiet', '--no-verify', '-m', message);
+}
+
+function collectScope(cwd: string): TaskReviewScope {
+  return collectTaskReviewScope({ cwd, baseRange: resolveReviewScopeBaseRange(cwd) });
+}
+
+function collectedPaths(cwd: string): readonly string[] {
+  const scope = collectScope(cwd);
+  if (scope.kind !== 'collected') {
+    throw new Error(`expected a collected scope, got ${scope.kind}`);
+  }
+  return scope.paths;
+}
+
+describe('collectTaskReviewScope', () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'takt-review-scope-'));
+    git(repo, 'init', '--quiet', '--initial-branch=main');
+    writeFileSync(join(repo, 'base.ts'), 'export const base = 1;\n');
+    writeFileSync(join(repo, 'untouched.ts'), 'export const untouched = 1;\n');
+    commitAll(repo, 'base');
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('reports zero changes on a clean base branch', () => {
+    expect(collectScope(repo)).toEqual({
+      kind: 'collected',
+      paths: [],
+      source: { kind: 'working_tree', baseRange: { kind: 'base_branch_head' } },
+    });
+  });
+
+  it('collects uncommitted working-tree changes, deletions and untracked files', () => {
+    writeFileSync(join(repo, 'base.ts'), 'export const base = 2;\n');
+    writeFileSync(join(repo, 'added.ts'), 'export const added = 1;\n');
+    unlinkSync(join(repo, 'untouched.ts'));
+
+    expect(collectedPaths(repo)).toEqual(['added.ts', 'base.ts', 'untouched.ts']);
+  });
+
+  it('collects committed changes on a task branch when the working tree is clean', () => {
+    git(repo, 'checkout', '--quiet', '-b', 'takt/20260807-feature');
+    writeFileSync(join(repo, 'implemented.ts'), 'export const implemented = 1;\n');
+    commitAll(repo, 'takt: implement');
+
+    const scope = collectScope(repo);
+
+    expect(scope.kind).toBe('collected');
+    if (scope.kind !== 'collected') return;
+    expect(scope.paths).toEqual(['implemented.ts']);
+    expect(scope.source).toEqual({
+      kind: 'working_tree',
+      baseRange: { kind: 'branch_base', baseCommit: expect.any(String) },
+    });
+    expect(git(repo, 'status', '--porcelain')).toBe('');
+  });
+
+  it('collects the union of committed, uncommitted and untracked changes', () => {
+    git(repo, 'checkout', '--quiet', '-b', 'takt/20260807-feature');
+    writeFileSync(join(repo, 'committed.ts'), 'export const committed = 1;\n');
+    commitAll(repo, 'takt: implement');
+    writeFileSync(join(repo, 'base.ts'), 'export const base = 3;\n');
+    writeFileSync(join(repo, 'untracked.ts'), 'export const untracked = 1;\n');
+
+    expect(collectedPaths(repo)).toEqual(['base.ts', 'committed.ts', 'untracked.ts']);
+  });
+
+  it('excludes gitignored files', () => {
+    writeFileSync(join(repo, '.gitignore'), 'ignored.ts\n');
+    commitAll(repo, 'ignore');
+    writeFileSync(join(repo, 'ignored.ts'), 'export const ignored = 1;\n');
+    writeFileSync(join(repo, 'tracked-change.ts'), 'export const tracked = 1;\n');
+
+    expect(collectedPaths(repo)).toEqual(['tracked-change.ts']);
+  });
+
+  it('reports that the directory is not a git repository', () => {
+    const plainDir = mkdtempSync(join(tmpdir(), 'takt-review-scope-plain-'));
+    try {
+      expect(collectScope(plainDir)).toEqual({ kind: 'not_a_git_repository' });
+    } finally {
+      rmSync(plainDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports not-a-repository for a directory that does not exist', () => {
+    expect(collectScope(join(repo, 'missing-dir'))).toEqual({ kind: 'not_a_git_repository' });
+  });
+
+  it('lists untracked files when the repository has no commits yet', () => {
+    const fresh = mkdtempSync(join(tmpdir(), 'takt-review-scope-empty-'));
+    try {
+      git(fresh, 'init', '--quiet', '--initial-branch=main');
+      writeFileSync(join(fresh, 'first.ts'), 'export const first = 1;\n');
+
+      expect(collectScope(fresh)).toEqual({
+        kind: 'collected',
+        paths: ['first.ts'],
+        source: { kind: 'working_tree', baseRange: { kind: 'no_commits' } },
+      });
+    } finally {
+      rmSync(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to working-tree-only scope and says so when the base cannot be resolved', () => {
+    git(repo, 'checkout', '--quiet', '-b', 'takt/20260807-feature');
+    writeFileSync(join(repo, 'implemented.ts'), 'export const implemented = 1;\n');
+    commitAll(repo, 'takt: implement');
+    // reflog を落とし、base ブランチも消して、分岐点の手がかりを両方奪う。
+    rmSync(join(repo, '.git', 'logs'), { recursive: true, force: true });
+    git(repo, 'branch', '-D', 'main');
+    writeFileSync(join(repo, 'base.ts'), 'export const base = 4;\n');
+
+    const scope = collectScope(repo);
+
+    expect(scope.kind).toBe('collected');
+    if (scope.kind !== 'collected') return;
+    expect(scope.paths).toEqual(['base.ts']);
+    expect(scope.source).toEqual({
+      kind: 'working_tree',
+      baseRange: { kind: 'unresolved', reason: expect.stringContaining('no base ref') },
+    });
+  });
+
+  it('resolves the base from refs/takt/base when the base branch is absent (isolated clone)', () => {
+    const baseCommit = git(repo, 'rev-parse', 'HEAD');
+    git(repo, 'checkout', '--quiet', '-b', 'takt/20260807-feature');
+    git(repo, 'update-ref', 'refs/takt/base/takt/20260807-feature', baseCommit);
+    writeFileSync(join(repo, 'implemented.ts'), 'export const implemented = 1;\n');
+    commitAll(repo, 'takt: implement');
+    rmSync(join(repo, '.git', 'logs'), { recursive: true, force: true });
+    git(repo, 'branch', '-D', 'main');
+
+    expect(resolveReviewScopeBaseRange(repo)).toEqual({ kind: 'branch_base', baseCommit });
+    expect(collectedPaths(repo)).toEqual(['implemented.ts']);
+  });
+
+  it('prefers the newer branch point when the reflog entry predates the merge base', () => {
+    // base ブランチを進めてから取り込むと、reflog の最古エントリは実際の分岐点より古くなる。
+    git(repo, 'checkout', '--quiet', '-b', 'takt/20260807-feature');
+    writeFileSync(join(repo, 'implemented.ts'), 'export const implemented = 1;\n');
+    commitAll(repo, 'takt: implement');
+    git(repo, 'checkout', '--quiet', 'main');
+    writeFileSync(join(repo, 'main-only.ts'), 'export const mainOnly = 1;\n');
+    commitAll(repo, 'main moves on');
+    const mergeBase = git(repo, 'rev-parse', 'HEAD');
+    git(repo, 'checkout', '--quiet', 'takt/20260807-feature');
+    git(repo, 'merge', '--quiet', '--no-edit', 'main');
+
+    expect(resolveReviewScopeBaseRange(repo)).toEqual({ kind: 'branch_base', baseCommit: mergeBase });
+    expect(collectedPaths(repo)).toEqual(['implemented.ts']);
+  });
+
+  it('prefers the reflog branch point when it postdates the merge base', () => {
+    const firstCommit = git(repo, 'rev-parse', 'HEAD');
+    writeFileSync(join(repo, 'mid.ts'), 'export const mid = 1;\n');
+    commitAll(repo, 'mid');
+    writeFileSync(join(repo, 'top.ts'), 'export const top = 1;\n');
+    commitAll(repo, 'top');
+    const branchPoint = git(repo, 'rev-parse', 'HEAD');
+
+    git(repo, 'checkout', '--quiet', '-b', 'takt/20260807-feature');
+    // ブランチ履歴を巻き戻すと merge-base は最初のコミットまで後退するが、
+    // 実際に枝を切った地点は reflog 側の新しい方である。
+    git(repo, 'reset', '--hard', '--quiet', firstCommit);
+    writeFileSync(join(repo, 'implemented.ts'), 'export const implemented = 1;\n');
+    commitAll(repo, 'takt: implement');
+
+    expect(git(repo, 'merge-base', 'main', 'takt/20260807-feature')).toBe(firstCommit);
+    expect(resolveReviewScopeBaseRange(repo)).toEqual({
+      kind: 'branch_base',
+      baseCommit: branchPoint,
+    });
+  });
+});
+
+describe('pull request derived scope', () => {
+  let repo: string;
+  let baseRef: string;
+  let headRef: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'takt-review-scope-pr-'));
+    git(repo, 'init', '--quiet', '--initial-branch=main');
+    writeFileSync(join(repo, 'base.ts'), 'export const base = 1;\n');
+    commitAll(repo, 'base');
+    baseRef = 'refs/takt/pr-base/feature';
+    headRef = 'refs/heads/feature';
+    git(repo, 'update-ref', baseRef, git(repo, 'rev-parse', 'HEAD'));
+    git(repo, 'checkout', '--quiet', '-b', 'feature');
+    writeFileSync(join(repo, 'pr-change.ts'), 'export const prChange = 1;\n');
+    commitAll(repo, 'pr change');
+    // レビューはクリーンな base ブランチ上で走る（作業ツリー差分は空）。
+    git(repo, 'checkout', '--quiet', 'main');
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  function prContext(materialized: boolean) {
+    return createPullRequestContext({
+      source: 'pr_review',
+      prNumber: 42,
+      baseBranch: 'main',
+      headBranch: 'feature',
+      baseBranchSource: 'pull_request',
+      ...(materialized ? { baseDiffRef: baseRef, headDiffRef: headRef } : {}),
+    });
+  }
+
+  function collectWithPr(materialized: boolean): TaskReviewScope {
+    return collectTaskReviewScope({
+      cwd: repo,
+      baseRange: resolveReviewScopeBaseRange(repo),
+      prContext: prContext(materialized),
+    });
+  }
+
+  it('uses the PR diff range when the working tree is clean', () => {
+    const withoutPr = collectScope(repo);
+    expect(withoutPr).toEqual({
+      kind: 'collected',
+      paths: [],
+      source: { kind: 'working_tree', baseRange: { kind: 'base_branch_head' } },
+    });
+
+    expect(collectWithPr(true)).toEqual({
+      kind: 'collected',
+      paths: ['pr-change.ts'],
+      source: {
+        kind: 'pull_request',
+        prNumber: 42,
+        diffRange: { baseDiffRef: baseRef, headDiffRef: headRef },
+        includesWorkingTree: false,
+        baseRange: { kind: 'base_branch_head' },
+      },
+    });
+  });
+
+  // `--pr` は PR のレビューコメントを取り込んで修正するフロー。同じ実行で
+  // 作業ツリーが変わるので、その変更もレビュー対象に入らなければならない。
+  it('unions the PR diff range with local changes made during the run', () => {
+    writeFileSync(join(repo, 'fix-for-review.ts'), 'export const fix = 1;\n');
+    writeFileSync(join(repo, 'base.ts'), 'export const base = 2;\n');
+
+    const scope = collectWithPr(true);
+
+    expect(scope.kind).toBe('collected');
+    if (scope.kind !== 'collected') return;
+    expect(scope.paths).toEqual(['base.ts', 'fix-for-review.ts', 'pr-change.ts']);
+    expect(scope.source).toEqual({
+      kind: 'pull_request',
+      prNumber: 42,
+      diffRange: { baseDiffRef: baseRef, headDiffRef: headRef },
+      includesWorkingTree: true,
+      baseRange: { kind: 'base_branch_head' },
+    });
+  });
+
+  it('lists local changes even when the PR diff range is not materialized', () => {
+    writeFileSync(join(repo, 'fix-for-review.ts'), 'export const fix = 1;\n');
+
+    const scope = collectWithPr(false);
+
+    expect(scope.kind).toBe('collected');
+    if (scope.kind !== 'collected') return;
+    expect(scope.paths).toEqual(['fix-for-review.ts']);
+    expect(scope.source).toEqual({
+      kind: 'pull_request',
+      prNumber: 42,
+      includesWorkingTree: true,
+      baseRange: { kind: 'base_branch_head' },
+    });
+  });
+
+  it('forwards the PR context through the engine-boundary resolver', () => {
+    const resolve = createTaskReviewScopeResolver({
+      getCwd: () => repo,
+      getPrContext: () => prContext(true),
+    });
+
+    const scope = resolve();
+
+    expect(scope.kind).toBe('collected');
+    if (scope.kind !== 'collected') return;
+    expect(scope.paths).toEqual(['pr-change.ts']);
+    expect(scope.source.kind).toBe('pull_request');
+  });
+
+  it('drops the diff range when the recorded refs no longer exist', () => {
+    git(repo, 'update-ref', '-d', baseRef);
+
+    const scope = collectWithPr(true);
+
+    expect(scope.kind).toBe('collected');
+    if (scope.kind !== 'collected') return;
+    expect(scope.source).toEqual({
+      kind: 'pull_request',
+      prNumber: 42,
+      includesWorkingTree: false,
+      baseRange: { kind: 'base_branch_head' },
+    });
+  });
+});
+
+describe('createTaskReviewScopeResolver', () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'takt-review-scope-resolver-'));
+    git(repo, 'init', '--quiet', '--initial-branch=main');
+    writeFileSync(join(repo, 'base.ts'), 'export const base = 1;\n');
+    commitAll(repo, 'base');
+    git(repo, 'checkout', '--quiet', '-b', 'takt/20260807-feature');
+    writeFileSync(join(repo, 'implemented.ts'), 'export const implemented = 1;\n');
+    commitAll(repo, 'takt: implement');
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('keeps the resolved base across calls while re-reading the working tree', () => {
+    const resolve = createTaskReviewScopeResolver({
+      getCwd: () => repo,
+      getPrContext: () => undefined,
+    });
+
+    const first = resolve();
+    expect(first.kind).toBe('collected');
+    if (first.kind !== 'collected') return;
+    expect(first.paths).toEqual(['implemented.ts']);
+    const firstSource = first.source;
+
+    writeFileSync(join(repo, 'later.ts'), 'export const later = 1;\n');
+    const second = resolve();
+
+    expect(second.kind).toBe('collected');
+    if (second.kind !== 'collected') return;
+    expect(second.paths).toEqual(['implemented.ts', 'later.ts']);
+    expect(second.source).toEqual(firstSource);
+  });
+
+  // no_commits を保持すると、初コミット後にトラッキング済み変更が恒久的に見えなくなる。
+  it('re-resolves the base after the first commit lands in an empty repository', () => {
+    const fresh = mkdtempSync(join(tmpdir(), 'takt-review-scope-empty-resolver-'));
+    try {
+      git(fresh, 'init', '--quiet', '--initial-branch=main');
+      writeFileSync(join(fresh, 'first.ts'), 'export const first = 1;\n');
+      const resolve = createTaskReviewScopeResolver({
+        getCwd: () => fresh,
+        getPrContext: () => undefined,
+      });
+
+      const beforeCommit = resolve();
+      expect(beforeCommit).toEqual({
+        kind: 'collected',
+        paths: ['first.ts'],
+        source: { kind: 'working_tree', baseRange: { kind: 'no_commits' } },
+      });
+
+      commitAll(fresh, 'first');
+      writeFileSync(join(fresh, 'first.ts'), 'export const first = 2;\n');
+      const afterCommit = resolve();
+
+      expect(afterCommit).toEqual({
+        kind: 'collected',
+        paths: ['first.ts'],
+        source: { kind: 'working_tree', baseRange: { kind: 'base_branch_head' } },
+      });
+    } finally {
+      rmSync(fresh, { recursive: true, force: true });
+    }
+  });
+
+  // not_a_git_repository も遷移する（worktree が後から作られる経路）。
+  it('re-resolves once a directory becomes a git repository', () => {
+    const plain = mkdtempSync(join(tmpdir(), 'takt-review-scope-plain-resolver-'));
+    try {
+      const resolve = createTaskReviewScopeResolver({
+        getCwd: () => plain,
+        getPrContext: () => undefined,
+      });
+      expect(resolve()).toEqual({ kind: 'not_a_git_repository' });
+
+      git(plain, 'init', '--quiet', '--initial-branch=main');
+      writeFileSync(join(plain, 'new.ts'), 'export const created = 1;\n');
+
+      expect(resolve()).toEqual({
+        kind: 'collected',
+        paths: ['new.ts'],
+        source: { kind: 'working_tree', baseRange: { kind: 'no_commits' } },
+      });
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/task-review-scope.test.ts
+++ b/src/__tests__/task-review-scope.test.ts
@@ -11,7 +11,7 @@
  */
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { devNull, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -29,6 +29,10 @@ function git(cwd: string, ...args: string[]): string {
     stdio: 'pipe',
     env: {
       ...process.env,
+      // 実行環境の gitconfig から隔離する。core.excludesFile や init.defaultBranch、
+      // commit.gpgsign のようなユーザー設定が fixture の期待値を壊さないようにする。
+      GIT_CONFIG_GLOBAL: devNull,
+      GIT_CONFIG_SYSTEM: devNull,
       GIT_AUTHOR_NAME: 'TAKT test',
       GIT_AUTHOR_EMAIL: 'takt-test@example.invalid',
       GIT_COMMITTER_NAME: 'TAKT test',

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import type { WorkflowStep, WorkflowState, Language, WorkflowResumePointEntry, McpServerConfig } from '../../models/types.js';
 import type { StepProviderOptions } from '../../models/workflow-types.js';
+import type { TaskReviewScope } from '../review-scope.js';
 import type { RunAgentOptions } from '../../../agents/runner.js';
 import type { WorkflowMeta } from '../../../agents/types.js';
 import type { StructuredCaller } from '../../../agents/structured-caller.js';
@@ -93,6 +94,7 @@ export class OptionsBuilder {
       reviewScopeSnapshotId: string;
       findingContractFreezeKey: string;
     }) => FindingContractInstructionContext | undefined,
+    private readonly getReviewScope?: () => TaskReviewScope,
   ) {}
 
   /**
@@ -614,6 +616,7 @@ export class OptionsBuilder {
     return {
       cwd: this.getCwd(),
       task: this.getTask?.(),
+      reviewScope: this.getReviewScope?.(),
       reportDir: join(this.getCwd(), this.getReportDir()),
       language: this.getLanguage(),
       interactive: this.engineOptions.interactive,

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -107,6 +107,7 @@ import { invalidateExpectedPersonaSession, invalidatePersonaSessionIfExpected } 
 import type { InstructionBuildTransaction } from './instruction-build-transaction.js';
 import { evaluatePostExecutionRules } from './post-execution-rule-evaluator.js';
 import type { PullRequestContext } from '../pr-context.js';
+import type { TaskReviewScope } from '../review-scope.js';
 import { requireWorkflowResumeStackSnapshot } from '../run/resume-point.js';
 import {
   correctStructuredOutputOnce,
@@ -212,6 +213,8 @@ export interface StepExecutorDeps {
   readonly getWorkflowCallVars?: () => Readonly<Record<string, string | number | boolean>> | undefined;
   readonly getRetryNote: () => string | undefined;
   readonly getPrContext?: () => PullRequestContext | undefined;
+  /** Changed file set for this task. Recomputed per instruction build (the working tree moves). */
+  readonly getReviewScope: () => TaskReviewScope;
   readonly getObservabilityRunId?: () => string | undefined;
   readonly observabilityEnabled?: () => boolean;
   readonly sanitizeObservabilityText?: (text: string) => string;
@@ -1895,6 +1898,7 @@ export class StepExecutor {
       workflowCallVars: this.deps.getWorkflowCallVars?.(),
       retryNote: this.deps.getRetryNote(),
       prContext: this.deps.getPrContext?.(),
+      reviewScope: this.deps.getReviewScope(),
       policyContents: policySnapshot
         ? policySnapshot.content.map((content) => ({ content, sourcePath: policySnapshot.sourcePath }))
         : step.policyContents,

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -49,6 +49,7 @@ import {
 } from '../findings/context.js';
 import { renderLoopMonitorFindingsSummary } from '../findings/loop-monitor-summary.js';
 import { computeReviewScopeSnapshotId } from '../findings/snapshot.js';
+import { createTaskReviewScopeResolver } from '../review-scope.js';
 import {
   computeRestatementRequestId,
   createFindingReviewPresentationContextV2,
@@ -626,6 +627,12 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     };
   };
 
+  // base の解決は ref 走査を伴うため、ラン境界で一度だけ解決して保持する。
+  const getReviewScope = createTaskReviewScopeResolver({
+    getCwd: params.getCwd,
+    getPrContext: () => params.options.prContext,
+  });
+
   const optionsBuilder = new OptionsBuilder(
     params.options,
     params.getCwd,
@@ -640,6 +647,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     buildFindingContractInstructionContext,
     () => params.task,
     buildFindingEscalationInstructionContext,
+    getReviewScope,
   );
 
   const dynamicFacetSelector = new DynamicFacetSelectorCoordinator({
@@ -692,6 +700,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     getWorkflowCallVars: () => params.options.workflowCallVars,
     getRetryNote: () => params.options.retryNote,
     getPrContext: () => params.options.prContext,
+    getReviewScope,
     getObservabilityRunId: () => params.options.observabilityRunId,
     observabilityEnabled: () => params.options.observability?.enabled === true,
     sanitizeObservabilityText: params.options.sanitizeObservabilityText,

--- a/src/core/workflow/findings/finding-scope-binding.ts
+++ b/src/core/workflow/findings/finding-scope-binding.ts
@@ -59,6 +59,10 @@ export function issueFindingScopeBindings(input: {
   const workflowTaskDigest = computeWorkflowTaskDigest(input.workflowTask);
   const findingContractDigest = findingContentAddress('finding-contract-config', input.contract);
   const bindings: FindingScopeBinding[] = [];
+  // changedPaths は base コミット以降のコミット済み変更も含む（review-scope.ts）。
+  // そのため作業ツリー差分が空になる構成でも allowedRoots が空にならず、
+  // タスク範囲外の finding に対する dismissal 根拠が成立し得る。判定が緩む方向では
+  // なく締まる方向に動くのは意図した挙動である。
   const allowedRoots = input.reviewScopeSnapshot.changedPaths === undefined
     ? []
     : binarySortedUnique(input.reviewScopeSnapshot.changedPaths);

--- a/src/core/workflow/findings/finding-scope-binding.ts
+++ b/src/core/workflow/findings/finding-scope-binding.ts
@@ -60,9 +60,15 @@ export function issueFindingScopeBindings(input: {
   const findingContractDigest = findingContentAddress('finding-contract-config', input.contract);
   const bindings: FindingScopeBinding[] = [];
   // changedPaths は base コミット以降のコミット済み変更も含む（review-scope.ts）。
-  // そのため作業ツリー差分が空になる構成でも allowedRoots が空にならず、
-  // タスク範囲外の finding に対する dismissal 根拠が成立し得る。判定が緩む方向では
-  // なく締まる方向に動くのは意図した挙動である。
+  // binding は述語が outside と判定した finding にだけ発行され、それが
+  // 「タスク範囲外」を根拠とする dismissal の材料になる。したがって
+  // コミット済み変更が加わることの効果は2方向ある。
+  // - allowedRoots が空だった構成（作業ツリー差分が空）では binding がそもそも
+  //   発行されなかった。非空になることで範囲外 finding への dismissal 根拠が
+  //   新たに成立する。
+  // - allowedRoots に path が増えることは、その path 上の finding を outside 判定
+  //   から外し、その finding の dismissal 根拠を成立させなくする。
+  // どちらもレビュー範囲と証拠検証範囲を揃えた結果であり、意図した挙動である。
   const allowedRoots = input.reviewScopeSnapshot.changedPaths === undefined
     ? []
     : binarySortedUnique(input.reviewScopeSnapshot.changedPaths);

--- a/src/core/workflow/findings/snapshot.ts
+++ b/src/core/workflow/findings/snapshot.ts
@@ -6,6 +6,7 @@ import {
   collectTaskReviewScope,
   resolveReviewScopeBaseRange,
   type ReviewScopeBaseRange,
+  type TaskReviewScope,
 } from '../review-scope.js';
 
 const HASH_CHUNK_BYTES = 1024 * 1024;
@@ -630,11 +631,18 @@ function captureSnapshot(
   // 証拠検証のスコープとレビュアーへ提示するスコープは同じ計算でなければならない。
   // untracked は上で読んだものをそのまま渡し、inventory と changedPaths の由来を
   // 同一瞬間の読み取りへ揃える。
-  const taskScope = collectTaskReviewScope({
-    cwd,
-    baseRange,
-    untracked: untracked.map((path) => decodeRepositoryPath(path)),
-  });
+  // review-scope 側の例外（spawn 失敗・非 UTF-8 パス等）は素の Error なので、
+  // ここで snapshot の失敗分類へ統合する。経路によって失敗の型が変わらないようにする。
+  let taskScope: TaskReviewScope;
+  try {
+    taskScope = collectTaskReviewScope({
+      cwd,
+      baseRange,
+      untracked: untracked.map((path) => decodeRepositoryPath(path)),
+    });
+  } catch (cause) {
+    return fail('review scope', cwd, cause);
+  }
   if (taskScope.kind !== 'collected') {
     return fail('review scope', cwd, new Error('review scope requires a git repository'));
   }
@@ -722,10 +730,16 @@ function computeStableSnapshot(
     return fail('capture recursion', cwd, new Error('directory cycle detected'));
   }
   visitedDirectories.add(identity);
-  // base はブランチの分岐点なのでキャプチャ間で動かない。ref 走査を伴うため
-  // この cwd につき一度だけ解決し、2回のキャプチャで共有する。
-  const baseRange = resolveReviewScopeBaseRange(cwd);
   try {
+    // base はブランチの分岐点なのでキャプチャ間で動かない。ref 走査を伴うため
+    // この cwd につき一度だけ解決し、2回のキャプチャで共有する。
+    // try の内側で解決する: 例外時も finally が visitedDirectories を掃除する。
+    let baseRange: ReviewScopeBaseRange;
+    try {
+      baseRange = resolveReviewScopeBaseRange(cwd);
+    } catch (cause) {
+      return fail('review scope', cwd, cause);
+    }
     for (let attempt = 0; attempt < CAPTURE_ATTEMPTS; attempt += 1) {
       const first = captureSnapshot(cwd, visitedDirectories, includeEvidence, baseRange);
       const second = captureSnapshot(cwd, visitedDirectories, includeEvidence, baseRange);

--- a/src/core/workflow/findings/snapshot.ts
+++ b/src/core/workflow/findings/snapshot.ts
@@ -2,6 +2,11 @@ import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { closeSync, constants, fstatSync, lstatSync, openSync, readSync, readlinkSync, type Stats } from 'node:fs';
 import { truncateUtf8 } from '../../../shared/utils/utf8.js';
+import {
+  collectTaskReviewScope,
+  resolveReviewScopeBaseRange,
+  type ReviewScopeBaseRange,
+} from '../review-scope.js';
 
 const HASH_CHUNK_BYTES = 1024 * 1024;
 const CAPTURE_ATTEMPTS = 3;
@@ -610,6 +615,7 @@ function captureSnapshot(
   cwd: string,
   visitedDirectories: Set<string>,
   includeEvidence: boolean,
+  baseRange: ReviewScopeBaseRange,
 ): CapturedSnapshot {
   const trackedOutput = runGit(cwd, ['ls-files', '--cached', '--stage', '-z']);
   const untrackedOutput = runGit(cwd, ['ls-files', '--others', '--exclude-standard', '-z']);
@@ -621,11 +627,18 @@ function captureSnapshot(
   const tracked = parseNulEntries(trackedOutput, 'git ls-files --cached --stage -z parse', cwd)
     .map((record) => parseTrackedEntry(record, cwd));
   const untracked = parseNulEntries(untrackedOutput, 'git ls-files --others --exclude-standard -z parse', cwd);
-  const trackedChanged = parseNulEntries(
-    runGit(cwd, ['diff', '--name-only', '-z', 'HEAD', '--']),
-    'git diff --name-only -z parse',
+  // 証拠検証のスコープとレビュアーへ提示するスコープは同じ計算でなければならない。
+  // untracked は上で読んだものをそのまま渡し、inventory と changedPaths の由来を
+  // 同一瞬間の読み取りへ揃える。
+  const taskScope = collectTaskReviewScope({
     cwd,
-  );
+    baseRange,
+    untracked: untracked.map((path) => decodeRepositoryPath(path)),
+  });
+  if (taskScope.kind !== 'collected') {
+    return fail('review scope', cwd, new Error('review scope requires a git repository'));
+  }
+  const changedPaths = taskScope.paths;
   const excluded = parseNulEntries(
     excludedOutput,
     'git ls-files --others --ignored --exclude-standard --directory -z parse',
@@ -664,8 +677,7 @@ function captureSnapshot(
   const presentationDigest = createHash('sha256')
     .update(trackedDiff ?? '')
     .update(JSON.stringify(untrackedEvidence))
-    .update(JSON.stringify([...new Set([...trackedChanged, ...untracked]
-      .map((path) => decodeRepositoryPath(path)))].sort()))
+    .update(JSON.stringify(changedPaths))
     .digest('hex');
   return {
     inventory,
@@ -679,8 +691,7 @@ function captureSnapshot(
         ? {}
         : { content: Buffer.from(entry.queryEntry.content) }),
     })),
-    changedPaths: [...new Set([...trackedChanged, ...untracked]
-      .map((path) => decodeRepositoryPath(path)))].sort(),
+    changedPaths: [...changedPaths],
   };
 }
 
@@ -711,10 +722,13 @@ function computeStableSnapshot(
     return fail('capture recursion', cwd, new Error('directory cycle detected'));
   }
   visitedDirectories.add(identity);
+  // base はブランチの分岐点なのでキャプチャ間で動かない。ref 走査を伴うため
+  // この cwd につき一度だけ解決し、2回のキャプチャで共有する。
+  const baseRange = resolveReviewScopeBaseRange(cwd);
   try {
     for (let attempt = 0; attempt < CAPTURE_ATTEMPTS; attempt += 1) {
-      const first = captureSnapshot(cwd, visitedDirectories, includeEvidence);
-      const second = captureSnapshot(cwd, visitedDirectories, includeEvidence);
+      const first = captureSnapshot(cwd, visitedDirectories, includeEvidence, baseRange);
+      const second = captureSnapshot(cwd, visitedDirectories, includeEvidence, baseRange);
       if (first.snapshotId === second.snapshotId
         && first.inventory.equals(second.inventory)
         && first.presentationDigest === second.presentationDigest) {

--- a/src/core/workflow/instruction/ReportInstructionBuilder.ts
+++ b/src/core/workflow/instruction/ReportInstructionBuilder.ts
@@ -39,6 +39,8 @@ export interface ReportInstructionContext {
   lastResponse?: string;
   /** Finding Contract context available in tool-less report phase. */
   findingContract?: InstructionContext['findingContract'];
+  /** Engine-computed changed file set for `{review_scope}` in output contracts. */
+  reviewScope?: InstructionContext['reviewScope'];
 }
 
 /**
@@ -81,6 +83,7 @@ export class ReportInstructionBuilder {
       reportDir: this.context.reportDir,
       language,
       findingContract: this.context.findingContract,
+      reviewScope: this.context.reviewScope,
       // phase 2 は「これから書く」フェーズ。契約テンプレート内の {report:X} が
       // 自分自身（未作成）を指す構成を存在検証で落とさない。consumer 保護
       // （実行前の欠落検出）は phase 1 のインストラクション側で行われる。

--- a/src/core/workflow/instruction/escape.ts
+++ b/src/core/workflow/instruction/escape.ts
@@ -11,6 +11,7 @@ import type { WorkflowStep } from '../../models/types.js';
 import type { InstructionContext } from './instruction-context.js';
 import { resolveWorkflowStateReference } from '../state/workflow-state-access.js';
 import { REPORT_REFERENCE_PATTERN, resolveReportReference } from './report-reference.js';
+import { renderTaskReviewScope } from '../review-scope.js';
 import { escapeTemplateChars } from 'faceted-prompting';
 
 export { escapeTemplateChars } from 'faceted-prompting';
@@ -78,6 +79,13 @@ export function replaceTemplatePlaceholders(
   result = result.replace(
     /\{user_inputs\}/g,
     escapeTemplateChars(userInputsStr),
+  );
+
+  // Replace {review_scope}. 本文は renderTaskReviewScope 側でエスケープ済みなので
+  // ここでは再エスケープしない。
+  result = result.replace(
+    /\{review_scope\}/g,
+    () => renderTaskReviewScope(context.reviewScope, context.language ?? 'en'),
   );
 
   // Replace {report_dir}

--- a/src/core/workflow/instruction/instruction-context.ts
+++ b/src/core/workflow/instruction/instruction-context.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../models/types.js';
 import { loadTemplate } from '../../../shared/prompts/index.js';
 import type { PullRequestContext } from '../pr-context.js';
+import type { TaskReviewScope } from '../review-scope.js';
 import type { FindingReviewPresentationContext } from '../findings/review-publication.js';
 
 export type FindingContractReviewerOutputStrategy =
@@ -115,6 +116,11 @@ export interface InstructionContext {
   retryNote?: string;
   /** Structured PR context resolved at the execution boundary. */
   prContext?: PullRequestContext;
+  /**
+   * Engine-computed changed file set for this task, resolved at the execution
+   * boundary and rendered by the `{review_scope}` placeholder.
+   */
+  reviewScope?: TaskReviewScope;
   /** Resolved policy content strings for injection into instruction */
   policyContents?: readonly ResolvedFacetContent[];
   /** Source path for policy snapshot */

--- a/src/core/workflow/phase-runner.ts
+++ b/src/core/workflow/phase-runner.ts
@@ -14,6 +14,7 @@ import type {
   FindingContractInstructionContext,
   FindingContractReviewerOutputStrategy,
 } from './instruction/instruction-context.js';
+import type { TaskReviewScope } from './review-scope.js';
 export {
   generateReportPhase,
   runReportPhase,
@@ -35,6 +36,8 @@ export interface BasePhaseRunnerContext {
   cwd: string;
   /** Original workflow task. Phase 2 needs this even after a new-session retry. */
   task?: string;
+  /** Engine-computed changed file set, so Phase 2 output contracts resolve {review_scope}. */
+  reviewScope?: TaskReviewScope;
   /** Report directory path */
   reportDir: string;
   /** Language for instructions */

--- a/src/core/workflow/report-phase-runner.ts
+++ b/src/core/workflow/report-phase-runner.ts
@@ -191,6 +191,7 @@ async function executeReportPhase(
     const firstAttemptInstruction = new ReportInstructionBuilder(step, {
       cwd: ctx.cwd,
       task: ctx.task,
+      reviewScope: ctx.reviewScope,
       reportDir: ctx.reportDir,
       stepIteration,
       language: ctx.language,
@@ -263,6 +264,7 @@ async function executeReportPhase(
     const baseRetryInstruction = new ReportInstructionBuilder(step, {
       cwd: ctx.cwd,
       task: ctx.task,
+      reviewScope: ctx.reviewScope,
       reportDir: ctx.reportDir,
       stepIteration,
       language: ctx.language,

--- a/src/core/workflow/review-scope.ts
+++ b/src/core/workflow/review-scope.ts
@@ -1,0 +1,515 @@
+/**
+ * タスクのレビュースコープ（このタスクの変更対象ファイル集合）の算出と提示。
+ *
+ * ## 作業ツリー計算（cwd 由来）
+ *
+ * 次の和集合である。レビューが走る時点でタスクの変更が既にブランチへ
+ * コミット済みの構成では HEAD との差分が空になり、コミット済み範囲を
+ * 含めないとレビュアーから変更が見えない。これは PR / ブランチレビュー、
+ * エージェント自身がコミットするワークフロー、ベンチのチェックポイント
+ * コミット、worktree クローンの自動コミット後の再レビューで発生する。
+ * - base コミット..HEAD のコミット済み変更
+ * - HEAD と working tree の差分（削除を含む）
+ * - untracked ファイル（ignored を除く）
+ *
+ * この作業ツリー計算は Finding Contract の証拠検証（snapshot.ts の
+ * changedPaths）と共有する。別々の git コマンドで範囲を決めると
+ * 「レビューした範囲」と「証拠として受理される範囲」がずれるためである。
+ *
+ * ## PR diff range の合成（指示注入側だけの拡張）
+ *
+ * prContext を持つ実行では、上の作業ツリー計算に PR の diff range
+ * `base...head` を **加えた和集合** をレビュアーへ提示する。`--pr` は
+ * 「PR のレビューコメントを取り込んで修正する」フローであり、同じ実行の中で
+ * 作業ツリーが変更される。かつ headDiffRef はコミット済みしか映さず
+ * auto-commit はワークフロー完了後なので、PR diff range だけでは
+ * 修正→再レビューのループでレビュアーが修正前の姿を渡される。
+ *
+ * この合成は指示注入側だけの拡張である。snapshot.ts へ prContext は渡さない。
+ * FC の証拠検証は cwd の実体に対する byte-exact 検証であり、cwd に存在しない
+ * PR 側のパスを受理範囲へ入れてはならない。したがって不変条件は
+ * 「作業ツリー計算が両者で同一」であって「最終集合が同一」ではない。
+ */
+
+import { execFileSync } from 'node:child_process';
+import { statSync } from 'node:fs';
+import type { Language } from '../models/types.js';
+import { loadTemplate } from '../../shared/prompts/index.js';
+import { escapeTemplateChars } from 'faceted-prompting';
+import { toCloneBaseRef, toPullRequestBaseRef } from '../../shared/utils/gitBranchValidation.js';
+import { resolveMergeBase } from '../../infra/task/branchBaseCandidateResolver.js';
+import { resolveBranchEntryPointFromReflog } from '../../infra/task/branchEntryPointResolver.js';
+import { detectDefaultBranch } from '../../infra/task/branchList.js';
+import { getCurrentBranch } from '../../infra/task/git.js';
+import type { PullRequestContext } from './pr-context.js';
+
+const GIT_MAX_BUFFER = 64 * 1024 * 1024;
+
+/** プロンプト肥大を防ぐ表示上限。超過分は残件数を明示して省略する。 */
+export const REVIEW_SCOPE_MAX_LISTED_PATHS = 200;
+
+const DETACHED_HEAD_BRANCH = 'HEAD';
+const MISSING_REF_EXIT_STATUS = 1;
+
+export type ReviewScopeBaseRange =
+  /** cwd が git リポジトリではない。 */
+  | { readonly kind: 'not_a_git_repository' }
+  /** base コミットが確定し、そこから HEAD までのコミット済み変更を含む。 */
+  | { readonly kind: 'branch_base'; readonly baseCommit: string }
+  /** 現在のブランチが base ブランチそのもの。タスク由来のコミット範囲は存在しない。 */
+  | { readonly kind: 'base_branch_head' }
+  /** コミットがまだ1つもないリポジトリ。 */
+  | { readonly kind: 'no_commits' }
+  /** base を特定できなかった。コミット済み変更は一覧に含まれない。 */
+  | { readonly kind: 'unresolved'; readonly reason: string };
+
+export interface ReviewScopeDiffRange {
+  readonly baseDiffRef: string;
+  readonly headDiffRef: string;
+}
+
+export type ReviewScopeSource =
+  | { readonly kind: 'working_tree'; readonly baseRange: ReviewScopeBaseRange }
+  | {
+    readonly kind: 'pull_request';
+    readonly prNumber: number;
+    /** ローカルに materialize された PR の diff range。未 materialize なら undefined。 */
+    readonly diffRange?: ReviewScopeDiffRange;
+    /** cwd の作業ツリー計算が paths へ寄与したか（この実行のローカル変更の有無）。 */
+    readonly includesWorkingTree: boolean;
+    readonly baseRange: ReviewScopeBaseRange;
+  };
+
+export type TaskReviewScope =
+  | { readonly kind: 'not_a_git_repository' }
+  | {
+    readonly kind: 'collected';
+    /** 重複排除・ソート済みのリポジトリ相対パス。 */
+    readonly paths: readonly string[];
+    readonly source: ReviewScopeSource;
+  };
+
+export interface TaskReviewScopeInput {
+  readonly cwd: string;
+  /** 境界で一度だけ解決した base。 */
+  readonly baseRange: ReviewScopeBaseRange;
+  /** PR 由来の実行のみ設定される。作業ツリー計算に PR の diff range を加える。 */
+  readonly prContext?: PullRequestContext;
+  /**
+   * 同一瞬間に読んだ untracked を共有するための注入口。snapshot.ts は
+   * inventory と changedPaths の由来を同じ読み取りへ揃えるために渡す。
+   */
+  readonly untracked?: readonly string[];
+}
+
+function runGit(cwd: string, args: string[]): Buffer {
+  return execFileSync('git', args, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: GIT_MAX_BUFFER,
+  });
+}
+
+/**
+ * git の終了コードを返す。spawn 失敗（git 未インストール等）は述語へ潰さず送出する。
+ * 「コマンドを実行できなかった」と「git が false を返した」は別の事実である。
+ */
+function gitExitStatus(cwd: string, args: string[]): number {
+  try {
+    runGit(cwd, args);
+    return 0;
+  } catch (cause) {
+    const status = (cause as { status?: unknown }).status;
+    if (typeof status !== 'number') {
+      throw cause;
+    }
+    return status;
+  }
+}
+
+function isExistingDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function refExists(cwd: string, ref: string): boolean {
+  const status = gitExitStatus(cwd, ['rev-parse', '--verify', '--quiet', ref]);
+  if (status === 0) {
+    return true;
+  }
+  if (status === MISSING_REF_EXIT_STATUS) {
+    return false;
+  }
+  throw new Error(`git rev-parse --verify ${ref} failed with exit status ${status}`);
+}
+
+/**
+ * NUL 区切りパスの解析。
+ * snapshot.ts の parseNulEntries とは別実装で、非 UTF-8 パスや壊れた出力に対して
+ * 投げる例外型が経路ごとに異なる（あちらは ReviewScopeSnapshotError）。証拠検証側は
+ * inventory 用にパスを Buffer のまま扱う必要があるため統合していない。
+ */
+function parseNulPaths(output: Buffer, command: string): string[] {
+  if (output.length === 0) {
+    return [];
+  }
+  if (output[output.length - 1] !== 0) {
+    throw new Error(`${command}: NUL-terminated output is missing its final delimiter`);
+  }
+
+  const paths: string[] = [];
+  let start = 0;
+  while (start < output.length) {
+    const end = output.indexOf(0, start);
+    if (end === start) {
+      throw new Error(`${command}: NUL-terminated output contains an empty path`);
+    }
+    const raw = output.subarray(start, end);
+    const decoded = raw.toString('utf8');
+    if (!Buffer.from(decoded, 'utf8').equals(raw)) {
+      throw new Error(`${command}: repository path is not reversibly UTF-8 encoded`);
+    }
+    paths.push(decoded);
+    start = end + 1;
+  }
+  return paths;
+}
+
+function sortedUnique(paths: readonly string[]): string[] {
+  return [...new Set(paths)].sort();
+}
+
+type AncestryCheck = 'ancestor' | 'not_ancestor' | 'undetermined';
+
+/**
+ * 0 / 1 以外（オブジェクト喪失による 128 など）は「判定不能」として扱う。
+ * base の絞り込みは最適化であり、ここで実行を止める価値はない。
+ * base 解決全体の fail-fast（ref 検証・HEAD 検証）はそのまま維持している。
+ */
+function checkAncestry(cwd: string, ancestor: string, descendant: string): AncestryCheck {
+  const status = gitExitStatus(cwd, ['merge-base', '--is-ancestor', ancestor, descendant]);
+  if (status === 0) {
+    return 'ancestor';
+  }
+  return status === MISSING_REF_EXIT_STATUS ? 'not_ancestor' : 'undetermined';
+}
+
+/**
+ * reflog の分岐点と merge-base の両方が取れたときは子孫側（新しい方）を採る。
+ * rebase や base ブランチ取り込みの後は reflog の最古エントリが実際の分岐点より
+ * 古くなり、無関係な差分までスコープが膨張するため。
+ * 祖先関係が無い場合と判定不能な場合は、HEAD との共通祖先であることが
+ * 保証されている merge-base を採る。
+ */
+function pickNarrowerBase(cwd: string, reflogBase: string, mergeBase: string): string {
+  return checkAncestry(cwd, mergeBase, reflogBase) === 'ancestor' ? reflogBase : mergeBase;
+}
+
+/**
+ * merge-base の相手となる ref を選ぶ。TAKT がクローンへ materialize した base ref を
+ * 優先し、無ければ検出した default branch を使う。origin remote を削除したクローンでは
+ * ローカルに base ブランチが残らないため、この候補列が必要になる。
+ * 既存ブランチをそのまま clone する resume 経路では3候補とも存在しないことがあり、
+ * その場合は reflog へ、それも無ければ unresolved になる（docs に制約として記載）。
+ */
+function resolveBaseRefCandidate(
+  cwd: string,
+  branch: string,
+  defaultBranch: string,
+): string | undefined {
+  const candidates = [toPullRequestBaseRef(branch), toCloneBaseRef(branch), defaultBranch];
+  return candidates.find((ref) => refExists(cwd, ref));
+}
+
+function resolveMergeBaseCommit(
+  cwd: string,
+  branch: string,
+  defaultBranch: string,
+): string | undefined {
+  const baseRef = resolveBaseRefCandidate(cwd, branch, defaultBranch);
+  if (baseRef === undefined) {
+    return undefined;
+  }
+  try {
+    const commit = resolveMergeBase(cwd, baseRef, branch);
+    return commit.length === 0 ? undefined : commit;
+  } catch (cause) {
+    // 共通祖先が無い（履歴が独立している）と merge-base は非ゼロ終了する。
+    // spawn 失敗はここでも潰さず送出する。
+    if (typeof (cause as { status?: unknown }).status !== 'number') {
+      throw cause;
+    }
+    return undefined;
+  }
+}
+
+/**
+ * base の解決。ref 候補の列挙と merge-base 計算を伴うため、ラン境界で一度だけ
+ * 実行して保持する（createTaskReviewScopeResolver）。
+ */
+export function resolveReviewScopeBaseRange(cwd: string): ReviewScopeBaseRange {
+  // spawnSync は「git が無い」場合も「cwd が無い」場合も同じ ENOENT を返す。
+  // 存在しないディレクトリを先に弾いておくことで、残る ENOENT を git 未導入として
+  // 送出できる（実行できなかった事実を not_a_git_repository へ潰さない）。
+  if (!isExistingDirectory(cwd)) {
+    return { kind: 'not_a_git_repository' };
+  }
+  if (gitExitStatus(cwd, ['rev-parse', '--git-dir']) !== 0) {
+    return { kind: 'not_a_git_repository' };
+  }
+  const headStatus = gitExitStatus(cwd, ['rev-parse', '--verify', '--quiet', 'HEAD']);
+  if (headStatus === MISSING_REF_EXIT_STATUS) {
+    return { kind: 'no_commits' };
+  }
+  if (headStatus !== 0) {
+    throw new Error(`git rev-parse --verify HEAD failed with exit status ${headStatus}`);
+  }
+
+  const branch = getCurrentBranch(cwd);
+  if (branch === DETACHED_HEAD_BRANCH) {
+    return { kind: 'unresolved', reason: 'HEAD is detached' };
+  }
+
+  const defaultBranch = detectDefaultBranch(cwd);
+  if (branch === defaultBranch) {
+    return { kind: 'base_branch_head' };
+  }
+
+  const mergeBase = resolveMergeBaseCommit(cwd, branch, defaultBranch);
+  const reflogBase = resolveBranchEntryPointFromReflog(cwd, branch)?.baseCommit;
+  if (mergeBase !== undefined && reflogBase !== undefined) {
+    return { kind: 'branch_base', baseCommit: pickNarrowerBase(cwd, reflogBase, mergeBase) };
+  }
+  if (mergeBase !== undefined) {
+    return { kind: 'branch_base', baseCommit: mergeBase };
+  }
+  if (reflogBase !== undefined) {
+    return { kind: 'branch_base', baseCommit: reflogBase };
+  }
+  return {
+    kind: 'unresolved',
+    reason: `no base ref for ${branch} and no branch entry point in the reflog`,
+  };
+}
+
+function readUntrackedPaths(cwd: string): string[] {
+  return parseNulPaths(
+    runGit(cwd, ['ls-files', '--others', '--exclude-standard', '-z']),
+    'git ls-files --others',
+  );
+}
+
+function collectWorkingTreePaths(
+  cwd: string,
+  baseRange: ReviewScopeBaseRange,
+  untracked: readonly string[],
+): string[] {
+  if (baseRange.kind === 'no_commits') {
+    return sortedUnique(untracked);
+  }
+
+  const workingTree = parseNulPaths(
+    runGit(cwd, ['diff', '--name-only', '-z', 'HEAD', '--']),
+    'git diff --name-only HEAD',
+  );
+  const committed = baseRange.kind === 'branch_base'
+    ? parseNulPaths(
+      runGit(cwd, ['diff', '--name-only', '-z', baseRange.baseCommit, 'HEAD', '--']),
+      'git diff --name-only <base> HEAD',
+    )
+    : [];
+
+  return sortedUnique([...committed, ...workingTree, ...untracked]);
+}
+
+function materializedDiffRange(
+  cwd: string,
+  prContext: PullRequestContext,
+): ReviewScopeDiffRange | undefined {
+  const { baseDiffRef, headDiffRef } = prContext;
+  if (baseDiffRef === undefined || headDiffRef === undefined) {
+    return undefined;
+  }
+  return refExists(cwd, baseDiffRef) && refExists(cwd, headDiffRef)
+    ? { baseDiffRef, headDiffRef }
+    : undefined;
+}
+
+/**
+ * PR の diff range と、この実行のローカル変更（作業ツリー計算）の和集合。
+ * `--pr` は修正を伴うフローなので、同じ実行で作られた変更も対象に含める。
+ */
+function collectPullRequestScope(
+  cwd: string,
+  prContext: PullRequestContext,
+  baseRange: ReviewScopeBaseRange,
+  workingTreePaths: readonly string[],
+): TaskReviewScope {
+  const diffRange = materializedDiffRange(cwd, prContext);
+  const pullRequestPaths = diffRange === undefined
+    ? []
+    : parseNulPaths(
+      runGit(cwd, [
+        'diff',
+        '--name-only',
+        '-z',
+        `${diffRange.baseDiffRef}...${diffRange.headDiffRef}`,
+        '--',
+      ]),
+      'git diff --name-only <base>...<head>',
+    );
+
+  return {
+    kind: 'collected',
+    paths: sortedUnique([...pullRequestPaths, ...workingTreePaths]),
+    source: {
+      kind: 'pull_request',
+      prNumber: prContext.prNumber,
+      ...(diffRange === undefined ? {} : { diffRange }),
+      includesWorkingTree: workingTreePaths.length > 0,
+      baseRange,
+    },
+  };
+}
+
+/** 解決済みの base を受け取り、変更対象ファイル集合を算出する。 */
+export function collectTaskReviewScope(input: TaskReviewScopeInput): TaskReviewScope {
+  if (input.baseRange.kind === 'not_a_git_repository') {
+    return { kind: 'not_a_git_repository' };
+  }
+  const untracked = input.untracked ?? readUntrackedPaths(input.cwd);
+  const workingTreePaths = collectWorkingTreePaths(input.cwd, input.baseRange, untracked);
+  if (input.prContext !== undefined) {
+    return collectPullRequestScope(input.cwd, input.prContext, input.baseRange, workingTreePaths);
+  }
+  return {
+    kind: 'collected',
+    paths: workingTreePaths,
+    source: { kind: 'working_tree', baseRange: input.baseRange },
+  };
+}
+
+/**
+ * ラン中に別の kind へ遷移し得る base はキャッシュしない。
+ * `no_commits` は初コミットで `branch_base` / `base_branch_head` へ、
+ * `not_a_git_repository` は `git init` や worktree 生成で、
+ * `base_branch_head` はブランチ切り替えで変わる。特に `no_commits` を
+ * 保持すると初コミット後にトラッキング済み変更が恒久的に見えなくなる。
+ * `branch_base`（分岐点は動かない）と `unresolved`（手がかりが無い状態は
+ * ラン中に回復しない）だけを保持し、ref 走査の再実行を避ける。
+ */
+function isStableBaseRange(baseRange: ReviewScopeBaseRange): boolean {
+  return baseRange.kind === 'branch_base' || baseRange.kind === 'unresolved';
+}
+
+/**
+ * ラン境界で作る解決器。分岐点はラン中に動かないので cwd ごとに保持し、
+ * 作業ツリーは動くので毎回読み直す。
+ */
+export function createTaskReviewScopeResolver(deps: {
+  readonly getCwd: () => string;
+  readonly getPrContext: () => PullRequestContext | undefined;
+}): () => TaskReviewScope {
+  const stableBaseRangeByCwd = new Map<string, ReviewScopeBaseRange>();
+  return () => {
+    const cwd = deps.getCwd();
+    const cached = stableBaseRangeByCwd.get(cwd);
+    const baseRange = cached ?? resolveReviewScopeBaseRange(cwd);
+    if (cached === undefined && isStableBaseRange(baseRange)) {
+      stableBaseRangeByCwd.set(cwd, baseRange);
+    }
+    const prContext = deps.getPrContext();
+    return collectTaskReviewScope({
+      cwd,
+      baseRange,
+      ...(prContext === undefined ? {} : { prContext }),
+    });
+  };
+}
+
+type ReviewScopeTemplateVars = Record<string, string | boolean | null>;
+
+function buildPathVars(paths: readonly string[]): ReviewScopeTemplateVars {
+  if (paths.length === 0) {
+    return { noPaths: true };
+  }
+  const listed = paths.slice(0, REVIEW_SCOPE_MAX_LISTED_PATHS);
+  const omittedCount = paths.length - listed.length;
+  return {
+    hasPaths: true,
+    totalCount: String(paths.length),
+    pathList: escapeTemplateChars(listed.map((path) => `- ${path}`).join('\n')),
+    hasOmitted: omittedCount > 0,
+    shownCount: String(listed.length),
+    omittedCount: String(omittedCount),
+  };
+}
+
+function buildBaseRangeVars(baseRange: ReviewScopeBaseRange): ReviewScopeTemplateVars {
+  switch (baseRange.kind) {
+    case 'not_a_git_repository':
+      return { notRepository: true };
+    case 'branch_base':
+      return {
+        isBranchBase: true,
+        baseCommit: escapeTemplateChars(baseRange.baseCommit.slice(0, 12)),
+      };
+    case 'base_branch_head':
+      return { isBaseBranchHead: true };
+    case 'no_commits':
+      return { isNoCommits: true };
+    case 'unresolved':
+      return {
+        isBaseUnresolved: true,
+        baseUnresolvedReason: escapeTemplateChars(baseRange.reason),
+      };
+  }
+}
+
+function buildSourceVars(source: ReviewScopeSource): ReviewScopeTemplateVars {
+  if (source.kind !== 'pull_request') {
+    return buildBaseRangeVars(source.baseRange);
+  }
+  const prNumber = String(source.prNumber);
+  // base 内訳は PR 経路でも必ず出す。ローカル分は作業ツリー計算そのものなので、
+  // base が unresolved ならコミット済み変更が抜けている事実を非 PR 経路と同じく
+  // 開示しなければならない。
+  const baseRangeVars = buildBaseRangeVars(source.baseRange);
+  if (source.diffRange === undefined) {
+    // 算出範囲の文言自体が「ローカル変更のみ」と述べるので内訳行は重複になる。
+    return { ...baseRangeVars, isPullRequestWithoutDiffRange: true, prNumber };
+  }
+  return {
+    ...baseRangeVars,
+    isPullRequest: true,
+    prNumber,
+    diffRange: escapeTemplateChars(
+      `${source.diffRange.baseDiffRef}...${source.diffRange.headDiffRef}`,
+    ),
+    ...(source.includesWorkingTree ? { includesWorkingTree: true } : { noWorkingTreeChange: true }),
+  };
+}
+
+function buildScopeVars(scope: TaskReviewScope | undefined): ReviewScopeTemplateVars {
+  if (scope === undefined) {
+    return { notComputed: true };
+  }
+  if (scope.kind === 'not_a_git_repository') {
+    return { notRepository: true };
+  }
+  return { ...buildPathVars(scope.paths), ...buildSourceVars(scope.source) };
+}
+
+/**
+ * {review_scope} の本文を組み立てる。
+ * スコープが得られない場合も、その事実を述べる文言に解決する（空文字にしない）。
+ */
+export function renderTaskReviewScope(
+  scope: TaskReviewScope | undefined,
+  language: Language,
+): string {
+  return loadTemplate('parts/review_scope', language, buildScopeVars(scope)).trim();
+}

--- a/src/features/prompt/preview.ts
+++ b/src/features/prompt/preview.ts
@@ -25,6 +25,10 @@ import { resolveDeterministicAutoRoutingProviderInfo, toAutoRoutingStepMetadata 
 import { buildFindingManagerStep } from '../../core/workflow/findings/manager-step.js';
 import { buildFindingTerminalAdjudicationStep } from '../../core/workflow/findings/adjudication-step.js';
 import {
+  collectTaskReviewScope,
+  resolveReviewScopeBaseRange,
+} from '../../core/workflow/review-scope.js';
+import {
   validateFindingContractSyntheticProviderModels,
   type FindingContractSyntheticProviderValidationOptions,
 } from '../../core/workflow/engine/WorkflowValidator.js';
@@ -199,6 +203,7 @@ function buildInstructionContext(
     // （containment 検証は維持される）。
     validateReportReferences: false,
     language,
+    reviewScope: collectTaskReviewScope({ cwd, baseRange: resolveReviewScopeBaseRange(cwd) }),
   };
 }
 
@@ -223,6 +228,7 @@ function previewAgentStep(
       reportDir: '.takt/runs/preview/reports',
       stepIteration: 1,
       language,
+      reviewScope: context.reviewScope,
     });
     console.log('\n--- Phase 2 (Report Output) ---\n');
     console.log(reportBuilder.build());

--- a/src/features/prompt/preview.ts
+++ b/src/features/prompt/preview.ts
@@ -27,6 +27,7 @@ import { buildFindingTerminalAdjudicationStep } from '../../core/workflow/findin
 import {
   collectTaskReviewScope,
   resolveReviewScopeBaseRange,
+  type TaskReviewScope,
 } from '../../core/workflow/review-scope.js';
 import {
   validateFindingContractSyntheticProviderModels,
@@ -187,6 +188,7 @@ function buildInstructionContext(
   stepIndex: number,
   step: WorkflowStep,
   language: Language,
+  reviewScope: TaskReviewScope,
 ): InstructionContext {
   return {
     task: '<task content>',
@@ -203,7 +205,7 @@ function buildInstructionContext(
     // （containment 検証は維持される）。
     validateReportReferences: false,
     language,
-    reviewScope: collectTaskReviewScope({ cwd, baseRange: resolveReviewScopeBaseRange(cwd) }),
+    reviewScope,
   };
 }
 
@@ -213,10 +215,11 @@ function previewAgentStep(
   stepIndex: number,
   step: WorkflowStep,
   language: Language,
+  reviewScope: TaskReviewScope,
 ): void {
   printStepExecutionMetadata(step);
 
-  const context = buildInstructionContext(cwd, config, stepIndex, step, language);
+  const context = buildInstructionContext(cwd, config, stepIndex, step, language, reviewScope);
   const phase1Builder = new InstructionBuilder(step, context);
   console.log('\n--- Phase 1 (Main Execution) ---\n');
   console.log(phase1Builder.build());
@@ -297,6 +300,10 @@ export async function previewPrompts(
   printFindingContractMetadata(config, providerResolution);
   blankLine();
 
+  // レビュー範囲はプレビュー実行ごとに1度だけ解決する。ステップ・並列サブステップごとに
+  // 再解決すると、同じプレビュー出力の中で提示される範囲がずれ得る。
+  const reviewScope = collectTaskReviewScope({ cwd, baseRange: resolveReviewScopeBaseRange(cwd) });
+
   for (const [i, step] of config.steps.entries()) {
     const separator = '='.repeat(60);
     const safeStepName = sanitizeTerminalText(step.name);
@@ -316,10 +323,10 @@ export async function previewPrompts(
           ? step.parallel.fixed.some((fixed) => fixed === substep) ? 'fixed' : 'pool candidate'
           : 'parallel';
         console.log(`\n--- ${role} substep ${subIndex + 1}: ${safeSubstepName} (persona: ${safeSubstepPersonaDisplayName}) ---\n`);
-        previewAgentStep(cwd, config, i, substep, language);
+        previewAgentStep(cwd, config, i, substep, language, reviewScope);
       }
     } else {
-      previewAgentStep(cwd, config, i, step, language);
+      previewAgentStep(cwd, config, i, step, language, reviewScope);
     }
 
     blankLine();

--- a/src/features/prompt/preview.ts
+++ b/src/features/prompt/preview.ts
@@ -44,6 +44,7 @@ import { redactProviderOptions } from '../../core/workflow/providerOptionsRedact
 import { header, info, error, blankLine } from '../../shared/ui/index.js';
 import { DEFAULT_WORKFLOW_NAME } from '../../shared/constants.js';
 import { sanitizeTerminalText } from '../../shared/utils/text.js';
+import { getErrorMessage } from '../../shared/utils/error.js';
 import { translateWorkflowConfigError } from '../../shared/workflowConfigMetadata.js';
 
 function printStepExecutionMetadata(step: WorkflowStep): void {
@@ -182,13 +183,33 @@ function printFindingContractMetadata(
   info(`Finding adjudicator model: ${formatConfiguredValue(adjudicatorProviderInfo.model)}`);
 }
 
+/**
+ * レビュー範囲はプレビュー実行ごとに1度だけ解決する。ステップ・並列サブステップごとに
+ * 再解決すると、同じプレビュー出力の中で提示される範囲がずれ得る。
+ *
+ * `takt prompt` は診断ツールであり、レビュー範囲はプレビュー対象の一部でしかない。
+ * git が使えない、リポジトリが壊れている、パスが非 UTF-8 といった理由で範囲を
+ * 解決できなくても、プロンプト本体のプレビューは見せる価値がある。そのため
+ * ここだけ例外を診断値へ変換する。**この変換は preview 経路限定** であり、
+ * 実行時（WorkflowEngineSetup 経由）のスコープ解決は fail-fast のまま変えない。
+ * 範囲が undefined のとき `{review_scope}` は「算出していません」に解決する。
+ */
+function resolvePreviewReviewScope(cwd: string): TaskReviewScope | undefined {
+  try {
+    return collectTaskReviewScope({ cwd, baseRange: resolveReviewScopeBaseRange(cwd) });
+  } catch (err) {
+    info(`Review scope unavailable: ${sanitizeTerminalText(getErrorMessage(err))}`);
+    return undefined;
+  }
+}
+
 function buildInstructionContext(
   cwd: string,
   config: WorkflowConfig,
   stepIndex: number,
   step: WorkflowStep,
   language: Language,
-  reviewScope: TaskReviewScope,
+  reviewScope: TaskReviewScope | undefined,
 ): InstructionContext {
   return {
     task: '<task content>',
@@ -215,7 +236,7 @@ function previewAgentStep(
   stepIndex: number,
   step: WorkflowStep,
   language: Language,
-  reviewScope: TaskReviewScope,
+  reviewScope: TaskReviewScope | undefined,
 ): void {
   printStepExecutionMetadata(step);
 
@@ -300,9 +321,7 @@ export async function previewPrompts(
   printFindingContractMetadata(config, providerResolution);
   blankLine();
 
-  // レビュー範囲はプレビュー実行ごとに1度だけ解決する。ステップ・並列サブステップごとに
-  // 再解決すると、同じプレビュー出力の中で提示される範囲がずれ得る。
-  const reviewScope = collectTaskReviewScope({ cwd, baseRange: resolveReviewScopeBaseRange(cwd) });
+  const reviewScope = resolvePreviewReviewScope(cwd);
 
   for (const [i, step] of config.steps.entries()) {
     const separator = '='.repeat(60);

--- a/src/infra/task/clone-exec.ts
+++ b/src/infra/task/clone-exec.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { execFileSync, spawn } from 'node:child_process';
 import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
 import {
+  toCloneBaseRef,
   toLocalBranchRef,
   toPullRequestBaseRef,
   toRemoteTrackingBranchRef,
@@ -183,7 +184,7 @@ export function fetchBaseBranchIntoIsolatedClone(projectDir: string, clonePath: 
       '--force',
       '--no-write-fetch-head',
       projectDir,
-      `${toRemoteTrackingBranchRef(branch)}:refs/takt/base/${branch}`,
+      `${toRemoteTrackingBranchRef(branch)}:${toCloneBaseRef(branch)}`,
     ]);
   } catch {
     throw new Error(REMOTE_BRANCH_FETCH_FAILED_MESSAGE);
@@ -202,7 +203,7 @@ export async function fetchBaseBranchIntoIsolatedCloneAbortable(
       '--force',
       '--no-write-fetch-head',
       projectDir,
-      `${toRemoteTrackingBranchRef(branch)}:refs/takt/base/${branch}`,
+      `${toRemoteTrackingBranchRef(branch)}:${toCloneBaseRef(branch)}`,
     ], abortSignal);
   } catch (err) {
     if (isTaskAbortError(err)) {

--- a/src/shared/prompts/en/parts/review_scope.md
+++ b/src/shared/prompts/en/parts/review_scope.md
@@ -1,0 +1,39 @@
+<!-- markdownlint-disable MD041 -->
+<!--
+  template: parts/review_scope
+  vars: notComputed, notRepository, noPaths,
+        hasPaths, totalCount, pathList, hasOmitted, shownCount, omittedCount,
+        isPullRequest, isPullRequestWithoutDiffRange, prNumber, diffRange,
+        includesWorkingTree, noWorkingTreeChange,
+        isBranchBase, baseCommit, isBaseBranchHead, isNoCommits,
+        isBaseUnresolved, baseUnresolvedReason
+  builder: renderTaskReviewScope (src/core/workflow/review-scope.ts)
+
+  The base-range detail (isBranchBase / isBaseBranchHead / isNoCommits /
+  isBaseUnresolved) is emitted on the PR path too: the local part of a PR-derived
+  scope is the working-tree computation, so an unresolved base — meaning committed
+  changes are missing from the list — must be disclosed there as well.
+-->
+{{#if hasPaths}}Files changed by this task, computed by TAKT — {{totalCount}} total:
+
+{{pathList}}
+{{/if}}{{#if hasOmitted}}
+(Only {{shownCount}} entries are listed; {{omittedCount}} more are omitted.)
+{{/if}}{{#if noPaths}}TAKT detected no changes in this working directory.
+{{/if}}{{#if notRepository}}TAKT could not compute the changed files: the working directory is not a Git repository.
+{{/if}}{{#if notComputed}}TAKT did not compute the changed files in this execution context.
+{{/if}}{{#if isPullRequest}}
+Coverage: the diff range `{{diffRange}}` of PR #{{prNumber}} plus the local changes of this run.
+{{/if}}{{#if isPullRequestWithoutDiffRange}}
+Coverage: the local changes of this run only. The review target is PR #{{prNumber}}, but its diff range is not available locally, so it could not be listed.
+{{/if}}{{#if includesWorkingTree}}Local changes made during this run are included in the list above.
+{{/if}}{{#if noWorkingTreeChange}}This run added no local changes, so the review target is the PR-side diff only.
+{{/if}}{{#if isBranchBase}}
+Local change coverage: commits since base commit `{{baseCommit}}`, uncommitted changes, and untracked files.
+{{/if}}{{#if isBaseBranchHead}}
+Local change coverage: uncommitted changes and untracked files. The current branch is the base branch, so no committed range is included.
+{{/if}}{{#if isNoCommits}}
+Local change coverage: untracked files only. This repository has no commits yet.
+{{/if}}{{#if isBaseUnresolved}}
+Local change coverage: uncommitted changes and untracked files. The base commit could not be determined ({{baseUnresolvedReason}}), so committed changes are not listed.
+{{/if}}

--- a/src/shared/prompts/ja/parts/review_scope.md
+++ b/src/shared/prompts/ja/parts/review_scope.md
@@ -1,0 +1,38 @@
+<!-- markdownlint-disable MD041 -->
+<!--
+  template: parts/review_scope
+  vars: notComputed, notRepository, noPaths,
+        hasPaths, totalCount, pathList, hasOmitted, shownCount, omittedCount,
+        isPullRequest, isPullRequestWithoutDiffRange, prNumber, diffRange,
+        includesWorkingTree, noWorkingTreeChange,
+        isBranchBase, baseCommit, isBaseBranchHead, isNoCommits,
+        isBaseUnresolved, baseUnresolvedReason
+  builder: renderTaskReviewScope (src/core/workflow/review-scope.ts)
+
+  base 内訳（isBranchBase / isBaseBranchHead / isNoCommits / isBaseUnresolved）は
+  PR 経路でも必ず出す。PR 経路のローカル分は作業ツリー計算そのものなので、
+  base を特定できずコミット済み変更が抜けている事実は同じく開示する必要がある。
+-->
+{{#if hasPaths}}TAKT が算出した、今回のタスクの変更対象ファイル（{{totalCount}} 件）:
+
+{{pathList}}
+{{/if}}{{#if hasOmitted}}
+（表示は {{shownCount}} 件までです。残り {{omittedCount}} 件は省略されています）
+{{/if}}{{#if noPaths}}TAKT はこの作業ディレクトリで変更を検出しませんでした。
+{{/if}}{{#if notRepository}}TAKT は変更対象ファイルを算出できませんでした。作業ディレクトリが Git リポジトリではありません。
+{{/if}}{{#if notComputed}}TAKT はこの実行コンテキストで変更対象ファイルを算出していません。
+{{/if}}{{#if isPullRequest}}
+算出範囲: PR #{{prNumber}} の diff range `{{diffRange}}` と、この実行のローカル変更。
+{{/if}}{{#if isPullRequestWithoutDiffRange}}
+算出範囲: この実行のローカル変更のみ。レビュー対象は PR #{{prNumber}} ですが、その diff range がローカルに用意されていないため一覧に含められませんでした。
+{{/if}}{{#if includesWorkingTree}}この実行で加えられたローカル変更も上の一覧に含まれています。
+{{/if}}{{#if noWorkingTreeChange}}この実行ではローカルに追加の変更がないため、レビュー対象は PR 側の差分だけです。
+{{/if}}{{#if isBranchBase}}
+ローカル変更の範囲: base コミット `{{baseCommit}}` 以降のコミット済み変更、未コミット変更、未追跡ファイル。
+{{/if}}{{#if isBaseBranchHead}}
+ローカル変更の範囲: 未コミット変更と未追跡ファイル。現在のブランチが base ブランチのため、コミット済み変更は含みません。
+{{/if}}{{#if isNoCommits}}
+ローカル変更の範囲: 未追跡ファイルのみ。このリポジトリにはまだコミットがありません。
+{{/if}}{{#if isBaseUnresolved}}
+ローカル変更の範囲: 未コミット変更と未追跡ファイル。base コミットを特定できなかったため（{{baseUnresolvedReason}}）、コミット済み変更は含まれていません。
+{{/if}}

--- a/src/shared/utils/gitBranchValidation.ts
+++ b/src/shared/utils/gitBranchValidation.ts
@@ -84,6 +84,12 @@ export function toPullRequestBaseRef(branch: string): string {
   return `refs/takt/pr-base/${branch}`;
 }
 
+/** Base branch tip materialized into an isolated clone whose origin remote is removed. */
+export function toCloneBaseRef(branch: string): string {
+  assertValidLocalBranchName(branch);
+  return `refs/takt/base/${branch}`;
+}
+
 function hasInvalidGitBranchCharacter(branch: string): boolean {
   for (const char of branch) {
     const code = char.charCodeAt(0);


### PR DESCRIPTION
## 背景(実測で確定した欠陥)

レビュアーは「何が変更されたか」を自前の git diff で探しているが、worktree クローン実行では base と同一コミットから枝を切るため差分が空に見え、実装877行が構造的に不可視になる事故が実走行で発生した(レビュー0件)。エンジンは FC 証拠検証用に正しいスコープ計算を持っており、これをレビュアーへ渡していないのが原因。プロンプト実験でファイル一覧の明示だけで gemma4:31b の検出が 0→1件(diff 外の経路不整合、major)に改善することを実測済み。

## 変更内容

- 新モジュール `review-scope.ts` が変更集合の定義を単独所有: base(reflog 分岐点と merge-base の子孫側)以降のコミット済み変更 + working tree 差分 + untracked の和集合。FC の snapshot.ts はこの計算を共有(レビュー提示範囲と証拠検証の作業ツリー計算が同一に)
- `{review_scope}` テンプレート変数を `{task}` 等と同じ層で解決し、共有 partial `review-round-scope` 経由で汎用レビュアー10本(ja/en)へ自動供給。Phase 2(output contract)と `takt prompt` プレビューにも配線
- PR 実行(prContext あり)は PR diff range と作業ツリー差分の**和集合**(--pr は修正フローのため、実行中のローカル変更が見える)。「PR 側の差分だけ」はローカル変更が実際に無いときのみ表示
- 取得不能時は事実を明示(非git / 変更ゼロ / base 特定不能でコミット済みが欠ける旨 / PR diff range 未取得)。黙殺・全ファイル対象への勝手なフォールバックなし。200件上限+残数明示
- base 解決はラン境界で一度だけ(状態遷移し得る kind のみ再解決)。副産物として FC serial テスト群が 273s→145s に短縮

## 品質過程

独立 Opus レビュー3巡: BLOCK-1(review-* ワークフローで「変更ゼロを前提にせよ」の誤事実注入)→ 修正 → 新 BLOCK(PR 分岐が「作業ツリーは対象外」と断定、--pr の修正フロー実態と矛盾)→ 和集合化で修正 → APPROVE。SHOULD 7件・NIT 多数も全対応。FC への影響は「allowedRoots 空→非空で範囲外 finding の dismissal 根拠が成立し得る(締まる方向)」を意図された挙動として明記。

## テスト

新規2ファイル41件(working-tree のみ / コミット済みのみ / 和集合 / PR 和集合 / PR 未実体化 / 非git / 変更ゼロ / no_commits→初コミット遷移 / git init 遷移 / rebase 後の子孫側採用 / 200件打ち切り / Phase 2 解決 / 10レビュアー×ja,en への供給 / unresolved 開示)。既存対象20ファイル449件 green、tsc/lint クリーン、golden/compatibility-baseline 不変。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 作業ツリー、コミット済み変更、PR差分を統合し、レビュー対象範囲を自動表示できるようになりました。
  * 変更ファイル一覧、除外件数、Gitやベースコミットの状態をレビュー指示に反映します。
  * 英語・日本語のレビュー表示に対応しました。
  * レビュー範囲を取得できない場合も、診断情報を表示してプレビューを継続します。

* **ドキュメント**
  * レビュー範囲の算出方法、例外時の表示、ベースコミットの扱いを文書化しました。

* **テスト**
  * Git環境、PR差分、未追跡ファイル、変更なしなどの各条件を検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->