### PR TITLE
fix(finding-contract): 終端処分済み anomaly を以後の全変更経路から除外する

### DIFF
--- a/src/__tests__/finding-fc-intake-contract.test.ts
+++ b/src/__tests__/finding-fc-intake-contract.test.ts
@@ -975,6 +975,74 @@ describe('FC intake contract', () => {
       }]);
       expect(verbatimLinked.reviewerAnomalies![0]!.promotedFindingId).toBe('F-0010');
     });
+
+    /**
+     * 実走行(2026-08-07)の停止事故。終端処分済みの anomaly が以後のラウンドでも
+     * 提示され続け、最後の言い直しが照合を通った瞬間に promotedFindingId が付いて
+     * 終端処分と同居し、台帳不変条件で run ごと落ちた。
+     *
+     * 形は実データそのまま: intake-contract-incomplete /
+     * restatement_exhausted_claim_bearing / 旧契約語彙の missingRequirements。
+     */
+    it('does not promote an anomaly that already carries a terminal disposition', () => {
+      const claim = 'The legacy signal setting no longer matches the requested contract.';
+      const base = buildBatchCase('terminal', claim, '6', 'b');
+      const { ledger, anomalyOf } = anomaliesFor([base]);
+      const anomaly = anomalyOf(base.source);
+      const bindings = [{
+        request: batchRequestFor(base.source, anomaly.id, claim),
+        publicationId: 'publication-terminal',
+        reportDigest: batchReportDigest,
+      }];
+      const disposedLedger: FindingLedger = {
+        ...ledger,
+        rawFindings: [base.source, base.admitted],
+        findings: [batchFindingFor(base.admitted, 'F-0011')],
+        reviewerAnomalies: ledger.reviewerAnomalies!.map((entry) => ({
+          ...entry,
+          intakeContract: {
+            ...entry.intakeContract!,
+            // 実データの旧契約語彙（binary 昇順・重複なし）。
+            missingRequirements: ['relation', 'severity'] as const,
+            terminalDisposition: {
+              kind: 'restatement_exhausted_claim_bearing' as const,
+              workflowOutcome: 'review_integrity_unresolved' as const,
+              decidedAt: observedAt,
+              terminalPublicationId: 'publication-terminal-source',
+              reason: 'Restatement presentation limit 2 was reached without verified correspondence',
+            },
+          },
+        })),
+      };
+      // fixture は raw canonical snapshot を持たないため、この不変条件だけを見る。
+      const anomalyViolations = (ledgerUnderTest: FindingLedger) => (
+        collectFindingLedgerProjectionInvariantViolations(ledgerUnderTest)
+          .filter((violation) => violation.path[0] === 'reviewerAnomalies')
+      );
+      expect(anomalyViolations(disposedLedger)).toEqual([]);
+
+      const linked = linkPromotedReviewerAnomalies(disposedLedger, [{
+        lineageKey: 'lineage-terminal',
+        rawFindingId: base.admitted.rawFindingId,
+        restatementRequestBindings: bindings,
+      }]);
+
+      expect(linked.reviewerAnomalies![0]!.promotedFindingId).toBeUndefined();
+      expect(anomalyViolations(linked)).toEqual([]);
+
+      // 正の対照: 同じ fixture から終端処分だけを外すと昇格が成立する。上の拒否が
+      // 「終端処分由来」であって fixture 由来でないことの識別。
+      const openLinked = linkPromotedReviewerAnomalies({
+        ...ledger,
+        rawFindings: [base.source, base.admitted],
+        findings: [batchFindingFor(base.admitted, 'F-0011')],
+      }, [{
+        lineageKey: 'lineage-terminal',
+        rawFindingId: base.admitted.rawFindingId,
+        restatementRequestBindings: bindings,
+      }]);
+      expect(openLinked.reviewerAnomalies![0]!.promotedFindingId).toBe('F-0011');
+    });
   });
 
   /**

--- a/src/__tests__/finding-fc-intake-contract.test.ts
+++ b/src/__tests__/finding-fc-intake-contract.test.ts
@@ -44,7 +44,10 @@ import { computeRawPayloadDigest } from '../core/models/finding-contract-identit
 import { createEmptyFindingContractRegistries } from '../core/models/finding-contract-seed.js';
 import { collectFindingLedgerProjectionInvariantViolations } from '../core/models/finding-ledger-invariants.js';
 import { buildFindingContractInstruction } from '../core/workflow/instruction/finding-contract-instruction.js';
-import { renderFindingLedgerInstructionSummary } from '../core/workflow/findings/context.js';
+import {
+  buildFindingsRuleContext,
+  renderFindingLedgerInstructionSummary,
+} from '../core/workflow/findings/context.js';
 import {
   rawCanonicalSnapshotFixture,
   reviewerRawExtractionFixture,
@@ -1042,6 +1045,120 @@ describe('FC intake contract', () => {
         restatementRequestBindings: bindings,
       }]);
       expect(openLinked.reviewerAnomalies![0]!.promotedFindingId).toBe('F-0011');
+    });
+  });
+
+  /**
+   * 終端処分は決着であり、以後どの経路も触らない。ここでは「触らない」の残り2面
+   * （upsert の取り込み先選定と、when() へ出す提示系カウンタ）を固定する。
+   */
+  describe('terminal disposition closes the episode', () => {
+    const terminalDisposition = {
+      kind: 'restatement_exhausted_claim_bearing' as const,
+      workflowOutcome: 'review_integrity_unresolved' as const,
+      decidedAt: observedAt,
+      terminalPublicationId: 'publication-closed',
+      reason: 'Restatement presentation limit 6 was reached without verified correspondence',
+    };
+    /** 実データの形の intake anomaly を1件だけ持つ台帳を作る。 */
+    const disposedLedger = (rawFindingId: string) => {
+      const wire = incompleteRaw(rawFindingId, {
+        rawExcerpt: 'The closed defect remains observable.',
+      });
+      const spec = createReviewerAnomalySpec({
+        wire,
+        canonical: canonicalItem(wire).canonical,
+        anomalyKind: 'intake-contract-incomplete',
+        reason: 'Independent reviewer observation does not satisfy the product admission contract',
+        intakeContract: {
+          observationClass: 'claim-bearing',
+          classificationAuthorityId: 'system/intake_observation_classification_v1',
+          reasonCodes: ['product-identity-incomplete'],
+          // 実データの旧契約語彙（binary 昇順・重複なし）。
+          missingRequirements: ['relation', 'severity'],
+          presentationOwnerReviewer: wire.reviewer,
+          presentationLimit: 6,
+        },
+      });
+      const ledger = applyReviewerAnomalySpecsToLedger(emptyLedger(), [spec], {
+        workflowName: 'peer-review',
+        stepName: observedAt.stepName,
+        runId: observedAt.runId,
+        timestamp: observedAt.timestamp,
+      }, new Set());
+      return {
+        wire,
+        spec,
+        ledger: {
+          ...ledger,
+          rawFindings: [wire],
+          reviewerAnomalies: ledger.reviewerAnomalies!.map((entry) => ({
+            ...entry,
+            intakeContract: { ...entry.intakeContract!, terminalDisposition },
+          })),
+        },
+      };
+    };
+
+    it('lands a re-observation as a new episode instead of mutating the closed one', () => {
+      const { wire, spec, ledger } = disposedLedger('raw-closed-source');
+      const closed = ledger.reviewerAnomalies![0]!;
+      // 同じ主張の再観測。stable key は sourceBinding の excerpt digest で決まるので
+      // raw finding id だけが変わる（ラウンドごとの名前空間付き id を再現）。
+      const reobserved = incompleteRaw('raw-closed-reobserved', {
+        rawExcerpt: wire.rawExcerpt,
+        sourceBinding: wire.sourceBinding,
+      });
+      const respec = createReviewerAnomalySpec({
+        wire: reobserved,
+        canonical: canonicalItem(reobserved).canonical,
+        anomalyKind: 'intake-contract-incomplete',
+        reason: 'Independent reviewer observation does not satisfy the product admission contract',
+        // 取り込みが組む defect は分類結果だけを持つ。終端処分は台帳側の決着記録。
+        intakeContract: spec.intakeContract!,
+      });
+      expect(respec.stableKey).toBe(closed.stableKey);
+
+      const applied = applyReviewerAnomalySpecsToLedger({
+        ...ledger,
+        rawFindings: [wire, reobserved],
+      }, [respec], {
+        workflowName: 'peer-review',
+        stepName: observedAt.stepName,
+        runId: observedAt.runId,
+        timestamp: '2026-08-05T01:00:00.000Z',
+      }, new Set());
+
+      // 決着済み episode は1バイトも動かない。
+      expect(applied.reviewerAnomalies![0]).toEqual(closed);
+      // 再観測は別 episode として着地する（観測は消えない）。
+      expect(applied.reviewerAnomalies).toHaveLength(2);
+      const fresh = applied.reviewerAnomalies![1]!;
+      expect(fresh.id).not.toBe(closed.id);
+      expect(fresh.sourceRawFindingIds).toEqual([reobserved.rawFindingId]);
+      expect(fresh.intakeContract?.terminalDisposition).toBeUndefined();
+      // 決着済みは live episode ではないので「未決着が複数」にはならない。
+      expect(collectFindingLedgerProjectionInvariantViolations(applied)
+        .filter((violation) => violation.path[0] === 'reviewerAnomalies'))
+        .toEqual([]);
+    });
+
+    it('keeps a closed anomaly out of the counters that route back to presentation', () => {
+      const { ledger } = disposedLedger('raw-closed-counter');
+      const anomalyId = ledger.reviewerAnomalies![0]!.id;
+      // 提示予算は残っている（1 回だけ提示済み / 上限 6）。修正が無いと
+      // restatementReadyCount が 1 のまま needs_review へ送り続ける。
+      const context = buildFindingsRuleContext(
+        ledger,
+        process.cwd(),
+        new Map([[anomalyId, 1]]),
+      ).reviewerAnomalies;
+
+      expect(context.restatementReadyCount).toBe(0);
+      expect(context.requiresGuaranteedPresentationCount).toBe(0);
+      // 終端はゲートを塞ぎ続け、terminal adjudication ルートへ送る。
+      expect(context.claimBearingTerminalCount).toBe(1);
+      expect(context.count).toBe(1);
     });
   });
 

--- a/src/__tests__/finding-fc-restatement-slot.test.ts
+++ b/src/__tests__/finding-fc-restatement-slot.test.ts
@@ -657,7 +657,12 @@ describe('FC restatement slot — per-pass request batches', () => {
 
   function makeServices(
     presentationLimit: number,
-    options: { escalates?: boolean; nonIntakeAnomaly?: boolean } = {},
+    options: {
+      escalates?: boolean;
+      nonIntakeAnomaly?: boolean;
+      /** 提示予算を残したまま終端処分された intake anomaly を再現する。 */
+      terminallyDisposed?: boolean;
+    } = {},
   ) {
     const escalates = options.escalates ?? true;
     const cwd = process.cwd();
@@ -701,7 +706,7 @@ describe('FC restatement slot — per-pass request batches', () => {
       candidateFromStoredRawFinding(raw, 'reviewer-stable-key'),
       { ledger: emptyLedger },
     ).canonical;
-    const ledger = applyReviewerAnomalySpecsToLedger(emptyLedger, [
+    const anomalyLedger = applyReviewerAnomalySpecsToLedger(emptyLedger, [
       createReviewerAnomalySpec({
         wire: raw,
         canonical,
@@ -734,6 +739,28 @@ describe('FC restatement slot — per-pass request batches', () => {
       runId: observedAt.runId,
       timestamp: observedAt.timestamp,
     }, new Set());
+    const ledger = options.terminallyDisposed === true
+      ? {
+        ...anomalyLedger,
+        reviewerAnomalies: anomalyLedger.reviewerAnomalies!.map((entry) => (
+          entry.intakeContract === undefined
+            ? entry
+            : {
+              ...entry,
+              intakeContract: {
+                ...entry.intakeContract,
+                terminalDisposition: {
+                  kind: 'restatement_exhausted_claim_bearing' as const,
+                  workflowOutcome: 'review_integrity_unresolved' as const,
+                  decidedAt: observedAt,
+                  terminalPublicationId: 'publication-terminal',
+                  reason: `Restatement presentation limit ${presentationLimit} was reached without verified correspondence`,
+                },
+              },
+            }
+        )),
+      }
+      : anomalyLedger;
 
     const services = createWorkflowEngineServices({
       config: {
@@ -1010,6 +1037,22 @@ describe('FC restatement slot — per-pass request batches', () => {
       expect(ownerContexts?.ownerNeedsFullReview).toBe(true);
       const presentation = ownerContexts?.owner?.reviewer?.presentationContext;
       expect(presentation?.revision === 2 && presentation.restatementRequests).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  /**
+   * 実走行(2026-08-07)の停止事故の入口。終端処分は提示回数が正本と食い違えば
+   * 予算を残したまま確定し得る。その状態で提示を続けると、言い直しが照合を通った
+   * 瞬間に promotion が付いて終端処分と同居し、台帳不変条件で run ごと落ちる。
+   * 終端後は owner 枠も格上げ枠も request を作らない。
+   */
+  it('stops presenting an intake anomaly once it carries a terminal disposition', () => {
+    const { services, cleanup } = makeServices(2, { terminallyDisposed: true });
+    try {
+      expect(slotRequests(services, 'owner')).toBeUndefined();
+      expect(slotRequests(services, 'escalation')).toBeUndefined();
     } finally {
       cleanup();
     }

--- a/src/__tests__/finding-fc-restatement-slot.test.ts
+++ b/src/__tests__/finding-fc-restatement-slot.test.ts
@@ -666,10 +666,14 @@ describe('FC restatement slot — per-pass request batches', () => {
   ) {
     const escalates = options.escalates ?? true;
     const cwd = process.cwd();
-    const runPaths = buildRunPaths(cwd, `restatement-slot-${presentationLimit}`);
     // 提示回数の正本は report dir の canonical publication。パスごとに数え直すため、
-    // 実際に publication を書き込める隔離ディレクトリを使う。
+    // 実際に publication を書き込める隔離ディレクトリを使う。エンジンは
+    // runPaths.reportsAbs から数えるので、隔離先をそこへ束ねる。
     const reportDir = mkdtempSync(join(tmpdir(), 'takt-fc-restatement-slot-'));
+    const runPaths = {
+      ...buildRunPaths(cwd, `restatement-slot-${presentationLimit}`),
+      reportsAbs: reportDir,
+    };
     const raw = canonicalRawFindingFixture({
       rawFindingId: 'raw-slot',
       stepName: reviewerStep.name,
@@ -1092,8 +1096,11 @@ describe('FC restatement slot — owner 別 batch の枠按分', () => {
     options: { blankClaimAtom?: boolean } = {},
   ) {
     const cwd = process.cwd();
-    const runPaths = buildRunPaths(cwd, 'restatement-slot-allocation');
     const reportDir = mkdtempSync(join(tmpdir(), 'takt-fc-restatement-allocation-'));
+    const runPaths = {
+      ...buildRunPaths(cwd, 'restatement-slot-allocation'),
+      reportsAbs: reportDir,
+    };
     const observedAt = {
       runId: 'run-restatement-allocation',
       stepName: ownerNames[0]!,

--- a/src/__tests__/finding-reviewer-anomaly-settlement.test.ts
+++ b/src/__tests__/finding-reviewer-anomaly-settlement.test.ts
@@ -646,6 +646,67 @@ describe('reviewer anomaly settlement', () => {
     ).reviewIntegrity).toBeUndefined();
   });
 
+  /**
+   * 決着判定は候補を選ぶ anomalyLedger（コミット途中のビュー）ではなく、settlement を
+   * 書き込む nextLedger の episode で行う。同じコミット内で先に走る
+   * applyIntakeContractTerminalDispositions が終端処分を付けている場合、古いビューで
+   * 判定すると終端処分と settlement の同居違反を作る。
+   */
+  it('nextLedger側で終端処分を得たanomalyへはsettlementを書かない', () => {
+    const { previous, anomaliesApplied, next } = verifiedResolutionFixture();
+    const intakeContract = {
+      observationClass: 'claim-bearing' as const,
+      classificationAuthorityId: 'system/intake_observation_classification_v1' as const,
+      reasonCodes: ['product-identity-incomplete' as const],
+      // 実データの旧契約語彙（binary 昇順・重複なし）。
+      missingRequirements: ['relation' as const, 'severity' as const],
+      presentationOwnerReviewer: 'architecture',
+      presentationLimit: 6,
+    };
+    const openEpisode: ReviewerAnomalyEntry = {
+      ...anomaliesApplied.reviewerAnomalies![0]!,
+      kind: 'intake-contract-incomplete',
+      intakeContract,
+    };
+    const baselineView = { ...anomaliesApplied, reviewerAnomalies: [openEpisode] };
+    const openNext = { ...next, reviewerAnomalies: [openEpisode] };
+    const disposedNext = {
+      ...next,
+      reviewerAnomalies: [{
+        ...openEpisode,
+        intakeContract: {
+          ...intakeContract,
+          terminalDisposition: {
+            kind: 'restatement_exhausted_claim_bearing' as const,
+            workflowOutcome: 'review_integrity_unresolved' as const,
+            decidedAt: afterObservation,
+            terminalPublicationId: 'publication-closed',
+            reason: 'Restatement presentation limit 6 was reached without verified correspondence',
+          },
+        },
+      }],
+    };
+
+    // 対照: 書き込み先が未決着なら同じ入力で settlement が付く。
+    expect(settleReviewerAnomaliesFromAuthorizedTerminalEvents(
+      previous,
+      baselineView,
+      openNext,
+      WORKFLOW_TASK_DIGEST,
+    ).reviewerAnomalies![0]!.settlement?.kind).toBe('target_resolved_by_verified_evidence');
+
+    const guarded = settleReviewerAnomaliesFromAuthorizedTerminalEvents(
+      previous,
+      baselineView,
+      disposedNext,
+      WORKFLOW_TASK_DIGEST,
+    );
+
+    expect(guarded.reviewerAnomalies![0]!.settlement).toBeUndefined();
+    expect(guarded).toBe(disposedNext);
+    assertFindingLedgerProjectionInvariant(guarded);
+  });
+
   it.each([
     ['revision', (precondition: FindingMutationPrecondition) => ({
       ...precondition,

--- a/src/core/models/finding-ledger-invariants.ts
+++ b/src/core/models/finding-ledger-invariants.ts
@@ -33,6 +33,7 @@ import type {
 import { formatConflictId, type ConflictIdentity } from './finding-conflict-identity.js';
 import { computeInterpretationAttemptId } from './finding-interpretation-identity.js';
 import {
+  isConcludedReviewerAnomaly,
   reviewerAnomalySettlementEligibilityViolation,
 } from './finding-reviewer-anomaly-settlement-policy.js';
 import {
@@ -1428,7 +1429,11 @@ function collectReviewerAnomalyViolations(
       );
     }
     anomalyIdentityByStableKey.set(anomaly.stableKey, stableIdentity);
-    if (anomaly.promotedFindingId === undefined && anomaly.settlement === undefined) {
+    // 終端処分も決着なので live episode ではない。決着済みを live として数えると、
+    // 同じ観測が終端後に再び現れたときに新しい episode を起こせなくなり、観測を
+    // 捨てるか決着済み episode を書き換えるかの二択になる。判定は書き込み側
+    // （applyReviewerAnomalySpecsToLedger の upsert 対象選定）と同じ述語を使う。
+    if (!isConcludedReviewerAnomaly(anomaly)) {
       if (outstandingStableKeys.has(anomaly.stableKey)) {
         addViolation(
           violations,

--- a/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
+++ b/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
@@ -18,6 +18,26 @@ import type {
   ReviewerAnomalyTargetSettlement,
 } from './finding-types.js';
 
+/**
+ * 決着が確定し、以後どの経路も変更してはならない anomaly か。
+ *
+ * 「未決着（COMPLETE を塞ぐ）」を表す isOutstandingReviewerAnomaly とは別の述語
+ * である点が重要。claim-bearing の終端（restatement_exhausted_claim_bearing）は
+ * ゲートを塞ぎ続けるために outstanding のまま残るが、それは決着の効果であって
+ * 「まだ変更を受け付ける」という意味ではない。書き込み側が outstanding を可変性の
+ * 判定に流用すると、終端処分済みの anomaly へ settlement / promotion が後から付き、
+ * 台帳不変条件（終端処分と settlement / promotion の同居禁止）を破る。
+ *
+ * 書き込み側（reviewer-anomalies.ts / reviewer-anomaly-settlement.ts）と検証側
+ * （finding-ledger-invariants.ts）が同じ述語を共有するために models 層へ置く。
+ * 片方だけが「決着」の定義を変えると、書けるのに保存できない状態が生まれる。
+ */
+export function isConcludedReviewerAnomaly(anomaly: ReviewerAnomalyEntry): boolean {
+  return anomaly.promotedFindingId !== undefined
+    || anomaly.settlement !== undefined
+    || anomaly.intakeContract?.terminalDisposition !== undefined;
+}
+
 export interface ReviewerAnomalySettlementProjection {
   findings: readonly FindingLedgerEntry[];
   rawFindings: readonly RawFinding[];

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -63,6 +63,7 @@ import {
 } from '../findings/restatement-presentation-phase.js';
 import type { FindingRestatementSlotOwnerContexts } from '../findings/restatement-slot-runner.js';
 import {
+  isConcludedReviewerAnomaly,
   isOutstandingReviewerAnomaly,
   selectRestatementSourceClaimAtom,
 } from '../findings/reviewer-anomalies.js';
@@ -264,9 +265,7 @@ export function assertFindingReviewPresentationCapacity(input: {
   const unpresented = (input.ledger.reviewerAnomalies ?? [])
     .filter(hasIntakeContract)
     .filter((anomaly) => (
-      anomaly.promotedFindingId === undefined
-      && anomaly.settlement === undefined
-      && anomaly.intakeContract.terminalDisposition === undefined
+      !isConcludedReviewerAnomaly(anomaly)
       && (input.presentationCounts.get(anomaly.id) ?? 0) === 0
     ));
   if (unpresented.length === 0) {
@@ -368,8 +367,10 @@ function collectOutstandingIntakeAnomalies(input: {
     .filter(hasIntakeContract)
     .filter((anomaly) => (
       input.ownerStepNames.has(anomaly.intakeContract.presentationOwnerReviewer)
-      && anomaly.promotedFindingId === undefined
-      && anomaly.settlement === undefined
+      // 終端処分済みは提示予算が残っていても二度と提示しない。提示を続けると
+      // その言い直しが照合を通った瞬間に promotion が付き、終端処分と同居して
+      // 台帳不変条件を破る。終端後の行き先は terminal adjudication ルート。
+      && !isConcludedReviewerAnomaly(anomaly)
     ))
     .map((anomaly) => ({
       anomaly,

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -63,10 +63,12 @@ import {
 } from '../findings/restatement-presentation-phase.js';
 import type { FindingRestatementSlotOwnerContexts } from '../findings/restatement-slot-runner.js';
 import {
-  isConcludedReviewerAnomaly,
   isOutstandingReviewerAnomaly,
   selectRestatementSourceClaimAtom,
 } from '../findings/reviewer-anomalies.js';
+import {
+  isConcludedReviewerAnomaly,
+} from '../../models/finding-reviewer-anomaly-settlement-policy.js';
 import type { FindingTarget } from '../../models/finding-types.js';
 import { FINDING_ESCALATION_REVIEWER_ROUTING_KEY } from '../../models/finding-types.js';
 import type {
@@ -319,6 +321,13 @@ function targetPathsForRestatementRequest(target: FindingTarget): string[] {
 /**
  * 提示回数の正本は canonical review publication だけ。V2 context を持つ
  * publication の `presentedReviewerAnomalyIds` を publication ID 単位で数える。
+ *
+ * `reportDir` は必ず絶対パス（`runPaths.reportsAbs`）を渡すこと。
+ * `listFindingReviewPublications` は `resolve()` で解決するため、相対パスを渡すと
+ * エンジンの cwd ではなく `process.cwd()` 起点になる。worktree 実行のように両者が
+ * 一致しない構成では別のディレクトリを数え、提示回数が publication を書き込む側
+ * （StepExecutor / findings-manager の `reviewPublicationDir` = reportsAbs）と
+ * 食い違う。提示ラダーが進まないまま終端処分だけが確定する事故の前提条件になる。
  */
 function collectFindingReviewPresentationCounts(reportDir: string): Map<string, number> {
   const counts = new Map<string, number>();
@@ -514,7 +523,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
       ({ ledger, presentationCounts, contexts: frozenContexts } = frozenFindingContractInput);
     } else {
       ledger = params.findingLedgerStore.loadLedger();
-      presentationCounts = collectFindingReviewPresentationCounts(params.getReportDir());
+      presentationCounts = collectFindingReviewPresentationCounts(params.runPaths.reportsAbs);
       if (findingContractFreezeKey !== undefined) {
         frozenFindingContractInput = {
           contextKey: findingContractFreezeKey,
@@ -593,7 +602,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
       throw new Error('Finding contract is configured but finding ledger store is not available');
     }
     const ledger = params.findingLedgerStore.loadLedger();
-    const presentationCounts = collectFindingReviewPresentationCounts(params.getReportDir());
+    const presentationCounts = collectFindingReviewPresentationCounts(params.runPaths.reportsAbs);
     // 台帳はこの関数で1回だけ読むので、その要約も owner 数 × 枠数ぶん作り直さない。
     const ledgerFacts = {
       ledgerSummary: renderFindingLedgerInstructionSummary(ledger),

--- a/src/core/workflow/findings/context.ts
+++ b/src/core/workflow/findings/context.ts
@@ -14,7 +14,10 @@ import {
   formatFileQuoteLocation,
 } from './evidence-location.js';
 import { computeDismissCandidates } from './manager-utils.js';
-import { isOutstandingReviewerAnomaly } from './reviewer-anomalies.js';
+import {
+  isConcludedReviewerAnomaly,
+  isOutstandingReviewerAnomaly,
+} from './reviewer-anomalies.js';
 
 function resolveFindingLedgerInstructionProjection(ledger: FindingLedger): FindingLedger {
   const completed = ledger.pendingManagerCommit?.completed;
@@ -441,12 +444,15 @@ export function buildFindingsRuleContext(
       const intake = outstanding.filter((anomaly) => (
         anomaly.kind === 'intake-contract-incomplete' && anomaly.intakeContract !== undefined
       ));
+      // 提示へ送るためのカウンタは終端処分済みを除く。終端後はもう提示されないので、
+      // 残したままだと needs_review へ送り続けて何も進まないループになる。
+      const presentable = intake.filter((anomaly) => !isConcludedReviewerAnomaly(anomaly));
       return {
         count: outstanding.length,
-        requiresGuaranteedPresentationCount: intake.filter((anomaly) => (
+        requiresGuaranteedPresentationCount: presentable.filter((anomaly) => (
           (presentationCounts.get(anomaly.id) ?? 0) === 0
         )).length,
-        restatementReadyCount: intake.filter((anomaly) => {
+        restatementReadyCount: presentable.filter((anomaly) => {
           const count = presentationCounts.get(anomaly.id) ?? 0;
           return count > 0 && count < anomaly.intakeContract!.presentationLimit;
         }).length,

--- a/src/core/workflow/findings/context.ts
+++ b/src/core/workflow/findings/context.ts
@@ -14,10 +14,10 @@ import {
   formatFileQuoteLocation,
 } from './evidence-location.js';
 import { computeDismissCandidates } from './manager-utils.js';
+import { isOutstandingReviewerAnomaly } from './reviewer-anomalies.js';
 import {
   isConcludedReviewerAnomaly,
-  isOutstandingReviewerAnomaly,
-} from './reviewer-anomalies.js';
+} from '../../models/finding-reviewer-anomaly-settlement-policy.js';
 
 function resolveFindingLedgerInstructionProjection(ledger: FindingLedger): FindingLedger {
   const completed = ledger.pendingManagerCommit?.completed;

--- a/src/core/workflow/findings/reviewer-anomalies.ts
+++ b/src/core/workflow/findings/reviewer-anomalies.ts
@@ -30,6 +30,9 @@ import type {
 import { computeReviewerAnomalyStableKey } from './raw-canonicalization.js';
 import type { RestatementRequestBinding, RestatementRequestV1 } from './review-publication.js';
 import { FINDING_ESCALATION_REVIEWER_ROUTING_KEY } from '../../models/finding-types.js';
+import {
+  isConcludedReviewerAnomaly,
+} from '../../models/finding-reviewer-anomaly-settlement-policy.js';
 
 export interface ReviewerAnomalySpec {
   kind: ReviewerAnomalyKind;
@@ -343,16 +346,20 @@ export function applyReviewerAnomalySpecsToLedger(
     for (const index of matchingIndexes) {
       assertSameAnomalyIdentity(anomalies[index]!, spec);
     }
-    const outstandingIndexes = matchingIndexes.filter((index) => (
-      isOutstandingReviewerAnomaly(anomalies[index]!)
+    // upsert 先は「まだ変更を受け付ける episode」だけ。終端処分済みへ新しい観測を
+    // 混ぜると occurrences / lastObserved / sourceRawFindingIds / mismatchReason が
+    // 決着後に書き換わる。終端後の再観測は別 episode として着地させる
+    // （その判定は台帳不変条件の live episode 判定と同じ isConcluded を使う）。
+    const openIndexes = matchingIndexes.filter((index) => (
+      !isConcludedReviewerAnomaly(anomalies[index]!)
       && !closingAnomalyIds.has(anomalies[index]!.id)
     ));
-    if (outstandingIndexes.length > 1) {
+    if (openIndexes.length > 1) {
       throw new Error(
         `Reviewer anomaly stable key "${spec.stableKey}" has multiple outstanding episodes`,
       );
     }
-    const existingIndex = outstandingIndexes[0];
+    const existingIndex = openIndexes[0];
     const existing = existingIndex === undefined ? undefined : anomalies[existingIndex];
     if (existing !== undefined) {
       // crash/replay 冪等（review-integrity requirement）: occurrences は「観測された
@@ -553,6 +560,11 @@ export function linkPromotedReviewerAnomalies(
  * lifecycle-admission-failure）は言い直し経路を一切持たないため、この決着だけが
  * 唯一の終端になる。
  *
+ * この除外は「終端処分済みへ settlement を付けない」も兼ねている — 終端処分は
+ * intakeContract を持つ anomaly にしか付かないため。isOutstandingReviewerAnomaly
+ * ではなく intakeContract の有無が安全性を担っているので、この除外を緩める場合は
+ * 終端処分の判定（isConcludedReviewerAnomaly）をここへ足すこと。
+ *
  * 複数の観測者を持つ anomaly は、その全員が今ラウンドのレビューを登録している
  * ときだけ候補にする（every）。一部のレビュアーしか再レビューしていない状態で
  * 取り下げると、まだ再提示の機会を得ていない観測者の主張ごとゲートを緩めることになる。
@@ -649,20 +661,4 @@ export function isOutstandingReviewerAnomaly(anomaly: ReviewerAnomalyEntry): boo
     && anomaly.settlement === undefined
     && anomaly.intakeContract?.terminalDisposition?.workflowOutcome
       !== 'non_claim_observation_rejected';
-}
-
-/**
- * 決着が確定し、以後どの経路も変更してはならない anomaly か。
- *
- * `isOutstandingReviewerAnomaly` とは別の述語である点が重要。claim-bearing の
- * 終端（restatement_exhausted_claim_bearing）は「未決着として COMPLETE を塞ぎ
- * 続ける」ため outstanding のまま残るが、それは決着の効果であって「まだ変更を
- * 受け付ける」という意味ではない。書き込み側が outstanding を可変性の判定に
- * 流用すると、終端処分済みの anomaly へ settlement / promotion が後から付き、
- * 台帳不変条件（終端処分と settlement / promotion の同居禁止）を破る。
- */
-export function isConcludedReviewerAnomaly(anomaly: ReviewerAnomalyEntry): boolean {
-  return anomaly.promotedFindingId !== undefined
-    || anomaly.settlement !== undefined
-    || anomaly.intakeContract?.terminalDisposition !== undefined;
 }

--- a/src/core/workflow/findings/reviewer-anomalies.ts
+++ b/src/core/workflow/findings/reviewer-anomalies.ts
@@ -474,8 +474,7 @@ export function linkPromotedReviewerAnomalies(
       if (
         findingId === undefined
         || anomaly?.kind !== 'intake-contract-incomplete'
-        || anomaly.promotedFindingId !== undefined
-        || anomaly.settlement !== undefined
+        || isConcludedReviewerAnomaly(anomaly)
         || sourceRaw === undefined
         || admittedRaw === undefined
         || binding.reportDigest !== admittedRaw.sourceBinding.reportDigest
@@ -521,7 +520,7 @@ export function linkPromotedReviewerAnomalies(
   }
   let changed = false;
   const updated = anomalies.map((anomaly) => {
-    if (!isOutstandingReviewerAnomaly(anomaly)) {
+    if (isConcludedReviewerAnomaly(anomaly)) {
       return anomaly;
     }
     if (anomaly.kind === 'intake-contract-incomplete') {
@@ -650,4 +649,20 @@ export function isOutstandingReviewerAnomaly(anomaly: ReviewerAnomalyEntry): boo
     && anomaly.settlement === undefined
     && anomaly.intakeContract?.terminalDisposition?.workflowOutcome
       !== 'non_claim_observation_rejected';
+}
+
+/**
+ * 決着が確定し、以後どの経路も変更してはならない anomaly か。
+ *
+ * `isOutstandingReviewerAnomaly` とは別の述語である点が重要。claim-bearing の
+ * 終端（restatement_exhausted_claim_bearing）は「未決着として COMPLETE を塞ぎ
+ * 続ける」ため outstanding のまま残るが、それは決着の効果であって「まだ変更を
+ * 受け付ける」という意味ではない。書き込み側が outstanding を可変性の判定に
+ * 流用すると、終端処分済みの anomaly へ settlement / promotion が後から付き、
+ * 台帳不変条件（終端処分と settlement / promotion の同居禁止）を破る。
+ */
+export function isConcludedReviewerAnomaly(anomaly: ReviewerAnomalyEntry): boolean {
+  return anomaly.promotedFindingId !== undefined
+    || anomaly.settlement !== undefined
+    || anomaly.intakeContract?.terminalDisposition !== undefined;
 }

--- a/src/core/workflow/findings/reviewer-anomaly-settlement.ts
+++ b/src/core/workflow/findings/reviewer-anomaly-settlement.ts
@@ -7,7 +7,7 @@ import type {
   ReviewerAnomalyEntry,
   ReviewerAnomalyTargetSettlement,
 } from './types.js';
-import { isOutstandingReviewerAnomaly } from './reviewer-anomalies.js';
+import { isConcludedReviewerAnomaly } from './reviewer-anomalies.js';
 
 function settlementKind(
   event: FindingLifecycleEvent,
@@ -70,7 +70,7 @@ export function settleReviewerAnomaliesFromAuthorizedTerminalEvents(
   }
   const settlementByAnomalyId = new Map(
     anomalyLedger.reviewerAnomalies
-      .filter(isOutstandingReviewerAnomaly)
+      .filter((anomaly) => !isConcludedReviewerAnomaly(anomaly))
       .flatMap((anomaly) => {
         const settlement = eligibleSettlement({
           eventBaselineLedger,

--- a/src/core/workflow/findings/reviewer-anomaly-settlement.ts
+++ b/src/core/workflow/findings/reviewer-anomaly-settlement.ts
@@ -1,4 +1,5 @@
 import {
+  isConcludedReviewerAnomaly,
   reviewerAnomalySettlementEligibilityViolation,
 } from '../../models/finding-reviewer-anomaly-settlement-policy.js';
 import type {
@@ -7,7 +8,6 @@ import type {
   ReviewerAnomalyEntry,
   ReviewerAnomalyTargetSettlement,
 } from './types.js';
-import { isConcludedReviewerAnomaly } from './reviewer-anomalies.js';
 
 function settlementKind(
   event: FindingLifecycleEvent,
@@ -68,9 +68,19 @@ export function settleReviewerAnomaliesFromAuthorizedTerminalEvents(
   if (anomalyLedger.reviewerAnomalies === undefined) {
     return nextLedger;
   }
+  // 決着判定は書き込み先（nextLedger）の episode で行う。候補を選ぶ anomalyLedger は
+  // このコミットの途中ビューであり、同じ id が nextLedger 側で終端処分や昇格を
+  // 得ていることがある。古いビューで判定すると、決着済みへ settlement を書いて
+  // 終端処分との同居違反を作る。
+  const writeTargetById = new Map(
+    (nextLedger.reviewerAnomalies ?? []).map((anomaly) => [anomaly.id, anomaly] as const),
+  );
   const settlementByAnomalyId = new Map(
     anomalyLedger.reviewerAnomalies
-      .filter((anomaly) => !isConcludedReviewerAnomaly(anomaly))
+      .filter((anomaly) => {
+        const writeTarget = writeTargetById.get(anomaly.id);
+        return writeTarget !== undefined && !isConcludedReviewerAnomaly(writeTarget);
+      })
       .flatMap((anomaly) => {
         const settlement = eligibleSettlement({
           eventBaselineLedger,


### PR DESCRIPTION
## 症状

PR #1230 マージ後のエンジンで、実 run が台帳不変条件違反で死亡した。

```
Step execution failed: [{"code":"custom","path":["reviewerAnomalies",1,"intakeContract","terminalDisposition"],
"message":"Intake contract terminal disposition for anomaly \"RA-BAD620F4372E\" conflicts with its classification or settlement"}]
```

発火した不変量は `src/core/models/finding-ledger-invariants.ts` の
「`terminalDisposition` と `promotedFindingId` / `settlement` は同居できない」。

## 真因の再構成

検証用 run（`20260807-181424-implement-using-only-the-files-wpfrtt`）の台帳・
publication・セッションログから、次のように再構成できた。

1. `RA-BAD620F4372E` は `intake-contract-incomplete` / `claim-bearing` の anomaly で、
   owner は `coding-review`、`presentationLimit` は 6。
2. 言い直し slot のあるパスで提示回数が上限に達し、
   `applyIntakeContractTerminalDispositions` が
   `restatement_exhausted_claim_bearing` / `review_integrity_unresolved` を確定させた
   （台帳スナップショット 19:29:53 時点で終端処分済み）。
3. **にもかかわらず、その後のパスでも同じ anomaly が言い直し対象として選ばれ続けた。**
   実際に run の publication 8 件すべてが `RA-BAD620F4372E` を
   `presentedReviewerAnomalyIds` に載せており、終端処分の後に生成された
   `followup-coding-review-*` も含まれる。
4. 提示が続いた結果、最後の言い直しが byte-exact 照合
   （`hasRestatementCorrespondence`）を通り、`linkPromotedReviewerAnomalies` が
   終端処分済みの anomaly へ `promotedFindingId` を張った。
5. その候補状態が保存前検証で拒否され、run が abort した
   （コミット前検証なので DB には残らない。永続化済みの台帳自体は現在も整合しており、
   実際に不変量チェッカを流しても violation は 0 件）。

### なぜ「終端後も触れた」のか

`isOutstandingReviewerAnomaly` の流用が原因。

```ts
export function isOutstandingReviewerAnomaly(anomaly: ReviewerAnomalyEntry): boolean {
  return anomaly.promotedFindingId === undefined
    && anomaly.settlement === undefined
    && anomaly.intakeContract?.terminalDisposition?.workflowOutcome
      !== 'non_claim_observation_rejected';
}
```

claim-bearing の終端（`review_integrity_unresolved`）は **意図的に** outstanding の
まま残る。COMPLETE を塞ぎ続けるのが終端の効果だからで、これは正しい。
しかし「未決着（＝ゲートを塞ぐ）」と「可変（＝まだ変更を受け付ける）」は別の概念で、
書き込み側と提示対象選定がこの1つの述語を両方の意味で使っていた。

- `linkPromotedReviewerAnomalies` — `terminalDisposition` を見ていない
- `settleReviewerAnomaliesFromAuthorizedTerminalEvents` — 同上
- `collectOutstandingIntakeAnomalies`（提示対象選定）— 同上

`withdrawReviewerAnomaliesSupersededByReview` だけは `intakeContract !== undefined` を
除外していたため無傷だった。

## 修正

「決着済みで、以後どの経路も変更してはならない」を表す
`isConcludedReviewerAnomaly` を分離し、変更経路と提示対象選定へ適用する。

| 経路 | 変更 |
|---|---|
| `linkPromotedReviewerAnomalies` | 終端処分済みへ `promotedFindingId` を張らない |
| `settleReviewerAnomaliesFromAuthorizedTerminalEvents` | 終端処分済みを settle しない |
| `collectOutstandingIntakeAnomalies` | 終端処分済みへ言い直し request を作らない |
| `findings.reviewerAnomalies` の提示系カウンタ | `requiresGuaranteedPresentationCount` / `restatementReadyCount` から終端処分済みを除く |

最後のカウンタ修正は提示停止とセットで必要。提示を止めただけだと、終端処分済みが
`restatementReadyCount > 0` として残り、`needs_review` へ送られるのに slot が
何も出さない空回りになる。終端後の正しい行き先は
`claimBearingTerminalCount > 0` → `needs_terminal_adjudication`。

再処分（`applyIntakeContractTerminalDispositions`）は元から
`defect.terminalDisposition !== undefined` で早期 return しており、変更不要。

不変量は正しいので緩めていない。レガシー互換の特別扱いも入れていない。

## テスト

実データの形（`intake-contract-incomplete` + `restatement_exhausted_claim_bearing` +
旧契約語彙 `missingRequirements: [relation, severity]`）で 2 本追加した。

- `finding-fc-intake-contract.test.ts`
  「終端処分済みの anomaly は昇格しない」。同じ fixture から終端処分だけを外すと
  昇格が成立する正の対照付き。修正を外すと `expected 'F-0011' to be undefined` で赤。
- `finding-fc-restatement-slot.test.ts`
  「終端処分済みになったら owner 枠も格上げ枠も request を作らない」。
  修正を外すと request が生成されて赤。

どちらも修正を外して赤くなることを確認済み。

## ゲート

- `npm run build` — pass
- `npm run lint` — pass
- FC 系関連ファイル — pass
  （`finding-fc-intake-contract` / `finding-fc-restatement-slot` /
  `finding-reviewer-anomaly-settlement` / `finding-evidence-protocol-units` /
  `finding-verdict-claims-integrity` / `finding-review-integrity-gate` /
  `finding-contract-phase1` / `finding-loop-monitor-summary` /
  `finding-integrity-boundaries` / `takt-default-fc-builtins` /
  `finding-ledger-routing-builtins` / `finding-review-report-protocol` /
  `finding-contract-flow` / `finding-convergence`）

---

## 追記: 敵対レビュー / CodeRabbit 指摘の対応（2 コミット目）

### 変更経路の取り残し（`applyReviewerAnomalySpecsToLedger`）

upsert 先の選定が `isOutstandingReviewerAnomaly` のままで、終端処分済み episode へ
新しい観測がマージされ `occurrences` / `lastObserved` / `sourceRawFindingIds` /
`mismatchReason` が決着後に書き換わっていた。`isConcluded` へ切り替え、終端後の
再観測は別 episode として着地させる（観測は消さない）。

これに伴い**台帳不変条件の live episode 判定も同じ述語へ揃えた**。決着済みを live と
して数えると、新 episode が「未決着が複数」で弾かれ、観測を捨てるか決着済みを
書き換えるかの二択になる（この結合は赤緑で確認済み: 不変条件だけ戻すと新 episode の
テストが `has multiple outstanding episodes` で落ちる）。**終端処分と settlement /
promotion の同居禁止は一切緩めていない** — 今回の事故を捕まえた検査そのものは無傷。

述語は `core/models/finding-reviewer-anomaly-settlement-policy.ts` へ移し、書き込み側と
検証側が同じ定義を共有するようにした（片方だけ定義が動くと「書けるのに保存できない」
状態が生まれる）。

`withdrawReviewerAnomaliesSupersededByReview` は安全だが、その安全性が
`intakeContract === undefined` という離れた条件に依存している旨をコメントで明示した。

### 提示回数の数え口の2系統（事故の前提条件）

`collectFindingReviewPresentationCounts` の呼び出しだけが `getReportDir()`
（= `runPaths.reportsRel`、相対パス）を `resolve()` へ渡していた。同じ値を使う他の
利用者（`OptionsBuilder` / `StepExecutor`）はいずれも `join(cwd, ...)` してから使って
おり、ここ2箇所だけが素通しだった。結果、`process.cwd()` が run root と一致しない
worktree 実行では、publication を書き込む側（`reviewPublicationDir` =
`runPaths.reportsAbs`）と別のディレクトリを数える。

実 run で `presentationOrdinal` が 8 件すべて `1` のまま動かなかったのはこれが原因で、
提示ラダーが進まないまま提示回数だけが上限に達し、終端処分が確定していた。
両者を `runPaths.reportsAbs` へ一本化した（波及は当該2箇所のみ。`getReportDir` の
他の利用者は元から cwd と結合しているため変更不要）。

### settlement の判定ビュー（CodeRabbit #3738809653）

`settleReviewerAnomaliesFromAuthorizedTerminalEvents` の決着判定を、候補を選ぶ
`anomalyLedger`（コミット途中のビュー）ではなく書き込み先 `nextLedger` の episode で
行うようにした。現行の呼び出し順序では両ビューの `reviewerAnomalies` は一致するが、
同一コミット内で `applyIntakeContractTerminalDispositions` が先に走る構造である以上、
判定は書き込み先で行うのが正しい。安全側へ寄せた。

### 追加テスト（いずれも修正を外すと赤）

- `lands a re-observation as a new episode instead of mutating the closed one`
  — 終端処分済み episode は1バイトも動かず、再観測は別 episode になる
- `keeps a closed anomaly out of the counters that route back to presentation`
  — `restatementReadyCount === 0` / `requiresGuaranteedPresentationCount === 0` かつ
  `claimBearingTerminalCount === 1` / `count === 1`
- `nextLedger側で終端処分を得たanomalyへはsettlementを書かない`
  — 書き込み先が未決着なら settlement が付く正の対照付き

### 棄却した指摘

CodeRabbit #3738809642（テスト名を `should {expected} when {condition}` 形式へ）は
棄却。対象2ファイルはテスト名 29 件 / 51 件すべてが非 `should` の記述形
（`does not promote when ...` / `keeps ...`）で、追加した2件はその慣習に沿っている。
`.coderabbit.yaml` の path_instructions にも命名形式の規定は無い。ファイル内で
2件だけ別形式にすると一貫性が落ちるため現状維持。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 終端処分済みの異常を、後続の再提示による昇格・更新対象から除外しました。
  * 終端済みの異常に対する不要な担当者・エスカレーション提示要求を防止しました。
  * 提示容量、決済候補、関連カウンターの集計から処理完了済みの異常を除外しました。
  * 終端後の再観測は新しいエピソードとして扱われ、既存の記録を誤って変更しなくなりました。

* **テスト**
  * 終端済み・未処理のケースで、昇格、決済、台帳不変条件が正しく扱われることを確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->