### PR TITLE
fix: reassertsReviewerAnomalyIdのnullがcandidateを没収する射影漏れを修正する

### DIFF
--- a/src/__tests__/finding-extraction-fidelity.test.ts
+++ b/src/__tests__/finding-extraction-fidelity.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { hasRawFindingExtractionFidelityFailure } from '../core/workflow/findings/extraction-fidelity.js';
+import {
+  describeRawFindingExtractionFidelityFailure,
+  hasRawFindingExtractionFidelityFailure,
+} from '../core/workflow/findings/extraction-fidelity.js';
 import { projectReviewerRawStructuredOutputWithEnvelope } from '../core/workflow/findings/raw-canonicalization.js';
+import { ReviewerRawFindingSchema } from '../core/models/finding-schemas.js';
 
 const CLAIM_EXCERPT = 'Issue: src/example.ts still bypasses the required boundary.';
 const COMPLETE_CANDIDATE = {
@@ -69,5 +73,81 @@ describe('hasRawFindingExtractionFidelityFailure', () => {
 
     expect(projected.rawFindings).toEqual([{ rawExcerpt: CLAIM_EXCERPT, candidate: null }]);
     expect(hasRawFindingExtractionFidelityFailure(projected)).toBe(true);
+  });
+});
+
+describe('reassertsReviewerAnomalyId の null（生成 schema 準拠形）', () => {
+  // 生成 schema は reassertsReviewerAnomalyId を required かつ nullable と宣言する。
+  // schema を厳密に守る provider（claude-sdk）は echo 対象が無ければ必ず null を出す。
+  // これを projection が「不正な shape」として candidate ごと畳んでいたため、
+  // 健全な抽出が extraction-fidelity 失敗として全没収されていた。
+  const SCHEMA_CONFORMANT_CANDIDATE = {
+    ...COMPLETE_CANDIDATE,
+    reassertsReviewerAnomalyId: null,
+  };
+
+  it('should keep the candidate when reassertsReviewerAnomalyId is null', () => {
+    const projected = projectReviewerRawStructuredOutputWithEnvelope({
+      rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate: SCHEMA_CONFORMANT_CANDIDATE }],
+    }).structuredOutput;
+
+    expect(hasRawFindingExtractionFidelityFailure(projected)).toBe(false);
+    const item = (projected.rawFindings as { candidate: Record<string, unknown> }[])[0]!;
+    // null は「echo なし」＝キー欠落として畳む。post-hoc 検証は非空文字列の
+    // optional しか許さないため、null を record へ残してはいけない。
+    expect(Object.hasOwn(item.candidate, 'reassertsReviewerAnomalyId')).toBe(false);
+    expect(() => ReviewerRawFindingSchema.parse(item)).not.toThrow();
+  });
+
+  it('should keep a non-empty reassertsReviewerAnomalyId echo', () => {
+    const projected = projectReviewerRawStructuredOutputWithEnvelope({
+      rawFindings: [{
+        rawExcerpt: CLAIM_EXCERPT,
+        candidate: { ...COMPLETE_CANDIDATE, reassertsReviewerAnomalyId: 'anomaly-1' },
+      }],
+    }).structuredOutput;
+
+    expect(hasRawFindingExtractionFidelityFailure(projected)).toBe(false);
+    const item = (projected.rawFindings as { candidate: Record<string, unknown> }[])[0]!;
+    expect(item.candidate.reassertsReviewerAnomalyId).toBe('anomaly-1');
+  });
+
+  it('should collapse the candidate when reassertsReviewerAnomalyId is an empty string', () => {
+    const projected = projectReviewerRawStructuredOutputWithEnvelope({
+      rawFindings: [{
+        rawExcerpt: CLAIM_EXCERPT,
+        candidate: { ...COMPLETE_CANDIDATE, reassertsReviewerAnomalyId: '' },
+      }],
+    }).structuredOutput;
+
+    expect(projected.rawFindings).toEqual([{ rawExcerpt: CLAIM_EXCERPT, candidate: null }]);
+  });
+});
+
+describe('describeRawFindingExtractionFidelityFailure', () => {
+  it('should name the projected items that lost the claim and why', () => {
+    const describedNullCandidate = describeRawFindingExtractionFidelityFailure({
+      rawFindings: [
+        { rawExcerpt: CLAIM_EXCERPT, candidate: COMPLETE_CANDIDATE },
+        { rawExcerpt: 'Another stated problem.', candidate: null },
+      ],
+    });
+    expect(describedNullCandidate).toBe(
+      '1/2 projected items lost the claim (#1: candidate is null after projection)',
+    );
+
+    expect(describeRawFindingExtractionFidelityFailure({
+      rawFindings: [{
+        rawExcerpt: CLAIM_EXCERPT,
+        candidate: { ...COMPLETE_CANDIDATE, description: null },
+      }],
+    })).toBe('1/1 projected items lost the claim (#0: candidate description is null)');
+  });
+
+  it('should describe a structured output that carries no rawFindings array', () => {
+    expect(describeRawFindingExtractionFidelityFailure({ rawFindings: 'invalid' }))
+      .toBe('projected structured output has no rawFindings array');
+    expect(describeRawFindingExtractionFidelityFailure(undefined))
+      .toBe('projected structured output is not an object');
   });
 });

--- a/src/__tests__/finding-extraction-fidelity.test.ts
+++ b/src/__tests__/finding-extraction-fidelity.test.ts
@@ -112,6 +112,40 @@ describe('reassertsReviewerAnomalyId の null（生成 schema 準拠形）', () 
     expect(item.candidate.reassertsReviewerAnomalyId).toBe('anomaly-1');
   });
 
+  it('should keep the candidate when reassertsReviewerAnomalyId is absent or undefined', () => {
+    // required を緩く扱う provider はキーごと省略する。null 修正の前後で
+    // この経路が変わっていないことを固定する。
+    for (const candidate of [
+      { ...COMPLETE_CANDIDATE },
+      { ...COMPLETE_CANDIDATE, reassertsReviewerAnomalyId: undefined },
+    ]) {
+      const projected = projectReviewerRawStructuredOutputWithEnvelope({
+        rawFindings: [{ rawExcerpt: CLAIM_EXCERPT, candidate }],
+      }).structuredOutput;
+
+      expect(hasRawFindingExtractionFidelityFailure(projected)).toBe(false);
+      const item = (projected.rawFindings as { candidate: Record<string, unknown> }[])[0]!;
+      expect(Object.hasOwn(item.candidate, 'reassertsReviewerAnomalyId')).toBe(false);
+      expect(() => ReviewerRawFindingSchema.parse(item)).not.toThrow();
+    }
+  });
+
+  it('should collapse the candidate when reassertsReviewerAnomalyId is a non-string value', () => {
+    // null / undefined だけを「echo なし」として通し、それ以外の非文字列は
+    // 従来どおり shape 不正として candidate を破棄する。
+    for (const invalid of [1, 0, true, false, {}, [], { id: 'anomaly-1' }]) {
+      const projected = projectReviewerRawStructuredOutputWithEnvelope({
+        rawFindings: [{
+          rawExcerpt: CLAIM_EXCERPT,
+          candidate: { ...COMPLETE_CANDIDATE, reassertsReviewerAnomalyId: invalid },
+        }],
+      }).structuredOutput;
+
+      expect(projected.rawFindings).toEqual([{ rawExcerpt: CLAIM_EXCERPT, candidate: null }]);
+      expect(hasRawFindingExtractionFidelityFailure(projected)).toBe(true);
+    }
+  });
+
   it('should collapse the candidate when reassertsReviewerAnomalyId is an empty string', () => {
     const projected = projectReviewerRawStructuredOutputWithEnvelope({
       rawFindings: [{

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -95,6 +95,7 @@ import {
 import { resolveFindingContractReviewerOutputStrategy } from '../findings/reviewer-output-strategy.js';
 import {
   EXTRACTION_FIDELITY_INVALID_DETAIL,
+  describeRawFindingExtractionFidelityFailure,
   hasRawFindingExtractionFidelityFailure,
 } from '../findings/extraction-fidelity.js';
 import { clarifyAmbiguousRawRelationsOnce, type ReviewerRelationClarification } from '../findings/relation-coherence.js';
@@ -1016,6 +1017,18 @@ export class StepExecutor {
 
     const hasExtractionFidelityFailure = (response: AgentResponse): boolean =>
       hasRawFindingExtractionFidelityFailure(response.structuredOutput);
+    /**
+     * 判定は projection 後の structuredOutput に対して行われるため、モデルが
+     * 出した最終テキスト（content）だけをエラーへ載せても失敗理由が読めない。
+     * status と projection 後の内訳を必ず添える。
+     */
+    const extractionFidelityDiagnostics = (response: AgentResponse): string => (
+      hasExtractionFidelityFailure(response)
+        ? `[status=${response.status}; ${
+          describeRawFindingExtractionFidelityFailure(response.structuredOutput)
+        }] `
+        : `[status=${response.status}] `
+    );
 
     const initial = await execute('initial');
     const extractionFidelityFailure = initial.invalidDetail === undefined
@@ -1074,8 +1087,8 @@ export class StepExecutor {
           ...normalized.response,
           status: 'error',
           error: `Finding intake normalizer for reviewer "${input.reviewerStep.name}" extraction-fidelity correction failed: ${
-            normalized.response.error ?? normalized.response.content
-          }`,
+            extractionFidelityDiagnostics(normalized.response)
+          }${normalized.response.error ?? normalized.response.content}`,
         },
       };
     }
@@ -1093,6 +1106,8 @@ export class StepExecutor {
           ...normalized.response,
           status: 'error',
           error: `Finding intake normalizer for reviewer "${input.reviewerStep.name}" extraction-fidelity correction failed: ${
+            extractionFidelityDiagnostics(normalized.response)
+          }${
             normalized.invalidDetail
               ?? normalized.response.error
               ?? normalized.response.content

--- a/src/core/workflow/findings/extraction-fidelity.ts
+++ b/src/core/workflow/findings/extraction-fidelity.ts
@@ -60,3 +60,34 @@ export function hasRawFindingExtractionFidelityFailure(
   }
   return rawFindings.some(itemLostTheClaim);
 }
+
+/**
+ * 失敗の内訳（何番目の item が、candidate 全欠けか description 欠けか）を
+ * 1行で返す。判定対象は projection 後の structuredOutput なので、モデルが
+ * 出した生テキストだけを見ても失敗理由が分からない — projection が candidate を
+ * null へ畳んだのか、モデルが本当に claim を落としたのかを切り分けるために
+ * エラーメッセージへ載せる。
+ */
+export function describeRawFindingExtractionFidelityFailure(
+  structuredOutput: unknown,
+): string {
+  if (!isPlainObject(structuredOutput)) {
+    return 'projected structured output is not an object';
+  }
+  const rawFindings = Reflect.get(structuredOutput, 'rawFindings');
+  if (!Array.isArray(rawFindings)) {
+    return 'projected structured output has no rawFindings array';
+  }
+  const reasons = rawFindings.flatMap((item, index) => {
+    if (!itemLostTheClaim(item)) {
+      return [];
+    }
+    const candidate = isPlainObject(item) ? Reflect.get(item, 'candidate') : undefined;
+    return [`#${index}: ${
+      candidate === null || candidate === undefined
+        ? 'candidate is null after projection'
+        : 'candidate description is null'
+    }`];
+  });
+  return `${reasons.length}/${rawFindings.length} projected items lost the claim (${reasons.join('; ')})`;
+}

--- a/src/core/workflow/findings/raw-canonicalization.ts
+++ b/src/core/workflow/findings/raw-canonicalization.ts
@@ -693,6 +693,22 @@ function projectReviewerRawItem(
         record[key] = null;
         continue;
       }
+      // 生成 schema（RawFindingsOutputIntakeJsonSchema）は reassertsReviewerAnomalyId を
+      // required かつ nullable として宣言する。schema を厳密に守る provider
+      // （claude-sdk など）は echo 対象が無ければ必ず null を出す。null は
+      // 「echo なし」＝キー欠落と同義なので record へは載せない — post-hoc の
+      // ReviewerCandidatePayloadSchema は optional な非空文字列しか許さないため。
+      if (key === 'reassertsReviewerAnomalyId') {
+        if (value === null || value === undefined) {
+          continue;
+        }
+        if (typeof value === 'string' && value.length > 0) {
+          record[key] = value;
+        } else {
+          candidateShapeValid = false;
+        }
+        continue;
+      }
       if (key === 'relation') {
         const relation = pickRelation(value);
         if (relation !== undefined) {


### PR DESCRIPTION
## 真因(実走行+SDK直叩きの実測で確定)

intake normalizer を claude-sdk/opus に設定した実走行で、健全に見える出力が5レビュアー全員 extraction-fidelity 失敗になった。調査結果:

- claude SDK の structured_output と最終テキストは**バイト一致**(乖離仮説は棄却、SDK 直叩きで実測)
- 生成スキーマは `reassertsReviewerAnomalyId` を required かつ nullable と宣言しているが、抽出射影の null 許容キー一覧にこのキーだけが**登録漏れ**。スキーマに忠実な provider(claude-sdk)は echo 対象がなければ必ず `null` を出すため、汎用 string 分岐に落ちて candidate ごと没収 → 全アイテム喪失 → fidelity 失敗 → 訂正も同形で全滅
- required を緩く扱う provider(opencode 等)はキーを省略するため素通りしていた — スキーマ遵守が厳密なモデルほど失敗する穴。実走行ログ10呼び出し分を実コードに通して 10/10 再現、当該キー除去で 10/10 通過

## 修正

- 射影に `reassertsReviewerAnomalyId` 専用分岐を追加: null/undefined は「echo なし」としてキーごとスキップ(post-hoc スキーマが optional 非空文字列のみ許容のため)、非空文字列は保持、それ以外は従来どおり不正
- 観測性: fidelity 失敗のエラーに「projection 後の何番目のアイテムがなぜ没収されたか」と status を前置(従来は生テキストのみで、テキストが健全に見える失敗を切り分け不能だった)
- 同じ射影を共有する manager-intake / publication-correction / structured reviewer 経路も同時に直る

## テスト

回帰テスト追加(null で candidate 生存・キー欠落化、投影結果が post-hoc スキーマを通過、非空文字列保持、空文字は従来どおり不正、観測性文言)。対象 unit 240件 green、tsc/lint クリーン、golden 不変。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 抽出忠実性エラーの診断情報を拡充し、欠落した候補や説明の理由を確認しやすくしました。
  * エラー報告にレスポンス状況と詳細な診断内容を含めるよう改善しました。
  * レビュー担当者の異常 ID を適切に処理し、候補情報へ正しく反映します。

* **テスト**
  * 構造化出力の正常・不正な値や、候補情報の欠落に対する検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->