### PR TITLE
[#1208] compound-eye を provider 中立の eye1/eye2 として復活

### DIFF
--- a/builtins/en/workflows/compound-eye.yaml
+++ b/builtins/en/workflows/compound-eye.yaml
@@ -1,0 +1,162 @@
+name: compound-eye
+description: Multi-eye review - send the same instruction to two independently assigned eyes and synthesize both responses. Assign a different provider to each eye via runtime.yaml (provider.targets.steps -> eye1 / eye2); the workflow itself names no provider.
+capabilities: readonly
+max_steps: 10
+initial_step: evaluate
+steps:
+  - name: evaluate
+    tags:
+      - review
+    parallel:
+      - name: eye1
+        tags:
+          - review
+        edit: false
+        persona: coder
+        session: refresh
+        knowledge: architecture
+        rules:
+          - condition: done
+          - condition: failed
+        output_contracts:
+          report:
+            - name: eye1-review.md
+              format: |
+                ```markdown
+                # Eye 1 Review Result
+
+                ## Conclusion
+                {One-line conclusion}
+
+                ## Key Findings
+                - {finding 1}
+                - {finding 2}
+
+                ## Evidence
+                - {file:line and rationale}
+
+                ## Risks / Caveats
+                - {risk}
+
+                ## Recommended Next Step
+                - {action}
+                ```
+      - name: eye2
+        tags:
+          - review
+        edit: false
+        persona: coder
+        session: refresh
+        knowledge: architecture
+        rules:
+          - condition: done
+          - condition: failed
+        output_contracts:
+          report:
+            - name: eye2-review.md
+              format: |
+                ```markdown
+                # Eye 2 Review Result
+
+                ## Conclusion
+                {One-line conclusion}
+
+                ## Key Findings
+                - {finding 1}
+                - {finding 2}
+
+                ## Evidence
+                - {file:line and rationale}
+
+                ## Risks / Caveats
+                - {risk}
+
+                ## Recommended Next Step
+                - {action}
+                ```
+    rules:
+      - condition: any("done")
+        next: synthesize
+  - name: synthesize
+    tags:
+      - review
+    edit: false
+    persona: supervisor
+    rules:
+      - condition: synthesis complete
+        next: COMPLETE
+    instruction: |
+      Two eyes independently answered the same instruction. Depending on the
+      runtime.yaml assignment they may be different providers or models.
+      Synthesize their responses.
+
+      **Tasks:**
+      1. Read reports in the Report Directory
+         - `eye1-review.md` (eye 1's response)
+         - `eye2-review.md` (eye 2's response)
+         Note: If one report is missing (that eye failed), synthesize from the available report only
+      2. If both reports exist, compare and clarify:
+         - Points of agreement
+         - Points of disagreement
+         - Points mentioned by only one eye
+      3. Produce a synthesized conclusion
+
+      **Output format:**
+      ```markdown
+      # Multi-Eye Review Synthesis
+
+      ## Conclusion
+      {Synthesized conclusion}
+
+      ## Response Status
+      | Eye | Status |
+      |-----|--------|
+      | Eye 1 | ✅ / ❌ |
+      | Eye 2 | ✅ / ❌ |
+
+      ## Agreements
+      - {Points where both eyes agree}
+
+      ## Disagreements
+      | Topic | Eye 1 | Eye 2 |
+      |-------|-------|-------|
+      | {topic} | {eye 1's view} | {eye 2's view} |
+
+      ## Unique Findings
+      - **Eye 1 only:** {Points only eye 1 mentioned}
+      - **Eye 2 only:** {Points only eye 2 mentioned}
+
+      ## Overall Assessment
+      {Overall assessment considering both responses}
+      ```
+    output_contracts:
+      report:
+        - name: synthesis.md
+          format: |
+            ```markdown
+            # Multi-Eye Review Synthesis
+
+            ## Conclusion
+            {Synthesized conclusion}
+
+            ## Response Status
+            | Eye | Status |
+            |-----|--------|
+            | Eye 1 | ✅ / ❌ |
+            | Eye 2 | ✅ / ❌ |
+
+            ## Agreements
+            - {Points where both eyes agree}
+
+            ## Disagreements
+            | Topic | Eye 1 | Eye 2 |
+            |-------|-------|-------|
+            | {topic} | {eye 1's view} | {eye 2's view} |
+
+            ## Unique Findings
+            - **Eye 1 only:** {Points only eye 1 mentioned}
+            - **Eye 2 only:** {Points only eye 2 mentioned}
+
+            ## Overall Assessment
+            {Overall assessment considering both responses}
+            ```

--- a/builtins/ja/workflows/compound-eye.yaml
+++ b/builtins/ja/workflows/compound-eye.yaml
@@ -1,0 +1,161 @@
+name: compound-eye
+description: 複眼レビュー - 同じ指示を独立に割り当てた2つの eye へ同時に投げ、両者の回答を統合する。各 eye のプロバイダーは runtime.yaml（provider.targets.steps -> eye1 / eye2）で割り当てる。workflow 自身はプロバイダー名を持たない。
+capabilities: readonly
+max_steps: 10
+initial_step: evaluate
+steps:
+  - name: evaluate
+    tags:
+      - review
+    parallel:
+      - name: eye1
+        tags:
+          - review
+        edit: false
+        persona: coder
+        session: refresh
+        knowledge: architecture
+        rules:
+          - condition: done
+          - condition: failed
+        output_contracts:
+          report:
+            - name: eye1-review.md
+              format: |
+                ```markdown
+                # Eye 1 レビュー結果
+
+                ## 結論
+                {1行の結論}
+
+                ## 主要な発見
+                - {発見1}
+                - {発見2}
+
+                ## 根拠
+                - {file:line と理由}
+
+                ## リスク / 注意点
+                - {リスク}
+
+                ## 推奨する次の一手
+                - {アクション}
+                ```
+      - name: eye2
+        tags:
+          - review
+        edit: false
+        persona: coder
+        session: refresh
+        knowledge: architecture
+        rules:
+          - condition: done
+          - condition: failed
+        output_contracts:
+          report:
+            - name: eye2-review.md
+              format: |
+                ```markdown
+                # Eye 2 レビュー結果
+
+                ## 結論
+                {1行の結論}
+
+                ## 主要な発見
+                - {発見1}
+                - {発見2}
+
+                ## 根拠
+                - {file:line と理由}
+
+                ## リスク / 注意点
+                - {リスク}
+
+                ## 推奨する次の一手
+                - {アクション}
+                ```
+    rules:
+      - condition: any("done")
+        next: synthesize
+  - name: synthesize
+    tags:
+      - review
+    edit: false
+    persona: supervisor
+    rules:
+      - condition: synthesis complete
+        next: COMPLETE
+    instruction: |
+      2つの eye が同じ指示に独立に回答した。runtime.yaml の割り当てによっては
+      異なるプロバイダー・モデルである。両者の回答を統合せよ。
+
+      **タスク:**
+      1. Report Directory のレポートを読む
+         - `eye1-review.md`（eye 1 の回答）
+         - `eye2-review.md`（eye 2 の回答）
+         注意: 片方のレポートが無い場合（その eye が失敗した場合）は、あるレポートだけで統合する
+      2. 両方のレポートがある場合、比較して明確にする:
+         - 一致している点
+         - 食い違っている点
+         - 片方だけが言及している点
+      3. 統合した結論を出す
+
+      **出力フォーマット:**
+      ```markdown
+      # 複眼レビュー統合
+
+      ## 結論
+      {統合した結論}
+
+      ## 回答状況
+      | Eye | 状況 |
+      |-----|------|
+      | Eye 1 | ✅ / ❌ |
+      | Eye 2 | ✅ / ❌ |
+
+      ## 一致点
+      - {両者が一致した点}
+
+      ## 相違点
+      | 論点 | Eye 1 | Eye 2 |
+      |------|-------|-------|
+      | {論点} | {eye 1 の見解} | {eye 2 の見解} |
+
+      ## 片方のみの発見
+      - **Eye 1 のみ:** {eye 1 だけが言及した点}
+      - **Eye 2 のみ:** {eye 2 だけが言及した点}
+
+      ## 総合評価
+      {両者を踏まえた総合評価}
+      ```
+    output_contracts:
+      report:
+        - name: synthesis.md
+          format: |
+            ```markdown
+            # 複眼レビュー統合
+
+            ## 結論
+            {統合した結論}
+
+            ## 回答状況
+            | Eye | 状況 |
+            |-----|------|
+            | Eye 1 | ✅ / ❌ |
+            | Eye 2 | ✅ / ❌ |
+
+            ## 一致点
+            - {両者が一致した点}
+
+            ## 相違点
+            | 論点 | Eye 1 | Eye 2 |
+            |------|-------|-------|
+            | {論点} | {eye 1 の見解} | {eye 2 の見解} |
+
+            ## 片方のみの発見
+            - **Eye 1 のみ:** {eye 1 だけが言及した点}
+            - **Eye 2 のみ:** {eye 2 だけが言及した点}
+
+            ## 総合評価
+            {両者を踏まえた総合評価}
+            ```

--- a/docs/builtin-catalog.ja.md
+++ b/docs/builtin-catalog.ja.md
@@ -97,6 +97,7 @@ TAKT に同梱されているすべてのビルトイン workflow と persona �
 | その他 | `research` | リサーチ workflow: planner -> digger -> supervisor。質問せずに自律的にリサーチを実行。 |
 | | `deep-research` | ディープリサーチ workflow: plan -> dig -> analyze -> supervise。発見駆動型の調査で、浮上した疑問を多角的に分析。 |
 | | `magi` | エヴァンゲリオンにインスパイアされた合議システム。3つの AI persona (MELCHIOR, BALTHASAR, CASPER) が分析・投票。 |
+| | `compound-eye` | 複眼レビュー。同じ指示を2つの eye に同時に投げ、両者の回答を統合する。eye ごとのプロバイダーは runtime.yaml（`provider.targets.steps` -> `eye1` / `eye2`）で割り当てる。 |
 
 ローカルモデルだけで既存workflowを動かす場合は、各workflowへ provider/model を設定してください。ハイブリッド構成では、`review` をローカル provider へ、`boundary-review` と `final-gate` を commercial provider へルーティングしてください。タグは step の記載順に適用されるため、`merge-readiness-review` と `supervise` では後ろの `final-gate` が先の `review` を上書きします。`finding-contract-local-review` の integrity gate と `finding-contract-boundary-review` の final gate は同じ `merge-readiness-finding-contract-final-gate` subworkflow を呼ぶため、この1つの routing で両 stage を保証でき、workflow 自体へ provider/model を固定する必要はありません。
 

--- a/docs/builtin-catalog.md
+++ b/docs/builtin-catalog.md
@@ -97,6 +97,7 @@ Organized by category.
 | Others | `research` | Research workflow: planner -> digger -> supervisor. Autonomously executes research without asking questions. |
 | | `deep-research` | Deep research workflow: plan -> dig -> analyze -> supervise. Discovery-driven investigation that follows emerging questions with multi-perspective analysis. |
 | | `magi` | Deliberation system inspired by Evangelion. Three AI personas (MELCHIOR, BALTHASAR, CASPER) analyze and vote. |
+| | `compound-eye` | Multi-eye review: send the same instruction to two independently assigned eyes, then synthesize both responses. Assign providers per eye via runtime.yaml (`provider.targets.steps` -> `eye1` / `eye2`). |
 
 To run an existing workflow entirely with local models, configure its provider and model normally. For a hybrid setup, route `review` to the local provider and route both `boundary-review` and `final-gate` to the commercial provider. Tags are applied in step order, so `final-gate` overrides the earlier `review` route on both `merge-readiness-review` and `supervise`. The integrity gate in `finding-contract-local-review` and the final gate in `finding-contract-boundary-review` use the same `merge-readiness-finding-contract-final-gate` subworkflow, so this one route covers both stages without hardcoding a provider or model in the workflow.
 


### PR DESCRIPTION
## 目的

Stage 2 で廃止した compound-eye（複眼レビュー）を、INV-1（workflow に具体的な provider 名を書かない）と両立する形で復活させる。

## 設計

- sub-step 名を `claude-eye` / `codex-eye` → **`eye1` / `eye2`** の中立名へ
- workflow から `provider:` 直書きを排除。各 eye の割り当ては **runtime.yaml** で行う:

```yaml
provider:
  profiles:
    a: { provider: claude-sdk, model: opus }
    b: { provider: codex, model: gpt-5.5 }
  targets:
    steps:
      eye1: { profile: a }
      eye2: { profile: b }
```

- 能力は `capabilities: readonly` に一本化（旧 inline provider_options を置換）
- レポート名（`eye1-review.md` / `eye2-review.md`）・統合ステップの指示・出力フォーマットも eye 中立の語彙へ
- カタログ行（en/ja）を復元し、runtime.yaml での割り当て方法を明記

## 既知の性質

runtime.yaml の targets を設定しない場合、両 eye は同じ既定プロバイダーに解決される（同一モデルに2回聞く）。「sub-step 群が互いに異なるプロバイダーに解決されること」という多様性制約の宣言手段は現行設計に無く、fail-fast はしない。description とカタログで割り当てを促す。

## ベース

#1238（ja 移行）の上。マージ順: #1238 → 本PR（base を main へ付け替え後）