### PR TITLE
fix(finding-contract): conflict裁定ループの空回りと入力肥大を止め再裁定をコード変化に束縛する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,12 @@ jobs:
       - run: npm run test:it
 
   heavy_it_shard:
-    name: test:it:heavy parallel shard (${{ matrix.shard }}/4)
+    name: test:it:heavy parallel shard (${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     permissions:
       contents: read
     steps:
@@ -99,7 +99,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm run test:it:heavy:parallel -- --shard=${{ matrix.shard }}/4
+      - run: npm run test:it:heavy:parallel -- --shard=${{ matrix.shard }}/6
 
   heavy_it_serial:
     name: test:it:heavy serial (${{ matrix.group }})

--- a/builtins/en/workflows/finding-contract-boundary-review.yaml
+++ b/builtins/en/workflows/finding-contract-boundary-review.yaml
@@ -27,7 +27,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: final-gate
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/builtins/en/workflows/finding-contract-local-review.yaml
+++ b/builtins/en/workflows/finding-contract-local-review.yaml
@@ -27,7 +27,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: integrity-gate
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/builtins/en/workflows/merge-readiness-finding-contract-final-gate.yaml
+++ b/builtins/en/workflows/merge-readiness-finding-contract-final-gate.yaml
@@ -31,8 +31,8 @@ steps:
     rules:
       - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
         return: needs_conflict_adjudication
-      - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
-        return: needs_review
+      - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
+        return: needs_fix
       - condition: when(findings.conflicts.count > 0)
         next: ABORT
       - condition: when(findings.provisional.fixpoint == true)
@@ -81,8 +81,8 @@ steps:
     rules:
       - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
         return: needs_conflict_adjudication
-      - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
-        return: needs_review
+      - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
+        return: needs_fix
       - condition: when(findings.conflicts.count > 0)
         next: ABORT
       - condition: when(findings.provisional.fixpoint == true)

--- a/builtins/en/workflows/peer-review-suite-finding-contract-base.yaml
+++ b/builtins/en/workflows/peer-review-suite-finding-contract-base.yaml
@@ -27,8 +27,8 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
-          return: needs_review
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
+          return: needs_fix
         - condition: when(findings.conflicts.count > 0)
           next: ABORT
         - condition: when(findings.reviewerAnomalies.claimBearingTerminalCount > 0)

--- a/builtins/en/workflows/review-fix-takt-default-high.yaml
+++ b/builtins/en/workflows/review-fix-takt-default-high.yaml
@@ -141,7 +141,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: fix
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/builtins/en/workflows/takt-default-high.yaml
+++ b/builtins/en/workflows/takt-default-high.yaml
@@ -130,7 +130,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: fix
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/builtins/en/workflows/takt-default-team-high.yaml
+++ b/builtins/en/workflows/takt-default-team-high.yaml
@@ -138,7 +138,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: fix
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/builtins/ja/workflows/finding-contract-boundary-review.yaml
+++ b/builtins/ja/workflows/finding-contract-boundary-review.yaml
@@ -27,7 +27,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: final-gate
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/builtins/ja/workflows/finding-contract-local-review.yaml
+++ b/builtins/ja/workflows/finding-contract-local-review.yaml
@@ -27,7 +27,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: integrity-gate
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/builtins/ja/workflows/merge-readiness-finding-contract-final-gate.yaml
+++ b/builtins/ja/workflows/merge-readiness-finding-contract-final-gate.yaml
@@ -31,8 +31,8 @@ steps:
     rules:
       - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
         return: needs_conflict_adjudication
-      - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
-        return: needs_review
+      - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
+        return: needs_fix
       - condition: when(findings.conflicts.count > 0)
         next: ABORT
       - condition: when(findings.provisional.fixpoint == true)
@@ -76,8 +76,8 @@ steps:
     rules:
       - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
         return: needs_conflict_adjudication
-      - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
-        return: needs_review
+      - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
+        return: needs_fix
       - condition: when(findings.conflicts.count > 0)
         next: ABORT
       - condition: when(findings.provisional.fixpoint == true)

--- a/builtins/ja/workflows/peer-review-suite-finding-contract-base.yaml
+++ b/builtins/ja/workflows/peer-review-suite-finding-contract-base.yaml
@@ -27,8 +27,8 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
-          return: needs_review
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
+          return: needs_fix
         - condition: when(findings.conflicts.count > 0)
           next: ABORT
         - condition: when(findings.reviewerAnomalies.claimBearingTerminalCount > 0)

--- a/builtins/ja/workflows/review-fix-takt-default-high.yaml
+++ b/builtins/ja/workflows/review-fix-takt-default-high.yaml
@@ -141,7 +141,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: fix
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/builtins/ja/workflows/takt-default-high.yaml
+++ b/builtins/ja/workflows/takt-default-high.yaml
@@ -130,7 +130,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: fix
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/builtins/ja/workflows/takt-default-team-high.yaml
+++ b/builtins/ja/workflows/takt-default-team-high.yaml
@@ -138,7 +138,7 @@ steps:
       self:
         - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count > 0)
           next: finding-conflict-adjudication
-        - condition: when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)
+        - condition: when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)
           next: fix
         - condition: when(findings.conflicts.count > 0)
           next: ABORT

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -661,6 +661,7 @@ window は争点の finding の `target.paths` と file-quote evidence の行ア
 再裁定の snapshot identity には、争点の `target.paths` について review-scope capture が取得した
 現在内容の digest も含まれます。台帳の射影が同じでも fix によって対象コードの digest が変われば、
 新しい snapshot として再裁定できます。逆に対象コードも台帳射影も変わらない場合は再裁定しません。
+非 regular file は例外です。安定した通常ファイル内容 digest を取得できないため、capture ごとに常に変化扱いとなり、fresh snapshot を追加して再裁定できます。ただし再裁定回数と workflow の上限による有限性は維持されます。
 未確定かつコード無変化の反復では stop budget は進まないため、loop monitor または workflow の
 `max_steps` が有限停止を担います。
 

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -655,6 +655,15 @@ window は争点の finding の `target.paths` と file-quote evidence の行ア
 時も同じ attempt を再開し、重複呼び出しを発行しません。2回目も `verification_undetermined` なら
 そのラウンドを未確定として確定し、元のレビューステップへ戻ります。
 
+裁定 prompt の履歴参照は直近3件を本文として残し、それ以前は件数と digest に縮約します。
+これにより異議対応の関係を判断できる参照を残しながら、入力サイズを有界に保ちます。
+
+再裁定の snapshot identity には、争点の `target.paths` について review-scope capture が取得した
+現在内容の digest も含まれます。台帳の射影が同じでも fix によって対象コードの digest が変われば、
+新しい snapshot として再裁定できます。逆に対象コードも台帳射影も変わらない場合は再裁定しません。
+未確定かつコード無変化の反復では stop budget は進まないため、loop monitor または workflow の
+`max_steps` が有限停止を担います。
+
 conflict の ladder は `findings.rounds.budgetExhausted == false` の間、active conflict を fix / 再レビュー
 ループへ戻さなければなりません。最後の `when(findings.conflicts.count > 0)` → `ABORT` は予算枯渇後だけの
 出口であり、予算付きのループ rule より後ろに置きます。

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -669,6 +669,13 @@ before the provider call, so a crash or replay resumes the exact attempt rather 
 duplicate one. A second `verification_undetermined` settles that round and returns to the originating
 review step.
 
+The re-adjudication snapshot identity also includes the current content digest captured for the
+disputed `target.paths`. If a fix changes the target code digest while the ledger projection stays
+the same, the engine can create a fresh snapshot and adjudicate again. If neither the target code
+nor the ledger projection changes, it does not re-adjudicate. Non-regular targets are the exception:
+because they have no stable regular-file content digest, every capture is treated as changed and may
+create a fresh snapshot; the bounded adjudication and workflow limits still apply.
+
 Conflict ladders must keep an active conflict in the fix/review loop while
 `findings.rounds.budgetExhausted == false`. The final `when(findings.conflicts.count > 0)` → `ABORT`
 arm is only the exhausted-budget exit; it must follow the budget-aware loop arm.

--- a/scripts/test-classification.mjs
+++ b/scripts/test-classification.mjs
@@ -183,7 +183,6 @@ export const auditedIntegrationBoundaryTestFiles = Object.freeze([
   'src/__tests__/workflowCallResolver.test.ts',
   'src/__tests__/workflowDiscovery.test.ts',
   'src/__tests__/workflowExecution-debug-prompts.test.ts',
-  'src/__tests__/workflowExecution-finding-storage.integration.test.ts',
   'src/__tests__/workflowExecutionApi.test.ts',
   'src/__tests__/workflowExecutionBootstrapDirectResume.test.ts',
   'src/__tests__/workflowExecutionReporting.test.ts',
@@ -402,6 +401,8 @@ export const parallelIntegrationTestFiles = Object.freeze([
 // RPC timeout (spurious "Timeout calling onTaskUpdate" unhandled errors).
 // Add a file here only with a measured interference reason.
 export const serialGitTestFiles = Object.freeze([
+  // 2026-08-09: heavy 並列スライスで birpc onTaskUpdate 期限超過が CI 2コアランナーで2連続再現(#1264)。SQLite+fsync 負荷の実測干渉のため serial へ。
+  'src/__tests__/workflowExecution-finding-storage.integration.test.ts',
   'src/__tests__/finding-conflict-adjudication-engine.integration.test.ts',
   'src/__tests__/finding-conflict-adjudication-runner.integration.test.ts',
   'src/__tests__/finding-evidence-protocol.integration.test.ts',

--- a/scripts/test-classification.mjs
+++ b/scripts/test-classification.mjs
@@ -157,7 +157,6 @@ export const auditedIntegrationBoundaryTestFiles = Object.freeze([
   'src/__tests__/sessionState.test.ts',
   'src/__tests__/summarize-non-workflow-provider.test.ts',
   'src/__tests__/system-workflow-schema.test.ts',
-  'src/__tests__/takt-default-fc-builtins.test.ts',
   'src/__tests__/takt-default-fc-compatibility-baseline.test.ts',
   'src/__tests__/taskForceFailActions.test.ts',
   'src/__tests__/team-leader-finding-contract-recovery.test.ts',
@@ -401,6 +400,8 @@ export const parallelIntegrationTestFiles = Object.freeze([
 // RPC timeout (spurious "Timeout calling onTaskUpdate" unhandled errors).
 // Add a file here only with a measured interference reason.
 export const serialGitTestFiles = Object.freeze([
+  // 2026-08-09: ラウンド9で遷移表→実 WorkflowEngine シナリオへ置換した結果、Git fixture+SQLite I/O の重量級になった(#1264 shard 飽和の主因)。
+  'src/__tests__/takt-default-fc-builtins.test.ts',
   // 2026-08-09: heavy 並列スライスで birpc onTaskUpdate 期限超過が CI 2コアランナーで2連続再現(#1264)。SQLite+fsync 負荷の実測干渉のため serial へ。
   'src/__tests__/workflowExecution-finding-storage.integration.test.ts',
   'src/__tests__/finding-conflict-adjudication-engine.integration.test.ts',

--- a/src/__tests__/finding-conflict-adjudication-engine.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-engine.integration.test.ts
@@ -199,6 +199,9 @@ async function seedLedger(cwd: string): Promise<FindingLedgerStore> {
   });
   const landed = landUnownedConflictRawClaims({ ledger: authorized, observation: OBSERVATION });
   const reviewScopeSnapshot = captureReviewScopeProofSnapshot(cwd);
+  const queryInventoryByPath = new Map(
+    reviewScopeSnapshot.queryInventory.map((entry) => [entry.path, entry]),
+  );
   const ledger = refreshActiveConflictAdjudicationSnapshots({
     ledger: landed,
     originStep: 'reviewers',
@@ -206,7 +209,7 @@ async function seedLedger(cwd: string): Promise<FindingLedgerStore> {
     targetContentDigestsByConflict: new Map([[
       'C-FA2947446963',
       captureConflictTargetContentDigests(
-        reviewScopeSnapshot,
+        queryInventoryByPath,
         conflictTargetPaths({ ledger: landed, conflictId: 'C-FA2947446963' }),
       ),
     ]]),

--- a/src/__tests__/finding-conflict-adjudication-engine.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-engine.integration.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runAgent } from '../agents/runner.js';
+import { runStatusJudgmentPhase } from '../core/workflow/phase-runner.js';
 import type { WorkflowConfig } from '../core/models/index.js';
 import {
   freshConflictAdjudicationSnapshot,
@@ -16,6 +17,11 @@ import { verifiedFindingEvidenceFixture } from './helpers/finding-evidence.js';
 import { initializeGitFixture } from './helpers/git-fixture.js';
 import { authorizeFindingLedgerFixture } from './helpers/finding-lifecycle-fixture.js';
 import { makeRule, makeStep } from './test-helpers.js';
+import {
+  captureConflictTargetContentDigests,
+  captureReviewScopeProofSnapshot,
+} from '../core/workflow/findings/snapshot.js';
+import { conflictTargetPaths } from '../core/workflow/findings/conflict-target.js';
 
 vi.mock('../agents/runner.js', () => ({ runAgent: vi.fn() }));
 
@@ -35,7 +41,7 @@ const OBSERVATION = {
 };
 
 function isAdjudicationSchema(outputSchema: unknown): boolean {
-  const schemaText = JSON.stringify(outputSchema);
+  const schemaText = JSON.stringify(outputSchema) ?? '';
   return schemaText.includes('terminate_subject') && schemaText.includes('undetermined');
 }
 
@@ -97,6 +103,33 @@ function workflowConfig(cwd: string): WorkflowConfig {
         ),
         makeRule('when(findings.conflicts.count > 0)', 'ABORT'),
         makeRule('approved', 'COMPLETE'),
+      ],
+    })],
+  };
+}
+
+function loopingWorkflowConfig(cwd: string): WorkflowConfig {
+  const config = workflowConfig(cwd);
+  return {
+    ...config,
+    initialStep: 'reviewers',
+    maxSteps: 10,
+    loopMonitors: [{
+      cycle: ['reviewers', 'finding-conflict-adjudication'],
+      threshold: 1,
+      judge: {
+        persona: 'supervisor',
+        rules: [makeRule('when(true)', 'ABORT')],
+      },
+    }],
+    steps: [makeStep({
+      name: 'reviewers',
+      persona: 'coding-reviewer',
+      instruction: 'Review the code.',
+      rules: [
+        // The fixture already contains one active unresolved conflict; keep
+        // returning to adjudication so the loop monitor owns the finite exit.
+        makeRule('approved', 'finding-conflict-adjudication'),
       ],
     })],
   };
@@ -164,10 +197,19 @@ async function seedLedger(cwd: string): Promise<FindingLedgerStore> {
     lifecycleReservations: [],
     lifecycleEvents: [],
   });
+  const landed = landUnownedConflictRawClaims({ ledger: authorized, observation: OBSERVATION });
+  const reviewScopeSnapshot = captureReviewScopeProofSnapshot(cwd);
   const ledger = refreshActiveConflictAdjudicationSnapshots({
-    ledger: landUnownedConflictRawClaims({ ledger: authorized, observation: OBSERVATION }),
+    ledger: landed,
     originStep: 'reviewers',
     createdAt: OBSERVATION,
+    targetContentDigestsByConflict: new Map([[
+      'C-FA2947446963',
+      captureConflictTargetContentDigests(
+        reviewScopeSnapshot,
+        conflictTargetPaths({ ledger: landed, conflictId: 'C-FA2947446963' }),
+      ),
+    ]]),
   });
   const store = createLedgerStore(cwd);
   await store.updateLedger(() => ({ ledger, result: undefined }));
@@ -240,6 +282,50 @@ describe('finding-conflict-adjudication engine registry contract', () => {
       }),
     ]));
     expect(ledger.conflictClaimSettlements).toEqual([]);
+  });
+
+  it('stops an unchanged unresolved conflict loop through the loop monitor', async () => {
+    const store = await seedLedger(cwd);
+    vi.mocked(runStatusJudgmentPhase).mockResolvedValue({ label: 'approved', method: 'auto_select' });
+    vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
+      options?.onPromptResolved?.({ systemPrompt: 'system', userInstruction: instruction });
+      return isAdjudicationSchema(options?.outputSchema)
+        ? {
+            persona,
+            status: 'done',
+            content: '{}',
+            structuredOutput: {
+              proposal: {
+                kind: 'undetermined',
+                subjectIds: freshConflictAdjudicationSnapshot(
+                  store.loadLedger(),
+                  'C-FA2947446963',
+                ).subjects.map(({ subjectId }) => subjectId).sort(),
+                rationale: 'No verified terminal authority is available.',
+              },
+            },
+            timestamp: new Date('2026-06-13T02:00:00.000Z'),
+          }
+        : {
+            persona,
+            status: 'done',
+            content: 'approved',
+            timestamp: new Date('2026-06-13T00:00:01.000Z'),
+          };
+    });
+    const cycleDetected = vi.fn();
+    const engine = new WorkflowEngine(loopingWorkflowConfig(cwd), cwd, 'task', {
+      projectCwd: cwd,
+      provider: 'claude',
+      reportDirName: 'test-report-dir',
+    });
+    engine.on('step:cycle_detected', cycleDetected);
+
+    const result = await engine.run();
+
+    expect(result.status).toBe('aborted');
+    expect(cycleDetected).toHaveBeenCalledOnce();
+    expect(vi.mocked(runAgent).mock.calls.some(([persona]) => persona === 'supervisor')).toBe(true);
   });
 
   it('records legacy-shaped provider output as a diagnostic attempt without recreating adjudications', async () => {

--- a/src/__tests__/finding-conflict-adjudication-engine.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-engine.integration.test.ts
@@ -92,8 +92,8 @@ function workflowConfig(cwd: string): WorkflowConfig {
           'finding-conflict-adjudication',
         ),
         makeRule(
-          'when(findings.conflicts.count > 0 && findings.rounds.budgetExhausted == false)',
-          'reviewers',
+          'when(findings.conflicts.count > 0 && findings.conflicts.unadjudicated.count == 0 && findings.rounds.budgetExhausted == false)',
+          'ABORT',
         ),
         makeRule('when(findings.conflicts.count > 0)', 'ABORT'),
         makeRule('approved', 'COMPLETE'),

--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -24,6 +24,11 @@ import { initializeGitFixture } from './helpers/git-fixture.js';
 import { authorizeFindingLedgerFixture } from './helpers/finding-lifecycle-fixture.js';
 import { verifiedFindingEvidenceFixture } from './helpers/finding-evidence.js';
 import { MANAGER_INTERPRETATION_LIMITS } from '../core/workflow/findings/raw-finding-limits.js';
+import {
+  captureConflictTargetContentDigests,
+  captureReviewScopeProofSnapshot,
+} from '../core/workflow/findings/snapshot.js';
+import { conflictTargetPaths } from '../core/workflow/findings/conflict-target.js';
 
 vi.mock('../agents/agent-usecases.js', () => ({ executeAgent: vi.fn() }));
 const executeAgentMock = vi.mocked(executeAgent);
@@ -129,10 +134,19 @@ function seededLedger(cwd: string): FindingLedger {
     lifecycleReservations: [],
     lifecycleEvents: [],
   });
+  const landed = landUnownedConflictRawClaims({ ledger, observation: OBSERVATION });
+  const reviewScopeSnapshot = captureReviewScopeProofSnapshot(cwd);
   return refreshActiveConflictAdjudicationSnapshots({
-    ledger: landUnownedConflictRawClaims({ ledger, observation: OBSERVATION }),
+    ledger: landed,
     originStep: 'reviewers',
     createdAt: OBSERVATION,
+    targetContentDigestsByConflict: new Map([[
+      'C-FA2947446963',
+      captureConflictTargetContentDigests(
+        reviewScopeSnapshot,
+        conflictTargetPaths({ ledger: landed, conflictId: 'C-FA2947446963' }),
+      ),
+    ]]),
   });
 }
 
@@ -289,6 +303,45 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(2);
   });
 
+  it('re-adjudicates when a fix changes the conflict target code with the same ledger projection', async () => {
+    executeAgentMock.mockImplementation(async () => {
+      const snapshot = freshConflictAdjudicationSnapshot(
+        ledgerStore.loadLedger(),
+        'C-FA2947446963',
+      );
+      return {
+        persona: 'supervisor',
+        status: 'done' as const,
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'undetermined' as const,
+            subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+            rationale: 'The target needs another adjudication after the fix.',
+          },
+        },
+        timestamp: new Date(),
+      };
+    });
+
+    const first = runner();
+    await first.runner.run(first.step, state());
+    const original = freshConflictAdjudicationSnapshot(ledgerStore.loadLedger(), 'C-FA2947446963');
+    const before = ledgerStore.loadLedger();
+    writeFileSync(join(cwd, 'src', 'a.ts'), 'export const value = false;\n');
+    expect(ledgerStore.loadLedger().conflicts).toEqual(before.conflicts);
+
+    executeAgentMock.mockClear();
+    const second = runner();
+    await second.runner.run(second.step, state());
+
+    const changed = freshConflictAdjudicationSnapshot(ledgerStore.loadLedger(), 'C-FA2947446963');
+    expect(changed.conflictSnapshotId).not.toBe(original.conflictSnapshotId);
+    expect(changed.targetContentDigests).not.toEqual(original.targetContentDigests);
+    expect(executeAgentMock).toHaveBeenCalledTimes(2);
+    expect(ledgerStore.loadLedger().conflictAdjudicationSnapshots).toHaveLength(2);
+  });
+
   it('re-adjudicates only after the conflict subject snapshot changes', async () => {
     executeAgentMock.mockImplementation(async () => {
       const snapshot = freshConflictAdjudicationSnapshot(
@@ -398,8 +451,9 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       .toBeLessThanOrEqual(MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall);
     expect(instruction).toContain('"snapshotFormat": "reference-v1"');
     expect(instruction).toContain('sourceRawFindingCount');
-    expect(instruction).not.toContain('sourceRawFindingIds');
-    expect(instruction).not.toContain('evidenceBindingIds');
+    expect(instruction).toContain('sourceRawFindingIds');
+    expect(instruction).toContain('0-raw-4093');
+    expect(instruction).toContain('evidenceBindingIds');
   });
 
   it('re-adjudicates once with digest-bound target windows and applies a verified result', async () => {
@@ -822,7 +876,7 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(executeAgentMock).toHaveBeenCalledOnce();
   });
 
-  it('rejects changed conflict guidance without dispatching or replacing the real reservation', async () => {
+  it('releases a reserved call when its request digest changes and rebuilds the reservation', async () => {
     const crashingStore = crashAfterAdjudicationReservation({
       store: ledgerStore,
       purpose: 'conflict_adjudication',
@@ -834,14 +888,32 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     const reserved = ledgerStore.loadLedger().findingManagerProviderCalls[0]!;
     ledgerStore = reopenStore();
     const changedTarget = runner('Changed guidance.', ledgerStore);
+    executeAgentMock.mockImplementation(async () => {
+      const snapshot = freshConflictAdjudicationSnapshot(ledgerStore.loadLedger(), 'C-FA2947446963');
+      return {
+        persona: 'supervisor',
+        status: 'done' as const,
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'undetermined' as const,
+            subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+            rationale: 'No authority.',
+          },
+        },
+        timestamp: new Date(),
+      };
+    });
 
-    await expect(changedTarget.runner.run(changedTarget.step, state()))
-      .rejects.toThrow(/request changed/i);
-    expect(executeAgentMock).not.toHaveBeenCalled();
+    await changedTarget.runner.run(changedTarget.step, state());
+    expect(executeAgentMock).toHaveBeenCalledOnce();
     expect(ledgerStore.loadLedger().findingManagerProviderCalls[0]).toMatchObject({
       providerCallId: reserved.providerCallId,
-      state: 'reserved',
+      state: 'released',
     });
+    expect(ledgerStore.loadLedger().findingManagerProviderCalls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ state: 'settled', purpose: 'conflict_adjudication' }),
+    ]));
   });
 
   it('rejects additional conflict wire fields even when guidance requests them', async () => {

--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -7,12 +7,17 @@ import { createEngineProofRecord } from '../core/models/finding-evidence-record.
 import type { WorkflowState } from '../core/models/types.js';
 import { createFindingConflictAdjudicationRunner } from '../core/workflow/findings/adjudication-runner.js';
 import { buildFindingConflictAdjudicationStep } from '../core/workflow/findings/adjudication-step.js';
-import { renderConflictAdjudicationInstruction } from '../core/workflow/findings/adjudication-evidence.js';
+import {
+  renderConflictAdjudicationInstruction,
+  type ConflictAdjudicationHistoryOrder,
+} from '../core/workflow/findings/adjudication-evidence.js';
 import { landUnownedConflictRawClaims } from '../core/workflow/findings/conflict-claim-landing.js';
 import { applyFindingLifecycleCommands } from '../core/workflow/findings/lifecycle-transaction.js';
 import {
   buildConflictAdjudicationSnapshot,
   freshConflictAdjudicationSnapshot,
+  hasAlwaysChangingConflictTarget,
+  isActiveConflictUnadjudicated,
   refreshActiveConflictAdjudicationSnapshots,
 } from '../core/workflow/findings/conflict-adjudication-model.js';
 import { reserveFindingConflictAdjudication } from '../core/workflow/findings/adjudication-reservation.js';
@@ -429,6 +434,37 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(4);
   });
 
+  it('re-adjudicates a non-regular target even when its content digest is unavailable', async () => {
+    rmSync(join(cwd, 'src', 'a.ts'));
+    writeFileSync(join(cwd, 'src', 'target.ts'), 'export const value = true;\n');
+    symlinkSync('target.ts', join(cwd, 'src', 'a.ts'));
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: { invalid: true },
+      timestamp: new Date(),
+    });
+
+    const first = runner();
+    await first.runner.run(first.step, state());
+    const firstSnapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    expect(firstSnapshot.targetContentDigests).toEqual([
+      expect.objectContaining({ kind: 'symlink', contentDigest: null }),
+    ]);
+    expect(hasAlwaysChangingConflictTarget(firstSnapshot)).toBe(true);
+    expect(isActiveConflictUnadjudicated(ledgerStore.loadLedger(), 'C-FA2947446963')).toBe(true);
+
+    const second = runner();
+    await second.runner.run(second.step, state());
+
+    expect(executeAgentMock).toHaveBeenCalledTimes(2);
+    expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(2);
+  });
+
   it('keeps the adjudication wire bounded when durable snapshot collections grow', async () => {
     const snapshot = freshConflictAdjudicationSnapshot(
       ledgerStore.loadLedger(),
@@ -445,14 +481,34 @@ describe('finding-conflict-adjudication runner registry contract', () => {
         : [],
     }));
 
-    const instruction = renderConflictAdjudicationInstruction(inflated);
+    const observedAt = {
+      runId: 'history-test',
+      stepName: 'reviewers',
+      timestamp: '2026-08-08T00:00:00.000Z',
+    };
+    const history = Object.fromEntries([
+      'sourceRawFindingIds',
+      'sourceRawPayloadDigests',
+      'evidenceBindingIds',
+      'rawClaimLandingIds',
+      'priorSettlementIds',
+    ].map((key) => [
+      key,
+      new Map(inflated.subjects.flatMap((subject) => [
+        ...subject.sourceRawFindingIds,
+        ...subject.sourceRawPayloadDigests,
+        ...subject.evidenceBindingIds,
+        ...subject.rawClaimLandingIds,
+      ].map((value) => [value, observedAt] as const))),
+    ])) as ConflictAdjudicationHistoryOrder;
+    const instruction = renderConflictAdjudicationInstruction(inflated, history);
 
     expect(Buffer.byteLength(instruction, 'utf8'))
       .toBeLessThanOrEqual(MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall);
     expect(instruction).toContain('"snapshotFormat": "reference-v1"');
     expect(instruction).toContain('sourceRawFindingCount');
     expect(instruction).toContain('sourceRawFindingIds');
-    expect(instruction).toContain('0-raw-4093');
+    expect(instruction).toContain('0-raw-999');
     expect(instruction).toContain('evidenceBindingIds');
   });
 
@@ -876,6 +932,72 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(executeAgentMock).toHaveBeenCalledOnce();
   });
 
+  it('rebuilds a released second attempt without consuming its ordinal', async () => {
+    const snapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    const undetermined = {
+      persona: 'supervisor' as const,
+      status: 'done' as const,
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'undetermined' as const,
+          subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+          rationale: 'No authority.',
+        },
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    };
+    executeAgentMock.mockResolvedValueOnce(undetermined);
+    let crashed = false;
+    const crashingStore = new Proxy(ledgerStore, {
+      get(target, property, receiver) {
+        if (property !== 'updateLedger') {
+          const value = Reflect.get(target, property, receiver) as unknown;
+          return typeof value === 'function' ? value.bind(target) : value;
+        }
+        return async (...args: Parameters<FindingLedgerStore['updateLedger']>) => {
+          const mutation = await target.updateLedger(...args);
+          const groundedReservation = mutation.ledger.conflictAdjudicationAttempts.some((attempt) => (
+            attempt.stage === 'started' && attempt.attemptOrdinal === 2
+          ));
+          if (!crashed && groundedReservation) {
+            crashed = true;
+            throw new Error('simulated crash after second conflict WAL reservation');
+          }
+          return mutation;
+        };
+      },
+    });
+    const crashingTarget = runner('Original guidance.', crashingStore);
+    await expect(crashingTarget.runner.run(crashingTarget.step, state()))
+      .rejects.toThrow('simulated crash after second conflict WAL reservation');
+
+    ledgerStore = reopenStore();
+    executeAgentMock.mockClear();
+    executeAgentMock.mockResolvedValue(undetermined);
+    const resumedTarget = runner('Changed guidance.', ledgerStore);
+    await resumedTarget.runner.run(resumedTarget.step, state());
+
+    const ledger = ledgerStore.loadLedger();
+    expect(ledger.conflictAdjudicationAttempts).toHaveLength(2);
+    expect(ledger.conflictAdjudicationAttempts.map(({ attemptOrdinal }) => attemptOrdinal))
+      .toEqual([1, 2]);
+    expect(ledger.conflictAdjudicationAttempts).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({
+        stage: 'interrupted',
+        reason: 'reservation_released',
+      })]),
+    );
+    expect(ledger.findingManagerProviderCalls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ state: 'released' }),
+      expect.objectContaining({ state: 'settled' }),
+    ]));
+    expect(executeAgentMock).toHaveBeenCalledOnce();
+  });
+
   it('releases a reserved call when its request digest changes and rebuilds the reservation', async () => {
     const crashingStore = crashAfterAdjudicationReservation({
       store: ledgerStore,
@@ -906,7 +1028,7 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     });
 
     await changedTarget.runner.run(changedTarget.step, state());
-    expect(executeAgentMock).toHaveBeenCalledOnce();
+    expect(executeAgentMock).toHaveBeenCalledTimes(2);
     expect(ledgerStore.loadLedger().findingManagerProviderCalls[0]).toMatchObject({
       providerCallId: reserved.providerCallId,
       state: 'released',

--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -141,6 +141,9 @@ function seededLedger(cwd: string): FindingLedger {
   });
   const landed = landUnownedConflictRawClaims({ ledger, observation: OBSERVATION });
   const reviewScopeSnapshot = captureReviewScopeProofSnapshot(cwd);
+  const queryInventoryByPath = new Map(
+    reviewScopeSnapshot.queryInventory.map((entry) => [entry.path, entry]),
+  );
   return refreshActiveConflictAdjudicationSnapshots({
     ledger: landed,
     originStep: 'reviewers',
@@ -148,7 +151,7 @@ function seededLedger(cwd: string): FindingLedger {
     targetContentDigestsByConflict: new Map([[
       'C-FA2947446963',
       captureConflictTargetContentDigests(
-        reviewScopeSnapshot,
+        queryInventoryByPath,
         conflictTargetPaths({ ledger: landed, conflictId: 'C-FA2947446963' }),
       ),
     ]]),
@@ -486,21 +489,22 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       stepName: 'reviewers',
       timestamp: '2026-08-08T00:00:00.000Z',
     };
-    const history = Object.fromEntries([
-      'sourceRawFindingIds',
-      'sourceRawPayloadDigests',
-      'evidenceBindingIds',
-      'rawClaimLandingIds',
-      'priorSettlementIds',
-    ].map((key) => [
-      key,
-      new Map(inflated.subjects.flatMap((subject) => [
-        ...subject.sourceRawFindingIds,
-        ...subject.sourceRawPayloadDigests,
-        ...subject.evidenceBindingIds,
-        ...subject.rawClaimLandingIds,
-      ].map((value) => [value, observedAt] as const))),
-    ])) as ConflictAdjudicationHistoryOrder;
+    const historyValues = {
+      sourceRawFindingIds: inflated.subjects.flatMap(({ sourceRawFindingIds }) => sourceRawFindingIds),
+      sourceRawPayloadDigests: inflated.subjects.flatMap(({ sourceRawPayloadDigests }) => sourceRawPayloadDigests),
+      evidenceBindingIds: inflated.subjects.flatMap(({ evidenceBindingIds }) => evidenceBindingIds),
+      rawClaimLandingIds: [
+        ...inflated.rawClaimLandingIds,
+        ...inflated.subjects.flatMap(({ rawClaimLandingIds }) => rawClaimLandingIds),
+      ],
+      priorSettlementIds: inflated.priorSettlementIds,
+    } as const;
+    const history = Object.fromEntries(
+      Object.entries(historyValues).map(([key, values]) => [
+        key,
+        new Map(values.map((value) => [value, observedAt] as const)),
+      ]),
+    ) as ConflictAdjudicationHistoryOrder;
     const instruction = renderConflictAdjudicationInstruction(inflated, history);
 
     expect(Buffer.byteLength(instruction, 'utf8'))
@@ -508,6 +512,8 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(instruction).toContain('"snapshotFormat": "reference-v1"');
     expect(instruction).toContain('sourceRawFindingCount');
     expect(instruction).toContain('sourceRawFindingIds');
+    expect(instruction).toContain('sourceRawPayloadCount');
+    expect(instruction).toContain('sourceRawPayloadIds');
     expect(instruction).toContain('0-raw-999');
     expect(instruction).toContain('evidenceBindingIds');
   });

--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -7,7 +7,9 @@ import { createEngineProofRecord } from '../core/models/finding-evidence-record.
 import type { WorkflowState } from '../core/models/types.js';
 import { createFindingConflictAdjudicationRunner } from '../core/workflow/findings/adjudication-runner.js';
 import { buildFindingConflictAdjudicationStep } from '../core/workflow/findings/adjudication-step.js';
+import { renderConflictAdjudicationInstruction } from '../core/workflow/findings/adjudication-evidence.js';
 import { landUnownedConflictRawClaims } from '../core/workflow/findings/conflict-claim-landing.js';
+import { applyFindingLifecycleCommands } from '../core/workflow/findings/lifecycle-transaction.js';
 import {
   buildConflictAdjudicationSnapshot,
   freshConflictAdjudicationSnapshot,
@@ -21,6 +23,7 @@ import { createTestFindingLedgerStore } from './helpers/finding-storage.js';
 import { initializeGitFixture } from './helpers/git-fixture.js';
 import { authorizeFindingLedgerFixture } from './helpers/finding-lifecycle-fixture.js';
 import { verifiedFindingEvidenceFixture } from './helpers/finding-evidence.js';
+import { MANAGER_INTERPRETATION_LIMITS } from '../core/workflow/findings/raw-finding-limits.js';
 
 vi.mock('../agents/agent-usecases.js', () => ({ executeAgent: vi.fn() }));
 const executeAgentMock = vi.mocked(executeAgent);
@@ -250,7 +253,153 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(ledger.findingManagerProviderCalls).toEqual(expect.arrayContaining([
       expect.objectContaining({ state: 'settled', purpose: 'conflict_adjudication' }),
     ]));
+    expect(ledger.findingManagerProviderCalls.every((call) => (
+      call.requestByteLength <= MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall
+    ))).toBe(true);
     expect(executeAgentMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-adjudicate an unchanged conflict snapshot', async () => {
+    const snapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'undetermined',
+          subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+          rationale: 'No verified terminal authority is available.',
+        },
+      },
+      timestamp: new Date(),
+    });
+
+    const first = runner();
+    await first.runner.run(first.step, state());
+    executeAgentMock.mockClear();
+
+    const second = runner();
+    await second.runner.run(second.step, state());
+
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(2);
+  });
+
+  it('re-adjudicates only after the conflict subject snapshot changes', async () => {
+    executeAgentMock.mockImplementation(async () => {
+      const snapshot = freshConflictAdjudicationSnapshot(
+        ledgerStore.loadLedger(),
+        'C-FA2947446963',
+      );
+      return {
+        persona: 'supervisor',
+        status: 'done' as const,
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'undetermined' as const,
+            subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+            rationale: 'No verified terminal authority is available.',
+          },
+        },
+        timestamp: new Date(),
+      };
+    });
+
+    const first = runner();
+    await first.runner.run(first.step, state());
+    const originalSnapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    await ledgerStore.updateLedger((current) => {
+      const holding = current.findings.find((finding) => finding.provisional !== undefined);
+      if (holding?.provisional === undefined) {
+        throw new Error('Expected a conflict holding in the changed-snapshot fixture');
+      }
+      const { revision: _revision, ...holdingWithoutRevision } = holding;
+      void _revision;
+      const changed = applyFindingLifecycleCommands({
+        ledger: current,
+        commands: [{
+          operation: 'update_provisional',
+          changes: {
+            findings: [{
+              ...holdingWithoutRevision,
+              provisional: {
+                ...holding.provisional,
+                lastObservedAt: {
+                  ...OBSERVATION,
+                  timestamp: '2026-06-13T00:01:00.000Z',
+                },
+              },
+            }],
+            conflicts: [],
+          },
+          authority: { kind: 'verified_evidence' },
+          evidenceSourcesByTarget: new Map([[
+            `finding\0${holding.id}`,
+            { sourceRawFindingIds: holding.provisional.sourceRawFindingIds, authorityEvidenceIds: [] },
+          ]]),
+        }],
+        occurredAt: {
+          ...OBSERVATION,
+          timestamp: '2026-06-13T00:01:00.000Z',
+        },
+      });
+      return {
+        ledger: refreshActiveConflictAdjudicationSnapshots({
+          ledger: changed,
+          originStep: 'reviewers',
+          createdAt: OBSERVATION,
+        }),
+        result: undefined,
+      };
+    });
+    const changedSnapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    expect(changedSnapshot.conflictSnapshotId).not.toBe(originalSnapshot.conflictSnapshotId);
+
+    executeAgentMock.mockClear();
+    const second = runner();
+    await second.runner.run(second.step, state());
+
+    expect(executeAgentMock).toHaveBeenCalledTimes(2);
+    expect(ledgerStore.loadLedger().conflictAdjudicationSnapshots).toHaveLength(2);
+    expect(ledgerStore.loadLedger().conflictAdjudicationEpisodes).toHaveLength(2);
+    expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(4);
+  });
+
+  it('keeps the adjudication wire bounded when durable snapshot collections grow', async () => {
+    const snapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    const inflated = structuredClone(snapshot);
+    inflated.subjects = inflated.subjects.map((subject, subjectIndex) => ({
+      ...subject,
+      sourceRawFindingIds: Array.from({ length: 4096 }, (_, index) => `${subjectIndex}-raw-${index}`),
+      sourceRawPayloadDigests: Array.from({ length: 4096 }, (_, index) => `${subjectIndex}-payload-${index}`),
+      evidenceBindingIds: Array.from({ length: 4096 }, (_, index) => `${subjectIndex}-binding-${index}`),
+      rawClaimLandingIds: subject.role === 'holding_provisional'
+        ? Array.from({ length: 4096 }, (_, index) => `${subjectIndex}-landing-${index}`)
+        : [],
+    }));
+
+    const instruction = renderConflictAdjudicationInstruction(inflated);
+
+    expect(Buffer.byteLength(instruction, 'utf8'))
+      .toBeLessThanOrEqual(MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall);
+    expect(instruction).toContain('"snapshotFormat": "reference-v1"');
+    expect(instruction).toContain('sourceRawFindingCount');
+    expect(instruction).not.toContain('sourceRawFindingIds');
+    expect(instruction).not.toContain('evidenceBindingIds');
   });
 
   it('re-adjudicates once with digest-bound target windows and applies a verified result', async () => {

--- a/src/__tests__/finding-conflict-adjudication.test.ts
+++ b/src/__tests__/finding-conflict-adjudication.test.ts
@@ -16,6 +16,9 @@ import {
   hasSubstantiveVerifiedSettlementWitness,
   isConflictResolved,
 } from '../core/workflow/findings/conflict-adjudication-model.js';
+import {
+  buildConflictAdjudicationSnapshotReference,
+} from '../core/workflow/findings/adjudication-evidence.js';
 import { resolveConflictAdjudicationPlan } from '../core/workflow/findings/conflict-adjudication-verifier.js';
 
 const OBSERVATION = {
@@ -144,6 +147,72 @@ describe('finding lifecycle continuity', () => {
 });
 
 describe('verified conflict adjudication', () => {
+  it('selects the recent reference window by observation order and keeps set digests deterministic', () => {
+    const claim = {
+      ...subject('F-0001', head('finding', 'F-0001', 1)),
+      sourceRawFindingIds: ['raw-a', 'raw-b', 'raw-c', 'raw-d'],
+      sourceRawPayloadDigests: ['payload-a', 'payload-b', 'payload-c', 'payload-d'],
+      evidenceBindingIds: ['binding-a', 'binding-b', 'binding-c', 'binding-d'],
+      rawClaimLandingIds: ['landing-a', 'landing-b', 'landing-c', 'landing-d'],
+      role: 'holding_provisional' as const,
+    };
+    const current = snapshot([claim]);
+    current.rawClaimLandingIds = ['landing-a', 'landing-b', 'landing-c', 'landing-d'];
+    current.priorSettlementIds = ['settlement-a', 'settlement-b', 'settlement-c', 'settlement-d'];
+    const observation = (timestamp: string) => ({
+      runId: 'run-history',
+      stepName: 'reviewers',
+      timestamp,
+    });
+    const history = {
+      sourceRawFindingIds: new Map([
+        ['raw-a', observation('2026-08-04T00:00:04.000Z')],
+        ['raw-b', observation('2026-08-04T00:00:01.000Z')],
+        ['raw-c', observation('2026-08-04T00:00:03.000Z')],
+        ['raw-d', observation('2026-08-04T00:00:02.000Z')],
+      ]),
+      sourceRawPayloadDigests: new Map([
+        ['payload-a', observation('2026-08-04T00:00:04.000Z')],
+        ['payload-b', observation('2026-08-04T00:00:01.000Z')],
+        ['payload-c', observation('2026-08-04T00:00:03.000Z')],
+        ['payload-d', observation('2026-08-04T00:00:02.000Z')],
+      ]),
+      evidenceBindingIds: new Map([
+        ['binding-a', observation('2026-08-04T00:00:04.000Z')],
+        ['binding-b', observation('2026-08-04T00:00:01.000Z')],
+        ['binding-c', observation('2026-08-04T00:00:03.000Z')],
+        ['binding-d', observation('2026-08-04T00:00:02.000Z')],
+      ]),
+      rawClaimLandingIds: new Map([
+        ['landing-a', observation('2026-08-04T00:00:04.000Z')],
+        ['landing-b', observation('2026-08-04T00:00:01.000Z')],
+        ['landing-c', observation('2026-08-04T00:00:03.000Z')],
+        ['landing-d', observation('2026-08-04T00:00:02.000Z')],
+      ]),
+      priorSettlementIds: new Map([
+        ['settlement-a', observation('2026-08-04T00:00:04.000Z')],
+        ['settlement-b', observation('2026-08-04T00:00:01.000Z')],
+        ['settlement-c', observation('2026-08-04T00:00:03.000Z')],
+        ['settlement-d', observation('2026-08-04T00:00:02.000Z')],
+      ]),
+    };
+
+    const reference = buildConflictAdjudicationSnapshotReference(current, history);
+
+    expect(reference.rawClaimLandingIds).toEqual(['landing-d', 'landing-c', 'landing-a']);
+    expect(reference.priorSettlementIds).toEqual(['settlement-d', 'settlement-c', 'settlement-a']);
+    expect(reference.subjects[0]?.sourceRawFindingIds)
+      .toEqual(['raw-d', 'raw-c', 'raw-a']);
+    expect(reference.subjects[0]?.evidenceBindingIds)
+      .toEqual(['binding-d', 'binding-c', 'binding-a']);
+    expect(reference.rawClaimLandingDigest).toBe(
+      buildConflictAdjudicationSnapshotReference(current, {
+        ...history,
+        rawClaimLandingIds: new Map([...history.rawClaimLandingIds].reverse()),
+      }).rawClaimLandingDigest,
+    );
+  });
+
   it('issues branded terminate authority only for an exactly bound engine proof', () => {
     const findingHead = head('finding', 'F-0001', 1);
     const conflictHead = head('conflict', 'C-0001', 1);

--- a/src/__tests__/finding-conflict-adjudication.test.ts
+++ b/src/__tests__/finding-conflict-adjudication.test.ts
@@ -205,11 +205,27 @@ describe('verified conflict adjudication', () => {
       .toEqual(['raw-d', 'raw-c', 'raw-a']);
     expect(reference.subjects[0]?.evidenceBindingIds)
       .toEqual(['binding-d', 'binding-c', 'binding-a']);
+    const reordered = {
+      ...current,
+      rawClaimLandingIds: [...current.rawClaimLandingIds].reverse(),
+      priorSettlementIds: [...current.priorSettlementIds].reverse(),
+      subjects: current.subjects.map((subject) => ({
+        ...subject,
+        sourceRawFindingIds: [...subject.sourceRawFindingIds].reverse(),
+        sourceRawPayloadDigests: [...subject.sourceRawPayloadDigests].reverse(),
+        evidenceBindingIds: [...subject.evidenceBindingIds].reverse(),
+        rawClaimLandingIds: [...subject.rawClaimLandingIds].reverse(),
+      })),
+    };
     expect(reference.rawClaimLandingDigest).toBe(
-      buildConflictAdjudicationSnapshotReference(current, {
-        ...history,
-        rawClaimLandingIds: new Map([...history.rawClaimLandingIds].reverse()),
-      }).rawClaimLandingDigest,
+      buildConflictAdjudicationSnapshotReference(reordered, history).rawClaimLandingDigest,
+    );
+    expect(reference.subjects[0]?.sourceRawPayloadDigest).toBe(
+      buildConflictAdjudicationSnapshotReference(reordered, history)
+        .subjects[0]?.sourceRawPayloadDigest,
+    );
+    expect(reference.subjects[0]?.sourceRawPayloadIds).toEqual(
+      ['payload-d', 'payload-c', 'payload-a'],
     );
   });
 

--- a/src/__tests__/finding-ledger-routing-builtins.test.ts
+++ b/src/__tests__/finding-ledger-routing-builtins.test.ts
@@ -221,19 +221,19 @@ describe('builtin Finding ledger routing', () => {
   });
 
   it.each(['en', 'ja'] as const)('%s reviewer集約はconflict/provisionalの先行ルールを維持する', (language) => {
-    for (const raw of [
-      sharedReviewers(language),
-      localReviewers(language, 'reviewers'),
-      localReviewers(language, 'boundary-reviewers'),
-    ]) {
+    for (const [raw, expectedConflictTarget] of [
+      [sharedReviewers(language), 'fix'],
+      [localReviewers(language, 'reviewers'), 'integrity-gate'],
+      [localReviewers(language, 'boundary-reviewers'), 'final-gate'],
+    ] as const) {
       const step = toWorkflowStep(raw);
       expect(transition(step, { open: 1, conflicts: 1, unadjudicated: 1 }, 1))
         .toBe('finding-conflict-adjudication');
-      // adjudication に着地済みの conflict は self-loop に戻さず、各 workflow の
-      // downstream gate/fix へ進める。local/boundary は fix step を持たないため、
-      // ここで workflow 自身へ戻らないことが予算・loop monitor の有限性を保証する。
+      // 接地を含む裁定後も未確定な conflict は reviewers では解消できないため、
+      // fix または subworkflow の downstream gate へ進める。同一 snapshot は
+      // unadjudicated ではないので、ここで再裁定しないことも同時に保証する。
       const resolvedConflictTarget = transition(step, { open: 1, conflicts: 1 }, 1);
-      expect(resolvedConflictTarget).not.toBe(step.name);
+      expect(resolvedConflictTarget).toBe(expectedConflictTarget);
       expect(resolvedConflictTarget).not.toBe('finding-conflict-adjudication');
       expect(transition(step, { open: 1, conflicts: 1, roundBudgetExhausted: true }, 1))
         .toBe('ABORT');

--- a/src/__tests__/finding-plan-normalization.test.ts
+++ b/src/__tests__/finding-plan-normalization.test.ts
@@ -681,7 +681,7 @@ describe('reconcileCommitPlan の conflict registry 契約', () => {
       resolutionRenotifications: [],
       unsupportedRawFindingReports: [],
       healthyReviewerStableKeys: new Set(),
-    })).toThrow('must have exactly one fresh adjudication snapshot');
+    })).toThrow('must have the latest fresh adjudication snapshot');
   });
 });
 

--- a/src/__tests__/fixtures/takt-default-fc-compatibility-baseline.json
+++ b/src/__tests__/fixtures/takt-default-fc-compatibility-baseline.json
@@ -10,8 +10,8 @@
   },
   "adjudicatorPrompts": {
     "conflict": {
-      "bytes": 2774,
-      "sha256": "1988df324b72fb7f161a12c4cb58b42d2d638bb30cdca178ab1b9e765c15d37c"
+      "bytes": 3139,
+      "sha256": "8bbc2a6c8b9a96143117520ebc50357a23c7244820e83a212913c0793e97dd65"
     }
   },
   "managerPrompts": {

--- a/src/__tests__/fixtures/takt-default-fc-compatibility-baseline.json
+++ b/src/__tests__/fixtures/takt-default-fc-compatibility-baseline.json
@@ -10,8 +10,8 @@
   },
   "adjudicatorPrompts": {
     "conflict": {
-      "bytes": 3139,
-      "sha256": "8bbc2a6c8b9a96143117520ebc50357a23c7244820e83a212913c0793e97dd65"
+      "bytes": 3598,
+      "sha256": "c81afe67a46b3bbddd68d597266efd067c45fc45903fc4674fdceb1e60383f77"
     }
   },
   "managerPrompts": {

--- a/src/__tests__/fixtures/takt-default-fc-compatibility-baseline.json
+++ b/src/__tests__/fixtures/takt-default-fc-compatibility-baseline.json
@@ -10,8 +10,8 @@
   },
   "adjudicatorPrompts": {
     "conflict": {
-      "bytes": 3598,
-      "sha256": "c81afe67a46b3bbddd68d597266efd067c45fc45903fc4674fdceb1e60383f77"
+      "bytes": 3628,
+      "sha256": "cdbf29dda5ae7cd29c00419697f2b6366458085b12ccedbf7185fe485e558a0c"
     }
   },
   "managerPrompts": {

--- a/src/__tests__/releaseVerificationWiring.test.ts
+++ b/src/__tests__/releaseVerificationWiring.test.ts
@@ -260,9 +260,9 @@ describe('release verification wiring', () => {
       'npm run test:it',
     );
 
-    expect(heavyShardJob?.strategy?.matrix?.shard).toEqual([1, 2, 3, 4]);
+    expect(heavyShardJob?.strategy?.matrix?.shard).toEqual([1, 2, 3, 4, 5, 6]);
     expect(heavyShardJob?.steps?.map((step) => step.run).filter(Boolean)).toContain(
-      'npm run test:it:heavy:parallel -- --shard=${{ matrix.shard }}/4',
+      'npm run test:it:heavy:parallel -- --shard=${{ matrix.shard }}/6',
     );
 
     expect(heavySerialJob?.strategy?.matrix?.include).toEqual([

--- a/src/__tests__/takt-default-fc-builtins.test.ts
+++ b/src/__tests__/takt-default-fc-builtins.test.ts
@@ -1047,7 +1047,7 @@ describe('takt-default-fc builtins', () => {
           timestamp: new Date('2026-08-09T00:00:04.000Z'),
         };
       }
-      if ((JSON.stringify(outputSchema) ?? '').includes('terminate_subject')) {
+      if (persona === 'supervisor') {
         adjudicationCalls += 1;
         const adjudicationSnapshot = freshConflictAdjudicationSnapshot(
           store.loadLedger(),

--- a/src/__tests__/takt-default-fc-builtins.test.ts
+++ b/src/__tests__/takt-default-fc-builtins.test.ts
@@ -1,12 +1,20 @@
 import {
+  existsSync,
   mkdirSync,
+  mkdtempSync,
   readdirSync,
   readFileSync,
+  rmSync,
   writeFileSync,
 } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { runAgentMock } = vi.hoisted(() => ({ runAgentMock: vi.fn() }));
+vi.mock('../agents/runner.js', () => ({ runAgent: runAgentMock }));
+
 import { getAllParallelSubSteps } from '../core/models/index.js';
 import type {
   AgentResponse,
@@ -34,6 +42,21 @@ import { loadWorkflowFromFile } from '../infra/config/loaders/workflowFileLoader
 import { resolveRefToContent } from '../infra/config/loaders/resource-resolver.js';
 import { buildStepFragmentLookupDirs } from '../infra/config/loaders/stepFragmentLookupDirectories.js';
 import { resolveWorkflowStepFragments } from '../infra/config/loaders/workflowStepFragmentResolver.js';
+import { WorkflowEngine } from './helpers/workflow-engine.js';
+import { createTestFindingLedgerStore } from './helpers/finding-storage.js';
+import { initializeGitFixture } from './helpers/git-fixture.js';
+import { verifiedFindingEvidenceFixture } from './helpers/finding-evidence.js';
+import { authorizeFindingLedgerFixture } from './helpers/finding-lifecycle-fixture.js';
+import { landUnownedConflictRawClaims } from '../core/workflow/findings/conflict-claim-landing.js';
+import {
+  freshConflictAdjudicationSnapshot,
+  refreshActiveConflictAdjudicationSnapshots,
+} from '../core/workflow/findings/conflict-adjudication-model.js';
+import {
+  captureConflictTargetContentDigests,
+  captureReviewScopeProofSnapshot,
+} from '../core/workflow/findings/snapshot.js';
+import { conflictTargetPaths } from '../core/workflow/findings/conflict-target.js';
 
 type Language = 'en' | 'ja';
 
@@ -160,6 +183,179 @@ const EMPTY_FINDING_COUNTS: FindingCounts = {
 };
 
 let testRoot: string;
+let engineScenarioCwd: string | undefined;
+
+const ENGINE_SCENARIO_OBSERVATION = {
+  runId: 'builtin-fc-engine-scenario',
+  stepName: 'reviewers',
+  timestamp: '2026-08-09T00:00:00.000Z',
+};
+
+function createBuiltinEngineScenarioConfig(): WorkflowConfig {
+  const builtin = loadWorkflow('en', 'takt-default-high');
+  const reviewers = loadedStep(builtin, 'reviewers');
+  const fix = loadedStep(builtin, 'fix');
+  const reviewer = {
+    name: 'reviewers',
+    kind: 'agent' as const,
+    persona: 'reviewer',
+    personaDisplayName: 'reviewer',
+    instruction: 'Review the current implementation.',
+    passPreviousResponse: false,
+    rules: reviewers.rules?.filter((rule) => (
+      !containsAggregate(rule.condition)
+      && ['finding-conflict-adjudication', 'fix', 'ABORT'].includes(rule.next ?? '')
+    )),
+  };
+  return {
+    ...builtin,
+    name: 'builtin-fc-engine-scenario',
+    initialStep: 'reviewers',
+    maxSteps: 8,
+    loopMonitors: [],
+    findingContract: {
+      ...builtin.findingContract,
+      adjudicator: {
+        persona: 'supervisor',
+        instruction: 'adjudicate-finding-contract',
+      },
+    },
+    steps: [{
+      name: 'fix',
+      kind: 'agent' as const,
+      persona: 'coder',
+      personaDisplayName: 'coder',
+      instruction: 'Apply the fix.',
+      passPreviousResponse: false,
+      rules: fix.rules?.filter((rule) => rule.next === 'reviewers'),
+    }, reviewer],
+  };
+}
+
+async function seedBuiltinEngineScenarioLedger(cwd: string) {
+  const evidence = verifiedFindingEvidenceFixture({
+    cwd,
+    path: 'src/a.ts',
+    startLine: 1,
+    title: 'Disputed issue',
+    description: 'Reviewers disagree about the implementation.',
+    familyTag: 'bug',
+    targetFindingId: 'F-0001',
+  });
+  const authorized = authorizeFindingLedgerFixture({
+    workflowName: 'builtin-fc-engine-scenario',
+    nextId: 2,
+    updatedAt: ENGINE_SCENARIO_OBSERVATION.timestamp,
+    findings: [{
+      id: 'F-0001',
+      status: 'open',
+      lifecycle: 'new',
+      revision: 1,
+      severity: 'high',
+      title: 'Disputed issue',
+      description: 'Reviewers disagree about the implementation.',
+      evidenceIds: [evidence.record.evidenceId],
+      reviewers: ['reviewer'],
+      rawFindingIds: ['raw-1'],
+      firstSeen: ENGINE_SCENARIO_OBSERVATION,
+      lastSeen: ENGINE_SCENARIO_OBSERVATION,
+    }],
+    rawFindings: [{
+      rawFindingId: 'raw-1',
+      stepName: 'reviewers',
+      reviewer: 'reviewer',
+      familyTag: 'bug',
+      severity: 'high',
+      title: 'Disputed issue',
+      description: 'Reviewers disagree about the implementation.',
+      suggestion: null,
+      relation: 'persists',
+      targetFindingId: 'F-0001',
+      targetPrecondition: {
+        targetFindingId: 'F-0001',
+        targetRevision: 1,
+        targetStatus: 'open',
+        targetEvidenceHash: '0'.repeat(64),
+      },
+      evidence: [evidence.evidence],
+    }],
+    conflicts: [{
+      id: 'C-FA2947446963',
+      status: 'active',
+      findingIds: ['F-0001'],
+      rawFindingIds: ['raw-1'],
+      description: 'Reviewers disagree about the implementation.',
+      firstSeen: ENGINE_SCENARIO_OBSERVATION,
+      lastSeen: ENGINE_SCENARIO_OBSERVATION,
+      revision: 1,
+    }],
+    evidenceRecords: [evidence.record],
+    evidenceBindings: [],
+    lifecycleReservations: [],
+    lifecycleEvents: [],
+  });
+  const landed = landUnownedConflictRawClaims({
+    ledger: authorized,
+    observation: ENGINE_SCENARIO_OBSERVATION,
+  });
+  const snapshot = captureReviewScopeProofSnapshot(cwd);
+  const queryInventoryByPath = new Map(
+    snapshot.queryInventory.map((entry) => [entry.path, entry]),
+  );
+  const ledger = refreshActiveConflictAdjudicationSnapshots({
+    ledger: landed,
+    originStep: 'reviewers',
+    createdAt: ENGINE_SCENARIO_OBSERVATION,
+    targetContentDigestsByConflict: new Map([[
+      'C-FA2947446963',
+      captureConflictTargetContentDigests(
+        queryInventoryByPath,
+        conflictTargetPaths({ ledger: landed, conflictId: 'C-FA2947446963' }),
+      ),
+    ]]),
+  });
+  const store = createTestFindingLedgerStore({
+    projectCwd: cwd,
+    runId: 'test-report-dir',
+    reportDir: join(cwd, '.takt', 'runs', 'test-report-dir', 'reports'),
+    workflowName: 'builtin-fc-engine-scenario',
+  });
+  await store.updateLedger(() => ({ ledger, result: undefined }));
+  return store;
+}
+
+async function refreshBuiltinEngineScenarioSnapshot(
+  store: Awaited<ReturnType<typeof seedBuiltinEngineScenarioLedger>>,
+  cwd: string,
+): Promise<void> {
+  const snapshot = captureReviewScopeProofSnapshot(cwd);
+  const queryInventoryByPath = new Map(
+    snapshot.queryInventory.map((entry) => [entry.path, entry]),
+  );
+  await store.updateLedger((ledger) => ({
+    ledger: refreshActiveConflictAdjudicationSnapshots({
+      ledger,
+      originStep: 'reviewers',
+      createdAt: {
+        runId: 'builtin-fc-engine-scenario',
+        stepName: 'reviewers',
+        timestamp: new Date().toISOString(),
+      },
+      targetContentDigestsByConflict: new Map(
+        ledger.conflicts
+          .filter((conflict) => conflict.status === 'active')
+          .map((conflict) => [
+            conflict.id,
+            captureConflictTargetContentDigests(
+              queryInventoryByPath,
+              conflictTargetPaths({ ledger, conflictId: conflict.id }),
+            ),
+          ] as const),
+      ),
+    }),
+    result: undefined,
+  }));
+}
 
 function builtinPath(language: Language, ...parts: string[]): string {
   return join(process.cwd(), 'builtins', language, ...parts);
@@ -233,6 +429,17 @@ function conditionShape(condition: WorkflowRuleCondition): string {
       return `${condition.aggregate}(${condition.targetConditions.map(conditionShape).join(',')})`;
     case 'and':
       return `${conditionShape(condition.left)}&&${conditionShape(condition.right)}`;
+  }
+}
+
+function containsAggregate(condition: WorkflowRuleCondition): boolean {
+  switch (condition.kind) {
+    case 'aggregate':
+      return true;
+    case 'and':
+      return containsAggregate(condition.left) || containsAggregate(condition.right);
+    default:
+      return false;
   }
 }
 
@@ -486,6 +693,7 @@ function enumerateFindingCounts(): FindingCounts[] {
 }
 
 beforeEach(() => {
+  runAgentMock.mockReset();
   const configDir = process.env.TAKT_CONFIG_DIR;
   if (configDir === undefined) throw new Error('TAKT_CONFIG_DIR must be set by test-setup.ts');
   testRoot = dirname(configDir);
@@ -499,6 +707,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  if (engineScenarioCwd !== undefined && existsSync(engineScenarioCwd)) {
+    rmSync(engineScenarioCwd, { recursive: true, force: true });
+  }
+  engineScenarioCwd = undefined;
   invalidateGlobalConfigCache();
   invalidateAllResolvedConfigCache();
 });
@@ -783,34 +995,117 @@ describe('takt-default-fc builtins', () => {
     }
   });
 
-  it.each(LANGUAGES)('%s routes every adjudicated unresolved FC conflict to fix or its downstream gate', (language) => {
-    const targets = collectBuiltinFindingLadderSteps(language);
-    const expectedTargets = new Map([
-      ['finding-contract-boundary-review:boundary-reviewers', { nextStep: 'final-gate' }],
-      ['finding-contract-local-review:reviewers', { nextStep: 'integrity-gate' }],
-      ['merge-readiness-finding-contract-final-gate:merge-readiness-review', { returnValue: 'needs_fix' }],
-      ['merge-readiness-finding-contract-final-gate:supervise', { returnValue: 'needs_fix' }],
-      ['peer-review-suite-finding-contract-base:reviewers', { returnValue: 'needs_fix' }],
-      ['review-fix-takt-default-high:reviewers', { nextStep: 'fix' }],
-      ['takt-default-high:reviewers', { nextStep: 'fix' }],
-      ['takt-default-team-high:reviewers', { nextStep: 'fix' }],
-    ] as const);
+  it('executes the builtin FC conflict route through WorkflowEngine', async () => {
+    engineScenarioCwd = mkdtempSync(join(tmpdir(), 'takt-default-fc-engine-'));
+    mkdirSync(join(engineScenarioCwd, 'src'), { recursive: true });
+    writeFileSync(join(engineScenarioCwd, 'src', 'a.ts'), 'export const value = true;\n');
+    initializeGitFixture(engineScenarioCwd, ['src/a.ts']);
+    const store = await seedBuiltinEngineScenarioLedger(engineScenarioCwd);
+    let adjudicationCalls = 0;
+    let fixCalls = 0;
+    let codeChanges = 0;
+    let engine: WorkflowEngine;
+    runAgentMock.mockImplementation(async (...args: unknown[]) => {
+      const persona = typeof args[0] === 'string' ? args[0] : 'unknown';
+      const instruction = typeof args[1] === 'string' ? args[1] : '';
+      const options = args[2];
+      if (typeof options === 'object' && options !== null && 'onPromptResolved' in options
+        && typeof options.onPromptResolved === 'function') {
+        options.onPromptResolved({
+          systemPrompt: 'system',
+          userInstruction: typeof args[1] === 'string' ? args[1] : '',
+        });
+      }
+      const outputSchema = typeof options === 'object' && options !== null
+        && 'outputSchema' in options
+        ? options.outputSchema
+        : undefined;
+      const taskManifestMatch = /## Task manifest\s+```json\s+([\s\S]*?)\s+```/u.exec(instruction);
+      const taskManifest = taskManifestMatch?.[1] === undefined
+        ? undefined
+        : JSON.parse(taskManifestMatch[1]) as Record<string, unknown>;
+      if (typeof taskManifest?.taskId === 'string'
+        && Array.isArray(taskManifest.candidateIntents)) {
+        const evaluations = taskManifest.candidateIntents.flatMap((intent) => {
+          if (typeof intent !== 'object' || intent === null || typeof intent.intentId !== 'string') {
+            return [];
+          }
+          return [{
+            intentId: intent.intentId,
+            result: { kind: 'no_action', reason: 'No manager action is required.' },
+          }];
+        });
+        return {
+          persona,
+          status: 'done' as const,
+          content: '{}',
+          structuredOutput: {
+            taskId: taskManifest.taskId,
+            evaluations,
+            selectedIntentId: null,
+          },
+          timestamp: new Date('2026-08-09T00:00:04.000Z'),
+        };
+      }
+      if ((JSON.stringify(outputSchema) ?? '').includes('terminate_subject')) {
+        adjudicationCalls += 1;
+        const adjudicationSnapshot = freshConflictAdjudicationSnapshot(
+          store.loadLedger(),
+          'C-FA2947446963',
+        );
+        return {
+          persona,
+          status: 'done' as const,
+          content: '{}',
+          structuredOutput: {
+            proposal: {
+              kind: 'undetermined' as const,
+              subjectIds: adjudicationSnapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+              rationale: 'No verified terminal authority is available.',
+            },
+          },
+          timestamp: new Date('2026-08-09T00:00:02.000Z'),
+        };
+      }
+      if (persona === 'coder' || persona.includes('fix')) {
+        fixCalls += 1;
+        if (fixCalls === 1) {
+          codeChanges += 1;
+          writeFileSync(join(engineScenarioCwd!, 'src', 'a.ts'), 'export const value = false;\n');
+          await refreshBuiltinEngineScenarioSnapshot(store, engineScenarioCwd!);
+          (engine as unknown as { refreshFindingsState: () => void }).refreshFindingsState();
+        }
+        return {
+          persona,
+          status: 'done' as const,
+          content: 'Fixes are complete',
+          timestamp: new Date('2026-08-09T00:00:03.000Z'),
+        };
+      }
+      return {
+        persona,
+        status: 'done' as const,
+        content: 'No findings.',
+        timestamp: new Date('2026-08-09T00:00:01.000Z'),
+      };
+    });
 
-    for (const [workflow, stepName] of EXPECTED_FC_LADDER_STEPS) {
-      const step = findBuiltinLadderStep(targets, workflow, stepName, language);
-      const match = new RuleEvaluator(step, {
-        state: workflowState(step, {
-          ...EMPTY_FINDING_COUNTS,
-          open: 1,
-          conflicts: 1,
-          unadjudicated: 0,
-        }),
-      }).evaluate(undefined);
-      const key = `${workflow}:${stepName}`;
-      expect(match?.index, key).toBe(1);
-      expect(determineRuleTransition(step, match?.index ?? -1), key)
-        .toEqual(expectedTargets.get(key));
-    }
+    engine = new WorkflowEngine(
+      createBuiltinEngineScenarioConfig(),
+      engineScenarioCwd,
+      'Exercise the builtin conflict route.',
+      {
+        projectCwd: engineScenarioCwd,
+        provider: 'claude',
+        reportDirName: 'test-report-dir',
+      },
+    );
+    const result = await engine.run();
+
+    expect(result.status).toBe('aborted');
+    expect(adjudicationCalls).toBe(4);
+    expect(fixCalls).toBe(2);
+    expect(codeChanges).toBe(1);
   });
 
   it.each(LANGUAGES)('%s all builtin FC control ladders are total over the finding state product', (language) => {

--- a/src/__tests__/takt-default-fc-builtins.test.ts
+++ b/src/__tests__/takt-default-fc-builtins.test.ts
@@ -352,7 +352,7 @@ function expectedRuleMatch(counts: FindingCounts): ExpectedRuleMatch {
     return { index: 0, nextStep: 'finding-conflict-adjudication' };
   }
   if (counts.conflicts > 0 && !counts.roundBudgetExhausted) {
-    return { index: 1, returnValue: 'needs_review' };
+    return { index: 1, returnValue: 'needs_fix' };
   }
   if (counts.conflicts > 0) return { index: 2, nextStep: 'ABORT' };
   if (counts.claimBearingTerminalCount > 0) {
@@ -710,13 +710,13 @@ describe('takt-default-fc builtins', () => {
     );
   });
 
-  it.each(LANGUAGES)('%s keeps unresolved conflicts in review while stop budget remains', (language) => {
+  it.each(LANGUAGES)('%s routes adjudicated unresolved conflicts to fix while stop budget remains', (language) => {
     const reviewers = loadedStep(
       loadWorkflow(language, 'peer-review-suite-finding-contract-base'),
       'reviewers',
     );
     for (const [roundBudgetExhausted, expected] of [
-      [false, { returnValue: 'needs_review' }],
+      [false, { returnValue: 'needs_fix' }],
       [true, { nextStep: 'ABORT' }],
     ] as const) {
       const counts = {
@@ -780,6 +780,36 @@ describe('takt-default-fc builtins', () => {
       const enStep = findBuiltinLadderStep(targetsByLanguage.en, workflow, stepName, 'en');
       const jaStep = findBuiltinLadderStep(targetsByLanguage.ja, workflow, stepName, 'ja');
       expect(ladderSignature(jaStep), `${workflow}:${stepName}`).toEqual(ladderSignature(enStep));
+    }
+  });
+
+  it.each(LANGUAGES)('%s routes every adjudicated unresolved FC conflict to fix or its downstream gate', (language) => {
+    const targets = collectBuiltinFindingLadderSteps(language);
+    const expectedTargets = new Map([
+      ['finding-contract-boundary-review:boundary-reviewers', { nextStep: 'final-gate' }],
+      ['finding-contract-local-review:reviewers', { nextStep: 'integrity-gate' }],
+      ['merge-readiness-finding-contract-final-gate:merge-readiness-review', { returnValue: 'needs_fix' }],
+      ['merge-readiness-finding-contract-final-gate:supervise', { returnValue: 'needs_fix' }],
+      ['peer-review-suite-finding-contract-base:reviewers', { returnValue: 'needs_fix' }],
+      ['review-fix-takt-default-high:reviewers', { nextStep: 'fix' }],
+      ['takt-default-high:reviewers', { nextStep: 'fix' }],
+      ['takt-default-team-high:reviewers', { nextStep: 'fix' }],
+    ] as const);
+
+    for (const [workflow, stepName] of EXPECTED_FC_LADDER_STEPS) {
+      const step = findBuiltinLadderStep(targets, workflow, stepName, language);
+      const match = new RuleEvaluator(step, {
+        state: workflowState(step, {
+          ...EMPTY_FINDING_COUNTS,
+          open: 1,
+          conflicts: 1,
+          unadjudicated: 0,
+        }),
+      }).evaluate(undefined);
+      const key = `${workflow}:${stepName}`;
+      expect(match?.index, key).toBe(1);
+      expect(determineRuleTransition(step, match?.index ?? -1), key)
+        .toEqual(expectedTargets.get(key));
     }
   });
 

--- a/src/__tests__/takt-default-fc-compatibility-baseline.test.ts
+++ b/src/__tests__/takt-default-fc-compatibility-baseline.test.ts
@@ -12,7 +12,10 @@ import type {
   WorkflowStep,
 } from '../core/models/types.js';
 import { buildManagerInstruction } from '../core/workflow/findings/manager-agent.js';
-import { renderConflictAdjudicationInstruction } from '../core/workflow/findings/adjudication-evidence.js';
+import {
+  buildConflictAdjudicationHistoryOrder,
+  renderConflictAdjudicationInstruction,
+} from '../core/workflow/findings/adjudication-evidence.js';
 import {
   freshConflictAdjudicationSnapshot,
   refreshActiveConflictAdjudicationSnapshots,
@@ -274,7 +277,10 @@ function conflictPromptGolden(): { bytes: number; sha256: string } {
     createdAt: observation,
   });
   const snapshot = freshConflictAdjudicationSnapshot(ledger, 'C-FA2947446963');
-  return byteGolden(renderConflictAdjudicationInstruction(snapshot));
+  return byteGolden(renderConflictAdjudicationInstruction(
+    snapshot,
+    buildConflictAdjudicationHistoryOrder(ledger),
+  ));
 }
 
 async function collectManagerPrompts(

--- a/src/core/models/finding-contract-identity.ts
+++ b/src/core/models/finding-contract-identity.ts
@@ -369,6 +369,7 @@ export function computeConflictSnapshotId(
     coverageSnapshotDigest: snapshot.coverageSnapshotDigest,
     evidenceSnapshotDigest: snapshot.evidenceSnapshotDigest,
     subjects: binarySortedUnique(snapshot.subjects.map(({ subjectId }) => subjectId)),
+    targetContentDigests: binarySortedObjects(snapshot.targetContentDigests ?? []),
     originStep: snapshot.originStep,
   });
 }

--- a/src/core/models/finding-contract-types.ts
+++ b/src/core/models/finding-contract-types.ts
@@ -520,6 +520,12 @@ export type TerminalAdjudicationSettlement =
 
 export type ConflictClaimRole = 'product_finding' | 'holding_provisional';
 
+export interface ConflictTargetContentDigest {
+  path: string;
+  kind: string;
+  contentDigest: string | null;
+}
+
 interface ConflictClaimSubjectBase {
   subjectId: string;
   conflictId: string;
@@ -556,6 +562,7 @@ export interface ConflictAdjudicationSnapshot {
   rawClaimLandingIds: string[];
   priorSettlementIds: string[];
   subjects: ConflictClaimSubject[];
+  targetContentDigests?: ConflictTargetContentDigest[];
   originStep: string | null;
   createdAt: FindingObservation;
 }

--- a/src/core/models/finding-ledger-invariants.ts
+++ b/src/core/models/finding-ledger-invariants.ts
@@ -1074,7 +1074,7 @@ function collectConflictAndTerminalIdentityViolations(
       addViolation(
         violations,
         ['conflicts', index],
-        `Active conflict "${conflict.id}" must have exactly one fresh adjudication snapshot`,
+        `Active conflict "${conflict.id}" must have the latest fresh adjudication snapshot`,
       );
     }
   });

--- a/src/core/models/finding-ledger-invariants.ts
+++ b/src/core/models/finding-ledger-invariants.ts
@@ -632,9 +632,12 @@ function collectProviderAndAttemptViolations(
     );
     call.attemptIds.forEach((attemptId) => {
       const attempt = attemptsById.get(attemptId);
+      const historicalReleasedReservation = call.state === 'released'
+        && attempt !== undefined
+        && attempt.providerCallId !== call.providerCallId;
       if (
         attempt?.kind !== call.purpose
-        || attempt.providerCallId !== call.providerCallId
+        || (attempt.providerCallId !== call.providerCallId && !historicalReleasedReservation)
       ) {
         addViolation(
           violations,
@@ -679,7 +682,9 @@ function collectProviderAndAttemptViolations(
       call !== undefined
       && (
         (call.state !== 'settled' && call.state !== 'released' && attempt.stage !== 'started')
-        || (call.state === 'released' && attempt.stage !== 'interrupted')
+        || (call.state === 'released'
+          && attempt.stage !== 'interrupted'
+          && call.providerCallId === attempt.providerCallId)
         || (call.state === 'settled'
           && call.resultKind === 'interrupted_unknown'
           && attempt.stage !== 'interrupted'

--- a/src/core/models/finding-ledger-invariants.ts
+++ b/src/core/models/finding-ledger-invariants.ts
@@ -1058,7 +1058,14 @@ function collectConflictAndTerminalIdentityViolations(
         return sameValue(subject.expectedHead, subjectHead);
       })
     ));
-    if (freshSnapshots.length !== 1) {
+    const latestSnapshot = [...projection.conflictAdjudicationSnapshots]
+      .reverse()
+      .find((snapshot) => snapshot.conflictId === conflict.id);
+    const latestFreshSnapshot = freshSnapshots.at(-1);
+    if (
+      latestFreshSnapshot === undefined
+      || latestSnapshot?.conflictSnapshotId !== latestFreshSnapshot.conflictSnapshotId
+    ) {
       addViolation(
         violations,
         ['conflicts', index],

--- a/src/core/models/finding-schemas.ts
+++ b/src/core/models/finding-schemas.ts
@@ -2014,6 +2014,11 @@ const ConflictClaimSubjectSchema = z.discriminatedUnion('role', [
   ConflictProductSubjectSchema,
   ConflictHoldingSubjectSchema,
 ]);
+const ConflictTargetContentDigestSchema = z.object({
+  path: nonEmptyString,
+  kind: nonEmptyString,
+  contentDigest: Sha256Schema.nullable(),
+}).strict();
 export const ConflictAdjudicationSnapshotSchema = z.object({
   conflictSnapshotId: Sha256Schema,
   conflictId: nonEmptyString,
@@ -2024,6 +2029,7 @@ export const ConflictAdjudicationSnapshotSchema = z.object({
   rawClaimLandingIds: BinarySortedUniqueStringSetSchema,
   priorSettlementIds: BinarySortedUniqueStringSetSchema,
   subjects: z.array(ConflictClaimSubjectSchema),
+  targetContentDigests: z.array(ConflictTargetContentDigestSchema).optional(),
   originStep: nonEmptyString.nullable(),
   createdAt: FindingObservationSchema,
 }).strict();

--- a/src/core/workflow/findings/adjudication-evidence.ts
+++ b/src/core/workflow/findings/adjudication-evidence.ts
@@ -218,6 +218,94 @@ export function renderAdjudicationInstruction(snapshot: AdjudicationEvidenceSnap
   });
 }
 
+interface ConflictAdjudicationSubjectReference {
+  subjectId: string;
+  role: ConflictAdjudicationSnapshot['subjects'][number]['role'];
+  findingId: string;
+  expectedHead: ConflictAdjudicationSnapshot['subjects'][number]['expectedHead'];
+  targetIdentityHash: string | null;
+  claimIdentityHash: string | null;
+  semanticClaimIdentityHash: string | null;
+  claimSnapshotDigest: string;
+  evidenceSetDigest: string;
+  sourceRawFindingCount: number;
+  sourceRawFindingDigest: string;
+  sourceRawPayloadDigest: string;
+  evidenceBindingCount: number;
+  evidenceBindingDigest: string;
+  rawClaimLandingCount: number;
+  rawClaimLandingDigest: string;
+}
+
+interface ConflictAdjudicationSnapshotReference {
+  snapshotFormat: 'reference-v1';
+  conflictSnapshotId: string;
+  conflictId: string;
+  expectedConflictHead: ConflictAdjudicationSnapshot['expectedConflictHead'];
+  claimUniverseDigest: string;
+  coverageSnapshotDigest: string;
+  evidenceSnapshotDigest: string;
+  rawClaimLandingCount: number;
+  rawClaimLandingDigest: string;
+  priorSettlementCount: number;
+  priorSettlementDigest: string;
+  subjects: ConflictAdjudicationSubjectReference[];
+  originStep: string | null;
+}
+
+function digestStringSet(values: readonly string[]): string {
+  return createHash('sha256')
+    .update(canonicalJson([...values].sort(compareBinaryStrings)))
+    .digest('hex');
+}
+
+function subjectReference(
+  subject: ConflictAdjudicationSnapshot['subjects'][number],
+): ConflictAdjudicationSubjectReference {
+  return {
+    subjectId: subject.subjectId,
+    role: subject.role,
+    findingId: subject.findingId,
+    expectedHead: structuredClone(subject.expectedHead),
+    targetIdentityHash: subject.targetIdentityHash,
+    claimIdentityHash: subject.claimIdentityHash,
+    semanticClaimIdentityHash: subject.semanticClaimIdentityHash,
+    claimSnapshotDigest: subject.claimSnapshotDigest,
+    evidenceSetDigest: subject.evidenceSetDigest,
+    sourceRawFindingCount: subject.sourceRawFindingIds.length,
+    sourceRawFindingDigest: digestStringSet(subject.sourceRawFindingIds),
+    sourceRawPayloadDigest: digestStringSet(subject.sourceRawPayloadDigests),
+    evidenceBindingCount: subject.evidenceBindingIds.length,
+    evidenceBindingDigest: digestStringSet(subject.evidenceBindingIds),
+    rawClaimLandingCount: subject.rawClaimLandingIds.length,
+    rawClaimLandingDigest: digestStringSet(subject.rawClaimLandingIds),
+  };
+}
+
+/**
+ * Durable snapshot は台帳側の完全な入力を保持するが、provider には履歴配列を再送しない。
+ * subjectId と digest/count の参照だけを渡し、検証時の完全な snapshot は engine が解決する。
+ */
+export function buildConflictAdjudicationSnapshotReference(
+  snapshot: ConflictAdjudicationSnapshot,
+): ConflictAdjudicationSnapshotReference {
+  return {
+    snapshotFormat: 'reference-v1',
+    conflictSnapshotId: snapshot.conflictSnapshotId,
+    conflictId: snapshot.conflictId,
+    expectedConflictHead: structuredClone(snapshot.expectedConflictHead),
+    claimUniverseDigest: snapshot.claimUniverseDigest,
+    coverageSnapshotDigest: snapshot.coverageSnapshotDigest,
+    evidenceSnapshotDigest: snapshot.evidenceSnapshotDigest,
+    rawClaimLandingCount: snapshot.rawClaimLandingIds.length,
+    rawClaimLandingDigest: digestStringSet(snapshot.rawClaimLandingIds),
+    priorSettlementCount: snapshot.priorSettlementIds.length,
+    priorSettlementDigest: digestStringSet(snapshot.priorSettlementIds),
+    subjects: snapshot.subjects.map(subjectReference),
+    originStep: snapshot.originStep,
+  };
+}
+
 export function renderConflictAdjudicationInstruction(
   snapshot: ConflictAdjudicationSnapshot,
   grounding?: {
@@ -229,9 +317,10 @@ export function renderConflictAdjudicationInstruction(
     'Adjudicate the durable finding conflict snapshot below. You are read-only.',
     'Return exactly one configured proposal. References must use subjectId values from the snapshot and authorityRefIds must identify exact engine-proof records.',
     'Use merge_holding only for a verified identical claim, promote_holding only with verification supporting the complete product projection, terminate_subject only with verification supporting no-issue or refutation, and undetermined otherwise.',
+    'The snapshot below is an engine-owned reference. Historical ID collections are represented by count and digest; do not infer omitted members.',
     '',
     '## Durable conflict snapshot',
-    renderFencedJsonBlock(snapshot),
+    renderFencedJsonBlock(buildConflictAdjudicationSnapshotReference(snapshot)),
   ];
   if (grounding === undefined) {
     return instruction.join('\n');

--- a/src/core/workflow/findings/adjudication-evidence.ts
+++ b/src/core/workflow/findings/adjudication-evidence.ts
@@ -228,11 +228,15 @@ interface ConflictAdjudicationSubjectReference {
   semanticClaimIdentityHash: string | null;
   claimSnapshotDigest: string;
   evidenceSetDigest: string;
+  sourceRawFindingIds: string[];
   sourceRawFindingCount: number;
   sourceRawFindingDigest: string;
   sourceRawPayloadDigest: string;
+  sourceRawPayloadDigests: string[];
+  evidenceBindingIds: string[];
   evidenceBindingCount: number;
   evidenceBindingDigest: string;
+  rawClaimLandingIds: string[];
   rawClaimLandingCount: number;
   rawClaimLandingDigest: string;
 }
@@ -245,12 +249,23 @@ interface ConflictAdjudicationSnapshotReference {
   claimUniverseDigest: string;
   coverageSnapshotDigest: string;
   evidenceSnapshotDigest: string;
+  targetContentDigests: ConflictAdjudicationSnapshot['targetContentDigests'];
+  rawClaimLandingIds: string[];
   rawClaimLandingCount: number;
   rawClaimLandingDigest: string;
+  priorSettlementIds: string[];
   priorSettlementCount: number;
   priorSettlementDigest: string;
   subjects: ConflictAdjudicationSubjectReference[];
   originStep: string | null;
+}
+
+const INLINE_HISTORY_LIMIT = 3;
+
+function inlineHistory(values: readonly string[]): string[] {
+  // Keep a small recent reference window for dispute relations; older history
+  // remains bounded by its count and digest instead of disappearing entirely.
+  return values.slice(-INLINE_HISTORY_LIMIT);
 }
 
 function digestStringSet(values: readonly string[]): string {
@@ -272,19 +287,23 @@ function subjectReference(
     semanticClaimIdentityHash: subject.semanticClaimIdentityHash,
     claimSnapshotDigest: subject.claimSnapshotDigest,
     evidenceSetDigest: subject.evidenceSetDigest,
+    sourceRawFindingIds: inlineHistory(subject.sourceRawFindingIds),
     sourceRawFindingCount: subject.sourceRawFindingIds.length,
     sourceRawFindingDigest: digestStringSet(subject.sourceRawFindingIds),
     sourceRawPayloadDigest: digestStringSet(subject.sourceRawPayloadDigests),
+    sourceRawPayloadDigests: inlineHistory(subject.sourceRawPayloadDigests),
+    evidenceBindingIds: inlineHistory(subject.evidenceBindingIds),
     evidenceBindingCount: subject.evidenceBindingIds.length,
     evidenceBindingDigest: digestStringSet(subject.evidenceBindingIds),
+    rawClaimLandingIds: inlineHistory(subject.rawClaimLandingIds),
     rawClaimLandingCount: subject.rawClaimLandingIds.length,
     rawClaimLandingDigest: digestStringSet(subject.rawClaimLandingIds),
   };
 }
 
 /**
- * Durable snapshot は台帳側の完全な入力を保持するが、provider には履歴配列を再送しない。
- * subjectId と digest/count の参照だけを渡し、検証時の完全な snapshot は engine が解決する。
+ * Durable snapshot は台帳側の完全な入力を保持するが、provider には履歴全体を再送しない。
+ * 直近の少数参照と、それ以前を表す count/digest を渡し、完全な snapshot は engine が解決する。
  */
 export function buildConflictAdjudicationSnapshotReference(
   snapshot: ConflictAdjudicationSnapshot,
@@ -297,8 +316,11 @@ export function buildConflictAdjudicationSnapshotReference(
     claimUniverseDigest: snapshot.claimUniverseDigest,
     coverageSnapshotDigest: snapshot.coverageSnapshotDigest,
     evidenceSnapshotDigest: snapshot.evidenceSnapshotDigest,
+    targetContentDigests: snapshot.targetContentDigests ?? [],
+    rawClaimLandingIds: inlineHistory(snapshot.rawClaimLandingIds),
     rawClaimLandingCount: snapshot.rawClaimLandingIds.length,
     rawClaimLandingDigest: digestStringSet(snapshot.rawClaimLandingIds),
+    priorSettlementIds: inlineHistory(snapshot.priorSettlementIds),
     priorSettlementCount: snapshot.priorSettlementIds.length,
     priorSettlementDigest: digestStringSet(snapshot.priorSettlementIds),
     subjects: snapshot.subjects.map(subjectReference),
@@ -317,7 +339,7 @@ export function renderConflictAdjudicationInstruction(
     'Adjudicate the durable finding conflict snapshot below. You are read-only.',
     'Return exactly one configured proposal. References must use subjectId values from the snapshot and authorityRefIds must identify exact engine-proof records.',
     'Use merge_holding only for a verified identical claim, promote_holding only with verification supporting the complete product projection, terminate_subject only with verification supporting no-issue or refutation, and undetermined otherwise.',
-    'The snapshot below is an engine-owned reference. Historical ID collections are represented by count and digest; do not infer omitted members.',
+    'The snapshot below is an engine-owned reference. Historical ID collections retain a recent reference window and use count/digest for older members; do not infer omitted members.',
     '',
     '## Durable conflict snapshot',
     renderFencedJsonBlock(buildConflictAdjudicationSnapshotReference(snapshot)),

--- a/src/core/workflow/findings/adjudication-evidence.ts
+++ b/src/core/workflow/findings/adjudication-evidence.ts
@@ -232,8 +232,9 @@ interface ConflictAdjudicationSubjectReference {
   sourceRawFindingIds: string[];
   sourceRawFindingCount: number;
   sourceRawFindingDigest: string;
+  sourceRawPayloadIds: string[];
+  sourceRawPayloadCount: number;
   sourceRawPayloadDigest: string;
-  sourceRawPayloadDigests: string[];
   evidenceBindingIds: string[];
   evidenceBindingCount: number;
   evidenceBindingDigest: string;
@@ -327,16 +328,16 @@ function inlineHistory(
   values: readonly string[],
   observedAtByValue: ReadonlyMap<string, FindingObservation>,
 ): string[] {
-  const ordered = [...values].sort((left, right) => {
-    const leftObservedAt = observedAtByValue.get(left);
-    const rightObservedAt = observedAtByValue.get(right);
-    if (leftObservedAt === undefined || rightObservedAt === undefined) {
-      throw new Error(`Conflict adjudication history is missing an observation for ${leftObservedAt === undefined ? left : right}`);
-    }
-    return compareObservations(leftObservedAt, rightObservedAt)
-      || compareBinaryStrings(left, right);
-  });
-  return ordered.slice(-INLINE_HISTORY_LIMIT);
+  const missingValue = values.find((value) => !observedAtByValue.has(value));
+  if (missingValue !== undefined) {
+    throw new Error(`Conflict adjudication history is missing an observation for ${missingValue}`);
+  }
+  return values
+    .map((value) => ({ value, observedAt: observedAtByValue.get(value)! }))
+    .sort((left, right) => compareObservations(left.observedAt, right.observedAt)
+      || compareBinaryStrings(left.value, right.value))
+    .slice(-INLINE_HISTORY_LIMIT)
+    .map(({ value }) => value);
 }
 
 function digestStringSet(values: readonly string[]): string {
@@ -362,8 +363,9 @@ function subjectReference(
     sourceRawFindingIds: inlineHistory(subject.sourceRawFindingIds, history.sourceRawFindingIds),
     sourceRawFindingCount: subject.sourceRawFindingIds.length,
     sourceRawFindingDigest: digestStringSet(subject.sourceRawFindingIds),
+    sourceRawPayloadIds: inlineHistory(subject.sourceRawPayloadDigests, history.sourceRawPayloadDigests),
+    sourceRawPayloadCount: subject.sourceRawPayloadDigests.length,
     sourceRawPayloadDigest: digestStringSet(subject.sourceRawPayloadDigests),
-    sourceRawPayloadDigests: inlineHistory(subject.sourceRawPayloadDigests, history.sourceRawPayloadDigests),
     evidenceBindingIds: inlineHistory(subject.evidenceBindingIds, history.evidenceBindingIds),
     evidenceBindingCount: subject.evidenceBindingIds.length,
     evidenceBindingDigest: digestStringSet(subject.evidenceBindingIds),

--- a/src/core/workflow/findings/adjudication-evidence.ts
+++ b/src/core/workflow/findings/adjudication-evidence.ts
@@ -10,6 +10,7 @@ import type {
   FindingLedger,
   FindingLedgerConflict,
   FindingLedgerEntry,
+  FindingObservation,
   RawFinding,
 } from './types.js';
 import { compareBinaryStrings } from '../../../shared/utils/binary-string-comparator.js';
@@ -262,10 +263,80 @@ interface ConflictAdjudicationSnapshotReference {
 
 const INLINE_HISTORY_LIMIT = 3;
 
-function inlineHistory(values: readonly string[]): string[] {
-  // Keep a small recent reference window for dispute relations; older history
-  // remains bounded by its count and digest instead of disappearing entirely.
-  return values.slice(-INLINE_HISTORY_LIMIT);
+export interface ConflictAdjudicationHistoryOrder {
+  sourceRawFindingIds: ReadonlyMap<string, FindingObservation>;
+  sourceRawPayloadDigests: ReadonlyMap<string, FindingObservation>;
+  evidenceBindingIds: ReadonlyMap<string, FindingObservation>;
+  rawClaimLandingIds: ReadonlyMap<string, FindingObservation>;
+  priorSettlementIds: ReadonlyMap<string, FindingObservation>;
+}
+
+function rememberLatestObservation(
+  observations: Map<string, FindingObservation>,
+  key: string,
+  observation: FindingObservation,
+): void {
+  const current = observations.get(key);
+  if (
+    current === undefined
+    || compareObservations(current, observation) < 0
+  ) {
+    observations.set(key, structuredClone(observation));
+  }
+}
+
+export function buildConflictAdjudicationHistoryOrder(
+  ledger: FindingLedger,
+): ConflictAdjudicationHistoryOrder {
+  const sourceRawFindingIds = new Map<string, FindingObservation>();
+  const sourceRawPayloadDigests = new Map<string, FindingObservation>();
+  for (const snapshot of ledger.rawCanonicalSnapshots) {
+    rememberLatestObservation(sourceRawFindingIds, snapshot.rawFindingId, snapshot.capturedAt);
+    rememberLatestObservation(sourceRawPayloadDigests, snapshot.rawPayloadDigest, snapshot.capturedAt);
+  }
+  const evidenceBindingIds = new Map<string, FindingObservation>();
+  for (const event of ledger.lifecycleEvents) {
+    for (const bindingId of event.evidenceBindingIds) {
+      rememberLatestObservation(evidenceBindingIds, bindingId, event.occurredAt);
+    }
+  }
+  const rawClaimLandingIds = new Map<string, FindingObservation>();
+  for (const landing of ledger.conflictRawClaimLandings) {
+    rememberLatestObservation(rawClaimLandingIds, landing.rawClaimLandingId, landing.landedAt);
+  }
+  const priorSettlementIds = new Map<string, FindingObservation>();
+  for (const settlement of ledger.conflictClaimSettlements) {
+    rememberLatestObservation(priorSettlementIds, settlement.settlementId, settlement.recordedAt);
+  }
+  return {
+    sourceRawFindingIds,
+    sourceRawPayloadDigests,
+    evidenceBindingIds,
+    rawClaimLandingIds,
+    priorSettlementIds,
+  };
+}
+
+function compareObservations(left: FindingObservation, right: FindingObservation): number {
+  return compareBinaryStrings(left.timestamp, right.timestamp)
+    || compareBinaryStrings(left.runId, right.runId)
+    || compareBinaryStrings(left.stepName, right.stepName);
+}
+
+function inlineHistory(
+  values: readonly string[],
+  observedAtByValue: ReadonlyMap<string, FindingObservation>,
+): string[] {
+  const ordered = [...values].sort((left, right) => {
+    const leftObservedAt = observedAtByValue.get(left);
+    const rightObservedAt = observedAtByValue.get(right);
+    if (leftObservedAt === undefined || rightObservedAt === undefined) {
+      throw new Error(`Conflict adjudication history is missing an observation for ${leftObservedAt === undefined ? left : right}`);
+    }
+    return compareObservations(leftObservedAt, rightObservedAt)
+      || compareBinaryStrings(left, right);
+  });
+  return ordered.slice(-INLINE_HISTORY_LIMIT);
 }
 
 function digestStringSet(values: readonly string[]): string {
@@ -276,6 +347,7 @@ function digestStringSet(values: readonly string[]): string {
 
 function subjectReference(
   subject: ConflictAdjudicationSnapshot['subjects'][number],
+  history: ConflictAdjudicationHistoryOrder,
 ): ConflictAdjudicationSubjectReference {
   return {
     subjectId: subject.subjectId,
@@ -287,15 +359,15 @@ function subjectReference(
     semanticClaimIdentityHash: subject.semanticClaimIdentityHash,
     claimSnapshotDigest: subject.claimSnapshotDigest,
     evidenceSetDigest: subject.evidenceSetDigest,
-    sourceRawFindingIds: inlineHistory(subject.sourceRawFindingIds),
+    sourceRawFindingIds: inlineHistory(subject.sourceRawFindingIds, history.sourceRawFindingIds),
     sourceRawFindingCount: subject.sourceRawFindingIds.length,
     sourceRawFindingDigest: digestStringSet(subject.sourceRawFindingIds),
     sourceRawPayloadDigest: digestStringSet(subject.sourceRawPayloadDigests),
-    sourceRawPayloadDigests: inlineHistory(subject.sourceRawPayloadDigests),
-    evidenceBindingIds: inlineHistory(subject.evidenceBindingIds),
+    sourceRawPayloadDigests: inlineHistory(subject.sourceRawPayloadDigests, history.sourceRawPayloadDigests),
+    evidenceBindingIds: inlineHistory(subject.evidenceBindingIds, history.evidenceBindingIds),
     evidenceBindingCount: subject.evidenceBindingIds.length,
     evidenceBindingDigest: digestStringSet(subject.evidenceBindingIds),
-    rawClaimLandingIds: inlineHistory(subject.rawClaimLandingIds),
+    rawClaimLandingIds: inlineHistory(subject.rawClaimLandingIds, history.rawClaimLandingIds),
     rawClaimLandingCount: subject.rawClaimLandingIds.length,
     rawClaimLandingDigest: digestStringSet(subject.rawClaimLandingIds),
   };
@@ -307,6 +379,7 @@ function subjectReference(
  */
 export function buildConflictAdjudicationSnapshotReference(
   snapshot: ConflictAdjudicationSnapshot,
+  history: ConflictAdjudicationHistoryOrder,
 ): ConflictAdjudicationSnapshotReference {
   return {
     snapshotFormat: 'reference-v1',
@@ -317,19 +390,20 @@ export function buildConflictAdjudicationSnapshotReference(
     coverageSnapshotDigest: snapshot.coverageSnapshotDigest,
     evidenceSnapshotDigest: snapshot.evidenceSnapshotDigest,
     targetContentDigests: snapshot.targetContentDigests ?? [],
-    rawClaimLandingIds: inlineHistory(snapshot.rawClaimLandingIds),
+    rawClaimLandingIds: inlineHistory(snapshot.rawClaimLandingIds, history.rawClaimLandingIds),
     rawClaimLandingCount: snapshot.rawClaimLandingIds.length,
     rawClaimLandingDigest: digestStringSet(snapshot.rawClaimLandingIds),
-    priorSettlementIds: inlineHistory(snapshot.priorSettlementIds),
+    priorSettlementIds: inlineHistory(snapshot.priorSettlementIds, history.priorSettlementIds),
     priorSettlementCount: snapshot.priorSettlementIds.length,
     priorSettlementDigest: digestStringSet(snapshot.priorSettlementIds),
-    subjects: snapshot.subjects.map(subjectReference),
+    subjects: snapshot.subjects.map((subject) => subjectReference(subject, history)),
     originStep: snapshot.originStep,
   };
 }
 
 export function renderConflictAdjudicationInstruction(
   snapshot: ConflictAdjudicationSnapshot,
+  history: ConflictAdjudicationHistoryOrder,
   grounding?: {
     reviewScopeSnapshotId: string;
     windows: readonly FindingEvidenceSearchWindow[];
@@ -342,7 +416,7 @@ export function renderConflictAdjudicationInstruction(
     'The snapshot below is an engine-owned reference. Historical ID collections retain a recent reference window and use count/digest for older members; do not infer omitted members.',
     '',
     '## Durable conflict snapshot',
-    renderFencedJsonBlock(buildConflictAdjudicationSnapshotReference(snapshot)),
+    renderFencedJsonBlock(buildConflictAdjudicationSnapshotReference(snapshot, history)),
   ];
   if (grounding === undefined) {
     return instruction.join('\n');

--- a/src/core/workflow/findings/adjudication-reservation.ts
+++ b/src/core/workflow/findings/adjudication-reservation.ts
@@ -11,6 +11,7 @@ import type {
 import {
   createConflictAdjudicationEpisode,
   freshConflictAdjudicationSnapshot,
+  hasAlwaysChangingConflictTarget,
   isConflictSnapshotAdjudicated,
 } from './conflict-adjudication-model.js';
 import {
@@ -74,6 +75,7 @@ export async function reserveFindingConflictAdjudication(input: {
     const started = fresh.conflictAdjudicationAttempts.find((attempt) => (
       attempt.conflictId === conflict.id && attempt.stage === 'started'
     ));
+    let rebuildingAttempt: Extract<ConflictAdjudicationAttempt, { stage: 'started' }> | undefined;
     if (started?.stage === 'started') {
       const call = fresh.findingManagerProviderCalls.find(
         (candidate) => candidate.providerCallId === started.providerCallId,
@@ -117,17 +119,24 @@ export async function reserveFindingConflictAdjudication(input: {
           fresh = {
             ...fresh,
             findingManagerProviderCalls: released.calls,
-            conflictAdjudicationAttempts: fresh.conflictAdjudicationAttempts.map((attempt) => (
-              attempt.attemptId === started.attemptId
-                ? {
-                    ...started,
-                    stage: 'interrupted' as const,
-                    interruptedAt: structuredClone(input.observation),
-                    reason: 'reservation_released' as const,
-                  }
-                : attempt
-            )),
           };
+          if (started.conflictSnapshotId === snapshot.conflictSnapshotId && requestChanged) {
+            rebuildingAttempt = started;
+          } else {
+            fresh = {
+              ...fresh,
+              conflictAdjudicationAttempts: fresh.conflictAdjudicationAttempts.map((attempt) => (
+                attempt.attemptId === started.attemptId
+                  ? {
+                      ...started,
+                      stage: 'interrupted' as const,
+                      interruptedAt: structuredClone(input.observation),
+                      reason: 'reservation_released' as const,
+                    }
+                  : attempt
+              )),
+            };
+          }
         } else {
           if (snapshot.conflictSnapshotId !== input.expectedSnapshotId) {
             return { ledger: fresh, result: { started: false } };
@@ -175,25 +184,34 @@ export async function reserveFindingConflictAdjudication(input: {
           ))
         ))
     ));
-    const groundingRetryAllowed = input.allowGroundingRetry === true
+    const groundingRetryAllowed = rebuildingAttempt === undefined
+      && input.allowGroundingRetry === true
       && !groundingRetryAlreadyUsed
       && episodeAttempts.some((attempt) => (
         attempt.stage === 'completed'
         && attempt.attemptOrdinal === 1
         && attempt.result.kind === 'verification_undetermined'
       ));
-    if (isConflictSnapshotAdjudicated(fresh, snapshot) && !groundingRetryAllowed) {
+    const alwaysChangingTarget = hasAlwaysChangingConflictTarget(snapshot);
+    if (rebuildingAttempt === undefined
+      && isConflictSnapshotAdjudicated(fresh, snapshot)
+      && !groundingRetryAllowed
+      && !alwaysChangingTarget) {
       return { ledger: fresh, result: { started: false } };
     }
+    // 予約解放は provider 実行前なので attempt を消費しない。同じ snapshot digest の
+    // 予約を同じ ordinal で再構築し、次回に snapshot digest が一致すればこの経路を
+    // 再度通らないことを停止保証とする。
     const used = fresh.conflictAdjudicationAttempts.filter(
-      (attempt) => attempt.episodeId === ensured.episode.episodeId,
+      (attempt) => attempt.episodeId === ensured.episode.episodeId
+        && attempt.attemptId !== rebuildingAttempt?.attemptId,
     ).length;
     if (used >= ensured.episode.maxAttempts) {
       return { ledger: fresh, result: { started: false } };
     }
-    const attemptOrdinal = (used + 1) as 1 | 2;
-    const retryOrdinal = used as 0 | 1;
-    const attemptId = computeConflictAttemptId({
+    const attemptOrdinal = rebuildingAttempt?.attemptOrdinal ?? (used + 1) as 1 | 2;
+    const retryOrdinal = rebuildingAttempt?.retryOrdinal ?? used as 0 | 1;
+    const attemptId = rebuildingAttempt?.attemptId ?? computeConflictAttemptId({
       episodeId: ensured.episode.episodeId,
       attemptOrdinal,
       retryOrdinal,
@@ -239,7 +257,11 @@ export async function reserveFindingConflictAdjudication(input: {
       findingManagerProviderBudgetScopes: reserved.scopes,
       findingManagerProviderCalls: reserved.calls,
       conflictAdjudicationEpisodes: ensured.episodes,
-      conflictAdjudicationAttempts: [...fresh.conflictAdjudicationAttempts, attempt],
+      conflictAdjudicationAttempts: rebuildingAttempt === undefined
+        ? [...fresh.conflictAdjudicationAttempts, attempt]
+        : fresh.conflictAdjudicationAttempts.map((candidate) => (
+            candidate.attemptId === rebuildingAttempt.attemptId ? attempt : candidate
+          )),
     };
     return {
       ledger,

--- a/src/core/workflow/findings/adjudication-reservation.ts
+++ b/src/core/workflow/findings/adjudication-reservation.ts
@@ -1,4 +1,5 @@
 import {
+  computeFindingManagerRequestDigest,
   computeConflictAttemptId,
 } from '../../models/finding-contract-identity.js';
 import type {
@@ -106,7 +107,8 @@ export async function reserveFindingConflictAdjudication(input: {
         };
       }
       if (call.state === 'reserved') {
-        if (started.conflictSnapshotId !== snapshot.conflictSnapshotId) {
+        const requestChanged = call.requestDigest !== computeFindingManagerRequestDigest(input.requestBytes);
+        if (started.conflictSnapshotId !== snapshot.conflictSnapshotId || requestChanged) {
           const released = releaseFindingManagerProviderCall({
             calls: fresh.findingManagerProviderCalls,
             providerCallId: call.providerCallId,

--- a/src/core/workflow/findings/adjudication-runner.ts
+++ b/src/core/workflow/findings/adjudication-runner.ts
@@ -268,6 +268,9 @@ export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdj
       return { response: finish(state, step, value), instruction: '', providerInfo };
     };
     const reviewScopeSnapshot = captureReviewScopeProofSnapshot(deps.getCwd());
+    const queryInventoryByPath = new Map(
+      reviewScopeSnapshot.queryInventory.map((entry) => [entry.path, entry]),
+    );
     const runAttempt = async (groundingRequested: boolean): Promise<StepRunResult> => {
       const refreshed = await deps.ledgerStore.updateLedger((fresh) => {
         const targetContentDigestsByConflict = new Map(
@@ -276,7 +279,7 @@ export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdj
             .map((candidate) => [
               candidate.id,
               captureConflictTargetContentDigests(
-                reviewScopeSnapshot,
+                queryInventoryByPath,
                 conflictTargetPaths({ ledger: fresh, conflictId: candidate.id }),
               ),
             ] as const),

--- a/src/core/workflow/findings/adjudication-runner.ts
+++ b/src/core/workflow/findings/adjudication-runner.ts
@@ -18,7 +18,10 @@ import {
   buildFindingEvidenceSearchWindows,
   findingEvidenceAnchorLineFor,
 } from './evidence-search.js';
-import { captureReviewScopeProofSnapshot } from './snapshot.js';
+import {
+  captureConflictTargetContentDigests,
+  captureReviewScopeProofSnapshot,
+} from './snapshot.js';
 import {
   freshConflictAdjudicationSnapshot,
   isActiveConflictUnadjudicated,
@@ -34,6 +37,8 @@ import type { FindingAdjudicationStore } from './store.js';
 import type { FindingLedger, FindingObservation } from './types.js';
 import { composeFindingAdjudicationInstruction } from './adjudication-instruction.js';
 import { compareBinaryStrings } from '../../../shared/utils/binary-string-comparator.js';
+import { conflictTargetPaths } from './conflict-target.js';
+import { refreshActiveConflictAdjudicationSnapshots } from './conflict-adjudication-model.js';
 
 export interface FindingConflictAdjudicationRunnerDeps {
   ledgerStore: FindingAdjudicationStore;
@@ -205,17 +210,7 @@ function conflictGroundingTarget(ledger: FindingLedger, conflictId: string): {
   const rawFindings = rawFindingIds
     .map((rawFindingId) => ledger.rawFindings.find((raw) => raw.rawFindingId === rawFindingId))
     .filter((raw): raw is NonNullable<typeof raw> => raw !== undefined);
-  const targetPaths = new Set<string>();
-  for (const target of [
-    ...findings.map((finding) => finding.target),
-    ...rawFindings.map((raw) => raw.target),
-  ]) {
-    if (target?.kind === 'code') {
-      for (const path of target.paths) {
-        targetPaths.add(path);
-      }
-    }
-  }
+  const targetPaths = conflictTargetPaths({ ledger, conflictId });
   const anchorLines = new Map<string, number | undefined>();
   for (const path of targetPaths) {
     for (const raw of rawFindings) {
@@ -227,7 +222,7 @@ function conflictGroundingTarget(ledger: FindingLedger, conflictId: string): {
     }
   }
   return {
-    targetPaths: [...targetPaths].sort(compareBinaryStrings),
+    targetPaths,
     anchorLines,
   };
 }
@@ -269,8 +264,31 @@ export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdj
       deps.refreshFindingsState();
       return { response: finish(state, step, value), instruction: '', providerInfo };
     };
+    const reviewScopeSnapshot = captureReviewScopeProofSnapshot(deps.getCwd());
     const runAttempt = async (groundingRequested: boolean): Promise<StepRunResult> => {
-      const current = deps.ledgerStore.loadLedger();
+      const refreshed = await deps.ledgerStore.updateLedger((fresh) => {
+        const targetContentDigestsByConflict = new Map(
+          fresh.conflicts
+            .filter((candidate) => candidate.status === 'active')
+            .map((candidate) => [
+              candidate.id,
+              captureConflictTargetContentDigests(
+                reviewScopeSnapshot,
+                conflictTargetPaths({ ledger: fresh, conflictId: candidate.id }),
+              ),
+            ] as const),
+        );
+        return {
+          ledger: refreshActiveConflictAdjudicationSnapshots({
+            ledger: fresh,
+            originStep: lastOriginStep ?? step.name,
+            createdAt: observation,
+            targetContentDigestsByConflict,
+          }),
+          result: undefined,
+        };
+      });
+      const current = refreshed.ledger;
       const conflict = selectConflictForAdjudication(
         current,
         (candidate) => (
@@ -292,7 +310,6 @@ export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdj
         || hasGroundingRetryCandidate(current, conflict.id);
       const groundingInstruction = grounding
         ? (() => {
-            const reviewScopeSnapshot = captureReviewScopeProofSnapshot(deps.getCwd());
             const target = conflictGroundingTarget(current, conflict.id);
             const windows = buildFindingEvidenceSearchWindows({
               snapshot: reviewScopeSnapshot,

--- a/src/core/workflow/findings/adjudication-runner.ts
+++ b/src/core/workflow/findings/adjudication-runner.ts
@@ -13,7 +13,10 @@ import {
   commitFindingConflictAdjudication,
   completeFailedConflictAdjudication,
 } from './adjudication-commit.js';
-import { renderConflictAdjudicationInstruction } from './adjudication-evidence.js';
+import {
+  buildConflictAdjudicationHistoryOrder,
+  renderConflictAdjudicationInstruction,
+} from './adjudication-evidence.js';
 import {
   buildFindingEvidenceSearchWindows,
   findingEvidenceAnchorLineFor,
@@ -289,6 +292,7 @@ export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdj
         };
       });
       const current = refreshed.ledger;
+      const history = buildConflictAdjudicationHistoryOrder(current);
       const conflict = selectConflictForAdjudication(
         current,
         (candidate) => (
@@ -316,12 +320,12 @@ export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdj
               targetPaths: target.targetPaths,
               anchorLines: target.anchorLines,
             });
-            return renderConflictAdjudicationInstruction(snapshot, {
+            return renderConflictAdjudicationInstruction(snapshot, history, {
               reviewScopeSnapshotId: reviewScopeSnapshot.reviewScopeSnapshotId,
               windows,
             });
           })()
-        : renderConflictAdjudicationInstruction(snapshot);
+        : renderConflictAdjudicationInstruction(snapshot, history);
       const instruction = deps.stepExecutor.buildPhase1Instruction(
         composeFindingAdjudicationInstruction(deps.guidance, groundingInstruction),
         step,

--- a/src/core/workflow/findings/conflict-adjudication-model.ts
+++ b/src/core/workflow/findings/conflict-adjudication-model.ts
@@ -15,6 +15,7 @@ import type {
   ConflictAdjudicationSnapshot,
   ConflictClaimSettlement,
   ConflictClaimSubject,
+  ConflictTargetContentDigest,
 } from '../../models/finding-contract-types.js';
 import type {
   FindingLedger,
@@ -24,6 +25,29 @@ import type {
 } from './types.js';
 import { captureFindingLifecycleHead } from './lifecycle-mutation.js';
 import { hasVerifiedOrdinaryLifecycleCoverage } from '../../models/finding-lifecycle-continuity.js';
+
+function existingTargetContentDigests(
+  ledger: FindingLedger,
+  conflictId: string,
+): ConflictTargetContentDigest[] {
+  const existing = [...ledger.conflictAdjudicationSnapshots]
+    .reverse()
+    .find((snapshot) => snapshot.conflictId === conflictId);
+  return structuredClone(existing?.targetContentDigests ?? []);
+}
+
+function resolveTargetContentDigests(input: {
+  ledger: FindingLedger;
+  conflictId: string;
+  targetContentDigests?: readonly ConflictTargetContentDigest[];
+}): ConflictTargetContentDigest[] {
+  if (input.targetContentDigests !== undefined) {
+    return structuredClone([...input.targetContentDigests]);
+  }
+  // Lifecycle-only refreshes cannot recapture the working tree. Preserve the
+  // last engine-captured target digest until a review-scope capture replaces it.
+  return existingTargetContentDigests(input.ledger, input.conflictId);
+}
 
 function findingClaimSnapshotDigest(finding: FindingLedgerEntry): string {
   return findingContentAddress('conflict-finding-claim-snapshot', {
@@ -186,6 +210,7 @@ export function buildConflictAdjudicationSnapshot(input: {
   conflictId: string;
   originStep: string | null;
   createdAt: FindingObservation;
+  targetContentDigests?: readonly ConflictTargetContentDigest[];
 }): ConflictAdjudicationSnapshot {
   const conflict = input.ledger.conflicts.find((candidate) => candidate.id === input.conflictId);
   if (conflict === undefined || conflict.status !== 'active') {
@@ -255,6 +280,7 @@ export function buildConflictAdjudicationSnapshot(input: {
       evidenceSetDigest: subject.evidenceSetDigest,
     })),
   });
+  const targetContentDigests = resolveTargetContentDigests(input);
   const withoutId = {
     conflictId: conflict.id,
     expectedConflictHead,
@@ -264,6 +290,7 @@ export function buildConflictAdjudicationSnapshot(input: {
     rawClaimLandingIds,
     priorSettlementIds,
     subjects,
+    targetContentDigests,
     originStep: input.originStep,
   };
   return {
@@ -278,10 +305,11 @@ export function appendFreshConflictAdjudicationSnapshot(input: {
   conflictId: string;
   originStep: string | null;
   createdAt: FindingObservation;
+  targetContentDigests?: readonly ConflictTargetContentDigest[];
 }): { ledger: FindingLedger; snapshot: ConflictAdjudicationSnapshot } {
   const current = input.ledger.conflictAdjudicationSnapshots.find((snapshot) => (
     snapshot.conflictId === input.conflictId
-    && snapshotMatchesCurrentProjection(input.ledger, snapshot)
+    && snapshotMatchesCurrentProjection(input.ledger, snapshot, input.targetContentDigests)
   ));
   if (current !== undefined) {
     return { ledger: input.ledger, snapshot: current };
@@ -305,12 +333,14 @@ export function appendFreshConflictAdjudicationSnapshot(input: {
 function snapshotMatchesCurrentProjection(
   ledger: FindingLedger,
   snapshot: ConflictAdjudicationSnapshot,
+  targetContentDigests?: readonly ConflictTargetContentDigest[],
 ): boolean {
   const rebuilt = buildConflictAdjudicationSnapshot({
     ledger,
     conflictId: snapshot.conflictId,
     originStep: snapshot.originStep,
     createdAt: snapshot.createdAt,
+    targetContentDigests: targetContentDigests ?? snapshot.targetContentDigests ?? [],
   });
   return rebuilt.conflictSnapshotId === snapshot.conflictSnapshotId;
 }
@@ -319,6 +349,7 @@ export function refreshActiveConflictAdjudicationSnapshots(input: {
   ledger: FindingLedger;
   originStep: string | null;
   createdAt: FindingObservation;
+  targetContentDigestsByConflict?: ReadonlyMap<string, readonly ConflictTargetContentDigest[]>;
 }): FindingLedger {
   let ledger = input.ledger;
   for (const conflict of ledger.conflicts) {
@@ -330,6 +361,7 @@ export function refreshActiveConflictAdjudicationSnapshots(input: {
       conflictId: conflict.id,
       originStep: input.originStep,
       createdAt: input.createdAt,
+      targetContentDigests: input.targetContentDigestsByConflict?.get(conflict.id),
     }).ledger;
   }
   return ledger;
@@ -346,12 +378,13 @@ export function freshConflictAdjudicationSnapshot(
   const snapshots = ledger.conflictAdjudicationSnapshots.filter((snapshot) => (
     snapshot.conflictId === conflictId
     && canonicalJson(snapshot.expectedConflictHead) === canonicalJson(head)
-    && snapshotMatchesCurrentProjection(ledger, snapshot)
+    && snapshotMatchesCurrentProjection(ledger, snapshot, snapshot.targetContentDigests ?? [])
   ));
-  if (snapshots.length !== 1) {
-    throw new Error(`Active conflict "${conflictId}" must have exactly one fresh adjudication snapshot`);
+  const current = snapshots.at(-1);
+  if (current === undefined) {
+    throw new Error(`Active conflict "${conflictId}" must have a fresh adjudication snapshot`);
   }
-  return snapshots[0]!;
+  return current;
 }
 
 export function computeConflictAdjudicationRequestDigest(
@@ -362,6 +395,7 @@ export function computeConflictAdjudicationRequestDigest(
     coverageSnapshotDigest: snapshot.coverageSnapshotDigest,
     evidenceSnapshotDigest: snapshot.evidenceSnapshotDigest,
     subjects: snapshot.subjects,
+    targetContentDigests: snapshot.targetContentDigests ?? [],
   });
 }
 
@@ -408,6 +442,9 @@ export function isActiveConflictUnadjudicated(
   if (conflict === undefined || conflict.status !== 'active') {
     return false;
   }
+  // An unchanged conflict does not consume stop-budget rounds. The loop
+  // monitor (or the workflow max_steps boundary) is the finite escape hatch
+  // for repeated unresolved, code-unchanged rounds.
   return !isConflictSnapshotAdjudicated(
     ledger,
     freshConflictAdjudicationSnapshot(ledger, conflictId),

--- a/src/core/workflow/findings/conflict-adjudication-model.ts
+++ b/src/core/workflow/findings/conflict-adjudication-model.ts
@@ -434,6 +434,30 @@ export function isConflictSnapshotAdjudicated(
   ));
 }
 
+export function hasAlwaysChangingConflictTarget(
+  snapshot: ConflictAdjudicationSnapshot,
+): boolean {
+  return (snapshot.targetContentDigests ?? []).some((target) => (
+    target.kind !== 'file' || target.contentDigest === null
+  ));
+}
+
+function hasRemainingConflictAttempts(
+  ledger: FindingLedger,
+  snapshot: ConflictAdjudicationSnapshot,
+): boolean {
+  const episode = ledger.conflictAdjudicationEpisodes.find((candidate) => (
+    candidate.episodeId === computeConflictEpisodeId({
+      conflictId: snapshot.conflictId,
+      expectedConflictHead: snapshot.expectedConflictHead,
+      conflictSnapshotId: snapshot.conflictSnapshotId,
+    })
+  ));
+  return episode === undefined || ledger.conflictAdjudicationAttempts.filter(
+    (attempt) => attempt.episodeId === episode.episodeId,
+  ).length < episode.maxAttempts;
+}
+
 export function isActiveConflictUnadjudicated(
   ledger: FindingLedger,
   conflictId: string,
@@ -442,13 +466,15 @@ export function isActiveConflictUnadjudicated(
   if (conflict === undefined || conflict.status !== 'active') {
     return false;
   }
-  // An unchanged conflict does not consume stop-budget rounds. The loop
-  // monitor (or the workflow max_steps boundary) is the finite escape hatch
-  // for repeated unresolved, code-unchanged rounds.
-  return !isConflictSnapshotAdjudicated(
-    ledger,
-    freshConflictAdjudicationSnapshot(ledger, conflictId),
-  );
+  const snapshot = freshConflictAdjudicationSnapshot(ledger, conflictId);
+  if (!hasRemainingConflictAttempts(ledger, snapshot)) {
+    return false;
+  }
+  // An unchanged regular file does not consume stop-budget rounds. Non-regular
+  // targets intentionally have no content digest; they are always eligible for
+  // another bounded adjudication so a null digest cannot create a false negative.
+  return hasAlwaysChangingConflictTarget(snapshot)
+    || !isConflictSnapshotAdjudicated(ledger, snapshot);
 }
 
 function allProductClaimsDurablyCovered(

--- a/src/core/workflow/findings/conflict-target.ts
+++ b/src/core/workflow/findings/conflict-target.ts
@@ -4,6 +4,39 @@ import type {
   FindingProvisionalKind,
 } from './types.js';
 import { captureFindingLifecycleHead } from './lifecycle-mutation.js';
+import { compareBinaryStrings } from '../../../shared/utils/binary-string-comparator.js';
+
+export function conflictTargetPaths(input: {
+  ledger: FindingLedger;
+  conflictId: string;
+}): string[] {
+  const conflict = input.ledger.conflicts.find((candidate) => candidate.id === input.conflictId);
+  if (conflict === undefined) {
+    return [];
+  }
+  const findings = conflict.findingIds
+    .map((findingId) => input.ledger.findings.find((finding) => finding.id === findingId))
+    .filter((finding): finding is NonNullable<typeof finding> => finding !== undefined);
+  const rawFindingIds = [
+    ...new Set([
+      ...conflict.rawFindingIds,
+      ...findings.flatMap((finding) => finding.rawFindingIds),
+    ]),
+  ];
+  const rawFindings = rawFindingIds
+    .map((rawFindingId) => input.ledger.rawFindings.find((raw) => raw.rawFindingId === rawFindingId))
+    .filter((raw): raw is NonNullable<typeof raw> => raw !== undefined);
+  const paths = new Set<string>();
+  for (const target of [
+    ...findings.map((finding) => finding.target),
+    ...rawFindings.map((raw) => raw.target),
+  ]) {
+    if (target?.kind === 'code') {
+      target.paths.forEach((path) => paths.add(path));
+    }
+  }
+  return [...paths].sort(compareBinaryStrings);
+}
 
 export type ConflictTargetClassification =
   | {

--- a/src/core/workflow/findings/finding-integrity.ts
+++ b/src/core/workflow/findings/finding-integrity.ts
@@ -326,6 +326,7 @@ function assertStatefulRegistryTransition<Value>(input: {
   stateOf: (value: Value) => string;
   identityOf: (value: Value) => unknown;
   canTransition: (current: string, next: string) => boolean;
+  allowSameStateReplacement?: (current: Value, next: Value) => boolean;
   initialState: string;
   label: string;
 }): void {
@@ -339,15 +340,19 @@ function assertStatefulRegistryTransition<Value>(input: {
     }
     const existingState = input.stateOf(existing);
     const candidateState = input.stateOf(candidate);
+    const allowedReplacement = input.allowSameStateReplacement?.(existing, candidate) === true;
     if (
-      !sameCanonicalValue(input.identityOf(existing), input.identityOf(candidate))
-      || !input.canTransition(existingState, candidateState)
+      (!sameCanonicalValue(input.identityOf(existing), input.identityOf(candidate))
+        || !input.canTransition(existingState, candidateState))
+      && !allowedReplacement
     ) {
       throw new Error(
         `${input.label} "${input.idOf(existing)}" cannot transition from ${existingState} to ${candidateState}`,
       );
     }
-    if (existingState === candidateState && !sameCanonicalValue(existing, candidate)) {
+    if (existingState === candidateState
+      && !sameCanonicalValue(existing, candidate)
+      && !allowedReplacement) {
       throw new Error(`${input.label} "${input.idOf(existing)}" cannot be replaced`);
     }
   });
@@ -492,6 +497,32 @@ function assertContractRegistryTransitions(
   const canAttemptTransition = (from: string, to: string): boolean => from === to
     || (from === 'started' && ['interrupted', 'proposed', 'applied', 'completed'].includes(to))
     || (from === 'proposed' && ['applied', 'completed'].includes(to));
+  const rebuiltConflictAttemptIds = new Set<string>();
+  current.conflictAdjudicationAttempts.forEach((existing) => {
+    const candidate = next.conflictAdjudicationAttempts.find(
+      (attempt) => attempt.attemptId === existing.attemptId,
+    );
+    const releasedCall = next.findingManagerProviderCalls.find(
+      (call) => call.providerCallId === existing.providerCallId,
+    );
+    const replacementCall = candidate === undefined
+      ? undefined
+      : next.findingManagerProviderCalls.find(
+          (call) => call.providerCallId === candidate.providerCallId,
+        );
+    if (
+      existing.stage === 'started'
+      && candidate?.stage === 'started'
+      && candidate.episodeId === existing.episodeId
+      && candidate.attemptOrdinal === existing.attemptOrdinal
+      && candidate.retryOrdinal === existing.retryOrdinal
+      && candidate.providerCallId !== existing.providerCallId
+      && releasedCall?.state === 'released'
+      && replacementCall?.state === 'reserved'
+    ) {
+      rebuiltConflictAttemptIds.add(existing.attemptId);
+    }
+  });
   assertStatefulRegistryTransition({
     current: current.terminalAdjudicationAttempts,
     next: next.terminalAdjudicationAttempts,
@@ -509,6 +540,8 @@ function assertContractRegistryTransitions(
     stateOf: (attempt) => attempt.stage,
     identityOf: (attempt) => stateIdentity(attempt, attemptStateFields),
     canTransition: canAttemptTransition,
+    allowSameStateReplacement: (existing, candidate) => rebuiltConflictAttemptIds.has(existing.attemptId)
+      && candidate.stage === 'started',
     initialState: 'started',
     label: 'Conflict adjudication attempt',
   });

--- a/src/core/workflow/findings/finding-integrity.ts
+++ b/src/core/workflow/findings/finding-integrity.ts
@@ -340,12 +340,15 @@ function assertStatefulRegistryTransition<Value>(input: {
     }
     const existingState = input.stateOf(existing);
     const candidateState = input.stateOf(candidate);
-    const allowedReplacement = input.allowSameStateReplacement?.(existing, candidate) === true;
-    if (
-      (!sameCanonicalValue(input.identityOf(existing), input.identityOf(candidate))
-        || !input.canTransition(existingState, candidateState))
-      && !allowedReplacement
-    ) {
+    const allowedReplacement = existingState === candidateState
+      && input.allowSameStateReplacement?.(existing, candidate) === true;
+    if (!input.canTransition(existingState, candidateState)) {
+      throw new Error(
+        `${input.label} "${input.idOf(existing)}" cannot transition from ${existingState} to ${candidateState}`,
+      );
+    }
+    if (!sameCanonicalValue(input.identityOf(existing), input.identityOf(candidate))
+      && !allowedReplacement) {
       throw new Error(
         `${input.label} "${input.idOf(existing)}" cannot transition from ${existingState} to ${candidateState}`,
       );
@@ -491,6 +494,12 @@ function assertContractRegistryTransitions(
     'claimSettlementIds',
     'lifecycleEventIds',
   ] as const;
+  const rebuildExcludedAttemptFields = [
+    ...attemptStateFields,
+    'providerCallId',
+    'requestDigest',
+    'startedAt',
+  ] as const;
   // provider_result_unknown と reservation_released は、どちらも provider の
   // terminal result を確定できないまま終わった attempt の着地点であり、started
   // から interrupted への同じ一方向遷移として扱う。
@@ -519,6 +528,10 @@ function assertContractRegistryTransitions(
       && candidate.providerCallId !== existing.providerCallId
       && releasedCall?.state === 'released'
       && replacementCall?.state === 'reserved'
+      && sameCanonicalValue(
+        stateIdentity(existing, rebuildExcludedAttemptFields),
+        stateIdentity(candidate, rebuildExcludedAttemptFields),
+      )
     ) {
       rebuiltConflictAttemptIds.add(existing.attemptId);
     }

--- a/src/core/workflow/findings/manager-commit.ts
+++ b/src/core/workflow/findings/manager-commit.ts
@@ -24,13 +24,17 @@ import { issueManagerLifecycleAuthority } from './manager-lifecycle-authority.js
 import { assembleAndApplyManagerLifecycleTransactions } from './manager-lifecycle-assembly.js';
 import { applyRejectedObservationAttachments } from './manager-provisional-settlement.js';
 import { attachFixpointState } from './fixpoint.js';
-import type { ReviewScopeProofSnapshot } from './snapshot.js';
+import {
+  captureConflictTargetContentDigests,
+  type ReviewScopeProofSnapshot,
+} from './snapshot.js';
 import {
   settleReviewerAnomaliesFromAuthorizedTerminalEvents,
 } from './reviewer-anomaly-settlement.js';
 import { computeWorkflowTaskDigest } from './task-scope-adjudication.js';
 import { finalizeInterpretationCaseProjection } from './interpretation-case-finalizer.js';
 import { refreshActiveConflictAdjudicationSnapshots } from './conflict-adjudication-model.js';
+import { conflictTargetPaths } from './conflict-target.js';
 import {
   landUnownedConflictRawClaims,
 } from './conflict-claim-landing.js';
@@ -130,10 +134,22 @@ export async function commitFindingManagerRound(params: {
         ledger: interpretationFinalized,
         observation: params.observation,
       });
+      const targetContentDigestsByConflict = new Map(
+        withConflictLandings.conflicts
+          .filter((conflict) => conflict.status === 'active')
+          .map((conflict) => [
+            conflict.id,
+            captureConflictTargetContentDigests(
+              params.reviewScopeSnapshot,
+              conflictTargetPaths({ ledger: withConflictLandings, conflictId: conflict.id }),
+            ),
+          ] as const),
+      );
       const withConflictSnapshots = refreshActiveConflictAdjudicationSnapshots({
         ledger: withConflictLandings,
         originStep: params.input.parentStep.name,
         createdAt: params.observation,
+        targetContentDigestsByConflict,
       });
       // 言い直し slot の各パスは「レビューラウンドの内側の差し戻し」であって
       // 新しいレビューラウンドではない。marker は適用済み集合へ必ず入れる

--- a/src/core/workflow/findings/manager-commit.ts
+++ b/src/core/workflow/findings/manager-commit.ts
@@ -134,13 +134,16 @@ export async function commitFindingManagerRound(params: {
         ledger: interpretationFinalized,
         observation: params.observation,
       });
+      const queryInventoryByPath = new Map(
+        params.reviewScopeSnapshot.queryInventory.map((entry) => [entry.path, entry]),
+      );
       const targetContentDigestsByConflict = new Map(
         withConflictLandings.conflicts
           .filter((conflict) => conflict.status === 'active')
           .map((conflict) => [
             conflict.id,
             captureConflictTargetContentDigests(
-              params.reviewScopeSnapshot,
+              queryInventoryByPath,
               conflictTargetPaths({ ledger: withConflictLandings, conflictId: conflict.id }),
             ),
           ] as const),

--- a/src/core/workflow/findings/snapshot.ts
+++ b/src/core/workflow/findings/snapshot.ts
@@ -8,6 +8,8 @@ import {
   type ReviewScopeBaseRange,
   type TaskReviewScope,
 } from '../review-scope.js';
+import type { ConflictTargetContentDigest } from '../../models/finding-contract-types.js';
+import { compareBinaryStrings } from '../../../shared/utils/binary-string-comparator.js';
 
 const HASH_CHUNK_BYTES = 1024 * 1024;
 const CAPTURE_ATTEMPTS = 3;
@@ -85,6 +87,22 @@ export interface ReviewScopeProofSnapshot extends ReviewScopeSnapshot {
   queryInventory: ReviewScopeQueryInventoryEntry[];
   /** Engine-captured tracked/untracked paths that define the current task review scope. */
   changedPaths?: string[];
+}
+
+export function captureConflictTargetContentDigests(
+  snapshot: ReviewScopeProofSnapshot,
+  targetPaths: readonly string[],
+): ConflictTargetContentDigest[] {
+  const inventoryByPath = new Map(snapshot.queryInventory.map((entry) => [entry.path, entry]));
+  const uniquePaths = [...new Set(targetPaths)].sort(compareBinaryStrings);
+  return uniquePaths.map((path) => {
+    const entry = inventoryByPath.get(path);
+    return {
+      path,
+      kind: entry?.kind ?? 'missing',
+      contentDigest: entry?.contentDigest ?? null,
+    };
+  });
 }
 
 interface FileSnapshot {

--- a/src/core/workflow/findings/snapshot.ts
+++ b/src/core/workflow/findings/snapshot.ts
@@ -90,10 +90,9 @@ export interface ReviewScopeProofSnapshot extends ReviewScopeSnapshot {
 }
 
 export function captureConflictTargetContentDigests(
-  snapshot: ReviewScopeProofSnapshot,
+  inventoryByPath: ReadonlyMap<string, ReviewScopeQueryInventoryEntry>,
   targetPaths: readonly string[],
 ): ConflictTargetContentDigest[] {
-  const inventoryByPath = new Map(snapshot.queryInventory.map((entry) => [entry.path, entry]));
   const uniquePaths = [...new Set(targetPaths)].sort(compareBinaryStrings);
   return uniquePaths.map((path) => {
     const entry = inventoryByPath.get(path);


### PR DESCRIPTION
## 目的

run-16 の実測死因2つの修正。

1. **ループ意味論**: 未確定 conflict を reviewers に戻す設計は空回り(レビューは conflict を解消できない)— needs_fix へ変更し、**再裁定は争点の状態が変化したときのみ**(台帳射影+争点 target のコード内容 digest に束縛。regular file 以外は常に変化扱いの安全側)。同一 snapshot への再裁定は構造的に不可能に
2. **入力の有界化**: 死因は往復ごとに conflict snapshot の履歴配列を全再送していたこと。直近3件(時系列)は本文維持+それ以前は count/digest 参照へ縮約

付随: 予約解放は attempt 非消費(未消費解放)、旧 reserved と不一致時は解放→再構築の一本化(互換 decode なし)。脱出保証の分担(stop budget / loop monitor / max_steps)を docs に明文化。

## レビュー

codex (gpt-5.6-luna, xhigh) 敵対レビュー3巡(BLOCK 計4件検出・全修正・赤緑)。実装も codex。builtin 14 YAML ja/en 対称、全域性テスト更新済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 未裁定の競合が残る場合は、修正や後続ゲートへ進まず、競合の裁定を優先するようになりました。
  * 競合がすべて裁定済みでレビュー予算に余裕がある場合は、再レビューではなく修正対応へ進みます。
  * 対象内容が変化した場合のみ再裁定し、不要な再実行を抑制します。
  * 再裁定履歴は直近3件を保持し、それ以前は件数とダイジェストで管理します。
  * 内容に変化がない反復では停止予算を消費せず、適切に停止します。

* **ドキュメント**
  * 再裁定履歴、対象内容の変更検知、停止条件に関する仕様を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->