### PR TITLE
fix(finding-contract): conflict raw landingの永続registryを追記順に保つ

### DIFF
--- a/src/__tests__/finding-conflict-history-order.integration.test.ts
+++ b/src/__tests__/finding-conflict-history-order.integration.test.ts
@@ -77,7 +77,11 @@ function makeManagerOutput(rawFindingId: string): FindingManagerOutput {
   };
 }
 
-function makeLedger(cwd: string): FindingLedger {
+function makeUnlandedLedger(
+  cwd: string,
+  conflictRawFindingIds: readonly string[] = ['raw-previous', 'raw-generated'],
+  rawRelation: 'new' | 'persists' = 'new',
+): FindingLedger {
   const leapSecondObservation = {
     runId: 'run-0',
     stepName: 'reviewers',
@@ -102,9 +106,7 @@ function makeLedger(cwd: string): FindingLedger {
     targetFindingId: 'F-0001',
   });
 
-  return refreshActiveConflictAdjudicationSnapshots({
-    ledger: landUnownedConflictRawClaims({
-      ledger: authorizeFindingLedgerFixture({
+  const fixture = {
     workflowName: WORKFLOW_NAME,
     nextId: 2,
     updatedAt: nextMinuteObservation.timestamp,
@@ -129,22 +131,57 @@ function makeLedger(cwd: string): FindingLedger {
     rawFindings: [
       makeRawFinding('raw-previous', [evidence.evidence]),
       makeRawFinding('raw-generated', [evidence.evidence]),
-    ],
+    ].map((raw) => rawRelation === 'new'
+      ? raw
+      : { ...raw, relation: rawRelation, targetFindingId: 'F-0001' }),
     conflicts: [{
       id: conflictId,
       status: 'active',
       findingIds: ['F-0001'],
-      rawFindingIds: ['raw-previous', 'raw-generated'],
+      rawFindingIds: [...conflictRawFindingIds],
       description: 'Existing conflict.',
       firstSeen: leapSecondObservation,
       lastSeen: nextMinuteObservation,
       revision: 1,
     }],
-      }),
-      observation: nextMinuteObservation,
+  };
+  const authorized = authorizeFindingLedgerFixture(fixture);
+  if (rawRelation === 'new') {
+    return authorized;
+  }
+  const targetPrecondition = captureFindingMutationPrecondition(authorized, 'F-0001');
+  if (targetPrecondition === undefined) {
+    throw new Error('Fixture finding F-0001 has no target precondition');
+  }
+  const rawFindings = authorized.rawFindings.map((raw) => ({
+    ...raw,
+    relation: rawRelation,
+    targetFindingId: 'F-0001',
+    targetPrecondition,
+  }));
+  return authorizeFindingLedgerFixture({
+    ...fixture,
+    rawFindings,
+  });
+}
+
+function makeLedger(cwd: string): FindingLedger {
+  const unlanded = makeUnlandedLedger(cwd);
+  return refreshActiveConflictAdjudicationSnapshots({
+    ledger: landUnownedConflictRawClaims({
+      ledger: unlanded,
+      observation: {
+        runId: 'run-1',
+        stepName: 'final-gate',
+        timestamp: '2017-01-01T00:00:00.000Z',
+      },
     }),
     originStep: 'final-gate',
-    createdAt: nextMinuteObservation,
+    createdAt: {
+      runId: 'run-1',
+      stepName: 'final-gate',
+      timestamp: '2017-01-01T00:00:00.000Z',
+    },
   });
 }
 
@@ -210,6 +247,66 @@ describe('reconciled conflict lifecycle history order', () => {
     if (existsSync(cwd)) {
       rmSync(cwd, { recursive: true, force: true });
     }
+  });
+
+  it('appends a later conflict landing after the first-round landing', () => {
+    const unlanded = makeUnlandedLedger(cwd);
+    const sortedLandings = landUnownedConflictRawClaims({
+      ledger: unlanded,
+      observation: {
+        runId: 'run-order-probe',
+        stepName: 'reviewers',
+        timestamp: '2017-01-01T00:00:00.000Z',
+      },
+    }).conflictRawClaimLandings;
+    const firstRawFindingId = sortedLandings[1]!.rawFindingId;
+    const secondRawFindingId = sortedLandings[0]!.rawFindingId;
+    const firstRound = landUnownedConflictRawClaims({
+      ledger: makeUnlandedLedger(cwd, [firstRawFindingId], 'persists'),
+      observation: {
+        runId: 'run-1',
+        stepName: 'reviewers',
+        timestamp: '2017-01-01T00:00:00.000Z',
+      },
+    });
+    const conflict = firstRound.conflicts[0]!;
+    const secondRoundObservation = {
+      runId: 'run-2',
+      stepName: 'reviewers',
+      timestamp: '2017-01-01T00:01:00.000Z',
+    };
+    const updatedConflict = {
+      ...conflict,
+      rawFindingIds: [firstRawFindingId, secondRawFindingId],
+      lastSeen: secondRoundObservation,
+      revision: conflict.revision + 1,
+    };
+    const { revision: _revision, ...conflictProjection } = updatedConflict;
+    void _revision;
+    const afterFix = applyManagerDecisionLifecycleCommands({
+      current: firstRound,
+      proposed: {
+        ...firstRound,
+        conflicts: [updatedConflict],
+      },
+      commands: [{
+        operation: 'observe_conflict',
+        changes: { findings: [], conflicts: [conflictProjection] },
+        authority: { kind: 'verified_evidence' },
+        evidenceSourcesByTarget: new Map([[
+          `conflict\0${conflict.id}`,
+          { sourceRawFindingIds: [secondRawFindingId], authorityEvidenceIds: [] },
+        ]]),
+      }],
+      occurredAt: secondRoundObservation,
+    });
+    const secondRound = landUnownedConflictRawClaims({
+      ledger: afterFix,
+      observation: secondRoundObservation,
+    });
+
+    expect(secondRound.conflictRawClaimLandings.map((landing) => landing.rawFindingId))
+      .toEqual([firstRawFindingId, secondRawFindingId]);
   });
 
   it('preserves completed decisions and appends lifecycle authority through reconcile, persistence, and reservation', async () => {

--- a/src/__tests__/finding-conflict-history-order.integration.test.ts
+++ b/src/__tests__/finding-conflict-history-order.integration.test.ts
@@ -23,12 +23,26 @@ import { compareBinaryStrings } from '../shared/utils/binary-string-comparator.j
 import { verifiedFindingEvidenceFixture } from './helpers/finding-evidence.js';
 import { storedRawReconcileProvenance } from './helpers/finding-integrity.js';
 import {
+  applyFindingLedgerFixtureRevision,
   authorizeFindingLedgerFixture,
   canonicalRawFindingFixture,
   rawCanonicalSnapshotFixture,
 } from './helpers/finding-lifecycle-fixture.js';
 import { landUnownedConflictRawClaims } from '../core/workflow/findings/conflict-claim-landing.js';
 import { refreshActiveConflictAdjudicationSnapshots } from '../core/workflow/findings/conflict-adjudication-model.js';
+import {
+  computeConflictRawClaimLandingId,
+  computeConflictRawClaimSnapshotDigest,
+} from '../core/models/finding-contract-identity.js';
+import { finalizeInterpretationCaseProjection } from '../core/workflow/findings/interpretation-case-finalizer.js';
+import {
+  appendRawFindingsWithCanonicalSnapshots,
+  createRawCanonicalSnapshot,
+} from '../core/workflow/findings/raw-canonical-snapshot.js';
+import {
+  OBSERVATION,
+  taintedItems,
+} from './helpers/finding-interpretation-case-store-fixture.js';
 
 const WORKFLOW_NAME = 'peer-review';
 function makeRawFinding(
@@ -307,6 +321,168 @@ describe('reconciled conflict lifecycle history order', () => {
 
     expect(secondRound.conflictRawClaimLandings.map((landing) => landing.rawFindingId))
       .toEqual([firstRawFindingId, secondRawFindingId]);
+  });
+
+  it('preserves existing interpretation landings and appends a later case landing', () => {
+    const existingLedger = makeLedger(cwd);
+    const conflict = existingLedger.conflicts[0]!;
+    const existingLandings = existingLedger.conflictRawClaimLandings;
+    const candidateItems = Array.from({ length: 64 }, (_, index) => `raw-new-${index}`)
+      .map((rawFindingId) => taintedItems({
+        rawFindingIds: [rawFindingId],
+        ledger: existingLedger,
+        reviewerPersonaKey: 'conflict-history-reviewer-new',
+      })[0]!);
+    const newItem = candidateItems.find((item) => {
+      const snapshot = createRawCanonicalSnapshot({
+        item,
+        capturedAt: OBSERVATION,
+      });
+      const landingId = computeConflictRawClaimLandingId({
+        conflictId: conflict.id,
+        rawFindingId: item.canonical.rawFindingId,
+        rawCanonicalSnapshotId: snapshot.rawCanonicalSnapshotId,
+        rawPayloadDigest: snapshot.rawPayloadDigest,
+        claimSnapshotDigest: computeConflictRawClaimSnapshotDigest(snapshot),
+      });
+      return compareBinaryStrings(landingId, existingLandings[0]!.rawClaimLandingId) < 0;
+    });
+    if (newItem === undefined) {
+      throw new Error('Could not create a later landing that sorts before the existing history');
+    }
+
+    const caseId = 'conflict-history-finalize-case';
+    const existingHolding = existingLedger.findings.find(
+      (finding) => finding.id === existingLandings[0]!.holdingFindingId,
+    );
+    if (existingHolding?.provisional === undefined) {
+      throw new Error('Expected an existing conflict holding provisional');
+    }
+    const newHolding = {
+      ...existingHolding,
+      id: 'F-0099',
+      lifecycle: 'new' as const,
+      revision: 1,
+      evidenceIds: [],
+      rawFindingIds: [newItem.canonical.rawFindingId],
+      firstSeen: { ...OBSERVATION },
+      lastSeen: { ...OBSERVATION },
+      reviewers: [newItem.canonical.reviewer],
+      title: newItem.canonical.title ?? 'Interpretation conflict holding',
+      description: newItem.canonical.description ?? 'Interpretation conflict holding.',
+      target: newItem.wire.target,
+      targetIdentityHash: newItem.canonical.targetIdentityHash,
+      claimIdentityHash: newItem.canonical.claimIdentityHash,
+      semanticClaimIdentityHash: newItem.canonical.semanticClaimIdentityHash,
+      provisional: {
+        ...existingHolding.provisional,
+        stableKey: `${conflict.id}-${newItem.canonical.rawFindingId}`,
+        lineageKey: newItem.canonical.lineageKey,
+        sourceRawFindingIds: [newItem.canonical.rawFindingId],
+        reason: `Interpretation case conflicts with finding "${conflict.findingIds[0]}".`,
+        recoveryReviewerStableKey: newItem.canonical.reviewerStableKey,
+        firstObservedAt: { ...OBSERVATION },
+        lastObservedAt: { ...OBSERVATION },
+      },
+    };
+    const provisionalFinding = {
+      kind: 'raw-adjudication-unresolved' as const,
+      stableKey: newHolding.provisional.stableKey,
+      lineageKey: newHolding.provisional.lineageKey,
+      sourceRawFindingIds: [newItem.canonical.rawFindingId],
+      reason: `Interpretation case conflicts with finding "${conflict.findingIds[0]}".`,
+      title: newItem.canonical.title,
+      severity: newItem.canonical.severity,
+      ...(newItem.canonical.description === undefined
+        ? {}
+        : { description: newItem.canonical.description }),
+      ...(newItem.canonical.suggestion === undefined
+        ? {}
+        : { suggestion: newItem.canonical.suggestion }),
+      reviewers: [newItem.canonical.reviewer],
+      target: newItem.wire.target,
+      targetIdentityHash: newItem.canonical.targetIdentityHash,
+      claimIdentityHash: newItem.canonical.claimIdentityHash,
+      semanticClaimIdentityHash: newItem.canonical.semanticClaimIdentityHash,
+      recoveryReviewerStableKey: newItem.canonical.reviewerStableKey,
+    };
+    const prepared = {
+      cases: [{
+        caseId,
+        lineageKey: newItem.canonical.lineageKey,
+        semanticProjectionDigest: newItem.canonical.semanticClaimIdentityHash,
+        rawFindingIds: [newItem.canonical.rawFindingId],
+        attemptId: null,
+        decision: {
+          kind: 'open_conflict' as const,
+          targetFindingId: conflict.findingIds[0]!,
+        },
+        directSnapshot: {
+          roundIdentity: '1'.repeat(64),
+          policyClass: 'general' as const,
+        },
+        directItems: [newItem],
+        action: {
+          kind: 'open_product_conflict' as const,
+          conflict: {
+            findingIds: [...conflict.findingIds],
+            rawFindingIds: [newItem.canonical.rawFindingId],
+            description: provisionalFinding.reason,
+          },
+          provisionalFinding,
+        },
+      }],
+      managerOutput: makeManagerOutput(newItem.canonical.rawFindingId),
+      provisionalFindings: [provisionalFinding],
+    };
+    let settled = appendRawFindingsWithCanonicalSnapshots({
+      ledger: existingLedger,
+      items: [newItem],
+      capturedAt: OBSERVATION,
+    });
+    settled = applyFindingLedgerFixtureRevision({
+      ledger: settled,
+      entityKind: 'finding',
+      entity: newHolding,
+      contributionOrigin: {
+        kind: 'interpretation_case',
+        caseId,
+      },
+      sourceRawFindingId: newItem.canonical.rawFindingId,
+    });
+    const currentConflict = settled.conflicts.find(({ id }) => id === conflict.id);
+    if (currentConflict === undefined) {
+      throw new Error(`Existing conflict "${conflict.id}" is missing`);
+    }
+    settled = applyFindingLedgerFixtureRevision({
+      ledger: settled,
+      entityKind: 'conflict',
+      entity: {
+        ...currentConflict,
+        rawFindingIds: [
+          ...currentConflict.rawFindingIds,
+          newItem.canonical.rawFindingId,
+        ],
+        lastSeen: { ...OBSERVATION },
+        revision: currentConflict.revision + 1,
+      },
+      contributionOrigin: {
+        kind: 'interpretation_case',
+        caseId,
+      },
+      sourceRawFindingId: newItem.canonical.rawFindingId,
+    });
+    const finalized = finalizeInterpretationCaseProjection({
+      ledger: settled,
+      prepared,
+      observation: OBSERVATION,
+    });
+
+    expect(finalized.conflictRawClaimLandings.map((landing) => landing.rawFindingId))
+      .toEqual([
+        ...existingLandings.map((landing) => landing.rawFindingId),
+        newItem.canonical.rawFindingId,
+      ]);
   });
 
   it('preserves completed decisions and appends lifecycle authority through reconcile, persistence, and reservation', async () => {

--- a/src/core/workflow/findings/conflict-claim-landing.ts
+++ b/src/core/workflow/findings/conflict-claim-landing.ts
@@ -175,8 +175,7 @@ export function landUnownedConflictRawClaims(input: {
       });
       ledger = {
         ...landed.ledger,
-        conflictRawClaimLandings: [...landed.ledger.conflictRawClaimLandings, landed.landing]
-          .sort((left, right) => compareBinaryStrings(left.rawClaimLandingId, right.rawClaimLandingId)),
+        conflictRawClaimLandings: [...landed.ledger.conflictRawClaimLandings, landed.landing],
       };
       ownersByRawId.set(rawFindingId, landed.landing);
     }

--- a/src/core/workflow/findings/interpretation-case-finalizer.ts
+++ b/src/core/workflow/findings/interpretation-case-finalizer.ts
@@ -1494,8 +1494,7 @@ export function finalizeInterpretationCaseProjection(input: {
   return {
     ...settledLedger,
     updatedAt: input.observation.timestamp,
-    conflictRawClaimLandings: [...landingsByRawFindingId.values()]
-      .sort((left, right) => compareBinaryStrings(left.rawClaimLandingId, right.rawClaimLandingId)),
+    conflictRawClaimLandings: [...landingsByRawFindingId.values()],
     rawInterpretationOutcomes: [...existingByRawFindingId.values()]
       .sort((left, right) => compareBinaryStrings(left.rawFindingId, right.rawFindingId)),
     interpretationAttempts: settledLedger.interpretationAttempts.map((attempt) => {


### PR DESCRIPTION
## 目的

実 run(run-17)の死因修正。#1264 の履歴時系列化の後、永続 registry へ landing を追加した際に rawClaimLandingId で再ソートしており、2周目の新 landing が hash 順で index 0 に移動して `assertRegistryPrefix`(追記のみ・prefix 不変の検査)が正しく発火していた。

修正: **保存形(追記順)と表示形(prompt 用の直近3件時系列射影)を分離** — 永続 registry は常に追記順を維持、射影は読み出し側のまま。解釈ケース確定経路も同様。不変量検査は無緩和。

実 run 形状(1周目 landing → fix → 2周目 landing 追加)の赤緑回帰テスト付き。codex (luna, xhigh) レビュー APPROVE。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 競合する調査結果のランディング順序を、識別子順ではなく実際の登録順で保持するよう改善しました。
  - 後続ラウンドや解釈ケースで追加された結果も、既存のランディング順序を維持して表示・処理されます。

- **テスト**
  - 未ランディング状態から複数ラウンドのランディングまで、結果の順序を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->