### PR TITLE
fix: pass through provider effort values

### DIFF
--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -889,15 +889,17 @@ promotion は並列サブ step ではサポートされません。
 | `pass_previous_response` | `true` | 前の step の出力を `{previous_response}` に渡す |
 | `provider_options.claude.allowed_tools` | - | step または workflow に対する Claude ツール許可リスト |
 | `provider_options.claude.base_url` | - | `claude` / `claude-sdk` 用の Anthropic 互換 base URL（[configuration ガイド](./configuration.ja.md#provider-base-url-base_url) 参照） |
-| `provider_options.claude.effort` | - | Claude reasoning effort: `low`, `medium`, `high`, `xhigh`, `max`（`xhigh` は Opus 4.7 が必要） |
+| `provider_options.claude.effort` | - | Claude の provider 固有 reasoning effort 文字列。TAKT は値を provider へそのまま渡す（例: `low`、`high`、将来 provider が定義する値） |
 | `provider_options.claude.skills.enabled` | `false` | `claude-sdk`、`claude`、`claude-terminal` の Claude filesystem Skill 探索を有効化する（[configuration ガイド](./configuration.ja.md#claude-skill-の継承-skills) 参照） |
 | `provider_options.opencode.allowed_tools` | - | OpenCode のツール許可リスト。ツール名は `read`, `glob`, `grep`, `bash`, `websearch`, `webfetch` のように lowercase |
 | `provider_options.opencode.variant` | - | OpenCode の model variant。プロバイダー / model 固有の文字列としてパススルー |
 | `provider_options.opencode.guards` | `standard` / 60分 | OpenCode の guard profile、先勝ちの `model_profiles`、call wall-clock、text/reasoning byte 上限（[configuration ガイド](./configuration.ja.md#opencode-実行ガード)参照） |
 | `provider_options.codex.base_url` | - | Codex SDK constructor option 用の OpenAI 互換 base URL（[configuration ガイド](./configuration.ja.md#provider-base-url-base_url) 参照） |
 | `provider_options.codex.network_access` | - | Codex サンドボックスからのネットワークアクセスを許可（[configuration ガイド](./configuration.ja.md#ネットワークアクセス-network_access) 参照） |
+| `provider_options.codex.reasoning_effort` | - | Codex の provider 固有 reasoning effort 文字列。TAKT は値を provider へそのまま渡す |
 | `provider_options.codex.skills.repo` | `false` | 実行 CWD から repository root までの `.agents/skills` にある Codex Skill を継承（[configuration ガイド](./configuration.ja.md#codex-skill-の継承-skills) 参照） |
 | `provider_options.codex.skills.user` | `false` | user scope の Codex Skill を継承（[configuration ガイド](./configuration.ja.md#codex-skill-の継承-skills) 参照） |
+| `provider_options.copilot.effort` | - | Copilot の provider 固有 reasoning effort 文字列。TAKT は値を provider へそのまま渡す |
 | `provider_options.claude.sandbox.allow_unsandboxed_commands` | - | Claude の Bash を macOS Seatbelt サンドボックス外で実行（[configuration ガイド](./configuration.ja.md#claude-code-の-sandbox-制御-allow_unsandboxed_commands) 参照） |
 | `provider_options.kiro.agent` | - | Kiro CLI の custom agent 名。`kiro-cli chat --agent` として渡される。未指定の step は Kiro CLI 側の default agent を使用 |
 | `provider` | - | この step の provider を上書き (`claude`, `claude-sdk`, `claude-terminal`, `codex`, `opencode`, `cursor`, `copilot`, `kiro`, `mock`) |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -903,15 +903,17 @@ Promotion is not supported on parallel sub-steps.
 | `pass_previous_response` | `true` | Pass previous step's output to `{previous_response}` |
 | `provider_options.claude.allowed_tools` | - | Claude tool allowlist for the step or workflow |
 | `provider_options.claude.base_url` | - | Anthropic-compatible base URL for `claude` / `claude-sdk` (see [configuration guide](./configuration.md#provider-base-url-base_url)) |
-| `provider_options.claude.effort` | - | Claude reasoning effort: `low`, `medium`, `high`, `xhigh`, `max` (`xhigh` requires Opus 4.7) |
+| `provider_options.claude.effort` | - | Provider-specific Claude reasoning effort string, passed through to the provider (for example `low`, `high`, or a newer provider-defined value) |
 | `provider_options.claude.skills.enabled` | `false` | Enable Claude filesystem Skill discovery for `claude-sdk`, `claude`, and `claude-terminal` (see [configuration guide](./configuration.md#claude-skill-inheritance-skills)) |
 | `provider_options.opencode.allowed_tools` | - | OpenCode tool allowlist. Tool names are lowercase, for example `read`, `glob`, `grep`, `bash`, `websearch`, `webfetch` |
 | `provider_options.opencode.variant` | - | OpenCode model variant, passed through as a provider/model-specific string |
 | `provider_options.opencode.guards` | `standard` / 60 minutes | OpenCode guard profile, first-match `model_profiles`, call wall-clock, and text/reasoning byte limits (see [configuration guide](./configuration.md#opencode-execution-guards)) |
 | `provider_options.codex.base_url` | - | OpenAI-compatible base URL for Codex SDK constructor options (see [configuration guide](./configuration.md#provider-base-url-base_url)) |
 | `provider_options.codex.network_access` | - | Allow Codex sandbox to access the network (see [configuration guide](./configuration.md#network-access-network_access)) |
+| `provider_options.codex.reasoning_effort` | - | Provider-specific Codex reasoning effort string, passed through to the provider |
 | `provider_options.codex.skills.repo` | `false` | Inherit Codex Skills from `.agents/skills` between the execution CWD and repository root (see [configuration guide](./configuration.md#codex-skill-inheritance-skills)) |
 | `provider_options.codex.skills.user` | `false` | Inherit Codex Skills from user scope (see [configuration guide](./configuration.md#codex-skill-inheritance-skills)) |
+| `provider_options.copilot.effort` | - | Provider-specific Copilot reasoning effort string, passed through to the provider |
 | `provider_options.claude.sandbox.allow_unsandboxed_commands` | - | Run Claude Bash outside the macOS Seatbelt sandbox (see [configuration guide](./configuration.md#claude-code-sandbox-control-allow_unsandboxed_commands)) |
 | `provider_options.kiro.agent` | - | Kiro CLI custom agent name passed as `kiro-cli chat --agent`. Steps without it use the Kiro CLI default agent |
 | `provider` | - | Override provider for this step (`claude`, `claude-sdk`, `claude-terminal`, `codex`, `opencode`, `cursor`, `copilot`, `kiro`, or `mock`) |

--- a/src/__tests__/claude-executor.test.ts
+++ b/src/__tests__/claude-executor.test.ts
@@ -167,6 +167,12 @@ describe('SdkOptionsBuilder — outputFormat 変換', () => {
     expect(sdkOptions.effort).toBe('medium');
   });
 
+  it('provider が定義する effort 文字列を SDK options へそのまま渡す', () => {
+    const sdkOptions = buildSdkOptions({ cwd: '/tmp', effort: 'provider-defined' });
+
+    expect(sdkOptions.effort).toBe('provider-defined');
+  });
+
   it('outputSchema が outputFormat に変換される', () => {
     const schema = { type: 'object', properties: { step: { type: 'integer' } } };
     const sdkOptions = buildSdkOptions({ cwd: '/tmp', outputSchema: schema });

--- a/src/__tests__/codex-isolated-executor.test.ts
+++ b/src/__tests__/codex-isolated-executor.test.ts
@@ -222,6 +222,7 @@ function isolatedOptions(
   fake: ReturnType<typeof createFakeCodex>,
   mode: 'success' | 'error' | 'abort' | 'retry' | 'invalid-json' | 'leader-exit-error' | 'leader-exit-success',
   abortSignal?: AbortSignal,
+  reasoningEffort = 'medium',
 ) {
   writeFileSync(fake.modePath, mode);
   return {
@@ -235,7 +236,7 @@ function isolatedOptions(
       required: ['selected_ids', 'rationale'],
     },
     model: 'gpt-test',
-    reasoningEffort: 'medium' as const,
+    reasoningEffort,
     baseUrl: 'https://example.test/v1',
     networkAccess: true,
     openaiApiKey: 'explicit-test-key',
@@ -340,6 +341,22 @@ describe('CodexClient strict read-only isolation', () => {
     }
     expect(existsSync(call!.workspacePath)).toBe(false);
     expect(existsSync(dirname(call!.workspacePath))).toBe(false);
+  });
+
+  it('should preserve provider-defined effort strings in strict Codex CLI config', async () => {
+    const fake = createFakeCodex();
+    const effort = 'vendor"level';
+
+    const result = await new CodexClient().callCustom(
+      'selector',
+      'Choose reviewers.',
+      'Return only the schema.',
+      isolatedOptions(fake, 'success', undefined, effort),
+    );
+
+    expect(result.status).toBe('done');
+    const [call] = readObservations(fake.logPath);
+    expect(call?.args).toContain(`model_reasoning_effort=${JSON.stringify(effort)}`);
   });
 
   it('should clean private assets after a terminal provider error', async () => {

--- a/src/__tests__/codex-structured-output.test.ts
+++ b/src/__tests__/codex-structured-output.test.ts
@@ -319,7 +319,7 @@ describe('CodexClient — structuredOutput 抽出', () => {
     });
   });
 
-  it('provider_options.codex.reasoningEffort が ThreadOptions に反映される', async () => {
+  it('provider_options.codex.reasoningEffort が安全な config override に反映される', async () => {
     mockEvents = [
       { type: 'thread.started', thread_id: 'thread-1' },
       { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
@@ -328,12 +328,15 @@ describe('CodexClient — structuredOutput 抽出', () => {
     const client = new CodexClient();
     await client.call('coder', 'prompt', {
       cwd: '/tmp',
-      reasoningEffort: 'medium',
+      reasoningEffort: 'vendor"level',
     });
 
-    expect(lastThreadOptions).toMatchObject({
-      modelReasoningEffort: 'medium',
+    expect(lastCodexConstructorOptions).toMatchObject({
+      config: {
+        model_reasoning_effort: 'vendor"level',
+      },
     });
+    expect(lastThreadOptions).not.toHaveProperty('modelReasoningEffort');
   });
 
   it('codexPathOverride が Codex constructor options に反映される', async () => {

--- a/src/__tests__/config-env-overrides.test.ts
+++ b/src/__tests__/config-env-overrides.test.ts
@@ -866,24 +866,40 @@ describe('config traced env overrides', () => {
     });
   });
 
-  it('project config は不正な codex reasoning_effort env override を拒否する', () => {
-    const projectDir = join(testRoot, 'project-invalid-codex-effort-env');
+  it('project config は任意の codex reasoning_effort env override を反映する', () => {
+    const projectDir = join(testRoot, 'project-custom-codex-effort-env');
     const configDir = getProjectConfigDir(projectDir);
     mkdirSync(configDir, { recursive: true });
     writeFileSync(join(configDir, 'config.yaml'), 'provider: claude\n', 'utf-8');
     process.env.TAKT_PROVIDER_OPTIONS_CODEX_REASONING_EFFORT = 'extreme';
 
-    expect(() => loadProjectConfig(projectDir)).toThrow(/reasoning_effort/);
+    expect(loadProjectConfig(projectDir).providerOptions).toEqual({
+      codex: { reasoningEffort: 'extreme' },
+    });
   });
 
-  it('project config は不正な claude effort env override を拒否する', () => {
-    const projectDir = join(testRoot, 'project-invalid-claude-effort-env');
+  it('project config は任意の claude effort env override を反映する', () => {
+    const projectDir = join(testRoot, 'project-custom-claude-effort-env');
     const configDir = getProjectConfigDir(projectDir);
     mkdirSync(configDir, { recursive: true });
     writeFileSync(join(configDir, 'config.yaml'), 'provider: claude\n', 'utf-8');
     process.env.TAKT_PROVIDER_OPTIONS_CLAUDE_EFFORT = 'impossible';
 
-    expect(() => loadProjectConfig(projectDir)).toThrow(/effort/);
+    expect(loadProjectConfig(projectDir).providerOptions).toEqual({
+      claude: { effort: 'impossible' },
+    });
+  });
+
+  it('project config は任意の copilot effort env override を反映する', () => {
+    const projectDir = join(testRoot, 'project-custom-copilot-effort-env');
+    const configDir = getProjectConfigDir(projectDir);
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.yaml'), 'provider: copilot\n', 'utf-8');
+    process.env.TAKT_PROVIDER_OPTIONS_COPILOT_EFFORT = 'experimental';
+
+    expect(loadProjectConfig(projectDir).providerOptions).toEqual({
+      copilot: { effort: 'experimental' },
+    });
   });
 
   it('current logging env は global logging に反映する', () => {

--- a/src/__tests__/config-normalizers-provider-options.test.ts
+++ b/src/__tests__/config-normalizers-provider-options.test.ts
@@ -319,7 +319,7 @@ describe('buildRawTaktProvidersOrThrow', () => {
     ['an unknown nested selector option', {
       providerOptions: { codex: { skills: { repo: true, unknownSkill: true } } },
     }],
-    ['an invalid selector enum value', { providerOptions: { codex: { reasoningEffort: 'turbo' } } }],
+    ['an invalid selector effort type', { providerOptions: { codex: { reasoningEffort: 42 } } }],
     ['a blank selector model', { model: '   ' }],
     ['a snake_case selector alias', { provider_options: { codex: { reasoning_effort: 'medium' } } }],
     ['a snake_case nested option alias', { providerOptions: { codex: { reasoning_effort: 'medium' } } }],

--- a/src/__tests__/exec-command.test.ts
+++ b/src/__tests__/exec-command.test.ts
@@ -1419,7 +1419,7 @@ describe('exec command setup', () => {
       .map((call) => call[1]);
     expect(effortOptionSets).toHaveLength(3);
     for (const options of effortOptionSets) {
-      expect(options.map((option) => option.value)).toEqual(['__default_effort__', 'low', 'medium', 'high', 'xhigh', 'max']);
+      expect(options.map((option) => option.value)).toEqual(['__default_effort__', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
       expect(options[0]?.label).toContain('Default');
     }
   });

--- a/src/__tests__/exec-configValidation.test.ts
+++ b/src/__tests__/exec-configValidation.test.ts
@@ -54,7 +54,7 @@ describe('assertExecProviderEffort and providerSupportsExecEffort consistency', 
   );
 });
 
-describe('assertExecProviderEffort sufficiency for type narrowing', () => {
+describe('assertExecProviderEffort provider capability checks', () => {
   it('should pass validation for claude provider with valid effort — no redundant check needed', () => {
     const effort: ExecEffort = 'high';
     expect(() =>
@@ -76,10 +76,22 @@ describe('assertExecProviderEffort sufficiency for type narrowing', () => {
     ).not.toThrow();
   });
 
-  it('should reject provider with unsupported effort before any downstream code runs', () => {
+  it('should accept arbitrary effort values and leave support to the provider', () => {
     expect(() =>
       assertExecProviderEffort('codex', 'max', 'test'),
-    ).toThrow('does not support effort "max"');
+    ).not.toThrow();
+    expect(() =>
+      assertExecProviderEffort('claude', 'experimental', 'test'),
+    ).not.toThrow();
+    expect(() =>
+      assertExecProviderEffort('copilot', 'vendor-level', 'test'),
+    ).not.toThrow();
+  });
+
+  it('should reject effort for providers without effort support', () => {
+    expect(() =>
+      assertExecProviderEffort('opencode', 'high', 'test'),
+    ).toThrow('does not support effort "high"');
   });
 
   it('should allow codex provider when effort is undefined', () => {

--- a/src/__tests__/exec-configValidation.test.ts
+++ b/src/__tests__/exec-configValidation.test.ts
@@ -5,6 +5,7 @@ import {
   EXEC_EFFORTS,
   providerSupportsExecEffort,
   getSupportedExecEfforts,
+  resolveExecProviderEffort,
 } from '../features/exec/configValidation.js';
 import type { ExecEffort } from '../features/exec/types.js';
 
@@ -86,6 +87,17 @@ describe('assertExecProviderEffort provider capability checks', () => {
     expect(() =>
       assertExecProviderEffort('copilot', 'vendor-level', 'test'),
     ).not.toThrow();
+  });
+
+  it.each(['', '   '] as const)('should reject blank effort values', (effort) => {
+    expect(() => resolveExecProviderEffort('codex', effort, 'test'))
+      .toThrow(`does not support effort "${effort}"`);
+  });
+
+  it('should return the canonical trimmed effort value', () => {
+    expect(resolveExecProviderEffort('codex', '  custom-level  ', 'test')).toBe('custom-level');
+    expect(resolveExecProviderEffort('claude', '  experimental  ', 'test')).toBe('experimental');
+    expect(resolveExecProviderEffort('copilot', '  vendor-level  ', 'test')).toBe('vendor-level');
   });
 
   it('should reject effort for providers without effort support', () => {

--- a/src/__tests__/exec-configValidation.test.ts
+++ b/src/__tests__/exec-configValidation.test.ts
@@ -89,8 +89,11 @@ describe('assertExecProviderEffort provider capability checks', () => {
     ).not.toThrow();
   });
 
-  it.each(['', '   '] as const)('should reject blank effort values', (effort) => {
-    expect(() => resolveExecProviderEffort('codex', effort, 'test'))
+  it.each(
+    (['codex', 'claude', 'copilot'] as const).flatMap((provider) =>
+      (['', '   '] as const).map((effort) => [provider, effort] as const)),
+  )('should reject blank effort values for %s', (provider, effort) => {
+    expect(() => resolveExecProviderEffort(provider, effort, 'test'))
       .toThrow(`does not support effort "${effort}"`);
   });
 

--- a/src/__tests__/exec-configValidation.test.ts
+++ b/src/__tests__/exec-configValidation.test.ts
@@ -77,31 +77,37 @@ describe('assertExecProviderEffort provider capability checks', () => {
     ).not.toThrow();
   });
 
-  it('should accept arbitrary effort values and leave support to the provider', () => {
-    expect(() =>
-      assertExecProviderEffort('codex', 'max', 'test'),
-    ).not.toThrow();
-    expect(() =>
-      assertExecProviderEffort('claude', 'experimental', 'test'),
-    ).not.toThrow();
-    expect(() =>
-      assertExecProviderEffort('copilot', 'vendor-level', 'test'),
-    ).not.toThrow();
-  });
+  it.each([
+    ['codex', 'max'],
+    ['claude', 'experimental'],
+    ['copilot', 'vendor-level'],
+  ] as const)(
+    'should accept arbitrary effort values for %s/%s and leave support to the provider',
+    (provider, effort) => {
+      expect(() =>
+        assertExecProviderEffort(provider, effort, 'test'),
+      ).not.toThrow();
+    },
+  );
 
   it.each(
     (['codex', 'claude', 'copilot'] as const).flatMap((provider) =>
       (['', '   '] as const).map((effort) => [provider, effort] as const)),
-  )('should reject blank effort values for %s', (provider, effort) => {
+  )('should reject blank effort values for %s/%s', (provider, effort) => {
     expect(() => resolveExecProviderEffort(provider, effort, 'test'))
       .toThrow(`does not support effort "${effort}"`);
   });
 
-  it('should return the canonical trimmed effort value', () => {
-    expect(resolveExecProviderEffort('codex', '  custom-level  ', 'test')).toBe('custom-level');
-    expect(resolveExecProviderEffort('claude', '  experimental  ', 'test')).toBe('experimental');
-    expect(resolveExecProviderEffort('copilot', '  vendor-level  ', 'test')).toBe('vendor-level');
-  });
+  it.each([
+    ['codex', '  custom-level  ', 'custom-level'],
+    ['claude', '  experimental  ', 'experimental'],
+    ['copilot', '  vendor-level  ', 'vendor-level'],
+  ] as const)(
+    'should return the canonical trimmed effort value for %s/%s',
+    (provider, effort, expected) => {
+      expect(resolveExecProviderEffort(provider, effort, 'test')).toBe(expected);
+    },
+  );
 
   it('should reject effort for providers without effort support', () => {
     expect(() =>

--- a/src/__tests__/exec-presetStore.test.ts
+++ b/src/__tests__/exec-presetStore.test.ts
@@ -396,6 +396,24 @@ describe('exec preset store', () => {
     }
   });
 
+  it('should save and reload provider-defined effort strings for every effort provider', () => {
+    const globalConfigDir = mkdtempSync(join(tmpdir(), 'takt-exec-custom-effort-'));
+    const baseConfig = createExecConfig('custom-effort-worker');
+    const config: ExecConfig = {
+      ...baseConfig,
+      session: { ...baseConfig.session, provider: 'codex', effort: 'max' },
+      workers: [{ ...baseConfig.workers[0]!, provider: 'claude', effort: 'experimental' }],
+      reviews: [{ ...baseConfig.reviews[0]!, provider: 'copilot', effort: 'vendor-level' }],
+    };
+    try {
+      saveLastUsedExecConfig(config, { globalConfigDir });
+
+      expect(loadLastUsedExecConfig({ globalConfigDir })).toEqual(config);
+    } finally {
+      rmSync(globalConfigDir, { recursive: true, force: true });
+    }
+  });
+
   it('should save and delete project exec presets', () => {
     const projectDir = mkdtempSync(join(tmpdir(), 'takt-exec-project-preset-'));
     const config = createExecConfig('saved-worker');
@@ -700,16 +718,16 @@ describe('exec preset store', () => {
         /exec\.session\.provider: unsupported provider/,
       ],
       [
-        'bad-effort',
-        buildPresetYaml('bad-effort', {
+        'blank-effort',
+        buildPresetYaml('blank-effort', {
           session: [
             'session:',
             '  provider: claude',
             '  model: opus',
-            '  effort: impossible',
+            '  effort: "   "',
           ],
         }),
-        /exec\.session\.effort: unsupported effort/,
+        /exec\.session\.effort: expected non-empty string/,
       ],
       [
         'bad-actor-name',

--- a/src/__tests__/exec-workflowTemplate.test.ts
+++ b/src/__tests__/exec-workflowTemplate.test.ts
@@ -15,6 +15,16 @@ type ExecConfigOverrides = Omit<Partial<ExecConfig>, 'session' | 'replan' | 'loo
   loop?: Partial<ExecConfig['loop']>;
 };
 
+type RawProviderOptions = {
+  claude?: { effort?: string };
+  codex?: { reasoning_effort?: string };
+  copilot?: { effort?: string };
+};
+
+type RawParallelStep = {
+  provider_options?: RawProviderOptions;
+};
+
 const defaultExecWorkflowSkillOptions = {
   codex: { skills: { repo: true, user: true } },
 } as const;
@@ -44,10 +54,10 @@ type RawWorkflow = {
   loop_monitors?: Array<{
     cycle: string[];
     threshold: number;
-    judge: Record<string, unknown>;
+    judge: Record<string, unknown> & { provider_options?: RawProviderOptions };
   }>;
   report_formats?: Record<string, string>;
-  steps: Array<Record<string, unknown>>;
+  steps: Array<Record<string, unknown> & { parallel?: RawParallelStep[] }>;
 };
 
 function createExecConfig(overrides: ExecConfigOverrides = {}): ExecConfig {
@@ -584,23 +594,43 @@ describe('exec workflow template', () => {
     }
   });
 
-  it('should reject effort values that the selected provider cannot use', () => {
-    expect(() => buildExecWorkflowYaml(createExecConfig({
+  it('should pass through arbitrary effort values to the selected provider', () => {
+    const raw = parseRawWorkflow(buildExecWorkflowYaml(createExecConfig({
+      session: {
+        provider: 'codex',
+        model: 'gpt-5',
+        effort: 'max',
+      },
       workers: [
         {
           name: 'codex-worker',
-          provider: 'codex',
-          model: 'gpt-5',
-          effort: 'max',
+          provider: 'claude',
+          model: 'opus',
+          effort: 'experimental',
           instruction: 'exec-worker',
           knowledge: ['architecture'],
           policy: ['coding'],
         },
       ],
+      reviews: [
+        {
+          name: 'copilot-reviewer',
+          provider: 'copilot',
+          model: 'gpt-5',
+          effort: 'vendor-level',
+          instruction: 'exec-review',
+          knowledge: ['architecture'],
+          policy: ['review'],
+        },
+      ],
     }), {
-      workflowName: 'exec-invalid-effort-test',
-      taskDescription: 'Reject invalid effort',
-    })).toThrow(/does not support effort "max"/);
+      workflowName: 'exec-custom-effort-test',
+      taskDescription: 'Pass through custom effort',
+    }));
+
+    expect(raw.steps[0]?.parallel[0]?.provider_options?.claude?.effort).toBe('experimental');
+    expect(raw.steps[1]?.parallel[0]?.provider_options?.copilot?.effort).toBe('vendor-level');
+    expect(raw.loop_monitors?.[0]?.judge.provider_options?.codex?.reasoning_effort).toBe('max');
   });
 
   it('should reject effort for providers without effort support', () => {

--- a/src/__tests__/exec-workflowTemplate.test.ts
+++ b/src/__tests__/exec-workflowTemplate.test.ts
@@ -5,6 +5,7 @@ import { parse as parseYaml } from 'yaml';
 import { describe, expect, it } from 'vitest';
 import type { AgentWorkflowStep } from '../core/models/index.js';
 import { resolveLoopMonitorJudgeProviderModel, resolveStepProviderModel } from '../core/workflow/provider-resolution.js';
+import { resolveExecConfigProviderModel } from '../features/exec/runtimeConfig.js';
 import type { ExecConfig } from '../features/exec/types.js';
 import { buildExecWorkflowYaml as buildExecWorkflowYamlRaw } from '../features/exec/workflowTemplate.js';
 import { loadWorkflowFromFile } from '../infra/config/loaders/workflowFileLoader.js';
@@ -57,7 +58,10 @@ type RawWorkflow = {
     judge: Record<string, unknown> & { provider_options?: RawProviderOptions };
   }>;
   report_formats?: Record<string, string>;
-  steps: Array<Record<string, unknown> & { parallel?: RawParallelStep[] }>;
+  steps: Array<Record<string, unknown> & {
+    provider_options?: RawProviderOptions;
+    parallel?: RawParallelStep[];
+  }>;
 };
 
 function createExecConfig(overrides: ExecConfigOverrides = {}): ExecConfig {
@@ -595,18 +599,18 @@ describe('exec workflow template', () => {
   });
 
   it('should pass through arbitrary effort values to the selected provider', () => {
-    const raw = parseRawWorkflow(buildExecWorkflowYaml(createExecConfig({
+    const config = resolveExecConfigProviderModel(createExecConfig({
       session: {
         provider: 'codex',
         model: 'gpt-5',
-        effort: 'max',
+        effort: '  max  ',
       },
       workers: [
         {
           name: 'codex-worker',
           provider: 'claude',
           model: 'opus',
-          effort: 'experimental',
+          effort: '  experimental  ',
           instruction: 'exec-worker',
           knowledge: ['architecture'],
           policy: ['coding'],
@@ -617,20 +621,23 @@ describe('exec workflow template', () => {
           name: 'copilot-reviewer',
           provider: 'copilot',
           model: 'gpt-5',
-          effort: 'vendor-level',
+          effort: '  vendor-level  ',
           instruction: 'exec-review',
           knowledge: ['architecture'],
           policy: ['review'],
         },
       ],
-    }), {
+    }), {});
+    const raw = parseRawWorkflow(buildExecWorkflowYaml(config, {
       workflowName: 'exec-custom-effort-test',
       taskDescription: 'Pass through custom effort',
     }));
 
     expect(raw.steps[0]?.parallel[0]?.provider_options?.claude?.effort).toBe('experimental');
     expect(raw.steps[1]?.parallel[0]?.provider_options?.copilot?.effort).toBe('vendor-level');
+    expect(raw.steps[2]?.provider_options?.codex?.reasoning_effort).toBe('max');
     expect(raw.loop_monitors?.[0]?.judge.provider_options?.codex?.reasoning_effort).toBe('max');
+    expect(raw.loop_monitors?.[1]?.judge.provider_options?.codex?.reasoning_effort).toBe('max');
   });
 
   it('should reject effort for providers without effort support', () => {

--- a/src/__tests__/globalConfig-defaults.test.ts
+++ b/src/__tests__/globalConfig-defaults.test.ts
@@ -231,12 +231,12 @@ describe('loadGlobalConfig', () => {
       '          repo: true',
       '          unknown_skill: true',
     ]],
-    ['an invalid selector enum', [
+    ['an invalid selector effort type', [
       'takt_providers:',
       '  selector:',
       '    provider_options:',
       '      codex:',
-      '        reasoning_effort: turbo',
+      '        reasoning_effort: 42',
     ]],
   ])('should reject %s when loading global config', (_label, lines) => {
     mkdirSync(join(testHomeDir, '.takt'), { recursive: true });
@@ -489,7 +489,7 @@ describe('loadGlobalConfig', () => {
     ['an unknown nested selector option', {
       providerOptions: { codex: { skills: { repo: true, unknownSkill: true } } },
     }],
-    ['an invalid selector enum', { providerOptions: { codex: { reasoningEffort: 'turbo' } } }],
+    ['an invalid selector effort type', { providerOptions: { codex: { reasoningEffort: 42 } } }],
   ])('should reject %s when saving global config', (_label, selector) => {
     const taktDir = join(testHomeDir, '.takt');
     mkdirSync(taktDir, { recursive: true });

--- a/src/__tests__/projectConfig.test.ts
+++ b/src/__tests__/projectConfig.test.ts
@@ -593,7 +593,7 @@ unexpected_overrides:
       const configContent = [
         'provider_options:',
         '  codex:',
-        '    reasoning_effort: extreme',
+        "    reasoning_effort: '  extreme  '",
       ].join('\n');
       writeFileSync(configPath, configContent, 'utf-8');
 
@@ -646,13 +646,30 @@ unexpected_overrides:
       const configContent = [
         'provider_options:',
         '  claude:',
-        '    effort: impossible',
+        "    effort: '  impossible  '",
       ].join('\n');
       writeFileSync(configPath, configContent, 'utf-8');
 
       expect(loadProjectConfig(testDir).providerOptions).toEqual({
         claude: { effort: 'impossible' },
       });
+    });
+
+    it.each([
+      ['codex reasoning_effort', 'empty', '  codex:', '    reasoning_effort:', "''"],
+      ['codex reasoning_effort', 'whitespace-only', '  codex:', '    reasoning_effort:', "'   '"],
+      ['claude effort', 'empty', '  claude:', '    effort:', "''"],
+      ['claude effort', 'whitespace-only', '  claude:', '    effort:', "'   '"],
+    ])('should reject %s values that are %s', (_name, _valueKind, providerLine, effortLine, value) => {
+      const configPath = join(testDir, '.takt', 'config.yaml');
+      const configContent = [
+        'provider_options:',
+        providerLine,
+        `${effortLine} ${value}`,
+      ].join('\n');
+      writeFileSync(configPath, configContent, 'utf-8');
+
+      expect(() => loadProjectConfig(testDir)).toThrow(/effort/i);
     });
 
     it('should load project-local fields from project config yaml', () => {

--- a/src/__tests__/projectConfig.test.ts
+++ b/src/__tests__/projectConfig.test.ts
@@ -588,7 +588,7 @@ unexpected_overrides:
   });
 
   describe('migrated project-local fields', () => {
-    it('should fail fast when codex reasoning_effort is outside SDK enum', () => {
+    it('should pass through arbitrary codex reasoning_effort values', () => {
       const configPath = join(testDir, '.takt', 'config.yaml');
       const configContent = [
         'provider_options:',
@@ -597,7 +597,9 @@ unexpected_overrides:
       ].join('\n');
       writeFileSync(configPath, configContent, 'utf-8');
 
-      expect(() => loadProjectConfig(testDir)).toThrow(/reasoning_effort/);
+      expect(loadProjectConfig(testDir).providerOptions).toEqual({
+        codex: { reasoningEffort: 'extreme' },
+      });
     });
 
     it('should fail fast when Codex Skill inheritance is not boolean', () => {
@@ -639,7 +641,7 @@ unexpected_overrides:
       );
     });
 
-    it('should fail fast when claude effort is outside SDK enum', () => {
+    it('should pass through arbitrary claude effort values', () => {
       const configPath = join(testDir, '.takt', 'config.yaml');
       const configContent = [
         'provider_options:',
@@ -648,7 +650,9 @@ unexpected_overrides:
       ].join('\n');
       writeFileSync(configPath, configContent, 'utf-8');
 
-      expect(() => loadProjectConfig(testDir)).toThrow(/effort/);
+      expect(loadProjectConfig(testDir).providerOptions).toEqual({
+        claude: { effort: 'impossible' },
+      });
     });
 
     it('should load project-local fields from project config yaml', () => {
@@ -1273,13 +1277,13 @@ unexpected_overrides:
         ],
       ],
       [
-        'invalid selector enum',
+        'invalid selector effort type',
         [
           'takt_providers:',
           '  selector:',
           '    provider_options:',
           '      codex:',
-          '        reasoning_effort: turbo',
+          '        reasoning_effort: 42',
         ],
       ],
     ])('should reject %s in project config', (_name, lines) => {
@@ -1442,7 +1446,7 @@ unexpected_overrides:
       ['an unknown nested selector option', {
         providerOptions: { codex: { skills: { repo: true, unknownSkill: true } } },
       }],
-      ['an invalid selector enum', { providerOptions: { codex: { reasoningEffort: 'turbo' } } }],
+      ['an invalid selector effort type', { providerOptions: { codex: { reasoningEffort: 42 } } }],
     ])('should reject %s when saving project config', (_label, selector) => {
       const invalidConfig = {
         taktProviders: { selector },

--- a/src/__tests__/projectConfig.test.ts
+++ b/src/__tests__/projectConfig.test.ts
@@ -660,6 +660,8 @@ unexpected_overrides:
       ['codex reasoning_effort', 'whitespace-only', '  codex:', '    reasoning_effort:', "'   '"],
       ['claude effort', 'empty', '  claude:', '    effort:', "''"],
       ['claude effort', 'whitespace-only', '  claude:', '    effort:', "'   '"],
+      ['copilot effort', 'empty', '  copilot:', '    effort:', "''"],
+      ['copilot effort', 'whitespace-only', '  copilot:', '    effort:', "'   '"],
     ])('should reject %s values that are %s', (_name, _valueKind, providerLine, effortLine, value) => {
       const configPath = join(testDir, '.takt', 'config.yaml');
       const configContent = [

--- a/src/__tests__/provider-schema.test.ts
+++ b/src/__tests__/provider-schema.test.ts
@@ -189,7 +189,7 @@ describe('provider effort values', () => {
     expect(StepProviderOptionsSchema.parse(options)).toEqual(options);
   });
 
-  it('trims provider-specific effort strings and rejects blank values', () => {
+  it('trims provider-specific effort strings', () => {
     expect(StepProviderOptionsSchema.parse({
       codex: { reasoning_effort: '  custom-level  ' },
       claude: { effort: '  custom-level  ' },
@@ -199,7 +199,17 @@ describe('provider effort values', () => {
       claude: { effort: 'custom-level' },
       copilot: { effort: 'custom-level' },
     });
-    expect(() => StepProviderOptionsSchema.parse({ codex: { reasoning_effort: '   ' } })).toThrow(/effort/);
+  });
+
+  it.each([
+    ['codex', '', { codex: { reasoning_effort: '' } }],
+    ['codex', 'whitespace-only', { codex: { reasoning_effort: '   ' } }],
+    ['claude', '', { claude: { effort: '' } }],
+    ['claude', 'whitespace-only', { claude: { effort: '   ' } }],
+    ['copilot', '', { copilot: { effort: '' } }],
+    ['copilot', 'whitespace-only', { copilot: { effort: '   ' } }],
+  ])('rejects %s %s effort values', (_provider, _valueKind, options) => {
+    expect(() => StepProviderOptionsSchema.parse(options)).toThrow(/effort/);
   });
 });
 

--- a/src/__tests__/provider-schema.test.ts
+++ b/src/__tests__/provider-schema.test.ts
@@ -180,6 +180,29 @@ describe('Claude provider split (Zod)', () => {
   });
 });
 
+describe('provider effort values', () => {
+  it.each([
+    ['codex', { codex: { reasoning_effort: 'max' } }],
+    ['claude', { claude: { effort: 'vendor-level' } }],
+    ['copilot', { copilot: { effort: 'vendor-level' } }],
+  ])('accepts provider-specific effort strings for %s', (_provider, options) => {
+    expect(StepProviderOptionsSchema.parse(options)).toEqual(options);
+  });
+
+  it('trims provider-specific effort strings and rejects blank values', () => {
+    expect(StepProviderOptionsSchema.parse({
+      codex: { reasoning_effort: '  custom-level  ' },
+      claude: { effort: '  custom-level  ' },
+      copilot: { effort: '  custom-level  ' },
+    })).toEqual({
+      codex: { reasoning_effort: 'custom-level' },
+      claude: { effort: 'custom-level' },
+      copilot: { effort: 'custom-level' },
+    });
+    expect(() => StepProviderOptionsSchema.parse({ codex: { reasoning_effort: '   ' } })).toThrow(/effort/);
+  });
+});
+
 describe('Claude terminal provider contract', () => {
   beforeEach(() => {
     ProviderRegistry.resetInstance();

--- a/src/__tests__/workflow-step-fragments.test.ts
+++ b/src/__tests__/workflow-step-fragments.test.ts
@@ -838,7 +838,7 @@ provider_options:
     const workflowPath = writeWorkflow(projectDir, 'nested-override-schema-error', `  - uses: valid-options
     provider_options:
       codex:
-        reasoning_effort: invalid${COMPLETE_CALLER_RULES}`, 'valid-options');
+        reasoning_effort: 42${COMPLETE_CALLER_RULES}`, 'valid-options');
 
     let error: unknown;
     try {
@@ -857,7 +857,7 @@ provider_options:
     writeProjectFragment(projectDir, 'invalid-options', `instruction: valid
 provider_options:
   codex:
-    reasoning_effort: invalid
+    reasoning_effort: 42
     network_access: false
 `);
     const workflowPath = writeWorkflow(projectDir, 'fragment-leaf-provenance', `  - uses: invalid-options

--- a/src/core/models/schema-base.ts
+++ b/src/core/models/schema-base.ts
@@ -12,9 +12,6 @@ import { z } from 'zod/v4';
 import { PROVIDER_TYPES } from '../../shared/types/provider.js';
 import { STATUS_VALUES } from './status.js';
 import {
-  CLAUDE_EFFORT_VALUES,
-  CODEX_REASONING_EFFORT_VALUES,
-  COPILOT_EFFORT_VALUES,
   OPENCODE_GUARD_PROFILES,
   RUNTIME_PREPARE_PRESETS,
 } from './workflow-types.js';
@@ -74,10 +71,12 @@ const CodexSkillsShape = {
   user: z.boolean().optional(),
 };
 
+const ProviderEffortSchema = z.string().trim().min(1, 'effort must not be empty');
+
 const CodexProviderOptionShape = {
   base_url: z.string().min(1).optional(),
   network_access: z.boolean().optional(),
-  reasoning_effort: z.enum(CODEX_REASONING_EFFORT_VALUES).optional(),
+  reasoning_effort: ProviderEffortSchema.optional(),
   skills: z.object(CodexSkillsShape).optional(),
 };
 
@@ -120,7 +119,7 @@ const ClaudeSkillsSchema = z.object(ClaudeSkillsShape).strict();
 const ClaudeProviderOptionShape = {
   base_url: z.string().min(1).optional(),
   allowed_tools: z.array(z.string()).optional(),
-  effort: z.enum(CLAUDE_EFFORT_VALUES).optional(),
+  effort: ProviderEffortSchema.optional(),
   skills: ClaudeSkillsSchema.optional(),
   sandbox: z.object(ClaudeSandboxShape).optional(),
 };
@@ -140,7 +139,7 @@ const ClaudeTerminalProviderOptionsSchema = z.object({
 }).strict();
 
 const CopilotProviderOptionsSchema = z.object({
-  effort: z.enum(COPILOT_EFFORT_VALUES).optional(),
+  effort: ProviderEffortSchema.optional(),
 });
 
 const KiroProviderOptionsSchema = z.object({
@@ -566,7 +565,7 @@ const NormalizedStepProviderOptionsSchema = z.object({
   codex: z.object({
     baseUrl: z.string().min(1).optional(),
     networkAccess: z.boolean().optional(),
-    reasoningEffort: z.enum(CODEX_REASONING_EFFORT_VALUES).optional(),
+    reasoningEffort: ProviderEffortSchema.optional(),
     skills: z.object(CodexSkillsShape).strict().optional(),
   }).strict().optional(),
   opencode: z.object({
@@ -588,7 +587,7 @@ const NormalizedStepProviderOptionsSchema = z.object({
   claude: z.object({
     baseUrl: z.string().min(1).optional(),
     allowedTools: z.array(z.string()).optional(),
-    effort: z.enum(CLAUDE_EFFORT_VALUES).optional(),
+    effort: ProviderEffortSchema.optional(),
     skills: z.object(ClaudeSkillsShape).strict().optional(),
     sandbox: z.object({
       allowUnsandboxedCommands: z.boolean().optional(),
@@ -602,7 +601,7 @@ const NormalizedStepProviderOptionsSchema = z.object({
     transcriptPollIntervalMs: z.number().int().positive().optional(),
   }).strict().optional(),
   copilot: z.object({
-    effort: z.enum(COPILOT_EFFORT_VALUES).optional(),
+    effort: ProviderEffortSchema.optional(),
   }).strict().optional(),
   kiro: z.object({
     agent: z.string().min(1).optional(),

--- a/src/core/models/workflow-provider-options.ts
+++ b/src/core/models/workflow-provider-options.ts
@@ -65,12 +65,9 @@ export interface OpenCodeProviderOptions {
 
 export const RUNTIME_PREPARE_PRESETS = ['gradle', 'node'] as const;
 export type RuntimePreparePreset = (typeof RUNTIME_PREPARE_PRESETS)[number];
-export const CODEX_REASONING_EFFORT_VALUES = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
-export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORT_VALUES)[number];
-export const CLAUDE_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
-export type ClaudeEffort = (typeof CLAUDE_EFFORT_VALUES)[number];
-export const COPILOT_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh'] as const;
-export type CopilotEffort = (typeof COPILOT_EFFORT_VALUES)[number];
+export type CodexReasoningEffort = string;
+export type ClaudeEffort = string;
+export type CopilotEffort = string;
 const RUNTIME_PREPARE_PRESET_SET: ReadonlySet<string> = new Set(RUNTIME_PREPARE_PRESETS);
 
 export function isRuntimePreparePreset(entry: string): entry is RuntimePreparePreset {

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -69,9 +69,6 @@ export type {
 export {
   RUNTIME_PREPARE_PRESETS,
   OPENCODE_GUARD_PROFILES,
-  CODEX_REASONING_EFFORT_VALUES,
-  CLAUDE_EFFORT_VALUES,
-  COPILOT_EFFORT_VALUES,
   isRuntimePreparePreset,
 } from './workflow-provider-options.js';
 

--- a/src/features/exec/assistantSession.ts
+++ b/src/features/exec/assistantSession.ts
@@ -6,11 +6,6 @@ import {
 } from '../../infra/config/index.js';
 import type { PermissionMode, StepProviderOptions } from '../../core/models/index.js';
 import type { ImageAttachmentReference } from '../../shared/types/image-attachments.js';
-import type {
-  ClaudeEffort,
-  CodexReasoningEffort,
-  CopilotEffort,
-} from '../../core/models/workflow-types.js';
 import { callAIWithRetry, type SessionContext } from '../interactive/aiCaller.js';
 import type { FacetLookupConfig } from '../catalog/catalogFacets.js';
 import type {
@@ -37,13 +32,13 @@ function buildSessionProviderOptions(session: ResolvedExecSessionConfig): StepPr
     return undefined;
   }
   if (CLAUDE_TOOL_PROVIDERS.has(session.provider)) {
-    return { claude: { effort: session.effort as ClaudeEffort } };
+    return { claude: { effort: session.effort } };
   }
   if (session.provider === 'codex') {
-    return { codex: { reasoningEffort: session.effort as CodexReasoningEffort } };
+    return { codex: { reasoningEffort: session.effort } };
   }
   if (session.provider === 'copilot') {
-    return { copilot: { effort: session.effort as CopilotEffort } };
+    return { copilot: { effort: session.effort } };
   }
   throw new Error(`Unreachable: assertExecProviderEffort should have rejected provider "${session.provider}" with effort "${session.effort}"`);
 }

--- a/src/features/exec/configOps.ts
+++ b/src/features/exec/configOps.ts
@@ -7,6 +7,7 @@ import {
   assertExecProviderModel,
   assertExecProviderEffort,
   assertResolvedExecConfig,
+  normalizeExecEffort,
 } from './configValidation.js';
 import { resolveExecConfigProviderModel, resolveExecProviderModel, type ExecProviderModelDefaults } from './runtimeConfig.js';
 import type { ExecActorConfig, ExecConfig, ExecEffort, ResolvedExecActorConfig } from './types.js';
@@ -46,10 +47,14 @@ export function resolveEffortAfterProviderModelOverride(
   if (effort === undefined) {
     return undefined;
   }
-  if (currentProvider === nextProvider && currentModel === nextModel) {
-    return effort;
+  const normalizedEffort = normalizeExecEffort(effort);
+  if (normalizedEffort.length === 0) {
+    return normalizedEffort;
   }
-  return canKeepEffortForProvider(nextProvider, effort) ? effort : undefined;
+  if (currentProvider === nextProvider && currentModel === nextModel) {
+    return normalizedEffort;
+  }
+  return canKeepEffortForProvider(nextProvider, normalizedEffort) ? normalizedEffort : undefined;
 }
 
 export function resolveModelAfterProviderOverride(

--- a/src/features/exec/configValidation.ts
+++ b/src/features/exec/configValidation.ts
@@ -1,8 +1,3 @@
-import {
-  CLAUDE_EFFORT_VALUES,
-  CODEX_REASONING_EFFORT_VALUES,
-  COPILOT_EFFORT_VALUES,
-} from '../../core/models/workflow-types.js';
 import { validateProviderModelRequirements } from '../../core/workflow/provider-model-requirements.js';
 import type { ProviderType } from '../../infra/providers/index.js';
 import type { ExecActorConfig, ExecConfig, ExecEffort, ResolvedExecConfig } from './types.js';
@@ -23,6 +18,11 @@ export const EXEC_EFFORTS: readonly ExecEffort[] = ['minimal', 'low', 'medium', 
 const EXEC_OPTIONAL_MODEL_PROVIDERS: ReadonlySet<ProviderType> = new Set(['cursor', 'copilot', 'kiro']);
 
 export const CLAUDE_TOOL_PROVIDERS: ReadonlySet<ProviderType> = new Set(['claude', 'claude-sdk', 'claude-terminal']);
+const EXEC_EFFORT_PROVIDERS: ReadonlySet<ProviderType> = new Set([
+  ...CLAUDE_TOOL_PROVIDERS,
+  'codex',
+  'copilot',
+]);
 
 const EXEC_ACTOR_NAME_REGEX = /^[A-Za-z0-9_-]+$/;
 const RESERVED_EXEC_SESSION_KEY_BASES = new Set([
@@ -38,20 +38,11 @@ const RESERVED_EXEC_SESSION_KEY_BASES = new Set([
 ]);
 
 export function providerSupportsExecEffort(provider: ProviderType, effort: ExecEffort): boolean {
-  if (CLAUDE_TOOL_PROVIDERS.has(provider)) {
-    return CLAUDE_EFFORT_VALUES.includes(effort as typeof CLAUDE_EFFORT_VALUES[number]);
-  }
-  if (provider === 'codex') {
-    return CODEX_REASONING_EFFORT_VALUES.includes(effort as typeof CODEX_REASONING_EFFORT_VALUES[number]);
-  }
-  if (provider === 'copilot') {
-    return COPILOT_EFFORT_VALUES.includes(effort as typeof COPILOT_EFFORT_VALUES[number]);
-  }
-  return false;
+  return EXEC_EFFORT_PROVIDERS.has(provider) && effort.trim().length > 0;
 }
 
 export function getSupportedExecEfforts(provider: ProviderType): ExecEffort[] {
-  return EXEC_EFFORTS.filter((effort) => providerSupportsExecEffort(provider, effort));
+  return EXEC_EFFORT_PROVIDERS.has(provider) ? [...EXEC_EFFORTS] : [];
 }
 
 export function providerAllowsOmittedExecModel(provider: ProviderType): boolean {

--- a/src/features/exec/configValidation.ts
+++ b/src/features/exec/configValidation.ts
@@ -24,6 +24,10 @@ const EXEC_EFFORT_PROVIDERS: ReadonlySet<ProviderType> = new Set([
   'copilot',
 ]);
 
+export function normalizeExecEffort(effort: ExecEffort): ExecEffort {
+  return effort.trim();
+}
+
 const EXEC_ACTOR_NAME_REGEX = /^[A-Za-z0-9_-]+$/;
 const RESERVED_EXEC_SESSION_KEY_BASES = new Set([
   'execute',
@@ -38,7 +42,7 @@ const RESERVED_EXEC_SESSION_KEY_BASES = new Set([
 ]);
 
 export function providerSupportsExecEffort(provider: ProviderType, effort: ExecEffort): boolean {
-  return EXEC_EFFORT_PROVIDERS.has(provider) && effort.trim().length > 0;
+  return EXEC_EFFORT_PROVIDERS.has(provider) && normalizeExecEffort(effort).length > 0;
 }
 
 export function getSupportedExecEfforts(provider: ProviderType): ExecEffort[] {
@@ -67,12 +71,22 @@ export function assertExecProviderEffort(
   effort: ExecEffort | undefined,
   path: string,
 ): void {
+  resolveExecProviderEffort(provider, effort, path);
+}
+
+export function resolveExecProviderEffort(
+  provider: ProviderType,
+  effort: ExecEffort | undefined,
+  path: string,
+): ExecEffort | undefined {
   if (effort === undefined) {
-    return;
+    return undefined;
   }
-  if (!providerSupportsExecEffort(provider, effort)) {
+  const normalizedEffort = normalizeExecEffort(effort);
+  if (!providerSupportsExecEffort(provider, normalizedEffort)) {
     throw new Error(`Invalid exec config at ${path}: provider "${provider}" does not support effort "${effort}"`);
   }
+  return normalizedEffort;
 }
 
 function assertUniqueActorSessionKeys(actors: ExecActorConfig[]): void {

--- a/src/features/exec/presetStore.ts
+++ b/src/features/exec/presetStore.ts
@@ -5,7 +5,7 @@ import { getGlobalConfigDir } from '../../infra/config/paths.js';
 import type { ProviderType } from '../../infra/providers/index.js';
 import { getResourcesDir } from '../../infra/resources/index.js';
 import { debugLog } from '../../shared/utils/index.js';
-import { assertExecActorName, assertExecConfig, EXEC_EFFORTS, EXEC_PROVIDERS } from './configValidation.js';
+import { assertExecActorName, assertExecConfig, EXEC_PROVIDERS } from './configValidation.js';
 import {
   deleteProjectLocalFile,
   listProjectLocalDirectoryEntries,
@@ -106,11 +106,7 @@ function asEffort(value: unknown, path: string): ExecEffort | undefined {
   if (value === undefined) {
     return undefined;
   }
-  const effort = asString(value, path);
-  if (!EXEC_EFFORTS.includes(effort as ExecEffort)) {
-    throw new Error(`Invalid exec config at ${path}: unsupported effort "${effort}"`);
-  }
-  return effort as ExecEffort;
+  return asString(value, path);
 }
 
 function asModel(value: unknown, path: string): string | undefined {

--- a/src/features/exec/runtimeConfig.ts
+++ b/src/features/exec/runtimeConfig.ts
@@ -2,7 +2,7 @@ import { resolveNonWorkflowProviderOptions } from '../../infra/config/index.js';
 import { resolveAuxiliaryProviderEnvironment } from '../../infra/config/runtime-provider/provider-environment.js';
 import type { WorkflowConfig } from '../../core/models/index.js';
 import type { ProviderType } from '../../infra/providers/index.js';
-import { assertResolvedExecConfig } from './configValidation.js';
+import { assertResolvedExecConfig, resolveExecProviderEffort } from './configValidation.js';
 import type {
   ExecActorConfig,
   ExecCodexSkillInheritance,
@@ -95,9 +95,11 @@ function resolveSessionConfig(
   session: ExecSessionConfig,
   defaults: ExecProviderModelDefaults,
 ): ResolvedExecSessionConfig {
+  const providerModel = resolveExecProviderModel(session.provider, session.model, defaults, 'exec.session.provider');
   return {
     ...session,
-    ...resolveExecProviderModel(session.provider, session.model, defaults, 'exec.session.provider'),
+    ...providerModel,
+    effort: resolveExecProviderEffort(providerModel.provider, session.effort, 'exec.session.effort'),
   };
 }
 
@@ -106,9 +108,11 @@ function resolveActorConfig(
   defaults: ExecProviderModelDefaults,
   path: string,
 ): ResolvedExecActorConfig {
+  const providerModel = resolveExecProviderModel(actor.provider, actor.model, defaults, `${path}.provider`);
   return {
     ...actor,
-    ...resolveExecProviderModel(actor.provider, actor.model, defaults, path),
+    ...providerModel,
+    effort: resolveExecProviderEffort(providerModel.provider, actor.effort, `${path}.effort`),
   };
 }
 
@@ -119,8 +123,8 @@ export function resolveExecConfigProviderModel(
   const resolved = {
     ...config,
     session: resolveSessionConfig(config.session, defaults),
-    workers: config.workers.map((worker, index) => resolveActorConfig(worker, defaults, `exec.workers[${index}].provider`)),
-    reviews: config.reviews.map((review, index) => resolveActorConfig(review, defaults, `exec.reviews[${index}].provider`)),
+    workers: config.workers.map((worker, index) => resolveActorConfig(worker, defaults, `exec.workers[${index}]`)),
+    reviews: config.reviews.map((review, index) => resolveActorConfig(review, defaults, `exec.reviews[${index}]`)),
   };
   assertResolvedExecConfig(resolved);
   return resolved;

--- a/src/features/exec/types.ts
+++ b/src/features/exec/types.ts
@@ -1,6 +1,6 @@
 import type { ProviderType } from '../../infra/providers/index.js';
 
-export type ExecEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+export type ExecEffort = string;
 
 export interface ExecCodexSkillInheritance {
   readonly repo: boolean;

--- a/src/infra/claude/options-builder.ts
+++ b/src/infra/claude/options-builder.ts
@@ -85,6 +85,7 @@ export class SdkOptionsBuilder {
       sdkOptions.skills = [];
     }
     if (this.options.model) sdkOptions.model = this.options.model;
+    // The SDK's TypeScript union can lag values accepted by the Claude CLI runtime.
     if (this.options.effort) sdkOptions.effort = this.options.effort as Options['effort'];
     if (this.options.internalAgentIsolation !== 'strict-readonly' && this.options.skillsEnabled === false) {
       sdkOptions.skills = [];

--- a/src/infra/claude/options-builder.ts
+++ b/src/infra/claude/options-builder.ts
@@ -85,7 +85,7 @@ export class SdkOptionsBuilder {
       sdkOptions.skills = [];
     }
     if (this.options.model) sdkOptions.model = this.options.model;
-    if (this.options.effort) sdkOptions.effort = this.options.effort;
+    if (this.options.effort) sdkOptions.effort = this.options.effort as Options['effort'];
     if (this.options.internalAgentIsolation !== 'strict-readonly' && this.options.skillsEnabled === false) {
       sdkOptions.skills = [];
     }

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -4,7 +4,13 @@
  * Uses @openai/codex-sdk for native TypeScript integration.
  */
 
-import { Codex, type CodexOptions, type Input, type Thread, type TurnOptions } from '@openai/codex-sdk';
+import {
+  Codex,
+  type CodexOptions,
+  type Input,
+  type Thread,
+  type TurnOptions,
+} from '@openai/codex-sdk';
 import { USAGE_MISSING_REASONS } from '../../core/logging/contracts.js';
 import type { AgentResponse, ProviderUsageSnapshot } from '../../core/models/index.js';
 import { buildEnvWithNestedObservabilitySnapshot } from '../../shared/telemetry/index.js';
@@ -335,7 +341,6 @@ export class CodexClient {
       // back to its configured approval policy (e.g. on-request + approvals_reviewer=auto_review),
       // which auto-approves escalation past a read-only sandbox and lets writes through.
       approvalPolicy: 'never' as const,
-      ...(options.reasoningEffort ? { modelReasoningEffort: options.reasoningEffort } : {}),
       ...(options.networkAccess === undefined ? {} : { networkAccessEnabled: options.networkAccess }),
     };
     let threadId = options.sessionId;
@@ -379,6 +384,13 @@ export class CodexClient {
       return errorResponse;
     }
 
+    const codexConfig: CodexOptions['config'] = options.reasoningEffort === undefined
+      ? skillConfig
+      : {
+          ...(skillConfig ?? {}),
+          model_reasoning_effort: options.reasoningEffort,
+        };
+
     while (true) {
       const attempt = standardRetryCount + timeoutRetryCount + refusalRetryCount + 1;
       let currentThreadId = threadId;
@@ -392,7 +404,7 @@ export class CodexClient {
           ...(options.openaiApiKey ? { apiKey: options.openaiApiKey } : {}),
           ...(options.baseUrl !== undefined ? { baseUrl: options.baseUrl } : {}),
           ...(options.codexPathOverride ? { codexPathOverride: options.codexPathOverride } : {}),
-          ...(skillConfig !== undefined ? { config: skillConfig } : {}),
+          ...(codexConfig !== undefined ? { config: codexConfig } : {}),
         };
         const codex = new Codex(codexClientOptions);
         thread = threadId

--- a/src/infra/codex/strict-execution-profile.ts
+++ b/src/infra/codex/strict-execution-profile.ts
@@ -206,7 +206,7 @@ function buildStrictArgs(
     ...(model === undefined ? [] : ['--model', model]),
     ...(options.reasoningEffort === undefined
       ? []
-      : ['--config', `model_reasoning_effort="${options.reasoningEffort}"`]),
+      : ['--config', `model_reasoning_effort=${JSON.stringify(options.reasoningEffort)}`]),
     ...(options.baseUrl === undefined
       ? []
       : ['--config', `openai_base_url=${JSON.stringify(options.baseUrl)}`]),


### PR DESCRIPTION
## Summary

- replace TAKT-owned Codex, Claude, and Copilot effort enums with non-empty provider-defined strings
- pass custom effort values through workflow loading, normalized options, exec presets, generated workflows, and provider adapters
- serialize Codex effort values safely through both the SDK config path and strict CLI config arguments
- keep the built-in exec effort list as UI suggestions only, not as validation
- update English/Japanese workflow documentation and regression coverage

## Root cause

TAKT hard-coded provider effort values in Zod enums and exec validation. New values supported by a provider or its CLI were rejected during TAKT config loading before they could reach the downstream adapter.

## Impact

Provider-defined values such as Codex `max`, `ultra`, or future custom strings can be used without waiting for a TAKT release that updates an allowlist. Empty or whitespace-only values remain invalid, matching the existing configured-model string contract.

## Review

- implemented by a Luna max agent using the repository coding guidelines
- independently reviewed by a second Luna max agent
- the review found and fixed unsafe Codex SDK/CLI string forwarding by moving the normal SDK path to `CodexOptions.config` and JSON-encoding strict CLI values

## Validation

- `npm run test:type-contracts`
- `npm run build`
- `npm run lint`
- targeted unit, light integration, heavy integration, and serial workflow tests: 755 passed
- `git diff --check origin/main...HEAD`

Full E2E is left to GitHub Actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Claude、Codex、Copilot の推論 effort に、プロバイダーが定義する任意の文字列を指定できるようになりました。
  * 実行時の effort 設定で、「minimal」を含む選択肢を利用できます。
  * 指定した effort 値は前後の空白を除去して各プロバイダーへ渡されます。

* **ドキュメント**
  * 各プロバイダーの effort 設定に関する説明を更新しました。

* **改善**
  * 型が不正な値や空白のみの値を適切に検証するようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->