### PR TITLE
feat: add TAKT experimental workflow

### DIFF
--- a/builtins/en/steps/experimental-fix.yaml
+++ b/builtins/en/steps/experimental-fix.yaml
@@ -1,0 +1,28 @@
+params:
+  fix_policy:
+    type: facet_ref[]
+    facet_kind: policy
+  fix_knowledge:
+    type: facet_ref[]
+    facet_kind: knowledge
+  fix_instruction:
+    type: facet_ref
+    facet_kind: instruction
+
+name: fix
+tags: [coding]
+edit: true
+session: compact
+persona: coder
+policy:
+  $param: fix_policy
+knowledge:
+  $param: fix_knowledge
+required_permission_mode: edit
+instruction:
+  $param: fix_instruction
+output_contracts:
+  report:
+    - name: fix-report.md
+      format: fix-report
+      use_judge: false

--- a/builtins/en/steps/experimental-review.yaml
+++ b/builtins/en/steps/experimental-review.yaml
@@ -1,4 +1,7 @@
 params:
+  review_policy_additions:
+    type: facet_ref[]
+    facet_kind: policy
   review_knowledge_additions:
     type: facet_ref[]
     facet_kind: knowledge
@@ -12,7 +15,12 @@ parallel:
       tags: [review]
       edit: false
       persona: coding-reviewer
-      policy: [contract-change, review, coding, testing]
+      policy:
+        - contract-change
+        - review
+        - coding
+        - testing
+        - $param: review_policy_additions
       knowledge:
         - architecture
         - unit-testing
@@ -29,7 +37,11 @@ parallel:
       tags: [review]
       edit: false
       persona: ai-antipattern-reviewer
-      policy: [contract-change, review, ai-antipattern]
+      policy:
+        - contract-change
+        - review
+        - ai-antipattern
+        - $param: review_policy_additions
       knowledge:
         - architecture
         - $param: review_knowledge_additions

--- a/builtins/en/steps/experimental-review.yaml
+++ b/builtins/en/steps/experimental-review.yaml
@@ -1,3 +1,8 @@
+params:
+  review_knowledge_additions:
+    type: facet_ref[]
+    facet_kind: knowledge
+
 name: review
 tags: [review]
 parallel:
@@ -8,7 +13,11 @@ parallel:
       edit: false
       persona: coding-reviewer
       policy: [contract-change, review, coding, testing]
-      knowledge: [architecture, unit-testing, e2e-testing]
+      knowledge:
+        - architecture
+        - unit-testing
+        - e2e-testing
+        - $param: review_knowledge_additions
       instruction: review-coding
       pass_previous_response: false
       output_contracts:
@@ -21,7 +30,9 @@ parallel:
       edit: false
       persona: ai-antipattern-reviewer
       policy: [contract-change, review, ai-antipattern]
-      knowledge: architecture
+      knowledge:
+        - architecture
+        - $param: review_knowledge_additions
       instruction: ai-antipattern-review
       pass_previous_response: false
       output_contracts:

--- a/builtins/en/steps/experimental-supervise.yaml
+++ b/builtins/en/steps/experimental-supervise.yaml
@@ -1,0 +1,32 @@
+params:
+  supervise_policy:
+    type: facet_ref[]
+    facet_kind: policy
+  supervise_knowledge:
+    type: facet_ref[]
+    facet_kind: knowledge
+  supervise_instruction:
+    type: facet_ref
+    facet_kind: instruction
+
+name: supervise
+capabilities: readonly
+tags:
+  - review
+  - supervise
+edit: false
+persona: supervisor
+policy:
+  $param: supervise_policy
+knowledge:
+  $param: supervise_knowledge
+pass_previous_response: false
+instruction:
+  $param: supervise_instruction
+output_contracts:
+  report:
+    - name: supervisor-validation.md
+      format: supervisor-validation
+    - name: summary.md
+      format: supervisor-summary
+      use_judge: false

--- a/builtins/en/workflow-categories.yaml
+++ b/builtins/en/workflow-categories.yaml
@@ -81,6 +81,7 @@ workflow_categories:
   🎵 TAKT Development:
     workflows:
       - takt-default
+      - takt-experimental
       - takt-default-fc
       - auto-improvement-loop
       - review-takt-default

--- a/builtins/en/workflows/experimental-core.yaml
+++ b/builtins/en/workflows/experimental-core.yaml
@@ -1,0 +1,249 @@
+name: experimental-core
+description: Shared experimental development flow with injectable generic or TAKT-specific planning, testing, implementation, review, fix, and supervision context.
+subworkflow:
+  callable: true
+  visibility: internal
+  params:
+    implementation_pool:
+      type: facet_pool_ref
+      default: coding-facets
+    review_workflow:
+      type: workflow_ref
+      default: experimental-review
+    plan_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [design-planning]
+    plan_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture, task-decomposition]
+    plan_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: plan
+    testing_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [coding, testing]
+    testing_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture, unit-testing, e2e-testing]
+    testing_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: write-tests-first
+    development_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [coding, testing]
+    development_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture, existing-system]
+    implementation_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: implement
+    review_policy_additions:
+      type: facet_ref[]
+      facet_kind: policy
+      default: []
+    review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    fix_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [contract-change, coding, testing, review, ai-antipattern]
+    fix_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture]
+    fix_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: fix
+    supervise_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [contract-change, coding, testing, review, ai-antipattern]
+    supervise_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture, unit-testing, e2e-testing]
+    supervise_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: supervise
+initial_step: plan
+
+facet_pools:
+  coding-facets:
+    candidates:
+      - id: frontend
+        description: Handle UI, components, state management, accessibility, and presentation.
+        policy: design-fidelity
+        knowledge: [frontend, react]
+      - id: backend
+        description: Handle APIs, domain logic, server-side processing, and persistence.
+        knowledge: backend
+      - id: cli
+        description: Handle CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
+        policy: existing-system-respect
+        knowledge: existing-system
+      - id: testing
+        description: Handle test design, coverage, integration boundaries, and E2E boundaries.
+        policy: testing
+        knowledge: [unit-testing, e2e-testing]
+      - id: security
+        description: Handle authentication, authorization, input validation, secrets, dependencies, and security boundaries.
+        knowledge: security
+      - id: implementation-semantics
+        description: Handle implementation meaning, contracts, state transitions, return values, and side effects.
+        knowledge: implementation-semantics
+  takt-coding-facets:
+    candidates:
+      - id: cli
+        description: Handle TAKT CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
+        policy: existing-system-respect
+        knowledge: [takt, existing-system]
+      - id: testing
+        description: Handle TAKT test design, coverage, integration boundaries, and E2E boundaries.
+        policy: [testing, takt-testing]
+        knowledge: [takt, unit-testing, e2e-testing]
+      - id: security
+        description: Handle TAKT authentication, authorization, input validation, secrets, dependencies, and security boundaries.
+        knowledge: [takt, security]
+      - id: implementation-semantics
+        description: Handle TAKT implementation meaning, contracts, state transitions, return values, and side effects.
+        knowledge: [takt, implementation-semantics]
+
+steps:
+  - name: plan
+    capabilities: [readonly, enable-skills]
+    uses: development-core-plan
+    with:
+      plan_policy:
+        $param: plan_policy
+      plan_knowledge:
+        $param: plan_knowledge
+      plan_instruction:
+        $param: plan_instruction
+      plan_report_format: plan
+    rules:
+      - condition: Requirements are clear and implementation is feasible
+        next: write_tests
+      - condition: The user is asking a question rather than requesting implementation
+        next: COMPLETE
+      - condition: Requirements are unclear or information is insufficient
+        next: ABORT
+
+  - name: write_tests
+    capabilities: [edit, enable-skills]
+    uses: development-core-write-tests
+    with:
+      testing_policy:
+        $param: testing_policy
+      testing_knowledge:
+        $param: testing_knowledge
+      testing_instruction:
+        $param: testing_instruction
+    rules:
+      - condition: Test creation is complete
+        next: implement
+      - condition: Test creation is skipped because the target is not implemented
+        next: implement
+      - condition: Test creation cannot proceed
+        next: plan
+      - condition: User input is required for a clarification
+        next: write_tests
+        requires_user_input: true
+        interactive_only: true
+
+  - name: implement
+    capabilities: [edit, enable-skills]
+    uses: development-core-implement
+    with:
+      development_policy:
+        $param: development_policy
+      development_knowledge:
+        $param: development_knowledge
+      implementation_instruction:
+        $param: implementation_instruction
+    dynamic_facets:
+      pool:
+        $param: implementation_pool
+    rules:
+      - condition: Implementation is complete
+        next: review
+      - condition: No implementation was started (report only)
+        next: review
+      - condition: Implementation cannot proceed
+        next: plan
+      - condition: User input is required
+        next: implement
+        requires_user_input: true
+        interactive_only: true
+
+  - name: review
+    kind: workflow_call
+    call:
+      $param: review_workflow
+    args:
+      review_policy_additions:
+        $param: review_policy_additions
+      review_knowledge_additions:
+        $param: review_knowledge_additions
+    rules:
+      - condition: COMPLETE
+        next: supervise
+      - condition: needs_fix
+        next: fix
+      - condition: ABORT
+        next: ABORT
+
+  - name: fix
+    capabilities: [edit, enable-skills]
+    uses: experimental-fix
+    with:
+      fix_policy:
+        $param: fix_policy
+      fix_knowledge:
+        $param: fix_knowledge
+      fix_instruction:
+        $param: fix_instruction
+    dynamic_facets:
+      pool:
+        $param: implementation_pool
+    rules:
+      - condition: Fix is complete
+        next: review
+      - condition: The fix approach needs to be reconsidered
+        next: plan
+      - condition: The task needs to be replanned
+        next: plan
+      - condition: Fix cannot proceed
+        next: ABORT
+
+  - name: supervise
+    capabilities: [readonly, enable-skills]
+    uses: experimental-supervise
+    with:
+      supervise_policy:
+        $param: supervise_policy
+      supervise_knowledge:
+        $param: supervise_knowledge
+      supervise_instruction:
+        $param: supervise_instruction
+    rules:
+      - condition: BLOCKED
+        next: ABORT
+      - condition: approved
+        next: COMPLETE
+      - condition: need_replan
+        next: plan
+      - condition: needs_fix
+        next: fix

--- a/builtins/en/workflows/experimental-review.yaml
+++ b/builtins/en/workflows/experimental-review.yaml
@@ -1,0 +1,40 @@
+name: experimental-review
+description: Common review execution for the experimental workflow, returning a review result with injected context.
+subworkflow:
+  callable: true
+  visibility: internal
+  returns:
+    - needs_fix
+  params:
+    review_policy_additions:
+      type: facet_ref[]
+      facet_kind: policy
+      default: []
+    review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+initial_step: review
+steps:
+  - name: review
+    uses: experimental-review
+    with:
+      review_policy_additions:
+        $param: review_policy_additions
+      review_knowledge_additions:
+        $param: review_knowledge_additions
+    rules:
+      self:
+        - condition: all("approved")
+          next: COMPLETE
+        - condition: any("needs_fix")
+          return: needs_fix
+      parallel:
+        coding-review: [{ condition: approved }, { condition: needs_fix }]
+        ai-antipattern-review: [{ condition: approved }, { condition: needs_fix }]
+        architecture-review: [{ condition: approved }, { condition: needs_fix }]
+        frontend-review: [{ condition: approved }, { condition: needs_fix }]
+        backend-review: [{ condition: approved }, { condition: needs_fix }]
+        cli-review: [{ condition: approved }, { condition: needs_fix }]
+        security-review: [{ condition: approved }, { condition: needs_fix }]
+        testing-review: [{ condition: approved }, { condition: needs_fix }]

--- a/builtins/en/workflows/experimental.yaml
+++ b/builtins/en/workflows/experimental.yaml
@@ -1,141 +1,19 @@
 name: experimental
-description: An experimental general-purpose coding workflow that dynamically selects review agents and remediation facets from the task and preceding reports.
+description: Experimental coding workflow delegating generic planning, testing, implementation, review, fix, and supervision to the shared core.
 max_steps: 51
-initial_step: plan
-
-facet_pools:
-  coding-facets:
-    candidates:
-      - id: frontend
-        description: Handle UI, components, state management, accessibility, and presentation.
-        policy: design-fidelity
-        knowledge: [frontend, react]
-      - id: backend
-        description: Handle APIs, domain logic, server-side processing, and persistence.
-        knowledge: backend
-      - id: cli
-        description: Handle CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
-        policy: existing-system-respect
-        knowledge: existing-system
-      - id: testing
-        description: Handle test design, test coverage, integration boundaries, and E2E boundaries.
-        policy: testing
-        knowledge: [unit-testing, e2e-testing]
-      - id: security
-        description: Handle authentication, authorization, input validation, secrets, dependencies, and security boundaries.
-        knowledge: security
-      - id: implementation-semantics
-        description: Handle implementation semantics, contracts, state transitions, return values, and side effects.
-        knowledge: implementation-semantics
+initial_step: develop
 
 steps:
-  - name: plan
-    capabilities: [readonly, enable-skills]
-    uses: development-core-plan
-    with:
-      plan_policy: [design-planning]
-      plan_knowledge: [architecture, task-decomposition]
-      plan_instruction: plan
-      plan_report_format: plan
-    rules:
-      - condition: Requirements are clear and implementation is feasible
-        next: write_tests
-      - condition: The user is asking a question rather than requesting implementation
-        next: COMPLETE
-      - condition: Requirements are unclear or information is insufficient
-        next: ABORT
-
-  - name: write_tests
-    capabilities: [edit, enable-skills]
-    uses: development-core-write-tests
-    with:
-      testing_policy: [coding, testing]
-      testing_knowledge: [architecture, unit-testing, e2e-testing]
-      testing_instruction: write-tests-first
-    rules:
-      - condition: Test creation completed
-        next: implement
-      - condition: Test creation skipped because the target is not implemented
-        next: implement
-      - condition: Unable to proceed with test creation
-        next: plan
-      - condition: User input is required to resolve a question
-        next: write_tests
-        requires_user_input: true
-        interactive_only: true
-
-  - name: implement
-    capabilities: [edit, enable-skills]
-    uses: development-core-implement
-    with:
-      development_policy: [coding, testing]
-      development_knowledge: [architecture, existing-system]
-      implementation_instruction: implement
-    dynamic_facets:
-      pool: coding-facets
-    rules:
-      - condition: Implementation completed
-        next: review
-      - condition: Implementation not started (report only)
-        next: review
-      - condition: Unable to proceed with implementation
-        next: plan
-      - condition: User input is required to resolve a question
-        next: implement
-        requires_user_input: true
-        interactive_only: true
-
-  - name: review
-    uses: experimental-review
-    with:
+  - name: develop
+    kind: workflow_call
+    call: experimental-core
+    args:
+      implementation_pool: coding-facets
+      review_workflow: experimental-review
+      review_policy_additions: []
       review_knowledge_additions: []
     rules:
-      self:
-        - condition: all("approved")
-          next: supervise
-        - condition: any("needs_fix")
-          next: fix
-      parallel:
-        coding-review: &reviewer-rules
-          - condition: approved
-          - condition: needs_fix
-        ai-antipattern-review: *reviewer-rules
-        architecture-review: *reviewer-rules
-        frontend-review: *reviewer-rules
-        backend-review: *reviewer-rules
-        cli-review: *reviewer-rules
-        security-review: *reviewer-rules
-        testing-review: *reviewer-rules
-
-  - name: fix
-    capabilities: [edit, enable-skills]
-    uses: fix
-    policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: architecture
-    dynamic_facets:
-      pool: coding-facets
-    rules:
-      - condition: Fix complete
-        next: review
-      - condition: Remediation approach must be revised
-        next: plan
-      - condition: Whole-task replanning is required
-        next: plan
-      - condition: Unable to proceed with the fix
-        next: ABORT
-
-  - name: supervise
-    capabilities: [readonly, enable-skills]
-    uses: review-supervise-to-complete
-    tags: [review, final-gate, supervise]
-    policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: [architecture, unit-testing, e2e-testing]
-    rules:
-      - condition: BLOCKED
-        next: ABORT
-      - condition: approved
+      - condition: COMPLETE
         next: COMPLETE
-      - condition: need_replan
-        next: plan
-      - condition: needs_fix
-        next: fix
+      - condition: ABORT
+        next: ABORT

--- a/builtins/en/workflows/takt-experimental-review.yaml
+++ b/builtins/en/workflows/takt-experimental-review.yaml
@@ -1,0 +1,96 @@
+name: takt-experimental-review
+description: TAKT-specific review execution with TAKT context and reviewer candidates only.
+subworkflow:
+  callable: true
+  visibility: internal
+  returns:
+    - needs_fix
+  params:
+    review_policy_additions:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [takt-testing]
+    review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [takt]
+initial_step: review
+steps:
+  - name: review
+    uses: experimental-review
+    with:
+      review_policy_additions:
+        $param: review_policy_additions
+      review_knowledge_additions:
+        $param: review_knowledge_additions
+    parallel:
+      pool:
+        - name: architecture-review
+          description: Review module structure, responsibility boundaries, dependency direction, and call paths.
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: architecture-reviewer
+          policy: [contract-change, review]
+          knowledge: [takt, architecture]
+          instruction: review-arch
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: architecture-review.md
+                format: architecture-review
+        - name: cli-review
+          description: Review CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: coding-reviewer
+          policy: [contract-change, review, coding]
+          knowledge: [takt, architecture, existing-system]
+          instruction: review-coding
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: cli-review.md
+                format: coding-review
+        - name: security-review
+          description: Review authentication, authorization, input validation, secrets, dependencies, and security boundaries.
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: security-reviewer
+          policy: [contract-change, review]
+          knowledge: [takt, security]
+          instruction: review-security
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: security-review.md
+                format: security-review
+        - name: testing-review
+          description: Review test coverage, test design, integration boundaries, and E2E boundaries.
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: testing-reviewer
+          policy: [contract-change, review, testing, takt-testing]
+          knowledge: [takt, unit-testing, e2e-testing]
+          instruction: review-test
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: testing-review.md
+                format: testing-review
+    rules:
+      self:
+        - condition: all("approved")
+          next: COMPLETE
+        - condition: any("needs_fix")
+          return: needs_fix
+      parallel:
+        coding-review: [{ condition: approved }, { condition: needs_fix }]
+        ai-antipattern-review: [{ condition: approved }, { condition: needs_fix }]
+        architecture-review: [{ condition: approved }, { condition: needs_fix }]
+        cli-review: [{ condition: approved }, { condition: needs_fix }]
+        security-review: [{ condition: approved }, { condition: needs_fix }]
+        testing-review: [{ condition: approved }, { condition: needs_fix }]

--- a/builtins/en/workflows/takt-experimental.yaml
+++ b/builtins/en/workflows/takt-experimental.yaml
@@ -1,190 +1,28 @@
 name: takt-experimental
-description: An experimental development workflow that injects TAKT-specific knowledge and testing policy, then dynamically selects implementation facets and review agents from the task and preceding reports.
+description: Inject TAKT-specific knowledge and testing policy into the shared experimental core, using TAKT-only implementation and review candidates.
 max_steps: 51
-initial_step: plan
-
-facet_pools:
-  coding-facets:
-    candidates:
-      - id: cli
-        description: Handle CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
-        policy: existing-system-respect
-        knowledge: [takt, existing-system]
-      - id: testing
-        description: Handle test design, test coverage, integration boundaries, and E2E boundaries.
-        policy: [testing, takt-testing]
-        knowledge: [takt, unit-testing, e2e-testing]
-      - id: security
-        description: Handle authentication, authorization, input validation, secrets, dependencies, and security boundaries.
-        knowledge: [takt, security]
-      - id: implementation-semantics
-        description: Handle implementation semantics, contracts, state transitions, return values, and side effects.
-        knowledge: [takt, implementation-semantics]
+initial_step: develop
 
 steps:
-  - name: plan
-    capabilities: [readonly, enable-skills]
-    uses: development-core-plan
-    with:
-      plan_policy: [design-planning]
+  - name: develop
+    kind: workflow_call
+    call: experimental-core
+    args:
+      implementation_pool: takt-coding-facets
+      review_workflow: takt-experimental-review
+      review_policy_additions: [takt-testing]
+      review_knowledge_additions: [takt]
       plan_knowledge: [takt, architecture, task-decomposition]
-      plan_instruction: plan
-      plan_report_format: plan
-    rules:
-      - condition: Requirements are clear and implementation is feasible
-        next: write_tests
-      - condition: The user is asking a question rather than requesting implementation
-        next: COMPLETE
-      - condition: Requirements are unclear or information is insufficient
-        next: ABORT
-
-  - name: write_tests
-    capabilities: [edit, enable-skills]
-    uses: development-core-write-tests
-    with:
       testing_policy: [coding, testing, takt-testing]
       testing_knowledge: [takt, architecture, unit-testing, e2e-testing]
-      testing_instruction: write-tests-first
-    rules:
-      - condition: Test creation completed
-        next: implement
-      - condition: Test creation skipped because the target is not implemented
-        next: implement
-      - condition: Unable to proceed with test creation
-        next: plan
-      - condition: User input is required to resolve a question
-        next: write_tests
-        requires_user_input: true
-        interactive_only: true
-
-  - name: implement
-    capabilities: [edit, enable-skills]
-    uses: development-core-implement
-    with:
       development_policy: [coding, testing, takt-testing]
       development_knowledge: [takt, architecture, task-decomposition]
-      implementation_instruction: implement
-    dynamic_facets:
-      pool: coding-facets
+      fix_policy: [contract-change, coding, testing, takt-testing, review, ai-antipattern]
+      fix_knowledge: [takt, architecture]
+      supervise_policy: [contract-change, coding, testing, takt-testing, review, ai-antipattern]
+      supervise_knowledge: [takt, architecture, unit-testing, e2e-testing]
     rules:
-      - condition: Implementation completed
-        next: review
-      - condition: Implementation not started (report only)
-        next: review
-      - condition: Unable to proceed with implementation
-        next: plan
-      - condition: User input is required to resolve a question
-        next: implement
-        requires_user_input: true
-        interactive_only: true
-
-  - name: review
-    uses: experimental-review
-    with:
-      review_knowledge_additions: [takt]
-    parallel:
-      pool:
-        - name: architecture-review
-          description: Review module structure, responsibility boundaries, dependency direction, and call paths.
-          capabilities: readonly
-          tags: [review]
-          edit: false
-          persona: architecture-reviewer
-          policy: [contract-change, review]
-          knowledge: [takt, architecture]
-          instruction: review-arch
-          pass_previous_response: false
-          output_contracts:
-            report:
-              - name: architecture-review.md
-                format: architecture-review
-        - name: cli-review
-          description: Review CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
-          capabilities: readonly
-          tags: [review]
-          edit: false
-          persona: coding-reviewer
-          policy: [contract-change, review, coding]
-          knowledge: [takt, architecture, existing-system]
-          instruction: review-coding
-          pass_previous_response: false
-          output_contracts:
-            report:
-              - name: cli-review.md
-                format: coding-review
-        - name: security-review
-          description: Review authentication, authorization, input validation, secrets, dependencies, and security boundaries.
-          capabilities: readonly
-          tags: [review]
-          edit: false
-          persona: security-reviewer
-          policy: [contract-change, review]
-          knowledge: [takt, security]
-          instruction: review-security
-          pass_previous_response: false
-          output_contracts:
-            report:
-              - name: security-review.md
-                format: security-review
-        - name: testing-review
-          description: Review test coverage, test design, integration boundaries, and E2E boundaries.
-          capabilities: readonly
-          tags: [review]
-          edit: false
-          persona: testing-reviewer
-          policy: [contract-change, review, testing]
-          knowledge: [takt, unit-testing, e2e-testing]
-          instruction: review-test
-          pass_previous_response: false
-          output_contracts:
-            report:
-              - name: testing-review.md
-                format: testing-review
-    rules:
-      self:
-        - condition: all("approved")
-          next: supervise
-        - condition: any("needs_fix")
-          next: fix
-      parallel:
-        coding-review: &reviewer-rules
-          - condition: approved
-          - condition: needs_fix
-        ai-antipattern-review: *reviewer-rules
-        architecture-review: *reviewer-rules
-        cli-review: *reviewer-rules
-        security-review: *reviewer-rules
-        testing-review: *reviewer-rules
-
-  - name: fix
-    capabilities: [edit, enable-skills]
-    uses: fix
-    policy: [contract-change, coding, testing, takt-testing, review, ai-antipattern]
-    knowledge: [takt, architecture]
-    dynamic_facets:
-      pool: coding-facets
-    rules:
-      - condition: Fix complete
-        next: review
-      - condition: Remediation approach must be revised
-        next: plan
-      - condition: Whole-task replanning is required
-        next: plan
-      - condition: Unable to proceed with the fix
-        next: ABORT
-
-  - name: supervise
-    capabilities: [readonly, enable-skills]
-    uses: review-supervise-to-complete
-    tags: [review, final-gate, supervise]
-    policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: [takt, architecture, unit-testing, e2e-testing]
-    rules:
-      - condition: BLOCKED
-        next: ABORT
-      - condition: approved
+      - condition: COMPLETE
         next: COMPLETE
-      - condition: need_replan
-        next: plan
-      - condition: needs_fix
-        next: fix
+      - condition: ABORT
+        next: ABORT

--- a/builtins/en/workflows/takt-experimental.yaml
+++ b/builtins/en/workflows/takt-experimental.yaml
@@ -1,32 +1,25 @@
-name: experimental
-description: An experimental general-purpose coding workflow that dynamically selects review agents and remediation facets from the task and preceding reports.
+name: takt-experimental
+description: An experimental development workflow that injects TAKT-specific knowledge and testing policy, then dynamically selects implementation facets and review agents from the task and preceding reports.
 max_steps: 51
 initial_step: plan
 
 facet_pools:
   coding-facets:
     candidates:
-      - id: frontend
-        description: Handle UI, components, state management, accessibility, and presentation.
-        policy: design-fidelity
-        knowledge: [frontend, react]
-      - id: backend
-        description: Handle APIs, domain logic, server-side processing, and persistence.
-        knowledge: backend
       - id: cli
         description: Handle CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
         policy: existing-system-respect
-        knowledge: existing-system
+        knowledge: [takt, existing-system]
       - id: testing
         description: Handle test design, test coverage, integration boundaries, and E2E boundaries.
-        policy: testing
-        knowledge: [unit-testing, e2e-testing]
+        policy: [testing, takt-testing]
+        knowledge: [takt, unit-testing, e2e-testing]
       - id: security
         description: Handle authentication, authorization, input validation, secrets, dependencies, and security boundaries.
-        knowledge: security
+        knowledge: [takt, security]
       - id: implementation-semantics
         description: Handle implementation semantics, contracts, state transitions, return values, and side effects.
-        knowledge: implementation-semantics
+        knowledge: [takt, implementation-semantics]
 
 steps:
   - name: plan
@@ -34,7 +27,7 @@ steps:
     uses: development-core-plan
     with:
       plan_policy: [design-planning]
-      plan_knowledge: [architecture, task-decomposition]
+      plan_knowledge: [takt, architecture, task-decomposition]
       plan_instruction: plan
       plan_report_format: plan
     rules:
@@ -49,8 +42,8 @@ steps:
     capabilities: [edit, enable-skills]
     uses: development-core-write-tests
     with:
-      testing_policy: [coding, testing]
-      testing_knowledge: [architecture, unit-testing, e2e-testing]
+      testing_policy: [coding, testing, takt-testing]
+      testing_knowledge: [takt, architecture, unit-testing, e2e-testing]
       testing_instruction: write-tests-first
     rules:
       - condition: Test creation completed
@@ -68,8 +61,8 @@ steps:
     capabilities: [edit, enable-skills]
     uses: development-core-implement
     with:
-      development_policy: [coding, testing]
-      development_knowledge: [architecture, existing-system]
+      development_policy: [coding, testing, takt-testing]
+      development_knowledge: [takt, architecture, task-decomposition]
       implementation_instruction: implement
     dynamic_facets:
       pool: coding-facets
@@ -88,7 +81,65 @@ steps:
   - name: review
     uses: experimental-review
     with:
-      review_knowledge_additions: []
+      review_knowledge_additions: [takt]
+    parallel:
+      pool:
+        - name: architecture-review
+          description: Review module structure, responsibility boundaries, dependency direction, and call paths.
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: architecture-reviewer
+          policy: [contract-change, review]
+          knowledge: [takt, architecture]
+          instruction: review-arch
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: architecture-review.md
+                format: architecture-review
+        - name: cli-review
+          description: Review CLI commands, arguments, exit codes, configuration, logging, and existing CLI structure.
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: coding-reviewer
+          policy: [contract-change, review, coding]
+          knowledge: [takt, architecture, existing-system]
+          instruction: review-coding
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: cli-review.md
+                format: coding-review
+        - name: security-review
+          description: Review authentication, authorization, input validation, secrets, dependencies, and security boundaries.
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: security-reviewer
+          policy: [contract-change, review]
+          knowledge: [takt, security]
+          instruction: review-security
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: security-review.md
+                format: security-review
+        - name: testing-review
+          description: Review test coverage, test design, integration boundaries, and E2E boundaries.
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: testing-reviewer
+          policy: [contract-change, review, testing]
+          knowledge: [takt, unit-testing, e2e-testing]
+          instruction: review-test
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: testing-review.md
+                format: testing-review
     rules:
       self:
         - condition: all("approved")
@@ -101,8 +152,6 @@ steps:
           - condition: needs_fix
         ai-antipattern-review: *reviewer-rules
         architecture-review: *reviewer-rules
-        frontend-review: *reviewer-rules
-        backend-review: *reviewer-rules
         cli-review: *reviewer-rules
         security-review: *reviewer-rules
         testing-review: *reviewer-rules
@@ -110,8 +159,8 @@ steps:
   - name: fix
     capabilities: [edit, enable-skills]
     uses: fix
-    policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: architecture
+    policy: [contract-change, coding, testing, takt-testing, review, ai-antipattern]
+    knowledge: [takt, architecture]
     dynamic_facets:
       pool: coding-facets
     rules:
@@ -129,7 +178,7 @@ steps:
     uses: review-supervise-to-complete
     tags: [review, final-gate, supervise]
     policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: [architecture, unit-testing, e2e-testing]
+    knowledge: [takt, architecture, unit-testing, e2e-testing]
     rules:
       - condition: BLOCKED
         next: ABORT

--- a/builtins/ja/steps/experimental-fix.yaml
+++ b/builtins/ja/steps/experimental-fix.yaml
@@ -1,0 +1,28 @@
+params:
+  fix_policy:
+    type: facet_ref[]
+    facet_kind: policy
+  fix_knowledge:
+    type: facet_ref[]
+    facet_kind: knowledge
+  fix_instruction:
+    type: facet_ref
+    facet_kind: instruction
+
+name: fix
+tags: [coding]
+edit: true
+session: compact
+persona: coder
+policy:
+  $param: fix_policy
+knowledge:
+  $param: fix_knowledge
+required_permission_mode: edit
+instruction:
+  $param: fix_instruction
+output_contracts:
+  report:
+    - name: fix-report.md
+      format: fix-report
+      use_judge: false

--- a/builtins/ja/steps/experimental-review.yaml
+++ b/builtins/ja/steps/experimental-review.yaml
@@ -1,4 +1,7 @@
 params:
+  review_policy_additions:
+    type: facet_ref[]
+    facet_kind: policy
   review_knowledge_additions:
     type: facet_ref[]
     facet_kind: knowledge
@@ -12,7 +15,12 @@ parallel:
       tags: [review]
       edit: false
       persona: coding-reviewer
-      policy: [contract-change, review, coding, testing]
+      policy:
+        - contract-change
+        - review
+        - coding
+        - testing
+        - $param: review_policy_additions
       knowledge:
         - architecture
         - unit-testing
@@ -29,7 +37,11 @@ parallel:
       tags: [review]
       edit: false
       persona: ai-antipattern-reviewer
-      policy: [contract-change, review, ai-antipattern]
+      policy:
+        - contract-change
+        - review
+        - ai-antipattern
+        - $param: review_policy_additions
       knowledge:
         - architecture
         - $param: review_knowledge_additions

--- a/builtins/ja/steps/experimental-review.yaml
+++ b/builtins/ja/steps/experimental-review.yaml
@@ -1,3 +1,8 @@
+params:
+  review_knowledge_additions:
+    type: facet_ref[]
+    facet_kind: knowledge
+
 name: review
 tags: [review]
 parallel:
@@ -8,7 +13,11 @@ parallel:
       edit: false
       persona: coding-reviewer
       policy: [contract-change, review, coding, testing]
-      knowledge: [architecture, unit-testing, e2e-testing]
+      knowledge:
+        - architecture
+        - unit-testing
+        - e2e-testing
+        - $param: review_knowledge_additions
       instruction: review-coding
       pass_previous_response: false
       output_contracts:
@@ -21,7 +30,9 @@ parallel:
       edit: false
       persona: ai-antipattern-reviewer
       policy: [contract-change, review, ai-antipattern]
-      knowledge: architecture
+      knowledge:
+        - architecture
+        - $param: review_knowledge_additions
       instruction: ai-antipattern-review
       pass_previous_response: false
       output_contracts:

--- a/builtins/ja/steps/experimental-supervise.yaml
+++ b/builtins/ja/steps/experimental-supervise.yaml
@@ -1,0 +1,32 @@
+params:
+  supervise_policy:
+    type: facet_ref[]
+    facet_kind: policy
+  supervise_knowledge:
+    type: facet_ref[]
+    facet_kind: knowledge
+  supervise_instruction:
+    type: facet_ref
+    facet_kind: instruction
+
+name: supervise
+capabilities: readonly
+tags:
+  - review
+  - supervise
+edit: false
+persona: supervisor
+policy:
+  $param: supervise_policy
+knowledge:
+  $param: supervise_knowledge
+pass_previous_response: false
+instruction:
+  $param: supervise_instruction
+output_contracts:
+  report:
+    - name: supervisor-validation.md
+      format: supervisor-validation
+    - name: summary.md
+      format: supervisor-summary
+      use_judge: false

--- a/builtins/ja/workflow-categories.yaml
+++ b/builtins/ja/workflow-categories.yaml
@@ -81,6 +81,7 @@ workflow_categories:
   🎵 TAKT開発:
     workflows:
       - takt-default
+      - takt-experimental
       - takt-default-fc
       - auto-improvement-loop
       - review-takt-default

--- a/builtins/ja/workflows/experimental-core.yaml
+++ b/builtins/ja/workflows/experimental-core.yaml
@@ -1,0 +1,249 @@
+name: experimental-core
+description: 汎用・TAKT固有の差分を注入して計画、テスト、実装、レビュー、修正、最終監督を実行する実験的な共通開発フロー。
+subworkflow:
+  callable: true
+  visibility: internal
+  params:
+    implementation_pool:
+      type: facet_pool_ref
+      default: coding-facets
+    review_workflow:
+      type: workflow_ref
+      default: experimental-review
+    plan_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [design-planning]
+    plan_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture, task-decomposition]
+    plan_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: plan
+    testing_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [coding, testing]
+    testing_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture, unit-testing, e2e-testing]
+    testing_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: write-tests-first
+    development_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [coding, testing]
+    development_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture, existing-system]
+    implementation_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: implement
+    review_policy_additions:
+      type: facet_ref[]
+      facet_kind: policy
+      default: []
+    review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    fix_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [contract-change, coding, testing, review, ai-antipattern]
+    fix_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture]
+    fix_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: fix
+    supervise_policy:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [contract-change, coding, testing, review, ai-antipattern]
+    supervise_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [architecture, unit-testing, e2e-testing]
+    supervise_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: supervise
+initial_step: plan
+
+facet_pools:
+  coding-facets:
+    candidates:
+      - id: frontend
+        description: UI、コンポーネント、状態管理、アクセシビリティ、画面表示を扱う
+        policy: design-fidelity
+        knowledge: [frontend, react]
+      - id: backend
+        description: API、ドメインロジック、サーバー側処理、永続化を扱う
+        knowledge: backend
+      - id: cli
+        description: CLIコマンド、引数、終了コード、設定、ログ、既存CLI構造を扱う
+        policy: existing-system-respect
+        knowledge: existing-system
+      - id: testing
+        description: テスト設計、テストカバレッジ、統合境界、E2E境界を扱う
+        policy: testing
+        knowledge: [unit-testing, e2e-testing]
+      - id: security
+        description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界を扱う
+        knowledge: security
+      - id: implementation-semantics
+        description: 実装の意味、契約、状態遷移、戻り値、副作用を扱う
+        knowledge: implementation-semantics
+  takt-coding-facets:
+    candidates:
+      - id: cli
+        description: TAKTのCLIコマンド、引数、終了コード、設定、ログ、既存CLI構造を扱う
+        policy: existing-system-respect
+        knowledge: [takt, existing-system]
+      - id: testing
+        description: TAKTのテスト設計、カバレッジ、統合境界、E2E境界を扱う
+        policy: [testing, takt-testing]
+        knowledge: [takt, unit-testing, e2e-testing]
+      - id: security
+        description: TAKTの認証認可、入力検証、機密情報、依存関係、セキュリティ境界を扱う
+        knowledge: [takt, security]
+      - id: implementation-semantics
+        description: TAKT実装の意味、契約、状態遷移、戻り値、副作用を扱う
+        knowledge: [takt, implementation-semantics]
+
+steps:
+  - name: plan
+    capabilities: [readonly, enable-skills]
+    uses: development-core-plan
+    with:
+      plan_policy:
+        $param: plan_policy
+      plan_knowledge:
+        $param: plan_knowledge
+      plan_instruction:
+        $param: plan_instruction
+      plan_report_format: plan
+    rules:
+      - condition: 要件が明確で実装可能
+        next: write_tests
+      - condition: ユーザーが質問をしている（実装タスクではない）
+        next: COMPLETE
+      - condition: 要件が不明確、情報不足
+        next: ABORT
+
+  - name: write_tests
+    capabilities: [edit, enable-skills]
+    uses: development-core-write-tests
+    with:
+      testing_policy:
+        $param: testing_policy
+      testing_knowledge:
+        $param: testing_knowledge
+      testing_instruction:
+        $param: testing_instruction
+    rules:
+      - condition: テスト作成が完了した
+        next: implement
+      - condition: テスト対象が未実装のためテスト作成をスキップする
+        next: implement
+      - condition: テスト作成を進行できない
+        next: plan
+      - condition: ユーザーへの確認事項があるためユーザー入力が必要
+        next: write_tests
+        requires_user_input: true
+        interactive_only: true
+
+  - name: implement
+    capabilities: [edit, enable-skills]
+    uses: development-core-implement
+    with:
+      development_policy:
+        $param: development_policy
+      development_knowledge:
+        $param: development_knowledge
+      implementation_instruction:
+        $param: implementation_instruction
+    dynamic_facets:
+      pool:
+        $param: implementation_pool
+    rules:
+      - condition: 実装が完了した
+        next: review
+      - condition: 実装未着手（レポートのみ）
+        next: review
+      - condition: 実装を進行できない
+        next: plan
+      - condition: ユーザー入力が必要
+        next: implement
+        requires_user_input: true
+        interactive_only: true
+
+  - name: review
+    kind: workflow_call
+    call:
+      $param: review_workflow
+    args:
+      review_policy_additions:
+        $param: review_policy_additions
+      review_knowledge_additions:
+        $param: review_knowledge_additions
+    rules:
+      - condition: COMPLETE
+        next: supervise
+      - condition: needs_fix
+        next: fix
+      - condition: ABORT
+        next: ABORT
+
+  - name: fix
+    capabilities: [edit, enable-skills]
+    uses: experimental-fix
+    with:
+      fix_policy:
+        $param: fix_policy
+      fix_knowledge:
+        $param: fix_knowledge
+      fix_instruction:
+        $param: fix_instruction
+    dynamic_facets:
+      pool:
+        $param: implementation_pool
+    rules:
+      - condition: 修正完了
+        next: review
+      - condition: 修正方針の見直しが必要
+        next: plan
+      - condition: タスク全体の再計画が必要
+        next: plan
+      - condition: 修正を進行できない
+        next: ABORT
+
+  - name: supervise
+    capabilities: [readonly, enable-skills]
+    uses: experimental-supervise
+    with:
+      supervise_policy:
+        $param: supervise_policy
+      supervise_knowledge:
+        $param: supervise_knowledge
+      supervise_instruction:
+        $param: supervise_instruction
+    rules:
+      - condition: BLOCKED
+        next: ABORT
+      - condition: approved
+        next: COMPLETE
+      - condition: need_replan
+        next: plan
+      - condition: needs_fix
+        next: fix

--- a/builtins/ja/workflows/experimental-review.yaml
+++ b/builtins/ja/workflows/experimental-review.yaml
@@ -1,0 +1,40 @@
+name: experimental-review
+description: 実験的ワークフローの共通レビュー実行部。レビュー知識とポリシーを注入して結果を返す。
+subworkflow:
+  callable: true
+  visibility: internal
+  returns:
+    - needs_fix
+  params:
+    review_policy_additions:
+      type: facet_ref[]
+      facet_kind: policy
+      default: []
+    review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+initial_step: review
+steps:
+  - name: review
+    uses: experimental-review
+    with:
+      review_policy_additions:
+        $param: review_policy_additions
+      review_knowledge_additions:
+        $param: review_knowledge_additions
+    rules:
+      self:
+        - condition: all("approved")
+          next: COMPLETE
+        - condition: any("needs_fix")
+          return: needs_fix
+      parallel:
+        coding-review: [{ condition: approved }, { condition: needs_fix }]
+        ai-antipattern-review: [{ condition: approved }, { condition: needs_fix }]
+        architecture-review: [{ condition: approved }, { condition: needs_fix }]
+        frontend-review: [{ condition: approved }, { condition: needs_fix }]
+        backend-review: [{ condition: approved }, { condition: needs_fix }]
+        cli-review: [{ condition: approved }, { condition: needs_fix }]
+        security-review: [{ condition: approved }, { condition: needs_fix }]
+        testing-review: [{ condition: approved }, { condition: needs_fix }]

--- a/builtins/ja/workflows/experimental.yaml
+++ b/builtins/ja/workflows/experimental.yaml
@@ -1,141 +1,19 @@
 name: experimental
-description: タスクと直前のレポートに応じてレビューエージェント数と修正用ファセットを動的に選択する実験的な汎用コーディングワークフロー。
+description: 汎用の計画、テスト、実装、レビュー、修正、最終監督を共通コアへ委譲する実験的なコーディングワークフロー。
 max_steps: 51
-initial_step: plan
-
-facet_pools:
-  coding-facets:
-    candidates:
-      - id: frontend
-        description: UI、コンポーネント、状態管理、アクセシビリティ、画面表示を扱う
-        policy: design-fidelity
-        knowledge: [frontend, react]
-      - id: backend
-        description: API、ドメインロジック、サーバー側処理、永続化を扱う
-        knowledge: backend
-      - id: cli
-        description: CLIコマンド、引数、終了コード、設定、ログ、既存CLI構造を扱う
-        policy: existing-system-respect
-        knowledge: existing-system
-      - id: testing
-        description: テスト設計、テストカバレッジ、統合境界、E2E境界を扱う
-        policy: testing
-        knowledge: [unit-testing, e2e-testing]
-      - id: security
-        description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界を扱う
-        knowledge: security
-      - id: implementation-semantics
-        description: 実装の意味、契約、状態遷移、戻り値、副作用を扱う
-        knowledge: implementation-semantics
+initial_step: develop
 
 steps:
-  - name: plan
-    capabilities: [readonly, enable-skills]
-    uses: development-core-plan
-    with:
-      plan_policy: [design-planning]
-      plan_knowledge: [architecture, task-decomposition]
-      plan_instruction: plan
-      plan_report_format: plan
-    rules:
-      - condition: 要件が明確で実装可能
-        next: write_tests
-      - condition: ユーザーが質問をしている（実装タスクではない）
-        next: COMPLETE
-      - condition: 要件が不明確、情報不足
-        next: ABORT
-
-  - name: write_tests
-    capabilities: [edit, enable-skills]
-    uses: development-core-write-tests
-    with:
-      testing_policy: [coding, testing]
-      testing_knowledge: [architecture, unit-testing, e2e-testing]
-      testing_instruction: write-tests-first
-    rules:
-      - condition: テスト作成が完了した
-        next: implement
-      - condition: テスト対象が未実装のためテスト作成をスキップする
-        next: implement
-      - condition: テスト作成を進行できない
-        next: plan
-      - condition: ユーザーへの確認事項があるためユーザー入力が必要
-        next: write_tests
-        requires_user_input: true
-        interactive_only: true
-
-  - name: implement
-    capabilities: [edit, enable-skills]
-    uses: development-core-implement
-    with:
-      development_policy: [coding, testing]
-      development_knowledge: [architecture, existing-system]
-      implementation_instruction: implement
-    dynamic_facets:
-      pool: coding-facets
-    rules:
-      - condition: 実装が完了した
-        next: review
-      - condition: 実装未着手（レポートのみ）
-        next: review
-      - condition: 実装を進行できない
-        next: plan
-      - condition: ユーザー入力が必要
-        next: implement
-        requires_user_input: true
-        interactive_only: true
-
-  - name: review
-    uses: experimental-review
-    with:
+  - name: develop
+    kind: workflow_call
+    call: experimental-core
+    args:
+      implementation_pool: coding-facets
+      review_workflow: experimental-review
+      review_policy_additions: []
       review_knowledge_additions: []
     rules:
-      self:
-        - condition: all("approved")
-          next: supervise
-        - condition: any("needs_fix")
-          next: fix
-      parallel:
-        coding-review: &reviewer-rules
-          - condition: approved
-          - condition: needs_fix
-        ai-antipattern-review: *reviewer-rules
-        architecture-review: *reviewer-rules
-        frontend-review: *reviewer-rules
-        backend-review: *reviewer-rules
-        cli-review: *reviewer-rules
-        security-review: *reviewer-rules
-        testing-review: *reviewer-rules
-
-  - name: fix
-    capabilities: [edit, enable-skills]
-    uses: fix
-    policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: architecture
-    dynamic_facets:
-      pool: coding-facets
-    rules:
-      - condition: 修正完了
-        next: review
-      - condition: 修正方針の見直しが必要
-        next: plan
-      - condition: タスク全体の再計画が必要
-        next: plan
-      - condition: 修正を進行できない
-        next: ABORT
-
-  - name: supervise
-    capabilities: [readonly, enable-skills]
-    uses: review-supervise-to-complete
-    tags: [review, final-gate, supervise]
-    policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: [architecture, unit-testing, e2e-testing]
-    rules:
-      - condition: BLOCKED
-        next: ABORT
-      - condition: approved
+      - condition: COMPLETE
         next: COMPLETE
-      - condition: need_replan
-        next: plan
-      - condition: needs_fix
-        next: fix
+      - condition: ABORT
+        next: ABORT

--- a/builtins/ja/workflows/takt-experimental-review.yaml
+++ b/builtins/ja/workflows/takt-experimental-review.yaml
@@ -1,0 +1,96 @@
+name: takt-experimental-review
+description: TAKT固有のレビュー文脈と候補だけを注入する実験的レビュー実行部。
+subworkflow:
+  callable: true
+  visibility: internal
+  returns:
+    - needs_fix
+  params:
+    review_policy_additions:
+      type: facet_ref[]
+      facet_kind: policy
+      default: [takt-testing]
+    review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [takt]
+initial_step: review
+steps:
+  - name: review
+    uses: experimental-review
+    with:
+      review_policy_additions:
+        $param: review_policy_additions
+      review_knowledge_additions:
+        $param: review_knowledge_additions
+    parallel:
+      pool:
+        - name: architecture-review
+          description: モジュール構造、責務分割、依存方向、呼び出し経路をレビューする
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: architecture-reviewer
+          policy: [contract-change, review]
+          knowledge: [takt, architecture]
+          instruction: review-arch
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: architecture-review.md
+                format: architecture-review
+        - name: cli-review
+          description: CLIコマンド、引数、終了コード、設定、ログ、既存CLI構造をレビューする
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: coding-reviewer
+          policy: [contract-change, review, coding]
+          knowledge: [takt, architecture, existing-system]
+          instruction: review-coding
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: cli-review.md
+                format: coding-review
+        - name: security-review
+          description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界をレビューする
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: security-reviewer
+          policy: [contract-change, review]
+          knowledge: [takt, security]
+          instruction: review-security
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: security-review.md
+                format: security-review
+        - name: testing-review
+          description: テストカバレッジ、テスト設計、統合境界、E2E境界をレビューする
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: testing-reviewer
+          policy: [contract-change, review, testing, takt-testing]
+          knowledge: [takt, unit-testing, e2e-testing]
+          instruction: review-test
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: testing-review.md
+                format: testing-review
+    rules:
+      self:
+        - condition: all("approved")
+          next: COMPLETE
+        - condition: any("needs_fix")
+          return: needs_fix
+      parallel:
+        coding-review: [{ condition: approved }, { condition: needs_fix }]
+        ai-antipattern-review: [{ condition: approved }, { condition: needs_fix }]
+        architecture-review: [{ condition: approved }, { condition: needs_fix }]
+        cli-review: [{ condition: approved }, { condition: needs_fix }]
+        security-review: [{ condition: approved }, { condition: needs_fix }]
+        testing-review: [{ condition: approved }, { condition: needs_fix }]

--- a/builtins/ja/workflows/takt-experimental.yaml
+++ b/builtins/ja/workflows/takt-experimental.yaml
@@ -1,32 +1,25 @@
-name: experimental
-description: タスクと直前のレポートに応じてレビューエージェント数と修正用ファセットを動的に選択する実験的な汎用コーディングワークフロー。
+name: takt-experimental
+description: TAKT固有の知識とテストポリシーを注入し、タスクと直前のレポートに応じて実装ファセットとレビューエージェントを動的に選択する実験的な開発ワークフロー。
 max_steps: 51
 initial_step: plan
 
 facet_pools:
   coding-facets:
     candidates:
-      - id: frontend
-        description: UI、コンポーネント、状態管理、アクセシビリティ、画面表示を扱う
-        policy: design-fidelity
-        knowledge: [frontend, react]
-      - id: backend
-        description: API、ドメインロジック、サーバー側処理、永続化を扱う
-        knowledge: backend
       - id: cli
         description: CLIコマンド、引数、終了コード、設定、ログ、既存CLI構造を扱う
         policy: existing-system-respect
-        knowledge: existing-system
+        knowledge: [takt, existing-system]
       - id: testing
         description: テスト設計、テストカバレッジ、統合境界、E2E境界を扱う
-        policy: testing
-        knowledge: [unit-testing, e2e-testing]
+        policy: [testing, takt-testing]
+        knowledge: [takt, unit-testing, e2e-testing]
       - id: security
         description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界を扱う
-        knowledge: security
+        knowledge: [takt, security]
       - id: implementation-semantics
         description: 実装の意味、契約、状態遷移、戻り値、副作用を扱う
-        knowledge: implementation-semantics
+        knowledge: [takt, implementation-semantics]
 
 steps:
   - name: plan
@@ -34,7 +27,7 @@ steps:
     uses: development-core-plan
     with:
       plan_policy: [design-planning]
-      plan_knowledge: [architecture, task-decomposition]
+      plan_knowledge: [takt, architecture, task-decomposition]
       plan_instruction: plan
       plan_report_format: plan
     rules:
@@ -49,8 +42,8 @@ steps:
     capabilities: [edit, enable-skills]
     uses: development-core-write-tests
     with:
-      testing_policy: [coding, testing]
-      testing_knowledge: [architecture, unit-testing, e2e-testing]
+      testing_policy: [coding, testing, takt-testing]
+      testing_knowledge: [takt, architecture, unit-testing, e2e-testing]
       testing_instruction: write-tests-first
     rules:
       - condition: テスト作成が完了した
@@ -68,8 +61,8 @@ steps:
     capabilities: [edit, enable-skills]
     uses: development-core-implement
     with:
-      development_policy: [coding, testing]
-      development_knowledge: [architecture, existing-system]
+      development_policy: [coding, testing, takt-testing]
+      development_knowledge: [takt, architecture, task-decomposition]
       implementation_instruction: implement
     dynamic_facets:
       pool: coding-facets
@@ -88,7 +81,65 @@ steps:
   - name: review
     uses: experimental-review
     with:
-      review_knowledge_additions: []
+      review_knowledge_additions: [takt]
+    parallel:
+      pool:
+        - name: architecture-review
+          description: モジュール構造、責務分割、依存方向、呼び出し経路をレビューする
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: architecture-reviewer
+          policy: [contract-change, review]
+          knowledge: [takt, architecture]
+          instruction: review-arch
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: architecture-review.md
+                format: architecture-review
+        - name: cli-review
+          description: CLIコマンド、引数、終了コード、設定、ログ、既存CLI構造をレビューする
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: coding-reviewer
+          policy: [contract-change, review, coding]
+          knowledge: [takt, architecture, existing-system]
+          instruction: review-coding
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: cli-review.md
+                format: coding-review
+        - name: security-review
+          description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界をレビューする
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: security-reviewer
+          policy: [contract-change, review]
+          knowledge: [takt, security]
+          instruction: review-security
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: security-review.md
+                format: security-review
+        - name: testing-review
+          description: テストカバレッジ、テスト設計、統合境界、E2E境界をレビューする
+          capabilities: readonly
+          tags: [review]
+          edit: false
+          persona: testing-reviewer
+          policy: [contract-change, review, testing]
+          knowledge: [takt, unit-testing, e2e-testing]
+          instruction: review-test
+          pass_previous_response: false
+          output_contracts:
+            report:
+              - name: testing-review.md
+                format: testing-review
     rules:
       self:
         - condition: all("approved")
@@ -101,8 +152,6 @@ steps:
           - condition: needs_fix
         ai-antipattern-review: *reviewer-rules
         architecture-review: *reviewer-rules
-        frontend-review: *reviewer-rules
-        backend-review: *reviewer-rules
         cli-review: *reviewer-rules
         security-review: *reviewer-rules
         testing-review: *reviewer-rules
@@ -110,8 +159,8 @@ steps:
   - name: fix
     capabilities: [edit, enable-skills]
     uses: fix
-    policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: architecture
+    policy: [contract-change, coding, testing, takt-testing, review, ai-antipattern]
+    knowledge: [takt, architecture]
     dynamic_facets:
       pool: coding-facets
     rules:
@@ -129,7 +178,7 @@ steps:
     uses: review-supervise-to-complete
     tags: [review, final-gate, supervise]
     policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: [architecture, unit-testing, e2e-testing]
+    knowledge: [takt, architecture, unit-testing, e2e-testing]
     rules:
       - condition: BLOCKED
         next: ABORT

--- a/builtins/ja/workflows/takt-experimental.yaml
+++ b/builtins/ja/workflows/takt-experimental.yaml
@@ -1,190 +1,28 @@
 name: takt-experimental
-description: TAKT固有の知識とテストポリシーを注入し、タスクと直前のレポートに応じて実装ファセットとレビューエージェントを動的に選択する実験的な開発ワークフロー。
+description: TAKT固有の知識とテストポリシーを共通実験コアへ注入し、TAKT候補だけで実装とレビューを行うワークフロー。
 max_steps: 51
-initial_step: plan
-
-facet_pools:
-  coding-facets:
-    candidates:
-      - id: cli
-        description: CLIコマンド、引数、終了コード、設定、ログ、既存CLI構造を扱う
-        policy: existing-system-respect
-        knowledge: [takt, existing-system]
-      - id: testing
-        description: テスト設計、テストカバレッジ、統合境界、E2E境界を扱う
-        policy: [testing, takt-testing]
-        knowledge: [takt, unit-testing, e2e-testing]
-      - id: security
-        description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界を扱う
-        knowledge: [takt, security]
-      - id: implementation-semantics
-        description: 実装の意味、契約、状態遷移、戻り値、副作用を扱う
-        knowledge: [takt, implementation-semantics]
+initial_step: develop
 
 steps:
-  - name: plan
-    capabilities: [readonly, enable-skills]
-    uses: development-core-plan
-    with:
-      plan_policy: [design-planning]
+  - name: develop
+    kind: workflow_call
+    call: experimental-core
+    args:
+      implementation_pool: takt-coding-facets
+      review_workflow: takt-experimental-review
+      review_policy_additions: [takt-testing]
+      review_knowledge_additions: [takt]
       plan_knowledge: [takt, architecture, task-decomposition]
-      plan_instruction: plan
-      plan_report_format: plan
-    rules:
-      - condition: 要件が明確で実装可能
-        next: write_tests
-      - condition: ユーザーが質問をしている（実装タスクではない）
-        next: COMPLETE
-      - condition: 要件が不明確、情報不足
-        next: ABORT
-
-  - name: write_tests
-    capabilities: [edit, enable-skills]
-    uses: development-core-write-tests
-    with:
       testing_policy: [coding, testing, takt-testing]
       testing_knowledge: [takt, architecture, unit-testing, e2e-testing]
-      testing_instruction: write-tests-first
-    rules:
-      - condition: テスト作成が完了した
-        next: implement
-      - condition: テスト対象が未実装のためテスト作成をスキップする
-        next: implement
-      - condition: テスト作成を進行できない
-        next: plan
-      - condition: ユーザーへの確認事項があるためユーザー入力が必要
-        next: write_tests
-        requires_user_input: true
-        interactive_only: true
-
-  - name: implement
-    capabilities: [edit, enable-skills]
-    uses: development-core-implement
-    with:
       development_policy: [coding, testing, takt-testing]
       development_knowledge: [takt, architecture, task-decomposition]
-      implementation_instruction: implement
-    dynamic_facets:
-      pool: coding-facets
+      fix_policy: [contract-change, coding, testing, takt-testing, review, ai-antipattern]
+      fix_knowledge: [takt, architecture]
+      supervise_policy: [contract-change, coding, testing, takt-testing, review, ai-antipattern]
+      supervise_knowledge: [takt, architecture, unit-testing, e2e-testing]
     rules:
-      - condition: 実装が完了した
-        next: review
-      - condition: 実装未着手（レポートのみ）
-        next: review
-      - condition: 実装を進行できない
-        next: plan
-      - condition: ユーザー入力が必要
-        next: implement
-        requires_user_input: true
-        interactive_only: true
-
-  - name: review
-    uses: experimental-review
-    with:
-      review_knowledge_additions: [takt]
-    parallel:
-      pool:
-        - name: architecture-review
-          description: モジュール構造、責務分割、依存方向、呼び出し経路をレビューする
-          capabilities: readonly
-          tags: [review]
-          edit: false
-          persona: architecture-reviewer
-          policy: [contract-change, review]
-          knowledge: [takt, architecture]
-          instruction: review-arch
-          pass_previous_response: false
-          output_contracts:
-            report:
-              - name: architecture-review.md
-                format: architecture-review
-        - name: cli-review
-          description: CLIコマンド、引数、終了コード、設定、ログ、既存CLI構造をレビューする
-          capabilities: readonly
-          tags: [review]
-          edit: false
-          persona: coding-reviewer
-          policy: [contract-change, review, coding]
-          knowledge: [takt, architecture, existing-system]
-          instruction: review-coding
-          pass_previous_response: false
-          output_contracts:
-            report:
-              - name: cli-review.md
-                format: coding-review
-        - name: security-review
-          description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界をレビューする
-          capabilities: readonly
-          tags: [review]
-          edit: false
-          persona: security-reviewer
-          policy: [contract-change, review]
-          knowledge: [takt, security]
-          instruction: review-security
-          pass_previous_response: false
-          output_contracts:
-            report:
-              - name: security-review.md
-                format: security-review
-        - name: testing-review
-          description: テストカバレッジ、テスト設計、統合境界、E2E境界をレビューする
-          capabilities: readonly
-          tags: [review]
-          edit: false
-          persona: testing-reviewer
-          policy: [contract-change, review, testing]
-          knowledge: [takt, unit-testing, e2e-testing]
-          instruction: review-test
-          pass_previous_response: false
-          output_contracts:
-            report:
-              - name: testing-review.md
-                format: testing-review
-    rules:
-      self:
-        - condition: all("approved")
-          next: supervise
-        - condition: any("needs_fix")
-          next: fix
-      parallel:
-        coding-review: &reviewer-rules
-          - condition: approved
-          - condition: needs_fix
-        ai-antipattern-review: *reviewer-rules
-        architecture-review: *reviewer-rules
-        cli-review: *reviewer-rules
-        security-review: *reviewer-rules
-        testing-review: *reviewer-rules
-
-  - name: fix
-    capabilities: [edit, enable-skills]
-    uses: fix
-    policy: [contract-change, coding, testing, takt-testing, review, ai-antipattern]
-    knowledge: [takt, architecture]
-    dynamic_facets:
-      pool: coding-facets
-    rules:
-      - condition: 修正完了
-        next: review
-      - condition: 修正方針の見直しが必要
-        next: plan
-      - condition: タスク全体の再計画が必要
-        next: plan
-      - condition: 修正を進行できない
-        next: ABORT
-
-  - name: supervise
-    capabilities: [readonly, enable-skills]
-    uses: review-supervise-to-complete
-    tags: [review, final-gate, supervise]
-    policy: [contract-change, coding, testing, review, ai-antipattern]
-    knowledge: [takt, architecture, unit-testing, e2e-testing]
-    rules:
-      - condition: BLOCKED
-        next: ABORT
-      - condition: approved
+      - condition: COMPLETE
         next: COMPLETE
-      - condition: need_replan
-        next: plan
-      - condition: needs_fix
-        next: fix
+      - condition: ABORT
+        next: ABORT

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -121,11 +121,41 @@ call: merge-readiness-finding-contract-final-gate
 
 `uses` を宣言する concrete workflow step は、parallel sub-step を含め、呼び出し側に空でない rule 定義を必ず持ちます。非 parallel fragment の呼び出し側は `rules` 配列を、parallel fragment の呼び出し側は次に示す rule tree を使います。fragment は root と parallel sub-step のどちらにも `rules` を定義できません。これにより、遷移先の step 名を知る workflow が routing を所有します。fragment から別 fragment を参照する中間 `uses` は、concrete workflow がその参照 chain を呼び出すまではこの必須条件の対象外です。loader は rule のコピー、継承、fallback の自動生成を行いません。
 
-step fragment は root の `params` で必須の型付き parameter を宣言し、各 `uses` caller は `with` で値を束縛できます。facet parameter は `type: facet_ref` / `facet_ref[]` と、`policy` / `knowledge` / `instruction` / `persona` / `report_format` のいずれかの `facet_kind` を指定します。workflow の呼び出し先を表す parameter は `type: workflow_ref` とし、`facet_kind` は指定しません。fragment では default と optional parameter は利用できません。
+step fragment は root の `params` で必須の型付き parameter を宣言し、各 `uses` caller は `with` で値を束縛できます。facet parameter は `type: facet_ref` / `facet_ref[]` と、`policy` / `knowledge` / `instruction` / `persona` / `report_format` のいずれかの `facet_kind` を指定します。workflow の呼び出し先を表す parameter は `type: workflow_ref` とし、`facet_kind` は指定しません。dynamic facet pool 名を受け取る fragment は `facet_pool_ref` を `facet_kind` なしで指定できます。fragment では default と optional parameter は利用できません。
 
-`{ $param: name }` は宣言と対応する `policy`、`knowledge`、`persona`、`instruction`、`output_contracts.report[].format`、または `workflow_call.call` に配置します。`facet_ref` / `facet_ref[]` parameter は `policy` / `knowledge` の配列要素として固定参照と混在でき、配列値は順序を保ってその位置へ展開されます。空の `facet_ref[]` は要素を追加しません。すべての parameter 型は `workflow_call.args` の直接の値、または nested fragment caller の `with` に渡せます。nested fragment は lexical scope を使い、outer parameter を暗黙 capture できません。`with: { child_param: { $param: outer_param } }` と明示的に渡します。callable workflow parameter も同じ方法で渡せ、fragment 展開後に解決されます。resolver は未知・不足 binding、scalar/list 不一致、kind 不一致、未宣言参照、未対応 field の参照を拒否します。`params` と `with` は schema 検証前に消費され、`workflow_call` fragment 自身の `args` は保持・展開され、通常の caller overlay は parameter 展開後に適用されます。
+`{ $param: name }` は宣言と対応する `policy`、`knowledge`、`persona`、`instruction`、`output_contracts.report[].format`、`workflow_call.call`、または `facet_pool_ref` の `dynamic_facets.pool` に配置します。`facet_ref` / `facet_ref[]` parameter は `policy` / `knowledge` の配列要素として固定参照と混在でき、配列値は順序を保ってその位置へ展開されます。空の `facet_ref[]` は要素を追加しません。`facet_pool_ref` は policy や knowledge facet ではなく、呼び出される callable workflow のトップレベル `facet_pools` map にある pool 名の scalar です。すべての parameter 型は `workflow_call.args` の直接の値、または nested fragment caller の `with` に渡せます。nested fragment は lexical scope を使い、outer parameter を暗黙 capture できません。`with: { child_param: { $param: outer_param } }` と明示的に渡します。callable workflow parameter も同じ方法で渡せ、fragment 展開後に解決されます。resolver は未知・不足 binding、scalar/list 不一致、kind 不一致、未宣言参照、未対応 field の参照を拒否します。`params` と `with` は schema 検証前に消費され、`workflow_call` fragment 自身の `args` は保持・展開され、通常の caller overlay は parameter 展開後に適用されます。
 
 fragment が parallel step に解決される場合、呼び出し側は通常の配列ではなく strict な rule tree を指定します。`self` に parallel parent の空でない rule 配列を、`parallel` に明示的かつ一意な全 final child 名と各 child の空でない rule 配列を定義します。workflow の parallel step は nested にできないため、child rule tree は無効です。全 child を過不足なく1回ずつ列挙する必要があり、不明な child は指定できません。loader は fragment の展開後に rule tree を適用し、schema 検証前に各 step の通常の `rules` 配列へ変換します。
+
+例えば callable workflow は、step 定義を複製せず、fragment が使う実装 pool を child-local に差し替えられます。
+
+```yaml
+subworkflow:
+  callable: true
+  params:
+    implementation_pool:
+      type: facet_pool_ref
+      default: coding-facets
+
+facet_pools:
+  coding-facets:
+    candidates:
+      - id: backend
+        description: バックエンド変更を扱う
+        knowledge: backend
+
+steps:
+  - name: implement
+    uses: implementation-step
+    with:
+      implementation_pool:
+        $param: implementation_pool
+    dynamic_facets:
+      pool:
+        $param: implementation_pool
+```
+
+`facet_pool_ref` の引数と default は、callable child が宣言した pool 名の scalar でなければなりません。必須引数の未設定、配列値、未知の pool 名、`dynamic_facets.pool` の未解決・未宣言 `$param` は agent や selector の起動前にロードエラーになります。別 pool や全候補への暗黙 fallback はありません。
 
 ```yaml
 steps:
@@ -363,6 +393,8 @@ claim を失う等）で、既存の訂正1回でも直らないときは、TAKT
 pool はトップレベルの `facet_pools` map に定義し、step から `dynamic_facets` で参照します。pool は workflow 内に inline で定義するか、外部 resource ファイルとして定義できます。
 
 `dynamic_facets.max_selected` は任意です。指定した場合は選択数の上限として扱い、省略した場合は pool の全候補数まで選択できます。selector の失敗時に全候補へ自動 fallback する挙動ではありません。
+
+`dynamic_facets.pool` には、callable workflow が `type: facet_pool_ref` で宣言した parameter を `{ $param: implementation_pool }` として指定することもできます。値は通常の dynamic facet 検証前に解決されるため、その callable workflow の `facet_pools` map に存在する pool を指定する必要があります。未設定、scalar 以外、未知、未展開の値は agent や selector の起動前に fail-fast します。
 
 #### inline pool
 
@@ -1197,9 +1229,9 @@ subworkflow:
       default: peer-review-suite-base
 ```
 
-callable workflow に `max_steps` を指定しないでください。call tree 全体にはルート workflow の予算が適用されるため、明示的な指定は loader が拒否します。callable workflow は `workflow_call` からのみ開始できます。同じ実装に直接実行の入口も必要な場合は、callable workflow を呼び出す standalone のルート wrapper を用意します。
+builtin callable workflow では、call tree 全体の予算を root workflow が所有するため `max_steps` を省略します。同じ実装に直接実行の入口も必要な場合は standalone の root wrapper に `max_steps` を指定し、callable child は `workflow_call` から呼び出す設計にします。
 
-callable workflow の facet parameter は `facet_ref` / `facet_ref[]` と、`policy` / `knowledge` / `instruction` / `persona` / `report_format` の5種の `facet_kind` を使います。呼び出す callable workflow を表す `workflow_ref` parameter には `facet_kind` を指定せず、`call: { $param: reviewer_suite }` の形で利用できます。default は省略可能です。`facet_ref[]` の引数と default には空配列を指定でき、任意の追加 facet を表現できます。`policy` / `knowledge` では固定参照と scalar/list parameter を混在でき、list parameter は field の記載順を保ってその位置へ平坦化されます。parameter は `workflow_call.args` を通じてさらに下位へ渡すこともできます。
+callable workflow の facet parameter は `facet_ref` / `facet_ref[]` と、`policy` / `knowledge` / `instruction` / `persona` / `report_format` の5種の `facet_kind` を使います。呼び出す callable workflow を表す `workflow_ref` parameter には `facet_kind` を指定せず、`call: { $param: reviewer_suite }` の形で利用できます。`facet_pool_ref` parameter も `facet_kind` を指定せず、callable child のトップレベル `facet_pools` map にある pool 名の scalar を表します。`dynamic_facets.pool: { $param: implementation_pool }` の形で使用できます。default は省略可能です。`facet_ref[]` の引数と default には空配列を指定でき、任意の追加 facet を表現できます。`policy` / `knowledge` では固定参照と scalar/list parameter を混在でき、list parameter は field の記載順を保ってその位置へ平坦化されます。`facet_pool_ref` の必須引数未設定、配列などの型不一致、child-local でない pool、未展開 `$param` は実行前に fail-fast し、暗黙の pool fallback はありません。parameter は `workflow_call.args` を通じてさらに下位へ渡すこともできます。
 
 子が継承した `findings.*` 状態や Finding Contract 用出力形式を使う場合、または同じ要件を持つ別のサブワークフローへ委譲する場合は、`requires_finding_contract: true` を指定します。直近の呼出元は `finding_contract` を宣言するか、さらに上位の呼出元へ同じ要件を宣言する必要があります。連鎖内の各子は独自の台帳を作らず、契約所有元と同じ契約・台帳を使用します。
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -121,11 +121,41 @@ call: merge-readiness-finding-contract-final-gate
 
 Every concrete workflow step that declares `uses`, including a parallel sub-step, must declare its own non-empty rule specification. A non-parallel fragment caller uses a `rules` array; a parallel fragment caller uses the rule tree described below. A fragment cannot declare `rules` at its root or on any parallel sub-step. This keeps routing owned by the workflow that knows the destination step names; fragment-to-fragment `uses` is exempt until a concrete workflow calls the chain. The loader does not copy, inherit, or synthesize fallback rules.
 
-Step fragments may declare required typed parameters in root-level `params`, and each `uses` caller binds them with `with`. Facet parameters use `type: facet_ref` or `facet_ref[]` with `facet_kind: policy`, `knowledge`, `instruction`, `persona`, or `report_format`. Workflow target parameters use `type: workflow_ref` without `facet_kind`. Defaults and optional parameters are not supported in fragments.
+Step fragments may declare required typed parameters in root-level `params`, and each `uses` caller binds them with `with`. Facet parameters use `type: facet_ref` or `facet_ref[]` with `facet_kind: policy`, `knowledge`, `instruction`, `persona`, or `report_format`. Workflow target parameters use `type: workflow_ref` without `facet_kind`. A fragment that receives a dynamic facet pool name may use `type: facet_pool_ref` without `facet_kind`. Defaults and optional parameters are not supported in fragments.
 
-Use `{ $param: name }` in the field that matches its declaration: `policy`, `knowledge`, `persona`, `instruction`, `output_contracts.report[].format`, or `workflow_call.call`. A `facet_ref` or `facet_ref[]` parameter may also be an item within a `policy` or `knowledge` list; list values are spliced in place while preserving order, and an empty `facet_ref[]` contributes no item. Any parameter type may be passed as a direct `workflow_call.args` value or in a nested fragment caller's `with`. Nested fragments use lexical scope and cannot capture an outer parameter implicitly: pass it explicitly as `with: { child_param: { $param: outer_param } }`. A callable workflow parameter may be passed the same way and is resolved after fragment expansion. The resolver rejects unknown or missing bindings, cardinality or kind mismatches, undeclared references, and parameter references in unsupported fields. It consumes `params` and `with` before schema validation, preserves and expands a `workflow_call` fragment's own `args`, and applies ordinary caller overlays after parameter expansion.
+Use `{ $param: name }` in the field that matches its declaration: `policy`, `knowledge`, `persona`, `instruction`, `output_contracts.report[].format`, `workflow_call.call`, or `dynamic_facets.pool` for `facet_pool_ref`. A `facet_ref` or `facet_ref[]` parameter may also be an item within a `policy` or `knowledge` list; list values are spliced in place while preserving order, and an empty `facet_ref[]` contributes no item. A `facet_pool_ref` is a scalar key in the containing callable workflow's top-level `facet_pools` map, not a policy or knowledge facet. Any parameter type may be passed as a direct `workflow_call.args` value or in a nested fragment caller's `with`. Nested fragments use lexical scope and cannot capture an outer parameter implicitly: pass it explicitly as `with: { child_param: { $param: outer_param } }`. A callable workflow parameter may be passed the same way and is resolved after fragment expansion. The resolver rejects unknown or missing bindings, cardinality or kind mismatches, undeclared references, and parameter references in unsupported fields. It consumes `params` and `with` before schema validation, preserves and expands a `workflow_call` fragment's own `args`, and applies ordinary caller overlays after parameter expansion.
 
 When a fragment resolves to a parallel step, the caller supplies a strict rule tree instead of a plain array. `self` contains the parallel parent's non-empty rule array, and `parallel` maps every explicit, unique final child name to a non-empty rule array. Child rule trees are invalid because workflow parallel steps cannot be nested. The mapping must list all children exactly once and cannot contain unknown children. The loader applies the tree after fragment expansion and converts it to ordinary per-step `rules` arrays before schema validation.
+
+For example, a callable workflow can select a child-local implementation pool through a fragment without copying the fragment's step definition:
+
+```yaml
+subworkflow:
+  callable: true
+  params:
+    implementation_pool:
+      type: facet_pool_ref
+      default: coding-facets
+
+facet_pools:
+  coding-facets:
+    candidates:
+      - id: backend
+        description: Handle backend changes
+        knowledge: backend
+
+steps:
+  - name: implement
+    uses: implementation-step
+    with:
+      implementation_pool:
+        $param: implementation_pool
+    dynamic_facets:
+      pool:
+        $param: implementation_pool
+```
+
+`facet_pool_ref` arguments and defaults must be scalar names of pools declared by the callable child. A missing required argument, a list value, an unknown pool name, or an unresolved/undeclared `$param` in `dynamic_facets.pool` fails during loading before an agent or selector starts. The loader does not fall back to another pool or to all candidates.
 
 ```yaml
 steps:
@@ -374,6 +404,8 @@ A normal agent step can dynamically select additional `policy` and `knowledge` f
 Define a pool under the top-level `facet_pools` map, then reference it from a step with `dynamic_facets`. Pools can be defined inline in the workflow or as external resource files.
 
 `dynamic_facets.max_selected` is optional. When specified, it limits the number of selected candidates; when omitted, the selector may select up to every candidate in the pool. This does not add an all-candidate fallback when selector execution fails.
+
+`dynamic_facets.pool` may also use `{ $param: implementation_pool }` when the containing callable workflow declares `implementation_pool` with `type: facet_pool_ref`. The value is resolved before dynamic-facet validation and must name a pool in that callable workflow's top-level `facet_pools` map. An unset required parameter, a list or other non-scalar value, an unknown pool, or an unexpanded parameter reference fails before an agent or selector starts.
 
 #### Inline pool
 
@@ -1218,9 +1250,9 @@ subworkflow:
       default: peer-review-suite-base
 ```
 
-Do not set `max_steps` on a callable workflow. The loader rejects an explicit value because the root workflow's budget applies to the complete call tree. A callable workflow must be entered through `workflow_call`; use a standalone root wrapper when the same implementation also needs a direct entry point.
+Builtin callable workflows should omit `max_steps` because the root workflow owns the budget for the complete call tree. Keep `max_steps` on the standalone root wrapper when the shared implementation also needs a direct entry point; the callable child is intended to be entered through `workflow_call`.
 
-Callable workflow facet parameters use `facet_ref` or `facet_ref[]` and one of the five `facet_kind` values: `policy`, `knowledge`, `instruction`, `persona`, or `report_format`. A `workflow_ref` parameter identifies a callable workflow and omits `facet_kind`; it may be used as `call: { $param: reviewer_suite }`. Defaults are optional. A `facet_ref[]` argument or default may be empty, which is useful for optional additions. In `policy` and `knowledge`, scalar or list parameters can be mixed with fixed references; list values are flattened at their position while preserving the field's written order. Parameters can also be forwarded through `workflow_call.args`.
+Callable workflow facet parameters use `facet_ref` or `facet_ref[]` and one of the five `facet_kind` values: `policy`, `knowledge`, `instruction`, `persona`, or `report_format`. A `workflow_ref` parameter identifies a callable workflow and omits `facet_kind`; it may be used as `call: { $param: reviewer_suite }`. A `facet_pool_ref` parameter also omits `facet_kind` and identifies a scalar key in the callable child's top-level `facet_pools` map; it may be used as `dynamic_facets.pool: { $param: implementation_pool }`. Defaults are optional. A `facet_ref[]` argument or default may be empty, which is useful for optional additions. In `policy` and `knowledge`, scalar or list parameters can be mixed with fixed references; list values are flattened at their position while preserving the field's written order. Parameters can also be forwarded through `workflow_call.args`. For `facet_pool_ref`, a missing required argument, a list value, an unknown child-local pool, or an unexpanded `$param` fails before execution; there is no implicit pool fallback.
 
 Set `requires_finding_contract: true` when the child consumes inherited `findings.*` state or Finding Contract output formats, or delegates to another subworkflow with the same requirement. The immediate caller must either declare `finding_contract` or require it from its own caller. Every child in the chain uses the owning caller's contract and the same ledger rather than creating its own ledger.
 

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -20,6 +20,7 @@ import {
 import {
   invalidateAllResolvedConfigCache,
   invalidateGlobalConfigCache,
+  resolveWorkflowCallTarget,
 } from '../infra/config/index.js';
 import {
   getScenarioQueue,
@@ -81,6 +82,38 @@ function findWorkflowStep(workflow: WorkflowConfig, stepName: string): WorkflowS
     if (step.parallel !== undefined) pending.push(...getAllParallelSubSteps(step.parallel));
   }
   throw new Error(`Workflow step not found: ${stepName}`);
+}
+
+function loadCoreForWrapper(
+  language: 'en' | 'ja',
+  wrapper: WorkflowConfig,
+  projectDir: string,
+): WorkflowConfig {
+  const delegation = wrapper.steps.find((step) => step.name === 'develop');
+  if (delegation?.kind !== 'workflow_call' || typeof delegation.call !== 'string') {
+    return wrapper;
+  }
+  return loadWorkflowFromFile(
+    join(getBuiltinWorkflowsDir(language), `${delegation.call}.yaml`),
+    projectDir,
+    { callableArgs: delegation.args },
+  );
+}
+
+function loadReviewForCore(
+  language: 'en' | 'ja',
+  core: WorkflowConfig,
+  projectDir: string,
+): WorkflowConfig {
+  const review = findWorkflowStep(core, 'review');
+  if (review.kind !== 'workflow_call' || typeof review.call !== 'string') {
+    return core;
+  }
+  return loadWorkflowFromFile(
+    join(getBuiltinWorkflowsDir(language), `${review.call}.yaml`),
+    projectDir,
+    { callableArgs: review.args },
+  );
 }
 
 function findRuleIndex(step: WorkflowStep, ruleLabel: string): number {
@@ -146,6 +179,91 @@ describe('experimental builtin workflow', () => {
     invalidateAllResolvedConfigCache();
   });
 
+  it.each(['en', 'ja'] as const)('keeps the %s variants thin and isolates their injected pools', (language) => {
+    writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
+    invalidateAllResolvedConfigCache();
+    const generic = loadWorkflowFromFile(
+      join(getBuiltinWorkflowsDir(language), 'experimental.yaml'),
+      projectDir,
+    );
+    const takt = loadWorkflowFromFile(
+      join(getBuiltinWorkflowsDir(language), 'takt-experimental.yaml'),
+      projectDir,
+    );
+
+    for (const wrapper of [generic, takt]) {
+      expect(wrapper.facetPools).toBeUndefined();
+      expect(wrapper.steps).toHaveLength(1);
+      expect(wrapper.steps[0]).toMatchObject({
+        name: 'develop',
+        kind: 'workflow_call',
+        call: 'experimental-core',
+      });
+    }
+
+    const genericCore = loadCoreForWrapper(language, generic, projectDir);
+    const taktCore = loadCoreForWrapper(language, takt, projectDir);
+    const genericImplement = findWorkflowStep(genericCore, 'implement');
+    const taktImplement = findWorkflowStep(taktCore, 'implement');
+    expect(genericImplement.dynamicFacets?.pool).toBe('coding-facets');
+    expect(taktImplement.dynamicFacets?.pool).toBe('takt-coding-facets');
+    expect(genericCore.facetPools?.['coding-facets']?.candidates.map(({ id }) => id))
+      .toEqual(expect.arrayContaining(['frontend', 'backend']));
+    const taktCandidateIds = taktCore.facetPools?.['takt-coding-facets']?.candidates.map(({ id }) => id) ?? [];
+    expect(taktCandidateIds).not.toContain('frontend');
+    expect(taktCandidateIds).not.toContain('backend');
+    expect(findWorkflowStep(genericCore, 'review').call).toBe('experimental-review');
+    expect(findWorkflowStep(taktCore, 'review').call).toBe('takt-experimental-review');
+  });
+
+  it('fails fast for missing, wrongly typed, and unknown facet pool bindings', () => {
+    writeFileSync(join(projectDir, '.takt', 'config.yaml'), 'language: en\n');
+    invalidateAllResolvedConfigCache();
+    const corePath = join(getBuiltinWorkflowsDir('en'), 'experimental-core.yaml');
+    expect(() => loadWorkflowFromFile(corePath, projectDir, {
+      callableArgs: { implementation_pool: 'missing-pool' },
+    })).toThrow('references unknown facet pool "missing-pool"');
+    expect(() => loadWorkflowFromFile(corePath, projectDir, {
+      callableArgs: { implementation_pool: ['coding-facets'] },
+    })).toThrow('must be a scalar facet_pool_ref');
+
+    const customDir = join(projectDir, '.takt', 'workflows');
+    mkdirSync(customDir, { recursive: true });
+    const customPath = join(customDir, 'pool-contract.yaml');
+    writeFileSync(customPath, `name: pool-contract
+subworkflow:
+  callable: true
+  visibility: internal
+  params:
+    pool:
+      type: facet_pool_ref
+facet_pools:
+  available:
+    candidates:
+      - id: candidate
+        description: Candidate
+        policy: coding
+        knowledge: architecture
+initial_step: implement
+steps:
+  - name: implement
+    persona: coder
+    policy: coding
+    knowledge: architecture
+    instruction: implement
+    edit: true
+    dynamic_facets:
+      pool:
+        $param: pool
+    rules:
+      - condition: done
+        next: COMPLETE
+`, 'utf-8');
+    expect(() => loadWorkflowFromFile(customPath, projectDir)).toThrow(
+      'requires workflow_call arg "pool" for dynamic_facets.pool',
+    );
+  });
+
   it(
     'should run the full English workflow and replace the selected reviewer pool when review requires fixes',
     async () => {
@@ -156,22 +274,24 @@ describe('experimental builtin workflow', () => {
         join(getBuiltinWorkflowsDir(language), 'experimental.yaml'),
         projectDir,
       );
+      const scenarioWorkflow = loadCoreForWrapper(language, workflow, projectDir);
+      const reviewWorkflow = loadReviewForCore(language, scenarioWorkflow, projectDir);
       setMockScenario([
-        response(workflow, 'plan', 'planner', 'Requirements are clear and implementation is feasible'),
-        response(workflow, 'write_tests', 'coder', 'Test creation completed'),
+        response(scenarioWorkflow, 'plan', 'planner', 'Requirements are clear and implementation is feasible'),
+        response(scenarioWorkflow, 'write_tests', 'coder', 'Test creation is complete'),
         selection(['frontend'], 'Frontend implementation facets are required.'),
-        response(workflow, 'implement', 'coder', 'Implementation completed'),
+        response(scenarioWorkflow, 'implement', 'coder', 'Implementation is complete'),
         selection(['frontend-review'], 'The first review round covers frontend changes.'),
-        response(workflow, 'coding-review', 'coding-reviewer', 'needs_fix'),
-        response(workflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'needs_fix'),
-        response(workflow, 'frontend-review', 'frontend-reviewer', 'needs_fix'),
+        response(reviewWorkflow, 'coding-review', 'coding-reviewer', 'needs_fix'),
+        response(reviewWorkflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'needs_fix'),
+        response(reviewWorkflow, 'frontend-review', 'frontend-reviewer', 'needs_fix'),
         selection([], 'No additional remediation facets are needed.'),
-        response(workflow, 'fix', 'coder', 'Fix complete'),
+        response(scenarioWorkflow, 'fix', 'coder', 'Fix is complete'),
         selection(['security-review'], 'The second review round covers security changes.'),
-        response(workflow, 'coding-review', 'coding-reviewer', 'approved'),
-        response(workflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'approved'),
-        response(workflow, 'security-review', 'security-reviewer', 'approved'),
-        response(workflow, 'supervise', 'supervisor', 'approved'),
+        response(reviewWorkflow, 'coding-review', 'coding-reviewer', 'approved'),
+        response(reviewWorkflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'approved'),
+        response(reviewWorkflow, 'security-review', 'security-reviewer', 'approved'),
+        response(scenarioWorkflow, 'supervise', 'supervisor', 'approved'),
       ]);
       const engine = new WorkflowEngine(workflow, projectDir, 'Implement and review a frontend security change', {
         projectCwd: projectDir,
@@ -179,6 +299,8 @@ describe('experimental builtin workflow', () => {
         selectorProvider: SELECTOR_PROVIDER,
         selectorGitCommandRunner: SELECTOR_GIT_COMMAND_RUNNER,
         structuredCaller: new DefaultStructuredCaller(),
+        workflowCallResolver: ({ parentWorkflow, step, projectCwd, lookupCwd }) =>
+          resolveWorkflowCallTarget(parentWorkflow, step, projectCwd, lookupCwd),
       });
       engines.push(engine);
       const abortReasons: string[] = [];
@@ -192,21 +314,18 @@ describe('experimental builtin workflow', () => {
         iteration: state.iteration,
         remainingScenarios: getScenarioQueue()?.remaining,
       })).toBe('completed');
-      expect(state.stepIterations.get('plan')).toBe(1);
-      expect(state.stepIterations.get('write_tests')).toBe(1);
-      expect(state.stepIterations.get('implement')).toBe(1);
-      expect(state.stepIterations.get('review')).toBe(2);
-      expect(state.stepIterations.get('fix')).toBe(1);
-      const implementSelection = [...state.dynamicFacetSelections.values()]
+      const resumePoint = engine.getResumePoint();
+      const implementSelection = Object.values(resumePoint?.dynamic_facet_selections ?? {})
         .find((snapshot) => snapshot.step_name === 'implement');
       expect(implementSelection).toMatchObject({
         round: 1,
         selected_ids: ['frontend'],
       });
-      const reviewSelection = [...state.dynamicParallelSelections.values()]
-        .find((snapshot) => snapshot.step_name === 'review');
+      const reviewSelection = Object.values(resumePoint?.dynamic_parallel_selections ?? {})
+        .find((snapshot) => snapshot.step_name === 'review'
+          && snapshot.selected_pool_ids.includes('security-review'));
       expect(reviewSelection).toMatchObject({
-        round: 2,
+        round: 1,
         selected_pool_ids: ['security-review'],
         effective_selection_ids: [
           'coding-review',
@@ -214,7 +333,7 @@ describe('experimental builtin workflow', () => {
           'security-review',
         ],
       });
-      expect(workflow.steps.find((step) => step.name === 'review')?.parallel)
+      expect(findWorkflowStep(reviewWorkflow, 'review').parallel)
         .toMatchObject({ selection: { mode: 'replace' } });
 
       const reportCalls = reviewReportCalls();
@@ -227,14 +346,6 @@ describe('experimental builtin workflow', () => {
         .find((step) => step.name === 'ai-antipattern-review')
         ?.outputContracts.find((contract) => contract.name === 'ai-antipattern-review.md');
       expect(aiAntipatternReport).toBeDefined();
-      expect(existsSync(join(
-        projectDir,
-        '.takt',
-        'runs',
-        'test-report-dir',
-        'reports',
-        'ai-antipattern-review.md',
-      ))).toBe(true);
       expect(getScenarioQueue()?.remaining).toBe(0);
     },
     60_000,
@@ -250,7 +361,9 @@ describe('experimental builtin workflow', () => {
         join(getBuiltinWorkflowsDir(language), 'takt-experimental.yaml'),
         projectDir,
       );
-      const reviewStep = findWorkflowStep(workflow, 'review');
+      const scenarioWorkflow = loadCoreForWrapper(language, workflow, projectDir);
+      const reviewWorkflow = loadReviewForCore(language, scenarioWorkflow, projectDir);
+      const reviewStep = findWorkflowStep(reviewWorkflow, 'review');
       if (reviewStep.parallel === undefined || !isDynamicParallelSubSteps(reviewStep.parallel)) {
         throw new Error('TAKT experimental review must use a dynamic parallel pool');
       }
@@ -263,18 +376,18 @@ describe('experimental builtin workflow', () => {
       expect(fixedReviewers).toHaveLength(2);
       expect(fixedReviewers.every((step) => step.knowledgeContents?.some(({ content }) =>
         content.includes('# TAKT Architecture Knowledge')) === true)).toBe(true);
-      const implementStep = findWorkflowStep(workflow, 'implement');
+      const implementStep = findWorkflowStep(scenarioWorkflow, 'implement');
       expect(implementStep.policyContents?.some(({ content }) =>
         content.includes('# TAKT Test Execution Policy'))).toBe(true);
       setMockScenario([
-        response(workflow, 'plan', 'planner', 'Requirements are clear and implementation is feasible'),
-        response(workflow, 'write_tests', 'coder', 'Test creation completed'),
+        response(scenarioWorkflow, 'plan', 'planner', 'Requirements are clear and implementation is feasible'),
+        response(scenarioWorkflow, 'write_tests', 'coder', 'Test creation is complete'),
         selection(['testing'], 'The implementation changes test boundaries.'),
-        response(workflow, 'implement', 'coder', 'Implementation completed'),
+        response(scenarioWorkflow, 'implement', 'coder', 'Implementation is complete'),
         selection([], 'The fixed reviewers cover the changed test path.'),
-        response(workflow, 'coding-review', 'coding-reviewer', 'approved'),
-        response(workflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'approved'),
-        response(workflow, 'supervise', 'supervisor', 'approved'),
+        response(reviewWorkflow, 'coding-review', 'coding-reviewer', 'approved'),
+        response(reviewWorkflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'approved'),
+        response(scenarioWorkflow, 'supervise', 'supervisor', 'approved'),
       ]);
       const engine = new WorkflowEngine(workflow, projectDir, 'Implement a TAKT testing change', {
         projectCwd: projectDir,
@@ -282,6 +395,8 @@ describe('experimental builtin workflow', () => {
         selectorProvider: SELECTOR_PROVIDER,
         selectorGitCommandRunner: SELECTOR_GIT_COMMAND_RUNNER,
         structuredCaller: new DefaultStructuredCaller(),
+        workflowCallResolver: ({ parentWorkflow, step, projectCwd, lookupCwd }) =>
+          resolveWorkflowCallTarget(parentWorkflow, step, projectCwd, lookupCwd),
       });
       engines.push(engine);
 
@@ -292,14 +407,15 @@ describe('experimental builtin workflow', () => {
         iteration: state.iteration,
         remainingScenarios: getScenarioQueue()?.remaining,
       })).toBe('completed');
-      const implementSelection = [...state.dynamicFacetSelections.values()]
+      const resumePoint = engine.getResumePoint();
+      const implementSelection = Object.values(resumePoint?.dynamic_facet_selections ?? {})
         .find((snapshot) => snapshot.step_name === 'implement');
       expect(implementSelection).toMatchObject({
         selected_ids: ['testing'],
         selected_policy_refs: ['testing', 'takt-testing'],
         selected_knowledge_refs: ['takt', 'unit-testing', 'e2e-testing'],
       });
-      const reviewSelection = [...state.dynamicParallelSelections.values()]
+      const reviewSelection = Object.values(resumePoint?.dynamic_parallel_selections ?? {})
         .find((snapshot) => snapshot.step_name === 'review');
       expect(reviewSelection).toMatchObject({
         selected_pool_ids: [],
@@ -333,25 +449,32 @@ describe('experimental builtin workflow', () => {
       const language = 'ja';
       writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
       invalidateAllResolvedConfigCache();
-      const workflow = loadWorkflowFromFile(
+      const wrapper = loadWorkflowFromFile(
         join(getBuiltinWorkflowsDir(language), 'experimental.yaml'),
         projectDir,
       );
-      workflow.initialStep = 'review';
+      const scenarioWorkflow = loadCoreForWrapper(language, wrapper, projectDir);
+      const reviewWorkflow = loadReviewForCore(language, scenarioWorkflow, projectDir);
       setMockScenario([
+        response(scenarioWorkflow, 'plan', 'planner', '要件が明確で実装可能'),
+        response(scenarioWorkflow, 'write_tests', 'coder', 'テスト作成が完了した'),
+        selection(['testing'], 'Testing implementation facets are required.'),
+        response(scenarioWorkflow, 'implement', 'coder', '実装が完了した'),
         selection(['testing-review'], 'Testing review is required.'),
-        response(workflow, 'coding-review', 'coding-reviewer', 'needs_fix'),
-        response(workflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'needs_fix'),
-        response(workflow, 'testing-review', 'testing-reviewer', 'needs_fix'),
+        response(reviewWorkflow, 'coding-review', 'coding-reviewer', 'needs_fix'),
+        response(reviewWorkflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'needs_fix'),
+        response(reviewWorkflow, 'testing-review', 'testing-reviewer', 'needs_fix'),
         selection([], 'No additional remediation facets are needed.'),
-        response(workflow, 'fix', 'coder', '修正を進行できない'),
+        response(scenarioWorkflow, 'fix', 'coder', '修正を進行できない'),
       ]);
-      const engine = new WorkflowEngine(workflow, projectDir, 'Implement a change that cannot be remediated', {
+      const engine = new WorkflowEngine(wrapper, projectDir, 'Implement a change that cannot be remediated', {
         projectCwd: projectDir,
         provider: 'mock',
         selectorProvider: SELECTOR_PROVIDER,
         selectorGitCommandRunner: SELECTOR_GIT_COMMAND_RUNNER,
         structuredCaller: new DefaultStructuredCaller(),
+        workflowCallResolver: ({ parentWorkflow, step, projectCwd, lookupCwd }) =>
+          resolveWorkflowCallTarget(parentWorkflow, step, projectCwd, lookupCwd),
       });
       engines.push(engine);
       const abortReasons: string[] = [];
@@ -360,15 +483,9 @@ describe('experimental builtin workflow', () => {
       const state = await engine.run();
 
       expect(state.status).toBe('aborted');
-      expect(state.stepIterations.get('review'), JSON.stringify({
-        abortReasons,
-        currentStep: state.currentStep,
-        iteration: state.iteration,
-        remainingScenarios: getScenarioQueue()?.remaining,
-      })).toBe(1);
-      expect(state.stepIterations.get('fix')).toBe(1);
       expect(abortReasons).toEqual(['Workflow aborted by step transition']);
       expect(reviewReportCalls().filter((step) => step.name === 'ai-antipattern-review')).toHaveLength(1);
+      expect(vi.mocked(runReportPhase).mock.calls.filter(([step]) => step.name === 'fix')).toHaveLength(1);
       expect(getScenarioQueue()?.remaining).toBe(0);
     },
     60_000,

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -179,7 +179,7 @@ describe('experimental builtin workflow', () => {
     invalidateAllResolvedConfigCache();
   });
 
-  it.each(['en', 'ja'] as const)('keeps the %s variants thin and isolates their injected pools', (language) => {
+  it.each(['en', 'ja'] as const)('should keep the %s variants thin and isolate their injected pools when loading generic and TAKT wrappers', (language) => {
     writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
     invalidateAllResolvedConfigCache();
     const generic = loadWorkflowFromFile(
@@ -216,7 +216,7 @@ describe('experimental builtin workflow', () => {
     expect(findWorkflowStep(taktCore, 'review').call).toBe('takt-experimental-review');
   });
 
-  it('fails fast for missing, wrongly typed, and unknown facet pool bindings', () => {
+  it('should fail fast when facet pool bindings are missing, wrongly typed, or unknown', () => {
     writeFileSync(join(projectDir, '.takt', 'config.yaml'), 'language: en\n');
     invalidateAllResolvedConfigCache();
     const corePath = join(getBuiltinWorkflowsDir('en'), 'experimental-core.yaml');
@@ -265,7 +265,7 @@ steps:
   });
 
   it(
-    'should run the full English workflow and replace the selected reviewer pool when review requires fixes',
+    'should complete the English experimental wrapper after reviewer fixes when review requires remediation',
     async () => {
       const language = 'en';
       writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
@@ -352,7 +352,7 @@ steps:
   );
 
   it(
-    'should run the TAKT experimental workflow with TAKT-aware implementation and review candidates',
+    'should complete the TAKT experimental wrapper when TAKT testing facets and reviewers are selected',
     async () => {
       const language = 'en';
       writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
@@ -444,7 +444,7 @@ steps:
   );
 
   it(
-    'should abort when the Japanese experimental review rejection cannot be remediated',
+    'should abort the Japanese experimental wrapper when review findings cannot be remediated',
     async () => {
       const language = 'ja';
       writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   getAllParallelSubSteps,
+  isDynamicParallelSubSteps,
   type WorkflowConfig,
   type WorkflowStep,
 } from '../core/models/index.js';
@@ -237,6 +238,93 @@ describe('experimental builtin workflow', () => {
       expect(getScenarioQueue()?.remaining).toBe(0);
     },
     60_000,
+  );
+
+  it(
+    'should run the TAKT experimental workflow with TAKT-aware implementation and review candidates',
+    async () => {
+      const language = 'en';
+      writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
+      invalidateAllResolvedConfigCache();
+      const workflow = loadWorkflowFromFile(
+        join(getBuiltinWorkflowsDir(language), 'takt-experimental.yaml'),
+        projectDir,
+      );
+      const reviewStep = findWorkflowStep(workflow, 'review');
+      if (reviewStep.parallel === undefined || !isDynamicParallelSubSteps(reviewStep.parallel)) {
+        throw new Error('TAKT experimental review must use a dynamic parallel pool');
+      }
+      expect(reviewStep.parallel.pool.some((step) => step.name === 'testing-review')).toBe(true);
+      expect(reviewStep.parallel.pool.some((step) => step.name === 'frontend-review')).toBe(false);
+      expect(reviewStep.parallel.pool.some((step) => step.name === 'backend-review')).toBe(false);
+      const fixedReviewers = reviewStep.parallel.fixed.filter((step) =>
+        step.name === 'coding-review' || step.name === 'ai-antipattern-review',
+      );
+      expect(fixedReviewers).toHaveLength(2);
+      expect(fixedReviewers.every((step) => step.knowledgeContents?.some(({ content }) =>
+        content.includes('# TAKT Architecture Knowledge')) === true)).toBe(true);
+      const implementStep = findWorkflowStep(workflow, 'implement');
+      expect(implementStep.policyContents?.some(({ content }) =>
+        content.includes('# TAKT Test Execution Policy'))).toBe(true);
+      setMockScenario([
+        response(workflow, 'plan', 'planner', 'Requirements are clear and implementation is feasible'),
+        response(workflow, 'write_tests', 'coder', 'Test creation completed'),
+        selection(['testing'], 'The implementation changes test boundaries.'),
+        response(workflow, 'implement', 'coder', 'Implementation completed'),
+        selection([], 'The fixed reviewers cover the changed test path.'),
+        response(workflow, 'coding-review', 'coding-reviewer', 'approved'),
+        response(workflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'approved'),
+        response(workflow, 'supervise', 'supervisor', 'approved'),
+      ]);
+      const engine = new WorkflowEngine(workflow, projectDir, 'Implement a TAKT testing change', {
+        projectCwd: projectDir,
+        provider: 'mock',
+        selectorProvider: SELECTOR_PROVIDER,
+        selectorGitCommandRunner: SELECTOR_GIT_COMMAND_RUNNER,
+        structuredCaller: new DefaultStructuredCaller(),
+      });
+      engines.push(engine);
+
+      const state = await engine.run();
+
+      expect(state.status, JSON.stringify({
+        currentStep: state.currentStep,
+        iteration: state.iteration,
+        remainingScenarios: getScenarioQueue()?.remaining,
+      })).toBe('completed');
+      const implementSelection = [...state.dynamicFacetSelections.values()]
+        .find((snapshot) => snapshot.step_name === 'implement');
+      expect(implementSelection).toMatchObject({
+        selected_ids: ['testing'],
+        selected_policy_refs: ['testing', 'takt-testing'],
+        selected_knowledge_refs: ['takt', 'unit-testing', 'e2e-testing'],
+      });
+      const reviewSelection = [...state.dynamicParallelSelections.values()]
+        .find((snapshot) => snapshot.step_name === 'review');
+      expect(reviewSelection).toMatchObject({
+        selected_pool_ids: [],
+        effective_selection_ids: [
+          'coding-review',
+          'ai-antipattern-review',
+        ],
+      });
+      const reportCalls = reviewReportCalls();
+      const fixedReviewReportCalls = reportCalls.filter((step) =>
+        step.name === 'coding-review' || step.name === 'ai-antipattern-review',
+      );
+      expect(fixedReviewReportCalls.map((step) => step.name).sort()).toEqual([
+        'ai-antipattern-review',
+        'coding-review',
+      ]);
+      expect(fixedReviewReportCalls.every((step) => step.knowledgeContents?.some(({ content }) =>
+        content.includes('# TAKT Architecture Knowledge')) === true)).toBe(true);
+      const implementReportStep = vi.mocked(runReportPhase).mock.calls
+        .map(([step]) => step)
+        .find((step) => step.name === 'implement');
+      expect(implementReportStep?.policyContents?.some(({ content }) =>
+        content.includes('# TAKT Test Execution Policy'))).toBe(true);
+      expect(getScenarioQueue()?.remaining).toBe(0);
+    },
   );
 
   it(

--- a/src/__tests__/workflow-call-schema.test.ts
+++ b/src/__tests__/workflow-call-schema.test.ts
@@ -19,6 +19,50 @@ function createWorkflowCallStep(overrides: Record<string, unknown> = {}): Record
   };
 }
 
+function createDynamicPoolWorkflow(pool: unknown): Record<string, unknown> {
+  return {
+    name: 'invalid-dynamic-pool',
+    steps: [{
+      name: 'implement',
+      persona: 'coder',
+      instruction: 'Implement',
+      dynamic_facets: { pool },
+      rules: [{ condition: 'done', next: 'COMPLETE' }],
+    }],
+  };
+}
+
+function createCallableFacetPoolWorkflow(): Record<string, unknown> {
+  return {
+    name: 'invalid-callable-pool',
+    subworkflow: {
+      callable: true,
+      params: {
+        implementation_pool: { type: 'facet_pool_ref' },
+      },
+    },
+    policies: { policy: 'Policy' },
+    facet_pools: {
+      available: {
+        candidates: [{
+          id: 'candidate',
+          description: 'Candidate',
+          policy: 'policy',
+        }],
+      },
+    },
+    steps: [{
+      name: 'implement',
+      persona: 'coder',
+      instruction: 'Implement',
+      dynamic_facets: {
+        pool: { $param: 'implementation_pool' },
+      },
+      rules: [{ condition: 'done', next: 'COMPLETE' }],
+    }],
+  };
+}
+
 const workflowCallForbiddenFieldCases = [
   { field: 'persona', value: 'coder' },
   { field: 'persona_name', value: 'Coder' },
@@ -279,6 +323,59 @@ describe('workflow_call schema', () => {
       'pool',
     ]);
     expect((thrown as Error).message).toContain('dynamic_facets.pool has an unresolved parameter reference');
+  });
+
+  it.each([
+    { label: 'an array', value: ['available'] },
+    { label: 'null', value: null },
+  ])('should report the dynamic pool path when $label is supplied', ({ value }) => {
+    let thrown: unknown;
+    try {
+      normalizeWorkflowConfig(createDynamicPoolWorkflow(value), '/tmp');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(getWorkflowConfigErrorPath(thrown)).toEqual([
+      'steps',
+      0,
+      'dynamic_facets',
+      'pool',
+    ]);
+    expect((thrown as { message: string }).message).toContain(
+      `Invalid input: expected string, received ${value === null ? 'null' : 'array'}`,
+    );
+  });
+
+  it.each([
+    { label: 'an array', value: ['available'], expectedMessage: 'must be a scalar facet_pool_ref' },
+    { label: 'null', value: null, expectedMessage: 'references unknown facet pool "null"' },
+  ])('should report the callable argument path when $label is supplied', ({ value, expectedMessage }) => {
+    let thrown: unknown;
+    try {
+      normalizeWorkflowConfig(
+        createCallableFacetPoolWorkflow(),
+        '/tmp',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          callableArgs: {
+            implementation_pool: value as unknown as string | string[],
+          },
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(getWorkflowConfigErrorPath(thrown)).toEqual(['callableArgs', 'implementation_pool']);
+    expect((thrown as Error).message).toContain(expectedMessage);
   });
 
   it('accepts scalar vars only on workflow_call steps and preserves them after normalization', () => {

--- a/src/__tests__/workflow-call-schema.test.ts
+++ b/src/__tests__/workflow-call-schema.test.ts
@@ -32,6 +32,22 @@ function createDynamicPoolWorkflow(pool: unknown): Record<string, unknown> {
   };
 }
 
+function createRootDynamicFacetPoolWorkflow(poolName: string): Record<string, unknown> {
+  return {
+    ...createDynamicPoolWorkflow(poolName),
+    policies: { policy: 'Policy' },
+    facet_pools: {
+      available: {
+        candidates: [{
+          id: 'candidate',
+          description: 'Candidate',
+          policy: 'policy',
+        }],
+      },
+    },
+  };
+}
+
 function createCallableFacetPoolWorkflow(): Record<string, unknown> {
   return {
     name: 'invalid-callable-pool',
@@ -296,6 +312,49 @@ describe('workflow_call schema', () => {
     expect(prepared.raw.knowledge?.['__takt_discovery_param___knowledge_implementation_pool']).toBeDefined();
   });
 
+  it('should use the base synthetic pool name when the default name is inherited', () => {
+    const poolName = '__takt_discovery_pool__implementation_pool';
+    const raw = WorkflowConfigRawSchema.parse({
+      name: 'inherited-pool-discovery',
+      subworkflow: {
+        callable: true,
+        params: {
+          implementation_pool: { type: 'facet_pool_ref' },
+        },
+      },
+      policies: { policy: 'Discovery policy' },
+      knowledge: { knowledge: 'Discovery knowledge' },
+      steps: [{
+        name: 'implement',
+        persona: 'reviewer',
+        instruction: 'Review',
+        dynamic_facets: { pool: { $param: 'implementation_pool' } },
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      }],
+    });
+    const previousDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, poolName);
+
+    try {
+      Object.defineProperty(Object.prototype, poolName, {
+        configurable: true,
+        enumerable: false,
+        value: { inherited: true },
+        writable: true,
+      });
+
+      const prepared = prepareCallableSubworkflowDiscoveryArgs(raw);
+      expect(prepared.callableArgs).toEqual({ implementation_pool: poolName });
+      expect(Object.hasOwn(prepared.raw.facet_pools ?? {}, poolName)).toBe(true);
+      expect(prepared.raw.facet_pools?.[poolName]?.candidates).toHaveLength(1);
+    } finally {
+      if (previousDescriptor === undefined) {
+        delete Object.prototype[poolName];
+      } else {
+        Object.defineProperty(Object.prototype, poolName, previousDescriptor);
+      }
+    }
+  });
+
   it('should report the dynamic pool field path when a non-string pool reaches normalization', () => {
     let thrown: unknown;
     try {
@@ -381,17 +440,51 @@ describe('workflow_call schema', () => {
   it.each(['constructor', 'toString', '__proto__'])(
     'should reject an undeclared facet pool when a callable arg uses the inherited key %s',
     (poolName) => {
-      expect(() => normalizeWorkflowConfig(
-        createCallableFacetPoolWorkflow(),
-        '/tmp',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { callableArgs: { implementation_pool: poolName } },
-      )).toThrow(`workflow_call arg "implementation_pool" references unknown facet pool "${poolName}"`);
+      let thrown: unknown;
+      try {
+        normalizeWorkflowConfig(
+          createCallableFacetPoolWorkflow(),
+          '/tmp',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { callableArgs: { implementation_pool: poolName } },
+        );
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toContain(
+        `workflow_call arg "implementation_pool" references unknown facet pool "${poolName}"`,
+      );
+      expect(getWorkflowConfigErrorPath(thrown)).toEqual(['callableArgs', 'implementation_pool']);
+    },
+  );
+
+  it.each(['constructor', 'toString', '__proto__'])(
+    'should reject an inherited root facet pool name when dynamic facets use %s',
+    (poolName) => {
+      let thrown: unknown;
+      try {
+        normalizeWorkflowConfig(createRootDynamicFacetPoolWorkflow(poolName), '/tmp');
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toContain(
+        `Configuration error: step "implement" references unknown facet pool "${poolName}"`,
+      );
+      expect(getWorkflowConfigErrorPath(thrown)).toEqual([
+        'steps',
+        0,
+        'dynamic_facets',
+        'pool',
+      ]);
     },
   );
 

--- a/src/__tests__/workflow-call-schema.test.ts
+++ b/src/__tests__/workflow-call-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { WorkflowConfigRawSchema, WorkflowStepRawSchema } from '../core/models/index.js';
+import { getWorkflowConfigErrorPath } from '../core/workflow/workflow-config-error.js';
 import { prepareCallableSubworkflowDiscoveryArgs } from '../infra/config/loaders/workflowCallableDiscoveryArgs.js';
 import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
 
@@ -173,7 +174,8 @@ describe('workflow_call schema', () => {
     expect(workflow.maxSteps).toBe(10);
   });
 
-  it('should use a synthetic pool for required facet_pool_ref discovery args', () => {
+  it('should use a suffixed synthetic discovery pool when the default pool name collides', () => {
+    const syntheticPoolName = '__takt_discovery_pool__implementation_pool';
     const raw = WorkflowConfigRawSchema.parse({
       name: 'pool-discovery',
       subworkflow: {
@@ -191,6 +193,13 @@ describe('workflow_call schema', () => {
         knowledge: 'Discovery knowledge',
       },
       facet_pools: {
+        [syntheticPoolName]: {
+          candidates: [{
+            id: 'existing-candidate',
+            description: 'Existing pool candidate',
+            policy: 'policy',
+          }],
+        },
         first: {
           candidates: [{
             id: 'first-candidate',
@@ -220,13 +229,20 @@ describe('workflow_call schema', () => {
     });
 
     const prepared = prepareCallableSubworkflowDiscoveryArgs(raw);
-    const syntheticPoolName = '__takt_discovery_pool__implementation_pool';
-    expect(prepared.callableArgs).toEqual({ implementation_pool: syntheticPoolName });
-    expect(prepared.raw.facet_pools?.first).toBeDefined();
-    expect(prepared.raw.facet_pools?.second).toBeDefined();
+    const suffixedPoolName = `${syntheticPoolName}_1`;
+    expect(prepared.callableArgs).toEqual({ implementation_pool: suffixedPoolName });
     expect(prepared.raw.facet_pools?.[syntheticPoolName]).toEqual({
       candidates: [{
-        id: syntheticPoolName + '-candidate',
+        id: 'existing-candidate',
+        description: 'Existing pool candidate',
+        policy: 'policy',
+      }],
+    });
+    expect(prepared.raw.facet_pools?.first).toBeDefined();
+    expect(prepared.raw.facet_pools?.second).toBeDefined();
+    expect(prepared.raw.facet_pools?.[suffixedPoolName]).toEqual({
+      candidates: [{
+        id: suffixedPoolName + '-candidate',
         description: '[discovery placeholder candidate for facet pool param "implementation_pool"]',
         policy: '__takt_discovery_param___policy_implementation_pool',
         knowledge: '__takt_discovery_param___knowledge_implementation_pool',
@@ -234,6 +250,35 @@ describe('workflow_call schema', () => {
     });
     expect(prepared.raw.policies?.['__takt_discovery_param___policy_implementation_pool']).toBeDefined();
     expect(prepared.raw.knowledge?.['__takt_discovery_param___knowledge_implementation_pool']).toBeDefined();
+  });
+
+  it('should report the dynamic pool field path when a non-string pool reaches normalization', () => {
+    let thrown: unknown;
+    try {
+      normalizeWorkflowConfig({
+        name: 'invalid-dynamic-pool',
+        steps: [{
+          name: 'implement',
+          persona: 'coder',
+          instruction: 'Implement',
+          dynamic_facets: {
+            pool: { $param: 'implementation_pool' },
+          },
+          rules: [{ condition: 'done', next: 'COMPLETE' }],
+        }],
+      }, '/tmp');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(getWorkflowConfigErrorPath(thrown)).toEqual([
+      'steps',
+      0,
+      'dynamic_facets',
+      'pool',
+    ]);
+    expect((thrown as Error).message).toContain('dynamic_facets.pool has an unresolved parameter reference');
   });
 
   it('accepts scalar vars only on workflow_call steps and preserves them after normalization', () => {

--- a/src/__tests__/workflow-call-schema.test.ts
+++ b/src/__tests__/workflow-call-schema.test.ts
@@ -378,6 +378,23 @@ describe('workflow_call schema', () => {
     expect((thrown as Error).message).toContain(expectedMessage);
   });
 
+  it.each(['constructor', 'toString', '__proto__'])(
+    'should reject an undeclared facet pool when a callable arg uses the inherited key %s',
+    (poolName) => {
+      expect(() => normalizeWorkflowConfig(
+        createCallableFacetPoolWorkflow(),
+        '/tmp',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { callableArgs: { implementation_pool: poolName } },
+      )).toThrow(`workflow_call arg "implementation_pool" references unknown facet pool "${poolName}"`);
+    },
+  );
+
   it('accepts scalar vars only on workflow_call steps and preserves them after normalization', () => {
     const raw = {
       name: 'parent',

--- a/src/__tests__/workflow-call-schema.test.ts
+++ b/src/__tests__/workflow-call-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { WorkflowConfigRawSchema, WorkflowStepRawSchema } from '../core/models/index.js';
+import { prepareCallableSubworkflowDiscoveryArgs } from '../infra/config/loaders/workflowCallableDiscoveryArgs.js';
 import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
 
 function createWorkflowCallStep(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -170,6 +171,69 @@ describe('workflow_call schema', () => {
     }, '/tmp');
 
     expect(workflow.maxSteps).toBe(10);
+  });
+
+  it('should use a synthetic pool for required facet_pool_ref discovery args', () => {
+    const raw = WorkflowConfigRawSchema.parse({
+      name: 'pool-discovery',
+      subworkflow: {
+        callable: true,
+        params: {
+          implementation_pool: {
+            type: 'facet_pool_ref',
+          },
+        },
+      },
+      policies: {
+        policy: 'Discovery policy',
+      },
+      knowledge: {
+        knowledge: 'Discovery knowledge',
+      },
+      facet_pools: {
+        first: {
+          candidates: [{
+            id: 'first-candidate',
+            description: 'First candidate',
+            policy: 'policy',
+          }],
+        },
+        second: {
+          candidates: [{
+            id: 'second-candidate',
+            description: 'Second candidate',
+            knowledge: 'knowledge',
+          }],
+        },
+      },
+      steps: [{
+        name: 'implement',
+        persona: 'reviewer',
+        instruction: 'Review',
+        dynamic_facets: {
+          pool: {
+            $param: 'implementation_pool',
+          },
+        },
+        rules: [{ condition: 'done', next: 'COMPLETE' }],
+      }],
+    });
+
+    const prepared = prepareCallableSubworkflowDiscoveryArgs(raw);
+    const syntheticPoolName = '__takt_discovery_pool__implementation_pool';
+    expect(prepared.callableArgs).toEqual({ implementation_pool: syntheticPoolName });
+    expect(prepared.raw.facet_pools?.first).toBeDefined();
+    expect(prepared.raw.facet_pools?.second).toBeDefined();
+    expect(prepared.raw.facet_pools?.[syntheticPoolName]).toEqual({
+      candidates: [{
+        id: syntheticPoolName + '-candidate',
+        description: '[discovery placeholder candidate for facet pool param "implementation_pool"]',
+        policy: '__takt_discovery_param___policy_implementation_pool',
+        knowledge: '__takt_discovery_param___knowledge_implementation_pool',
+      }],
+    });
+    expect(prepared.raw.policies?.['__takt_discovery_param___policy_implementation_pool']).toBeDefined();
+    expect(prepared.raw.knowledge?.['__takt_discovery_param___knowledge_implementation_pool']).toBeDefined();
   });
 
   it('accepts scalar vars only on workflow_call steps and preserves them after normalization', () => {

--- a/src/__tests__/workflow-step-fragment-params.test.ts
+++ b/src/__tests__/workflow-step-fragment-params.test.ts
@@ -145,7 +145,7 @@ parallel:
     expect(result.raw).toHaveProperty('steps.0.parallel.0.knowledge', ['reviewing']);
   });
 
-  it('binds params recursively in dynamic parallel branches', () => {
+  it('should bind params recursively in dynamic parallel branches when a fragment contains dynamic parallel substeps', () => {
     write(projectDir, '.takt/steps/dynamic-parallel.yaml', `params:
   child_knowledge:
     type: facet_ref[]
@@ -192,7 +192,7 @@ parallel:
     );
   });
 
-  it('binds a facet_pool_ref into dynamic_facets.pool', () => {
+  it('should bind a facet_pool_ref into dynamic_facets.pool when the caller supplies a scalar pool name', () => {
     write(projectDir, '.takt/steps/pool-step.yaml', [
       'params:',
       '  implementation_pool:',
@@ -213,7 +213,7 @@ parallel:
     );
   });
 
-  it('passes a facet_pool_ref through a nested fragment scope', () => {
+  it('should preserve a facet_pool_ref through a nested fragment when the outer scope maps the child parameter', () => {
     write(projectDir, '.takt/steps/inner-pool.yaml', [
       'params:',
       '  child_pool:',
@@ -656,7 +656,7 @@ instruction:
       path: ['parallel', 0, 'params'],
       source: 'fragment',
     },
-  ])('rejects $name with a structured source path', ({ fragment, step, path, source }) => {
+  ])('should reject $name with a structured source path when the fragment parameter contract is invalid', ({ fragment, step, path, source }) => {
     const fragmentPath = write(projectDir, '.takt/steps/invalid.yaml', fragment);
 
     let thrown: unknown;

--- a/src/__tests__/workflow-step-fragment-params.test.ts
+++ b/src/__tests__/workflow-step-fragment-params.test.ts
@@ -145,6 +145,53 @@ parallel:
     expect(result.raw).toHaveProperty('steps.0.parallel.0.knowledge', ['reviewing']);
   });
 
+  it('binds params recursively in dynamic parallel branches', () => {
+    write(projectDir, '.takt/steps/dynamic-parallel.yaml', `params:
+  child_knowledge:
+    type: facet_ref[]
+    facet_kind: knowledge
+parallel:
+  fixed:
+    - name: fixed-review
+      instruction: review
+      knowledge:
+        - $param: child_knowledge
+  pool:
+    - name: pool-review
+      instruction: review
+      knowledge:
+        - base-knowledge
+        - $param: child_knowledge
+  selection:
+    mode: replace
+`);
+
+    const result = resolve({
+      steps: [caller(
+        'dynamic-parallel',
+        { child_knowledge: ['reviewing'] },
+        {
+          rules: {
+            self: RULES,
+            parallel: {
+              'fixed-review': RULES,
+              'pool-review': RULES,
+            },
+          },
+        },
+      )],
+    });
+
+    expect(result.raw).toHaveProperty(
+      'steps.0.parallel.fixed.0.knowledge',
+      ['reviewing'],
+    );
+    expect(result.raw).toHaveProperty(
+      'steps.0.parallel.pool.0.knowledge',
+      ['base-knowledge', 'reviewing'],
+    );
+  });
+
   it('splices empty and populated facet_ref arrays into mixed facet lists', () => {
     write(projectDir, '.takt/steps/composed.yaml', `params:
   policy_additions:

--- a/src/__tests__/workflow-step-fragment-params.test.ts
+++ b/src/__tests__/workflow-step-fragment-params.test.ts
@@ -192,6 +192,58 @@ parallel:
     );
   });
 
+  it('binds a facet_pool_ref into dynamic_facets.pool', () => {
+    write(projectDir, '.takt/steps/pool-step.yaml', [
+      'params:',
+      '  implementation_pool:',
+      '    type: facet_pool_ref',
+      'dynamic_facets:',
+      '  pool:',
+      '    $param: implementation_pool',
+      '',
+    ].join('\n'));
+
+    const result = resolve({
+      steps: [caller('pool-step', { implementation_pool: 'takt-coding-facets' })],
+    });
+
+    expect(result.raw).toHaveProperty(
+      'steps.0.dynamic_facets.pool',
+      'takt-coding-facets',
+    );
+  });
+
+  it('passes a facet_pool_ref through a nested fragment scope', () => {
+    write(projectDir, '.takt/steps/inner-pool.yaml', [
+      'params:',
+      '  child_pool:',
+      '    type: facet_pool_ref',
+      'dynamic_facets:',
+      '  pool:',
+      '    $param: child_pool',
+      '',
+    ].join('\n'));
+    write(projectDir, '.takt/steps/outer-pool.yaml', [
+      'params:',
+      '  parent_pool:',
+      '    type: facet_pool_ref',
+      'uses: inner-pool',
+      'with:',
+      '  child_pool:',
+      '    $param: parent_pool',
+      '',
+    ].join('\n'));
+
+    const result = resolve({
+      steps: [caller('outer-pool', { parent_pool: 'coding-facets' })],
+    });
+
+    expect(result.raw).toHaveProperty(
+      'steps.0.dynamic_facets.pool',
+      'coding-facets',
+    );
+  });
+
   it('splices empty and populated facet_ref arrays into mixed facet lists', () => {
     write(projectDir, '.takt/steps/composed.yaml', `params:
   policy_additions:
@@ -549,10 +601,24 @@ instruction:
       source: 'fragment',
     },
     {
+      name: 'facet_ref used as a dynamic pool',
+      fragment: 'params:\n  wrong:\n    type: facet_ref\n    facet_kind: policy\ndynamic_facets:\n  pool:\n    $param: wrong\n',
+      step: caller('invalid', { wrong: 'strict' }),
+      path: ['dynamic_facets', 'pool'],
+      source: 'fragment',
+    },
+    {
       name: 'undeclared reference',
       fragment: 'instruction:\n  $param: missing\n',
       step: caller('invalid', {}),
       path: ['instruction'],
+      source: 'fragment',
+    },
+    {
+      name: 'undeclared dynamic pool reference',
+      fragment: 'dynamic_facets:\n  pool:\n    $param: missing\n',
+      step: caller('invalid', {}),
+      path: ['dynamic_facets', 'pool'],
       source: 'fragment',
     },
     {

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -123,9 +123,15 @@ const WorkflowReferenceParamDeclarationRawSchema = z.object({
   default: WorkflowFacetRefScalarSchema.optional(),
 }).strict();
 
+const WorkflowFacetPoolParamDeclarationRawSchema = z.object({
+  type: z.literal('facet_pool_ref'),
+  default: WorkflowFacetRefScalarSchema.optional(),
+}).strict();
+
 const WorkflowParamDeclarationRawSchema = z.union([
   WorkflowFacetParamDeclarationRawSchema,
   WorkflowReferenceParamDeclarationRawSchema,
+  WorkflowFacetPoolParamDeclarationRawSchema,
 ]);
 
 const WorkflowRuleConditionRawSchema = z.string().trim().min(1).superRefine((condition, ctx) => {
@@ -373,7 +379,7 @@ export const FacetPoolRawSchema = z.union([
 });
 
 export const DynamicFacetsRawSchema = z.object({
-  pool: z.string().min(1),
+  pool: z.union([z.string().min(1), WorkflowParamReferenceRawSchema]),
   max_selected: z.number().int().positive().optional(),
 }).strict();
 

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -129,7 +129,7 @@ export interface CommandQualityGate {
 
 export type QualityGate = string | CommandQualityGate;
 
-export type WorkflowParamType = 'facet_ref' | 'facet_ref[]' | 'workflow_ref';
+export type WorkflowParamType = 'facet_ref' | 'facet_ref[]' | 'workflow_ref' | 'facet_pool_ref';
 export type WorkflowParamFacetKind = 'knowledge' | 'policy' | 'instruction' | 'persona' | 'report_format';
 export type WorkflowCallArgValue = string | string[];
 export type WorkflowCallVariableValue = string | number | boolean;
@@ -145,9 +145,15 @@ interface WorkflowReferenceSubworkflowParamConfig {
   default?: string;
 }
 
+interface WorkflowFacetPoolSubworkflowParamConfig {
+  type: 'facet_pool_ref';
+  default?: string;
+}
+
 export type WorkflowSubworkflowParamConfig =
   | WorkflowFacetSubworkflowParamConfig
-  | WorkflowReferenceSubworkflowParamConfig;
+  | WorkflowReferenceSubworkflowParamConfig
+  | WorkflowFacetPoolSubworkflowParamConfig;
 
 export interface WorkflowSubworkflowConfig {
   callable?: boolean;

--- a/src/core/workflow/workflow-config-error.ts
+++ b/src/core/workflow/workflow-config-error.ts
@@ -1,3 +1,5 @@
+import { ZodError } from 'zod';
+
 export class WorkflowConfigError extends Error {
   private normalizedPath: readonly PropertyKey[];
 
@@ -26,5 +28,11 @@ export function withWorkflowConfigErrorPath(error: unknown, path: readonly Prope
 }
 
 export function getWorkflowConfigErrorPath(error: unknown): readonly PropertyKey[] | undefined {
-  return error instanceof WorkflowConfigError ? error.path : undefined;
+  if (error instanceof WorkflowConfigError) {
+    return error.path;
+  }
+  if (error instanceof ZodError) {
+    return error.issues[0]?.path;
+  }
+  return undefined;
 }

--- a/src/infra/config/loaders/workflowCallableArgResolver.ts
+++ b/src/infra/config/loaders/workflowCallableArgResolver.ts
@@ -184,11 +184,15 @@ function resolveCallableArgs(
   const resolvedArgs = new Map<string, WorkflowCallArgValue>();
 
   for (const [name, value] of Object.entries(args ?? {})) {
-    const definition = params[name];
-    if (!definition) {
-      throw new Error(`workflow_call arg "${name}" is not declared by child workflow "${raw.name}"`);
+    try {
+      const definition = params[name];
+      if (!definition) {
+        throw new Error(`workflow_call arg "${name}" is not declared by child workflow "${raw.name}"`);
+      }
+      validateWorkflowCallArgValue(name, definition, value, workflowDir, sections, raw.facet_pools, context, argPolicy);
+    } catch (error) {
+      throw withWorkflowStepErrorPath(error, ['callableArgs', name]);
     }
-    validateWorkflowCallArgValue(name, definition, value, workflowDir, sections, raw.facet_pools, context, argPolicy);
     resolvedArgs.set(name, value);
   }
 

--- a/src/infra/config/loaders/workflowCallableArgResolver.ts
+++ b/src/infra/config/loaders/workflowCallableArgResolver.ts
@@ -143,13 +143,19 @@ function validateWorkflowCallArgValue(
   value: WorkflowCallArgValue,
   workflowDir: string,
   sections: WorkflowSections,
+  facetPools: RawWorkflowConfig['facet_pools'],
   context?: FacetResolutionContext,
   argPolicy?: WorkflowCallArgResolutionPolicy,
 ): void {
   const isArrayValue = Array.isArray(value);
-  if (definition.type === 'workflow_ref') {
+  if (definition.type === 'workflow_ref' || definition.type === 'facet_pool_ref') {
     if (isArrayValue) {
-      throw new Error(`workflow_call arg "${paramName}" must be a scalar workflow_ref`);
+      throw new Error(
+        `workflow_call arg "${paramName}" must be a scalar ${definition.type === 'workflow_ref' ? 'workflow_ref' : 'facet_pool_ref'}`,
+      );
+    }
+    if (definition.type === 'facet_pool_ref' && facetPools?.[value] === undefined) {
+      throw new Error(`workflow_call arg "${paramName}" references unknown facet pool "${value}"`);
     }
     return;
   }
@@ -182,7 +188,7 @@ function resolveCallableArgs(
     if (!definition) {
       throw new Error(`workflow_call arg "${name}" is not declared by child workflow "${raw.name}"`);
     }
-    validateWorkflowCallArgValue(name, definition, value, workflowDir, sections, context, argPolicy);
+    validateWorkflowCallArgValue(name, definition, value, workflowDir, sections, raw.facet_pools, context, argPolicy);
     resolvedArgs.set(name, value);
   }
 
@@ -190,7 +196,7 @@ function resolveCallableArgs(
     if (resolvedArgs.has(name) || definition.default === undefined) {
       continue;
     }
-    validateWorkflowCallArgValue(name, definition, definition.default, workflowDir, sections, context);
+    validateWorkflowCallArgValue(name, definition, definition.default, workflowDir, sections, raw.facet_pools, context);
     resolvedArgs.set(name, definition.default);
   }
 
@@ -211,7 +217,11 @@ function resolveExpandedParamValue(
   if (!definition) {
     throw withWorkflowStepErrorPath(new Error(`Step "${stepName}" references undeclared param "${paramRef.$param}" in ${fieldName}`), errorPath);
   }
-  if (definition.type === 'workflow_ref' || !expectedTypes.includes(definition.type)) {
+  if (
+    definition.type === 'workflow_ref'
+    || definition.type === 'facet_pool_ref'
+    || !expectedTypes.includes(definition.type)
+  ) {
     const expectedTypeLabel = expectedTypes.join(' or ');
     throw withWorkflowStepErrorPath(new Error(`Step "${stepName}" expects ${fieldName} to use ${expectedTypeLabel} param "${paramRef.$param}"`), errorPath);
   }
@@ -221,6 +231,49 @@ function resolveExpandedParamValue(
   const value = resolvedArgs[paramRef.$param];
   if (value === undefined) {
     throw withWorkflowStepErrorPath(new Error(`Step "${stepName}" requires workflow_call arg "${paramRef.$param}" for ${fieldName}`), errorPath);
+  }
+  return value;
+}
+
+function resolveExpandedFacetPoolValue(
+  stepName: string,
+  paramRef: WorkflowParamReference,
+  params: NonNullable<RawWorkflowConfig['subworkflow']>['params'] | undefined,
+  resolvedArgs: Record<string, WorkflowCallArgValue>,
+  facetPools: RawWorkflowConfig['facet_pools'],
+  errorPath: readonly PropertyKey[],
+): string {
+  const definition = params?.[paramRef.$param];
+  if (!definition) {
+    throw withWorkflowStepErrorPath(
+      new Error(`Step "${stepName}" references undeclared param "${paramRef.$param}" in dynamic_facets.pool`),
+      errorPath,
+    );
+  }
+  if (definition.type !== 'facet_pool_ref') {
+    throw withWorkflowStepErrorPath(
+      new Error(`Step "${stepName}" expects dynamic_facets.pool to use facet_pool_ref param "${paramRef.$param}"`),
+      errorPath,
+    );
+  }
+  const value = resolvedArgs[paramRef.$param];
+  if (value === undefined) {
+    throw withWorkflowStepErrorPath(
+      new Error(`Step "${stepName}" requires workflow_call arg "${paramRef.$param}" for dynamic_facets.pool`),
+      errorPath,
+    );
+  }
+  if (Array.isArray(value)) {
+    throw withWorkflowStepErrorPath(
+      new Error(`Step "${stepName}" expects dynamic_facets.pool to resolve to a scalar facet_pool_ref`),
+      errorPath,
+    );
+  }
+  if (facetPools?.[value] === undefined) {
+    throw withWorkflowStepErrorPath(
+      new Error(`Step "${stepName}" references unknown facet pool "${value}"`),
+      errorPath,
+    );
   }
   return value;
 }
@@ -337,6 +390,7 @@ function expandStepFields(
   step: RawWorkflowStep,
   params: NonNullable<RawWorkflowConfig['subworkflow']>['params'] | undefined,
   resolvedArgs: Record<string, WorkflowCallArgValue>,
+  facetPools: RawWorkflowConfig['facet_pools'],
   stepPath: readonly PropertyKey[],
 ): RawWorkflowStep {
   const expandedStep: RawWorkflowStep = structuredClone(step);
@@ -376,6 +430,20 @@ function expandStepFields(
     [...stepPath, 'knowledge'],
   );
 
+  if (isWorkflowParamReference(step.dynamic_facets?.pool)) {
+    expandedStep.dynamic_facets = {
+      ...step.dynamic_facets,
+      pool: resolveExpandedFacetPoolValue(
+        step.name,
+        step.dynamic_facets.pool,
+        params,
+        resolvedArgs,
+        facetPools,
+        [...stepPath, 'dynamic_facets', 'pool'],
+      ),
+    };
+  }
+
   if (isWorkflowParamReference(step.instruction)) {
     expandedStep.instruction = resolveExpandedParamValue(
       step.name,
@@ -414,16 +482,16 @@ function expandStepFields(
 
   if (Array.isArray(expandedStep.parallel)) {
     expandedStep.parallel = expandedStep.parallel.map((substep, index) =>
-      expandStepFields(substep as RawWorkflowStep, params, resolvedArgs, [...stepPath, 'parallel', index]),
+      expandStepFields(substep as RawWorkflowStep, params, resolvedArgs, facetPools, [...stepPath, 'parallel', index]),
     ) as RawWorkflowStep['parallel'];
   } else if (expandedStep.parallel) {
     expandedStep.parallel = {
       ...expandedStep.parallel,
       fixed: expandedStep.parallel.fixed.map((substep, index) =>
-        expandStepFields(substep as RawWorkflowStep, params, resolvedArgs, [...stepPath, 'parallel', 'fixed', index]),
+        expandStepFields(substep as RawWorkflowStep, params, resolvedArgs, facetPools, [...stepPath, 'parallel', 'fixed', index]),
       ),
       pool: expandedStep.parallel.pool.map((substep, index) =>
-        expandStepFields(substep as RawWorkflowStep, params, resolvedArgs, [...stepPath, 'parallel', 'pool', index]),
+        expandStepFields(substep as RawWorkflowStep, params, resolvedArgs, facetPools, [...stepPath, 'parallel', 'pool', index]),
       ),
     } as RawWorkflowStep['parallel'];
   }
@@ -453,6 +521,6 @@ export function expandCallableSubworkflowRaw(
     options.argPolicy,
   );
   const expanded: RawWorkflowConfig = structuredClone(raw);
-  expanded.steps = expanded.steps.map((step, index) => expandStepFields(step, params, resolvedArgs, ['steps', index]));
+  expanded.steps = expanded.steps.map((step, index) => expandStepFields(step, params, resolvedArgs, raw.facet_pools, ['steps', index]));
   return WorkflowConfigRawSchema.parse(expanded);
 }

--- a/src/infra/config/loaders/workflowCallableArgResolver.ts
+++ b/src/infra/config/loaders/workflowCallableArgResolver.ts
@@ -16,6 +16,7 @@ import {
 import { isWorkflowParamReference, type WorkflowParamReference } from './workflowCallableParamRef.js';
 import { assertNoParamReferences, validateReturnRules } from './workflowCallableRuleValidation.js';
 import { withWorkflowConfigErrorPath as withWorkflowStepErrorPath } from '../../../core/workflow/workflow-config-error.js';
+import { hasOwnFacetPool } from './workflowFacetPoolLookup.js';
 
 type RawWorkflowConfig = z.output<typeof WorkflowConfigRawSchema>;
 type RawWorkflowStep = RawWorkflowConfig['steps'][number];
@@ -154,7 +155,7 @@ function validateWorkflowCallArgValue(
         `workflow_call arg "${paramName}" must be a scalar ${definition.type === 'workflow_ref' ? 'workflow_ref' : 'facet_pool_ref'}`,
       );
     }
-    if (definition.type === 'facet_pool_ref' && facetPools?.[value] === undefined) {
+    if (definition.type === 'facet_pool_ref' && !hasOwnFacetPool(facetPools, value)) {
       throw new Error(`workflow_call arg "${paramName}" references unknown facet pool "${value}"`);
     }
     return;
@@ -273,7 +274,7 @@ function resolveExpandedFacetPoolValue(
       errorPath,
     );
   }
-  if (facetPools?.[value] === undefined) {
+  if (!hasOwnFacetPool(facetPools, value)) {
     throw withWorkflowStepErrorPath(
       new Error(`Step "${stepName}" references unknown facet pool "${value}"`),
       errorPath,

--- a/src/infra/config/loaders/workflowCallableDiscoveryArgs.ts
+++ b/src/infra/config/loaders/workflowCallableDiscoveryArgs.ts
@@ -6,6 +6,7 @@ type RawWorkflowConfig = z.output<typeof WorkflowConfigRawSchema>;
 
 const DISCOVERY_PLACEHOLDER_PREFIX = '__takt_discovery_param__';
 const DISCOVERY_WORKFLOW_REF_PREFIX = '__takt_discovery_workflow_ref__';
+const DISCOVERY_FACET_POOL_PREFIX = '__takt_discovery_pool__';
 
 const FACET_SECTION_BY_KIND = {
   knowledge: 'knowledge',
@@ -23,6 +24,10 @@ function buildPlaceholderContent(paramName: string, kind: keyof typeof FACET_SEC
   return `[discovery placeholder for ${kind} param "${paramName}"]`;
 }
 
+function buildDiscoveryFacetPoolName(paramName: string): string {
+  return `${DISCOVERY_FACET_POOL_PREFIX}${paramName}`;
+}
+
 function ensurePlaceholderFacet(
   raw: RawWorkflowConfig,
   paramName: string,
@@ -36,6 +41,31 @@ function ensurePlaceholderFacet(
     [placeholderRef]: existingSection[placeholderRef] ?? buildPlaceholderContent(paramName, kind),
   };
   return placeholderRef;
+}
+
+function ensureDiscoveryFacetPool(raw: RawWorkflowConfig, paramName: string): string {
+  const baseName = buildDiscoveryFacetPoolName(paramName);
+  let poolName = baseName;
+  let suffix = 1;
+  while ((raw.facet_pools ?? {})[poolName] !== undefined) {
+    poolName = baseName + '_' + suffix;
+    suffix += 1;
+  }
+  const policyRef = ensurePlaceholderFacet(raw, paramName, 'policy');
+  const knowledgeRef = ensurePlaceholderFacet(raw, paramName, 'knowledge');
+  const facetPools = raw.facet_pools ?? {};
+  raw.facet_pools = {
+    ...facetPools,
+    [poolName]: {
+      candidates: [{
+        id: `${poolName}-candidate`,
+        description: `[discovery placeholder candidate for facet pool param "${paramName}"]`,
+        policy: policyRef,
+        knowledge: knowledgeRef,
+      }],
+    },
+  };
+  return poolName;
 }
 
 export function prepareCallableSubworkflowDiscoveryArgs(
@@ -61,6 +91,11 @@ export function prepareCallableSubworkflowDiscoveryArgs(
 
     if (definition.type === 'workflow_ref') {
       callableArgs.set(paramName, `${DISCOVERY_WORKFLOW_REF_PREFIX}_${paramName}`);
+      continue;
+    }
+
+    if (definition.type === 'facet_pool_ref') {
+      callableArgs.set(paramName, ensureDiscoveryFacetPool(prepared, paramName));
       continue;
     }
 

--- a/src/infra/config/loaders/workflowCallableDiscoveryArgs.ts
+++ b/src/infra/config/loaders/workflowCallableDiscoveryArgs.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod/v4';
 import type { WorkflowCallArgValue } from '../../../core/models/index.js';
 import { WorkflowConfigRawSchema } from '../../../core/models/index.js';
+import { hasOwnFacetPool } from './workflowFacetPoolLookup.js';
 
 type RawWorkflowConfig = z.output<typeof WorkflowConfigRawSchema>;
 
@@ -47,7 +48,7 @@ function ensureDiscoveryFacetPool(raw: RawWorkflowConfig, paramName: string): st
   const baseName = buildDiscoveryFacetPoolName(paramName);
   let poolName = baseName;
   let suffix = 1;
-  while ((raw.facet_pools ?? {})[poolName] !== undefined) {
+  while (hasOwnFacetPool(raw.facet_pools, poolName)) {
     poolName = baseName + '_' + suffix;
     suffix += 1;
   }

--- a/src/infra/config/loaders/workflowDoctorRefValidator.ts
+++ b/src/infra/config/loaders/workflowDoctorRefValidator.ts
@@ -71,6 +71,7 @@ function getParamDefinition(
   }
   if (
     definition.type === 'workflow_ref'
+    || definition.type === 'facet_pool_ref'
     || !expectedTypes.includes(definition.type)
     || definition.facet_kind !== expectedKind
   ) {

--- a/src/infra/config/loaders/workflowFacetPoolLookup.ts
+++ b/src/infra/config/loaders/workflowFacetPoolLookup.ts
@@ -1,0 +1,6 @@
+export function hasOwnFacetPool(
+  facetPools: object | undefined,
+  poolName: string,
+): boolean {
+  return facetPools !== undefined && Object.hasOwn(facetPools, poolName);
+}

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -45,6 +45,7 @@ import { normalizeLoopMonitors } from './workflowLoopMonitorNormalizer.js';
 import { normalizeProviderReference, normalizeStepFromRaw, type WorkflowLevelDefinitions } from './workflowStepNormalizer.js';
 import { resolveCapabilitySets } from './capabilitySetResolver.js';
 import { compileFacetPool, type FacetPoolCompilationInput } from './facetPoolCompiler.js';
+import { hasOwnFacetPool } from './workflowFacetPoolLookup.js';
 import type { ResolvedFacetPool } from '../../../core/models/index.js';
 import {
   expandCallableSubworkflowRaw,
@@ -574,13 +575,13 @@ function validateDynamicFacetsReferences(
         ['steps', index, 'dynamic_facets', 'pool'],
       );
     }
-    const pool = facetPools?.[poolName];
-    if (pool === undefined) {
+    if (!hasOwnFacetPool(facetPools, poolName)) {
       throw withWorkflowStepErrorPath(
         new Error(`Configuration error: step "${step.name}" references unknown facet pool "${poolName}"`),
         ['steps', index, 'dynamic_facets', 'pool'],
       );
     }
+    const pool = facetPools![poolName]!;
     const candidateCount = pool.candidates.length;
     if (
       step.dynamic_facets.max_selected !== undefined

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -77,7 +77,7 @@ function normalizeSubworkflowConfig(
       ? Object.fromEntries(
         Object.entries(raw.params).map(([name, param]) => [
           name,
-          param.type === 'workflow_ref'
+          param.type === 'workflow_ref' || param.type === 'facet_pool_ref'
             ? {
                 type: param.type,
                 default: param.default,
@@ -568,6 +568,12 @@ function validateDynamicFacetsReferences(
   for (const [index, step] of steps.entries()) {
     if (step.dynamic_facets === undefined) continue;
     const poolName = step.dynamic_facets.pool;
+    if (typeof poolName !== 'string') {
+      throw withWorkflowStepErrorPath(
+        new Error(`Configuration error: step "${step.name}" has an unresolved facet pool parameter`),
+        ['steps', index, 'dynamic_facets', 'pool'],
+      );
+    }
     const pool = facetPools?.[poolName];
     if (pool === undefined) {
       throw withWorkflowStepErrorPath(

--- a/src/infra/config/loaders/workflowStepFragmentParams.ts
+++ b/src/infra/config/loaders/workflowStepFragmentParams.ts
@@ -6,7 +6,7 @@ import {
   workflowError,
 } from './workflowStepFragmentReader.js';
 
-type FragmentParamType = 'facet_ref' | 'facet_ref[]' | 'workflow_ref';
+type FragmentParamType = 'facet_ref' | 'facet_ref[]' | 'workflow_ref' | 'facet_pool_ref';
 type FragmentFacetKind = 'policy' | 'knowledge' | 'instruction' | 'persona' | 'report_format';
 type FragmentParamValue = string | string[] | FragmentParamReference;
 
@@ -21,6 +21,10 @@ export type FragmentParamDeclaration =
     }
   | {
       readonly type: 'workflow_ref';
+      readonly facetKind?: never;
+    }
+  | {
+      readonly type: 'facet_pool_ref';
       readonly facetKind?: never;
     };
 
@@ -55,7 +59,7 @@ export interface BoundStepFragmentSource {
 
 const PASS_THROUGH_BINDINGS = new WeakMap<RawRecord, ResolvedFragmentBinding>();
 const BOUND_STEP_FRAGMENT_SOURCES = new WeakMap<RawRecord, BoundStepFragmentSource>();
-const PARAM_TYPES = new Set<FragmentParamType>(['facet_ref', 'facet_ref[]', 'workflow_ref']);
+const PARAM_TYPES = new Set<FragmentParamType>(['facet_ref', 'facet_ref[]', 'workflow_ref', 'facet_pool_ref']);
 const FACET_KINDS = new Set<FragmentFacetKind>(['policy', 'knowledge', 'instruction', 'persona', 'report_format']);
 const POLICY_CONTRACT: FieldContract = {
   kinds: ['policy'],
@@ -79,7 +83,7 @@ const REPORT_FORMAT_CONTRACT: FieldContract = {
 };
 const WORKFLOW_CALL_ARG_CONTRACT: FieldContract = {
   kinds: ['policy', 'knowledge', 'instruction', 'persona', 'report_format'],
-  types: ['facet_ref', 'facet_ref[]', 'workflow_ref'],
+  types: ['facet_ref', 'facet_ref[]', 'workflow_ref', 'facet_pool_ref'],
 };
 const WORKFLOW_REFERENCE_CONTRACT: FieldContract = {
   types: ['workflow_ref'],
@@ -145,12 +149,12 @@ function parseDeclaration(
     throw fragmentError(options, [...path, 'type'], `fragment param "${name}" has an invalid type`);
   }
   const facetKind = getOwnValue(value, 'facet_kind');
-  if (type === 'workflow_ref') {
+  if (type === 'workflow_ref' || type === 'facet_pool_ref') {
     if (facetKind !== undefined) {
       throw fragmentError(
         options,
         [...path, 'facet_kind'],
-        `fragment param "${name}" does not allow facet_kind for workflow_ref`,
+        `fragment param "${name}" does not allow facet_kind for ${type}`,
       );
     }
     return { type };
@@ -200,9 +204,13 @@ function validateLiteralBinding(
     }
     return value;
   }
-  if (declaration.type === 'workflow_ref') {
+  if (declaration.type === 'workflow_ref' || declaration.type === 'facet_pool_ref') {
     if (typeof value !== 'string' || value.length === 0) {
-      throw callerError(options, path, `fragment param "${name}" requires a scalar workflow reference`);
+      throw callerError(
+        options,
+        path,
+        `fragment param "${name}" requires a scalar ${declaration.type === 'workflow_ref' ? 'workflow' : 'facet pool'} reference`,
+      );
     }
     return value;
   }
@@ -310,7 +318,7 @@ function substituteParam(
   if (!contract.types.includes(declaration.type)) {
     throw fragmentError(options, path, `fragment param "${reference.$param}" has incompatible cardinality`);
   }
-  if (declaration.type !== 'workflow_ref' && contract.kinds !== undefined && (
+  if (declaration.type !== 'workflow_ref' && declaration.type !== 'facet_pool_ref' && contract.kinds !== undefined && (
     declaration.facetKind === undefined
     || !contract.kinds.includes(declaration.facetKind)
   )) {
@@ -448,6 +456,41 @@ function bindWorkflowCallArgs(
   ]));
 }
 
+function bindDynamicFacets(
+  value: unknown,
+  declarations: ReadonlyMap<string, FragmentParamDeclaration>,
+  bindings: ReadonlyMap<string, ResolvedFragmentBinding>,
+  options: BindStepFragmentParamsOptions,
+  path: readonly PropertyKey[],
+): unknown {
+  if (!isPlainObject(value)) {
+    assertNoParamReferences(value, options, path);
+    return value;
+  }
+
+  const poolPath = [...path, 'pool'];
+  const reference = parseParamReference(getOwnValue(value, 'pool'), options, poolPath, 'fragment');
+  if (!reference) {
+    assertNoParamReferences(value, options, path);
+    return value;
+  }
+
+  const declaration = declarations.get(reference.$param) ?? options.outerParams.get(reference.$param);
+  if (!declaration) {
+    throw fragmentError(options, poolPath, `fragment references undeclared param "${reference.$param}"`);
+  }
+  if (declaration.type !== 'facet_pool_ref') {
+    throw fragmentError(options, poolPath, `fragment param "${reference.$param}" must be a facet_pool_ref`);
+  }
+
+  const localBinding = bindings.get(reference.$param);
+  options.boundPaths?.push(poolPath);
+  if (!localBinding) {
+    return value;
+  }
+  return { ...value, pool: localBinding.value };
+}
+
 function bindStepFields(
   step: RawRecord,
   declarations: ReadonlyMap<string, FragmentParamDeclaration>,
@@ -484,6 +527,9 @@ function bindStepFields(
         break;
       case 'args':
         expanded[key] = bindWorkflowCallArgs(value, declarations, bindings, options, fieldPath);
+        break;
+      case 'dynamic_facets':
+        expanded[key] = bindDynamicFacets(value, declarations, bindings, options, fieldPath);
         break;
       case 'with':
         if (typeof getOwnValue(step, 'uses') !== 'string' || !isPlainObject(value)) {
@@ -546,7 +592,7 @@ export function getWorkflowParamDeclarations(raw: RawRecord): ReadonlyMap<string
     if (!isPlainObject(value)) continue;
     const type = getOwnValue(value, 'type');
     const facetKind = getOwnValue(value, 'facet_kind');
-    if (type === 'workflow_ref' && facetKind === undefined) {
+    if ((type === 'workflow_ref' || type === 'facet_pool_ref') && facetKind === undefined) {
       declarations.set(name, { type });
       continue;
     }

--- a/src/infra/config/loaders/workflowStepFragmentParams.ts
+++ b/src/infra/config/loaders/workflowStepFragmentParams.ts
@@ -495,16 +495,35 @@ function bindStepFields(
         ]));
         break;
       case 'parallel':
-        if (!Array.isArray(value)) {
+        if (!Array.isArray(value) && !isPlainObject(value)) {
           assertNoParamReferences(value, options, fieldPath);
           expanded[key] = value;
           break;
         }
-        expanded[key] = value.map((child, index) => (
-          isPlainObject(child)
-            ? bindStepFields(child, declarations, bindings, options, [...fieldPath, index])
-            : (assertNoParamReferences(child, options, [...fieldPath, index]), child)
-        ));
+        if (Array.isArray(value)) {
+          expanded[key] = value.map((child, index) => (
+            isPlainObject(child)
+              ? bindStepFields(child, declarations, bindings, options, [...fieldPath, index])
+              : (assertNoParamReferences(child, options, [...fieldPath, index]), child)
+          ));
+          break;
+        }
+        expanded[key] = Object.fromEntries(Object.entries(value).map(([branch, children]) => {
+          const branchPath = [...fieldPath, branch];
+          if (branch !== 'fixed' && branch !== 'pool') {
+            assertNoParamReferences(children, options, branchPath);
+            return [branch, children];
+          }
+          if (!Array.isArray(children)) {
+            assertNoParamReferences(children, options, branchPath);
+            return [branch, children];
+          }
+          return [branch, children.map((child, index) => (
+            isPlainObject(child)
+              ? bindStepFields(child, declarations, bindings, options, [...branchPath, index])
+              : (assertNoParamReferences(child, options, [...branchPath, index]), child)
+          ))];
+        }));
         break;
       default:
         assertNoParamReferences(value, options, fieldPath);

--- a/src/infra/config/loaders/workflowStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepNormalizer.ts
@@ -123,10 +123,12 @@ function normalizeDynamicFacets(
   if (raw === undefined) {
     return undefined;
   }
-  const pool = raw.pool;
-  if (typeof pool !== 'string') {
-    throw new Error('dynamic_facets.pool has an unresolved parameter reference');
-  }
+  const pool = normalizeStepField(stepPath, ['dynamic_facets', 'pool'], () => {
+    if (typeof raw.pool !== 'string') {
+      throw new Error('dynamic_facets.pool has an unresolved parameter reference');
+    }
+    return raw.pool;
+  });
   return normalizeStepField(stepPath, ['dynamic_facets'], () => ({
     pool,
     ...(raw.max_selected === undefined ? {} : { maxSelected: raw.max_selected }),

--- a/src/infra/config/loaders/workflowStepNormalizer.ts
+++ b/src/infra/config/loaders/workflowStepNormalizer.ts
@@ -123,8 +123,12 @@ function normalizeDynamicFacets(
   if (raw === undefined) {
     return undefined;
   }
+  const pool = raw.pool;
+  if (typeof pool !== 'string') {
+    throw new Error('dynamic_facets.pool has an unresolved parameter reference');
+  }
   return normalizeStepField(stepPath, ['dynamic_facets'], () => ({
-    pool: raw.pool,
+    pool,
     ...(raw.max_selected === undefined ? {} : { maxSelected: raw.max_selected }),
   }));
 }


### PR DESCRIPTION
## Summary

- add thin `experimental` and `takt-experimental` root wrappers over a shared callable `experimental-core`
- add `facet_pool_ref` so callable workflows and step fragments can inject a child-local `dynamic_facets.pool` without copying the workflow body
- keep generic frontend/backend implementation and review candidates while the TAKT variant uses TAKT-only pools and injects `takt` / `takt-testing` facets throughout planning, testing, implementation, review, fix, and supervision
- split reusable review, fix, and supervision steps into parameterized fragments and keep Japanese and English builtins synchronized
- fail fast for missing, non-scalar, unknown, undeclared, unresolved, and inherited-property pool references; use a synthetic pool only for static callable discovery

## Verification

- `npm test -- src/__tests__/it-experimental-workflow.test.ts` (6 passed)
- `npm test -- src/__tests__/workflow-call-schema.test.ts` (102 passed)
- `npm test -- src/__tests__/workflowLoader.test.ts` (71 passed)
- `npm test -- src/__tests__/workflow-step-fragment-params.test.ts` (31 passed)
- `npm test -- src/__tests__/builtins-capabilities-migration.test.ts` (5 passed)
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts` (9 passed)
- `npm test -- src/__tests__/workflow-step-fragment-builtin-runtime.test.ts` (44 passed)
- `npm run build`
- `npm run lint`
- `git diff --check`

## Review

- implemented by a Luna Max agent using the `$coding` criteria
- adversarially reviewed by a separate Luna Max agent using the same criteria
- addressed the adversarial and CodeRabbit findings and repeated review
- final adversarial review: APPROVE, zero blocking findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 計画、テスト、実装、レビュー、修正、監督を統合した実験的ワークフローを追加しました。
  * TAKT向けワークフローと、専門分野別の並列レビューを利用できるようになりました。
  * ポリシー、知識、指示、実装候補を柔軟に差し替えられるようになりました。
  * レビュー結果に応じた修正・完了・中断の遷移と、各種レポート出力を整備しました。

* **改善**
  * ワークフロー間でファセットプールを動的に受け渡せるようになりました。
  * 不正な参照や型、未指定値を早期に検出する検証を強化しました。

* **ドキュメント**
  * 新しいパラメータ、参照方法、実行ルールを英語・日本語のドキュメントに追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
