### PR TITLE
fix(finding-contract): 同一主張の再観測でconflict裁定予算をリセットしない

### DIFF
--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { executeAgent } from '../agents/agent-usecases.js';
-import { createEngineProofRecord } from '../core/models/finding-evidence-record.js';
+import {
+  computeFileQuoteEvidenceRecordId,
+  createEngineProofRecord,
+} from '../core/models/finding-evidence-record.js';
 import type { WorkflowState } from '../core/models/types.js';
 import { createFindingConflictAdjudicationRunner } from '../core/workflow/findings/adjudication-runner.js';
 import { buildFindingConflictAdjudicationStep } from '../core/workflow/findings/adjudication-step.js';
@@ -13,6 +16,7 @@ import {
 } from '../core/workflow/findings/adjudication-evidence.js';
 import { landUnownedConflictRawClaims } from '../core/workflow/findings/conflict-claim-landing.js';
 import { applyFindingLifecycleCommands } from '../core/workflow/findings/lifecycle-transaction.js';
+import { applyRejectedObservationAttachments } from '../core/workflow/findings/manager-provisional-settlement.js';
 import {
   buildConflictAdjudicationSnapshot,
   freshConflictAdjudicationSnapshot,
@@ -26,7 +30,11 @@ import type { FindingLedgerStore } from '../core/workflow/findings/store.js';
 import { crashAfterAdjudicationReservation } from './helpers/finding-adjudication-reservation.js';
 import { createTestFindingLedgerStore } from './helpers/finding-storage.js';
 import { initializeGitFixture } from './helpers/git-fixture.js';
-import { authorizeFindingLedgerFixture } from './helpers/finding-lifecycle-fixture.js';
+import {
+  authorizeFindingLedgerFixture,
+  canonicalRawFindingFixture,
+  rawCanonicalSnapshotFixture,
+} from './helpers/finding-lifecycle-fixture.js';
 import { verifiedFindingEvidenceFixture } from './helpers/finding-evidence.js';
 import { MANAGER_INTERPRETATION_LIMITS } from '../core/workflow/findings/raw-finding-limits.js';
 import {
@@ -437,6 +445,160 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(4);
   });
 
+  it('resumes a grounding retry across a same-basis persisted snapshot after restart', async () => {
+    const initialSnapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    const initialLedger = ledgerStore.loadLedger();
+    const product = initialLedger.findings.find((finding) => (
+      finding.id === 'F-0001' && finding.provisional === undefined
+    ));
+    const raw = initialLedger.rawFindings.find((finding) => finding.rawFindingId === 'raw-1');
+    const quote = raw?.evidence[0];
+    if (product === undefined || raw === undefined || quote?.kind !== 'file_quote') {
+      throw new Error('Expected a product finding with a file quote in the retry fixture');
+    }
+    const additionalEvidencePayload = {
+      ...quote,
+      claimIdentityHash: product.claimIdentityHash,
+      fileHash: 'a'.repeat(64),
+    };
+    const additionalEvidence = {
+      evidenceId: computeFileQuoteEvidenceRecordId(additionalEvidencePayload),
+      ...additionalEvidencePayload,
+    };
+    const undeterminedResponse = async () => {
+      const snapshot = freshConflictAdjudicationSnapshot(
+        ledgerStore.loadLedger(),
+        'C-FA2947446963',
+      );
+      return {
+        persona: 'supervisor',
+        status: 'done' as const,
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'undetermined' as const,
+            subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+            rationale: 'No verified terminal authority is available.',
+          },
+        },
+        timestamp: new Date(),
+      };
+    };
+    executeAgentMock.mockImplementation(undeterminedResponse);
+
+    let crashed = false;
+    const crashingStore = new Proxy(ledgerStore, {
+      get(target, property, receiver) {
+        if (property === 'updateLedger') {
+          return async (...args: Parameters<FindingLedgerStore['updateLedger']>) => {
+            const mutation = await target.updateLedger(...args);
+            const hasFirstUndetermined = mutation.ledger.conflictAdjudicationAttempts.some((attempt) => (
+              attempt.attemptOrdinal === 1
+              && attempt.stage === 'completed'
+              && attempt.result.kind === 'verification_undetermined'
+            ));
+            const hasSecondAttempt = mutation.ledger.conflictAdjudicationAttempts.some((attempt) => (
+              attempt.attemptOrdinal === 2
+            ));
+            if (!crashed && hasFirstUndetermined && !hasSecondAttempt) {
+              crashed = true;
+              const persisted = await target.updateLedger((current) => {
+                const currentProduct = current.findings.find((finding) => (
+                  finding.id === 'F-0001' && finding.provisional === undefined
+                ));
+                if (currentProduct === undefined) {
+                  throw new Error('Expected a product finding while persisting new evidence');
+                }
+                const withEvidence = {
+                  ...current,
+                  evidenceRecords: [...current.evidenceRecords, additionalEvidence],
+                };
+                const { revision: _revision, ...productWithoutRevision } = currentProduct;
+                void _revision;
+                const changed = applyFindingLifecycleCommands({
+                  ledger: withEvidence,
+                  commands: [{
+                    operation: 'persist_finding',
+                    changes: {
+                      findings: [{
+                        ...productWithoutRevision,
+                        evidenceIds: [...currentProduct.evidenceIds, additionalEvidence.evidenceId],
+                        lifecycle: 'persists',
+                        lastSeen: {
+                          ...OBSERVATION,
+                          timestamp: '2026-06-13T00:01:00.000Z',
+                        },
+                      }],
+                      conflicts: [],
+                    },
+                    authority: { kind: 'verified_evidence' },
+                    evidenceSourcesByTarget: new Map([[
+                      `finding\0${currentProduct.id}`,
+                      { sourceRawFindingIds: currentProduct.rawFindingIds, authorityEvidenceIds: [] },
+                    ]]),
+                  }],
+                  occurredAt: {
+                    ...OBSERVATION,
+                    timestamp: '2026-06-13T00:01:00.000Z',
+                  },
+                });
+                return {
+                  ledger: refreshActiveConflictAdjudicationSnapshots({
+                    ledger: changed,
+                    originStep: 'reviewers',
+                    createdAt: OBSERVATION,
+                  }),
+                  result: undefined,
+                };
+              });
+              throw new Error('simulated crash after persisted observation');
+            }
+            return mutation;
+          };
+        }
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    const first = runner(undefined, crashingStore);
+    await expect(first.runner.run(first.step, state()))
+      .rejects.toThrow('simulated crash after persisted observation');
+
+    const interrupted = ledgerStore.loadLedger();
+    const persistedSnapshot = freshConflictAdjudicationSnapshot(
+      interrupted,
+      'C-FA2947446963',
+    );
+    expect(persistedSnapshot.conflictSnapshotId).not.toBe(initialSnapshot.conflictSnapshotId);
+    const initialProductSubject = initialSnapshot.subjects.find(({ findingId }) => findingId === 'F-0001');
+    const persistedProductSubject = persistedSnapshot.subjects.find(({ findingId }) => findingId === 'F-0001');
+    expect(persistedProductSubject?.claimSnapshotDigest)
+      .not.toBe(initialProductSubject?.claimSnapshotDigest);
+    expect(persistedProductSubject?.evidenceBindingIds)
+      .not.toEqual(initialProductSubject?.evidenceBindingIds);
+    expect(interrupted.conflictAdjudicationAttempts).toEqual([
+      expect.objectContaining({ attemptOrdinal: 1, result: expect.objectContaining({ kind: 'verification_undetermined' }) }),
+    ]);
+
+    ledgerStore = reopenStore();
+    executeAgentMock.mockClear();
+    executeAgentMock.mockImplementation(undeterminedResponse);
+    const resumed = runner(undefined, ledgerStore);
+    await resumed.runner.run(resumed.step, state());
+
+    expect(executeAgentMock).toHaveBeenCalledTimes(1);
+    expect(executeAgentMock.mock.calls[0]?.[1])
+      .toContain('Engine-provided target snapshot windows');
+    expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ attemptOrdinal: 1, result: expect.objectContaining({ kind: 'verification_undetermined' }) }),
+      expect.objectContaining({ attemptOrdinal: 2, result: expect.objectContaining({ kind: 'verification_undetermined' }) }),
+    ]));
+  });
+
   it('does not re-adjudicate after a same-claim persisted observation', async () => {
     executeAgentMock.mockImplementation(async () => {
       const snapshot = freshConflictAdjudicationSnapshot(
@@ -472,15 +634,34 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       if (product === undefined) {
         throw new Error('Expected a product finding in the persisted-observation fixture');
       }
+      const raw = current.rawFindings.find((finding) => finding.rawFindingId === 'raw-1');
+      const quote = raw?.evidence[0];
+      if (raw === undefined || quote?.kind !== 'file_quote') {
+        throw new Error('Expected a file quote for the persisted-observation fixture');
+      }
+      const additionalEvidencePayload = {
+        ...quote,
+        claimIdentityHash: product.claimIdentityHash,
+        fileHash: 'b'.repeat(64),
+      };
+      const additionalEvidence = {
+        evidenceId: computeFileQuoteEvidenceRecordId(additionalEvidencePayload),
+        ...additionalEvidencePayload,
+      };
+      const withEvidence = {
+        ...current,
+        evidenceRecords: [...current.evidenceRecords, additionalEvidence],
+      };
       const { revision: _revision, ...productWithoutRevision } = product;
       void _revision;
       const changed = applyFindingLifecycleCommands({
-        ledger: current,
+        ledger: withEvidence,
         commands: [{
           operation: 'persist_finding',
           changes: {
             findings: [{
               ...productWithoutRevision,
+              evidenceIds: [...product.evidenceIds, additionalEvidence.evidenceId],
               lifecycle: 'persists',
               lastSeen: {
                 ...OBSERVATION,
@@ -515,6 +696,12 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       'C-FA2947446963',
     );
     expect(afterObservation.conflictSnapshotId).not.toBe(originalSnapshot.conflictSnapshotId);
+    const originalProductSubject = originalSnapshot.subjects.find(({ findingId }) => findingId === 'F-0001');
+    const afterProductSubject = afterObservation.subjects.find(({ findingId }) => findingId === 'F-0001');
+    expect(afterProductSubject?.claimSnapshotDigest)
+      .not.toBe(originalProductSubject?.claimSnapshotDigest);
+    expect(afterProductSubject?.evidenceBindingIds)
+      .not.toEqual(originalProductSubject?.evidenceBindingIds);
     expect(isActiveConflictUnadjudicated(ledgerStore.loadLedger(), 'C-FA2947446963')).toBe(false);
 
     executeAgentMock.mockClear();
@@ -524,6 +711,206 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(executeAgentMock).not.toHaveBeenCalled();
     expect(ledgerStore.loadLedger().conflictAdjudicationSnapshots).toHaveLength(2);
     expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(2);
+  });
+
+  it('re-adjudicates after a new conflict claim landing is added', async () => {
+    executeAgentMock.mockImplementation(async () => {
+      const snapshot = freshConflictAdjudicationSnapshot(
+        ledgerStore.loadLedger(),
+        'C-FA2947446963',
+      );
+      return {
+        persona: 'supervisor',
+        status: 'done' as const,
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'undetermined' as const,
+            subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+            rationale: 'No verified terminal authority is available.',
+          },
+        },
+        timestamp: new Date(),
+      };
+    });
+
+    const first = runner();
+    await first.runner.run(first.step, state());
+    await ledgerStore.updateLedger((current) => {
+      const raw = current.rawFindings.find((finding) => finding.rawFindingId === 'raw-1');
+      const conflict = current.conflicts.find((candidate) => candidate.id === 'C-FA2947446963');
+      if (raw === undefined || conflict === undefined) {
+        throw new Error('Expected the original raw claim and conflict');
+      }
+      const additionalRaw = canonicalRawFindingFixture({
+        rawFindingId: 'raw-landing-addition',
+        stepName: raw.stepName,
+        reviewer: 'security-review',
+        familyTag: raw.familyTag,
+        severity: raw.severity,
+        title: raw.title,
+        description: raw.description,
+        suggestion: raw.suggestion,
+        relation: 'persists',
+        targetFindingId: 'F-0001',
+        targetPrecondition: raw.targetPrecondition,
+        evidence: raw.evidence,
+      });
+      const withRaw = {
+        ...current,
+        rawFindings: [...current.rawFindings, additionalRaw],
+        rawCanonicalSnapshots: [
+          ...current.rawCanonicalSnapshots,
+          rawCanonicalSnapshotFixture(additionalRaw, OBSERVATION),
+        ],
+      };
+      const { revision: _revision, ...conflictWithoutRevision } = conflict;
+      void _revision;
+      const observed = applyFindingLifecycleCommands({
+        ledger: withRaw,
+        commands: [{
+          operation: 'observe_conflict',
+          changes: {
+            findings: [],
+            conflicts: [{
+              ...conflictWithoutRevision,
+              rawFindingIds: [...conflict.rawFindingIds, additionalRaw.rawFindingId],
+              lastSeen: {
+                ...OBSERVATION,
+                timestamp: '2026-06-13T00:02:00.000Z',
+              },
+            }],
+          },
+          authority: { kind: 'verified_evidence' },
+          evidenceSourcesByTarget: new Map([[
+            `conflict\0${conflict.id}`,
+            { sourceRawFindingIds: [additionalRaw.rawFindingId], authorityEvidenceIds: [] },
+          ]]),
+        }],
+        occurredAt: {
+          ...OBSERVATION,
+          timestamp: '2026-06-13T00:02:00.000Z',
+        },
+      });
+      const landed = landUnownedConflictRawClaims({
+        ledger: observed,
+        observation: {
+          ...OBSERVATION,
+          timestamp: '2026-06-13T00:02:00.000Z',
+        },
+      });
+      return {
+        ledger: refreshActiveConflictAdjudicationSnapshots({
+          ledger: landed,
+          originStep: 'reviewers',
+          createdAt: OBSERVATION,
+        }),
+        result: undefined,
+      };
+    });
+
+    expect(ledgerStore.loadLedger().conflictRawClaimLandings).toHaveLength(2);
+    expect(isActiveConflictUnadjudicated(ledgerStore.loadLedger(), 'C-FA2947446963')).toBe(true);
+    executeAgentMock.mockClear();
+    const second = runner();
+    await second.runner.run(second.step, state());
+
+    expect(executeAgentMock).toHaveBeenCalled();
+  });
+
+  it('does not re-adjudicate after recording a rejected observation', async () => {
+    executeAgentMock.mockImplementation(async () => {
+      const snapshot = freshConflictAdjudicationSnapshot(
+        ledgerStore.loadLedger(),
+        'C-FA2947446963',
+      );
+      return {
+        persona: 'supervisor',
+        status: 'done' as const,
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'undetermined' as const,
+            subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+            rationale: 'No verified terminal authority is available.',
+          },
+        },
+        timestamp: new Date(),
+      };
+    });
+
+    const first = runner();
+    await first.runner.run(first.step, state());
+    await ledgerStore.updateLedger((current) => ({
+      ledger: refreshActiveConflictAdjudicationSnapshots({
+        ledger: applyRejectedObservationAttachments(
+          current,
+          [{
+            targetFindingId: 'F-0001',
+            rawFindingId: 'raw-1',
+            reason: 'The repeated observation did not pass evidence admission.',
+            rejectionCode: 'evidence_admission_failed',
+          }],
+          {
+            ...OBSERVATION,
+            timestamp: '2026-06-13T00:02:00.000Z',
+          },
+        ),
+        originStep: 'reviewers',
+        createdAt: OBSERVATION,
+      }),
+      result: undefined,
+    }));
+
+    expect(isActiveConflictUnadjudicated(ledgerStore.loadLedger(), 'C-FA2947446963')).toBe(false);
+    executeAgentMock.mockClear();
+    const second = runner();
+    await second.runner.run(second.step, state());
+
+    expect(executeAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('requires re-adjudication after the product claim identity changes', async () => {
+    executeAgentMock.mockImplementation(async () => {
+      const snapshot = freshConflictAdjudicationSnapshot(
+        ledgerStore.loadLedger(),
+        'C-FA2947446963',
+      );
+      return {
+        persona: 'supervisor',
+        status: 'done' as const,
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'undetermined' as const,
+            subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+            rationale: 'No verified terminal authority is available.',
+          },
+        },
+        timestamp: new Date(),
+      };
+    });
+    const first = runner();
+    await first.runner.run(first.step, state());
+
+    const current = ledgerStore.loadLedger();
+    const changed = {
+      ...current,
+      findings: current.findings.map((finding) => finding.id === 'F-0001'
+        ? {
+            ...finding,
+            claimIdentityHash: 'd'.repeat(64),
+            semanticClaimIdentityHash: 'e'.repeat(64),
+          }
+        : finding),
+    };
+    const refreshed = refreshActiveConflictAdjudicationSnapshots({
+      ledger: changed,
+      originStep: 'reviewers',
+      createdAt: OBSERVATION,
+    });
+
+    expect(isActiveConflictUnadjudicated(refreshed, 'C-FA2947446963')).toBe(true);
   });
 
   it('re-adjudicates a non-regular target even when its content digest is unavailable', async () => {

--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -437,6 +437,95 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(4);
   });
 
+  it('does not re-adjudicate after a same-claim persisted observation', async () => {
+    executeAgentMock.mockImplementation(async () => {
+      const snapshot = freshConflictAdjudicationSnapshot(
+        ledgerStore.loadLedger(),
+        'C-FA2947446963',
+      );
+      return {
+        persona: 'supervisor',
+        status: 'done' as const,
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'undetermined' as const,
+            subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+            rationale: 'No verified terminal authority is available.',
+          },
+        },
+        timestamp: new Date(),
+      };
+    });
+
+    const first = runner();
+    await first.runner.run(first.step, state());
+    const originalSnapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+
+    await ledgerStore.updateLedger((current) => {
+      const product = current.findings.find((finding) => (
+        finding.id === 'F-0001' && finding.provisional === undefined
+      ));
+      if (product === undefined) {
+        throw new Error('Expected a product finding in the persisted-observation fixture');
+      }
+      const { revision: _revision, ...productWithoutRevision } = product;
+      void _revision;
+      const changed = applyFindingLifecycleCommands({
+        ledger: current,
+        commands: [{
+          operation: 'persist_finding',
+          changes: {
+            findings: [{
+              ...productWithoutRevision,
+              lifecycle: 'persists',
+              lastSeen: {
+                ...OBSERVATION,
+                timestamp: '2026-06-13T00:02:00.000Z',
+              },
+            }],
+            conflicts: [],
+          },
+          authority: { kind: 'verified_evidence' },
+          evidenceSourcesByTarget: new Map([[
+            `finding\0${product.id}`,
+            { sourceRawFindingIds: product.rawFindingIds, authorityEvidenceIds: [] },
+          ]]),
+        }],
+        occurredAt: {
+          ...OBSERVATION,
+          timestamp: '2026-06-13T00:02:00.000Z',
+        },
+      });
+      return {
+        ledger: refreshActiveConflictAdjudicationSnapshots({
+          ledger: changed,
+          originStep: 'reviewers',
+          createdAt: OBSERVATION,
+        }),
+        result: undefined,
+      };
+    });
+
+    const afterObservation = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    expect(afterObservation.conflictSnapshotId).not.toBe(originalSnapshot.conflictSnapshotId);
+    expect(isActiveConflictUnadjudicated(ledgerStore.loadLedger(), 'C-FA2947446963')).toBe(false);
+
+    executeAgentMock.mockClear();
+    const second = runner();
+    await second.runner.run(second.step, state());
+
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(ledgerStore.loadLedger().conflictAdjudicationSnapshots).toHaveLength(2);
+    expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(2);
+  });
+
   it('re-adjudicates a non-regular target even when its content digest is unavailable', async () => {
     rmSync(join(cwd, 'src', 'a.ts'));
     writeFileSync(join(cwd, 'src', 'target.ts'), 'export const value = true;\n');

--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -23,6 +23,7 @@ import {
   hasAlwaysChangingConflictTarget,
   isActiveConflictUnadjudicated,
   refreshActiveConflictAdjudicationSnapshots,
+  sharesConflictAdjudicationBasis,
 } from '../core/workflow/findings/conflict-adjudication-model.js';
 import { reserveFindingConflictAdjudication } from '../core/workflow/findings/adjudication-reservation.js';
 import type { FindingContractConfig, FindingLedger } from '../core/workflow/findings/types.js';
@@ -593,6 +594,7 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(executeAgentMock).toHaveBeenCalledTimes(1);
     expect(executeAgentMock.mock.calls[0]?.[1])
       .toContain('Engine-provided target snapshot windows');
+    expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(2);
     expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toEqual(expect.arrayContaining([
       expect.objectContaining({ attemptOrdinal: 1, result: expect.objectContaining({ kind: 'verification_undetermined' }) }),
       expect.objectContaining({ attemptOrdinal: 2, result: expect.objectContaining({ kind: 'verification_undetermined' }) }),
@@ -702,6 +704,11 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       .not.toBe(originalProductSubject?.claimSnapshotDigest);
     expect(afterProductSubject?.evidenceBindingIds)
       .not.toEqual(originalProductSubject?.evidenceBindingIds);
+    expect(sharesConflictAdjudicationBasis(
+      ledgerStore.loadLedger(),
+      originalSnapshot,
+      afterObservation,
+    )).toBe(true);
     expect(isActiveConflictUnadjudicated(ledgerStore.loadLedger(), 'C-FA2947446963')).toBe(false);
 
     executeAgentMock.mockClear();
@@ -841,6 +848,10 @@ describe('finding-conflict-adjudication runner registry contract', () => {
 
     const first = runner();
     await first.runner.run(first.step, state());
+    const originalSnapshot = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
     await ledgerStore.updateLedger((current) => ({
       ledger: refreshActiveConflictAdjudicationSnapshots({
         ledger: applyRejectedObservationAttachments(
@@ -862,6 +873,15 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       result: undefined,
     }));
 
+    const afterObservation = freshConflictAdjudicationSnapshot(
+      ledgerStore.loadLedger(),
+      'C-FA2947446963',
+    );
+    expect(sharesConflictAdjudicationBasis(
+      ledgerStore.loadLedger(),
+      originalSnapshot,
+      afterObservation,
+    )).toBe(true);
     expect(isActiveConflictUnadjudicated(ledgerStore.loadLedger(), 'C-FA2947446963')).toBe(false);
     executeAgentMock.mockClear();
     const second = runner();
@@ -893,24 +913,62 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     const first = runner();
     await first.runner.run(first.step, state());
 
-    const current = ledgerStore.loadLedger();
-    const changed = {
-      ...current,
-      findings: current.findings.map((finding) => finding.id === 'F-0001'
-        ? {
-            ...finding,
-            claimIdentityHash: 'd'.repeat(64),
-            semanticClaimIdentityHash: 'e'.repeat(64),
-          }
-        : finding),
-    };
-    const refreshed = refreshActiveConflictAdjudicationSnapshots({
-      ledger: changed,
-      originStep: 'reviewers',
-      createdAt: OBSERVATION,
+    await ledgerStore.updateLedger((current) => {
+      const product = current.findings.find((finding) => (
+        finding.id === 'F-0001' && finding.provisional === undefined
+      ));
+      if (product === undefined) {
+        throw new Error('Expected a product finding in the identity fixture');
+      }
+      const { revision: _revision, ...productWithoutRevision } = product;
+      void _revision;
+      const changed = applyFindingLifecycleCommands({
+        ledger: current,
+        commands: [{
+          operation: 'update_provisional',
+          changes: {
+            findings: [{
+              ...productWithoutRevision,
+              claimIdentityHash: 'd'.repeat(64),
+              semanticClaimIdentityHash: 'e'.repeat(64),
+              lifecycle: 'persists',
+              provisional: {
+                kind: 'raw-meaning-ambiguous',
+                stableKey: 'identity-change-stable-key',
+                lineageKey: 'identity-change-lineage-key',
+                sourceRawFindingIds: ['raw-1'],
+                reason: 'The claim identity changed during the test.',
+                firstObservedAt: OBSERVATION,
+                lastObservedAt: OBSERVATION,
+                gateEffect: 'block',
+                firstObservedRound: 1,
+              },
+            }],
+            conflicts: [],
+          },
+          authority: { kind: 'verified_evidence' },
+          evidenceSourcesByTarget: new Map([[
+            `finding\0${product.id}`,
+            { sourceRawFindingIds: ['raw-1'], authorityEvidenceIds: [] },
+          ]]),
+        }],
+        occurredAt: OBSERVATION,
+      });
+      return {
+        ledger: refreshActiveConflictAdjudicationSnapshots({
+          ledger: changed,
+          originStep: 'reviewers',
+          createdAt: OBSERVATION,
+        }),
+        result: undefined,
+      };
     });
 
-    expect(isActiveConflictUnadjudicated(refreshed, 'C-FA2947446963')).toBe(true);
+    executeAgentMock.mockClear();
+    const second = runner();
+    await second.runner.run(second.step, state());
+
+    expect(executeAgentMock).toHaveBeenCalled();
   });
 
   it('re-adjudicates a non-regular target even when its content digest is unavailable', async () => {

--- a/src/core/workflow/findings/adjudication-reservation.ts
+++ b/src/core/workflow/findings/adjudication-reservation.ts
@@ -10,10 +10,10 @@ import type {
 } from '../../models/finding-contract-types.js';
 import {
   createConflictAdjudicationEpisode,
+  conflictAdjudicationAttemptsForBasis,
   freshConflictAdjudicationSnapshot,
   hasAlwaysChangingConflictTarget,
   isConflictSnapshotAdjudicated,
-  sharesConflictAdjudicationBasis,
 } from './conflict-adjudication-model.js';
 import {
   releaseFindingManagerProviderCall,
@@ -171,21 +171,7 @@ export async function reserveFindingConflictAdjudication(input: {
       snapshot,
       input.observation,
     );
-    const equivalentSnapshotIds = new Set(fresh.conflictAdjudicationSnapshots
-      .filter((candidate) => (
-        candidate.conflictId === conflict.id
-        && sharesConflictAdjudicationBasis(fresh, candidate, snapshot)
-      ))
-      .map((candidate) => candidate.conflictSnapshotId));
-    const episodeIds = new Set(fresh.conflictAdjudicationEpisodes
-      .filter((candidate) => (
-        candidate.conflictId === conflict.id
-        && equivalentSnapshotIds.has(candidate.conflictSnapshotId)
-      ))
-      .map((candidate) => candidate.episodeId));
-    const episodeAttempts = fresh.conflictAdjudicationAttempts.filter(
-      (attempt) => episodeIds.has(attempt.episodeId),
-    );
+    const episodeAttempts = conflictAdjudicationAttemptsForBasis(fresh, snapshot);
     const groundingRetryAlreadyUsed = episodeAttempts.some((attempt) => (
       attempt.attemptOrdinal === 2
       && fresh.findingManagerProviderCalls
@@ -215,9 +201,8 @@ export async function reserveFindingConflictAdjudication(input: {
     // 予約解放は provider 実行前なので attempt を消費しない。同じ snapshot digest の
     // 予約を同じ ordinal で再構築し、次回に snapshot digest が一致すればこの経路を
     // 再度通らないことを停止保証とする。
-    const used = fresh.conflictAdjudicationAttempts.filter(
-      (attempt) => episodeIds.has(attempt.episodeId)
-        && attempt.attemptId !== rebuildingAttempt?.attemptId,
+    const used = episodeAttempts.filter(
+      (attempt) => attempt.attemptId !== rebuildingAttempt?.attemptId,
     ).length;
     if (used >= ensured.episode.maxAttempts) {
       return { ledger: fresh, result: { started: false } };

--- a/src/core/workflow/findings/adjudication-reservation.ts
+++ b/src/core/workflow/findings/adjudication-reservation.ts
@@ -13,6 +13,7 @@ import {
   freshConflictAdjudicationSnapshot,
   hasAlwaysChangingConflictTarget,
   isConflictSnapshotAdjudicated,
+  sharesConflictAdjudicationBasis,
 } from './conflict-adjudication-model.js';
 import {
   releaseFindingManagerProviderCall,
@@ -170,8 +171,20 @@ export async function reserveFindingConflictAdjudication(input: {
       snapshot,
       input.observation,
     );
+    const equivalentSnapshotIds = new Set(fresh.conflictAdjudicationSnapshots
+      .filter((candidate) => (
+        candidate.conflictId === conflict.id
+        && sharesConflictAdjudicationBasis(fresh, candidate, snapshot)
+      ))
+      .map((candidate) => candidate.conflictSnapshotId));
+    const episodeIds = new Set(fresh.conflictAdjudicationEpisodes
+      .filter((candidate) => (
+        candidate.conflictId === conflict.id
+        && equivalentSnapshotIds.has(candidate.conflictSnapshotId)
+      ))
+      .map((candidate) => candidate.episodeId));
     const episodeAttempts = fresh.conflictAdjudicationAttempts.filter(
-      (attempt) => attempt.episodeId === ensured.episode.episodeId,
+      (attempt) => episodeIds.has(attempt.episodeId),
     );
     const groundingRetryAlreadyUsed = episodeAttempts.some((attempt) => (
       attempt.attemptOrdinal === 2
@@ -203,7 +216,7 @@ export async function reserveFindingConflictAdjudication(input: {
     // 予約を同じ ordinal で再構築し、次回に snapshot digest が一致すればこの経路を
     // 再度通らないことを停止保証とする。
     const used = fresh.conflictAdjudicationAttempts.filter(
-      (attempt) => attempt.episodeId === ensured.episode.episodeId
+      (attempt) => episodeIds.has(attempt.episodeId)
         && attempt.attemptId !== rebuildingAttempt?.attemptId,
     ).length;
     if (used >= ensured.episode.maxAttempts) {

--- a/src/core/workflow/findings/adjudication-runner.ts
+++ b/src/core/workflow/findings/adjudication-runner.ts
@@ -28,6 +28,7 @@ import {
 import {
   freshConflictAdjudicationSnapshot,
   isActiveConflictUnadjudicated,
+  sharesConflictAdjudicationBasis,
 } from './conflict-adjudication-model.js';
 import {
   dispatchFindingManagerProviderCall,
@@ -179,14 +180,20 @@ function hasGroundingRetryCandidate(
     return false;
   }
   const snapshot = freshConflictAdjudicationSnapshot(ledger, conflictId);
-  const episode = ledger.conflictAdjudicationEpisodes.find((candidate) => (
-    candidate.conflictSnapshotId === snapshot.conflictSnapshotId
-  ));
-  if (episode === undefined) {
-    return false;
-  }
+  const equivalentSnapshotIds = new Set(ledger.conflictAdjudicationSnapshots
+    .filter((candidate) => (
+      candidate.conflictId === conflictId
+      && sharesConflictAdjudicationBasis(ledger, candidate, snapshot)
+    ))
+    .map((candidate) => candidate.conflictSnapshotId));
+  const episodeIds = new Set(ledger.conflictAdjudicationEpisodes
+    .filter((candidate) => (
+      candidate.conflictId === conflictId
+      && equivalentSnapshotIds.has(candidate.conflictSnapshotId)
+    ))
+    .map((candidate) => candidate.episodeId));
   const attempts = ledger.conflictAdjudicationAttempts.filter((attempt) => (
-    attempt.episodeId === episode.episodeId
+    episodeIds.has(attempt.episodeId)
   ));
   return attempts.some((attempt) => (
     attempt.stage === 'completed'

--- a/src/core/workflow/findings/adjudication-runner.ts
+++ b/src/core/workflow/findings/adjudication-runner.ts
@@ -26,9 +26,9 @@ import {
   captureReviewScopeProofSnapshot,
 } from './snapshot.js';
 import {
+  conflictAdjudicationAttemptsForBasis,
   freshConflictAdjudicationSnapshot,
   isActiveConflictUnadjudicated,
-  sharesConflictAdjudicationBasis,
 } from './conflict-adjudication-model.js';
 import {
   dispatchFindingManagerProviderCall,
@@ -180,21 +180,7 @@ function hasGroundingRetryCandidate(
     return false;
   }
   const snapshot = freshConflictAdjudicationSnapshot(ledger, conflictId);
-  const equivalentSnapshotIds = new Set(ledger.conflictAdjudicationSnapshots
-    .filter((candidate) => (
-      candidate.conflictId === conflictId
-      && sharesConflictAdjudicationBasis(ledger, candidate, snapshot)
-    ))
-    .map((candidate) => candidate.conflictSnapshotId));
-  const episodeIds = new Set(ledger.conflictAdjudicationEpisodes
-    .filter((candidate) => (
-      candidate.conflictId === conflictId
-      && equivalentSnapshotIds.has(candidate.conflictSnapshotId)
-    ))
-    .map((candidate) => candidate.episodeId));
-  const attempts = ledger.conflictAdjudicationAttempts.filter((attempt) => (
-    episodeIds.has(attempt.episodeId)
-  ));
+  const attempts = conflictAdjudicationAttemptsForBasis(ledger, snapshot);
   return attempts.some((attempt) => (
     attempt.stage === 'completed'
     && attempt.attemptOrdinal === 1

--- a/src/core/workflow/findings/conflict-adjudication-model.ts
+++ b/src/core/workflow/findings/conflict-adjudication-model.ts
@@ -345,6 +345,105 @@ function snapshotMatchesCurrentProjection(
   return rebuilt.conflictSnapshotId === snapshot.conflictSnapshotId;
 }
 
+function sameConflictSubjectBasis(
+  left: ConflictClaimSubject,
+  right: ConflictClaimSubject,
+): boolean {
+  return left.role === right.role
+    && left.findingId === right.findingId
+    && left.targetIdentityHash === right.targetIdentityHash
+    && left.claimIdentityHash === right.claimIdentityHash
+    && left.semanticClaimIdentityHash === right.semanticClaimIdentityHash
+    && canonicalJson(left.rawClaimLandingIds) === canonicalJson(right.rawClaimLandingIds)
+    && canonicalJson(left.sourceRawFindingIds) === canonicalJson(right.sourceRawFindingIds)
+    && canonicalJson(left.sourceRawPayloadDigests) === canonicalJson(right.sourceRawPayloadDigests)
+    && canonicalJson(left.evidenceBindingIds) === canonicalJson(right.evidenceBindingIds)
+    && left.evidenceSetDigest === right.evidenceSetDigest
+    && left.claimSnapshotDigest === right.claimSnapshotDigest;
+}
+
+function lifecycleOperationAtHead(
+  ledger: FindingLedger,
+  head: ConflictClaimSubject['expectedHead'],
+): string | undefined {
+  return ledger.lifecycleEvents.find((event) => event.eventId === head.eventId)?.operation;
+}
+
+/**
+ * A fresh projection snapshot is still retained for the ledger invariant, but
+ * repeated evidence observation must not reset the adjudication stop budget.
+ * Only the observation operations that cannot change the conflict claim basis
+ * are folded into the previous adjudication basis.
+ */
+function isObservationOnlyConflictProjectionRefresh(input: {
+  ledger: FindingLedger;
+  previous: ConflictAdjudicationSnapshot;
+  current: ConflictAdjudicationSnapshot;
+}): boolean {
+  if (
+    input.previous.conflictId !== input.current.conflictId
+    || canonicalJson(input.previous.expectedConflictHead)
+      !== canonicalJson(input.current.expectedConflictHead)
+    || input.previous.claimUniverseDigest !== input.current.claimUniverseDigest
+    || canonicalJson(input.previous.rawClaimLandingIds)
+      !== canonicalJson(input.current.rawClaimLandingIds)
+    || canonicalJson(input.previous.priorSettlementIds)
+      !== canonicalJson(input.current.priorSettlementIds)
+    || canonicalJson(input.previous.targetContentDigests ?? [])
+      !== canonicalJson(input.current.targetContentDigests ?? [])
+  ) {
+    return false;
+  }
+
+  const previousSubjects = [...input.previous.subjects].sort((left, right) => (
+    compareBinaryStrings(`${left.role}\0${left.findingId}`, `${right.role}\0${right.findingId}`)
+  ));
+  const currentSubjects = [...input.current.subjects].sort((left, right) => (
+    compareBinaryStrings(`${left.role}\0${left.findingId}`, `${right.role}\0${right.findingId}`)
+  ));
+  if (previousSubjects.length !== currentSubjects.length) {
+    return false;
+  }
+
+  let headChanged = false;
+  for (let index = 0; index < previousSubjects.length; index += 1) {
+    const previous = previousSubjects[index]!;
+    const current = currentSubjects[index]!;
+    if (!sameConflictSubjectBasis(previous, current)) {
+      if (
+        previous.role !== 'product_finding'
+        || current.role !== 'product_finding'
+        || previous.findingId !== current.findingId
+        || previous.targetIdentityHash !== current.targetIdentityHash
+        || previous.claimIdentityHash !== current.claimIdentityHash
+        || previous.semanticClaimIdentityHash !== current.semanticClaimIdentityHash
+      ) {
+        return false;
+      }
+    }
+    if (canonicalJson(previous.expectedHead) === canonicalJson(current.expectedHead)) {
+      continue;
+    }
+    headChanged = true;
+    const operation = lifecycleOperationAtHead(input.ledger, current.expectedHead);
+    const observationOnly = operation === 'record_rejected_observation'
+      || (current.role === 'product_finding' && operation === 'persist_finding');
+    if (!observationOnly) {
+      return false;
+    }
+  }
+  return headChanged;
+}
+
+function sharesConflictAdjudicationBasis(
+  ledger: FindingLedger,
+  previous: ConflictAdjudicationSnapshot,
+  current: ConflictAdjudicationSnapshot,
+): boolean {
+  return previous.conflictSnapshotId === current.conflictSnapshotId
+    || isObservationOnlyConflictProjectionRefresh({ ledger, previous, current });
+}
+
 export function refreshActiveConflictAdjudicationSnapshots(input: {
   ledger: FindingLedger;
   originStep: string | null;
@@ -421,8 +520,11 @@ export function isConflictSnapshotAdjudicated(
   snapshot: ConflictAdjudicationSnapshot,
 ): boolean {
   return ledger.conflictAdjudicationAttempts.some((attempt) => (
-    attempt.conflictSnapshotId === snapshot.conflictSnapshotId
-    && canonicalJson(attempt.expectedConflictHead) === canonicalJson(snapshot.expectedConflictHead)
+    ledger.conflictAdjudicationSnapshots.some((candidate) => (
+      candidate.conflictSnapshotId === attempt.conflictSnapshotId
+      && sharesConflictAdjudicationBasis(ledger, candidate, snapshot)
+      && canonicalJson(attempt.expectedConflictHead) === canonicalJson(candidate.expectedConflictHead)
+    ))
     && ledger.findingManagerProviderCalls.some((call) => (
       call.providerCallId === attempt.providerCallId
       && call.requestDigest === attempt.requestDigest
@@ -446,16 +548,23 @@ function hasRemainingConflictAttempts(
   ledger: FindingLedger,
   snapshot: ConflictAdjudicationSnapshot,
 ): boolean {
-  const episode = ledger.conflictAdjudicationEpisodes.find((candidate) => (
-    candidate.episodeId === computeConflictEpisodeId({
-      conflictId: snapshot.conflictId,
-      expectedConflictHead: snapshot.expectedConflictHead,
-      conflictSnapshotId: snapshot.conflictSnapshotId,
-    })
+  const equivalentSnapshotIds = new Set(ledger.conflictAdjudicationSnapshots
+    .filter((candidate) => (
+      candidate.conflictId === snapshot.conflictId
+      && sharesConflictAdjudicationBasis(ledger, candidate, snapshot)
+    ))
+    .map((candidate) => candidate.conflictSnapshotId));
+  const episodes = ledger.conflictAdjudicationEpisodes.filter((episode) => (
+    episode.conflictId === snapshot.conflictId
+    && equivalentSnapshotIds.has(episode.conflictSnapshotId)
   ));
-  return episode === undefined || ledger.conflictAdjudicationAttempts.filter(
-    (attempt) => attempt.episodeId === episode.episodeId,
-  ).length < episode.maxAttempts;
+  if (episodes.length === 0) {
+    return true;
+  }
+  const attemptCount = ledger.conflictAdjudicationAttempts.filter((attempt) => (
+    episodes.some((episode) => episode.episodeId === attempt.episodeId)
+  )).length;
+  return attemptCount < Math.max(...episodes.map((episode) => episode.maxAttempts));
 }
 
 export function isActiveConflictUnadjudicated(

--- a/src/core/workflow/findings/conflict-adjudication-model.ts
+++ b/src/core/workflow/findings/conflict-adjudication-model.ts
@@ -11,6 +11,7 @@ import {
 } from '../../models/finding-contract-identity.js';
 import type {
   AdjudicatedConflictClaimSettlement,
+  ConflictAdjudicationAttempt,
   ConflictAdjudicationEpisode,
   ConflictAdjudicationSnapshot,
   ConflictClaimSettlement,
@@ -22,6 +23,7 @@ import type {
   FindingLedgerConflict,
   FindingLedgerEntry,
   FindingObservation,
+  FindingLifecycleOperation,
 } from './types.js';
 import { captureFindingLifecycleHead } from './lifecycle-mutation.js';
 import { hasVerifiedOrdinaryLifecycleCoverage } from '../../models/finding-lifecycle-continuity.js';
@@ -362,11 +364,26 @@ function sameConflictSubjectBasis(
     && left.claimSnapshotDigest === right.claimSnapshotDigest;
 }
 
-function lifecycleOperationAtHead(
+function lifecycleOperationsBetweenHeads(
   ledger: FindingLedger,
-  head: ConflictClaimSubject['expectedHead'],
-): string | undefined {
-  return ledger.lifecycleEvents.find((event) => event.eventId === head.eventId)?.operation;
+  previous: ConflictClaimSubject['expectedHead'],
+  current: ConflictClaimSubject['expectedHead'],
+): FindingLifecycleOperation[] | undefined {
+  const revisionGap = current.revision - previous.revision;
+  if (revisionGap !== 1) {
+    return undefined;
+  }
+  const operations = ledger.lifecycleEvents.flatMap((event) => (
+    event.transitions
+      .filter((transition) => (
+        transition.after.entityKind === current.entityKind
+        && transition.after.entityId === current.entityId
+        && transition.after.revision > previous.revision
+        && transition.after.revision <= current.revision
+      ))
+      .map(() => event.operation)
+  ));
+  return operations.length === revisionGap ? operations : undefined;
 }
 
 /**
@@ -424,17 +441,30 @@ function isObservationOnlyConflictProjectionRefresh(input: {
     if (canonicalJson(previous.expectedHead) === canonicalJson(current.expectedHead)) {
       continue;
     }
-    headChanged = true;
-    const operation = lifecycleOperationAtHead(input.ledger, current.expectedHead);
-    const observationOnly = operation === 'record_rejected_observation'
-      || (current.role === 'product_finding' && operation === 'persist_finding');
-    if (!observationOnly) {
+    const operations = lifecycleOperationsBetweenHeads(
+      input.ledger,
+      previous.expectedHead,
+      current.expectedHead,
+    );
+    if (
+      operations === undefined
+      || operations.some((operation) => (
+        operation !== 'record_rejected_observation'
+        && !(current.role === 'product_finding' && operation === 'persist_finding')
+      ))
+    ) {
       return false;
     }
+    headChanged = true;
   }
   return headChanged;
 }
 
+/**
+ * `previous` must be the ledger candidate snapshot and `current` must be the
+ * latest projection snapshot. The observation-only check reads the lifecycle
+ * head on `current`, so swapping the arguments can change the result.
+ */
 export function sharesConflictAdjudicationBasis(
   ledger: FindingLedger,
   previous: ConflictAdjudicationSnapshot,
@@ -442,6 +472,27 @@ export function sharesConflictAdjudicationBasis(
 ): boolean {
   return previous.conflictSnapshotId === current.conflictSnapshotId
     || isObservationOnlyConflictProjectionRefresh({ ledger, previous, current });
+}
+
+export function conflictAdjudicationAttemptsForBasis(
+  ledger: FindingLedger,
+  snapshot: ConflictAdjudicationSnapshot,
+): ConflictAdjudicationAttempt[] {
+  const equivalentSnapshotIds = new Set(ledger.conflictAdjudicationSnapshots
+    .filter((candidate) => (
+      candidate.conflictId === snapshot.conflictId
+      && sharesConflictAdjudicationBasis(ledger, candidate, snapshot)
+    ))
+    .map((candidate) => candidate.conflictSnapshotId));
+  const episodeIds = new Set(ledger.conflictAdjudicationEpisodes
+    .filter((episode) => (
+      episode.conflictId === snapshot.conflictId
+      && equivalentSnapshotIds.has(episode.conflictSnapshotId)
+    ))
+    .map((episode) => episode.episodeId));
+  return ledger.conflictAdjudicationAttempts.filter((attempt) => (
+    episodeIds.has(attempt.episodeId)
+  ));
 }
 
 export function refreshActiveConflictAdjudicationSnapshots(input: {

--- a/src/core/workflow/findings/conflict-adjudication-model.ts
+++ b/src/core/workflow/findings/conflict-adjudication-model.ts
@@ -435,7 +435,7 @@ function isObservationOnlyConflictProjectionRefresh(input: {
   return headChanged;
 }
 
-function sharesConflictAdjudicationBasis(
+export function sharesConflictAdjudicationBasis(
   ledger: FindingLedger,
   previous: ConflictAdjudicationSnapshot,
   current: ConflictAdjudicationSnapshot,


### PR DESCRIPTION
## 目的

実 run で reviewers↔conflict裁定の往復が再発した死因の修正。同一 conflict の同一 claim に persists 観測が毎周追加されるたびに snapshot が変わり、裁定予算(attempt budget)がリセットされて未裁定扱いに戻っていた(5周で anomaly +54 の膨張も、この無駄な reviewers 再実行の副産物)。

## 修正

- **persist_finding / record_rejected_observation では裁定 episode をリセットしない**。claim identity / target / raw landing / 対象コード digest / update_provisional の変化は従来どおり新しい裁定対象
- snapshot は最新 projection として保存(#1265 の追記順不変量と整合)
- **grounding retry は同一 basis の episode 系列で継続**(crash 窓で S0 の未実行 attempt を S1 が引き継ぐ)

実 run の台帳での検証: 修正後 activeUnadjudicated=false(往復が止まる)。crash→persist_finding→retry 継続の赤緑テスト、landing/claim identity 変更の再裁定テスト付き。codex (luna, xhigh) レビュー2巡 APPROVE。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **不具合修正**
  - 同一の競合基盤に属する複数のスナップショットやエピソードを横断して、判定済み状態と再試行回数を正しく管理できるようになりました。
  - 新しい証拠や競合クレームの追加、主張識別子の変更を適切に検知し、必要に応じて再判定を実行します。
  - 観測結果の更新や却下のみの場合は不要な再判定を避け、状態だけを更新するようになりました。
  - 再起動後も、同一条件に基づくグラウンディング再試行を一貫して扱えるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->