### PR TITLE
fix: レビュアーのレポートファイルをpublication成否と独立に必ず書き出す

### DIFF
--- a/src/__tests__/step-executor.test.ts
+++ b/src/__tests__/step-executor.test.ts
@@ -16,6 +16,8 @@ import {
   makeWorkflowResumePointEntry,
 } from './test-helpers.js';
 import { createTeamLeaderPlanningStep } from '../core/workflow/engine/team-leader-common.js';
+import { runStatusJudgmentPhase } from '../core/workflow/status-judgment-phase.js';
+import { normalizeRule } from '../infra/config/loaders/workflowRuleNormalizer.js';
 import { PHASE1_EMPTY_OUTPUT_ERROR } from '../core/workflow/engine/phase1-empty-recovery.js';
 
 vi.mock('../agents/agent-usecases.js', () => ({
@@ -932,6 +934,94 @@ describe('StepExecutor', () => {
     expect(harness.normalizeFindingIntake).toHaveBeenCalledTimes(2);
   });
 
+  /**
+   * 実走行の回帰: 報告拒否のレビュアーは publication を持たないまま
+   * applyPostExecutionRulesOnly（= Phase 3）へ進む。レポートファイルを
+   * publication 成立時にしか書いていなかったため、use_judge の Phase 3 が
+   * 「Status judgment requires existing use_judge reports」で run ごと落ちた。
+   * 取り込みの成否とレポートの実在は別物なので、拒否された本文もファイルに残す。
+   */
+  it('報告拒否でもレポートは実在し、use_judge の Phase 3 がその本文を読む', async () => {
+    const unboundFinding = {
+      rawExcerpt: 'This sentence never appears in the report body.',
+      candidate: COMPLETE_CANDIDATE,
+    };
+    const unboundResponse = {
+      persona: 'default',
+      status: 'done' as const,
+      content: '{}',
+      structuredOutput: { rawFindings: [unboundFinding] },
+      timestamp: new Date('2026-07-31T00:00:01.000Z'),
+    };
+    const harness = createPlainTextPublicationHarness(
+      [unboundResponse, unboundResponse],
+      PLAIN_TEXT_REPORT_CONTENT,
+    );
+
+    const result = await harness.executor.prepareFindingReviewPublication({
+      step: harness.step,
+      executableStep: harness.step,
+      parentStepName: 'reviewers',
+      stepIteration: 1,
+      state: harness.state,
+      phase1Response: {
+        persona: 'reviewer',
+        status: 'done',
+        content: 'phase 1 investigation',
+        timestamp: new Date('2026-07-31T00:00:00.000Z'),
+      },
+      agentOptions: { resolvedProvider: 'mock' },
+      onProviderAttempt: vi.fn(),
+      updatePersonaSession: harness.updatePersonaSession,
+    });
+    expect('reportRejection' in result).toBe(true);
+
+    // レポートを読む Phase 3 は throw せず、拒否された本文で判定できる。
+    const judgedStep = makeStep({
+      name: 'review',
+      persona: 'reviewer',
+      instruction: 'Review.',
+      outputContracts: [
+        { name: 'review.md', format: 'review', formatRef: 'review-finding-contract' },
+      ],
+      rules: [
+        normalizeRule({ condition: 'needs_fix', next: 'fix' }),
+        normalizeRule({ condition: 'approved', next: 'COMPLETE' }),
+      ],
+    });
+    const judgeStatus = vi.fn(async (
+      structuredInstruction: string,
+      _tagInstruction: string,
+      _candidates: unknown[],
+      options: {
+        onStructuredPromptResolved?: (parts: {
+          systemPrompt: string;
+          userInstruction: string;
+        }) => void;
+      },
+    ) => {
+      options.onStructuredPromptResolved?.({
+        systemPrompt: 'judge system',
+        userInstruction: structuredInstruction,
+      });
+      return { candidateIndex: 0, method: 'structured_output' as const };
+    });
+    const judgment = await runStatusJudgmentPhase(judgedStep, {
+      cwd,
+      reportDir: runPaths.reportsAbs,
+      iteration: 1,
+      resolveStepProviderModel: () => ({ provider: 'mock', model: 'judge-model' }),
+      structuredCaller: { judgeStatus },
+    } as unknown as Parameters<typeof runStatusJudgmentPhase>[1]);
+
+    expect(judgment.label).toBe('needs_fix');
+    expect(judgeStatus.mock.calls[0]![0]).toContain(harness.reportContent);
+
+    // publication の成否と無関係に、レポートは拒否された本文のまま実在する。
+    expect(readFileSync(join(runPaths.reportsAbs, 'review.md'), 'utf-8'))
+      .toBe(harness.reportContent);
+  });
+
   it('正規化係の出力形の失敗は report rejection にせず次候補へ後退する', async () => {
     // Given: binding ではなく candidate 喪失（正規化係側の問題）。
     const lostClaimResponse = {
@@ -1126,8 +1216,9 @@ describe('StepExecutor', () => {
 
     expect(harness.normalizeFindingIntake).toHaveBeenCalledTimes(2);
     expect(executeAgent).toHaveBeenCalledOnce();
-    expect(() => readFileSync(join(runPaths.reportsAbs, 'review.md'), 'utf8'))
-      .toThrow();
+    // レポートは正規化の成否と無関係に実在する（publication は成立していない）。
+    expect(readFileSync(join(runPaths.reportsAbs, 'review.md'), 'utf8'))
+      .toBe(harness.reportContent);
     expect(loadPendingFindingReviewNormalization(
       runPaths.reportsAbs,
       {

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -44,6 +44,7 @@ import {
   runReportPhase,
   ReportPhaseGenerationError,
 } from '../phase-runner.js';
+import { writeReportFile } from '../report-writer.js';
 import { RuleDetectionExhaustedError } from '../evaluation/RuleDetectionExhaustedError.js';
 import type {
   BasePhaseRunnerContext,
@@ -1339,6 +1340,9 @@ export class StepExecutor {
       const persistedReviewerRuntime = reviewerRuntime(
         pending.reviewerExecutionIdentity,
       );
+      // 保存済みの報告も「レポートは在る」状態にそろえる。正規化が拒否・失敗して
+      // publication が成立しない経路でも、Phase 3 と後続 step は同じファイルを読む。
+      writeReportFile(reportDir, pending.reportName, pending.reportContent);
       const normalized = await this.normalizePlainTextFindingReview({
         reviewerStep: input.step,
         reportResponse,
@@ -1562,6 +1566,11 @@ export class StepExecutor {
     const completedReviewerRuntime = reviewerRuntime(
       completedReviewerExecutionIdentity,
     );
+    // レビュアーの markdown レポートはこの時点で実在する。取り込み（正規化）の
+    // 成否はレポートの有無と関係ないので、publication の成立を待たずに書き出す。
+    // Phase 3 の use_judge も後続 step のレポート参照もこのファイルを読むため、
+    // 拒否・失敗した報告でも「レポートは在る」状態にそろえる。
+    writeReportFile(publicationReportDir, report.reportName, report.reportContent);
     persistPendingFindingReviewNormalization(
       publicationReportDir,
       createPendingFindingReviewNormalization({


### PR DESCRIPTION
## 実走行2件で確定したバグ

一本道化(#1227)以降、レビュアーのレポートファイルは publication 成立時にしか書かれなかった。正規化が報告側原因(report_source)で拒否されると publication が作られず、そのまま Phase 3(use_judge = レポートファイルからのステータス判定)に到達してファイル不在で run ごと停止する。

実走行の証拠: 2巡目のレビューサイトに publication 成立した2レビュアーのファイルだけが存在し、拒否された3レビュアーのファイルが不在。判定順で最初の不在レビュアー(security-review / ai-antipattern-review-2nd)で throw。さらに悪質な二次事象として、**resume のレポート継承により1巡目は前 run の古いレポートを読んで判定が通っていた**(落ちない代わりに誤判定)。

## 修正

レポート生成直後(pending 保存より前)と pending resume 経路の両方で、レポート本文を即ファイルへ書き出す。「レビュー報告はモデルが書いた時点で実在し、取り込み(正規化)の成否で消えない」という原則に Phase 3 を揃える。publication 成立時の publishReportFile は同一内容 no-op なので二重書きなし、継承された古い内容は既存機構どおり history 退避の上で上書き。

## テスト

新規:「報告拒否でもレポートは実在し、use_judge の Phase 3 がその本文を読んで判定する」— writeReportFile を外すと実走行と同一のエラーで落ちることを実証済み。既存1件の期待値(ファイル不在の固定)を実在+本文一致へ更新。tsc / lint / 対象13ファイル 339 テスト green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * レビューの公開可否や正規化結果にかかわらず、レビューレポートが保存されるようになりました。
  * 保存されたレポートを後続の判定処理で正しく読み込めるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->