### PR TITLE
fix: support global assistant Gherkin configuration

### DIFF
--- a/builtins/en/config.yaml
+++ b/builtins/en/config.yaml
@@ -64,6 +64,8 @@ language: en        # UI language: en | ja
 
 # Interactive mode
 # interactive_preview_steps: 3 # Number of step previews in interactive mode (0-10)
+# assistant:
+#   gherkin: true              # Generate final task instructions as Markdown + focused Gherkin
 
 # Provider routing for workflow steps (recommended)
 # provider_routing:

--- a/builtins/ja/config.yaml
+++ b/builtins/ja/config.yaml
@@ -64,6 +64,8 @@ language: ja         # 表示言語: ja | en
 
 # インタラクティブモード
 # interactive_preview_steps: 3 # インタラクティブモードでの step プレビュー数 (0-10)
+# assistant:
+#   gherkin: true              # 最終指示書を Markdown + 要所の Gherkin で生成
 
 # workflow step の provider routing（推奨）
 # provider_routing:

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -30,6 +30,8 @@ task_poll_interval_ms: 500    # takt run での新規タスクポーリング間
 interactive_preview_steps: 3  # インタラクティブモードでの step プレビュー数（0-10、デフォルト: 3）
 auto_requeue_max_attempts: 0  # takt run 中の失敗 workflow task 自動 requeue 上限（非負整数、デフォルト: 0 = 無効）
 ignore_exceed: false          # takt run / takt watch で --ignore-exceed 相当を適用（デフォルト: false）
+assistant:
+  gherkin: false              # 最終指示書を Markdown + 要所の Gherkin で生成
 # auto_fetch: false           # クローン作成前にリモートを fetch（デフォルト: false）
 # base_branch: main           # クローン作成のベースブランチ（デフォルト: リモートのデフォルトブランチ）
 
@@ -188,6 +190,7 @@ ignore_exceed: false          # takt run / takt watch で --ignore-exceed 相当
 | `concurrency` | number (1-10) | `1` | `takt run` の並列タスク数 |
 | `task_poll_interval_ms` | number (100-5000) | `500` | 新規タスクのポーリング間隔 |
 | `interactive_preview_steps` | number (0-10) | `3` | インタラクティブモードでの step プレビュー数 |
+| `assistant.gherkin` | boolean | `false` | assistant 対話から生成する最終指示書で、重要な観測可能動作、状態遷移、境界、失敗、不変条件を最小数の Gherkin Scenario に整理します。プロジェクト設定で明示した値がグローバル値より優先されます。 |
 | `auto_requeue_max_attempts` | 非負整数 | `0` | `takt run` 中に失敗した workflow task を自動 requeue する上限回数。`0` で無効 |
 | `ignore_exceed` | boolean | `false` | `takt run` / `takt watch` の iteration 上限無視を設定します。CLI で `--ignore-exceed` を指定した場合は CLI 指定が優先されます |
 | `sync_project_local_takt_on_retry` | boolean | `true` | retry / 再実行前にルートの project-local `.takt` を worktree へ同期。`false` で worktree 側のコピーを維持 |
@@ -355,7 +358,7 @@ terminal tool の完全一致反復は、廃止された累積検出ではなく
 | `ignore_exceed` | boolean | `false`（global 設定またはデフォルト由来） | `takt run` / `takt watch` の iteration 上限無視を設定します。CLI で `--ignore-exceed` を指定した場合は CLI 指定が優先されます |
 | `base_branch` | string | - | クローン作成のベースブランチ（グローバルを上書き、デフォルト: リモートのデフォルトブランチ） |
 | `assistant.init_files` | string[] | - | project config 専用のインタラクティブ assistant 初期コンテキストファイル。パスは project root 相対で指定します。絶対パス、project root 外へ解決されるパス、`.env*` / `.npmrc` / `.pypirc` / `.netrc` / `*.pem` / `*.key` / `.git/**` などの機密ファイルパターンは拒否されます。存在しないパス、ディレクトリ、読めないファイルは分かるエラーになります。最大16ファイルまで指定でき、1ファイルは256KiB、合計本文は1MiBまでです。未設定または空の場合、`CLAUDE.md`、`AGENT.md`、`AGENTS.md`、`TAKT.md` などは自動探索されません。assistant の provider/model だけを制御する `takt_providers.assistant` とは別設定です。 |
-| `assistant.gherkin` | boolean | `false` | project config 専用の opt-in 設定です。quiet モードを含む assistant 対話から最終指示書を生成するとき、背景、範囲、実装詳細、設計意図、制約、確認方法は Markdown に残し、重要な観測可能動作、状態遷移、境界、失敗、不変条件だけを最小数の Gherkin Scenario で整理するよう要約エージェントへ指示します。未設定または `false` の場合は既存の Markdown 指示書プロンプトを維持します。 |
+| `assistant.gherkin` | boolean | `false` | グローバル設定を上書きする opt-in 設定です。quiet モードを含む assistant 対話から最終指示書を生成するとき、背景、範囲、実装詳細、設計意図、制約、確認方法は Markdown に残し、重要な観測可能動作、状態遷移、境界、失敗、不変条件だけを最小数の Gherkin Scenario で整理するよう要約エージェントへ指示します。未設定の場合はグローバル値、どちらも未設定の場合は `false` になります。 |
 | `provider_options` | object | - | provider 固有オプション |
 | `provider_profiles` | object | - | provider 固有のパーミッションプロファイル |
 | `vcs_provider` | `"github"` \| `"gitlab"` | 自動検出 | VCS プロバイダー（グローバルを上書き） |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,8 @@ task_poll_interval_ms: 500    # Polling interval for new tasks during takt run (
 interactive_preview_steps: 3  # Step previews in interactive mode (0-10, default: 3)
 auto_requeue_max_attempts: 0  # Auto-requeue failed workflow tasks during takt run (non-negative integer, default: 0 = disabled)
 ignore_exceed: false          # Applies to takt run and takt watch like --ignore-exceed (default: false)
+assistant:
+  gherkin: false              # Generate final task instructions as Markdown + focused Gherkin
 # auto_fetch: false           # Fetch remote before cloning (default: false)
 # base_branch: main           # Base branch for clone creation (default: remote default branch)
 
@@ -188,6 +190,7 @@ ignore_exceed: false          # Applies to takt run and takt watch like --ignore
 | `concurrency` | number (1-10) | `1` | Parallel task count for `takt run` |
 | `task_poll_interval_ms` | number (100-5000) | `500` | Polling interval for new tasks |
 | `interactive_preview_steps` | number (0-10) | `3` | Step previews in interactive mode |
+| `assistant.gherkin` | boolean | `false` | Organize important observable behavior, state transitions, boundaries, failures, and invariants in a minimal number of Gherkin scenarios in final task instructions generated from assistant conversations. An explicit project value overrides the global value. |
 | `auto_requeue_max_attempts` | non-negative integer | `0` | Maximum automatic requeue attempts for failed workflow tasks during `takt run`; `0` disables automatic requeue |
 | `ignore_exceed` | boolean | `false` | Configures iteration-limit bypass for `takt run` and `takt watch`; a CLI `--ignore-exceed` flag takes precedence when specified |
 | `sync_project_local_takt_on_retry` | boolean | `true` | Sync the root project-local `.takt` into the worktree before retry / re-execution; set `false` to keep the worktree copy |
@@ -360,7 +363,7 @@ Project config accepts most global keys and overrides their global values (e.g. 
 | `ignore_exceed` | boolean | `false` (from global/default) | Configures iteration-limit bypass for `takt run` and `takt watch`; a CLI `--ignore-exceed` flag takes precedence when specified |
 | `base_branch` | string | - | Base branch for clone creation (overrides global, default: remote default branch) |
 | `assistant.init_files` | string[] | - | Project-only interactive assistant initial context files. Paths must be relative to the project root; absolute paths, paths resolving outside the project root, and sensitive file patterns such as `.env*`, `.npmrc`, `.pypirc`, `.netrc`, `*.pem`, `*.key`, and `.git/**` are rejected. Missing paths, directories, and unreadable files fail with a clear error. At most 16 files are allowed; each file is limited to 256 KiB and the combined content is limited to 1 MiB. When unset or empty, TAKT does not auto-discover `CLAUDE.md`, `AGENT.md`, `AGENTS.md`, `TAKT.md`, or other files. This is separate from `takt_providers.assistant`, which only controls the assistant provider/model. |
-| `assistant.gherkin` | boolean | `false` | Project-only opt-in for final task instructions generated from assistant conversations, including quiet mode. When enabled, TAKT keeps background, scope, implementation details, design intent, constraints, and verification in Markdown, and asks the summarizer to use a minimal number of Gherkin scenarios only for important observable behavior, state transitions, boundaries, failures, and invariants. Unset or `false` preserves the existing Markdown instruction prompt. |
+| `assistant.gherkin` | boolean | `false` | Project override for final task instructions generated from assistant conversations, including quiet mode. When enabled, TAKT keeps background, scope, implementation details, design intent, constraints, and verification in Markdown, and asks the summarizer to use a minimal number of Gherkin scenarios only for important observable behavior, state transitions, boundaries, failures, and invariants. When unset, TAKT uses the global value; when both are unset, it defaults to `false`. |
 | `provider_options` | object | - | Provider-specific options |
 | `provider_profiles` | object | - | Provider-specific permission profiles |
 | `vcs_provider` | `"github"` \| `"gitlab"` | auto-detect | VCS provider (overrides global) |

--- a/src/__tests__/assistantConfig.test.ts
+++ b/src/__tests__/assistantConfig.test.ts
@@ -19,6 +19,7 @@ vi.mock('../infra/config/paths.js', async (importOriginal) => {
 });
 
 const { resolveAssistantConfigLayers } = await import('../features/interactive/assistantConfig.js');
+const { shouldUseGherkinTaskInstructions } = await import('../features/interactive/taskInstructionFormat.js');
 const { invalidateGlobalConfigCache } = await import('../infra/config/global/globalConfig.js');
 const { invalidateAllResolvedConfigCache } = await import('../infra/config/resolveConfigValue.js');
 const { getProjectConfigDir } = await import('../infra/config/paths.js');
@@ -96,6 +97,33 @@ describe('assistantConfig', () => {
       },
     });
   });
+
+  it.each([
+    ['global value', true, undefined, true],
+    ['project false override', true, false, false],
+    ['project true override', false, true, true],
+  ] as const)(
+    'should resolve Gherkin task instructions from %s',
+    (_label, globalGherkin, projectGherkin, expected) => {
+      writeFileSync(
+        globalConfigPath,
+        ['language: en', 'assistant:', `  gherkin: ${globalGherkin}`].join('\n'),
+        'utf-8',
+      );
+
+      if (projectGherkin !== undefined) {
+        const configDir = getProjectConfigDir(projectDir);
+        mkdirSync(configDir, { recursive: true });
+        writeFileSync(
+          join(configDir, 'config.yaml'),
+          ['assistant:', `  gherkin: ${projectGherkin}`].join('\n'),
+          'utf-8',
+        );
+      }
+
+      expect(shouldUseGherkinTaskInstructions(projectDir)).toBe(expected);
+    },
+  );
 
   it('should keep assistant-only resolver out of infra config public exports', async () => {
     const infraConfig = await import('../infra/config/index.js');

--- a/src/__tests__/globalConfig-defaults.test.ts
+++ b/src/__tests__/globalConfig-defaults.test.ts
@@ -71,6 +71,17 @@ describe('loadGlobalConfig', () => {
     expect(config.interactivePreviewSteps).toBeUndefined();
   });
 
+  it.each([true, false])('should load assistant.gherkin=%s from global config.yaml', (gherkin) => {
+    mkdirSync(join(testHomeDir, '.takt'), { recursive: true });
+    writeFileSync(
+      getGlobalConfigPath(),
+      ['assistant:', `  gherkin: ${gherkin}`].join('\n'),
+      'utf-8',
+    );
+
+    expect(loadGlobalConfig().assistant).toEqual({ gherkin });
+  });
+
   it.each(['codex', 'claude'])('should accept an external %s selector base_url in global config', (provider) => {
     mkdirSync(join(testHomeDir, '.takt'), { recursive: true });
     writeFileSync(getGlobalConfigPath(), [
@@ -390,6 +401,21 @@ describe('loadGlobalConfig', () => {
     expect(raw).toContain('assistant:');
     expect(raw).toContain('provider: claude');
     expect(raw).toContain('model: haiku');
+  });
+
+  it.each([true, false])('should preserve assistant.gherkin=%s when saving global config', (gherkin) => {
+    const taktDir = join(testHomeDir, '.takt');
+    mkdirSync(taktDir, { recursive: true });
+    writeFileSync(getGlobalConfigPath(), 'language: en\n', 'utf-8');
+
+    saveGlobalConfig({
+      ...loadGlobalConfig(),
+      assistant: { gherkin },
+    });
+    invalidateGlobalConfigCache();
+
+    expect(loadGlobalConfig().assistant).toEqual({ gherkin });
+    expect(readFileSync(getGlobalConfigPath(), 'utf-8')).toContain(`gherkin: ${gherkin}`);
   });
 
   it('should persist selector provider options when saving global config', () => {

--- a/src/__tests__/provider-schema.test.ts
+++ b/src/__tests__/provider-schema.test.ts
@@ -284,6 +284,20 @@ describe('Claude terminal provider contract', () => {
 });
 
 describe('Schemas accept opencode provider', () => {
+  it('should accept assistant.gherkin in GlobalConfigSchema', () => {
+    const result = GlobalConfigSchema.parse({
+      assistant: { gherkin: true },
+    });
+
+    expect(result.assistant).toEqual({ gherkin: true });
+  });
+
+  it('should reject assistant.init_files in GlobalConfigSchema', () => {
+    expect(() => GlobalConfigSchema.parse({
+      assistant: { init_files: ['docs/context.md'] },
+    })).toThrow(/init_files|unrecognized/i);
+  });
+
   it('should accept opencode in GlobalConfigSchema provider field', () => {
     const result = GlobalConfigSchema.parse({ provider: 'opencode' });
     expect(result.provider).toBe('opencode');

--- a/src/core/models/config-schemas.ts
+++ b/src/core/models/config-schemas.ts
@@ -62,6 +62,10 @@ export const AssistantConfigSchema = z.object({
   gherkin: z.boolean().optional(),
 }).strict();
 
+export const GlobalAssistantConfigSchema = z.object({
+  gherkin: z.boolean().optional(),
+}).strict();
+
 export const ProviderRoutingSchema = z.object({
   personas: z.record(z.string(), PersonaProviderReferenceSchema).optional(),
   tags: z.record(z.string(), PersonaProviderReferenceSchema).optional(),
@@ -181,6 +185,7 @@ export const GlobalConfigSchema = ProjectConfigObjectBaseSchema
   .omit({ submodules: true, with_submodules: true, assistant: true })
   .merge(GlobalOnlyConfigSchema)
   .extend({
+    assistant: GlobalAssistantConfigSchema.optional(),
     provider: ProviderReferenceSchema.optional().default('claude'),
   })
   .strict();

--- a/src/core/models/config-types.ts
+++ b/src/core/models/config-types.ts
@@ -157,6 +157,11 @@ export interface AssistantConfig {
   gherkin?: boolean;
 }
 
+export interface GlobalAssistantConfig {
+  /** Generate final task instructions as human-readable Markdown with focused Gherkin scenarios. */
+  gherkin?: boolean;
+}
+
 /** Step-specific quality gates override */
 export interface StepQualityGatesOverride {
   qualityGates?: QualityGate[];
@@ -385,6 +390,8 @@ export interface ProjectConfig {
  * — handled by the resolution layer.
  */
 export interface GlobalConfig extends Omit<ProjectConfig, 'submodules' | 'withSubmodules' | 'assistant'> {
+  /** Global default for assistant task-instruction formatting. */
+  assistant?: GlobalAssistantConfig;
   /** @globalOnly */
   language: Language;
   /** @globalOnly */

--- a/src/features/interactive/taskInstructionFormat.ts
+++ b/src/features/interactive/taskInstructionFormat.ts
@@ -1,5 +1,10 @@
+import { loadGlobalConfig } from '../../infra/config/global/globalConfig.js';
 import { loadProjectConfig } from '../../infra/config/project/projectConfig.js';
 
 export function shouldUseGherkinTaskInstructions(projectDir: string): boolean {
-  return loadProjectConfig(projectDir).assistant?.gherkin === true;
+  const projectValue = loadProjectConfig(projectDir).assistant?.gherkin;
+  if (projectValue !== undefined) {
+    return projectValue;
+  }
+  return loadGlobalConfig().assistant?.gherkin === true;
 }

--- a/src/infra/config/global/globalConfigCore.ts
+++ b/src/infra/config/global/globalConfigCore.ts
@@ -18,6 +18,7 @@ import {
   normalizeRateLimitFallback,
   normalizeAutoRoutingConfig,
   normalizeTelemetryConfig,
+  normalizeAssistantConfig,
 } from '../configNormalizers.js';
 import {
   resolveAliasedPreviewCount,
@@ -211,6 +212,7 @@ export class GlobalConfigManager {
       pipeline: normalizePipelineConfig(
         parsed.pipeline as { default_branch_prefix?: string; commit_message_template?: string; pr_body_template?: string } | undefined,
       ),
+      assistant: normalizeAssistantConfig(parsed.assistant),
       taktProviders: normalizeTaktProviders(
         parsed.takt_providers as {
           assistant?: {

--- a/src/infra/config/global/globalConfigSerializer.ts
+++ b/src/infra/config/global/globalConfigSerializer.ts
@@ -8,6 +8,7 @@ import {
   denormalizeRateLimitFallback,
   denormalizeTelemetryConfig,
   denormalizeAutoRoutingConfig,
+  denormalizeAssistantConfig,
 } from '../configNormalizers.js';
 import { denormalizeObservabilityConfig } from '../observabilityConfig.js';
 
@@ -222,6 +223,10 @@ export function serializeGlobalConfig(config: GlobalConfig): Record<string, unkn
       pipelineRaw.pr_body_template = config.pipeline.prBodyTemplate;
     }
     if (Object.keys(pipelineRaw).length > 0) raw.pipeline = pipelineRaw;
+  }
+  const rawAssistant = denormalizeAssistantConfig(config.assistant);
+  if (rawAssistant) {
+    raw.assistant = rawAssistant;
   }
   const rawPersonaProviders = denormalizePersonaProviders(config.personaProviders);
   if (rawPersonaProviders && Object.keys(rawPersonaProviders).length > 0) {

--- a/src/infra/config/resolvedConfig.ts
+++ b/src/infra/config/resolvedConfig.ts
@@ -2,7 +2,7 @@ import type { GlobalConfig, ResolvedObservabilityConfig } from '../../core/model
 import type { ProjectConfig } from './types.js';
 
 export interface LoadedConfig
-  extends Omit<GlobalConfig, 'language'>,
+  extends Omit<GlobalConfig, 'language' | 'assistant'>,
     ProjectConfig {
   language: GlobalConfig['language'];
   observability: ResolvedObservabilityConfig;

--- a/src/infra/config/traced/tracedConfigSchema.ts
+++ b/src/infra/config/traced/tracedConfigSchema.ts
@@ -153,6 +153,8 @@ const GLOBAL_TRACKED_KEYS = [
   'rate_limit_fallback.switch_chain',
   'workflow_overrides',
   'pipeline',
+  'assistant',
+  'assistant.gherkin',
   'takt_providers',
   'persona_providers',
   'provider_routing',


### PR DESCRIPTION
## Summary

- allow `assistant.gherkin` in global `~/.takt/config.yaml`
- resolve Gherkin formatting with project override precedence over the global default
- persist and trace the global setting while keeping `assistant.init_files` project-only
- document the setting and expose it in the builtin global config templates
- add schema, load/save, and precedence coverage

## Root cause

The assistant configuration was explicitly omitted from the global schema and `GlobalConfig` type, and task-instruction formatting only read the project config. As a result, the documented global-style setting was rejected and never reached the formatting decision.

## Validation

- `npm run build`
- `npm run lint`
- `npm test -- src/__tests__/provider-schema.test.ts`
- `npm test -- src/__tests__/globalConfig-defaults.test.ts`
- `npm test -- src/__tests__/assistantConfig.test.ts`
- `npm test -- src/__tests__/reset-global-config.test.ts`
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts`

A separate GPT-5.6 Luna review at max reasoning found one missing builtin-template update; that finding is included in this PR. Full mock E2E is left to GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `assistant.gherkin` 設定を追加し、最終タスク指示を Markdown と Gherkin 形式で生成できるようになりました。
  * プロジェクト設定を優先し、未設定時はグローバル設定を継承します。双方未設定時は無効です。

* **ドキュメント**
  * 日本語・英語の設定例とリファレンスを更新しました。

* **テスト**
  * 設定の読み込み、保存、継承、上書き動作を検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->