### PR TITLE
fix(test): isolate resource-heavy unit tests from fast shards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,10 @@
 - `npm run build`: compile TypeScript and copy runtime prompts, i18n files, and presets into `dist/`.
 - `npm run watch`: run the TypeScript compiler in incremental watch mode.
 - `npm run lint`: run ESLint on `src/`.
-- `npm test`: run the unit gate; targeted source tests are routed to their unit or integration runner.
+- `npm test`: run the fast unit gate in four concurrent shards. Resource-heavy unit tests are excluded and announced in the output; targeted source tests are routed to their unit, heavy-unit, or integration runner.
+- `npm run test:unit:heavy`: run the resource-heavy unit slice with one worker when the changed area needs it.
 - `npm run test:e2e:mock`: run E2E tests against the mock provider.
-- `npm run check:release`: run the full release verification path: build, lint, unit, integration, prompt-eval, and all E2E suites.
+- `npm run check:release`: run the full release verification path: build, lint, fast unit (four shards), heavy unit, integration, prompt-eval, and all E2E suites.
 
 ## Coding Style & Naming Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,18 +15,19 @@ TAKT (TAKT Agent Koordination Topology) is a multi-agent orchestration CLI. It r
 | `npm run build` | `tsc` (+ prompt-evals tsconfig) plus copies of `src/shared/prompts/{en,ja}/**/*.md`, `src/shared/i18n/*.yaml`, and `src/core/runtime/presets/*.sh` into `dist/`. Skipping any copy breaks runtime resolution. |
 | `npm run watch` | TypeScript incremental build (no asset copy). |
 | `npm run lint` | ESLint on `src/`. `no-explicit-any` is error; unused vars must be prefixed `_`. |
-| `npm test` | Fast unit gate: type-contracts tsc, then 4 shards launched **concurrently** (`Promise.all` in `scripts/run-npm-test.mjs`, each shard `--maxWorkers=1`). Excludes integration/regression/performance tests. |
+| `npm test` | Fast unit gate: type-contracts tsc, then 4 shards launched **concurrently** (`Promise.all` in `scripts/run-npm-test.mjs`, each shard `--maxWorkers=1`). Excludes integration/regression/performance and resource-heavy unit tests; the output names the follow-up command. |
+| `npm run test:unit:heavy` | Resource-heavy unit slice, run with one worker when relevant. `check:release` always runs it after the fast 4-shard gate. |
 | `npm run test:it` | Integration gate: parallel IT slice (`it-*`, `*.integration/regression/performance.test.ts`), then the serial group. |
-| `npm test -- src/__tests__/<file>.test.ts` | Route a single file to the correct runner (unit, parallel-IT, or serial). Multiple routed runners execute sequentially and return the first failing exit code. |
+| `npm test -- src/__tests__/<file>.test.ts` | Route a single file to the correct runner (unit, heavy-unit, parallel-IT, or serial). Multiple routed runners execute concurrently and return the first failing exit code. |
 | `npm test -- -t "<pattern>"` | Run unit tests whose name matches `<pattern>`. |
 | `npm run test:prompt-evals` | Deterministic OpenCode prompt-eval smoke gate (11 cases, no API cost). Part of `check:release`; not part of routine gates. |
 | `npm run test:e2e:mock` | Full mock-provider E2E suite (parallel shards). Single spec: `npx vitest run --config vitest.config.e2e.mock.ts e2e/specs/<file>.e2e.ts`. |
 | `npm run test:e2e:provider:{claude,claude-sdk,codex,opencode,cursor}` | E2E against a real provider (slow, costs API credits). |
-| `npm run check:release` | Full pre-release gate: build + lint + test + test:it + prompt-evals + e2e. |
+| `npm run check:release` | Full pre-release gate: build + lint + fast 4-shard unit + heavy unit + test:it + prompt-evals + e2e. |
 
 ### Test pool behavior (worth knowing before "fixing" flakes)
 
-- Serial-group membership lives in `scripts/test-classification.mjs` (`serialGitTestFiles`). Membership is about **measured IO interference** (fsync/spawnSync storms that block a worker past vitest's 60s birpc deadline), not correctness. Add files only with a measured reason; `releaseVerificationWiring.test.ts` fails if a listed file does not exist.
+- Heavy-unit and serial-IT membership lives in `scripts/test-classification.mjs` (`heavyUnitTestFiles`, `serialGitTestFiles`). Membership is about **measured IO interference** (fsync/spawnSync storms that block a worker past vitest's birpc deadline), not correctness. Add files only with a measured reason; `releaseVerificationWiring.test.ts` fails if a listed file does not exist.
 - `dangerouslyIgnoreUnhandledErrors: !process.env.CI` (vitest.config.shared.ts): the spurious `[vitest-worker]: Timeout calling "onTaskUpdate"` error is tolerated locally (4 concurrent shards on one machine) but **fatal on CI**. The parallel IT slice runs single-worker on CI (`maxWorkers: process.env.CI ? 1 : 4`) for the same reason.
 - Because that noise still makes a shard exit non-zero locally, `npm test` re-measures such a shard **once** (`scripts/vitest-birpc-noise.mjs`): only when the shard's own output shows zero failed tests, at least one passed test, and no reported error other than `[vitest-worker]: Timeout calling "onTaskUpdate"`. One real test failure, one unrecognized error headline, or `CI` set → no re-measurement, exit code stands. The re-measurement is announced on stderr; a silent shard exit is never rescued.
 - Reading that output means shards run through a pipe (`scripts/teed-command.mjs`) instead of inheriting the terminal, so **`npm test` output is now non-TTY: no color and no live progress rewriting**. That module takes the exit code from `exit` and gives `close` only a short deadline — a shard's grandchild can hold the stdout pipe open forever, and waiting on `close` alone hangs the gate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ npm run test:prompt-evals
 npm run test:e2e:mock
 ```
 
-`npm test` is the unit gate. Integration, regression, and performance tests run through `npm run test:it`; the deterministic OpenCode prompt smoke suite runs through `npm run test:prompt-evals`. `npm test -- <test-file>` routes each specified source test to exactly one unit, parallel integration, serial Git, or serial workflow runner. Routed runners execute sequentially, attempt every selected runner, and return the first failing child exit code. Release maintainers can run `npm run check:release` for the complete release path, including all provider E2E suites.
+`npm test` is the fast unit gate: it runs four concurrent shards and reports the resource-heavy unit files it excludes. Run `npm run test:unit:heavy` when the changed area needs those tests. Integration, regression, and performance tests run through `npm run test:it`; the deterministic OpenCode prompt smoke suite runs through `npm run test:prompt-evals`. `npm test -- <test-file>` routes each specified source test to exactly one fast-unit, heavy-unit, parallel integration, serial Git, or serial workflow runner. Selected runners execute concurrently and return the first failing child exit code. Release maintainers can run `npm run check:release` for the complete path: fast unit shards, heavy unit tests, integration tests, prompt smoke tests, and all provider E2E suites.
 
 See the [E2E testing overview](./docs/testing/e2e.md) for how to run the E2E suites and their prerequisites.
 

--- a/docs/CONTRIBUTING.ja.md
+++ b/docs/CONTRIBUTING.ja.md
@@ -46,7 +46,7 @@ npm run test:prompt-evals
 npm run test:e2e:mock
 ```
 
-`npm test` は unit gate です。integration・regression・performance テストは `npm run test:it`、決定的な OpenCode prompt smoke suite は `npm run test:prompt-evals` で実行します。`npm test -- <test-file>` は、指定した各 source test を unit、parallel integration、serial Git、serial workflow のいずれか1つへ振り分けます。選択された runner は順番にすべて実行され、最初に失敗した子プロセスの終了コードを返します。リリース担当者は、全 provider の E2E suite を含む完全な release path を `npm run check:release` で検証できます。
+`npm test` は fast unit gate です。4シャードを並列実行し、除外した高負荷unitファイルを出力で通知します。変更範囲が該当する場合は `npm run test:unit:heavy` を実行してください。integration・regression・performance テストは `npm run test:it`、決定的な OpenCode prompt smoke suite は `npm run test:prompt-evals` で実行します。`npm test -- <test-file>` は、指定した各 source test を fast unit、heavy unit、parallel integration、serial Git、serial workflow のいずれか1つへ振り分けます。選択されたrunnerは並列実行され、最初に失敗した子プロセスの終了コードを返します。リリース担当者は、fast unit 4シャード、heavy unit、integration、prompt smoke、全providerのE2E suiteを含む完全なrelease pathを `npm run check:release` で検証できます。
 
 E2E テストの実行方法と前提条件は [E2E テスト概要](./testing/e2e.md) を参照してください。
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:type-contracts": "tsc --noEmit -p tsconfig.type-contracts.json",
     "test:unit": "vitest run --config vitest.config.unit.parallel.ts",
     "test:unit:parallel": "vitest run --config vitest.config.unit.parallel.ts",
+    "test:unit:heavy": "vitest run --config vitest.config.unit.heavy.ts",
     "test:it": "npm run test:it:parallel && npm run test:it:serial",
     "test:it:parallel": "vitest run --config vitest.config.it.parallel.ts",
     "test:it:serial": "node scripts/run-it-serial-groups.mjs",
@@ -71,7 +72,7 @@
     "test:e2e:opencode": "npm run test:e2e:provider:opencode",
     "test:e2e:cursor": "npm run test:e2e:provider:cursor",
     "lint": "eslint src/",
-    "check:release": "npm run build && npm run lint && npm run test && npm run test:it && npm run test:prompt-evals && npm run test:e2e:all; code=$?; if [ \"$code\" -eq 0 ]; then msg='check:release passed'; else msg=\"check:release failed (exit=$code)\"; fi; if command -v osascript >/dev/null 2>&1; then osascript -e \"display notification \\\"$msg\\\" with title \\\"takt\\\" subtitle \\\"Release Check\\\"\" >/dev/null 2>&1 || true; fi; echo \"[takt] $msg\"; exit $code",
+    "check:release": "npm run build && npm run lint && npm run test && npm run test:unit:heavy && npm run test:it && npm run test:prompt-evals && npm run test:e2e:all; code=$?; if [ \"$code\" -eq 0 ]; then msg='check:release passed'; else msg=\"check:release failed (exit=$code)\"; fi; if command -v osascript >/dev/null 2>&1; then osascript -e \"display notification \\\"$msg\\\" with title \\\"takt\\\" subtitle \\\"Release Check\\\"\" >/dev/null 2>&1 || true; fi; echo \"[takt] $msg\"; exit $code",
     "prepublishOnly": "npm run lint && npm run build",
     "canary:coder": "node scripts/canary-coder.mjs"
   },

--- a/scripts/run-npm-test.mjs
+++ b/scripts/run-npm-test.mjs
@@ -3,6 +3,7 @@
 import { basename, isAbsolute, relative } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
+  heavyUnitTestFiles,
   serialGitTestFiles,
   serialWorkflowTestFiles,
 } from './test-classification.mjs';
@@ -12,6 +13,7 @@ import { isBirpcNoiseOnlyFailure } from './vitest-birpc-noise.mjs';
 
 const UNIT_SHARDS = ['1/4', '2/4', '3/4', '4/4'];
 const NO_ARG_UNIT_RUN_OPTIONS = ['--maxWorkers=1'];
+const HEAVY_UNIT_NOTICE = `[takt] Fast unit gate only: ${heavyUnitTestFiles.length} heavy test files are excluded. Run "npm run test:unit:heavy" when needed; "npm run check:release" runs them after the 4 shards.`;
 const VITEST_OPTIONS_WITH_REQUIRED_VALUE = new Set([
   '-c',
   '-r',
@@ -75,6 +77,7 @@ export function selectNpmTestRuns(args) {
   }
   return [
     buildTargetedRun('test:unit:parallel', targets.shared, targets.unit),
+    buildTargetedRun('test:unit:heavy', targets.shared, targets.heavyUnit),
     buildTargetedRun('test:it:parallel', targets.shared, targets.integration),
     buildTargetedRun('test:it:serial:git', targets.shared, targets.serialGit),
     buildTargetedRun('test:it:serial:workflow', targets.shared, targets.serialWorkflow),
@@ -88,6 +91,7 @@ function buildDefaultRuns(shared) {
 
 function hasExplicitTargets(targets) {
   return targets.unit.length > 0
+    || targets.heavyUnit.length > 0
     || targets.integration.length > 0
     || targets.serialGit.length > 0
     || targets.serialWorkflow.length > 0;
@@ -96,6 +100,7 @@ function hasExplicitTargets(targets) {
 function splitTestTargets(args) {
   const shared = [];
   const unit = [];
+  const heavyUnit = [];
   const integration = [];
   const serialGit = [];
   const serialWorkflow = [];
@@ -116,6 +121,8 @@ function splitTestTargets(args) {
           shared[shared.length - 1] = normalizeOptionalOptionWithoutValue(arg);
         }
       }
+    } else if (isHeavyUnitTarget(arg)) {
+      heavyUnit.push(normalizeTestTarget(arg));
     } else if (isSerialGitTarget(arg)) {
       serialGit.push(normalizeTestTarget(arg));
     } else if (isSerialWorkflowTarget(arg)) {
@@ -127,7 +134,7 @@ function splitTestTargets(args) {
     }
   }
 
-  return { shared, unit, integration, serialGit, serialWorkflow };
+  return { shared, unit, heavyUnit, integration, serialGit, serialWorkflow };
 }
 
 function buildTargetedRun(script, shared, targets) {
@@ -186,6 +193,10 @@ function isSerialGitTarget(arg) {
   return serialGitTestFiles.includes(normalizeTestTarget(arg));
 }
 
+function isHeavyUnitTarget(arg) {
+  return heavyUnitTestFiles.includes(normalizeTestTarget(arg));
+}
+
 function isSerialWorkflowTarget(arg) {
   return serialWorkflowTestFiles.includes(normalizeTestTarget(arg));
 }
@@ -198,7 +209,11 @@ function normalizeTestTarget(arg) {
   if (workspaceRelative.includes('/')) {
     return workspaceRelative;
   }
-  const matchingClassifiedTargets = [...serialGitTestFiles, ...serialWorkflowTestFiles]
+  const matchingClassifiedTargets = [
+    ...heavyUnitTestFiles,
+    ...serialGitTestFiles,
+    ...serialWorkflowTestFiles,
+  ]
     .filter((target) => basename(target) === workspaceRelative);
   return matchingClassifiedTargets.length === 1
     ? matchingClassifiedTargets[0]
@@ -238,6 +253,9 @@ async function remeasureBirpcNoiseShards(results, runCommand) {
 }
 
 export async function runNpmTest(args, runCommand = runNpmCommand) {
+  if (!hasExplicitTargets(splitTestTargets(args))) {
+    console.log(HEAVY_UNIT_NOTICE);
+  }
   const runs = selectNpmTestRuns(args);
   const results = await Promise.all(runs.map(async (run) => {
     const result = await runCommand(run.npmArgs);

--- a/scripts/test-classification.d.mts
+++ b/scripts/test-classification.d.mts
@@ -1,3 +1,4 @@
 export const parallelIntegrationTestGlobs: readonly string[];
+export const heavyUnitTestFiles: readonly string[];
 export const serialGitTestFiles: readonly string[];
 export const serialWorkflowTestFiles: readonly string[];

--- a/scripts/test-classification.mjs
+++ b/scripts/test-classification.mjs
@@ -5,6 +5,18 @@ export const parallelIntegrationTestGlobs = Object.freeze([
   'src/__tests__/**/*.performance.test.ts',
 ]);
 
+// These unit tests run full workflow engines, create repositories, or spawn
+// child processes. Under the four-shard unit gate they have repeatedly
+// exceeded the per-test ceiling or starved vitest's worker RPC. Keep them out
+// of the routine gate and run them with the dedicated single-worker runner.
+export const heavyUnitTestFiles = Object.freeze([
+  'src/__tests__/codex-isolated-executor.test.ts',
+  'src/__tests__/finding-review-integrity-gate.test.ts',
+  'src/__tests__/team-leader-finding-contract-runner.test.ts',
+  'src/__tests__/workflow-step-fragment-builtin-runtime.test.ts',
+  'src/__tests__/workflow-step-fragment-runtime.test.ts',
+]);
+
 // Escape hatch for tests that must not run concurrently with the rest of the
 // IT slice. A 2026-08 audit found zero files with shared mutable state (all
 // use mkdtemp isolation under pool:'forks'), so membership is not about

--- a/src/__tests__/codex-isolated-executor.test.ts
+++ b/src/__tests__/codex-isolated-executor.test.ts
@@ -862,7 +862,7 @@ describe('CodexClient strict read-only isolation', () => {
         server.close((error) => error ? reject(error) : resolve());
       });
     }
-  }, 15_000);
+  }, 120_000);
 
   it('should disable strict selector features and expose no plugins in the isolated profile', () => {
     const fake = createFakeCodex();

--- a/src/__tests__/finding-review-integrity-gate.test.ts
+++ b/src/__tests__/finding-review-integrity-gate.test.ts
@@ -298,7 +298,7 @@ describe('review-integrity gate failure payload (engine level)', () => {
       classificationAuthorityIds: ['system/intake_observation_classification_v1'],
       publicationIds: [],
     });
-  }, 60_000);
+  }, 120_000);
 });
 
 describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', () => {
@@ -362,9 +362,8 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
     // 古い episode になり得る。
     expect(outstanding[0]?.kind).toBe('quote-mismatch');
   // engine を実走させる。slot のラウンドを予算から外したことで実際のレビュー
-  // ラウンドが走るようになり、既定の 15s では 4 shard 同時実行に耐えない。
-  // 実測（単独実行）: 4.8-6.9s。4 shard 同時実行の劣化ぶんを見て 60s を取る。
-  }, 60_000);
+  // ラウンドが走るようになり、4 shard 同時実行時の遅延を見込んで共有タイムアウトを 120s とする。
+  }, 120_000);
 
   it('fail-closed: returnValue 終端（return: ...）で完了しようとしても、未昇格 anomaly が残る限り completion gate が拒否して abort する（codex 検証2巡目#1: gate を迂回する完了経路を塞ぐ）', async () => {
     mockReviewerEmitsHallucination();
@@ -404,9 +403,8 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
     expect(result.returnValue).toBeUndefined();
     expect(abortReason).toContain('reviewer anomaly');
   // engine を実走させる。slot のラウンドを予算から外したことで実際のレビュー
-  // ラウンドが走るようになり、既定の 15s では 4 shard 同時実行に耐えない。
-  // 実測（単独実行）: 4.8-6.9s。4 shard 同時実行の劣化ぶんを見て 60s を取る。
-  }, 60_000);
+  // ラウンドが走るようになり、4 shard 同時実行時の遅延を見込んで共有タイムアウトを 120s とする。
+  }, 120_000);
 
   it('merge-readiness child の need_replan は親の replan → implement → reviewers へ進み write_tests を通らない', async () => {
     mockReviewerEmitsHallucination();
@@ -487,9 +485,8 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
     expect(personas).toEqual(expect.arrayContaining(['planner', 'coder', 'reviewer-after-replan']));
     expect(personas).not.toContain('test-writer');
   // engine を実走させる。slot のラウンドを予算から外したことで実際のレビュー
-  // ラウンドが走るようになり、既定の 15s では 4 shard 同時実行に耐えない。
-  // 実測（単独実行）: 4.8-6.9s。4 shard 同時実行の劣化ぶんを見て 60s を取る。
-  }, 60_000);
+  // ラウンドが走るようになり、4 shard 同時実行時の遅延を見込んで共有タイムアウトを 120s とする。
+  }, 120_000);
 
   it('review_budget 枯渇後は replan → implement → reviewers へ進み、write_tests を再実行せず loop monitor で有限停止する', async () => {
     mockReviewerEmitsHallucination();
@@ -609,8 +606,8 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
         .toBe(true);
     }
   // slot のラウンドを予算から外したことで、予算枯渇までに実際のレビューラウンドが
-  // 走るようになり実行時間が伸びた（39s 実測）。既定の 15s では足りない。
-  }, 60_000);
+  // 走るようになり実行時間が伸びた（39s 実測）。共有タイムアウトを 120s とする。
+  }, 120_000);
 
   it('final-gate supervisor の単一Finding Contract報告を1回だけ取り込み、raw findingを重複保存しない', async () => {
     mockReviewerEmitsHallucination();
@@ -670,7 +667,6 @@ describe('review-integrity gate (engine level, codex 検証ブロッカー#1)', 
     expect(rawFindings).toHaveLength(2);
     expect(new Set(rawFindings.map((finding) => finding.rawFindingId)).size).toBe(rawFindings.length);
   // engine を実走させる。slot のラウンドを予算から外したことで実際のレビュー
-  // ラウンドが走るようになり、既定の 15s では 4 shard 同時実行に耐えない。
-  // 実測（単独実行）: 4.8-6.9s。4 shard 同時実行の劣化ぶんを見て 60s を取る。
-  }, 60_000);
+  // ラウンドが走るようになり、4 shard 同時実行時の遅延を見込んで共有タイムアウトを 120s とする。
+  }, 120_000);
 });

--- a/src/__tests__/finding-review-observability-wiring.test.ts
+++ b/src/__tests__/finding-review-observability-wiring.test.ts
@@ -29,7 +29,7 @@ vi.mock('../agents/finding-intake-normalizer-usecase.js', () => ({
   normalizeFindingIntake: vi.fn(),
 }));
 
-const SLOW_ENGINE_TEST_TIMEOUT_MS = 60_000;
+const SLOW_ENGINE_TEST_TIMEOUT_MS = 120_000;
 
 class CapturingSpanExporter implements SpanExporter {
   readonly spans: ReadableSpan[] = [];

--- a/src/__tests__/it-cli-list-selector-overrides.test.ts
+++ b/src/__tests__/it-cli-list-selector-overrides.test.ts
@@ -315,7 +315,7 @@ describe('IT: CLI list selector overrides', () => {
       expect.objectContaining({ personaName: 'architecture', provider: 'mock', model: CLI_MODEL }),
       expect.objectContaining({ personaName: 'frontend', provider: 'mock', model: CLI_MODEL }),
     ]));
-  }, 60_000);
+  }, 120_000);
 
   it('should use one CLI override for instruct preview, selector, and participants from the list command', async () => {
     createTerminalTask(environment.projectDir, 'completed');
@@ -337,5 +337,5 @@ describe('IT: CLI list selector overrides', () => {
       expect.objectContaining({ personaName: 'architecture', provider: 'mock', model: CLI_MODEL }),
       expect.objectContaining({ personaName: 'frontend', provider: 'mock', model: CLI_MODEL }),
     ]));
-  }, 60_000);
+  }, 120_000);
 });

--- a/src/__tests__/it-clone-isolation.test.ts
+++ b/src/__tests__/it-clone-isolation.test.ts
@@ -196,7 +196,7 @@ describe('shared clone generated metadata isolation', () => {
       fixture.clonePath,
       ['rev-parse', result.pullRequestBaseRef!],
     ).toString().trim()).toBe(rewrittenBase);
-  }, 60_000);
+  }, 120_000);
 
   it('force-updates existing remote-tracking and PR base refs in the same repository', () => {
     const fixture = createPullRequestRepoFixture();
@@ -227,7 +227,7 @@ describe('shared clone generated metadata isolation', () => {
         ['rev-parse', `refs/takt/pr-base/${fixture.baseBranch}`],
       ).toString().trim(),
     ).toBe(rewrittenBase);
-  }, 60_000);
+  }, 120_000);
 
   it('does not leave the source repo path in clone .git metadata for local branch clones', () => {
     const tempDir = createTempDir();

--- a/src/__tests__/it-opencode-list-shim.test.ts
+++ b/src/__tests__/it-opencode-list-shim.test.ts
@@ -211,7 +211,7 @@ describe.skipIf(!shouldRun)('IT: opencode list tool shim against the real binary
     const versionAllowsShim = versionAllowsListToolShim(opencodeVersion!);
     const registryAllowsShim = registryAllowsListToolShim(shimlessRegistry);
     expect(versionAllowsShim && !registryAllowsShim).toBe(false);
-  }, 60_000);
+  }, 120_000);
 
   it('exposes list to the model when read is enabled and executes it end to end', async () => {
     recorder.captured.length = 0;
@@ -234,7 +234,7 @@ describe.skipIf(!shouldRun)('IT: opencode list tool shim against the real binary
       .filter((message) => message.role === 'tool')
       .map((message) => String(message.content));
     expect(toolMessages.join('\n')).toContain('seeded-marker.txt');
-  }, 60_000);
+  }, 120_000);
 
   it('hides list from the model when the read-shaped tools are disabled', async () => {
     recorder.captured.length = 0;
@@ -254,7 +254,7 @@ describe.skipIf(!shouldRun)('IT: opencode list tool shim against the real binary
     expect(toolNames).not.toContain('list');
     // 全ツールが消えたのではなく、read 系だけが隠れたことの対照。
     expect(toolNames).toContain('todowrite');
-  }, 60_000);
+  }, 120_000);
 });
 
 describe.skipIf(shouldRun)('IT: opencode list tool shim (skipped)', () => {

--- a/src/__tests__/npmTestEntrypoint.test.ts
+++ b/src/__tests__/npmTestEntrypoint.test.ts
@@ -17,6 +17,7 @@ import {
   itTestGlobs,
   parallelSrcRunnerConfig,
   srcTestInclude,
+  unitHeavyTestGlobs,
 } from '../../vitest.config.shared.js';
 
 afterEach(() => {
@@ -35,7 +36,7 @@ describe('parallel test runner configuration', () => {
     expect(unitConfig).toMatchObject({
       test: {
         include: srcTestInclude,
-        exclude: [...itTestGlobs, ...itSerialTestGlobs],
+        exclude: [...itTestGlobs, ...itSerialTestGlobs, ...unitHeavyTestGlobs],
       },
     });
     expect(parallelIntegrationConfig).toMatchObject({
@@ -68,6 +69,7 @@ describe('npm test execution', () => {
 
   it('should run unit shards concurrently when no target is provided', async () => {
     const events: string[] = [];
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const run = vi.fn(async (npmArgs: string[]) => {
       const script = npmArgs[1]!;
       events.push(`start:${script}`);
@@ -89,6 +91,9 @@ describe('npm test execution', () => {
       'finish:test:unit:parallel',
     ]);
     expect(run).toHaveBeenCalledTimes(4);
+    expect(log).toHaveBeenCalledWith(
+      `[takt] Fast unit gate only: ${unitHeavyTestGlobs.length} heavy test files are excluded. Run "npm run test:unit:heavy" when needed; "npm run check:release" runs them after the 4 shards.`,
+    );
     expect(code).toBe(0);
   });
 
@@ -372,6 +377,19 @@ describe('npm test entrypoint routing', () => {
     ]);
   });
 
+  it('should route a targeted heavy unit file to the single-worker runner', () => {
+    expect(selectNpmTestRuns(['finding-review-integrity-gate.test.ts'])).toEqual([
+      {
+        npmArgs: [
+          'run',
+          'test:unit:heavy',
+          '--',
+          'src/__tests__/finding-review-integrity-gate.test.ts',
+        ],
+      },
+    ]);
+  });
+
   it('should route former serial workflow members to the unit runner', () => {
     const args = ['src/__tests__/workflowLoader.test.ts'];
 
@@ -380,18 +398,20 @@ describe('npm test entrypoint routing', () => {
     ]);
   });
 
-  it('should route mixed unit, parallel IT, and serial targets exactly once', () => {
+  it('should route mixed unit, heavy unit, parallel IT, and serial targets exactly once', () => {
     const args = [
       'src/__tests__/acpAgent.test.ts',
+      'src/__tests__/finding-review-integrity-gate.test.ts',
       'src/__tests__/it-acp-workflow-bridge.test.ts',
       'src/__tests__/finding-evidence-protocol.integration.test.ts',
       'src/__tests__/config.test.ts',
     ];
 
     expect(selectNpmTestRuns(args)).toEqual([
-      { npmArgs: ['run', 'test:unit:parallel', '--', args[0], args[3]] },
-      { npmArgs: ['run', 'test:it:parallel', '--', args[1]] },
-      { npmArgs: ['run', 'test:it:serial:git', '--', args[2]] },
+      { npmArgs: ['run', 'test:unit:parallel', '--', args[0], args[4]] },
+      { npmArgs: ['run', 'test:unit:heavy', '--', args[1]] },
+      { npmArgs: ['run', 'test:it:parallel', '--', args[2]] },
+      { npmArgs: ['run', 'test:it:serial:git', '--', args[3]] },
     ]);
   });
 

--- a/src/__tests__/releaseVerificationWiring.test.ts
+++ b/src/__tests__/releaseVerificationWiring.test.ts
@@ -12,11 +12,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  heavyUnitTestFiles,
   parallelIntegrationTestGlobs,
   serialGitTestFiles,
   serialWorkflowTestFiles,
 } from '../../scripts/test-classification.mjs';
 import parallelIntegrationConfig from '../../vitest.config.it.parallel.js';
+import heavyUnitConfig from '../../vitest.config.unit.heavy.js';
 import unitConfig from '../../vitest.config.unit.parallel.js';
 
 interface PackageManifest {
@@ -74,6 +76,7 @@ describe('release verification wiring', () => {
       test: 'npm run test:type-contracts && node scripts/run-npm-test.mjs',
       'test:unit': 'vitest run --config vitest.config.unit.parallel.ts',
       'test:unit:parallel': 'vitest run --config vitest.config.unit.parallel.ts',
+      'test:unit:heavy': 'vitest run --config vitest.config.unit.heavy.ts',
       'test:it': 'npm run test:it:parallel && npm run test:it:serial',
       'test:it:parallel': 'vitest run --config vitest.config.it.parallel.ts',
       'test:it:serial': 'node scripts/run-it-serial-groups.mjs',
@@ -90,6 +93,7 @@ describe('release verification wiring', () => {
       'npm run build',
       'npm run lint',
       'npm run test',
+      'npm run test:unit:heavy',
       'npm run test:it',
       'npm run test:prompt-evals',
       'npm run test:e2e:all',
@@ -104,6 +108,7 @@ describe('release verification wiring', () => {
       'run build',
       'run lint',
       'run test',
+      'run test:unit:heavy',
       'run test:it',
       'run test:prompt-evals',
       'run test:e2e:all',
@@ -118,11 +123,16 @@ describe('release verification wiring', () => {
       expectedCommands: ['run build', 'run lint'],
     },
     {
+      failingCommand: 'run test:unit:heavy',
+      expectedCommands: ['run build', 'run lint', 'run test', 'run test:unit:heavy'],
+    },
+    {
       failingCommand: 'run test:prompt-evals',
       expectedCommands: [
         'run build',
         'run lint',
         'run test',
+        'run test:unit:heavy',
         'run test:it',
         'run test:prompt-evals',
       ],
@@ -138,7 +148,8 @@ describe('release verification wiring', () => {
     expect(result.stdout).toContain('[takt] check:release failed (exit=23)');
   });
 
-  it('should keep the parallel and serial integration classifications disjoint', () => {
+  it('should keep fast unit, heavy unit, and integration classifications disjoint', () => {
+    const heavyUnit = new Set(heavyUnitTestFiles);
     const serialGit = new Set(serialGitTestFiles);
     const serialWorkflow = new Set(serialWorkflowTestFiles);
     const serialFiles = [...serialGit, ...serialWorkflow];
@@ -147,10 +158,17 @@ describe('release verification wiring', () => {
     for (const testFile of serialFiles) {
       expect(existsSync(new URL(`../../${testFile}`, import.meta.url))).toBe(true);
     }
+    for (const testFile of heavyUnit) {
+      expect(existsSync(new URL(`../../${testFile}`, import.meta.url))).toBe(true);
+      expect(serialGit.has(testFile)).toBe(false);
+      expect(serialWorkflow.has(testFile)).toBe(false);
+    }
+    expect(heavyUnitConfig.test?.include).toEqual(heavyUnitTestFiles);
     expect(parallelIntegrationConfig.test?.exclude).toEqual(serialFiles);
     expect(unitConfig.test?.exclude).toEqual([
       ...parallelIntegrationTestGlobs,
       ...serialFiles,
+      ...heavyUnitTestFiles,
     ]);
   });
 });

--- a/src/__tests__/team-leader-finding-contract-runner.test.ts
+++ b/src/__tests__/team-leader-finding-contract-runner.test.ts
@@ -674,7 +674,7 @@ describe('TeamLeaderRunner finding_contract_fix', () => {
     expect(
       operation.children.find((child) => child.id === 'part:repair-first:completion')?.attempts,
     ).toHaveLength(3);
-  }, 60_000);
+  }, 120_000);
 
   it('redispatches a rate-limited part with the fallback provider instead of replaying it', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'takt-finding-contract-rate-limit-'));

--- a/src/__tests__/workflow-step-fragment-builtin-runtime.test.ts
+++ b/src/__tests__/workflow-step-fragment-builtin-runtime.test.ts
@@ -506,7 +506,7 @@ describe('builtin step fragment runtime contracts', () => {
     expect(state.status, abortReasons.join('\n')).toBe('completed');
     expect(vi.mocked(runAgent).mock.calls.slice(0, reviewerPersonas.length).map(([persona]) => persona).sort())
       .toEqual([...reviewerPersonas].sort());
-  }, 60_000);
+  }, 120_000);
 
   it('resolves and executes a relative workflow_call declared by a step fragment', async () => {
     const parentPath = join(projectDir, '.takt', 'workflows', 'parent.yaml');
@@ -612,7 +612,7 @@ describe('builtin step fragment runtime contracts', () => {
     ]);
     const conflictAdjudicationCalls = needsConflictAdjudication ? 2 : 0;
     expect(vi.mocked(runAgent)).toHaveBeenCalledTimes(4 + (nextStep ? 1 : 0) + conflictAdjudicationCalls);
-  }, 60_000);
+  }, 120_000);
 });
 
 type RawStep = Record<string, unknown>;

--- a/vitest.config.it.parallel.ts
+++ b/vitest.config.it.parallel.ts
@@ -12,8 +12,8 @@ export default defineConfig({
     ...parallelSrcRunnerConfig,
     // Integration tests drive real engines, git repositories, and fsync-heavy
     // stores; under a loaded worker pool individual tests can legitimately
-    // exceed the 15s unit default.
-    testTimeout: 60_000,
+    // use the shared 120s test timeout.
+    testTimeout: 120_000,
     // fsync and spawnSync serialize at the device/kernel level, so extra
     // workers only add contention: a worker stuck >60s in synchronous IO
     // trips the vitest worker RPC timeout as a spurious unhandled error.

--- a/vitest.config.shared.ts
+++ b/vitest.config.shared.ts
@@ -1,11 +1,14 @@
 import type { UserConfig } from 'vitest/config';
 import {
+  heavyUnitTestFiles,
   parallelIntegrationTestGlobs,
   serialGitTestFiles,
   serialWorkflowTestFiles,
 } from './scripts/test-classification.mjs';
 
 export const srcTestInclude = ['src/__tests__/**/*.test.ts'];
+
+export const unitHeavyTestGlobs = [...heavyUnitTestFiles];
 
 export const itTestGlobs = [...parallelIntegrationTestGlobs];
 
@@ -24,11 +27,9 @@ export const itSerialTestGlobs = [
   ...itSerialWorkflowLoaderTestGlobs,
 ];
 
-// Windows runners spawn processes and touch the filesystem an order of
-// magnitude slower than the Linux/macOS ones, so tests that pass everywhere
-// else hit the shared 15s ceiling there. Three of the four windows job
-// failures in the last 100 CI runs were "Test timed out in 15000ms".
-const testTimeout = process.platform === 'win32' ? 60_000 : 15_000;
+// Some workflow tests spawn processes and perform fsync-heavy persistence.
+// Keep one sufficiently large ceiling for every platform and runner.
+const testTimeout = 120_000;
 
 export const commonSrcTestConfig = {
   env: {
@@ -64,7 +65,7 @@ export const parallelSrcRunnerConfig = {
 } satisfies UserConfig['test'];
 
 export const serialSrcRunnerConfig = {
-  testTimeout: 60_000,
+  testTimeout: 120_000,
   passWithNoTests: true,
   pool: 'threads',
   poolOptions: {

--- a/vitest.config.unit.heavy.ts
+++ b/vitest.config.unit.heavy.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import {
+  commonSrcTestConfig,
+  serialSrcRunnerConfig,
+  unitHeavyTestGlobs,
+} from './vitest.config.shared.js';
+
+export default defineConfig({
+  test: {
+    ...commonSrcTestConfig,
+    ...serialSrcRunnerConfig,
+    include: unitHeavyTestGlobs,
+  },
+});

--- a/vitest.config.unit.parallel.ts
+++ b/vitest.config.unit.parallel.ts
@@ -5,6 +5,7 @@ import {
   itTestGlobs,
   parallelSrcRunnerConfig,
   srcTestInclude,
+  unitHeavyTestGlobs,
 } from './vitest.config.shared.js';
 
 export default defineConfig({
@@ -12,6 +13,6 @@ export default defineConfig({
     ...commonSrcTestConfig,
     ...parallelSrcRunnerConfig,
     include: srcTestInclude,
-    exclude: [...itTestGlobs, ...itSerialTestGlobs],
+    exclude: [...itTestGlobs, ...itSerialTestGlobs, ...unitHeavyTestGlobs],
   },
 });


### PR DESCRIPTION
## Summary

- keep routine `npm test` fast by excluding five measured resource-heavy unit files from its four concurrent shards
- add a single-worker `test:unit:heavy` runner and automatically route targeted heavy files to it
- run the heavy unit slice immediately after the fast unit gate in `check:release`
- standardize source unit/integration test timeouts at 120 seconds and document the new test contract for agents and contributors

## Verification

- `npm run build`
- `npm run lint`
- `npm test` — four shards completed with exit 0
- `npm run test:unit:heavy` — 5 files, 73 passed, 1 skipped
- `npm run test:it` — parallel: 519 passed / 3 skipped; serial: 113 passed
- `npm run test:prompt-evals` — 11 smoke cases passed with OpenCode 1.18.2 selected ahead of a stale local asdf shim
- `npm run test:e2e:mock` — 172 passed, 4 skipped, 30 todo
- targeted runner/release wiring tests — 46 passed

## Notes

- Real-provider E2E was not run because it sends test data to external services and was not authorized in this session.
- Local parallel unit and integration runs still emitted the existing non-fatal Vitest `onTaskUpdate` RPC noise once and twice respectively; every assertion passed and both commands exited 0. The dedicated heavy slice emitted no such error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - `npm test` が高速なユニットテストを4シャードで並列実行するようになりました。
  - 高負荷テストは通常実行から分離され、必要に応じて `npm run test:unit:heavy` で実行できます。
  - テスト種別ごとの実行先が明確になり、対象外テストも通知されます。
  - `npm run check:release` で高速・高負荷ユニット、統合、プロンプト評価、E2Eテストを確認できるようになりました。

- **ドキュメント**
  - テストの分類、実行方法、リリース検証範囲の説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->