### PR TITLE
feat: add experimental dynamic coding workflow

### DIFF
--- a/builtins/en/steps/experimental-review.yaml
+++ b/builtins/en/steps/experimental-review.yaml
@@ -1,0 +1,117 @@
+name: review
+tags: [review]
+parallel:
+  fixed:
+    - name: coding-review
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: coding-reviewer
+      policy: [contract-change, review, coding, testing]
+      knowledge: [architecture, unit-testing, e2e-testing]
+      instruction: review-coding
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: coding-review.md
+            format: coding-review
+    - name: ai-antipattern-review
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: ai-antipattern-reviewer
+      policy: [contract-change, review, ai-antipattern]
+      knowledge: architecture
+      instruction: ai-antipattern-review
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: ai-antipattern-review.md
+            format: ai-antipattern-review
+  pool:
+    - name: architecture-review
+      description: Review module structure, responsibility boundaries, dependency direction, and call paths.
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: architecture-reviewer
+      policy: [contract-change, review]
+      knowledge: architecture
+      instruction: review-arch
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: architecture-review.md
+            format: architecture-review
+    - name: frontend-review
+      description: Review UI, components, state management, accessibility, and presentation.
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: frontend-reviewer
+      policy: [contract-change, review]
+      knowledge: [frontend, react]
+      instruction: review-frontend
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: frontend-review.md
+            format: frontend-review
+    - name: backend-review
+      description: Review APIs, domain logic, server-side processing, and persistence.
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: coding-reviewer
+      policy: [contract-change, review, coding]
+      knowledge: [backend, architecture]
+      instruction: review-coding
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: backend-review.md
+            format: coding-review
+    - name: cli-review
+      description: Review CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: coding-reviewer
+      policy: [contract-change, review, coding]
+      knowledge: [architecture, existing-system]
+      instruction: review-coding
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: cli-review.md
+            format: coding-review
+    - name: security-review
+      description: Review authentication, authorization, input validation, secrets, dependencies, and security boundaries.
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: security-reviewer
+      policy: [contract-change, review]
+      knowledge: security
+      instruction: review-security
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: security-review.md
+            format: security-review
+    - name: testing-review
+      description: Review test coverage, test design, integration boundaries, and E2E boundaries.
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: testing-reviewer
+      policy: [contract-change, review, testing]
+      knowledge: [unit-testing, e2e-testing]
+      instruction: review-test
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: testing-review.md
+            format: testing-review
+  selection:
+    mode: replace

--- a/builtins/en/workflow-categories.yaml
+++ b/builtins/en/workflow-categories.yaml
@@ -3,6 +3,7 @@ workflow_categories:
     workflows:
       - simple
       - default
+      - experimental
       - default-mini
       - default-high
       - cli

--- a/builtins/en/workflows/experimental.yaml
+++ b/builtins/en/workflows/experimental.yaml
@@ -1,0 +1,139 @@
+name: experimental
+description: An experimental general-purpose coding workflow that dynamically selects review agents and remediation facets from the task and preceding reports.
+max_steps: 51
+initial_step: plan
+
+facet_pools:
+  coding-facets:
+    candidates:
+      - id: frontend
+        description: Handle UI, components, state management, accessibility, and presentation.
+        policy: design-fidelity
+        knowledge: [frontend, react]
+      - id: backend
+        description: Handle APIs, domain logic, server-side processing, and persistence.
+        knowledge: backend
+      - id: cli
+        description: Handle CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
+        policy: existing-system-respect
+        knowledge: existing-system
+      - id: testing
+        description: Handle test design, test coverage, integration boundaries, and E2E boundaries.
+        policy: testing
+        knowledge: [unit-testing, e2e-testing]
+      - id: security
+        description: Handle authentication, authorization, input validation, secrets, dependencies, and security boundaries.
+        knowledge: security
+      - id: implementation-semantics
+        description: Handle implementation semantics, contracts, state transitions, return values, and side effects.
+        knowledge: implementation-semantics
+
+steps:
+  - name: plan
+    capabilities: [readonly, enable-skills]
+    uses: development-core-plan
+    with:
+      plan_policy: [design-planning]
+      plan_knowledge: [architecture, task-decomposition]
+      plan_instruction: plan
+      plan_report_format: plan
+    rules:
+      - condition: Requirements are clear and implementation is feasible
+        next: write_tests
+      - condition: The user is asking a question rather than requesting implementation
+        next: COMPLETE
+      - condition: Requirements are unclear or information is insufficient
+        next: ABORT
+
+  - name: write_tests
+    capabilities: [edit, enable-skills]
+    uses: development-core-write-tests
+    with:
+      testing_policy: [coding, testing]
+      testing_knowledge: [architecture, unit-testing, e2e-testing]
+      testing_instruction: write-tests-first
+    rules:
+      - condition: Test creation completed
+        next: implement
+      - condition: Test creation skipped because the target is not implemented
+        next: implement
+      - condition: Unable to proceed with test creation
+        next: plan
+      - condition: User input is required to resolve a question
+        next: write_tests
+        requires_user_input: true
+        interactive_only: true
+
+  - name: implement
+    capabilities: [edit, enable-skills]
+    uses: development-core-implement
+    with:
+      development_policy: [coding, testing]
+      development_knowledge: [architecture, existing-system]
+      implementation_instruction: implement
+    dynamic_facets:
+      pool: coding-facets
+    rules:
+      - condition: Implementation completed
+        next: review
+      - condition: Implementation not started (report only)
+        next: review
+      - condition: Unable to proceed with implementation
+        next: plan
+      - condition: User input is required to resolve a question
+        next: implement
+        requires_user_input: true
+        interactive_only: true
+
+  - name: review
+    uses: experimental-review
+    rules:
+      self:
+        - condition: all("approved")
+          next: supervise
+        - condition: any("needs_fix")
+          next: fix
+      parallel:
+        coding-review: &reviewer-rules
+          - condition: approved
+          - condition: needs_fix
+        ai-antipattern-review: *reviewer-rules
+        architecture-review: *reviewer-rules
+        frontend-review: *reviewer-rules
+        backend-review: *reviewer-rules
+        cli-review: *reviewer-rules
+        security-review: *reviewer-rules
+        testing-review: *reviewer-rules
+
+  - name: fix
+    capabilities: [edit, enable-skills]
+    uses: fix
+    policy: [contract-change, coding, testing, review, ai-antipattern]
+    knowledge: architecture
+    dynamic_facets:
+      pool: coding-facets
+    rules:
+      - condition: Fix complete
+        next: review
+      - condition: Remediation approach must be revised
+        next: plan
+      - condition: Whole-task replanning is required
+        next: plan
+      - condition: Unable to proceed with the fix
+        next: ABORT
+
+  - name: supervise
+    capabilities: [readonly, enable-skills]
+    uses: review-supervise-to-complete
+    tags: [review, final-gate, supervise]
+    policy: [contract-change, coding, testing, review, ai-antipattern]
+    knowledge: [architecture, unit-testing, e2e-testing]
+    rules:
+      - condition: BLOCKED
+        next: ABORT
+      - condition: approved
+        next: COMPLETE
+      - condition: need_replan
+        next: plan
+      - condition: needs_fix
+        next: fix

--- a/builtins/ja/steps/experimental-review.yaml
+++ b/builtins/ja/steps/experimental-review.yaml
@@ -1,0 +1,117 @@
+name: review
+tags: [review]
+parallel:
+  fixed:
+    - name: coding-review
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: coding-reviewer
+      policy: [contract-change, review, coding, testing]
+      knowledge: [architecture, unit-testing, e2e-testing]
+      instruction: review-coding
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: coding-review.md
+            format: coding-review
+    - name: ai-antipattern-review
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: ai-antipattern-reviewer
+      policy: [contract-change, review, ai-antipattern]
+      knowledge: architecture
+      instruction: ai-antipattern-review
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: ai-antipattern-review.md
+            format: ai-antipattern-review
+  pool:
+    - name: architecture-review
+      description: モジュール構造、責務分割、依存方向、呼び出し経路をレビューする
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: architecture-reviewer
+      policy: [contract-change, review]
+      knowledge: architecture
+      instruction: review-arch
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: architecture-review.md
+            format: architecture-review
+    - name: frontend-review
+      description: UI、コンポーネント、状態管理、アクセシビリティをレビューする
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: frontend-reviewer
+      policy: [contract-change, review]
+      knowledge: [frontend, react]
+      instruction: review-frontend
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: frontend-review.md
+            format: frontend-review
+    - name: backend-review
+      description: API、ドメインロジック、サーバー側処理、永続化をレビューする
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: coding-reviewer
+      policy: [contract-change, review, coding]
+      knowledge: [backend, architecture]
+      instruction: review-coding
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: backend-review.md
+            format: coding-review
+    - name: cli-review
+      description: CLIコマンド、引数、終了コード、設定、ログ、既存CLI構造をレビューする
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: coding-reviewer
+      policy: [contract-change, review, coding]
+      knowledge: [architecture, existing-system]
+      instruction: review-coding
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: cli-review.md
+            format: coding-review
+    - name: security-review
+      description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界をレビューする
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: security-reviewer
+      policy: [contract-change, review]
+      knowledge: security
+      instruction: review-security
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: security-review.md
+            format: security-review
+    - name: testing-review
+      description: テストカバレッジ、テスト設計、統合境界、E2E境界をレビューする
+      capabilities: readonly
+      tags: [review]
+      edit: false
+      persona: testing-reviewer
+      policy: [contract-change, review, testing]
+      knowledge: [unit-testing, e2e-testing]
+      instruction: review-test
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: testing-review.md
+            format: testing-review
+  selection:
+    mode: replace

--- a/builtins/ja/workflow-categories.yaml
+++ b/builtins/ja/workflow-categories.yaml
@@ -3,6 +3,7 @@ workflow_categories:
     workflows:
       - simple
       - default
+      - experimental
       - default-mini
       - default-high
       - cli

--- a/builtins/ja/workflows/experimental.yaml
+++ b/builtins/ja/workflows/experimental.yaml
@@ -1,0 +1,139 @@
+name: experimental
+description: タスクと直前のレポートに応じてレビューエージェント数と修正用ファセットを動的に選択する実験的な汎用コーディングワークフロー。
+max_steps: 51
+initial_step: plan
+
+facet_pools:
+  coding-facets:
+    candidates:
+      - id: frontend
+        description: UI、コンポーネント、状態管理、アクセシビリティ、画面表示を扱う
+        policy: design-fidelity
+        knowledge: [frontend, react]
+      - id: backend
+        description: API、ドメインロジック、サーバー側処理、永続化を扱う
+        knowledge: backend
+      - id: cli
+        description: CLIコマンド、引数、終了コード、設定、ログ、既存CLI構造を扱う
+        policy: existing-system-respect
+        knowledge: existing-system
+      - id: testing
+        description: テスト設計、テストカバレッジ、統合境界、E2E境界を扱う
+        policy: testing
+        knowledge: [unit-testing, e2e-testing]
+      - id: security
+        description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界を扱う
+        knowledge: security
+      - id: implementation-semantics
+        description: 実装の意味、契約、状態遷移、戻り値、副作用を扱う
+        knowledge: implementation-semantics
+
+steps:
+  - name: plan
+    capabilities: [readonly, enable-skills]
+    uses: development-core-plan
+    with:
+      plan_policy: [design-planning]
+      plan_knowledge: [architecture, task-decomposition]
+      plan_instruction: plan
+      plan_report_format: plan
+    rules:
+      - condition: 要件が明確で実装可能
+        next: write_tests
+      - condition: ユーザーが質問をしている（実装タスクではない）
+        next: COMPLETE
+      - condition: 要件が不明確、情報不足
+        next: ABORT
+
+  - name: write_tests
+    capabilities: [edit, enable-skills]
+    uses: development-core-write-tests
+    with:
+      testing_policy: [coding, testing]
+      testing_knowledge: [architecture, unit-testing, e2e-testing]
+      testing_instruction: write-tests-first
+    rules:
+      - condition: テスト作成が完了した
+        next: implement
+      - condition: テスト対象が未実装のためテスト作成をスキップする
+        next: implement
+      - condition: テスト作成を進行できない
+        next: plan
+      - condition: ユーザーへの確認事項があるためユーザー入力が必要
+        next: write_tests
+        requires_user_input: true
+        interactive_only: true
+
+  - name: implement
+    capabilities: [edit, enable-skills]
+    uses: development-core-implement
+    with:
+      development_policy: [coding, testing]
+      development_knowledge: [architecture, existing-system]
+      implementation_instruction: implement
+    dynamic_facets:
+      pool: coding-facets
+    rules:
+      - condition: 実装が完了した
+        next: review
+      - condition: 実装未着手（レポートのみ）
+        next: review
+      - condition: 実装を進行できない
+        next: plan
+      - condition: ユーザー入力が必要
+        next: implement
+        requires_user_input: true
+        interactive_only: true
+
+  - name: review
+    uses: experimental-review
+    rules:
+      self:
+        - condition: all("approved")
+          next: supervise
+        - condition: any("needs_fix")
+          next: fix
+      parallel:
+        coding-review: &reviewer-rules
+          - condition: approved
+          - condition: needs_fix
+        ai-antipattern-review: *reviewer-rules
+        architecture-review: *reviewer-rules
+        frontend-review: *reviewer-rules
+        backend-review: *reviewer-rules
+        cli-review: *reviewer-rules
+        security-review: *reviewer-rules
+        testing-review: *reviewer-rules
+
+  - name: fix
+    capabilities: [edit, enable-skills]
+    uses: fix
+    policy: [contract-change, coding, testing, review, ai-antipattern]
+    knowledge: architecture
+    dynamic_facets:
+      pool: coding-facets
+    rules:
+      - condition: 修正完了
+        next: review
+      - condition: 修正方針の見直しが必要
+        next: plan
+      - condition: タスク全体の再計画が必要
+        next: plan
+      - condition: 修正を進行できない
+        next: ABORT
+
+  - name: supervise
+    capabilities: [readonly, enable-skills]
+    uses: review-supervise-to-complete
+    tags: [review, final-gate, supervise]
+    policy: [contract-change, coding, testing, review, ai-antipattern]
+    knowledge: [architecture, unit-testing, e2e-testing]
+    rules:
+      - condition: BLOCKED
+        next: ABORT
+      - condition: approved
+        next: COMPLETE
+      - condition: need_replan
+        next: plan
+      - condition: needs_fix
+        next: fix

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -350,6 +350,8 @@ claim を失う等）で、既存の訂正1回でも直らないときは、TAKT
 
 pool はトップレベルの `facet_pools` map に定義し、step から `dynamic_facets` で参照します。pool は workflow 内に inline で定義するか、外部 resource ファイルとして定義できます。
 
+`dynamic_facets.max_selected` は任意です。指定した場合は選択数の上限として扱い、省略した場合は pool の全候補数まで選択できます。selector の失敗時に全候補へ自動 fallback する挙動ではありません。
+
 #### inline pool
 
 inline pool は workflow YAML 内に直接記述します。候補の `policy` / `knowledge` 参照は、通常の step と同じ workflow-local facet namespace で解決します。workflow の `policies` / `knowledge` section map による alias と、通常の bare facet lookup の両方が使えます。
@@ -492,7 +494,7 @@ selector には少なくとも次を渡します。
 - タスク開始時点からの累積差分
 - 候補 ID と description
 
-facet 本文は selector に渡しません。selector は厳格な structured output schema（`additionalProperties: false`、`selected_ids` は pool の候補 ID を `enum` とする unique array、加えて必須の `rationale` 文字列）に対して候補 ID と理由だけを返します。pool 外 ID、重複 ID、`max_selected` 超過は拒否します。selector 失敗時は main agent を起動せず fail-fast し、全候補や空選択への暗黙 fallback はありません。selector 自身を dynamic facet selection や auto routing の対象にしません。
+facet 本文は selector に渡しません。selector は厳格な structured output schema（`additionalProperties: false`、`selected_ids` は pool の候補 ID を `enum` とする unique array、加えて必須の `rationale` 文字列）に対して候補 ID と理由だけを返します。pool 外 ID、重複 ID、指定した `max_selected` の超過は拒否します。selector 失敗時は main agent を起動せず fail-fast し、全候補や空選択への暗黙 fallback はありません。selector 自身を dynamic facet selection や auto routing の対象にしません。
 
 selector provider は #1136 の `runtime.yaml` の `provider.targets.internal_agents.selector` で解決します。未指定時は runtime の通常 default を使います。
 
@@ -549,7 +551,7 @@ MVP では実行途中の facet hot swap を行いません。必要領域が変
 - 外部 pool での nested `uses`、`params`、`$param`
 - 外部 resource の探索、trust、file validation 違反
 - `dynamic_facets.pool` が未知
-- `max_selected` が不正または候補数を超える
+- 指定した `max_selected` が不正または候補数を超える
 - 通常 agent step 以外への `dynamic_facets` 指定
 
 selector 実行時に次のいずれかが成立すると main agent 起動前に失敗します。
@@ -558,7 +560,7 @@ selector 実行時に次のいずれかが成立すると main agent 起動前�
 - structured output が不成立
 - `selected_ids` が配列でない
 - 非文字列、重複、未知 ID
-- `max_selected` 超過
+- 指定した `max_selected` の超過
 
 暗黙 fallback はありません。
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -357,6 +357,8 @@ A normal agent step can dynamically select additional `policy` and `knowledge` f
 
 Define a pool under the top-level `facet_pools` map, then reference it from a step with `dynamic_facets`. Pools can be defined inline in the workflow or as external resource files.
 
+`dynamic_facets.max_selected` is optional. When specified, it limits the number of selected candidates; when omitted, the selector may select up to every candidate in the pool. This does not add an all-candidate fallback when selector execution fails.
+
 #### Inline pool
 
 An inline pool lives in the workflow YAML. Its candidate `policy` / `knowledge` references resolve through the same workflow-local facet namespace as ordinary steps: the workflow `policies` / `knowledge` section maps and bare facet lookup both work.
@@ -499,7 +501,7 @@ The selector receives at least:
 - The cumulative diff since the task started
 - Candidate IDs and descriptions
 
-Facet bodies are not sent to the selector. The selector returns only candidate IDs and a rationale against a strict structured output schema (`additionalProperties: false`, `selected_ids` as a unique array whose items are an `enum` of the pool's candidate IDs, plus a required `rationale` string). Pool-external IDs, duplicate IDs, and selections exceeding `max_selected` are rejected. Selector failure stops the run before the main agent starts; there is no implicit fallback to all candidates or to an empty selection. The selector itself is not subject to dynamic facet selection or auto routing.
+Facet bodies are not sent to the selector. The selector returns only candidate IDs and a rationale against a strict structured output schema (`additionalProperties: false`, `selected_ids` as a unique array whose items are an `enum` of the pool's candidate IDs, plus a required `rationale` string). Pool-external IDs, duplicate IDs, and selections exceeding a specified `max_selected` are rejected. Selector failure stops the run before the main agent starts; there is no implicit fallback to all candidates or to an empty selection. The selector itself is not subject to dynamic facet selection or auto routing.
 
 The selector provider is resolved through #1136's `provider.targets.internal_agents.selector` in `runtime.yaml`. When left unspecified, the runtime's normal default is used.
 
@@ -556,7 +558,7 @@ Loading fails before execution when any of these hold:
 - An external pool uses nested `uses`, `params`, or `$param`
 - External resource lookup, trust, or file validation fails
 - `dynamic_facets.pool` is unknown
-- `max_selected` is invalid or exceeds the candidate count
+- A specified `max_selected` is invalid or exceeds the candidate count
 - `dynamic_facets` is declared on a non-agent step
 
 Selector execution fails before the main agent starts when:
@@ -565,7 +567,7 @@ Selector execution fails before the main agent starts when:
 - Structured output is not established
 - `selected_ids` is not an array
 - An ID is non-string, duplicate, or unknown
-- `max_selected` is exceeded
+- A specified `max_selected` is exceeded
 
 There is no implicit fallback.
 

--- a/src/__tests__/dynamic-facet-context-builder.test.ts
+++ b/src/__tests__/dynamic-facet-context-builder.test.ts
@@ -109,4 +109,21 @@ describe('DynamicFacetContextBuilder (C-SELECTOR-INPUT, C-SELECTOR-INVOKE)', () 
     expect(instruction).not.toContain('(root)');
     expect(instruction).toContain('Max selected:\n4');
   });
+
+  it('should render unlimited when maxSelected is omitted', () => {
+    const instruction = buildDynamicFacetSelectorInstruction({
+      task: 'task',
+      workflowName: 'wf',
+      stepName: 'fix',
+      workflowCallPath: [],
+      isReentry: false,
+      stepIteration: 1,
+      reports: '',
+      unresolvedFindings: '',
+      cumulativeDiff: '',
+      pool,
+    });
+
+    expect(instruction).toContain('Max selected:\nunlimited');
+  });
 });

--- a/src/__tests__/dynamic-facet-selector-coordinator.test.ts
+++ b/src/__tests__/dynamic-facet-selector-coordinator.test.ts
@@ -37,12 +37,24 @@ function makePool(candidates: { id: string; description: string }[]): ResolvedFa
   };
 }
 
-function makeStep(maxSelected = 4): NormalAgentWorkflowStep {
+function makeStep(maxSelected: number | undefined = 4): NormalAgentWorkflowStep {
   return {
     name: 'fix',
     personaDisplayName: 'coder',
     instruction: 'Fix',
-    dynamicFacets: { pool: 'fix', maxSelected },
+    dynamicFacets: {
+      pool: 'fix',
+      ...(maxSelected === undefined ? {} : { maxSelected }),
+    },
+  };
+}
+
+function makeUnlimitedStep(): NormalAgentWorkflowStep {
+  return {
+    name: 'fix',
+    personaDisplayName: 'coder',
+    instruction: 'Fix',
+    dynamicFacets: { pool: 'fix' },
   };
 }
 
@@ -129,6 +141,30 @@ describe('DynamicFacetSelectorCoordinator', () => {
     await expect(
       coordinator.resolveDynamicFacets(step, makeState(), 'task', pool),
     ).rejects.toThrow('must NOT have more than 2 items');
+  });
+
+  it('accepts all pool candidates when max_selected is omitted', async () => {
+    const pool = makePool([
+      { id: 'a', description: 'A' },
+      { id: 'b', description: 'B' },
+      { id: 'c', description: 'C' },
+    ]);
+    const step = makeUnlimitedStep();
+    const response: AgentResponse = {
+      persona: 'selector',
+      status: 'done',
+      content: '',
+      timestamp: new Date(),
+      structuredOutput: { selected_ids: ['a', 'b', 'c'], rationale: 'all facets are relevant' },
+    };
+    mockedExecuteAgent.mockResolvedValueOnce(response);
+
+    const coordinator = new DynamicFacetSelectorCoordinator(buildDeps());
+    const result = await coordinator.resolveDynamicFacets(step, makeState(), 'task', pool);
+
+    expect(result.selectedIds).toEqual(['a', 'b', 'c']);
+    const executeOptions = mockedExecuteAgent.mock.calls[0]?.[2] as { properties?: { selected_ids?: { maxItems?: number } } };
+    expect(executeOptions.properties?.selected_ids?.maxItems).toBeUndefined();
   });
 
   it('restores from snapshot without invoking selector when identity is in resumedDynamicFacetSteps', async () => {

--- a/src/__tests__/facet-pool-schema.test.ts
+++ b/src/__tests__/facet-pool-schema.test.ts
@@ -56,6 +56,25 @@ describe('facet_pools schema (C-CANDIDATE-SCHEMA, C-USES-INLINE-MIX, C-EXTERNAL-
       expect(() => WorkflowConfigRawSchema.parse(raw)).not.toThrow();
     });
 
+    it('should accept dynamic_facets without max_selected (unlimited selection)', () => {
+      const raw = baseWorkflowWithFacetPools({
+        fix: {
+          candidates: [
+            { id: 'backend', description: 'API、repository、server-side実装を扱う', knowledge: 'backend-api' },
+          ],
+        },
+      }, [{
+        name: 'fix',
+        persona: 'coder',
+        policy: ['coding'],
+        dynamic_facets: { pool: 'fix' },
+        instruction: 'fix',
+        edit: true,
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      }]);
+      expect(() => WorkflowConfigRawSchema.parse(raw)).not.toThrow();
+    });
+
     it('should accept a candidate that bundles multiple facets as arrays (C-CANDIDATE-SCHEMA bundle)', () => {
       const raw = baseWorkflowWithFacetPools({
         fix: {

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WorkflowStep } from '../core/models/index.js';
+import { semanticRuleCandidatesOf } from '../core/models/workflow-rule-condition.js';
+import { WorkflowEngine } from '../core/workflow/index.js';
+import { RuleDetectionExhaustedError } from '../core/workflow/evaluation/RuleDetectionExhaustedError.js';
+import type { SelectorGitCommandRunner } from '../core/workflow/dynamic-parallel/selector-git-command-runner.js';
+import { DefaultStructuredCaller } from '../agents/structured-caller.js';
+import { loadWorkflowFromFile } from '../infra/config/loaders/workflowFileLoader.js';
+import {
+  getBuiltinWorkflowsDir,
+} from '../infra/config/paths.js';
+import {
+  invalidateAllResolvedConfigCache,
+  invalidateGlobalConfigCache,
+} from '../infra/config/index.js';
+import {
+  getScenarioQueue,
+  resetScenario,
+  setMockScenario,
+  type ScenarioEntry,
+} from '../infra/mock/index.js';
+import { cleanupWorkflowEngine } from './engine-test-helpers.js';
+
+vi.mock('../core/workflow/phase-runner.js', () => ({
+  runReportPhase: vi.fn().mockImplementation(async (
+    step: WorkflowStep,
+    _stepIteration: number,
+    context: { reportDir: string; lastResponse?: string },
+  ) => {
+    mkdirSync(context.reportDir, { recursive: true });
+    for (const contract of step.outputContracts ?? []) {
+      writeFileSync(join(context.reportDir, contract.name), context.lastResponse ?? 'Mock report');
+    }
+  }),
+  runStatusJudgmentPhase: vi.fn().mockImplementation((
+    step: WorkflowStep,
+    context: { interactive?: boolean; lastResponse?: string },
+  ) => {
+    const match = /RULE:(\d+)/u.exec(context.lastResponse ?? '');
+    const candidateIndex = match === null ? -1 : Number.parseInt(match[1]!, 10);
+    const candidate = semanticRuleCandidatesOf(
+      step.rules ?? [],
+      context.interactive === true,
+    )[candidateIndex];
+    if (candidate === undefined) {
+      throw new RuleDetectionExhaustedError(step.name);
+    }
+    return { label: candidate.label, method: 'phase3_tag' as const };
+  }),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
+  generateSessionId: vi.fn().mockReturnValue('test-session-id'),
+}));
+
+import { runReportPhase } from '../core/workflow/phase-runner.js';
+
+const SELECTOR_PROVIDER = {
+  provider: 'mock' as const,
+  providerOptions: {},
+  nativeTools: [],
+};
+const SELECTOR_GIT_COMMAND_RUNNER: SelectorGitCommandRunner = {
+  run: async () => ({ output: Buffer.alloc(0), bytes: 0 }),
+};
+
+function response(persona: string, ruleIndex: number): ScenarioEntry {
+  return {
+    persona,
+    status: 'done',
+    content: `RULE:${ruleIndex}`,
+  };
+}
+
+function selection(selectedIds: string[], rationale: string): ScenarioEntry {
+  return {
+    persona: 'takt-internal',
+    status: 'done',
+    content: rationale,
+    structuredOutput: {
+      selected_ids: selectedIds,
+      rationale,
+    },
+  };
+}
+
+function reviewReportCalls(): WorkflowStep[] {
+  return vi.mocked(runReportPhase).mock.calls
+    .map(([step]) => step)
+    .filter((step) => step.tags?.includes('review') === true);
+}
+
+describe('experimental builtin workflow', () => {
+  let projectDir: string;
+  let globalConfigDir: string;
+  let previousConfigDir: string | undefined;
+  let engines: WorkflowEngine[];
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'takt-experimental-workflow-'));
+    globalConfigDir = mkdtempSync(join(tmpdir(), 'takt-experimental-workflow-global-'));
+    previousConfigDir = process.env.TAKT_CONFIG_DIR;
+    process.env.TAKT_CONFIG_DIR = globalConfigDir;
+    engines = [];
+    vi.clearAllMocks();
+    invalidateGlobalConfigCache();
+    invalidateAllResolvedConfigCache();
+
+    mkdirSync(join(projectDir, '.takt'), { recursive: true });
+  });
+
+  afterEach(() => {
+    for (const engine of engines) cleanupWorkflowEngine(engine);
+    resetScenario();
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(globalConfigDir, { recursive: true, force: true });
+    if (previousConfigDir === undefined) delete process.env.TAKT_CONFIG_DIR;
+    else process.env.TAKT_CONFIG_DIR = previousConfigDir;
+    invalidateGlobalConfigCache();
+    invalidateAllResolvedConfigCache();
+  });
+
+  it(
+    'runs fixed reviewers on every English review round and replaces the selected reviewer pool',
+    async () => {
+      const language = 'en';
+      writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
+      invalidateAllResolvedConfigCache();
+      const workflow = loadWorkflowFromFile(
+        join(getBuiltinWorkflowsDir(language), 'experimental.yaml'),
+        projectDir,
+      );
+      workflow.initialStep = 'review';
+      setMockScenario([
+        selection(['frontend-review'], 'The first review round covers frontend changes.'),
+        response('coding-reviewer', 1),
+        response('ai-antipattern-reviewer', 1),
+        response('frontend-reviewer', 1),
+        selection([], 'No additional remediation facets are needed.'),
+        response('coder', 0),
+        selection(['security-review'], 'The second review round covers security changes.'),
+        response('coding-reviewer', 0),
+        response('ai-antipattern-reviewer', 0),
+        response('security-reviewer', 0),
+        response('supervisor', 1),
+      ]);
+      const engine = new WorkflowEngine(workflow, projectDir, 'Implement and review a frontend security change', {
+        projectCwd: projectDir,
+        provider: 'mock',
+        selectorProvider: SELECTOR_PROVIDER,
+        selectorGitCommandRunner: SELECTOR_GIT_COMMAND_RUNNER,
+        structuredCaller: new DefaultStructuredCaller(),
+      });
+      engines.push(engine);
+      const abortReasons: string[] = [];
+      engine.on('workflow:abort', (_state, reason) => abortReasons.push(reason));
+
+      const state = await engine.run();
+
+      expect(state.status, JSON.stringify({
+        abortReasons,
+        currentStep: state.currentStep,
+        iteration: state.iteration,
+        remainingScenarios: getScenarioQueue()?.remaining,
+      })).toBe('completed');
+      expect(state.stepIterations.get('review')).toBe(2);
+      expect(state.stepIterations.get('fix')).toBe(1);
+      const reviewSelection = [...state.dynamicParallelSelections.values()]
+        .find((snapshot) => snapshot.step_name === 'review');
+      expect(reviewSelection).toMatchObject({
+        round: 2,
+        selected_pool_ids: ['security-review'],
+        effective_selection_ids: [
+          'coding-review',
+          'ai-antipattern-review',
+          'security-review',
+        ],
+      });
+      expect(workflow.steps.find((step) => step.name === 'review')?.parallel)
+        .toMatchObject({ selection: { mode: 'replace' } });
+
+      const reportCalls = reviewReportCalls();
+      expect(reportCalls.filter((step) => step.name === 'ai-antipattern-review')).toHaveLength(2);
+      expect(reportCalls.filter((step) => step.name === 'coding-review')).toHaveLength(2);
+      expect(reportCalls.filter((step) => step.name === 'frontend-review')).toHaveLength(1);
+      expect(reportCalls.filter((step) => step.name === 'security-review')).toHaveLength(1);
+      expect(reportCalls.some((step) => step.name === 'backend-review')).toBe(false);
+      const aiAntipatternReport = reportCalls
+        .find((step) => step.name === 'ai-antipattern-review')
+        ?.outputContracts.find((contract) => contract.name === 'ai-antipattern-review.md');
+      expect(aiAntipatternReport).toBeDefined();
+      expect(existsSync(join(
+        projectDir,
+        '.takt',
+        'runs',
+        'test-report-dir',
+        'reports',
+        'ai-antipattern-review.md',
+      ))).toBe(true);
+      expect(getScenarioQueue()?.remaining).toBe(0);
+    },
+    60_000,
+  );
+
+  it(
+    'routes the Japanese experimental review rejection through fix and aborts when remediation cannot proceed',
+    async () => {
+      const language = 'ja';
+      writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
+      invalidateAllResolvedConfigCache();
+      const workflow = loadWorkflowFromFile(
+        join(getBuiltinWorkflowsDir(language), 'experimental.yaml'),
+        projectDir,
+      );
+      workflow.initialStep = 'review';
+      setMockScenario([
+        selection(['testing-review'], 'Testing review is required.'),
+        response('coding-reviewer', 1),
+        response('ai-antipattern-reviewer', 1),
+        response('testing-reviewer', 1),
+        selection([], 'No additional remediation facets are needed.'),
+        response('coder', 3),
+      ]);
+      const engine = new WorkflowEngine(workflow, projectDir, 'Implement a change that cannot be remediated', {
+        projectCwd: projectDir,
+        provider: 'mock',
+        selectorProvider: SELECTOR_PROVIDER,
+        selectorGitCommandRunner: SELECTOR_GIT_COMMAND_RUNNER,
+        structuredCaller: new DefaultStructuredCaller(),
+      });
+      engines.push(engine);
+      const abortReasons: string[] = [];
+      engine.on('workflow:abort', (_state, reason) => abortReasons.push(reason));
+
+      const state = await engine.run();
+
+      expect(state.status).toBe('aborted');
+      expect(state.stepIterations.get('review'), JSON.stringify({
+        abortReasons,
+        currentStep: state.currentStep,
+        iteration: state.iteration,
+        remainingScenarios: getScenarioQueue()?.remaining,
+      })).toBe(1);
+      expect(state.stepIterations.get('fix')).toBe(1);
+      expect(reviewReportCalls().filter((step) => step.name === 'ai-antipattern-review')).toHaveLength(1);
+      expect(getScenarioQueue()?.remaining).toBe(0);
+    },
+    60_000,
+  );
+});

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { WorkflowStep } from '../core/models/index.js';
+import {
+  getAllParallelSubSteps,
+  type WorkflowConfig,
+  type WorkflowStep,
+} from '../core/models/index.js';
 import { semanticRuleCandidatesOf } from '../core/models/workflow-rule-condition.js';
 import { WorkflowEngine } from '../core/workflow/index.js';
 import { RuleDetectionExhaustedError } from '../core/workflow/evaluation/RuleDetectionExhaustedError.js';
@@ -69,7 +73,31 @@ const SELECTOR_GIT_COMMAND_RUNNER: SelectorGitCommandRunner = {
   run: async () => ({ output: Buffer.alloc(0), bytes: 0 }),
 };
 
-function response(persona: string, ruleIndex: number): ScenarioEntry {
+function findWorkflowStep(workflow: WorkflowConfig, stepName: string): WorkflowStep {
+  const pending = [...workflow.steps];
+  for (const step of pending) {
+    if (step.name === stepName) return step;
+    if (step.parallel !== undefined) pending.push(...getAllParallelSubSteps(step.parallel));
+  }
+  throw new Error(`Workflow step not found: ${stepName}`);
+}
+
+function findRuleIndex(step: WorkflowStep, ruleLabel: string): number {
+  const ruleIndex = semanticRuleCandidatesOf(step.rules ?? [], false)
+    .findIndex((candidate) => candidate.label === ruleLabel);
+  if (ruleIndex < 0) {
+    throw new Error(`Rule label not found for step "${step.name}": ${ruleLabel}`);
+  }
+  return ruleIndex;
+}
+
+function response(
+  workflow: WorkflowConfig,
+  stepName: string,
+  persona: string,
+  ruleLabel: string,
+): ScenarioEntry {
+  const ruleIndex = findRuleIndex(findWorkflowStep(workflow, stepName), ruleLabel);
   return {
     persona,
     status: 'done',
@@ -97,15 +125,10 @@ function reviewReportCalls(): WorkflowStep[] {
 
 describe('experimental builtin workflow', () => {
   let projectDir: string;
-  let globalConfigDir: string;
-  let previousConfigDir: string | undefined;
   let engines: WorkflowEngine[];
 
   beforeEach(() => {
     projectDir = mkdtempSync(join(tmpdir(), 'takt-experimental-workflow-'));
-    globalConfigDir = mkdtempSync(join(tmpdir(), 'takt-experimental-workflow-global-'));
-    previousConfigDir = process.env.TAKT_CONFIG_DIR;
-    process.env.TAKT_CONFIG_DIR = globalConfigDir;
     engines = [];
     vi.clearAllMocks();
     invalidateGlobalConfigCache();
@@ -118,15 +141,12 @@ describe('experimental builtin workflow', () => {
     for (const engine of engines) cleanupWorkflowEngine(engine);
     resetScenario();
     rmSync(projectDir, { recursive: true, force: true });
-    rmSync(globalConfigDir, { recursive: true, force: true });
-    if (previousConfigDir === undefined) delete process.env.TAKT_CONFIG_DIR;
-    else process.env.TAKT_CONFIG_DIR = previousConfigDir;
     invalidateGlobalConfigCache();
     invalidateAllResolvedConfigCache();
   });
 
   it(
-    'runs fixed reviewers on every English review round and replaces the selected reviewer pool',
+    'should run the full English workflow and replace the selected reviewer pool when review requires fixes',
     async () => {
       const language = 'en';
       writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
@@ -135,19 +155,22 @@ describe('experimental builtin workflow', () => {
         join(getBuiltinWorkflowsDir(language), 'experimental.yaml'),
         projectDir,
       );
-      workflow.initialStep = 'review';
       setMockScenario([
+        response(workflow, 'plan', 'planner', 'Requirements are clear and implementation is feasible'),
+        response(workflow, 'write_tests', 'coder', 'Test creation completed'),
+        selection(['frontend'], 'Frontend implementation facets are required.'),
+        response(workflow, 'implement', 'coder', 'Implementation completed'),
         selection(['frontend-review'], 'The first review round covers frontend changes.'),
-        response('coding-reviewer', 1),
-        response('ai-antipattern-reviewer', 1),
-        response('frontend-reviewer', 1),
+        response(workflow, 'coding-review', 'coding-reviewer', 'needs_fix'),
+        response(workflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'needs_fix'),
+        response(workflow, 'frontend-review', 'frontend-reviewer', 'needs_fix'),
         selection([], 'No additional remediation facets are needed.'),
-        response('coder', 0),
+        response(workflow, 'fix', 'coder', 'Fix complete'),
         selection(['security-review'], 'The second review round covers security changes.'),
-        response('coding-reviewer', 0),
-        response('ai-antipattern-reviewer', 0),
-        response('security-reviewer', 0),
-        response('supervisor', 1),
+        response(workflow, 'coding-review', 'coding-reviewer', 'approved'),
+        response(workflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'approved'),
+        response(workflow, 'security-review', 'security-reviewer', 'approved'),
+        response(workflow, 'supervise', 'supervisor', 'approved'),
       ]);
       const engine = new WorkflowEngine(workflow, projectDir, 'Implement and review a frontend security change', {
         projectCwd: projectDir,
@@ -168,8 +191,17 @@ describe('experimental builtin workflow', () => {
         iteration: state.iteration,
         remainingScenarios: getScenarioQueue()?.remaining,
       })).toBe('completed');
+      expect(state.stepIterations.get('plan')).toBe(1);
+      expect(state.stepIterations.get('write_tests')).toBe(1);
+      expect(state.stepIterations.get('implement')).toBe(1);
       expect(state.stepIterations.get('review')).toBe(2);
       expect(state.stepIterations.get('fix')).toBe(1);
+      const implementSelection = [...state.dynamicFacetSelections.values()]
+        .find((snapshot) => snapshot.step_name === 'implement');
+      expect(implementSelection).toMatchObject({
+        round: 1,
+        selected_ids: ['frontend'],
+      });
       const reviewSelection = [...state.dynamicParallelSelections.values()]
         .find((snapshot) => snapshot.step_name === 'review');
       expect(reviewSelection).toMatchObject({
@@ -208,7 +240,7 @@ describe('experimental builtin workflow', () => {
   );
 
   it(
-    'routes the Japanese experimental review rejection through fix and aborts when remediation cannot proceed',
+    'should abort when the Japanese experimental review rejection cannot be remediated',
     async () => {
       const language = 'ja';
       writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
@@ -220,11 +252,11 @@ describe('experimental builtin workflow', () => {
       workflow.initialStep = 'review';
       setMockScenario([
         selection(['testing-review'], 'Testing review is required.'),
-        response('coding-reviewer', 1),
-        response('ai-antipattern-reviewer', 1),
-        response('testing-reviewer', 1),
+        response(workflow, 'coding-review', 'coding-reviewer', 'needs_fix'),
+        response(workflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'needs_fix'),
+        response(workflow, 'testing-review', 'testing-reviewer', 'needs_fix'),
         selection([], 'No additional remediation facets are needed.'),
-        response('coder', 3),
+        response(workflow, 'fix', 'coder', '修正を進行できない'),
       ]);
       const engine = new WorkflowEngine(workflow, projectDir, 'Implement a change that cannot be remediated', {
         projectCwd: projectDir,
@@ -247,6 +279,7 @@ describe('experimental builtin workflow', () => {
         remainingScenarios: getScenarioQueue()?.remaining,
       })).toBe(1);
       expect(state.stepIterations.get('fix')).toBe(1);
+      expect(abortReasons).toEqual(['Workflow aborted by step transition']);
       expect(reviewReportCalls().filter((step) => step.name === 'ai-antipattern-review')).toHaveLength(1);
       expect(getScenarioQueue()?.remaining).toBe(0);
     },

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -374,7 +374,7 @@ export const FacetPoolRawSchema = z.union([
 
 export const DynamicFacetsRawSchema = z.object({
   pool: z.string().min(1),
-  max_selected: z.number().int().positive(),
+  max_selected: z.number().int().positive().optional(),
 }).strict();
 
 /** Team leader configuration schema for dynamic part decomposition */

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -225,7 +225,7 @@ export interface ResolvedFacetPool {
 
 export interface DynamicFacetsConfig {
   readonly pool: string;
-  readonly maxSelected: number;
+  readonly maxSelected?: number;
 }
 
 export interface DynamicFacetSelectionSnapshot {

--- a/src/core/workflow/dynamic-facets/dynamicFacetContextBuilder.ts
+++ b/src/core/workflow/dynamic-facets/dynamicFacetContextBuilder.ts
@@ -11,7 +11,7 @@ export interface DynamicFacetSelectorInstructionInput {
   readonly unresolvedFindings: string;
   readonly cumulativeDiff: string;
   readonly pool: ResolvedFacetPool;
-  readonly maxSelected: number;
+  readonly maxSelected?: number;
 }
 
 export function buildDynamicFacetSelectorInstruction(input: DynamicFacetSelectorInstructionInput): string {
@@ -42,6 +42,6 @@ export function buildDynamicFacetSelectorInstruction(input: DynamicFacetSelector
     '',
     `Candidates:\n${candidates}`,
     '',
-    `Max selected:\n${input.maxSelected}`,
+    `Max selected:\n${input.maxSelected ?? 'unlimited'}`,
   ].join('\n');
 }

--- a/src/core/workflow/dynamic-facets/dynamicFacetResumeState.ts
+++ b/src/core/workflow/dynamic-facets/dynamicFacetResumeState.ts
@@ -107,7 +107,10 @@ function validateDynamicFacetSelections(
           `Dynamic facet selection snapshot for step "${step.name}" references candidate id "${missingId}" that is not in pool "${pool.name}"`,
         );
       }
-      if (snapshot.selected_ids.length > step.dynamicFacets.maxSelected) {
+      if (
+        step.dynamicFacets.maxSelected !== undefined
+        && snapshot.selected_ids.length > step.dynamicFacets.maxSelected
+      ) {
         throw new Error(
           `Dynamic facet selection snapshot for step "${step.name}" has ${snapshot.selected_ids.length} selected ids but max_selected is ${step.dynamicFacets.maxSelected}`,
         );

--- a/src/core/workflow/dynamic-facets/dynamicFacetSelectorCoordinator.ts
+++ b/src/core/workflow/dynamic-facets/dynamicFacetSelectorCoordinator.ts
@@ -154,7 +154,10 @@ export class DynamicFacetSelectorCoordinator {
       selectorResult = validateSelectorResponse(response, outputSchema, step.name, redact, { label: 'Dynamic facet' });
       signal?.throwIfAborted();
       selectedIds = selectorResult.selectedIds;
-      if (selectedIds.length > step.dynamicFacets.maxSelected) {
+      if (
+        step.dynamicFacets.maxSelected !== undefined
+        && selectedIds.length > step.dynamicFacets.maxSelected
+      ) {
         throw new Error(
           `Dynamic facet selector for "${step.name}" selected ${selectedIds.length} candidates, exceeding max_selected ${step.dynamicFacets.maxSelected}`,
         );

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -576,7 +576,10 @@ function validateDynamicFacetsReferences(
       );
     }
     const candidateCount = pool.candidates.length;
-    if (step.dynamic_facets.max_selected > candidateCount) {
+    if (
+      step.dynamic_facets.max_selected !== undefined
+      && step.dynamic_facets.max_selected > candidateCount
+    ) {
       throw withWorkflowStepErrorPath(
         new Error(
           `Configuration error: step "${step.name}" dynamic_facets.max_selected (${step.dynamic_facets.max_selected}) exceeds candidate count (${candidateCount}) of pool "${poolName}"`,

--- a/src/infra/config/loaders/workflowPreview.ts
+++ b/src/infra/config/loaders/workflowPreview.ts
@@ -59,7 +59,7 @@ export interface StepPreview {
   dynamicSelectionMode?: 'replace' | 'cumulative';
   dynamicFacets?: {
     readonly pool: string;
-    readonly maxSelected: number;
+    readonly maxSelected?: number;
     readonly candidates: readonly {
       readonly id: string;
       readonly description: string;
@@ -312,7 +312,7 @@ function resolveDynamicFacetsPreview(
   workflow: WorkflowConfig,
   step: WorkflowStep,
 ): { dynamicFacets: NonNullable<StepPreview['dynamicFacets']> } | Record<string, never> {
-  const dynamicFacets = (step as { dynamicFacets?: { readonly pool: string; readonly maxSelected: number } }).dynamicFacets;
+  const dynamicFacets = (step as { dynamicFacets?: { readonly pool: string; readonly maxSelected?: number } }).dynamicFacets;
   if (dynamicFacets === undefined) return {};
   const pool = workflow.facetPools?.[dynamicFacets.pool];
   if (pool === undefined) return {};

--- a/src/infra/config/loaders/workflowStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepNormalizer.ts
@@ -125,7 +125,7 @@ function normalizeDynamicFacets(
   }
   return normalizeStepField(stepPath, ['dynamic_facets'], () => ({
     pool: raw.pool,
-    maxSelected: raw.max_selected,
+    ...(raw.max_selected === undefined ? {} : { maxSelected: raw.max_selected }),
   }));
 }
 


### PR DESCRIPTION
## Summary

- 汎用コーディング向けの `experimental` workflow を日英 builtin に追加
- `plan` / `write_tests` / `implement` / `review` / `fix` / `supervise` を step fragment の `uses` で構成
- `implement` と `fix` でタスク・直前レポートに応じて facet pool を動的選択
- review は coding / AI antipattern を固定し、architecture / frontend / backend / CLI / security / testing を動的 pool から選択
- `dynamic_facets.max_selected` を任意化し、省略時は pool の全候補を選択可能に変更
- `experimental` を Quick Start カテゴリへ追加

## Execution Report

- `npm run build`
- `npm run lint`
- 対象テスト 5 files / 232 tests passed
- Codex 追加確認 6 files / 151 tests passed
- `takt workflow doctor` 日英とも成功
- Codex review: 明確な不具合なし
- full `npm test` は 574 秒後に exit 130 で中断（失敗アサーションは観測されず）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 実験的な汎用コーディングワークフローを追加しました。
  - 計画、テスト、実装、並列レビュー、修正、最終確認までを自動化します。
  - コーディング、AIアンチパターン、セキュリティ、アーキテクチャなど複数のレビューを実行できます。
  - クイックスタートから実験的ワークフローを選択できます。
  - 動的な候補選択で、上限を指定しない場合は全候補を選択できます。

- **ドキュメント**
  - 動的選択の上限仕様と、選択結果の検証条件を明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->