### PR TITLE
fix(finding-contract): 裁定リクエストのraw参照を縮約し入力上限を裁定専用96KiBに適正化する

### DIFF
--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -8,9 +8,13 @@ import {
   createEngineProofRecord,
 } from '../core/models/finding-evidence-record.js';
 import type { WorkflowState } from '../core/models/types.js';
-import { createFindingConflictAdjudicationRunner } from '../core/workflow/findings/adjudication-runner.js';
+import {
+  createFindingConflictAdjudicationRunner,
+  serializeFindingConflictAdjudicationRequest,
+} from '../core/workflow/findings/adjudication-runner.js';
 import { buildFindingConflictAdjudicationStep } from '../core/workflow/findings/adjudication-step.js';
 import {
+  buildConflictAdjudicationSnapshotReference,
   renderConflictAdjudicationInstruction,
   type ConflictAdjudicationHistoryOrder,
 } from '../core/workflow/findings/adjudication-evidence.js';
@@ -1010,11 +1014,23 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     const inflated = structuredClone(snapshot);
     inflated.subjects = inflated.subjects.map((subject, subjectIndex) => ({
       ...subject,
-      sourceRawFindingIds: Array.from({ length: 4096 }, (_, index) => `${subjectIndex}-raw-${index}`),
-      sourceRawPayloadDigests: Array.from({ length: 4096 }, (_, index) => `${subjectIndex}-payload-${index}`),
-      evidenceBindingIds: Array.from({ length: 4096 }, (_, index) => `${subjectIndex}-binding-${index}`),
+      sourceRawFindingIds: Array.from(
+        { length: 4096 },
+        (_, index) => `${subjectIndex}-raw-${index}-${'finding-context/'.repeat(50)}${index}`,
+      ),
+      sourceRawPayloadDigests: Array.from(
+        { length: 4096 },
+        (_, index) => `${subjectIndex.toString(16)}${index.toString(16).padStart(8, '0')}${'p'.repeat(55)}`,
+      ),
+      evidenceBindingIds: Array.from(
+        { length: 4096 },
+        (_, index) => `${subjectIndex.toString(16)}${index.toString(16).padStart(8, '0')}${'b'.repeat(55)}`,
+      ),
       rawClaimLandingIds: subject.role === 'holding_provisional'
-        ? Array.from({ length: 4096 }, (_, index) => `${subjectIndex}-landing-${index}`)
+        ? Array.from(
+            { length: 4096 },
+            (_, index) => `${subjectIndex.toString(16)}${index.toString(16).padStart(8, '0')}${'l'.repeat(55)}`,
+          )
         : [],
     }));
 
@@ -1040,8 +1056,51 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       ]),
     ) as ConflictAdjudicationHistoryOrder;
     const instruction = renderConflictAdjudicationInstruction(inflated, history);
+    const reference = buildConflictAdjudicationSnapshotReference(inflated, history);
+    const compactRawFindingId = reference.subjects
+      .flatMap(({ sourceRawFindingIds }) => sourceRawFindingIds)
+      .find((value) => value.startsWith('raw-ref:'));
+    const step = runner().step;
+    const phase1Instruction = [
+      '# Finding Contract adjudication',
+      '',
+      'Judge only the supplied ledger subject and the engine-issued proofs and scope bindings.',
+      '',
+      'Do not dismiss or terminate without claim-specific verified evidence or a matching scope binding. Choose the undetermined outcome when evidence does not correspond byte-for-byte to the candidate, when the scope differs, or when the result cannot be determined.',
+      '',
+      'Do not perform a new review, edit code, or invent evidence, authority, or findings. Do not treat reviewer or coder confidence, or their silence, as evidence.',
+      '',
+      '---',
+      '',
+      instruction,
+    ].join('\n');
+    const request = serializeFindingConflictAdjudicationRequest({
+      step,
+      phase1Instruction,
+      agentOptions: {
+        cwd: '/Users/nrs/work/git/takt-worktrees/20260807T1751-pr-komento-no-wodaunroodoshite-4bcef608f0695f48',
+        projectCwd: '/Users/nrs/work/git/takt-worktrees/20260807T1751-pr-komento-no-wodaunroodoshite-4bcef608f0695f48',
+        provider: 'claude',
+        model: 'claude-sonnet',
+        resolvedProvider: 'claude',
+        resolvedModel: 'claude-sonnet',
+        personaPath: '/Users/nrs/work/git/takt/builtins/ja/facets/personas/supervisor.md',
+        workflowBundleResourceRoot: '/Users/nrs/work/git/takt/builtins',
+        language: 'ja',
+        allowedTools: [],
+        workflowMeta: {
+          workflowName: 'peer-review-suite-finding-contract-base',
+          currentStep: 'finding-conflict-adjudication',
+          stepsList: [{ name: 'reviewers' }, { name: 'finding-conflict-adjudication' }],
+          currentPosition: '2/2',
+        },
+        outputSchema: step.structuredOutput?.schema,
+      },
+    });
 
     expect(Buffer.byteLength(instruction, 'utf8'))
+      .toBeLessThanOrEqual(MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall);
+    expect(Buffer.byteLength(request, 'utf8'))
       .toBeLessThanOrEqual(MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall);
     expect(instruction).toContain('"snapshotFormat": "reference-v1"');
     expect(instruction).toContain('sourceRawFindingCount');
@@ -1050,6 +1109,10 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(instruction).toContain('sourceRawPayloadIds');
     expect(instruction).toContain('0-raw-999');
     expect(instruction).toContain('evidenceBindingIds');
+    expect(compactRawFindingId).toMatch(/^raw-ref:.*….*#sha256:[0-9a-f]{64}$/);
+    expect(reference.subjects[0]?.sourceRawFindingCount).toBe(4096);
+    expect(reference.subjects[0]?.sourceRawFindingDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(request).not.toContain(inflated.subjects[0]?.sourceRawFindingIds[0] ?? '');
   });
 
   it('re-adjudicates once with digest-bound target windows and applies a verified result', async () => {

--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -41,12 +41,16 @@ import {
   rawCanonicalSnapshotFixture,
 } from './helpers/finding-lifecycle-fixture.js';
 import { verifiedFindingEvidenceFixture } from './helpers/finding-evidence.js';
-import { MANAGER_INTERPRETATION_LIMITS } from '../core/workflow/findings/raw-finding-limits.js';
+import {
+  CONFLICT_ADJUDICATION_INPUT_MAX_BYTES,
+  MANAGER_INTERPRETATION_LIMITS,
+} from '../core/workflow/findings/raw-finding-limits.js';
 import {
   captureConflictTargetContentDigests,
   captureReviewScopeProofSnapshot,
 } from '../core/workflow/findings/snapshot.js';
 import { conflictTargetPaths } from '../core/workflow/findings/conflict-target.js';
+import { formatConflictId } from '../core/models/finding-conflict-identity.js';
 
 vi.mock('../agents/agent-usecases.js', () => ({ executeAgent: vi.fn() }));
 const executeAgentMock = vi.mocked(executeAgent);
@@ -90,69 +94,95 @@ function contract(cwd: string): FindingContractConfig {
   };
 }
 
-function seededLedger(cwd: string): FindingLedger {
-  const evidence = verifiedFindingEvidenceFixture({
-    cwd,
-    path: 'src/a.ts',
-    startLine: 1,
-    title: 'Disputed issue',
-    description: 'The bug is present.',
-    familyTag: 'bug',
-    targetFindingId: 'F-0001',
+function seededLedger(
+  cwd: string,
+  options: { productCount?: number; rawFindingsPerProduct?: number } = {},
+): FindingLedger {
+  const productCount = options.productCount ?? 1;
+  const rawFindingsPerProduct = options.rawFindingsPerProduct ?? 1;
+  const products = Array.from({ length: productCount }, (_, productIndex) => {
+    const findingId = `F-${String(productIndex + 1).padStart(4, '0')}`;
+    const evidence = verifiedFindingEvidenceFixture({
+      cwd,
+      path: 'src/a.ts',
+      startLine: 1,
+      title: productCount === 1 ? 'Disputed issue' : `Disputed issue ${findingId}`,
+      description: productCount === 1 ? 'The bug is present.' : `The bug is present in ${findingId}.`,
+      familyTag: 'bug',
+      targetFindingId: findingId,
+    });
+    return { findingId, evidence };
   });
-  const ledger = authorizeFindingLedgerFixture({
-    workflowName: 'runner-test',
-    nextId: 2,
-    updatedAt: OBSERVATION.timestamp,
-    findings: [{
-      id: 'F-0001',
-      status: 'open',
-      lifecycle: 'new',
-      revision: 1,
-      severity: 'high',
-      title: 'Disputed issue',
-      description: 'The bug is present.',
-      evidenceIds: [evidence.record.evidenceId],
-      reviewers: ['coding-review'],
-      rawFindingIds: ['raw-1'],
-      firstSeen: OBSERVATION,
-      lastSeen: OBSERVATION,
-    }],
-    rawFindings: [{
-      rawFindingId: 'raw-1',
+  const rawFindingIdFor = (productIndex: number, rawIndex: number): string => (
+    rawFindingsPerProduct === 1
+      ? `raw-${productIndex + 1}`
+      : `raw-${productIndex + 1}-${String(rawIndex + 1).padStart(4, '0')}`
+  );
+  const rawFindings = products.flatMap(({ findingId, evidence }, productIndex) => (
+    Array.from({ length: rawFindingsPerProduct }, (_, rawIndex) => ({
+      rawFindingId: rawFindingIdFor(productIndex, rawIndex),
       stepName: 'reviewers',
       reviewer: 'coding-review',
       familyTag: 'bug',
-      severity: 'high',
-      title: 'Disputed issue',
-      description: 'The bug is present.',
+      severity: 'high' as const,
+      title: productCount === 1 ? 'Disputed issue' : `Disputed issue ${findingId}`,
+      description: productCount === 1 ? 'The bug is present.' : `The bug is present in ${findingId}.`,
       suggestion: null,
-      relation: 'persists',
-      targetFindingId: 'F-0001',
+      relation: 'persists' as const,
+      targetFindingId: findingId,
       targetPrecondition: {
-        targetFindingId: 'F-0001',
+        targetFindingId: findingId,
         targetRevision: 1,
-        targetStatus: 'open',
+        targetStatus: 'open' as const,
         targetEvidenceHash: '0'.repeat(64),
       },
       evidence: [evidence.evidence],
-    }],
+    }))
+  ));
+  const ledger = authorizeFindingLedgerFixture({
+    workflowName: 'runner-test',
+    nextId: productCount + 1,
+    updatedAt: OBSERVATION.timestamp,
+    findings: products.map(({ findingId, evidence }) => ({
+      id: findingId,
+      status: 'open' as const,
+      lifecycle: 'new' as const,
+      revision: 1,
+      severity: 'high' as const,
+      title: productCount === 1 ? 'Disputed issue' : `Disputed issue ${findingId}`,
+      description: productCount === 1 ? 'The bug is present.' : `The bug is present in ${findingId}.`,
+      evidenceIds: [evidence.record.evidenceId],
+      reviewers: ['coding-review'],
+      rawFindingIds: rawFindings
+        .filter((rawFinding) => rawFinding.targetFindingId === findingId)
+        .map(({ rawFindingId }) => rawFindingId),
+      firstSeen: OBSERVATION,
+      lastSeen: OBSERVATION,
+    })),
+    rawFindings,
     conflicts: [{
-      id: 'C-FA2947446963',
+      id: formatConflictId({
+        findingIds: products.map(({ findingId }) => findingId),
+        rawFindingIds: products.map((_, productIndex) => rawFindingIdFor(productIndex, 0)),
+      }),
       status: 'active',
-      findingIds: ['F-0001'],
-      rawFindingIds: ['raw-1'],
+      findingIds: products.map(({ findingId }) => findingId),
+      rawFindingIds: products.map((_, productIndex) => rawFindingIdFor(productIndex, 0)),
       description: 'Reviewers disagree about F-0001.',
       firstSeen: OBSERVATION,
       lastSeen: OBSERVATION,
       revision: 1,
     }],
-    evidenceRecords: [evidence.record],
+    evidenceRecords: products.map(({ evidence }) => evidence.record),
     evidenceBindings: [],
     lifecycleReservations: [],
     lifecycleEvents: [],
   });
   const landed = landUnownedConflictRawClaims({ ledger, observation: OBSERVATION });
+  const conflictId = landed.conflicts[0]?.id;
+  if (conflictId === undefined) {
+    throw new Error('Expected the fixture to contain a conflict');
+  }
   const reviewScopeSnapshot = captureReviewScopeProofSnapshot(cwd);
   const queryInventoryByPath = new Map(
     reviewScopeSnapshot.queryInventory.map((entry) => [entry.path, entry]),
@@ -162,11 +192,11 @@ function seededLedger(cwd: string): FindingLedger {
     originStep: 'reviewers',
     createdAt: OBSERVATION,
     targetContentDigestsByConflict: new Map([[
-      'C-FA2947446963',
-      captureConflictTargetContentDigests(
-        queryInventoryByPath,
-        conflictTargetPaths({ ledger: landed, conflictId: 'C-FA2947446963' }),
-      ),
+      conflictId,
+      captureConflictTargetContentDigests(queryInventoryByPath, conflictTargetPaths({
+        ledger: landed,
+        conflictId,
+      })),
     ]]),
   });
 }
@@ -233,11 +263,11 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     };
   }
 
-  function reopenStore(): FindingLedgerStore {
+  function reopenStore(runId = 'run-1'): FindingLedgerStore {
     return createTestFindingLedgerStore({
       projectCwd: cwd,
-      runId: 'run-1',
-      reportDir: join(cwd, '.takt', 'runs', 'run-1', 'reports'),
+      runId,
+      reportDir: join(cwd, '.takt', 'runs', runId, 'reports'),
       workflowName: 'runner-test',
     });
   }
@@ -289,7 +319,7 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       expect.objectContaining({ state: 'settled', purpose: 'conflict_adjudication' }),
     ]));
     expect(ledger.findingManagerProviderCalls.every((call) => (
-      call.requestByteLength <= MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall
+      call.requestByteLength <= CONFLICT_ADJUDICATION_INPUT_MAX_BYTES
     ))).toBe(true);
     expect(executeAgentMock).toHaveBeenCalledTimes(2);
   });
@@ -1099,9 +1129,9 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     });
 
     expect(Buffer.byteLength(instruction, 'utf8'))
-      .toBeLessThanOrEqual(MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall);
+      .toBeLessThanOrEqual(CONFLICT_ADJUDICATION_INPUT_MAX_BYTES);
     expect(Buffer.byteLength(request, 'utf8'))
-      .toBeLessThanOrEqual(MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall);
+      .toBeLessThanOrEqual(CONFLICT_ADJUDICATION_INPUT_MAX_BYTES);
     expect(instruction).toContain('"snapshotFormat": "reference-v1"');
     expect(instruction).toContain('sourceRawFindingCount');
     expect(instruction).toContain('sourceRawFindingIds');
@@ -1113,6 +1143,97 @@ describe('finding-conflict-adjudication runner registry contract', () => {
     expect(reference.subjects[0]?.sourceRawFindingCount).toBe(4096);
     expect(reference.subjects[0]?.sourceRawFindingDigest).toMatch(/^[0-9a-f]{64}$/);
     expect(request).not.toContain(inflated.subjects[0]?.sourceRawFindingIds[0] ?? '');
+  });
+
+  it('keeps ten subjects with large ID collections in one conflict adjudication call', async () => {
+    const manyRunId = 'run-many-subjects';
+    mkdirSync(join(cwd, '.takt', 'runs', manyRunId, 'reports'), { recursive: true });
+    ledgerStore = reopenStore(manyRunId);
+    await ledgerStore.updateLedger(() => ({
+      ledger: seededLedger(cwd, { productCount: 5, rawFindingsPerProduct: 40 }),
+      result: undefined,
+    }));
+
+    const conflictId = ledgerStore.loadLedger().conflicts[0]!.id;
+    const snapshot = freshConflictAdjudicationSnapshot(ledgerStore.loadLedger(), conflictId);
+    expect(snapshot.subjects).toHaveLength(10);
+    const expectedSubjectIds = snapshot.subjects.map(({ subjectId }) => subjectId);
+    const proofBySubjectId = new Map(snapshot.subjects.map((subject, index) => {
+      const proof = createEngineProofRecord({
+        kind: 'engine_proof',
+        purpose: 'lifecycle_authority',
+        verifierId: 'takt.finding-lifecycle-policy',
+        verifierVersion: '1',
+        workflowName: 'runner-test',
+        runId: 'run-1',
+        scopeIdentity: SCOPE_IDENTITY,
+        snapshotId: snapshot.conflictSnapshotId,
+        claimIdentityHash: null,
+        targetFindingId: subject.findingId,
+        subject: {
+          kind: 'finding_no_issue_after_verification',
+          adjudicationKind: 'conflict',
+          subjectId: subject.subjectId,
+          findingId: subject.findingId,
+          expectedHead: subject.expectedHead,
+          claimSnapshotDigest: subject.claimSnapshotDigest,
+          rawClaimRefIds: subject.rawClaimLandingIds,
+        },
+        dependencyDigests: [snapshot.conflictSnapshotId],
+        resultDigest: `${index.toString(16).padStart(2, '0')}${'a'.repeat(62)}`,
+        issuedAt: OBSERVATION.timestamp,
+      });
+      return [subject.subjectId, proof] as const;
+    }));
+    await ledgerStore.updateLedger((current) => ({
+      ledger: {
+        ...current,
+        evidenceRecords: [...current.evidenceRecords, ...proofBySubjectId.values()],
+      },
+      result: undefined,
+    }));
+
+    const subjectIdsByRequest: string[][] = [];
+    executeAgentMock.mockImplementation(async (_persona, prompt) => {
+      const subjectIds = expectedSubjectIds.filter((subjectId) => (
+        prompt.includes(`"subjectId":"${subjectId}"`)
+        || prompt.includes(`"subjectId": "${subjectId}"`)
+      ));
+      subjectIdsByRequest.push(subjectIds);
+      const subjectId = subjectIds[0];
+      const proof = subjectId === undefined ? undefined : proofBySubjectId.get(subjectId);
+      if (proof === undefined) {
+        throw new Error('Expected a proof-backed subject in the conflict adjudication request');
+      }
+      return {
+        persona: 'supervisor',
+        status: 'done' as const,
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'terminate_subject' as const,
+            subjectId,
+            basis: 'finding_no_issue_after_verification' as const,
+            authorityRefIds: [proof.evidenceId],
+            rationale: 'The fixture proof supports termination.',
+          },
+        },
+        timestamp: new Date(),
+      };
+    });
+
+    const target = runner(undefined, ledgerStore);
+    await target.runner.run(target.step, state());
+
+    const adjudicationCalls = ledgerStore.loadLedger().findingManagerProviderCalls.filter((call) => (
+      call.purpose === 'conflict_adjudication'
+    ));
+    expect(adjudicationCalls).toHaveLength(1);
+    expect(adjudicationCalls[0]!.requestByteLength)
+      .toBeGreaterThan(MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall);
+    expect(adjudicationCalls[0]!.requestByteLength)
+      .toBeLessThanOrEqual(CONFLICT_ADJUDICATION_INPUT_MAX_BYTES);
+    expect(subjectIdsByRequest).toEqual([expectedSubjectIds]);
   });
 
   it('re-adjudicates once with digest-bound target windows and applies a verified result', async () => {

--- a/src/__tests__/finding-conflict-adjudication.test.ts
+++ b/src/__tests__/finding-conflict-adjudication.test.ts
@@ -229,6 +229,31 @@ describe('verified conflict adjudication', () => {
     );
   });
 
+  it('keeps emoji intact when compacting at surrogate boundaries', () => {
+    const rawFindingId = `${'a'.repeat(11)}😀${'b'.repeat(200)}😀${'c'.repeat(11)}`;
+    const current = snapshot([{
+      ...subject('F-0001', head('finding', 'F-0001', 1)),
+      sourceRawFindingIds: [rawFindingId],
+    }]);
+    const history = {
+      sourceRawFindingIds: new Map([[rawFindingId, OBSERVATION]]),
+      sourceRawPayloadDigests: new Map(),
+      evidenceBindingIds: new Map(),
+      rawClaimLandingIds: new Map(),
+      priorSettlementIds: new Map(),
+    };
+
+    const compact = buildConflictAdjudicationSnapshotReference(current, history)
+      .subjects[0]?.sourceRawFindingIds[0];
+
+    expect(compact).toMatch(
+      new RegExp(
+        `^raw-ref:${'a'.repeat(11)}😀…😀${'c'.repeat(11)}#sha256:[0-9a-f]{64}$`,
+        'u',
+      ),
+    );
+  });
+
   it('issues branded terminate authority only for an exactly bound engine proof', () => {
     const findingHead = head('finding', 'F-0001', 1);
     const conflictHead = head('conflict', 'C-0001', 1);

--- a/src/core/workflow/findings/adjudication-evidence.ts
+++ b/src/core/workflow/findings/adjudication-evidence.ts
@@ -263,6 +263,7 @@ interface ConflictAdjudicationSnapshotReference {
 }
 
 const INLINE_HISTORY_LIMIT = 3;
+const INLINE_RAW_FINDING_ID_LIMIT_BYTES = 192;
 
 export interface ConflictAdjudicationHistoryOrder {
   sourceRawFindingIds: ReadonlyMap<string, FindingObservation>;
@@ -340,6 +341,23 @@ function inlineHistory(
     .map(({ value }) => value);
 }
 
+function compactInlineRawFindingId(rawFindingId: string): string {
+  if (Buffer.byteLength(rawFindingId, 'utf8') <= INLINE_RAW_FINDING_ID_LIMIT_BYTES) {
+    return rawFindingId;
+  }
+  const digest = createHash('sha256').update(rawFindingId).digest('hex');
+  // 12 characters on each side keeps the rendered reference below the 192-byte
+  // cap even when an ID contains four-byte UTF-8 characters.
+  return `raw-ref:${rawFindingId.slice(0, 12)}…${rawFindingId.slice(-12)}#sha256:${digest}`;
+}
+
+function inlineRawFindingHistory(
+  values: readonly string[],
+  observedAtByValue: ReadonlyMap<string, FindingObservation>,
+): string[] {
+  return inlineHistory(values, observedAtByValue).map(compactInlineRawFindingId);
+}
+
 function digestStringSet(values: readonly string[]): string {
   return createHash('sha256')
     .update(canonicalJson([...values].sort(compareBinaryStrings)))
@@ -360,7 +378,9 @@ function subjectReference(
     semanticClaimIdentityHash: subject.semanticClaimIdentityHash,
     claimSnapshotDigest: subject.claimSnapshotDigest,
     evidenceSetDigest: subject.evidenceSetDigest,
-    sourceRawFindingIds: inlineHistory(subject.sourceRawFindingIds, history.sourceRawFindingIds),
+    // Composite raw finding IDs include serialized run context. Keep a bounded
+    // member reference; the complete ID set remains covered by count + digest.
+    sourceRawFindingIds: inlineRawFindingHistory(subject.sourceRawFindingIds, history.sourceRawFindingIds),
     sourceRawFindingCount: subject.sourceRawFindingIds.length,
     sourceRawFindingDigest: digestStringSet(subject.sourceRawFindingIds),
     sourceRawPayloadIds: inlineHistory(subject.sourceRawPayloadDigests, history.sourceRawPayloadDigests),
@@ -378,6 +398,7 @@ function subjectReference(
 /**
  * Durable snapshot は台帳側の完全な入力を保持するが、provider には履歴全体を再送しない。
  * 直近の少数参照と、それ以前を表す count/digest を渡し、完全な snapshot は engine が解決する。
+ * 長大な raw finding ID は個別 digest 付きの代表参照に縮約する。
  */
 export function buildConflictAdjudicationSnapshotReference(
   snapshot: ConflictAdjudicationSnapshot,

--- a/src/core/workflow/findings/adjudication-evidence.ts
+++ b/src/core/workflow/findings/adjudication-evidence.ts
@@ -346,9 +346,10 @@ function compactInlineRawFindingId(rawFindingId: string): string {
     return rawFindingId;
   }
   const digest = createHash('sha256').update(rawFindingId).digest('hex');
-  // 12 characters on each side keeps the rendered reference below the 192-byte
+  // 12 code points on each side keeps the rendered reference below the 192-byte
   // cap even when an ID contains four-byte UTF-8 characters.
-  return `raw-ref:${rawFindingId.slice(0, 12)}…${rawFindingId.slice(-12)}#sha256:${digest}`;
+  const codePoints = [...rawFindingId];
+  return `raw-ref:${codePoints.slice(0, 12).join('')}…${codePoints.slice(-12).join('')}#sha256:${digest}`;
 }
 
 function inlineRawFindingHistory(

--- a/src/core/workflow/findings/adjudication-reservation.ts
+++ b/src/core/workflow/findings/adjudication-reservation.ts
@@ -19,7 +19,10 @@ import {
   releaseFindingManagerProviderCall,
   reserveFindingManagerProviderCall,
 } from './finding-manager-provider-call.js';
-import { MANAGER_INTERPRETATION_LIMITS } from './raw-finding-limits.js';
+import {
+  CONFLICT_ADJUDICATION_INPUT_MAX_BYTES,
+  MANAGER_INTERPRETATION_LIMITS,
+} from './raw-finding-limits.js';
 import type { FindingAdjudicationStore, FindingLedgerMutation } from './store.js';
 import type { FindingObservation } from './types.js';
 
@@ -222,7 +225,7 @@ export async function reserveFindingConflictAdjudication(input: {
       roundMarker: input.roundMarker,
       limits: {
         maxCallsPerRound: MANAGER_INTERPRETATION_LIMITS.maxManagerCallsPerStep,
-        maxAdapterVisibleInputBytesPerCall: MANAGER_INTERPRETATION_LIMITS.maxInputBytesPerCall,
+        maxAdapterVisibleInputBytesPerCall: CONFLICT_ADJUDICATION_INPUT_MAX_BYTES,
         maxOutputTokensPerCall: MANAGER_INTERPRETATION_LIMITS.maxOutputTokensPerCall,
         maxChargedInputTokensPerRound: MANAGER_INTERPRETATION_LIMITS.maxInputTokensPerStep,
         maxChargedOutputTokensPerRound: MANAGER_INTERPRETATION_LIMITS.maxOutputTokensPerStep,

--- a/src/core/workflow/findings/adjudication-runner.ts
+++ b/src/core/workflow/findings/adjudication-runner.ts
@@ -80,7 +80,7 @@ function response(input: {
   };
 }
 
-function requestBytes(input: {
+export function serializeFindingConflictAdjudicationRequest(input: {
   step: WorkflowStep;
   phase1Instruction: string;
   agentOptions: ReturnType<OptionsBuilder['buildAgentOptions']>;
@@ -331,7 +331,11 @@ export function createFindingConflictAdjudicationRunner(deps: FindingConflictAdj
         ...deps.optionsBuilder.buildAgentOptions(step, runtime),
         sessionId: undefined,
       };
-      const exactRequestBytes = requestBytes({ step, phase1Instruction: instruction, agentOptions });
+      const exactRequestBytes = serializeFindingConflictAdjudicationRequest({
+        step,
+        phase1Instruction: instruction,
+        agentOptions,
+      });
       const reserved = await reserveFindingConflictAdjudication({
         ledgerStore: deps.ledgerStore,
         conflictId: conflict.id,

--- a/src/core/workflow/findings/raw-finding-limits.ts
+++ b/src/core/workflow/findings/raw-finding-limits.ts
@@ -49,6 +49,14 @@ export const MANAGER_INTERPRETATION_LIMITS = {
   maxInterpretationEpochsPerLineage: 2,
 } as const;
 
+/**
+ * conflict adjudication は想定する 10 subjects と長大な ID 集合を 1 呼び出しで
+ * 扱うため、実測した 27,279 bytes のリクエストにプロンプト差分の余裕を加えた
+ * 96 KiB を上限とする。128K コンテキスト級モデルに合わせた値だが、これは暴走を
+ * 防止する guard であり、入力が無制限になるわけではないため有界性は維持する。
+ */
+export const CONFLICT_ADJUDICATION_INPUT_MAX_BYTES = 98_304;
+
 export const MANAGER_ACTION_RECOVERY_LIMITS = {
   maxAttempts: 2,
 } as const;


### PR DESCRIPTION
## 目的

クリーン台帳でも初回 conflict 裁定が「Provider request exceeds the adapter-visible input ceiling」で失敗する実測死因の修正。

実測分解: 上限 24,000B に対しリクエスト 25,205B。支配項は workflow スタック JSON を含む長大な合成 raw finding ID 群(4.4KB)。

## 修正(最小形)

1. **provider 向け参照のみ** 192B 超の raw ID を代表+SHA-256 digest に縮約(台帳の完全 ID は不変・count/集合 digest 維持)
2. **裁定呼び出し専用の入力上限を 96KiB に**。24,000B は raw intake 向けの保守値で、128K コンテキスト級モデルが担う裁定には不釣り合いに小さかった。raw intake 側は不変。有界性(暴走防止)は維持

subjects 10 件+長大 ID 集合が1呼び出しで通る回帰テスト付き。当初検討した subject 分割(チャンク化)は複雑化のため破棄し、この定数適正化を採用(owner ruling)。codex (luna, xhigh) レビュー APPROVE。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 競合調停で扱える入力サイズを拡大し、大量の検出結果や複数の対象を含むリクエストに対応しました。
  * 長い検出結果IDをコンパクトに表示し、先頭・末尾の情報とダイジェストを保持できるようにしました。
  * 複数の対象に対する競合調停を、より効率的に一度の処理で実行できるようになりました。

* **テスト**
  * 複数プロダクト、大量データ、複数対象を含む競合調停シナリオの検証を拡充しました。
  * 絵文字を含む長いIDの省略表示も検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->