### PR TITLE
fix(test): stabilize serial workflow integration

### DIFF
--- a/scripts/test-classification.mjs
+++ b/scripts/test-classification.mjs
@@ -72,7 +72,6 @@ const legacyParallelIntegrationTestFiles = Object.freeze([
   'src/__tests__/workflow-step-fragment-provider-provenance.test.ts',
   'src/__tests__/workflow-step-fragments.test.ts',
   'src/__tests__/workflowEngine-restart.test.ts',
-  'src/__tests__/workflowExecution-claude-terminal.test.ts',
 ]);
 
 // These tests were audited against their actual runtime behavior rather than
@@ -426,4 +425,5 @@ export const serialWorkflowTestFiles = Object.freeze([
   'src/__tests__/team-leader-finding-contract-runner.test.ts',
   'src/__tests__/workflow-step-fragment-builtin-runtime.test.ts',
   'src/__tests__/workflow-step-fragment-runtime.test.ts',
+  'src/__tests__/workflowExecution-claude-terminal.test.ts',
 ]);

--- a/src/__tests__/npmTestEntrypoint.test.ts
+++ b/src/__tests__/npmTestEntrypoint.test.ts
@@ -387,13 +387,13 @@ describe('npm test entrypoint routing', () => {
   });
 
   it('should route a resource-heavy integration file to the serial workflow runner', () => {
-    expect(selectNpmTestRuns(['finding-review-integrity-gate.test.ts'])).toEqual([
+    expect(selectNpmTestRuns(['workflowExecution-claude-terminal.test.ts'])).toEqual([
       {
         npmArgs: [
           'run',
           'test:it:heavy:serial:workflow',
           '--',
-          'src/__tests__/finding-review-integrity-gate.test.ts',
+          'src/__tests__/workflowExecution-claude-terminal.test.ts',
         ],
       },
     ]);

--- a/src/__tests__/workflow-step-fragment-runtime.test.ts
+++ b/src/__tests__/workflow-step-fragment-runtime.test.ts
@@ -349,10 +349,9 @@ describe('workflow step fragment runtime contract', () => {
     });
     expect(fragmentResult.resumePoint?.stack[0]?.step_iterations)
       .toEqual(inlineResult.resumePoint?.stack[0]?.step_iterations);
-  // inline と fragment の engine を2本とも実走させる。差し戻し slot が提示予算ぶん
-  // 反復するようになって実行時間が伸びた。実測（単独実行）35s、4 shard 同時実行で
-  // 65s — 60s では足りない。
-  }, 120_000);
+  // inline と fragment の engine を2本とも実走させるため、ローカルの cold run では
+  // 既定の120秒を超える。処理停止ではなく完走することを確認できる余裕を持たせる。
+  }, 240_000);
 
   it('resumes inline and fragment workflows from the same saved step, iteration, and transition', async () => {
     writeFile(projectDir, '.takt/steps/review.yaml', [


### PR DESCRIPTION
## 概要

ローカルの heavy integration 実行で発生した Vitest worker RPC timeout と、cold run 時の workflow step fragment timeout を安定化します。

## 変更内容

- workflowExecution-claude-terminal.test.ts を heavy parallel から serial workflow グループへ移動
- 対象指定時に serial workflow runner へルーティングされることを回帰テストで固定
- 2本の完全workflowを実走する step fragment テストの timeout を 120秒から240秒へ延長

## 検証

- npm test -- src/__tests__/workflowExecution-claude-terminal.test.ts
- npm test -- src/__tests__/releaseVerificationWiring.test.ts
- npm test -- src/__tests__/npmTestEntrypoint.test.ts
- npm test -- src/__tests__/workflow-step-fragment-runtime.test.ts
- npm run test:it:heavy:serial:workflow

最終結果: 6 files passed, 79 tests passed, 1 skipped。onTaskUpdate timeout と test timeout は再発していません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - ワークフロー実行に関する統合テストをシリアル実行へ変更し、テストの安定性を向上しました。
  - シリアル実行ランナーの対象テストを更新しました。
  - 長時間のワークフロー実行を考慮し、テストのタイムアウト時間を延長しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->