### PR TITLE
fix(finding-contract): 完了ゲートが終端処分済み anomaly を配線漏れと誤診しないようにする

### DIFF
--- a/builtins/en/workflows/merge-readiness-finding-contract-final-gate.yaml
+++ b/builtins/en/workflows/merge-readiness-finding-contract-final-gate.yaml
@@ -44,10 +44,15 @@ steps:
         return: need_replan
       - condition: when(findings.provisional.count > 0)
         return: need_replan
-      # A claim-bearing reviewer anomaly that exhausted its restatement budget cannot be
-      # resolved by another review or by terminal adjudication. Route it to COMPLETE so the
-      # engine review-integrity gate reports review_integrity_unresolved as a visible
-      # failure — returning needs_review here loops between review and the final gate forever.
+      # A claim-bearing reviewer anomaly that exhausted its restatement budget. This step
+      # holds terminal_adjudication authority, so the findings-manager round that runs before
+      # rule evaluation issues a reviewer_anomaly control task; anomalies the adjudicator can
+      # machine-verify as outside the task scope are already settled by the time this rule is
+      # evaluated. What remains is what the adjudicator did not dismiss — another review will
+      # not resolve it, so route it to COMPLETE and let the engine review-integrity gate report
+      # review_integrity_unresolved as a visible failure. Returning needs_review here loops
+      # between review and the final gate forever. There is no automatic rescue: only an
+      # adjudication settles this, and the run fails when the adjudicator declines.
       # It precedes the open.count needs_fix rule because the engine review-integrity
       # invariant forbids completion while this anomaly stands, so a fix loop cannot pay off.
       - condition: when(findings.reviewerAnomalies.claimBearingTerminalCount > 0)
@@ -83,10 +88,15 @@ steps:
         return: need_replan
       - condition: when(findings.provisional.count > 0)
         return: need_replan
-      # A claim-bearing reviewer anomaly that exhausted its restatement budget cannot be
-      # resolved by another review or by terminal adjudication. Route it to COMPLETE so the
-      # engine review-integrity gate reports review_integrity_unresolved as a visible
-      # failure — returning needs_review here loops between review and the final gate forever.
+      # A claim-bearing reviewer anomaly that exhausted its restatement budget. This step
+      # holds terminal_adjudication authority, so the findings-manager round that runs before
+      # rule evaluation issues a reviewer_anomaly control task; anomalies the adjudicator can
+      # machine-verify as outside the task scope are already settled by the time this rule is
+      # evaluated. What remains is what the adjudicator did not dismiss — another review will
+      # not resolve it, so route it to COMPLETE and let the engine review-integrity gate report
+      # review_integrity_unresolved as a visible failure. Returning needs_review here loops
+      # between review and the final gate forever. There is no automatic rescue: only an
+      # adjudication settles this, and the run fails when the adjudicator declines.
       # It precedes the open.count needs_fix rule because the engine review-integrity
       # invariant forbids completion while this anomaly stands, so a fix loop cannot pay off.
       - condition: when(findings.reviewerAnomalies.claimBearingTerminalCount > 0)

--- a/builtins/ja/workflows/merge-readiness-finding-contract-final-gate.yaml
+++ b/builtins/ja/workflows/merge-readiness-finding-contract-final-gate.yaml
@@ -44,10 +44,14 @@ steps:
         return: need_replan
       - condition: when(findings.provisional.count > 0)
         return: need_replan
-      # 言い直し予算を使い切った claim-bearing な reviewer anomaly は、再レビューでも
-      # terminal adjudication でも解消できない。ここで COMPLETE へ送り、エンジンの
+      # 言い直し予算を使い切った claim-bearing な reviewer anomaly。このステップは
+      # terminal_adjudication 権限を持つので、ルール評価より前に走る findings-manager
+      # ラウンドで reviewer_anomaly control task が回り、task 範囲外と機械検証できた
+      # ものは裁定却下として決着済みになる。ここへ残るのは裁定が却下しなかったもの
+      # だけ — 再レビューでは解消しないので COMPLETE へ送り、エンジンの
       # review-integrity ゲート(review_integrity_unresolved)に可視的な失敗として
-      # 落とす — needs_review へ戻すと再レビューと最終ゲートを無限に往復する。
+      # 落とす。needs_review へ戻すと再レビューと最終ゲートを無限に往復する。
+      # 自動救済はしない: 決着は裁定だけで、裁定が却下しなければ run は失敗する。
       # open.count の needs_fix より前に置く: この anomaly が残る限りエンジンの
       # review-integrity 不変条件により完了できないため、修正ループは無駄弾になる。
       - condition: when(findings.reviewerAnomalies.claimBearingTerminalCount > 0)
@@ -83,10 +87,14 @@ steps:
         return: need_replan
       - condition: when(findings.provisional.count > 0)
         return: need_replan
-      # 言い直し予算を使い切った claim-bearing な reviewer anomaly は、再レビューでも
-      # terminal adjudication でも解消できない。ここで COMPLETE へ送り、エンジンの
+      # 言い直し予算を使い切った claim-bearing な reviewer anomaly。このステップは
+      # terminal_adjudication 権限を持つので、ルール評価より前に走る findings-manager
+      # ラウンドで reviewer_anomaly control task が回り、task 範囲外と機械検証できた
+      # ものは裁定却下として決着済みになる。ここへ残るのは裁定が却下しなかったもの
+      # だけ — 再レビューでは解消しないので COMPLETE へ送り、エンジンの
       # review-integrity ゲート(review_integrity_unresolved)に可視的な失敗として
-      # 落とす — needs_review へ戻すと再レビューと最終ゲートを無限に往復する。
+      # 落とす。needs_review へ戻すと再レビューと最終ゲートを無限に往復する。
+      # 自動救済はしない: 決着は裁定だけで、裁定が却下しなければ run は失敗する。
       # open.count の needs_fix より前に置く: この anomaly が残る限りエンジンの
       # review-integrity 不変条件により完了できないため、修正ループは無駄弾になる。
       - condition: when(findings.reviewerAnomalies.claimBearingTerminalCount > 0)

--- a/src/__tests__/finding-dismiss.test.ts
+++ b/src/__tests__/finding-dismiss.test.ts
@@ -32,6 +32,9 @@ import {
 } from './helpers/finding-manager-publication.js';
 import { findingManagerTaskResponse } from './helpers/finding-manager-task-response.js';
 import { processInterpretationLiveClaims } from '../core/workflow/findings/interpretation-live-claims.js';
+import { isOutstandingReviewerAnomaly } from '../core/workflow/findings/reviewer-anomalies.js';
+import { applyCommitLedgerStates } from '../core/workflow/findings/manager-commit-finalization.js';
+import { computeWorkflowTaskDigest } from '../core/workflow/findings/task-scope-adjudication.js';
 
 vi.mock('../agents/agent-usecases.js', () => ({
   executeAgent: vi.fn(),
@@ -669,5 +672,213 @@ describe('runFindingManagerForStep dismiss round trip', () => {
     } finally {
       rmSync(reportDir, { recursive: true, force: true });
     }
+  });
+});
+
+
+/**
+ * 実走行(2026-08)の最終ゲートの形。raw も dispute も conflict も無く、用があるのは
+ * 終端処分済み anomaly の裁定だけ、というラウンド。provider を呼ぶ条件に裁定対象を
+ * 含めないと、権限があっても reviewer_anomaly task が一度も作られない。
+ */
+describe('runFindingManagerForStep reviewer anomaly adjudication round', () => {
+  const workflowTask = 'Rename the legacy signal fields under src/infra/config/runtime-provider/.';
+  const recordedClaim = 'The legacy signal setting no longer matches the requested contract.';
+
+  function terminalAnomalyLedger(): FindingLedger {
+    const source = canonicalRawFindingFixture({
+      rawFindingId: 'raw-anomaly-source',
+      stepName: 'reviewers',
+      reviewer: 'arch-review',
+      familyTag: null,
+      severity: null,
+      title: null,
+      description: recordedClaim,
+      suggestion: null,
+      relation: 'new',
+      targetFindingId: null,
+      rawExcerpt: recordedClaim,
+      evidence: [],
+    });
+    return makeLedger([], {
+      rawFindings: [source],
+      reviewerAnomalies: [{
+        id: 'RA-TERMINAL',
+        kind: 'intake-contract-incomplete',
+        stableKey: 'stable-terminal',
+        lineageKey: 'lineage-terminal',
+        sourceRawFindingIds: [source.rawFindingId],
+        sourceIntakeIds: [],
+        reviewers: ['arch-review'],
+        title: 'Reviewer evidence anomaly',
+        claimedExcerpt: recordedClaim,
+        mismatchReason: 'Independent reviewer observation does not satisfy the product admission contract',
+        intakeContract: {
+          observationClass: 'claim-bearing',
+          classificationAuthorityId: 'system/intake_observation_classification_v1',
+          reasonCodes: ['product-identity-incomplete'],
+          missingRequirements: ['relation', 'severity'],
+          presentationOwnerReviewer: 'arch-review',
+          presentationLimit: 6,
+          terminalDisposition: {
+            kind: 'restatement_exhausted_claim_bearing',
+            workflowOutcome: 'review_integrity_unresolved',
+            decidedAt: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-07-01T00:00:00.000Z' },
+            terminalPublicationId: 'b'.repeat(64),
+            reason: 'Restatement presentation limit 6 was reached without verified correspondence',
+          },
+        },
+        firstObserved: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-07-01T00:00:00.000Z' },
+        lastObserved: { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-07-01T00:00:00.000Z' },
+        occurrences: 1,
+      }],
+    });
+  }
+
+  /** 裁定が出た後に昇格が確定した anomaly（保存時に不適格になるケース）。 */
+  function promotedAnomalyLedger(): FindingLedger {
+    const base = terminalAnomalyLedger();
+    return {
+      ...base,
+      reviewerAnomalies: base.reviewerAnomalies!.map((anomaly) => ({
+        ...anomaly,
+        promotedFindingId: 'F-0001',
+      })),
+    };
+  }
+
+  const runRound = async (
+    managerAuthority: 'standard' | 'terminal_adjudication',
+  ): Promise<FindingLedger> => {
+    const repository = new RevisionedFindingLedgerTestRepository(terminalAnomalyLedger());
+    const reportDir = mkdtempSync(join(tmpdir(), 'takt-anomaly-adjudication-'));
+    const publicationDouble = createFindingManagerPublicationDouble(
+      (report) => join(reportDir, `findings-manager-validation.${report.stepName}.json`),
+      repository,
+    );
+    const ledgerStore: FindingLedgerStore = {
+      ledgerIdentity: '/test/anomaly-adjudication/ledger.json',
+      workflowName: 'peer-review',
+      loadLedger: () => repository.loadLedger(),
+      updateLedger: (mutator, revalidateBeforeSave) => (
+        repository.updateLedger(mutator, revalidateBeforeSave)
+      ),
+      interpretationLiveClaims: processInterpretationLiveClaims,
+      saveLedgerSnapshot: () => {},
+      saveRawFindings: () => {},
+      saveManagerValidationReport: () => {},
+      ...publicationDouble,
+    };
+    executeAgentMock.mockClear();
+    executeAgentMock.mockImplementation(async (_persona, instruction) => {
+      const manifest = JSON.parse(
+        /## Task manifest\n```json\n([\s\S]*?)\n```/.exec(instruction as string)![1]!,
+      ) as { taskId: string; candidateIntents: Array<{ intentId: string; entityId: string }> };
+      return {
+        status: 'done',
+        content: '',
+        structuredOutput: {
+          taskId: manifest.taskId,
+          evaluations: manifest.candidateIntents.map((intent) => ({
+            intentId: intent.intentId,
+            result: {
+              kind: 'dismiss',
+              anomalyId: intent.entityId,
+              basis: 'outside_task_scope',
+              reason: 'The claim targets a module the task never asked to change',
+              taskQuote: 'Rename the legacy signal fields',
+              claimQuote: recordedClaim.slice(0, 24),
+            },
+          })),
+          selectedIntentId: manifest.candidateIntents[0]!.intentId,
+        },
+      } as unknown as AgentResponse;
+    });
+
+    try {
+      const result = await runFindingManagerForStep({
+        contract: {
+          manager: { persona: 'findings-manager', instruction: 'Reconcile findings.', outputContract: 'Return JSON.' },
+        } as never,
+        ledgerStore,
+        optionsBuilder: {
+          buildAgentOptions: () => ({}),
+          resolveStepProviderModel: () => ({ provider: 'codex', model: 'gpt-test' }),
+        } as never,
+        stepExecutor: {
+          buildPhase1Instruction: (instruction: string) => instruction,
+          recordSynthesizedAgentUsage: () => {},
+          normalizeStructuredOutput: (_step: WorkflowStep, response: AgentResponse) => response,
+        } as never,
+        cwd: process.cwd(),
+        parentStep: { kind: 'agent', name: 'merge-readiness-review', persona: 'reviewer', edit: false } as WorkflowStep,
+        stepIteration: 1,
+        subResults: [],
+        workflowName: 'peer-review',
+        runId: 'run-adjudication',
+        callNamespace: '',
+        timestamp: '2026-07-02T00:00:00.000Z',
+        managerAuthority,
+        workflowTask,
+      });
+      return result.ledger;
+    } finally {
+      rmSync(reportDir, { recursive: true, force: true });
+    }
+  };
+
+  it('runs the adjudication round when the only work is a terminally disposed anomaly', async () => {
+    const ledger = await runRound('terminal_adjudication');
+
+    // raw も dispute も conflict も無いラウンドでも provider が呼ばれる。
+    expect(executeAgentMock).toHaveBeenCalled();
+    expect(ledger.reviewerAnomalies![0]!.settlement).toMatchObject({
+      kind: 'dismissed_by_terminal_adjudication',
+      basis: 'outside_task_scope',
+      claimQuote: recordedClaim.slice(0, 24),
+    });
+    // 決着したのでゲートを塞がなくなる。
+    expect(isOutstandingReviewerAnomaly(ledger.reviewerAnomalies![0]!)).toBe(false);
+  });
+
+  it('records why an ineligible adjudication was not saved', async () => {
+    // 保存時に不採用になった裁定を無言で捨てない。ここでは裁定が出た後に同ラウンドで
+    // 昇格が確定した場合を再現する（決着済みは裁定で上書きしない）。
+    const rejections = applyCommitLedgerStates({
+      runInput: {
+        workflowName: 'peer-review',
+        parentStep: { name: 'merge-readiness-review' },
+        runId: 'run-adjudication',
+        timestamp: '2026-07-02T00:00:00.000Z',
+        subResults: [],
+        workflowTask,
+      } as never,
+      freshLedger: promotedAnomalyLedger(),
+      settledLedger: promotedAnomalyLedger(),
+      baseAnomalySpecs: [],
+      pendingRejectedObservations: [],
+      verifiedEvidenceCandidates: [],
+      anomalyAdjudications: [{
+        anomalyId: 'RA-TERMINAL',
+        basis: 'outside_task_scope',
+        reason: 'out of scope',
+        taskQuote: 'Rename the legacy signal fields',
+        claimQuote: recordedClaim.slice(0, 24),
+        workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+        adjudicationTaskId: 'd'.repeat(64),
+      }],
+    }).adjudicationRejections;
+
+    expect(rejections).toHaveLength(1);
+    expect(rejections[0]).toContain('RA-TERMINAL');
+    expect(rejections[0]).toContain('promoted anomalies cannot be settled');
+  });
+
+  it('leaves the anomaly outstanding when the call holds no terminal authority', async () => {
+    const ledger = await runRound('standard');
+
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(ledger.reviewerAnomalies![0]!.settlement).toBeUndefined();
+    expect(isOutstandingReviewerAnomaly(ledger.reviewerAnomalies![0]!)).toBe(true);
   });
 });

--- a/src/__tests__/finding-evidence-protocol-units.test.ts
+++ b/src/__tests__/finding-evidence-protocol-units.test.ts
@@ -615,6 +615,7 @@ describe('後続レビュー登録による reviewer anomaly の決着ライフ�
       baseAnomalySpecs: input.baseAnomalySpecs ?? [],
       pendingRejectedObservations: [],
       verifiedEvidenceCandidates: input.verifiedEvidenceCandidates ?? [],
+      anomalyAdjudications: [],
     }).ledger;
   }
 

--- a/src/__tests__/finding-fc-intake-contract.test.ts
+++ b/src/__tests__/finding-fc-intake-contract.test.ts
@@ -70,6 +70,10 @@ import { parseFindingLedger } from '../core/models/finding-schemas.js';
 import {
   classifyIntakeReviewIntegrityFailure,
 } from '../core/workflow/findings/review-integrity.js';
+import {
+  reviewerAnomalySettlementEligibilityViolation,
+} from '../core/models/finding-reviewer-anomaly-settlement-policy.js';
+import { computeWorkflowTaskDigest } from '../core/workflow/findings/task-scope-adjudication.js';
 
 const observedAt: FindingObservation = {
   runId: 'run-fc-intake',
@@ -392,6 +396,7 @@ describe('FC intake contract', () => {
       baseAnomalySpecs: [],
       pendingRejectedObservations: [],
       verifiedEvidenceCandidates: [],
+      anomalyAdjudications: [],
     });
 
     const terminal = committed.ledger.reviewerAnomalies![0]!.intakeContract!.terminalDisposition;
@@ -1210,6 +1215,145 @@ describe('FC intake contract', () => {
         })?.code).toBe('restatement_exhausted_claim_bearing');
       });
 
+      /**
+       * 救済経路の全体像。終端処分済みは自動では決着せず、terminal adjudication の
+       * 裁定却下だけが決着させる。決着したら完了ゲートは通る。
+       */
+      it('lets the completion gate pass once terminal adjudication dismissed the anomaly', () => {
+        const { wire, ledger } = disposedLedger('raw-closed-adjudicated');
+        const anomaly = ledger.reviewerAnomalies![0]!;
+        const workflowTask = 'Rename the legacy signal fields under src/infra/config/runtime-provider/.';
+        const settlement = {
+          kind: 'dismissed_by_terminal_adjudication' as const,
+          basis: 'outside_task_scope' as const,
+          // workflow task の byte-exact 部分文字列。
+          taskQuote: 'Rename the legacy signal fields',
+          workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+          // anomaly が記録した claim 本文の byte-exact 部分文字列。
+          claimQuote: wire.rawExcerpt!.slice(0, 20),
+          adjudicationTaskId: 'd'.repeat(64),
+          reason: 'The claim targets a module the task never asked to change',
+          decidedAt: observedAt,
+        };
+
+        expect(reviewerAnomalySettlementEligibilityViolation({
+          projection: ledger,
+          anomaly,
+          settlement,
+          sourceHead: { kind: 'projection' },
+          workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+        })).toBeUndefined();
+
+        const settled = {
+          ...ledger,
+          reviewerAnomalies: [{ ...anomaly, settlement }],
+        };
+        // 台帳不変条件（成立条件つき）を通り、未決着でなくなり、完了ゲートも通る。
+        expect(collectFindingLedgerProjectionInvariantViolations(settled)
+          .filter((violation) => violation.path[0] === 'reviewerAnomalies'))
+          .toEqual([]);
+        expect(isOutstandingReviewerAnomaly(settled.reviewerAnomalies[0]!)).toBe(false);
+        expect(classifyIntakeReviewIntegrityFailure({
+          anomalies: settled.reviewerAnomalies.filter(isOutstandingReviewerAnomaly),
+          presentationCounts: new Map(),
+        })).toBeUndefined();
+      });
+
+      it.each([
+        ['a claim quote that is not in the recorded claim', {
+          claimQuote: 'a paraphrase the reviewer never wrote',
+        }],
+        ['a workflow task binding from another task', {
+          workflowTaskDigest: 'e'.repeat(64),
+        }],
+      ] as const)('refuses an adjudication with %s', (_label, override) => {
+        const { wire, ledger } = disposedLedger('raw-closed-refused');
+        const workflowTask = 'Rename the legacy signal fields under src/infra/config/runtime-provider/.';
+
+        expect(reviewerAnomalySettlementEligibilityViolation({
+          projection: ledger,
+          anomaly: ledger.reviewerAnomalies![0]!,
+          settlement: {
+            kind: 'dismissed_by_terminal_adjudication',
+            basis: 'outside_task_scope',
+            taskQuote: 'Rename the legacy signal fields',
+            workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+            claimQuote: wire.rawExcerpt!.slice(0, 20),
+            adjudicationTaskId: 'd'.repeat(64),
+            reason: 'The claim targets a module the task never asked to change',
+            decidedAt: observedAt,
+            ...override,
+          },
+          sourceHead: { kind: 'projection' },
+          workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+        })).toBeDefined();
+      });
+
+      it('keeps forbidding a non-adjudication settlement on a terminally disposed anomaly', () => {
+        // 裁定却下だけが終端処分と同居できる。他の決着が同居できると、提示が
+        // 止まらず昇格や取り下げが後付けされる実事故を捕まえた検査が緩む。
+        const { ledger } = disposedLedger('raw-closed-forbidden');
+        const anomaly = ledger.reviewerAnomalies![0]!;
+
+        expect(collectFindingLedgerProjectionInvariantViolations({
+          ...ledger,
+          reviewerAnomalies: [{
+            ...anomaly,
+            settlement: {
+              kind: 'withdrawn_by_subsequent_review',
+              supersedingPublications: [{ reviewer: anomaly.reviewers[0]!, publicationId: 'a'.repeat(64) }],
+              decidedAt: observedAt,
+            },
+          }],
+        }).filter((violation) => violation.path.at(-1) === 'terminalDisposition'))
+          .toHaveLength(1);
+      });
+
+      it('refuses to adjudicate an anomaly whose restatement ladder is still open', () => {
+        // 対象は終端処分済みだけ。ラダーの途中で裁定却下できると、言い直しの機会を
+        // 奪ったうえに可視的失敗も消える。
+        const raw = incompleteRaw('raw-open-adjudication', {
+          rawExcerpt: 'The open defect remains observable.',
+        });
+        const workflowTask = 'Rename the legacy signal fields.';
+        const openLedger = applyReviewerAnomalySpecsToLedger(emptyLedger(), [createReviewerAnomalySpec({
+          wire: raw,
+          canonical: canonicalItem(raw).canonical,
+          anomalyKind: 'intake-contract-incomplete',
+          reason: 'Independent reviewer observation does not satisfy the product admission contract',
+          intakeContract: {
+            observationClass: 'claim-bearing',
+            classificationAuthorityId: 'system/intake_observation_classification_v1',
+            reasonCodes: ['product-identity-incomplete'],
+            missingRequirements: ['relation', 'severity'],
+            presentationOwnerReviewer: raw.reviewer,
+            presentationLimit: 6,
+          },
+        })], {
+          workflowName: 'peer-review',
+          stepName: observedAt.stepName,
+          runId: observedAt.runId,
+          timestamp: observedAt.timestamp,
+        }, new Set());
+
+        expect(reviewerAnomalySettlementEligibilityViolation({
+          projection: { ...openLedger, rawFindings: [raw] },
+          anomaly: openLedger.reviewerAnomalies![0]!,
+          settlement: {
+            kind: 'dismissed_by_terminal_adjudication',
+            basis: 'outside_task_scope',
+            taskQuote: 'Rename the legacy signal fields',
+            workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+            claimQuote: 'The open defect',
+            adjudicationTaskId: 'd'.repeat(64),
+            reason: 'out of scope',
+            decidedAt: observedAt,
+          },
+          sourceHead: { kind: 'projection' },
+          workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+        })).toBeDefined();
+      });
+
       it('still reports the unpresented cause while the anomaly is open', () => {
         // 正の対照: 終端処分が無い anomaly は「提示されていない」＝配線漏れのまま。
         const raw = incompleteRaw('raw-open-diagnosis', {
@@ -1629,6 +1773,7 @@ describe('FC intake contract', () => {
           reportDigest: admitted.sourceBinding.reportDigest,
         }],
       }],
+      anomalyAdjudications: [],
     });
 
     expect(committed.ledger.reviewerAnomalies?.[0]?.promotedFindingId).toBe('F-0001');
@@ -1710,6 +1855,7 @@ describe('FC intake contract', () => {
       baseAnomalySpecs: [spec],
       pendingRejectedObservations: [],
       verifiedEvidenceCandidates: [],
+      anomalyAdjudications: [],
     });
 
     expect(committed.ledger.reviewerAnomalies?.[0]?.intakeContract?.terminalDisposition)

--- a/src/__tests__/finding-fc-intake-contract.test.ts
+++ b/src/__tests__/finding-fc-intake-contract.test.ts
@@ -67,6 +67,9 @@ import {
 import { createProvisionalClaimBindingAuthorizationReference } from '../core/models/finding-provisional-claim-authorization.js';
 import { createEngineProofRecord } from '../core/models/finding-evidence-record.js';
 import { parseFindingLedger } from '../core/models/finding-schemas.js';
+import {
+  classifyIntakeReviewIntegrityFailure,
+} from '../core/workflow/findings/review-integrity.js';
 
 const observedAt: FindingObservation = {
   runId: 'run-fc-intake',
@@ -1159,6 +1162,87 @@ describe('FC intake contract', () => {
       // 終端はゲートを塞ぎ続け、terminal adjudication ルートへ送る。
       expect(context.claimBearingTerminalCount).toBe(1);
       expect(context.count).toBe(1);
+    });
+
+    /**
+     * 完了ゲートの診断が原因を指すこと。決着済みを「提示されていない（配線漏れ）」と
+     * 報告すると、実際の原因（終端処分が未決着のまま残っている）が隠れる。
+     */
+    describe('completion gate diagnosis', () => {
+      it('reports the exhausted cause for a terminally disposed anomaly instead of an unpresented one', () => {
+        const { ledger } = disposedLedger('raw-closed-diagnosis');
+        const classification = classifyIntakeReviewIntegrityFailure({
+          anomalies: ledger.reviewerAnomalies!,
+          // 提示は別の workflow_call 名前空間で行われたため、このゲートからは0件に見える。
+          presentationCounts: new Map(),
+        });
+
+        expect(classification?.code).toBe('restatement_exhausted_claim_bearing');
+        expect(classification?.unpresentedIds).toEqual([]);
+        expect(classification?.reason).toContain('restatement limit was exhausted');
+        expect(classification?.anomalyIds).toEqual([ledger.reviewerAnomalies![0]!.id]);
+      });
+
+      it('reports the exhausted cause for a terminal that never demanded a presentation', () => {
+        // undemandable_claim_atom は提示を1回も行わずに終端する正規の kind。
+        // 提示回数をどう数え直しても「提示済み」にはならないので、決着済みを
+        // unpresented から外すことでしか正しく診断できない。
+        const { ledger } = disposedLedger('raw-closed-undemandable');
+        const undemandable = {
+          ...ledger,
+          reviewerAnomalies: ledger.reviewerAnomalies!.map((entry) => ({
+            ...entry,
+            intakeContract: {
+              ...entry.intakeContract!,
+              terminalDisposition: {
+                kind: 'undemandable_claim_atom' as const,
+                workflowOutcome: 'review_integrity_unresolved' as const,
+                decidedAt: observedAt,
+                reason: 'The recorded observation carries no claim body that a restatement request could ask back',
+              },
+            },
+          })),
+        };
+
+        expect(classifyIntakeReviewIntegrityFailure({
+          anomalies: undemandable.reviewerAnomalies,
+          presentationCounts: new Map(),
+        })?.code).toBe('restatement_exhausted_claim_bearing');
+      });
+
+      it('still reports the unpresented cause while the anomaly is open', () => {
+        // 正の対照: 終端処分が無い anomaly は「提示されていない」＝配線漏れのまま。
+        const raw = incompleteRaw('raw-open-diagnosis', {
+          rawExcerpt: 'The open defect remains observable.',
+        });
+        const ledger = applyReviewerAnomalySpecsToLedger(emptyLedger(), [createReviewerAnomalySpec({
+          wire: raw,
+          canonical: canonicalItem(raw).canonical,
+          anomalyKind: 'intake-contract-incomplete',
+          reason: 'Independent reviewer observation does not satisfy the product admission contract',
+          intakeContract: {
+            observationClass: 'claim-bearing',
+            classificationAuthorityId: 'system/intake_observation_classification_v1',
+            reasonCodes: ['product-identity-incomplete'],
+            missingRequirements: ['relation', 'severity'],
+            presentationOwnerReviewer: raw.reviewer,
+            presentationLimit: 6,
+          },
+        })], {
+          workflowName: 'peer-review',
+          stepName: observedAt.stepName,
+          runId: observedAt.runId,
+          timestamp: observedAt.timestamp,
+        }, new Set());
+
+        const classification = classifyIntakeReviewIntegrityFailure({
+          anomalies: ledger.reviewerAnomalies!,
+          presentationCounts: new Map(),
+        });
+
+        expect(classification?.code).toBe('review_integrity_unresolved_unpresented');
+        expect(classification?.unpresentedIds).toEqual([ledger.reviewerAnomalies![0]!.id]);
+      });
     });
   });
 

--- a/src/__tests__/finding-fc-intake-contract.test.ts
+++ b/src/__tests__/finding-fc-intake-contract.test.ts
@@ -1295,18 +1295,28 @@ describe('FC intake contract', () => {
         const { ledger } = disposedLedger('raw-closed-forbidden');
         const anomaly = ledger.reviewerAnomalies![0]!;
 
-        expect(collectFindingLedgerProjectionInvariantViolations({
-          ...ledger,
-          reviewerAnomalies: [{
-            ...anomaly,
-            settlement: {
-              kind: 'withdrawn_by_subsequent_review',
-              supersedingPublications: [{ reviewer: anomaly.reviewers[0]!, publicationId: 'a'.repeat(64) }],
-              decidedAt: observedAt,
-            },
-          }],
-        }).filter((violation) => violation.path.at(-1) === 'terminalDisposition'))
-          .toHaveLength(1);
+        const withSettlement = (settlement: NonNullable<typeof anomaly.settlement>) => (
+          collectFindingLedgerProjectionInvariantViolations({
+            ...ledger,
+            reviewerAnomalies: [{ ...anomaly, settlement }],
+          }).filter((violation) => violation.path.at(-1) === 'terminalDisposition')
+        );
+
+        expect(withSettlement({
+          kind: 'withdrawn_by_subsequent_review',
+          supersedingPublications: [{ reviewer: anomaly.reviewers[0]!, publicationId: 'a'.repeat(64) }],
+          decidedAt: observedAt,
+        })).toHaveLength(1);
+        expect(withSettlement({
+          kind: 'target_resolved_by_verified_evidence',
+          findingId: 'F-0001',
+          lifecycleEventId: 'event-1',
+        })).toHaveLength(1);
+        expect(withSettlement({
+          kind: 'target_dismissed_by_terminal_adjudication',
+          findingId: 'F-0001',
+          lifecycleEventId: 'event-1',
+        })).toHaveLength(1);
       });
 
       it('refuses to adjudicate an anomaly whose restatement ladder is still open', () => {
@@ -1351,7 +1361,43 @@ describe('FC intake contract', () => {
           },
           sourceHead: { kind: 'projection' },
           workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
-        })).toBeDefined();
+        })).toBe('terminal adjudication may only dismiss a claim-bearing anomaly whose restatement ladder terminated unresolved');
+      });
+
+      it('refuses to settle an anomaly that is already settled', () => {
+        // 二重決着の禁止。決着済みの上書きは監査記録を壊す。
+        const { wire, ledger } = disposedLedger('raw-closed-twice');
+        const workflowTask = 'Rename the legacy signal fields under src/infra/config/runtime-provider/.';
+        const settled = {
+          ...ledger.reviewerAnomalies![0]!,
+          settlement: {
+            kind: 'dismissed_by_terminal_adjudication' as const,
+            basis: 'outside_task_scope' as const,
+            taskQuote: 'Rename the legacy signal fields',
+            workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+            claimQuote: wire.rawExcerpt!.slice(0, 20),
+            adjudicationTaskId: 'd'.repeat(64),
+            reason: 'already decided',
+            decidedAt: observedAt,
+          },
+        };
+
+        expect(reviewerAnomalySettlementEligibilityViolation({
+          projection: ledger,
+          anomaly: settled,
+          settlement: {
+            kind: 'dismissed_by_terminal_adjudication',
+            basis: 'outside_task_scope',
+            taskQuote: 'Rename the legacy signal fields',
+            workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+            claimQuote: wire.rawExcerpt!.slice(0, 20),
+            adjudicationTaskId: 'e'.repeat(64),
+            reason: 'a second decision',
+            decidedAt: observedAt,
+          },
+          sourceHead: { kind: 'projection' },
+          workflowTaskDigest: computeWorkflowTaskDigest(workflowTask),
+        })).toBe('already settled anomalies cannot be settled again');
       });
 
       it('still reports the unpresented cause while the anomaly is open', () => {

--- a/src/__tests__/finding-manager-task-contracts.test.ts
+++ b/src/__tests__/finding-manager-task-contracts.test.ts
@@ -36,7 +36,7 @@ function enumValues(
 describe('finding manager task contracts', () => {
   it.each([
     ['raw task', MainManagerRawTaskOutputJsonSchema, 3],
-    ['control task', MainManagerControlTaskOutputJsonSchema, 8],
+    ['control task', MainManagerControlTaskOutputJsonSchema, 10],
     ['entity binding task', FindingEntityBindingTaskOutputJsonSchema, 1],
   ])('declares matching string types for every enum in the projected %s output schema', (
     _name,
@@ -153,6 +153,22 @@ describe('finding manager task contracts', () => {
                 "kind",
                 "findingId",
                 "evidence",
+              ],
+            },
+            {
+              "basis": [
+                "outside_task_scope",
+              ],
+              "kind": [
+                "dismiss",
+              ],
+              "required": [
+                "kind",
+                "anomalyId",
+                "basis",
+                "reason",
+                "taskQuote",
+                "claimQuote",
               ],
             },
             {

--- a/src/__tests__/finding-manager-task-runner.test.ts
+++ b/src/__tests__/finding-manager-task-runner.test.ts
@@ -1583,4 +1583,80 @@ describe('reviewer anomaly adjudication control task', () => {
     expect(result.anomalyAdjudications).toEqual([]);
     expect(result.invalidAttemptMessages.join('\n')).toContain('byte-exact quote of the recorded claim');
   });
+
+  it('rejects a dismissal whose task quote is not in the workflow task', async () => {
+    executeAgentMock.mockImplementation(async (_persona, instruction) => {
+      const manifest = sectionJson<ControlManifestView>(instruction, '## Task manifest');
+      return response({
+        taskId: manifest.taskId,
+        evaluations: manifest.candidateIntents.map((intent) => ({
+          intentId: intent.intentId,
+          result: {
+            kind: 'dismiss',
+            anomalyId: intent.entityId,
+            basis: 'outside_task_scope',
+            reason: 'The claim targets a module the task never asked to change',
+            taskQuote: 'Delete every legacy signal field',
+            claimQuote: recordedClaim.slice(0, 24),
+          },
+        })),
+        selectedIntentId: manifest.candidateIntents[0]!.intentId,
+      });
+    });
+    const result = await runMainManagerTasks({
+      contract,
+      previousLedger: terminalAnomalyLedger(),
+      reviewScopeSnapshotId: 'scope-test',
+      residualRawFindings: [],
+      mechanicallyClassifiedCount: 0,
+      priorStepResponseText: undefined,
+      invalidLocationCandidates: new Map(),
+      dismissCandidates: new Map(),
+      evidenceRecordsByRawFindingId: new Map(),
+      managerStep,
+      runInput,
+      managerAuthority: 'terminal_adjudication',
+      workflowTask,
+      subResults: [],
+    });
+
+    expect(result.anomalyAdjudications).toEqual([]);
+    expect(result.invalidAttemptMessages.join('\n')).toContain('outside_task_scope taskQuote');
+  });
+
+  it('does not offer the product-finding dismissal shape in the adjudication prompt', async () => {
+    // findingId 形式を併記すると、必ず validation で落ちる形状を同時に提示することになる。
+    let prompt = '';
+    executeAgentMock.mockImplementation(async (_persona, instruction) => {
+      prompt = instruction;
+      const manifest = sectionJson<ControlManifestView>(instruction, '## Task manifest');
+      return response({
+        taskId: manifest.taskId,
+        evaluations: manifest.candidateIntents.map((intent) => ({
+          intentId: intent.intentId,
+          result: { kind: 'no_action', reason: 'in scope' },
+        })),
+        selectedIntentId: null,
+      });
+    });
+    await runMainManagerTasks({
+      contract,
+      previousLedger: terminalAnomalyLedger(),
+      reviewScopeSnapshotId: 'scope-test',
+      residualRawFindings: [],
+      mechanicallyClassifiedCount: 0,
+      priorStepResponseText: undefined,
+      invalidLocationCandidates: new Map(),
+      dismissCandidates: new Map(),
+      evidenceRecordsByRawFindingId: new Map(),
+      managerStep,
+      runInput,
+      managerAuthority: 'terminal_adjudication',
+      workflowTask,
+      subResults: [],
+    });
+
+    expect(prompt).toContain('"anomalyId"');
+    expect(prompt).not.toContain('"findingId":"<intent entityId>"');
+  });
 });

--- a/src/__tests__/finding-manager-task-runner.test.ts
+++ b/src/__tests__/finding-manager-task-runner.test.ts
@@ -1455,3 +1455,132 @@ describe('main manager bounded task runner', () => {
     }]);
   });
 });
+
+describe('reviewer anomaly adjudication control task', () => {
+  const workflowTask = 'Rename the legacy signal fields under src/infra/config/runtime-provider/.';
+  const recordedClaim = 'The legacy signal setting no longer matches the requested contract.';
+
+  function terminalAnomalyLedger(): FindingLedger {
+    const source = rawFinding(1, {
+      rawFindingId: 'raw-anomaly-source',
+      rawExcerpt: recordedClaim,
+      description: recordedClaim,
+    });
+    return emptyLedger({
+      rawFindings: [source],
+      reviewerAnomalies: [{
+        id: 'RA-TERMINAL',
+        kind: 'intake-contract-incomplete',
+        stableKey: 'stable-terminal',
+        lineageKey: 'lineage-terminal',
+        sourceRawFindingIds: [source.rawFindingId],
+        sourceIntakeIds: [],
+        reviewers: ['reviewer'],
+        title: 'Reviewer evidence anomaly',
+        claimedExcerpt: recordedClaim,
+        mismatchReason: 'Independent reviewer observation does not satisfy the product admission contract',
+        intakeContract: {
+          observationClass: 'claim-bearing',
+          classificationAuthorityId: 'system/intake_observation_classification_v1',
+          reasonCodes: ['product-identity-incomplete'],
+          missingRequirements: ['relation', 'severity'],
+          presentationOwnerReviewer: 'reviewer',
+          presentationLimit: 6,
+          terminalDisposition: {
+            kind: 'restatement_exhausted_claim_bearing',
+            workflowOutcome: 'review_integrity_unresolved',
+            decidedAt: { runId: 'run', stepName: 'reviewers', timestamp: '2026-07-29T00:00:00.000Z' },
+            terminalPublicationId: 'b'.repeat(64),
+            reason: 'Restatement presentation limit 6 was reached without verified correspondence',
+          },
+        },
+        firstObserved: { runId: 'run', stepName: 'reviewers', timestamp: '2026-07-29T00:00:00.000Z' },
+        lastObserved: { runId: 'run', stepName: 'reviewers', timestamp: '2026-07-29T00:00:00.000Z' },
+        occurrences: 1,
+      }],
+    });
+  }
+
+  const manifestFor = (
+    managerAuthority: RunFindingManagerForStepInput['managerAuthority'],
+  ) => createMainManagerControlTaskManifest({
+    previousLedger: terminalAnomalyLedger(),
+    reviewScopeSnapshotId: 'scope-test',
+    priorStepResponseText: undefined,
+    invalidLocationCandidates: new Map(),
+    dismissCandidates: new Map(),
+    managerAuthority,
+    workflowTask,
+    subResults: [],
+  });
+
+  it('issues the adjudication task only when the call holds terminal authority', () => {
+    // 権限の無いラウンドで問うと、返せない答えを毎ラウンド要求することになる。
+    expect(manifestFor('standard')).toHaveLength(0);
+
+    const tasks = manifestFor('terminal_adjudication');
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.task.kind).toBe('reviewer_anomaly');
+    expect(tasks[0]!.task.ownedEntityIds).toEqual(['RA-TERMINAL']);
+    expect(tasks[0]!.task.candidateIntents.map((intent) => intent.kind)).toEqual(['adjudicate_anomaly']);
+    // 権限の出所は task に束縛される。
+    expect(tasks[0]!.task.taskScopeContext?.managerAuthority).toBe('terminal_adjudication');
+  });
+
+  const runAdjudication = async (claimQuote: string) => {
+    executeAgentMock.mockImplementation(async (_persona, instruction) => {
+      const manifest = sectionJson<ControlManifestView>(instruction, '## Task manifest');
+      return response({
+        taskId: manifest.taskId,
+        evaluations: manifest.candidateIntents.map((intent) => ({
+          intentId: intent.intentId,
+          result: {
+            kind: 'dismiss',
+            anomalyId: intent.entityId,
+            basis: 'outside_task_scope',
+            reason: 'The claim targets a module the task never asked to change',
+            taskQuote: 'Rename the legacy signal fields',
+            claimQuote,
+          },
+        })),
+        selectedIntentId: manifest.candidateIntents[0]!.intentId,
+      });
+    });
+    return runMainManagerTasks({
+      contract,
+      previousLedger: terminalAnomalyLedger(),
+      reviewScopeSnapshotId: 'scope-test',
+      residualRawFindings: [],
+      mechanicallyClassifiedCount: 0,
+      priorStepResponseText: undefined,
+      invalidLocationCandidates: new Map(),
+      dismissCandidates: new Map(),
+      evidenceRecordsByRawFindingId: new Map(),
+      managerStep,
+      runInput,
+      managerAuthority: 'terminal_adjudication',
+      workflowTask,
+      subResults: [],
+    });
+  };
+
+  it('accepts a dismissal whose quotes are byte-exact', async () => {
+    const result = await runAdjudication(recordedClaim.slice(0, 24));
+
+    expect(result.anomalyAdjudications).toEqual([expect.objectContaining({
+      anomalyId: 'RA-TERMINAL',
+      basis: 'outside_task_scope',
+      taskQuote: 'Rename the legacy signal fields',
+      claimQuote: recordedClaim.slice(0, 24),
+    })]);
+    // product finding の決定系へは一切合流しない。
+    expect(result.decisions.dismissDecisions).toEqual([]);
+  });
+
+  it('rejects a dismissal whose claim quote is a paraphrase', async () => {
+    const result = await runAdjudication('a paraphrase the reviewer never wrote');
+
+    expect(result.anomalyAdjudications).toEqual([]);
+    expect(result.invalidAttemptMessages.join('\n')).toContain('byte-exact quote of the recorded claim');
+  });
+});

--- a/src/__tests__/finding-plan-normalization.test.ts
+++ b/src/__tests__/finding-plan-normalization.test.ts
@@ -1694,6 +1694,7 @@ describe('relation 別 intake と target atomization', () => {
             interpretationIntegrityDigests: new Map(),
             observation,
             verifiedEvidenceCandidates: [],
+            anomalyAdjudications: [],
             stopBudgetLimits: resolveStopBudgetLimits(undefined),
             stopBudgetRoundMarker: 'stale-round',
           });
@@ -1719,6 +1720,7 @@ describe('relation 別 intake と target atomization', () => {
           interpretationIntegrityDigests: new Map(),
           observation,
           verifiedEvidenceCandidates: [],
+          anomalyAdjudications: [],
           stopBudgetLimits: resolveStopBudgetLimits(undefined),
           stopBudgetRoundMarker: `round-${round}`,
         });

--- a/src/__tests__/finding-review-integrity-gate.test.ts
+++ b/src/__tests__/finding-review-integrity-gate.test.ts
@@ -66,7 +66,11 @@ import type { AgentResponse } from '../core/models/types.js';
 import { runAgent } from '../agents/runner.js';
 import { makeRule, makeStep } from './test-helpers.js';
 import { createTestFindingLedgerStore } from './helpers/finding-storage.js';
-import { reviewerRawExtractionFixture } from './helpers/finding-lifecycle-fixture.js';
+import {
+  canonicalRawFindingFixture,
+  rawCanonicalSnapshotFixture,
+  reviewerRawExtractionFixture,
+} from './helpers/finding-lifecycle-fixture.js';
 import { initializeGitFixture } from './helpers/git-fixture.js';
 import { stopBudgetRoundsCompleted } from '../core/workflow/findings/stop-budget.js';
 import { isOutstandingReviewerAnomaly } from '../core/workflow/findings/reviewer-anomalies.js';
@@ -163,6 +167,139 @@ function loadRootLedger(cwd: string, workflowName: string) {
     workflowName,
   }).loadLedger();
 }
+
+/**
+ * 終端処分済み anomaly を持つ台帳を先に置き、実 engine の COMPLETE ゲートが
+ * どう診断するかを failure payload まで固定する。提示は別 namespace で行われた
+ * 想定なので、このゲートから見た提示回数は 0 件。
+ */
+describe('review-integrity gate failure payload (engine level)', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = createTestTmpDir();
+    vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
+      options?.onPromptResolved?.({ systemPrompt: 'system', userInstruction: instruction });
+      return {
+        persona,
+        status: 'done',
+        content: 'approved',
+        timestamp: new Date('2026-06-13T00:00:02.000Z'),
+      };
+    });
+  });
+
+  afterEach(() => {
+    if (existsSync(cwd)) {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports the exhausted code with the anomaly identity for a terminally disposed claim', async () => {
+    const workflowName = 'review-integrity-payload';
+    const store = createTestFindingLedgerStore({
+      projectCwd: cwd,
+      runId: 'test-report-dir',
+      reportDir: join(cwd, '.takt', 'runs', 'test-report-dir', 'reports'),
+      workflowName,
+    });
+    const observation = { runId: 'seed', stepName: 'reviewers', timestamp: '2026-06-13T00:00:00.000Z' };
+    const source = canonicalRawFindingFixture({
+      rawFindingId: 'raw-terminal-seed',
+      stepName: 'reviewers',
+      reviewer: 'reviewers',
+      familyTag: null,
+      severity: null,
+      title: null,
+      description: 'The legacy signal setting no longer matches the requested contract.',
+      suggestion: null,
+      relation: 'new',
+      targetFindingId: null,
+      evidence: [],
+      rawExcerpt: 'The legacy signal setting no longer matches the requested contract.',
+    });
+    await store.updateLedger((ledger) => ({
+      ledger: {
+        ...ledger,
+        rawFindings: [source],
+        rawCanonicalSnapshots: [rawCanonicalSnapshotFixture(source, observation)],
+        reviewerAnomalies: [{
+          id: 'RA-SEEDTERMINAL',
+          kind: 'intake-contract-incomplete',
+          stableKey: 'stable-seed-terminal',
+          lineageKey: 'lineage-seed-terminal',
+          sourceRawFindingIds: [source.rawFindingId],
+          sourceIntakeIds: [],
+          reviewers: ['reviewers'],
+          title: 'Reviewer evidence anomaly',
+          claimedExcerpt: source.rawExcerpt!,
+          mismatchReason: 'Independent reviewer observation does not satisfy the product admission contract',
+          intakeContract: {
+            observationClass: 'claim-bearing',
+            classificationAuthorityId: 'system/intake_observation_classification_v1',
+            reasonCodes: ['product-identity-incomplete'],
+            missingRequirements: ['relation', 'severity'],
+            presentationOwnerReviewer: 'reviewers',
+            presentationLimit: 6,
+            terminalDisposition: {
+              kind: 'restatement_exhausted_claim_bearing',
+              workflowOutcome: 'review_integrity_unresolved',
+              decidedAt: observation,
+              terminalPublicationId: 'b'.repeat(64),
+              reason: 'Restatement presentation limit 6 was reached without verified correspondence',
+            },
+          },
+          firstObserved: observation,
+          lastObserved: observation,
+          occurrences: 1,
+        }],
+      },
+      result: undefined,
+    }));
+
+    const config: WorkflowConfig = {
+      name: workflowName,
+      maxSteps: 2,
+      initialStep: 'gate',
+      provider: 'claude',
+      findingContract: {
+        manager: { persona: 'findings-manager', instruction: 'findings-manager', outputContract: 'findings-manager' },
+        adjudicator: { persona: 'supervisor' },
+      },
+      steps: [makeStep({
+        name: 'gate',
+        persona: 'gatekeeper',
+        instruction: 'Gate.',
+        rules: [makeRule('when(true)', 'COMPLETE')],
+      })],
+    };
+    const engine = new WorkflowEngine(config, cwd, 'task', {
+      projectCwd: cwd,
+      provider: 'claude',
+      reportDirName: 'test-report-dir',
+    });
+    let failure: { kind: string; details?: { reviewIntegrity?: Record<string, unknown> } } | undefined;
+    engine.on('workflow:abort', (
+      _state: unknown,
+      _reason: string,
+      _kind: string,
+      abortFailure?: typeof failure,
+    ) => { failure = abortFailure; });
+
+    const result = await engine.run();
+
+    expect(result.status).toBe('aborted');
+    expect(failure?.kind).toBe('review_integrity_unresolved');
+    // 決着済みは「提示されていない（配線漏れ）」ではなく exhausted として報告される。
+    expect(failure?.details?.reviewIntegrity).toEqual({
+      code: 'restatement_exhausted_claim_bearing',
+      anomalyIds: ['RA-SEEDTERMINAL'],
+      unpresentedIds: [],
+      classificationAuthorityIds: ['system/intake_observation_classification_v1'],
+      publicationIds: [],
+    });
+  }, 60_000);
+});
 
 describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', () => {
   let cwd: string;

--- a/src/core/models/finding-ledger-invariants.ts
+++ b/src/core/models/finding-ledger-invariants.ts
@@ -1392,6 +1392,8 @@ function reviewerAnomalySettlementLabel(settlement: ReviewerAnomalySettlement): 
       return 'terminal-dismissal';
     case 'withdrawn_by_subsequent_review':
       return 'subsequent-review withdrawal';
+    case 'dismissed_by_terminal_adjudication':
+      return 'terminal-adjudication dismissal';
     default: {
       const unexpected: never = settlement;
       throw new Error(`Unsupported reviewer anomaly settlement: ${JSON.stringify(unexpected)}`);
@@ -1487,11 +1489,16 @@ function collectReviewerAnomalyViolations(
         // 言い直しで要求できる claim 本文が無い観測の終端は、observationClass 由来の
         // 対応表の外にある（提示を1回も行わずに決着する唯一の kind）。
         const undemandableTerminal = defect.terminalDisposition?.kind === 'undemandable_claim_atom';
+        // 終端処分と同居してよい決着は、終端処分を成立条件に持つ裁定却下だけ。
+        // 昇格・検証済み解消・後続レビューによる取り下げは「ラダーが終端したのに
+        // ラダー由来の決着も付いた」という矛盾記録になるので同居を禁じ続ける
+        // （提示が止まらず昇格が後付けされた実事故を捕まえたのがこの検査）。
+        const adjudicatedTerminal = anomaly.settlement?.kind === 'dismissed_by_terminal_adjudication';
         if (
           defect.terminalDisposition !== undefined
           && (
             anomaly.promotedFindingId !== undefined
-            || anomaly.settlement !== undefined
+            || (anomaly.settlement !== undefined && !adjudicatedTerminal)
             || (undemandableTerminal
               && defect.terminalDisposition.workflowOutcome !== (
                 defect.observationClass === 'claim-bearing'

--- a/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
+++ b/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
@@ -12,6 +12,7 @@ import type {
   FindingLifecycleReservation,
   FindingMutationPrecondition,
   RawFinding,
+  ReviewerAnomalyAdjudicationSettlement,
   ReviewerAnomalyEntry,
   ReviewerAnomalyReviewWithdrawalSettlement,
   ReviewerAnomalySettlement,
@@ -322,6 +323,66 @@ function reviewWithdrawalEligibilityViolation(
     : 'withdrawal must record a superseding review for every reviewer that observed the anomaly';
 }
 
+/**
+ * 裁定が読んだと主張する claim 本文。台帳だけで再検証できる範囲に限る
+ * （anomaly の記録済み claim と、その出所 raw の本文）。
+ */
+export function reviewerAnomalyAdjudicationClaimTexts(
+  projection: Pick<ReviewerAnomalySettlementProjection, 'rawFindings'>,
+  anomaly: ReviewerAnomalyEntry,
+): string[] {
+  const sourceTexts = anomaly.sourceRawFindingIds.flatMap((rawFindingId) => {
+    const raw = projection.rawFindings.find(
+      (candidate) => candidate.rawFindingId === rawFindingId,
+    );
+    return raw === undefined
+      ? []
+      : [raw.description, raw.rawExcerpt].flatMap((text) => (
+        typeof text === 'string' && text.length > 0 ? [text] : []
+      ));
+  });
+  return [
+    ...(anomaly.claimedExcerpt === undefined ? [] : [anomaly.claimedExcerpt]),
+    ...sourceTexts,
+  ];
+}
+
+/**
+ * 終端処分済み anomaly の裁定却下が成立する条件。
+ *
+ * 対象は「言い直しラダーを使い切った claim-bearing」だけ。可視的失敗が既定で、
+ * 救済はこの裁定に限る建付けなので、対象外へ広げない。
+ */
+function adjudicationEligibilityViolation(input: {
+  projection: ReviewerAnomalySettlementProjection;
+  anomaly: ReviewerAnomalyEntry;
+  settlement: ReviewerAnomalyAdjudicationSettlement;
+  workflowTaskDigest: string | null;
+}): string | undefined {
+  const anomaly = input.anomaly;
+  if (anomaly.promotedFindingId !== undefined) {
+    return 'promoted anomalies cannot be settled';
+  }
+  if (
+    anomaly.kind !== 'intake-contract-incomplete'
+    || anomaly.intakeContract?.terminalDisposition?.workflowOutcome !== 'review_integrity_unresolved'
+  ) {
+    return 'terminal adjudication may only dismiss a claim-bearing anomaly whose restatement ladder terminated unresolved';
+  }
+  if (
+    input.workflowTaskDigest !== null
+    && input.settlement.workflowTaskDigest !== input.workflowTaskDigest
+  ) {
+    return 'adjudication is bound to a different workflow task';
+  }
+  // 記録済みの claim 本文に対する byte-exact 部分文字列であること。裁定が実在の
+  // 主張を読んだ証跡で、台帳だけで再検証できる唯一の根拠。
+  return reviewerAnomalyAdjudicationClaimTexts(input.projection, anomaly)
+    .some((text) => text.includes(input.settlement.claimQuote))
+    ? undefined
+    : 'adjudication claimQuote is not a byte-exact quote of the recorded claim';
+}
+
 export function reviewerAnomalySettlementEligibilityViolation(input: {
   projection: ReviewerAnomalySettlementProjection;
   anomaly: ReviewerAnomalyEntry;
@@ -332,6 +393,14 @@ export function reviewerAnomalySettlementEligibilityViolation(input: {
   const settlement = input.settlement;
   if (settlement.kind === 'withdrawn_by_subsequent_review') {
     return reviewWithdrawalEligibilityViolation(input.anomaly, settlement);
+  }
+  if (settlement.kind === 'dismissed_by_terminal_adjudication') {
+    return adjudicationEligibilityViolation({
+      projection: input.projection,
+      anomaly: input.anomaly,
+      settlement,
+      workflowTaskDigest: input.workflowTaskDigest,
+    });
   }
   if (input.anomaly.kind === 'protocol-anomaly') {
     return 'protocol anomalies cannot be settled';

--- a/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
+++ b/src/core/models/finding-reviewer-anomaly-settlement-policy.ts
@@ -348,6 +348,21 @@ export function reviewerAnomalyAdjudicationClaimTexts(
 }
 
 /**
+ * 裁定にかけられる anomaly か。「言い直しラダーを使い切った claim-bearing」だけで、
+ * 決着済み（昇格・settlement）は含めない。
+ *
+ * 候補選定（どの anomaly を裁定へ出すか）と成立条件（どの settlement を受理するか）が
+ * 同じ集合を指すよう、両者がこの1つの述語を共有する。片方だけ広いと「出したのに
+ * 受理されない」または「出していないのに書ける」が生まれる。
+ */
+export function isAdjudicableReviewerAnomaly(anomaly: ReviewerAnomalyEntry): boolean {
+  return anomaly.kind === 'intake-contract-incomplete'
+    && anomaly.intakeContract?.terminalDisposition?.workflowOutcome === 'review_integrity_unresolved'
+    && anomaly.promotedFindingId === undefined
+    && anomaly.settlement === undefined;
+}
+
+/**
  * 終端処分済み anomaly の裁定却下が成立する条件。
  *
  * 対象は「言い直しラダーを使い切った claim-bearing」だけ。可視的失敗が既定で、
@@ -363,10 +378,14 @@ function adjudicationEligibilityViolation(input: {
   if (anomaly.promotedFindingId !== undefined) {
     return 'promoted anomalies cannot be settled';
   }
-  if (
-    anomaly.kind !== 'intake-contract-incomplete'
-    || anomaly.intakeContract?.terminalDisposition?.workflowOutcome !== 'review_integrity_unresolved'
-  ) {
+  // 二重決着の明示拒否。現在の呼び出し側は書き込み前に決着済みを外すため到達しないが、
+  // 到達不能性に寄りかからず構造で保証する（決着済みの上書きは監査記録を壊す）。
+  if (anomaly.settlement !== undefined && anomaly.settlement !== input.settlement) {
+    return 'already settled anomalies cannot be settled again';
+  }
+  // 既に settlement を持つ anomaly はここへ来ない（呼び出し側が書き込み前に判定する）
+  // ため、候補述語からは settlement 条件だけ外して評価する。
+  if (!isAdjudicableReviewerAnomaly({ ...anomaly, settlement: undefined })) {
     return 'terminal adjudication may only dismiss a claim-bearing anomaly whose restatement ladder terminated unresolved';
   }
   if (

--- a/src/core/models/finding-schemas.ts
+++ b/src/core/models/finding-schemas.ts
@@ -776,6 +776,16 @@ export const ReviewerAnomalyEntrySchema = z.object({
         )),
       decidedAt: FindingObservationSchema,
     }).strict(),
+    z.object({
+      kind: z.literal('dismissed_by_terminal_adjudication'),
+      basis: z.literal('outside_task_scope'),
+      taskQuote: nonEmptyString,
+      workflowTaskDigest: Sha256Schema,
+      claimQuote: nonEmptyString,
+      adjudicationTaskId: Sha256Schema,
+      reason: nonEmptyString,
+      decidedAt: FindingObservationSchema,
+    }).strict(),
   ]).optional(),
 }).strict().superRefine((value, ctx) => {
   if (value.kind === 'intake-contract-incomplete' && value.intakeContract === undefined) {
@@ -2265,6 +2275,7 @@ const FindingManagerValidationReportSchema = z.object({
         'invalidate',
         'duplicate',
         'dismiss',
+        'reviewer_anomaly',
       ]),
       ownedIds: z.array(rawFindingIdString),
       status: z.literal('succeeded'),
@@ -2282,6 +2293,7 @@ const FindingManagerValidationReportSchema = z.object({
         'invalidate',
         'duplicate',
         'dismiss',
+        'reviewer_anomaly',
       ]),
       ownedIds: z.array(rawFindingIdString),
       status: z.enum(['failed', 'input_overflow']),

--- a/src/core/models/finding-types.ts
+++ b/src/core/models/finding-types.ts
@@ -1187,7 +1187,8 @@ export type FindingManagerTaskKind =
   | 'conflict'
   | 'invalidate'
   | 'duplicate'
-  | 'dismiss';
+  | 'dismiss'
+  | 'reviewer_anomaly';
 
 /** Provider task の非権威監査。台帳変更権限や lifecycle head の正本には使わない。 */
 export type FindingManagerTaskAudit =
@@ -1650,9 +1651,39 @@ export interface ReviewerAnomalyReviewWithdrawalSettlement {
   decidedAt: FindingObservation;
 }
 
+/**
+ * 終端処分済み(restatement_exhausted_claim_bearing / undemandable_claim_atom)の
+ * claim-bearing anomaly を、terminal adjudication 権限を持つ裁定が却下したことによる
+ * 決着。
+ *
+ * 言い直しラダーを使い切った claim-bearing の観測は、可視的失敗が既定であって
+ * 自動では決着しない。救済はこの裁定だけで、根拠は機械検証可能な2つの逐語引用に
+ * 限る:
+ *   - taskQuote: workflow task の byte-exact 部分文字列。「この主張は今回の task の
+ *     範囲外である」という判断の根拠。product finding の outside_task_scope 却下と
+ *     同じ流儀で、後から workflowTaskDigest によって束縛を再検証できる。
+ *   - claimQuote: anomaly が記録した claim 本文の byte-exact 部分文字列。裁定が
+ *     実在の主張を読んだ証跡。台帳だけで再検証できる。
+ *
+ * adjudicationTaskId は権限の出所になった control task。engine が
+ * managerAuthority === 'terminal_adjudication' のときにしか発行しないため、
+ * 設定だけでこの決着へ到達する経路は無い。
+ */
+export interface ReviewerAnomalyAdjudicationSettlement {
+  kind: 'dismissed_by_terminal_adjudication';
+  basis: 'outside_task_scope';
+  taskQuote: string;
+  workflowTaskDigest: string;
+  claimQuote: string;
+  adjudicationTaskId: string;
+  reason: string;
+  decidedAt: FindingObservation;
+}
+
 export type ReviewerAnomalySettlement =
   | ReviewerAnomalyTargetSettlement
-  | ReviewerAnomalyReviewWithdrawalSettlement;
+  | ReviewerAnomalyReviewWithdrawalSettlement
+  | ReviewerAnomalyAdjudicationSettlement;
 
 /**
  * 二系統台帳(review-integrity protocol)の review-integrity レコード。product finding

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -71,6 +71,9 @@ import { injectFindingConflictAdjudicationStep } from '../findings/adjudication-
 import { createFindingConflictAdjudicationRunner } from '../findings/adjudication-runner.js';
 import { rebindPendingManagerPublicationAtBootstrap } from '../findings/manager-commit.js';
 import { isOutstandingReviewerAnomaly } from '../findings/reviewer-anomalies.js';
+import {
+  classifyIntakeReviewIntegrityFailure,
+} from '../findings/review-integrity.js';
 import { listFindingReviewPublications } from '../findings/review-publication.js';
 import { compareBinaryStrings } from '../../../shared/utils/binary-string-comparator.js';
 import { ERROR_MESSAGES } from '../constants.js';
@@ -628,17 +631,9 @@ export class WorkflowEngine extends EventEmitter {
     reason: string;
     failure: import('../types.js').WorkflowStepFailureSummary;
   } | undefined {
-    const intakeAnomalies = anomalies.filter((anomaly) => (
-      anomaly.kind === 'intake-contract-incomplete'
-      && anomaly.intakeContract !== undefined
-    ));
-    if (intakeAnomalies.length === 0) {
-      return undefined;
-    }
-    const publications = listFindingReviewPublications(this.runPaths.reportsAbs);
     const presentationCounts = new Map<string, number>();
     const publicationIdsByAnomalyId = new Map<string, string[]>();
-    for (const publication of publications) {
+    for (const publication of listFindingReviewPublications(this.runPaths.reportsAbs)) {
       if (publication.presentationContext?.revision !== 2) continue;
       for (const anomalyId of publication.presentationContext.presentedReviewerAnomalyIds) {
         presentationCounts.set(anomalyId, (presentationCounts.get(anomalyId) ?? 0) + 1);
@@ -649,31 +644,17 @@ export class WorkflowEngine extends EventEmitter {
         publicationIdsByAnomalyId.set(anomalyId, publicationIds);
       }
     }
-    const unpresentedIds = intakeAnomalies
-      .filter((anomaly) => (presentationCounts.get(anomaly.id) ?? 0) === 0)
-      .map(({ id }) => id)
-      .sort(compareBinaryStrings);
-    const exhaustedIds = intakeAnomalies
-      .filter((anomaly) => (
-        anomaly.intakeContract!.terminalDisposition?.workflowOutcome === 'review_integrity_unresolved'
-        || (anomaly.intakeContract!.observationClass === 'claim-bearing'
-          && (presentationCounts.get(anomaly.id) ?? 0) >= anomaly.intakeContract!.presentationLimit)
-      ))
-      .map(({ id }) => id)
-      .sort(compareBinaryStrings);
-    if (unpresentedIds.length === 0 && exhaustedIds.length === 0) {
+    const classification = classifyIntakeReviewIntegrityFailure({
+      anomalies,
+      presentationCounts,
+    });
+    if (classification === undefined) {
       return undefined;
     }
-    const anomalyIds = intakeAnomalies.map(({ id }) => id).sort(compareBinaryStrings);
-    const publicationIds = [...new Set(intakeAnomalies.flatMap(({ id }) => (
+    const { code, reason, anomalyIds, unpresentedIds, classificationAuthorityIds } = classification;
+    const publicationIds = [...new Set(anomalyIds.flatMap((id) => (
       publicationIdsByAnomalyId.get(id) ?? []
     )))].sort(compareBinaryStrings);
-    const code = unpresentedIds.length > 0
-      ? 'review_integrity_unresolved_unpresented' as const
-      : 'restatement_exhausted_claim_bearing' as const;
-    const reason = code === 'review_integrity_unresolved_unpresented'
-      ? `Review-integrity reviewer anomaly restatement could not be presented for anomaly IDs: ${unpresentedIds.join(', ')}`
-      : `Review-integrity reviewer anomaly restatement limit was exhausted for anomaly IDs: ${exhaustedIds.join(', ')}`;
     return {
       reason,
       failure: createRunFailure({
@@ -686,9 +667,7 @@ export class WorkflowEngine extends EventEmitter {
             code,
             anomalyIds,
             unpresentedIds,
-            classificationAuthorityIds: [...new Set(intakeAnomalies.map(
-              ({ intakeContract }) => intakeContract!.classificationAuthorityId,
-            ))].sort(compareBinaryStrings),
+            classificationAuthorityIds,
             publicationIds,
           },
         },

--- a/src/core/workflow/findings/manager-commit-finalization.ts
+++ b/src/core/workflow/findings/manager-commit-finalization.ts
@@ -180,6 +180,8 @@ function applyReviewerAnomalyAdjudications(input: {
   adjudications: readonly ReviewerAnomalyAdjudicationDecision[];
   workflowTask: string;
   observation: FindingObservation;
+  /** 不採用になった裁定の理由。監査レポートへ載せるため呼び出し側が受け取る。 */
+  rejections: string[];
 }): FindingLedger {
   const anomalies = input.ledger.reviewerAnomalies;
   if (anomalies === undefined || input.adjudications.length === 0) {
@@ -205,13 +207,18 @@ function applyReviewerAnomalyAdjudications(input: {
       reason: adjudication.reason,
       decidedAt: input.observation,
     };
-    if (reviewerAnomalySettlementEligibilityViolation({
+    const violation = reviewerAnomalySettlementEligibilityViolation({
       projection: input.ledger,
       anomaly,
       settlement,
       sourceHead: { kind: 'projection' },
       workflowTaskDigest,
-    }) !== undefined) {
+    });
+    if (violation !== undefined) {
+      // 無言で捨てない。裁定が出たのに保存されなかった事実と理由を監査へ残す。
+      input.rejections.push(
+        `reviewerAnomalyAdjudications: anomaly "${anomaly.id}" rejected at save time: ${violation}`,
+      );
       return anomaly;
     }
     changed = true;
@@ -482,7 +489,10 @@ export function applyCommitLedgerStates(input: {
   ledger: FindingLedger;
   reviewerAnomalyLandings: ReviewerAnomalyLandingReport[];
   rejectedObservationAttachments: RejectedObservationAttachment[];
+  /** 保存時に不採用となった裁定の理由。manager validation report へ載せる。 */
+  adjudicationRejections: string[];
 } {
+  const adjudicationRejections: string[] = [];
   const rejectedObservations = classifyRejectedObservations(
     input.pendingRejectedObservations,
     input.settledLedger,
@@ -565,9 +575,11 @@ export function applyCommitLedgerStates(input: {
     adjudications: input.anomalyAdjudications,
     workflowTask: input.runInput.workflowTask,
     observation,
+    rejections: adjudicationRejections,
   });
   return {
     ledger: withAdjudications,
+    adjudicationRejections,
     reviewerAnomalyLandings: anomalySpecs.map((spec) => ({
       kind: spec.kind,
       stableKey: spec.stableKey,

--- a/src/core/workflow/findings/manager-commit-finalization.ts
+++ b/src/core/workflow/findings/manager-commit-finalization.ts
@@ -47,6 +47,12 @@ import {
 } from './resolution-renotification.js';
 import { resolveCurrentLifecycleObservationTarget } from './reviewer-anomaly-policy.js';
 import {
+  reviewerAnomalySettlementEligibilityViolation,
+} from '../../models/finding-reviewer-anomaly-settlement-policy.js';
+import type { ReviewerAnomalyAdjudicationSettlement } from '../../models/finding-types.js';
+import type { ReviewerAnomalyAdjudicationDecision } from './manager-task-contracts.js';
+import { computeWorkflowTaskDigest } from './task-scope-adjudication.js';
+import {
   listFindingReviewPublications,
   type CanonicalFindingReviewPublication,
 } from './review-publication.js';
@@ -159,6 +165,59 @@ function applyIntakeContractTerminalDispositions(input: {
     };
   });
   return changed ? { ...input.ledger, reviewerAnomalies } : input.ledger;
+}
+
+/**
+ * 裁定が却下した終端処分済み anomaly へ settlement を書き込む。
+ *
+ * 成立判定は書き込み先の台帳（このコミットで出来上がる配列）で行い、台帳側の
+ * 成立条件（reviewerAnomalySettlementEligibilityViolation）をそのまま使う。裁定を
+ * 出した時点と保存時点で状態がずれた anomaly（同ラウンドで昇格した等）は黙って
+ * 落とす — 決着済みを二重に決着させない。
+ */
+function applyReviewerAnomalyAdjudications(input: {
+  ledger: FindingLedger;
+  adjudications: readonly ReviewerAnomalyAdjudicationDecision[];
+  workflowTask: string;
+  observation: FindingObservation;
+}): FindingLedger {
+  const anomalies = input.ledger.reviewerAnomalies;
+  if (anomalies === undefined || input.adjudications.length === 0) {
+    return input.ledger;
+  }
+  const workflowTaskDigest = computeWorkflowTaskDigest(input.workflowTask);
+  const adjudicationByAnomalyId = new Map(
+    input.adjudications.map((adjudication) => [adjudication.anomalyId, adjudication] as const),
+  );
+  let changed = false;
+  const updated = anomalies.map((anomaly) => {
+    const adjudication = adjudicationByAnomalyId.get(anomaly.id);
+    if (adjudication === undefined) {
+      return anomaly;
+    }
+    const settlement: ReviewerAnomalyAdjudicationSettlement = {
+      kind: 'dismissed_by_terminal_adjudication',
+      basis: adjudication.basis,
+      taskQuote: adjudication.taskQuote,
+      workflowTaskDigest: adjudication.workflowTaskDigest,
+      claimQuote: adjudication.claimQuote,
+      adjudicationTaskId: adjudication.adjudicationTaskId,
+      reason: adjudication.reason,
+      decidedAt: input.observation,
+    };
+    if (reviewerAnomalySettlementEligibilityViolation({
+      projection: input.ledger,
+      anomaly,
+      settlement,
+      sourceHead: { kind: 'projection' },
+      workflowTaskDigest,
+    }) !== undefined) {
+      return anomaly;
+    }
+    changed = true;
+    return { ...anomaly, settlement };
+  });
+  return changed ? { ...input.ledger, reviewerAnomalies: updated } : input.ledger;
 }
 
 function classifyRejectedObservations(
@@ -418,6 +477,7 @@ export function applyCommitLedgerStates(input: {
   baseAnomalySpecs: ReviewerAnomalySpec[];
   pendingRejectedObservations: RawAdmissionEvaluation['pendingRejectedObservations'];
   verifiedEvidenceCandidates: RawAdmissionEvaluation['verifiedEvidenceCandidates'];
+  anomalyAdjudications: readonly ReviewerAnomalyAdjudicationDecision[];
 }): {
   ledger: FindingLedger;
   reviewerAnomalyLandings: ReviewerAnomalyLandingReport[];
@@ -498,8 +558,16 @@ export function applyCommitLedgerStates(input: {
     publicationIdsByReviewer,
     observation,
   });
-  return {
+  // 裁定は決着済みを触らないので、他の決着経路が全て終わった後の台帳で成立を
+  // 判定する（このコミットで昇格・取り下げになった anomaly は対象から落ちる）。
+  const withAdjudications = applyReviewerAnomalyAdjudications({
     ledger: withWithdrawals,
+    adjudications: input.anomalyAdjudications,
+    workflowTask: input.runInput.workflowTask,
+    observation,
+  });
+  return {
+    ledger: withAdjudications,
     reviewerAnomalyLandings: anomalySpecs.map((spec) => ({
       kind: spec.kind,
       stableKey: spec.stableKey,

--- a/src/core/workflow/findings/manager-commit-plan.ts
+++ b/src/core/workflow/findings/manager-commit-plan.ts
@@ -1388,6 +1388,7 @@ export function buildFindingManagerCommitMutation(
     baseAnomalySpecs: prepared.anomalySpecs,
     pendingRejectedObservations: admission.pendingRejectedObservations,
     verifiedEvidenceCandidates: admission.verifiedEvidenceCandidates,
+    anomalyAdjudications: params.managerDecision.anomalyAdjudications,
   });
   const finalizedLedger = appendRawFindingsWithCanonicalSnapshots({
     ledger: finalized.ledger,

--- a/src/core/workflow/findings/manager-commit-plan.ts
+++ b/src/core/workflow/findings/manager-commit-plan.ts
@@ -1412,7 +1412,11 @@ export function buildFindingManagerCommitMutation(
         cwd: input.cwd,
       }), interpretationPrepared),
       lifecycleManagerOutput: reconcilePlan.managerOutput,
-      staleRejections: [...staleRejections, ...reconcilePlan.normalizationRejections],
+      staleRejections: [
+        ...staleRejections,
+        ...reconcilePlan.normalizationRejections,
+        ...finalized.adjudicationRejections,
+      ],
       unsupportedRawFindingReports: revalidated.unsupportedRawFindingReports,
       admissionRejections: admission.admissionRejections,
       provisionalLandings,

--- a/src/core/workflow/findings/manager-contracts.ts
+++ b/src/core/workflow/findings/manager-contracts.ts
@@ -86,8 +86,18 @@ export interface InterpretationCaseRunResult {
   stats: InterpretationStatsReport;
 }
 
+import type {
+  ReviewerAnomalyAdjudicationDecision,
+} from './manager-task-contracts.js';
+
 export interface ManagerDecisionStageResult {
   managerOutput: FindingManagerOutput;
+  /**
+   * 終端処分済み reviewer anomaly の裁定却下。product finding の決定系
+   * （managerOutput）とは別系統なので合流させない — anomaly は findings 配列に
+   * 一切現れないレコードで、reconciler の不変条件も別物。
+   */
+  anomalyAdjudications: ReviewerAnomalyAdjudicationDecision[];
   conflictTargetHeads: Map<string, CapturedManagerConflictHead>;
   invalidAttempts: FindingManagerValidationAttemptReport[];
   cleanProvisionalSpecs: ProvisionalFindingSpec[];

--- a/src/core/workflow/findings/manager-decision.ts
+++ b/src/core/workflow/findings/manager-decision.ts
@@ -208,6 +208,7 @@ export async function runManagerDecisionStage(params: {
 
   return {
     managerOutput,
+    anomalyAdjudications: taskExecution?.anomalyAdjudications ?? [],
     conflictTargetHeads: taskExecution?.conflictTargetHeads ?? new Map(),
     invalidAttempts,
     cleanProvisionalSpecs,

--- a/src/core/workflow/findings/manager-decision.ts
+++ b/src/core/workflow/findings/manager-decision.ts
@@ -17,7 +17,10 @@ import type {
 import type { ManagerDecisionStageResult, RunFindingManagerForStepInput } from './manager-contracts.js';
 import { runInterpretationCases } from './interpretation-case-runner.js';
 import { assembleCleanManagerDecision } from './manager-clean-decision.js';
-import { runMainManagerTasks } from './manager-task-runner.js';
+import {
+  adjudicableReviewerAnomalies,
+  runMainManagerTasks,
+} from './manager-task-runner.js';
 import {
   hasLifecycleProductTransitionCapability,
   hasLifecycleTransitionIntent,
@@ -95,11 +98,20 @@ export async function runManagerDecisionStage(params: {
     });
     const hasDisputeClaims = hasDisputeClaimsHeading(input.priorStepResponseText);
     const hasActiveConflict = previousLedger.conflicts.some((conflict) => conflict.status === 'active');
+    // 裁定対象の anomaly も provider を呼ぶ理由になる。ここに含めないと、raw も
+    // dispute も conflict も無い最終ゲートのラウンド（＝裁定だけが用のある典型）で
+    // runMainManagerTasks が呼ばれず、権限があっても reviewer_anomaly task が
+    // 一度も生成されない。
+    const hasAdjudicableAnomaly = adjudicableReviewerAnomalies({
+      ledger: previousLedger,
+      managerAuthority: input.managerAuthority,
+    }).length > 0;
     const needsAgent = mechanical.residualRawFindings.length > 0
       || hasDisputeClaims
       || hasActiveConflict
       || invalidLocationCandidateFindingIds.size > 0
-      || dismissCandidateFindingIds.size > 0;
+      || dismissCandidateFindingIds.size > 0
+      || hasAdjudicableAnomaly;
 
     let initialInvalidAttempts: FindingManagerValidationAttemptReport[] = [];
     let taskExecution: Awaited<ReturnType<typeof runMainManagerTasks>> | undefined;

--- a/src/core/workflow/findings/manager-task-contracts.ts
+++ b/src/core/workflow/findings/manager-task-contracts.ts
@@ -222,6 +222,9 @@ export function parseFindingEntityBindingTaskOutput(
 export const MAIN_MANAGER_CONTROL_TASK_KINDS = [
   'finding_control',
   'conflict',
+  // 終端処分済み claim-bearing anomaly の裁定。terminal adjudication 権限が
+  // あるときだけ engine が発行する（権限が無ければ task 自体が作られない）。
+  'reviewer_anomaly',
 ] as const;
 
 export type MainManagerControlTaskKind = typeof MAIN_MANAGER_CONTROL_TASK_KINDS[number];
@@ -231,6 +234,7 @@ export const MAIN_MANAGER_CONTROL_INTENT_KINDS = [
   'conflict',
   'invalidate',
   'dismiss',
+  'adjudicate_anomaly',
 ] as const;
 
 export type MainManagerControlIntentKind =
@@ -314,11 +318,26 @@ const otherDismissResultSchema = z.object({
   evidence: z.string().min(1).max(2_048),
 }).strict();
 
+/**
+ * 終端処分済み anomaly の裁定却下。product finding の却下とは payload が別物
+ * （findingId ではなく anomalyId、根拠は task 引用と claim 引用の2本立て）なので
+ * union の別枝として持つ。findingId を要求する枝とは必須フィールドで排他になる。
+ */
+const reviewerAnomalyDismissResultSchema = z.object({
+  kind: z.literal('dismiss'),
+  anomalyId: z.string().min(1),
+  basis: z.literal('outside_task_scope'),
+  reason: z.string().min(1).max(2_048),
+  taskQuote: z.string().min(1).max(2_048),
+  claimQuote: z.string().min(1).max(2_048),
+}).strict();
+
 export const MainManagerControlTaskResultSchema = z.union([
   noActionResultSchema,
   disputeResultSchema,
   conflictResultSchema,
   invalidateResultSchema,
+  reviewerAnomalyDismissResultSchema,
   taskScopeDismissResultSchema,
   otherDismissResultSchema,
 ]);
@@ -326,6 +345,20 @@ export const MainManagerControlTaskResultSchema = z.union([
 export type MainManagerControlTaskResult = z.infer<
   typeof MainManagerControlTaskResultSchema
 >;
+
+/**
+ * 裁定が terminal adjudication 権限で下した anomaly 却下。engine が検証済みの
+ * 逐語引用と権限の出所（adjudicationTaskId）をそのまま台帳の settlement へ写す。
+ */
+export interface ReviewerAnomalyAdjudicationDecision {
+  anomalyId: string;
+  basis: 'outside_task_scope';
+  reason: string;
+  taskQuote: string;
+  claimQuote: string;
+  workflowTaskDigest: string;
+  adjudicationTaskId: string;
+}
 
 export interface MainManagerControlTaskOutput {
   taskId: string;
@@ -384,6 +417,19 @@ const controlResultJsonSchemas = [
       kind: { type: 'string', const: 'invalidate' },
       findingId: { type: 'string', minLength: 1 },
       evidence: { type: 'string', minLength: 1, maxLength: 2_048 },
+    },
+  },
+  {
+    type: 'object',
+    additionalProperties: false,
+    required: ['kind', 'anomalyId', 'basis', 'reason', 'taskQuote', 'claimQuote'],
+    properties: {
+      kind: { type: 'string', const: 'dismiss' },
+      anomalyId: { type: 'string', minLength: 1 },
+      basis: { type: 'string', const: 'outside_task_scope' },
+      reason: { type: 'string', minLength: 1, maxLength: 2_048 },
+      taskQuote: { type: 'string', minLength: 1, maxLength: 2_048 },
+      claimQuote: { type: 'string', minLength: 1, maxLength: 2_048 },
     },
   },
   {

--- a/src/core/workflow/findings/manager-task-runner.ts
+++ b/src/core/workflow/findings/manager-task-runner.ts
@@ -19,6 +19,9 @@ import {
 } from './manager-agent.js';
 import { buildFindingManagerControlTaskStep } from './manager-step.js';
 import {
+  reviewerAnomalyAdjudicationClaimTexts,
+} from '../../models/finding-reviewer-anomaly-settlement-policy.js';
+import {
   MAIN_MANAGER_INPUT_MAX_BYTES,
   MAIN_MANAGER_RAW_TASK_MAX_ITEMS,
   parseMainManagerControlTaskOutput,
@@ -29,6 +32,7 @@ import {
   type MainManagerControlTaskOutput,
   type MainManagerRawTask,
   type MainManagerRawTaskDecision,
+  type ReviewerAnomalyAdjudicationDecision,
 } from './manager-task-contracts.js';
 import {
   collectTaskScopeReportExcerpts,
@@ -54,6 +58,7 @@ import type {
   FindingProvisionalKind,
   FindingManagerTaskAudit,
   RawFinding,
+  ReviewerAnomalyEntry,
 } from './types.js';
 
 const CONTEXT_CANDIDATE_LIMITS = [16, 8, 4, 0] as const;
@@ -67,6 +72,8 @@ export interface MainManagerRawFailure {
 
 export interface MainManagerTaskExecution {
   decisions: FindingManagerDecisions;
+  /** 終端処分済み anomaly の裁定却下。product finding の決定とは別系統。 */
+  anomalyAdjudications: ReviewerAnomalyAdjudicationDecision[];
   conflictTargetHeads: Map<string, CapturedManagerConflictHead>;
   rawFailures: Map<string, MainManagerRawFailure>;
   invalidAttemptMessages: string[];
@@ -816,6 +823,24 @@ function boundedPriorTextForFinding(
   return priorStepResponseText.slice(start, start + CONTROL_PRIOR_TEXT_LIMIT);
 }
 
+/**
+ * 裁定にかけられる anomaly。「言い直しラダーを使い切った claim-bearing」だけで、
+ * 決着済み（昇格・settlement・非 claim-bearing の終端）は含めない。
+ * 台帳側の成立条件（reviewerAnomalySettlementEligibilityViolation）と同じ集合。
+ */
+export function adjudicableReviewerAnomalies(
+  ledger: FindingLedger,
+): ReviewerAnomalyEntry[] {
+  return (ledger.reviewerAnomalies ?? [])
+    .filter((anomaly) => (
+      anomaly.kind === 'intake-contract-incomplete'
+      && anomaly.intakeContract?.terminalDisposition?.workflowOutcome === 'review_integrity_unresolved'
+      && anomaly.promotedFindingId === undefined
+      && anomaly.settlement === undefined
+    ))
+    .sort((left, right) => compareBinaryStrings(left.id, right.id));
+}
+
 function controlTask(
   previousLedger: FindingLedger,
   reviewScopeSnapshotId: string,
@@ -828,13 +853,16 @@ function controlTask(
   const sortedIntents = [...candidateIntents].sort((left, right) => (
     compareBinaryStrings(left.intentId, right.intentId)
   ));
+  // reviewer anomaly は lifecycle を持たない別系統のレコードなので head は常に null。
   const targetHeads = new Map(sortedIds.map((entityId) => [
     entityId,
-    captureFindingLifecycleHead(
-      previousLedger,
-      kind === 'conflict' ? 'conflict' : 'finding',
-      entityId,
-    ) ?? null,
+    kind === 'reviewer_anomaly'
+      ? null
+      : captureFindingLifecycleHead(
+        previousLedger,
+        kind === 'conflict' ? 'conflict' : 'finding',
+        entityId,
+      ) ?? null,
   ]));
   const conflictEvidenceSetHashes = new Map(
     kind === 'conflict'
@@ -978,6 +1006,30 @@ export function createMainManagerControlTaskManifest(input: {
       taskScopeContext,
     ));
   }
+  // 終端処分済み claim-bearing anomaly の裁定枠。terminal adjudication 権限が
+  // 無いラウンドでは task 自体を作らない — 権限の無い呼び出しに「却下してよいか」を
+  // 問うと、返せない答えを毎ラウンド要求することになる。
+  if (input.managerAuthority === 'terminal_adjudication') {
+    for (const anomaly of adjudicableReviewerAnomalies(input.previousLedger)) {
+      tasks.push(controlTask(
+        input.previousLedger,
+        input.reviewScopeSnapshotId,
+        'reviewer_anomaly',
+        [anomaly.id],
+        [controlIntent(
+          'adjudicate_anomaly',
+          anomaly.id,
+          `Restatement ladder terminated unresolved: ${anomaly.intakeContract!.terminalDisposition!.reason}`,
+        )],
+        {
+          managerAuthority: input.managerAuthority,
+          workflowTaskDigest: computeWorkflowTaskDigest(input.workflowTask),
+          workflowTask: input.workflowTask,
+          reportExcerpts: [],
+        },
+      ));
+    }
+  }
   for (const conflict of [...input.previousLedger.conflicts]
     .filter((candidate) => candidate.status === 'active')
     .sort((left, right) => compareBinaryStrings(left.id, right.id))) {
@@ -1010,7 +1062,11 @@ function controlContextLedger(
       ? previousLedger.conflicts
         .filter((conflict) => task.ownedEntityIds.includes(conflict.id))
         .flatMap((conflict) => conflict.findingIds)
-      : task.ownedEntityIds,
+      // reviewer anomaly は product finding ではないので finding 射影は空にする。
+      // 対象の本文は「Recorded reviewer anomaly claims」で別途渡す。
+      : task.kind === 'reviewer_anomaly'
+        ? []
+        : task.ownedEntityIds,
   );
   const selectedConflicts = previousLedger.conflicts
     .filter((conflict) => (
@@ -1041,6 +1097,11 @@ function buildControlTaskInstruction(input: {
       ? ['Dismissal is applied only through verified terminal adjudication. Return no_action here and leave the claim open.']
       : ['Dismissal is not authorized in this control task. Return no_action and leave the claim open.'];
   const taskScopeContext = input.task.taskScopeContext;
+  const adjudicatedAnomalies = input.task.kind === 'reviewer_anomaly'
+    ? (input.previousLedger.reviewerAnomalies ?? []).filter(
+      (anomaly) => input.task.ownedEntityIds.includes(anomaly.id),
+    )
+    : [];
   return [
     input.contract.manager.instruction,
     '',
@@ -1049,6 +1110,23 @@ function buildControlTaskInstruction(input: {
     'Return exactly one object whose only top-level fields are taskId, evaluations, and selectedIntentId. Do not return rawDecisions, dismissDecisions, or any other legacy envelope field.',
     'Each evaluations entry must contain exactly intentId and result. Exact-cover every candidate intent.',
     'An outside_task_scope result has exactly this shape: {"kind":"dismiss","findingId":"<intent entityId>","basis":"outside_task_scope","reason":"<separate reason>","taskQuote":"<non-empty byte-exact workflow task substring>"}. It has no evidence field.',
+    ...(input.task.kind !== 'reviewer_anomaly' ? [] : [
+      '',
+      '## Reviewer anomaly adjudication',
+      'This task adjudicates a reviewer anomaly, not a product finding. A reviewer anomaly is a claim a reviewer raised that never became a machine-verifiable product finding; its restatement ladder is over, so it now blocks completion as a visible review-integrity failure.',
+      'Dismiss it only when the claim is outside the scope of the original workflow task. If the claim is in scope, return no_action and let the run fail visibly — an in-scope claim that could not be substantiated is a real review-integrity failure, not something to wave through.',
+      'A reviewer anomaly dismissal has exactly this shape: {"kind":"dismiss","anomalyId":"<intent entityId>","basis":"outside_task_scope","reason":"<separate reason>","taskQuote":"<non-empty byte-exact workflow task substring>","claimQuote":"<non-empty byte-exact substring of the recorded claim below>"}. It has no findingId and no evidence field.',
+      'Both quotes are verified byte-exact by the engine. Copy them verbatim; a paraphrase or a summary is rejected.',
+      '',
+      '### Recorded reviewer anomaly claims',
+      renderFencedJsonBlock(adjudicatedAnomalies.map((anomaly) => ({
+        anomalyId: anomaly.id,
+        reviewers: anomaly.reviewers,
+        title: anomaly.title,
+        recordedClaim: reviewerAnomalyAdjudicationClaimTexts(input.previousLedger, anomaly),
+        terminalDisposition: anomaly.intakeContract?.terminalDisposition,
+      }))),
+    ]),
     '',
     'This is one engine-owned control task. Return the exact taskId and exact-cover evaluations for every candidate intent.',
     'Set selectedIntentId to null when every evaluation is no_action. Otherwise select exactly one intent, return its matching action, and return no_action for every other intent.',
@@ -1100,7 +1178,11 @@ function buildControlTaskInstruction(input: {
 function validateControlTaskOutput(
   task: MainManagerControlTask,
   output: MainManagerControlTaskOutput,
+  previousLedger: FindingLedger,
 ): MainManagerControlTaskOutput['evaluations'] {
+  const anomalyById = new Map(
+    (previousLedger.reviewerAnomalies ?? []).map((anomaly) => [anomaly.id, anomaly] as const),
+  );
   if (output.taskId !== task.taskId) {
     throw new Error(`Control task "${task.taskId}" returned mismatched taskId "${output.taskId}"`);
   }
@@ -1132,7 +1214,8 @@ function validateControlTaskOutput(
     const kindMatches = (
       (intent.kind === 'dispute' && (result.kind === 'waive' || result.kind === 'note'))
       || (intent.kind === 'conflict' && (result.kind === 'resolve' || result.kind === 'keep'))
-      || intent.kind === result.kind
+      || (intent.kind === 'adjudicate_anomaly' && result.kind === 'dismiss' && 'anomalyId' in result)
+      || (intent.kind === result.kind && !('anomalyId' in result))
     );
     if (!kindMatches) {
       throw new Error(
@@ -1148,6 +1231,25 @@ function validateControlTaskOutput(
       throw new Error(
         `Control intent "${intent.intentId}" returned out-of-scope conflict "${result.conflictId}"`,
       );
+    }
+    if ('anomalyId' in result) {
+      if (result.anomalyId !== intent.entityId) {
+        throw new Error(
+          `Control intent "${intent.intentId}" returned out-of-scope reviewer anomaly "${result.anomalyId}"`,
+        );
+      }
+      // 記録済みの claim 本文に対する byte-exact 部分文字列であること。裁定が実在の
+      // 主張を読んだ証跡で、要約や言い換えは根拠にならない。
+      const anomaly = anomalyById.get(result.anomalyId);
+      if (
+        anomaly === undefined
+        || !reviewerAnomalyAdjudicationClaimTexts(previousLedger, anomaly)
+          .some((text) => text.includes(result.claimQuote))
+      ) {
+        throw new Error(
+          `Control intent "${intent.intentId}" returned a claimQuote that is not a byte-exact quote of the recorded claim`,
+        );
+      }
     }
     if (
       result.kind === 'dismiss'
@@ -1170,6 +1272,7 @@ function validateControlTaskOutput(
 
 function appendControlResult(
   decisions: FindingManagerDecisions,
+  anomalyAdjudications: ReviewerAnomalyAdjudicationDecision[],
   result: MainManagerControlTaskOutput['evaluations'][number]['result'],
   task: MainManagerControlTask,
 ): void {
@@ -1200,6 +1303,23 @@ function appendControlResult(
       });
       return;
     case 'dismiss':
+      if ('anomalyId' in result) {
+        if (task.taskScopeContext === undefined) {
+          throw new Error(
+            `Control task "${task.taskId}" lacks an outside_task_scope binding`,
+          );
+        }
+        anomalyAdjudications.push({
+          anomalyId: result.anomalyId,
+          basis: result.basis,
+          reason: result.reason,
+          taskQuote: result.taskQuote,
+          claimQuote: result.claimQuote,
+          workflowTaskDigest: task.taskScopeContext.workflowTaskDigest,
+          adjudicationTaskId: task.taskId,
+        });
+        return;
+      }
       if (result.basis === 'outside_task_scope') {
         if (task.taskScopeContext === undefined) {
           throw new Error(
@@ -1239,11 +1359,13 @@ async function executeControlTasks(input: {
   subResults: RunFindingManagerForStepInput['subResults'];
 }): Promise<{
   decisions: FindingManagerDecisions;
+  anomalyAdjudications: ReviewerAnomalyAdjudicationDecision[];
   conflictTargetHeads: Map<string, CapturedManagerConflictHead>;
   invalidAttemptMessages: string[];
   audits: FindingManagerTaskAudit[];
 }> {
   const decisions = emptyDecisions();
+  const anomalyAdjudications: ReviewerAnomalyAdjudicationDecision[] = [];
   const conflictTargetHeads = new Map<string, CapturedManagerConflictHead>();
   const invalidAttemptMessages: string[] = [];
   const audits: FindingManagerTaskAudit[] = [];
@@ -1287,9 +1409,9 @@ async function executeControlTasks(input: {
       const output = parseMainManagerControlTaskOutput(
         responseStructuredOutput(response, `Control task "${item.task.taskId}"`),
       );
-      const evaluations = validateControlTaskOutput(item.task, output);
+      const evaluations = validateControlTaskOutput(item.task, output, input.previousLedger);
       for (const evaluation of evaluations) {
-        appendControlResult(decisions, evaluation.result, item.task);
+        appendControlResult(decisions, anomalyAdjudications, evaluation.result, item.task);
         if (
           evaluation.result.kind === 'resolve'
           || evaluation.result.kind === 'keep'
@@ -1328,7 +1450,7 @@ async function executeControlTasks(input: {
       });
     }
   }
-  return { decisions, conflictTargetHeads, invalidAttemptMessages, audits };
+  return { decisions, anomalyAdjudications, conflictTargetHeads, invalidAttemptMessages, audits };
 }
 
 function assertFixedPrefixFits(input: {
@@ -1421,6 +1543,7 @@ export async function runMainManagerTasks(input: {
       duplicateDecisions: control.decisions.duplicateDecisions,
       dismissDecisions: control.decisions.dismissDecisions,
     },
+    anomalyAdjudications: control.anomalyAdjudications,
     conflictTargetHeads: control.conflictTargetHeads,
     rawFailures: raw.failures,
     invalidAttemptMessages: [

--- a/src/core/workflow/findings/manager-task-runner.ts
+++ b/src/core/workflow/findings/manager-task-runner.ts
@@ -19,6 +19,7 @@ import {
 } from './manager-agent.js';
 import { buildFindingManagerControlTaskStep } from './manager-step.js';
 import {
+  isAdjudicableReviewerAnomaly,
   reviewerAnomalyAdjudicationClaimTexts,
 } from '../../models/finding-reviewer-anomaly-settlement-policy.js';
 import {
@@ -824,20 +825,21 @@ function boundedPriorTextForFinding(
 }
 
 /**
- * 裁定にかけられる anomaly。「言い直しラダーを使い切った claim-bearing」だけで、
- * 決着済み（昇格・settlement・非 claim-bearing の終端）は含めない。
- * 台帳側の成立条件（reviewerAnomalySettlementEligibilityViolation）と同じ集合。
+ * このラウンドで裁定へ出す anomaly。権限の判定込みの唯一の入口で、
+ * manifest（task を作るか）と needsAgent（そもそも provider を呼ぶか）が共有する。
+ * 片方だけが条件を持つと、権限があるのに task が作られないラウンドが生まれる。
+ *
+ * 適格性そのものは台帳側の成立条件と同じ述語（isAdjudicableReviewerAnomaly）を使う。
  */
-export function adjudicableReviewerAnomalies(
-  ledger: FindingLedger,
-): ReviewerAnomalyEntry[] {
-  return (ledger.reviewerAnomalies ?? [])
-    .filter((anomaly) => (
-      anomaly.kind === 'intake-contract-incomplete'
-      && anomaly.intakeContract?.terminalDisposition?.workflowOutcome === 'review_integrity_unresolved'
-      && anomaly.promotedFindingId === undefined
-      && anomaly.settlement === undefined
-    ))
+export function adjudicableReviewerAnomalies(input: {
+  ledger: FindingLedger;
+  managerAuthority: RunFindingManagerForStepInput['managerAuthority'];
+}): ReviewerAnomalyEntry[] {
+  if (input.managerAuthority !== 'terminal_adjudication') {
+    return [];
+  }
+  return (input.ledger.reviewerAnomalies ?? [])
+    .filter(isAdjudicableReviewerAnomaly)
     .sort((left, right) => compareBinaryStrings(left.id, right.id));
 }
 
@@ -1009,8 +1011,11 @@ export function createMainManagerControlTaskManifest(input: {
   // 終端処分済み claim-bearing anomaly の裁定枠。terminal adjudication 権限が
   // 無いラウンドでは task 自体を作らない — 権限の無い呼び出しに「却下してよいか」を
   // 問うと、返せない答えを毎ラウンド要求することになる。
-  if (input.managerAuthority === 'terminal_adjudication') {
-    for (const anomaly of adjudicableReviewerAnomalies(input.previousLedger)) {
+  {
+    for (const anomaly of adjudicableReviewerAnomalies({
+      ledger: input.previousLedger,
+      managerAuthority: input.managerAuthority,
+    })) {
       tasks.push(controlTask(
         input.previousLedger,
         input.reviewScopeSnapshotId,
@@ -1022,7 +1027,7 @@ export function createMainManagerControlTaskManifest(input: {
           `Restatement ladder terminated unresolved: ${anomaly.intakeContract!.terminalDisposition!.reason}`,
         )],
         {
-          managerAuthority: input.managerAuthority,
+          managerAuthority: 'terminal_adjudication',
           workflowTaskDigest: computeWorkflowTaskDigest(input.workflowTask),
           workflowTask: input.workflowTask,
           reportExcerpts: [],
@@ -1109,7 +1114,11 @@ function buildControlTaskInstruction(input: {
     'The Finding Manager instruction above may describe a legacy rawDecisions/dismissDecisions envelope. That envelope is disabled for this control task.',
     'Return exactly one object whose only top-level fields are taskId, evaluations, and selectedIntentId. Do not return rawDecisions, dismissDecisions, or any other legacy envelope field.',
     'Each evaluations entry must contain exactly intentId and result. Exact-cover every candidate intent.',
-    'An outside_task_scope result has exactly this shape: {"kind":"dismiss","findingId":"<intent entityId>","basis":"outside_task_scope","reason":"<separate reason>","taskQuote":"<non-empty byte-exact workflow task substring>"}. It has no evidence field.',
+    // findingId 形式の却下は product finding 用。reviewer anomaly の task で併記すると
+    // 必ず validation で落ちる形状を同時に提示することになるので出さない。
+    ...(input.task.kind === 'reviewer_anomaly' ? [] : [
+      'An outside_task_scope result has exactly this shape: {"kind":"dismiss","findingId":"<intent entityId>","basis":"outside_task_scope","reason":"<separate reason>","taskQuote":"<non-empty byte-exact workflow task substring>"}. It has no evidence field.',
+    ]),
     ...(input.task.kind !== 'reviewer_anomaly' ? [] : [
       '',
       '## Reviewer anomaly adjudication',

--- a/src/core/workflow/findings/review-integrity.ts
+++ b/src/core/workflow/findings/review-integrity.ts
@@ -22,9 +22,14 @@ import type {
   FindingContractReviewBudgetConfig,
   FindingLedger,
   FindingLedgerReviewIntegrityState,
+  ReviewerAnomalyEntry,
 } from './types.js';
 import { addRoundMarker } from './round-marker.js';
 import { isOutstandingReviewerAnomaly } from './reviewer-anomalies.js';
+import {
+  isConcludedReviewerAnomaly,
+} from '../../models/finding-reviewer-anomaly-settlement-policy.js';
+import { compareBinaryStrings } from '../../../shared/utils/binary-string-comparator.js';
 
 /**
  * finding_contract.review_budget が省略した場合の既定値。「無制限を許さない」
@@ -58,6 +63,79 @@ export function reviewIntegrityRoundsCompleted(ledger: FindingLedger): number {
 /** 未昇格かつ未settleの reviewer anomaly が1件でも残っているか。 */
 function hasOutstandingReviewerAnomalies(ledger: FindingLedger): boolean {
   return (ledger.reviewerAnomalies ?? []).some(isOutstandingReviewerAnomaly);
+}
+
+export type IntakeReviewIntegrityFailureCode =
+  | 'review_integrity_unresolved_unpresented'
+  | 'restatement_exhausted_claim_bearing';
+
+export interface IntakeReviewIntegrityFailureClassification {
+  readonly code: IntakeReviewIntegrityFailureCode;
+  readonly reason: string;
+  readonly anomalyIds: string[];
+  readonly unpresentedIds: string[];
+  readonly classificationAuthorityIds: string[];
+}
+
+/**
+ * 完了直前の review-integrity ゲートが、残った intake anomaly をどう診断するか。
+ *
+ * 2つの原因を区別する:
+ *   - `unpresented`: 言い直しの機会が一度も与えられていない（ワークフローの配線漏れ）
+ *   - `exhausted`: 提示ラダーが終わり、終端処分として決着している（可視的失敗）
+ *
+ * 終端処分済み（intakeContract.terminalDisposition あり）は unpresented の対象から
+ * 外す。提示回数は終端処分の判定材料であって、決着後の診断材料ではない —
+ * `undemandable_claim_atom` は提示を1回も行わずに終端する正規の kind なので、
+ * 提示回数をどう数え直しても「提示されていない」は真にならない。ここで外さないと、
+ * 決着済みの anomaly が常に配線漏れとして報告され、診断が原因を指さなくなる。
+ *
+ * 純関数。提示回数の収集（IO）は呼び出し側が行う。
+ */
+export function classifyIntakeReviewIntegrityFailure(input: {
+  /** 未決着の reviewer anomaly（isOutstandingReviewerAnomaly で絞り込み済み）。 */
+  readonly anomalies: readonly ReviewerAnomalyEntry[];
+  readonly presentationCounts: ReadonlyMap<string, number>;
+}): IntakeReviewIntegrityFailureClassification | undefined {
+  const intakeAnomalies = input.anomalies.filter((anomaly) => (
+    anomaly.kind === 'intake-contract-incomplete'
+    && anomaly.intakeContract !== undefined
+  ));
+  if (intakeAnomalies.length === 0) {
+    return undefined;
+  }
+  const unpresentedIds = intakeAnomalies
+    .filter((anomaly) => (
+      !isConcludedReviewerAnomaly(anomaly)
+      && (input.presentationCounts.get(anomaly.id) ?? 0) === 0
+    ))
+    .map(({ id }) => id)
+    .sort(compareBinaryStrings);
+  const exhaustedIds = intakeAnomalies
+    .filter((anomaly) => (
+      anomaly.intakeContract!.terminalDisposition?.workflowOutcome === 'review_integrity_unresolved'
+      || (anomaly.intakeContract!.observationClass === 'claim-bearing'
+        && (input.presentationCounts.get(anomaly.id) ?? 0) >= anomaly.intakeContract!.presentationLimit)
+    ))
+    .map(({ id }) => id)
+    .sort(compareBinaryStrings);
+  if (unpresentedIds.length === 0 && exhaustedIds.length === 0) {
+    return undefined;
+  }
+  const code: IntakeReviewIntegrityFailureCode = unpresentedIds.length > 0
+    ? 'review_integrity_unresolved_unpresented'
+    : 'restatement_exhausted_claim_bearing';
+  return {
+    code,
+    reason: code === 'review_integrity_unresolved_unpresented'
+      ? `Review-integrity reviewer anomaly restatement could not be presented for anomaly IDs: ${unpresentedIds.join(', ')}`
+      : `Review-integrity reviewer anomaly restatement limit was exhausted for anomaly IDs: ${exhaustedIds.join(', ')}`,
+    anomalyIds: intakeAnomalies.map(({ id }) => id).sort(compareBinaryStrings),
+    unpresentedIds,
+    classificationAuthorityIds: [...new Set(intakeAnomalies.map(
+      ({ intakeContract }) => intakeContract!.classificationAuthorityId,
+    ))].sort(compareBinaryStrings),
+  };
 }
 
 /**


### PR DESCRIPTION
## 事象

resume した run が COMPLETE 遷移直前の review-integrity ゲートで abort。

```
Review-integrity reviewer anomaly restatement could not be presented for anomaly IDs: RA-2C89260D5D8E, RA-67A2D73530C5
```

この2件は終端処分済み（`restatement_exhausted_claim_bearing` /
`review_integrity_unresolved`）の claim-bearing anomaly。「一度も提示されていない
（＝ワークフローの配線漏れ）」は事実に反し、診断が原因を指していない。

## この PR で直すもの — ゲートの誤診

検証 run（`20260807-213705-implement-using-only-the-files-0wl0ym`）の台帳と report
ツリーから確認した事実。

- publication は workflow_call の子の namespace 配下にある
  （`reports/subworkflows/…--step-initial-reviewers--…/.takt-report-internal/finding-review-publications/`）。
  ゲートは `listFindingReviewPublications(this.runPaths.reportsAbs)` で**自 namespace
  しか見ない**ため、トップレベルのゲートからは提示回数が常に 0 件に見える。
- 結果、決着済みの anomaly が毎回 unpresented 判定に落ち、`exhausted` 側の正しい
  code/message が出ない（両方の条件が成立していても unpresented が優先される）。

### 採った修正と、その設計判断

**決着済み（`intakeContract.terminalDisposition` あり）を unpresented の判定対象から
外す**。namespace 横断で数え直す案は採らなかった。理由:

1. `undemandable_claim_atom` は**提示を1回も行わずに終端する正規の kind**である。
   提示回数をどこから何件数え直しても「提示された」は真にならないので、数え口を
   直しても決着済みは unpresented と誤診され続ける。除外でしか正しく診断できない。
2. 提示回数は終端処分を**決める**ための材料であって、決着した後の診断材料ではない。
   決着後に提示回数を問うのは分類の誤りで、これは #1232 で入れた「終端は終端」
   （提示対象選定・提示系ルールカウンタから決着済みを外す）と同じ規則の適用先違い。

未決着の intake anomaly についてはゲートの提示回数が namespace ローカルのままである
点は残る（`refreshFindingsState` の提示カウンタも同じ局所性を持つ）。これは診断の
truthfulness には影響せず（未決着なら unpresented 判定自体が正しい fail-closed）、
予算計上の意味論に触れる別変更なので本 PR には入れていない。後述の follow-up 参照。

### 構造

診断の分類を `WorkflowEngine` の private メソッドから
`classifyIntakeReviewIntegrityFailure`（純関数、`findings/review-integrity.ts`）へ
切り出した。エンジン側は publication の収集（IO）だけを持つ。単体で赤緑が取れる。

## テスト（いずれも修正を外すと赤）

- `reports the exhausted cause for a terminally disposed anomaly instead of an unpresented one`
  — 提示回数 0 件（別 namespace で提示済み）でも code は `restatement_exhausted_claim_bearing`、
  `unpresentedIds` は空
- `reports the exhausted cause for a terminal that never demanded a presentation`
  — `undemandable_claim_atom`。数え直しでは直せないケース
- `still reports the unpresented cause while the anomaly is open`
  — 正の対照。未決着なら unpresented のまま（配線漏れ検出を失わない）

## ゲート

- `npm run build` — pass
- `npm run lint` — pass
- `finding-fc-intake-contract` 40/40 pass、`finding-reviewer-anomaly-settlement` /
  `finding-fc-restatement-slot` / `finding-contract-phase1` /
  `finding-loop-monitor-summary` / `finding-convergence` /
  `finding-stop-budget.integration` pass
- `finding-review-integrity-gate.test.ts` の
  `review_budget 枯渇後は replan → …` はこの環境で timeout するが、**main（本 PR の
  src 変更を stash した状態）でも同じく timeout する**ことを同一マシンで確認済み
  （baseline 253s / 変更後 190s、いずれも 60s の test timeout に到達）。本 PR の
  変更対象は intake anomaly の分類のみで、当該テストの anomaly は `quote-mismatch`
  （非 intake）のため分類器は従来どおり `undefined` を返す経路に入る。

## 本丸: 終端処分済み anomaly の裁定却下経路（engine wire 拡張）

### なぜ配線ではなく能力の追加なのか

- adjudicator の structured output 語彙は `promote_independent` / `merge_existing` /
  `dismiss` / `undetermined` の4種で、payload が全て product finding 参照
  （`finding-schemas.ts:1732-1761`）。
- 候補選定 `selectTerminalAdjudicationCandidates` は `ledger.findings` のみを走査し、
  `open` かつ `provisional` かつ特定 kind に限る
  （`terminal-adjudication-candidates.ts:181-189`）。reviewer anomaly は構造上
  候補にならない。実 run でも terminal adjudication ラウンドが 9 回作られて members は
  全て 0 件だった。
- `ReviewerAnomalySettlement` の adjudication 由来は
  `target_dismissed_by_terminal_adjudication` だけで、これは anomaly が**参照する
  product finding** が dismiss されたときに派生的に付く。今回の anomaly は
  `relation: null` の新規主張で対象 finding を持たないため成立しない。
- builtin もこれを意図的な行き止まりとして実装していた（ladder コメントに
  「terminal adjudication でも解消できない」）。

### 追加したもの

| 層 | 変更 |
|---|---|
| wire | `reviewer_anomaly` control task（`finding_control` / `conflict` と同列）。発行は `managerAuthority === 'terminal_adjudication'` のラウンドだけ。対象は終端処分済み claim-bearing のみ |
| 決着語彙 | `{no_action \| dismiss}`。dismiss の根拠は workflow task の byte-exact 引用 + anomaly の記録済み claim の byte-exact 引用の2本立て。要約・言い換えは wire 検証で弾く |
| 台帳 | 新 settlement 種別 `dismissed_by_terminal_adjudication`（Zod + eligibility + 不変条件）。成立条件は終端処分済み claim-bearing に限定し、`workflowTaskDigest` と claim 引用を再検証 |
| commit | 裁定は `FindingManagerOutput` へ合流させず別系統 `anomalyAdjudications` として運び、他の決着経路が全て終わった後の台帳で成立を再判定してから書き込む |
| builtin | final gate（ja/en）の ladder コメントを新しい意味論へ更新。裁定が却下しなかった anomaly は従来どおり COMPLETE へ送って可視的失敗にする |

基礎語彙は `outside_task_scope` の1つだけにした。台帳と workflow task という
engine が保持するテキストに対する byte-exact 照合だけで完結し、新しい証拠検証機構を
必要としない唯一の基礎だから。他の基礎（refutation 系）は engine proof の発行が
必要で、増やすなら別の設計判断が要る。

### 不変条件は緩めていない

終端処分と同居してよい決着は「終端処分を成立条件に持つ裁定却下」だけに限定した。
昇格・検証済み解消・後続レビュー取り下げの同居禁止は据え置きで、提示が止まらず昇格が
後付けされた実事故（#1232）を捕まえた検査はそのまま効く。この限定は回帰テストで固定
してある（`keeps forbidding a non-adjudication settlement on a terminally disposed anomaly`）。

### 自動救済はしない

終端処分済みは可視的失敗が既定。決着するのは裁定却下だけで、裁定が「範囲内の主張だ」と
判断すれば run は従来どおり失敗する。「終端処分済み = 自動 settle」の経路は作っていない。

### 追加テスト

- `lets the completion gate pass once terminal adjudication dismissed the anomaly`
  — 裁定 settle → 台帳不変条件 OK → 未決着でなくなる → 完了ゲート通過
- `refuses an adjudication with %s`（claim 引用が言い換え / 別 task の digest）
- `refuses to adjudicate an anomaly whose restatement ladder is still open`
- `keeps forbidding a non-adjudication settlement on a terminally disposed anomaly`
- `issues the adjudication task only when the call holds terminal authority`
- `accepts a dismissal whose quotes are byte-exact` / `rejects a dismissal whose claim quote is a paraphrase`

### follow-up 候補

- ゲートと `refreshFindingsState` の提示回数が namespace ローカルである点。未決着
  anomaly の診断精度に影響するが、予算計上の意味論に触れるため別途設計判断が要る


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 終端済みのレビュー異常を、終端裁定によって却下できるようになりました。
  - 裁定結果は通常の却下処理と分離して記録され、対象外の異常が再提示されるのを防止します。
  - 引用内容の厳密な一致を検証し、不正な裁定や不適切な決着を拒否します。
  - レビュー整合性エラーの分類精度を向上しました。

- **テスト**
  - 終端裁定、無効な裁定、異常の再提示防止に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->