### PR TITLE
[#1208] capabilities の複数指定対応と実行時配線の修正

### DIFF
--- a/builtins/skill/references/yaml-schema.md
+++ b/builtins/skill/references/yaml-schema.md
@@ -16,6 +16,11 @@ workflow_config:
     codex:
       network_access: true
 
+# 能力プリセット参照（任意）。全 step の既定。step / parallel サブステップにも書け、
+# step 側は既定を置換する。リストは左から右へマージし後勝ち。
+# 同梱プリセット: readonly / edit / enable-skills
+capabilities: readonly
+
 # セクションマップ（キー → ファイルパスの対応表）
 policies:                     # ポリシー定義（任意）
   coding: ../policies/coding.md
@@ -66,6 +71,7 @@ fragment root の `params` は必須の型付き parameter を宣言し、`uses`
   session: refresh             # セッション管理: continue / refresh / compact（任意）
   pass_previous_response: true # 前の出力を渡すか（デフォルト: true）
   allowed_tools: [...]         # 許可ツール一覧（任意、参考情報）
+  capabilities: readonly       # 能力プリセット参照（任意）。名前かリスト。workflow 既定を置換する
   output_contracts: [...]      # 出力契約設定（任意）
   quality_gates: [...]         # agent step 用の品質 gate（文字列指示 / command gate、任意）
   rules: [...]                 # 遷移ルール（必須）

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -1019,7 +1019,7 @@ workflow_config:
 ```yaml
 workflow_config:
   provider_options:
-    extends: review-readonly
+    extends: readonly
 
 steps:
   - name: implement
@@ -1039,6 +1039,23 @@ claude:
 opencode:
   allowed_tools: [read, glob, grep, bash, websearch, webfetch]
 ```
+
+### `capabilities`
+
+`capabilities` は、step の能力（ツール許可リスト・network access・sandbox・skills）を与える provider-options プリセットを1つ以上名前で参照します。`provider_options` の参照専用形で、値はプリセット名（または名前のリスト）のみで、inline の options block は書けません。受理されるのは能力 leaf（`allowed_tools` / `network_access` / `sandbox` / `skills`）だけで、品質系・マシン固有系の leaf（`effort`、`base_url`、`guards` など）を含むプリセットはロード時に fail fast します。それらは `runtime.yaml` に置きます。
+
+このキーは workflow トップレベル（全 step の既定）、step、parallel サブステップの3箇所に書けます。step 自身の `capabilities` は workflow 既定とマージせず置換します。リストは左から右へマージされ、同じ leaf を宣言している場合は後の名前が勝ちます。
+
+```yaml
+capabilities: readonly
+
+steps:
+  - name: implement
+    capabilities: [edit, enable-skills]
+```
+
+プリセットの解決は `provider_options.extends` と同一です（project → global → builtins、repertoire package スコープ対応）。同梱プリセットは `readonly`（読み取り・検索・シェル・Web 検索 + network access）、`edit`（`readonly` + ファイルの作成・編集）、`enable-skills`（Codex の repo/user skills）です。未解決の名前は fail fast します。`system` / `workflow_call` step は `capabilities` を拒否します。
+
 
 ### `workflow_config.runtime`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1032,7 +1032,7 @@ workflow_config:
 ```yaml
 workflow_config:
   provider_options:
-    extends: review-readonly
+    extends: readonly
 
 steps:
   - name: implement
@@ -1052,6 +1052,23 @@ claude:
 opencode:
   allowed_tools: [read, glob, grep, bash, websearch, webfetch]
 ```
+
+### `capabilities`
+
+`capabilities` names one or more provider-options presets that grant a step its abilities: tool allowlists, network access, sandbox, and skills. It is the reference-only form of `provider_options` — the value is a preset name (or a list of names), never an inline options block, and only capability leaves (`allowed_tools` / `network_access` / `sandbox` / `skills`) are accepted. A preset carrying a quality or machine leaf (`effort`, `base_url`, `guards`, ...) fails fast at load time; those belong in `runtime.yaml`.
+
+The key is available at the workflow top level (the default for every step), on a step, and on a parallel sub-step. A step's own `capabilities` replaces the workflow default rather than merging with it. A list merges its entries left to right, so a later name wins on a leaf both declare:
+
+```yaml
+capabilities: readonly
+
+steps:
+  - name: implement
+    capabilities: [edit, enable-skills]
+```
+
+Presets resolve exactly like `provider_options.extends` (project → global → builtins, with repertoire package scoping). The bundled presets are `readonly` (read, search, shell, and web lookup plus network access), `edit` (`readonly` plus file creation and editing), and `enable-skills` (Codex repo/user skills). An unresolved name fails fast. `system` and `workflow_call` steps reject `capabilities`.
+
 
 ### `workflow_config.runtime`
 

--- a/src/__tests__/engine-capabilities-provider-options.test.ts
+++ b/src/__tests__/engine-capabilities-provider-options.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { runAgent } from '../agents/runner.js';
 import { mockRuleEvaluation } from './rule-evaluator-test-double.js';
 import { WorkflowEngine } from '../core/workflow/engine/WorkflowEngine.js';
+import { GitSelectorCommandRunner } from '../infra/task/selector-git-command-runner.js';
 import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
 import { applyDefaultMocks, createTestTmpDir, makeResponse, mockRuleEvaluationSequence, mockRunAgentSequence } from './engine-test-helpers.js';
 
@@ -35,6 +37,12 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
  * 届いて初めて意味を持つ。ロード時の畳み込みだけを検証すると、エンジンが読まない
  * フィールドに乗ったまま実行時 no-op になる後退（実際に起きた）を見逃す。
  */
+
+const MOCK_SELECTOR_PROVIDER = {
+  provider: 'mock' as const,
+  providerOptions: {},
+  nativeTools: [],
+};
 
 let tmpDir: string;
 
@@ -201,5 +209,92 @@ describe('capabilities reach the final provider call', () => {
       claude: { allowedTools: ['Read', 'Grep'] },
       opencode: { networkAccess: true },
     });
+  });
+
+  it('should pass inherited and own capability options to runAgent when dynamic parallel runs fixed and pool sub-steps', async () => {
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'wf',
+        max_steps: 2,
+        initial_step: 'reviewers',
+        steps: [
+          {
+            name: 'reviewers',
+            capabilities: 'provider-options/inspect.yaml',
+            parallel: {
+              fixed: [
+                {
+                  name: 'fixed-inherits',
+                  persona: 'architecture',
+                  instruction: 'review architecture',
+                  rules: [{ condition: 'approved', next: 'COMPLETE' }],
+                },
+              ],
+              pool: [
+                {
+                  name: 'pool-declares-own',
+                  persona: 'frontend',
+                  description: 'frontend review',
+                  instruction: 'review frontend',
+                  capabilities: 'provider-options/writer.yaml',
+                  rules: [{ condition: 'approved', next: 'COMPLETE' }],
+                },
+                {
+                  name: 'pool-unselected',
+                  persona: 'backend',
+                  description: 'backend review',
+                  instruction: 'review backend',
+                  rules: [{ condition: 'approved', next: 'COMPLETE' }],
+                },
+              ],
+              selection: { mode: 'replace' },
+            },
+            rules: [{ condition: 'all("approved")', next: 'COMPLETE' }],
+          },
+        ],
+      },
+      tmpDir,
+    );
+    vi.mocked(runAgent).mockImplementation(async (persona, task, options) => {
+      if (options?.outputSchema) {
+        return makeResponse({
+          persona: persona ?? 'selector',
+          structuredOutput: { selected_ids: ['pool-declares-own'], rationale: 'frontend changed' },
+        });
+      }
+      options?.onPromptResolved?.({ systemPrompt: '', userInstruction: task });
+      return makeResponse({ persona: persona ?? 'reviewer', content: 'approved' });
+    });
+    vi.mocked(mockRuleEvaluation).mockReturnValue({ index: 0, method: 'phase3_tag' });
+
+    // dynamic parallel の selection snapshot は git 管理下の作業ツリーを前提とする
+    execFileSync('git', ['init', '--quiet'], { cwd: tmpDir });
+    writeFileSync(join(tmpDir, 'tracked.ts'), 'const x = 1;\n', 'utf-8');
+    execFileSync('git', ['add', 'tracked.ts'], { cwd: tmpDir });
+    execFileSync('git', ['-c', 'user.email=t@example.com', '-c', 'user.name=T', 'commit', '--quiet', '-m', 'init'], { cwd: tmpDir });
+
+    const engine = new WorkflowEngine(config, tmpDir, 'task', {
+      projectCwd: tmpDir,
+      provider: 'claude',
+      selectorProvider: MOCK_SELECTOR_PROVIDER,
+      selectorGitCommandRunner: new GitSelectorCommandRunner(),
+    });
+    const ran = await engine.run();
+
+    expect(ran.status).toBe('completed');
+    const byName = new Map(
+      vi.mocked(runAgent).mock.calls.map((call) => [
+        call[2].permissionResolution?.stepName,
+        call[2].providerOptions,
+      ]),
+    );
+    expect(byName.get('fixed-inherits')).toEqual({
+      claude: { allowedTools: ['Read', 'Grep'] },
+      opencode: { networkAccess: true },
+    });
+    expect(byName.get('pool-declares-own')).toEqual({
+      claude: { allowedTools: ['Read', 'Edit', 'Write'] },
+    });
+    expect(byName.has('pool-unselected')).toBe(false);
   });
 });

--- a/src/__tests__/engine-capabilities-provider-options.test.ts
+++ b/src/__tests__/engine-capabilities-provider-options.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runAgent } from '../agents/runner.js';
+import { mockRuleEvaluation } from './rule-evaluator-test-double.js';
+import { WorkflowEngine } from '../core/workflow/engine/WorkflowEngine.js';
+import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
+import { applyDefaultMocks, createTestTmpDir, makeResponse, mockRuleEvaluationSequence, mockRunAgentSequence } from './engine-test-helpers.js';
+
+vi.mock('../agents/runner.js', () => ({
+  runAgent: vi.fn(),
+}));
+
+vi.mock('../core/workflow/evaluation/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../core/workflow/evaluation/index.js')>();
+  const { MockRuleEvaluator } = await import('./rule-evaluator-test-double.js');
+  return {
+    ...actual,
+    RuleEvaluator: MockRuleEvaluator,
+  };
+});
+
+vi.mock('../core/workflow/phase-runner.js', () => ({
+  runReportPhase: vi.fn().mockResolvedValue(undefined),
+  runStatusJudgmentPhase: vi.fn().mockResolvedValue({ label: '', method: 'auto_select' }),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
+}));
+
+/**
+ * `capabilities:` は workflow YAML から最終的な runAgent 呼び出しの providerOptions まで
+ * 届いて初めて意味を持つ。ロード時の畳み込みだけを検証すると、エンジンが読まない
+ * フィールドに乗ったまま実行時 no-op になる後退（実際に起きた）を見逃す。
+ */
+
+let tmpDir: string;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  applyDefaultMocks();
+  tmpDir = createTestTmpDir();
+  mkdirSync(join(tmpDir, 'provider-options'), { recursive: true });
+  writeFileSync(
+    join(tmpDir, 'provider-options', 'inspect.yaml'),
+    'claude:\n  allowed_tools:\n    - Read\n    - Grep\nopencode:\n  network_access: true\n',
+  );
+  writeFileSync(
+    join(tmpDir, 'provider-options', 'writer.yaml'),
+    'claude:\n  allowed_tools:\n    - Read\n    - Edit\n    - Write\n',
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function agentOptionsOfCall(index: number) {
+  return vi.mocked(runAgent).mock.calls[index]![2];
+}
+
+describe('capabilities reach the final provider call', () => {
+  it('should pass the resolved capability options to runAgent when a step declares capabilities', async () => {
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'wf',
+        max_steps: 2,
+        initial_step: 'plan',
+        steps: [
+          {
+            name: 'plan',
+            instruction: '{task}',
+            capabilities: 'provider-options/inspect.yaml',
+            rules: [{ condition: 'done', next: 'COMPLETE' }],
+          },
+        ],
+      },
+      tmpDir,
+    );
+    mockRunAgentSequence([makeResponse({ persona: 'agent', content: 'done' })]);
+    mockRuleEvaluationSequence([{ index: 0, method: 'phase3_tag' }]);
+
+    const state = await new WorkflowEngine(config, tmpDir, 'task', {
+      projectCwd: tmpDir,
+      provider: 'claude',
+    }).run();
+
+    expect(state.status).toBe('completed');
+    expect(agentOptionsOfCall(0).providerOptions).toEqual({
+      claude: { allowedTools: ['Read', 'Grep'] },
+      opencode: { networkAccess: true },
+    });
+  });
+
+  it('should pass the parent capability options to runAgent when a parallel sub-step declares none', async () => {
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'wf',
+        max_steps: 2,
+        initial_step: 'review',
+        capabilities: 'provider-options/writer.yaml',
+        steps: [
+          {
+            name: 'review',
+            capabilities: 'provider-options/inspect.yaml',
+            parallel: [
+              { name: 'inherits-parent', instruction: 'review' },
+              {
+                name: 'declares-own',
+                instruction: 'review',
+                capabilities: 'provider-options/writer.yaml',
+              },
+            ],
+            rules: [{ condition: 'all(done)', next: 'COMPLETE' }],
+          },
+        ],
+      },
+      tmpDir,
+    );
+    mockRunAgentSequence([
+      makeResponse({ persona: 'agent', content: 'done' }),
+      makeResponse({ persona: 'agent', content: 'done' }),
+    ]);
+    vi.mocked(mockRuleEvaluation).mockReturnValue({ index: 0, method: 'phase3_tag' });
+
+    const state = await new WorkflowEngine(config, tmpDir, 'task', {
+      projectCwd: tmpDir,
+      provider: 'claude',
+    }).run();
+
+    expect(state.status).toBe('completed');
+    const byName = new Map(
+      vi.mocked(runAgent).mock.calls.map((call) => [
+        call[2].permissionResolution?.stepName,
+        call[2].providerOptions,
+      ]),
+    );
+    expect(byName.get('inherits-parent')).toEqual({
+      claude: { allowedTools: ['Read', 'Grep'] },
+      opencode: { networkAccess: true },
+    });
+    expect(byName.get('declares-own')).toEqual({
+      claude: { allowedTools: ['Read', 'Edit', 'Write'] },
+    });
+  });
+
+  it('should pass the step capability options to part runAgent calls when a team_leader step declares capabilities', async () => {
+    const config = normalizeWorkflowConfig(
+      {
+        name: 'wf',
+        max_steps: 2,
+        initial_step: 'implement',
+        steps: [
+          {
+            name: 'implement',
+            instruction: '{task}',
+            capabilities: 'provider-options/inspect.yaml',
+            team_leader: {
+              max_concurrency: 2,
+              timeout_ms: 10000,
+            },
+            rules: [{ condition: 'done', next: 'COMPLETE' }],
+          },
+        ],
+      },
+      tmpDir,
+    );
+    const responses = [
+      makeResponse({
+        persona: 'leader',
+        structuredOutput: { parts: [{ id: 'part-1', title: 'API', instruction: 'implement api' }] },
+      }),
+      makeResponse({ persona: 'coder', content: 'API done' }),
+      makeResponse({
+        persona: 'leader',
+        structuredOutput: { done: true, reasoning: 'enough', parts: [] },
+      }),
+    ];
+    vi.mocked(runAgent).mockImplementation(async (persona, task, options) => {
+      options?.onPromptResolved?.({ systemPrompt: '', userInstruction: task });
+      return responses.shift()!;
+    });
+    mockRuleEvaluationSequence([{ index: 0, method: 'phase3_tag' }]);
+
+    const state = await new WorkflowEngine(config, tmpDir, 'task', {
+      projectCwd: tmpDir,
+      provider: 'claude',
+    }).run();
+
+    expect(state.status).toBe('completed');
+    const partCall = vi.mocked(runAgent).mock.calls.find(
+      (call) => call[2].permissionResolution?.stepName === 'implement.part-1',
+    );
+    expect(partCall).toBeDefined();
+    expect(partCall![2].providerOptions).toEqual({
+      claude: { allowedTools: ['Read', 'Grep'] },
+      opencode: { networkAccess: true },
+    });
+  });
+});

--- a/src/__tests__/runtime-yaml-boundary-capabilities-resolution.test.ts
+++ b/src/__tests__/runtime-yaml-boundary-capabilities-resolution.test.ts
@@ -116,7 +116,7 @@ describe('CT-CAP-5 capabilities and direct provider_options coexist on the same 
 describe('capabilities reach the engine provider-options layers', () => {
   // 検出済みの後退: capabilities は step.providerOptions にだけ畳み込まれ、エンジンが実際に
   // 読む layer 側に乗らず実行時 no-op になっていた。このテストは実行時経路そのものを固定する。
-  it('should expose the resolved capability options on the runtime layer merge', async () => {
+  it('should expose the resolved capability options on the runtime layer merge when a step declares capabilities', async () => {
     const { mergeStepProviderOptionsLayers, resolveStepCapabilityProviderOptions } = await import(
       '../infra/config/providerOptions.js'
     );
@@ -133,7 +133,7 @@ describe('capabilities reach the engine provider-options layers', () => {
       .toEqual({ claude: { allowedTools: ['Read'] }, opencode: { networkAccess: true } });
   });
 
-  it('should let the workflow provider_options layer override the capabilities layer', async () => {
+  it('should let the workflow provider_options layer override the capabilities layer when both declare the same leaf', async () => {
     const { mergeStepProviderOptionsLayers } = await import('../infra/config/providerOptions.js');
     writeCapabilitySet('base-tools', 'claude:\n  allowed_tools:\n    - Read\n');
     const config = normalize(
@@ -147,7 +147,7 @@ describe('capabilities reach the engine provider-options layers', () => {
 });
 
 describe('capabilities accepts a list of set names', () => {
-  it('should merge listed sets left to right onto the step', () => {
+  it('should merge listed sets left to right onto the step when capabilities is a list', () => {
     writeCapabilitySet('tools', 'claude:\n  allowed_tools:\n    - Read\n');
     writeCapabilitySet('skills-grant', 'codex:\n  skills:\n    repo: true\n    user: true\n');
     const config = normalize({}, [
@@ -164,7 +164,7 @@ describe('capabilities accepts a list of set names', () => {
     });
   });
 
-  it('should let a later listed set win on a leaf both declare', () => {
+  it('should let a later listed set win when multiple listed sets declare the same leaf', () => {
     writeCapabilitySet('narrow', 'claude:\n  allowed_tools:\n    - Read\n');
     writeCapabilitySet('wide', 'claude:\n  allowed_tools:\n    - Read\n    - Edit\n');
     const config = normalize({}, [

--- a/src/__tests__/runtime-yaml-boundary-capabilities-resolution.test.ts
+++ b/src/__tests__/runtime-yaml-boundary-capabilities-resolution.test.ts
@@ -112,3 +112,92 @@ describe('CT-CAP-5 capabilities and direct provider_options coexist on the same 
     expect(step.providerOptions?.claude?.allowedTools).toEqual(['Read', 'Bash']);
   });
 });
+
+describe('capabilities reach the engine provider-options layers', () => {
+  // 検出済みの後退: capabilities は step.providerOptions にだけ畳み込まれ、エンジンが実際に
+  // 読む layer 側に乗らず実行時 no-op になっていた。このテストは実行時経路そのものを固定する。
+  it('should expose the resolved capability options on the runtime layer merge', async () => {
+    const { mergeStepProviderOptionsLayers, resolveStepCapabilityProviderOptions } = await import(
+      '../infra/config/providerOptions.js'
+    );
+    writeCapabilitySet('runtime-check', 'claude:\n  allowed_tools:\n    - Read\nopencode:\n  network_access: true\n');
+    const config = normalize({}, [
+      { name: 'implement', instruction: '{task}', capabilities: 'provider-options/runtime-check.yaml' },
+    ]);
+    const step = config.steps[0] as AgentWorkflowStep;
+    expect(resolveStepCapabilityProviderOptions(step)).toEqual({
+      claude: { allowedTools: ['Read'] },
+      opencode: { networkAccess: true },
+    });
+    expect(mergeStepProviderOptionsLayers(step, { providerRouting: undefined, personaProviders: undefined }))
+      .toEqual({ claude: { allowedTools: ['Read'] }, opencode: { networkAccess: true } });
+  });
+
+  it('should let the workflow provider_options layer override the capabilities layer', async () => {
+    const { mergeStepProviderOptionsLayers } = await import('../infra/config/providerOptions.js');
+    writeCapabilitySet('base-tools', 'claude:\n  allowed_tools:\n    - Read\n');
+    const config = normalize(
+      { workflow_config: { provider_options: { claude: { allowed_tools: ['Read', 'Edit'] } } } },
+      [{ name: 'implement', instruction: '{task}', capabilities: 'provider-options/base-tools.yaml' }],
+    );
+    const step = config.steps[0] as AgentWorkflowStep;
+    expect(mergeStepProviderOptionsLayers(step, { providerRouting: undefined, personaProviders: undefined }))
+      .toEqual({ claude: { allowedTools: ['Read', 'Edit'] } });
+  });
+});
+
+describe('capabilities accepts a list of set names', () => {
+  it('should merge listed sets left to right onto the step', () => {
+    writeCapabilitySet('tools', 'claude:\n  allowed_tools:\n    - Read\n');
+    writeCapabilitySet('skills-grant', 'codex:\n  skills:\n    repo: true\n    user: true\n');
+    const config = normalize({}, [
+      {
+        name: 'implement',
+        instruction: '{task}',
+        capabilities: ['provider-options/tools.yaml', 'provider-options/skills-grant.yaml'],
+      },
+    ]);
+    const step = config.steps[0] as AgentWorkflowStep;
+    expect(step.providerOptions).toEqual({
+      claude: { allowedTools: ['Read'] },
+      codex: { skills: { repo: true, user: true } },
+    });
+  });
+
+  it('should let a later listed set win on a leaf both declare', () => {
+    writeCapabilitySet('narrow', 'claude:\n  allowed_tools:\n    - Read\n');
+    writeCapabilitySet('wide', 'claude:\n  allowed_tools:\n    - Read\n    - Edit\n');
+    const config = normalize({}, [
+      {
+        name: 'implement',
+        instruction: '{task}',
+        capabilities: ['provider-options/narrow.yaml', 'provider-options/wide.yaml'],
+      },
+    ]);
+    const step = config.steps[0] as AgentWorkflowStep;
+    expect(step.providerOptions?.claude?.allowedTools).toEqual(['Read', 'Edit']);
+  });
+
+  it('should fail fast when any listed set does not resolve', () => {
+    writeCapabilitySet('tools', 'claude:\n  allowed_tools:\n    - Read\n');
+    expect(() => normalize({}, [
+      {
+        name: 'implement',
+        instruction: '{task}',
+        capabilities: ['provider-options/tools.yaml', 'provider-options/ghost.yaml'],
+      },
+    ])).toThrow(/capabilities|not found/i);
+  });
+
+  it('should fail fast when any listed set carries a non-capability leaf', () => {
+    writeCapabilitySet('tools', 'claude:\n  allowed_tools:\n    - Read\n');
+    writeCapabilitySet('impure', 'claude:\n  effort: high\n');
+    expect(() => normalize({}, [
+      {
+        name: 'implement',
+        instruction: '{task}',
+        capabilities: ['provider-options/tools.yaml', 'provider-options/impure.yaml'],
+      },
+    ])).toThrow(/not a capability leaf/);
+  });
+});

--- a/src/__tests__/team-leader-common.test.ts
+++ b/src/__tests__/team-leader-common.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { PartDefinition, WorkflowStep } from '../core/models/types.js';
 import { createPartStep, createTeamLeaderPlanningStep } from '../core/workflow/engine/team-leader-common.js';
+import {
+  resolveDirectStepProviderOptions,
+  resolveStepCapabilityProviderOptions,
+  resolveStepWorkflowProviderOptions,
+} from '../infra/config/providerOptions.js';
 import { InstructionBuilder } from '../core/workflow/instruction/InstructionBuilder.js';
 import { makeInstructionContext } from './test-helpers.js';
 
@@ -97,6 +102,34 @@ describe('createPartStep', () => {
 
     // Then
     expect(partStep.providerOptions).toEqual(step.providerOptions);
+  });
+
+  it('carries every provider-options field the runtime layer merge reads onto the part step', () => {
+    // resolveDirectStepProviderOptions / resolveStepWorkflowProviderOptions /
+    // resolveStepCapabilityProviderOptions は step 上のフィールド有無で読む対象を切り替える。
+    // part step がどれかを落とすと、親では効いていたオプションが part だけ黙って消える。
+    const step: WorkflowStep = {
+      name: 'implement',
+      persona: 'coder',
+      personaDisplayName: 'Coder',
+      instruction: 'do work',
+      passPreviousResponse: false,
+      providerOptions: { codex: { networkAccess: true } },
+      directProviderOptions: { codex: { networkAccess: true } },
+      workflowProviderOptions: { opencode: { networkAccess: true } },
+      capabilityProviderOptions: { claude: { allowedTools: ['Read'] } },
+      teamLeader: {
+        persona: 'leader',
+        maxConcurrency: 3,
+        timeoutMs: 900000,
+      },
+    };
+
+    const partStep = createPartStep(step, { id: 'part-1', title: 'API', instruction: 'implement api' });
+
+    expect(resolveDirectStepProviderOptions(partStep)).toEqual({ codex: { networkAccess: true } });
+    expect(resolveStepWorkflowProviderOptions(partStep)).toEqual({ opencode: { networkAccess: true } });
+    expect(resolveStepCapabilityProviderOptions(partStep)).toEqual({ claude: { allowedTools: ['Read'] } });
   });
 
   it('keeps part personaDisplayName aligned with the part persona for personaProviders lookup', () => {

--- a/src/__tests__/team-leader-common.test.ts
+++ b/src/__tests__/team-leader-common.test.ts
@@ -104,7 +104,7 @@ describe('createPartStep', () => {
     expect(partStep.providerOptions).toEqual(step.providerOptions);
   });
 
-  it('carries every provider-options field the runtime layer merge reads onto the part step', () => {
+  it('should carry every provider-options field the runtime layer merge reads when creating a part step', () => {
     // resolveDirectStepProviderOptions / resolveStepWorkflowProviderOptions /
     // resolveStepCapabilityProviderOptions は step 上のフィールド有無で読む対象を切り替える。
     // part step がどれかを落とすと、親では効いていたオプションが part だけ黙って消える。

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -45,7 +45,9 @@ const WorkflowStepNameSchema = z.string().min(1);
 // Issue #1208 Stage 1 — additive capability/MCP reference surface.
 // `capabilities` names a capability-set (an existing provider-options named resource, formalized);
 // `mcp` names one or more MCP servers defined at the workflow top level (or, later, in runtime.yaml).
-const WorkflowCapabilitiesRefSchema = z.string().min(1).optional();
+const WorkflowCapabilitiesRefSchema = z
+  .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
+  .optional();
 const WorkflowMcpRefListSchema = z.array(z.string().min(1)).min(1).optional();
 
 export const WorkflowParamReferenceRawSchema = z.object({

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -292,6 +292,7 @@ interface AgentWorkflowStepBase extends WorkflowStepBase {
   providerOptions?: StepProviderOptions;
   directProviderOptions?: StepProviderOptions;
   workflowProviderOptions?: StepProviderOptions;
+  capabilityProviderOptions?: StepProviderOptions;
   edit?: boolean;
   qualityGates?: QualityGate[];
   structuredOutput?: WorkflowStructuredOutput;

--- a/src/core/workflow/engine/team-leader-common.ts
+++ b/src/core/workflow/engine/team-leader-common.ts
@@ -50,6 +50,7 @@ export function createPartStep(step: WorkflowStep, part: PartDefinition): Workfl
       ? { directProviderOptions: step.directProviderOptions }
       : {}),
     ...('workflowProviderOptions' in step ? { workflowProviderOptions: step.workflowProviderOptions } : {}),
+    ...('capabilityProviderOptions' in step ? { capabilityProviderOptions: step.capabilityProviderOptions } : {}),
     mcpServers: step.mcpServers,
     provider: step.provider,
     providerSpecified: step.providerSpecified,

--- a/src/core/workflow/provider-options-trace.ts
+++ b/src/core/workflow/provider-options-trace.ts
@@ -34,6 +34,7 @@ export type ProviderResolutionSource =
   | 'step'
   | 'workflow_call'
   | 'workflow'
+  | 'capabilities'
   | 'project'
   | 'global'
   | 'runtime-v1'

--- a/src/core/workflow/provider-resolution.ts
+++ b/src/core/workflow/provider-resolution.ts
@@ -116,6 +116,8 @@ const PROVIDER_MODEL_SOURCE_PRIORITY: Record<ProviderResolutionSource, number> =
   'auto.dynamic': 8,
   'auto.fallback': 8,
   workflow: 9,
+  // Listed only to satisfy the shared source union; a capability set never carries provider/model.
+  capabilities: 9,
   project: 10,
   global: 11,
   'runtime-v1': 11,

--- a/src/infra/config/loaders/capabilitySetResolver.ts
+++ b/src/infra/config/loaders/capabilitySetResolver.ts
@@ -1,21 +1,8 @@
-/**
- * Capability-set resolution (issue #1208 Stage 1).
- *
- * A `capabilities:` reference names an existing provider-options named resource, formalized as a
- * capability-set. Resolution reuses the provider-options resolver (4-layer lookup, `@owner/repo/name`
- * references, realpath cycle detection, upward-layer sealing) via its `extends` entry point, then
- * purifies the result: through the `capabilities:` path only capability leaves are permitted
- * (`allowed_tools` / `network_access` / `sandbox` / `skills`). Any quality/cost or machine-specific
- * leaf (effort, base_url, guards, variant, …) fails fast at load time — those belong in runtime.yaml,
- * not in a workflow's capability declaration. The legacy `provider_options.extends` path keeps
- * accepting every leaf and runs unchanged (Stage 1 parallel run; purification is capabilities-only).
- */
-
 import type { StepProviderOptions } from '../../../core/models/workflow-types.js';
 import type { FacetResolutionContext } from './resource-resolver.js';
+import { mergeProviderOptions } from '../providerOptions.js';
 import { resolveWorkflowProviderOptions } from './workflowProviderOptionsResolver.js';
 
-/** Normalized (camelCase) leaf keys that a capability-set may declare. */
 const CAPABILITY_LEAF_KEYS: ReadonlySet<string> = new Set([
   'allowedTools',
   'networkAccess',
@@ -40,11 +27,27 @@ function assertCapabilityLeavesOnly(name: string, options: StepProviderOptions):
   }
 }
 
-/**
- * Resolve a `capabilities:` reference into a purified provider-options bundle. Throws when the
- * reference cannot be resolved, resolves to nothing, or carries a non-capability leaf.
- */
-export function resolveCapabilitySet(
+/** Later names win on a leaf several sets declare. */
+export function resolveCapabilitySets(
+  names: string | readonly string[],
+  workflowDir: string,
+  context: FacetResolutionContext | undefined,
+): StepProviderOptions {
+  if (typeof names === 'string') {
+    return resolveCapabilitySet(names, workflowDir, context);
+  }
+  const merged = mergeProviderOptions(
+    ...names.map((name) => resolveCapabilitySet(name, workflowDir, context)),
+  );
+  if (merged === undefined) {
+    throw new Error(
+      `Configuration error: capabilities [${names.join(', ')}] resolved to no capability options`,
+    );
+  }
+  return merged;
+}
+
+function resolveCapabilitySet(
   name: string,
   workflowDir: string,
   context: FacetResolutionContext | undefined,

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -43,7 +43,7 @@ import {
 } from './workflowNormalizationPolicies.js';
 import { normalizeLoopMonitors } from './workflowLoopMonitorNormalizer.js';
 import { normalizeProviderReference, normalizeStepFromRaw, type WorkflowLevelDefinitions } from './workflowStepNormalizer.js';
-import { resolveCapabilitySet } from './capabilitySetResolver.js';
+import { resolveCapabilitySets } from './capabilitySetResolver.js';
 import { compileFacetPool, type FacetPoolCompilationInput } from './facetPoolCompiler.js';
 import type { ResolvedFacetPool } from '../../../core/models/index.js';
 import {
@@ -483,11 +483,9 @@ export function normalizeWorkflowConfig(
     workflowDir,
     context,
   );
-  // Issue #1208: resolve the workflow-level capability default once, and expose the top-level
-  // `mcp_servers` definitions, so every step's `capabilities:` / `mcp:` reference resolves.
   const workflowDefinitions: WorkflowLevelDefinitions = {
     ...(parsed.capabilities !== undefined
-      ? { capabilityOptions: resolveCapabilitySet(parsed.capabilities, workflowDir, context) }
+      ? { capabilityOptions: resolveCapabilitySets(parsed.capabilities, workflowDir, context) }
       : {}),
     ...(parsed.mcp_servers !== undefined ? { mcpServers: parsed.mcp_servers } : {}),
   };

--- a/src/infra/config/loaders/workflowStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepNormalizer.ts
@@ -459,6 +459,12 @@ export function normalizeStepFromRaw(
     knowledgeContents,
   };
 
+  // parallel 親の capabilities は sub-step の既定になる（sub-step 自身の宣言が置換する）。
+  // 渡さないと、親が readonly を宣言していても無宣言の子が workflow 既定へ落ちて広くなる。
+  const subStepWorkflowDefinitions = effectiveCapabilityOptions === undefined
+    ? workflowDefinitions
+    : { ...workflowDefinitions, capabilityOptions: effectiveCapabilityOptions };
+
   if (step.parallel && Array.isArray(step.parallel) && step.parallel.length > 0) {
     const normalizedStep: AgentWorkflowStep = {
       ...normalizedAgentFields,
@@ -482,7 +488,7 @@ export function normalizeStepFromRaw(
           globalOverrides,
           workflowArpeggioPolicy,
           workflowMcpServersPolicy,
-          workflowDefinitions,
+          subStepWorkflowDefinitions,
         ),
       ),
       ...(step.concurrency != null ? { concurrency: step.concurrency } : {}),
@@ -515,7 +521,7 @@ export function normalizeStepFromRaw(
       globalOverrides,
       workflowArpeggioPolicy,
       workflowMcpServersPolicy,
-      workflowDefinitions,
+      subStepWorkflowDefinitions,
       );
       return normalized as DynamicParallelFixedSubStep;
     };

--- a/src/infra/config/loaders/workflowStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepNormalizer.ts
@@ -37,7 +37,7 @@ import { resolveStructuredOutput } from './workflowStructuredOutputResolver.js';
 import { normalizeWorkflowEffects } from './workflowSystemStepNormalizer.js';
 import { parseAiConditionExpression } from '../../../core/models/workflow-condition-expression.js';
 import { resolveWorkflowProviderOptions } from './workflowProviderOptionsResolver.js';
-import { resolveCapabilitySet } from './capabilitySetResolver.js';
+import { resolveCapabilitySets } from './capabilitySetResolver.js';
 import { resolveWorkflowMcpReferences } from './workflowMcpReferenceResolver.js';
 import type { McpServerConfig } from '../../../core/models/index.js';
 import { isWorkflowParamReference } from './workflowCallableParamRef.js';
@@ -47,12 +47,7 @@ import { withWorkflowConfigErrorPath as withWorkflowStepErrorPath } from '../../
 type RawStep = z.output<typeof WorkflowStepRawSchema>;
 type RawProviderReference = RawStep['provider'];
 
-/**
- * Workflow-level inputs threaded down to every step so `capabilities:` / `mcp:` references resolve
- * (issue #1208 Stage 1). `capabilityOptions` is the workflow-level capability default (a step's own
- * `capabilities:` replaces it, not merges); `mcpServers` are the top-level definitions that a step
- * `mcp:` reference resolves against.
- */
+/** Workflow-level inputs threaded down to every step so `capabilities:` / `mcp:` references resolve. */
 export interface WorkflowLevelDefinitions {
   capabilityOptions?: StepProviderOptions;
   mcpServers?: Record<string, McpServerConfig>;
@@ -379,11 +374,10 @@ export function normalizeStepFromRaw(
     globalOverrides,
   ));
 
-  // Capability-set resolution (issue #1208): a step's own `capabilities:` REPLACES the workflow
-  // default (never merges); the purified capability options sit at the lowest layer so an explicit
-  // `provider_options` on the same step still wins.
+  // A step's own `capabilities:` replaces the workflow default rather than merging, and sits below
+  // `provider_options` so an explicit option on the same step still wins.
   const stepCapabilityOptions = step.capabilities !== undefined
-    ? normalizeStepField(stepPath, ['capabilities'], () => resolveCapabilitySet(step.capabilities!, workflowDir, context))
+    ? normalizeStepField(stepPath, ['capabilities'], () => resolveCapabilitySets(step.capabilities!, workflowDir, context))
     : undefined;
   const effectiveCapabilityOptions = stepCapabilityOptions ?? workflowDefinitions?.capabilityOptions;
   const directProviderOptions = mergeProviderOptions(inheritedDirectProviderOptions, normalizedProvider.providerOptions);
@@ -424,6 +418,7 @@ export function normalizeStepFromRaw(
     providerOptions,
     directProviderOptions,
     workflowProviderOptions: inheritedWorkflowProviderOptions,
+    capabilityProviderOptions: effectiveCapabilityOptions,
     edit: step.edit,
     allowGitCommit: step.allow_git_commit ?? inheritedAllowGitCommit ?? false,
     instruction: instruction || '{task}',

--- a/src/infra/config/providerOptions.ts
+++ b/src/infra/config/providerOptions.ts
@@ -524,11 +524,22 @@ export function resolveStepWorkflowProviderOptions(step: WorkflowStep): StepProv
   return undefined;
 }
 
+export function resolveStepCapabilityProviderOptions(step: WorkflowStep): StepProviderOptions | undefined {
+  if ('capabilityProviderOptions' in step) {
+    return step.capabilityProviderOptions;
+  }
+  return undefined;
+}
+
 export function resolveStepProviderOptionsLayers(
   step: WorkflowStep,
   context: StepProviderOptionsLayerContext,
 ): ProviderOptionsLayer[] {
   const layers: ProviderOptionsLayer[] = [
+    {
+      source: 'capabilities',
+      options: resolveStepCapabilityProviderOptions(step),
+    },
     {
       source: 'workflow',
       options: resolveStepWorkflowProviderOptions(step),


### PR DESCRIPTION
## 目的

issue #1208 Stage 2 の土台となるエンジン変更。2点からなる。

## 1. capabilities の複数指定

`capabilities` はキー名どおり複数形として、単一名に加えて名前リストを受理する（`policy` / `knowledge` と同じ union 形式）。

```yaml
capabilities: readonly
steps:
  - name: implement
    capabilities: [edit, enable-skills]
```

- リストは左から右へマージし、同じ leaf は後の名前が勝つ
- 各エントリは単独で検証され、未解決名・非能力 leaf は位置によらず fail fast

## 2. 実行時配線の欠落修正（敵対レビューで検出）

`capabilities` はロード時に `step.providerOptions` へ畳み込まれるだけで、エンジンが実際に読む `directProviderOptions` / `workflowProviderOptions` のどちらにも乗らず、**実行時には完全な no-op** だった（#1231 由来）。ビルトイン移行を当てると 434 step の実効 providerOptions が undefined になることを実測で確認している。

- `WorkflowStep.capabilityProviderOptions` を追加し、layer merge の最下層として配線
- `team_leader` の part step がこのフィールドを複製しない欠落（敵対レビュー第2ラウンドで検出）も修正
- 実行時経路そのものを検証するテストで固定。既存テストはエンジンが読まないフィールドを検証しており、この欠落を素通りさせていた

## 検証

- 実 `OptionsBuilder` 経由で `RunAgentOptions.providerOptions` に能力が届くことを実測確認（敵対レビュアーによる独立再現込み）
- `ProviderResolutionSource` の網羅 consumer は priority map のみで、更新済み（tsc が網羅を強制）
- typecheck / lint / 対象テスト通過

## 関連

- #1208 / #1231（配線欠落の混入元）
- 後続: #1233（この上に載るビルトイン移行）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ワークフロー、ステップ、並列サブステップで能力プリセットを指定できるようになりました。
  * 複数プリセットを指定でき、左から右へ統合され、後続の設定が優先されます。
  * ステップごとに既定値を置き換えられ、個別のプロバイダー設定も優先されます。

* **改善**
  * 未解決のプリセットや不正な設定を検出し、設定エラーを表示します。

* **ドキュメント**
  * 能力設定の継承・統合規則、適用範囲、制限事項を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->