### PR TITLE
fix(finding-contract): call-site identityの冗長形をやめmanager裁定の空射影黙殺を廃止する

### DIFF
--- a/src/__tests__/finding-manager-task-runner.test.ts
+++ b/src/__tests__/finding-manager-task-runner.test.ts
@@ -885,6 +885,7 @@ describe('main manager bounded task runner', () => {
       selectedFindingIds: string[];
     }>(firstInstruction, '## Context coverage');
     expect(manifest.rawFindings.length).toBeLessThan(16);
+    expect(coverage.candidateFindingCount).toBeGreaterThan(0);
     expect(coverage.selectedFindingIds.length).toBe(coverage.candidateFindingCount);
     expect(result.decisions.rawDecisions).toHaveLength(16);
   });

--- a/src/__tests__/finding-manager-task-runner.test.ts
+++ b/src/__tests__/finding-manager-task-runner.test.ts
@@ -863,6 +863,32 @@ describe('main manager bounded task runner', () => {
     expect(result.rawFailures.size).toBe(0);
   });
 
+  it('splits multi-raw input before reducing ledger candidates', async () => {
+    const raws = Array.from({ length: 16 }, (_, index) => rawFinding(index + 1, {
+      description: `Large semantic body ${'x'.repeat(1_400)}`,
+    }));
+    let firstInstruction = '';
+    executeAgentMock.mockImplementation(async (_persona, instruction) => {
+      if (firstInstruction === '') {
+        firstInstruction = instruction;
+      }
+      return successfulRawResponse(instruction);
+    });
+
+    const result = await run(raws, emptyLedger({
+      findings: raws.map((_raw, index) => ledgerFinding(index + 1)),
+    }));
+
+    const manifest = sectionJson<RawManifestView>(firstInstruction, '## Task manifest');
+    const coverage = sectionJson<{
+      candidateFindingCount: number;
+      selectedFindingIds: string[];
+    }>(firstInstruction, '## Context coverage');
+    expect(manifest.rawFindings.length).toBeLessThan(16);
+    expect(coverage.selectedFindingIds.length).toBe(coverage.candidateFindingCount);
+    expect(result.decisions.rawDecisions).toHaveLength(16);
+  });
+
   it('lands a single irreducible oversized raw as manager-input-overflow without calling the provider', async () => {
     const raw = rawFinding(1, {
       description: `Irreducible ${'x'.repeat(30_000)}`,
@@ -874,6 +900,63 @@ describe('main manager bounded task runner', () => {
     expect(result.rawFailures.get(raw.rawFindingId)?.kind)
       .toBe('manager-input-overflow');
     expect(result.taskAudits).toMatchObject([{ status: 'input_overflow' }]);
+  });
+
+  it('fails a one-raw input after the 16-to-8-to-4 candidates without an empty projection success', async () => {
+    const raw = rawFinding(1, {
+      title: 'Candidate issue 1',
+      description: `Candidate description 1 ${'x'.repeat(MAIN_MANAGER_INPUT_MAX_BYTES)}`,
+    });
+    const candidateFindings = Array.from({ length: 16 }, (_, index) => ({
+      ...ledgerFinding(index + 1),
+      title: 'Candidate issue 1',
+    }));
+    const attempts: string[] = [];
+    const executionInput = {
+      ...runInput,
+      stepExecutor: {
+        ...runInput.stepExecutor,
+        buildPhase1Instruction: (instruction: string) => {
+          if (!instruction.includes('__manager-prefix-check__')) {
+            attempts.push(instruction);
+          }
+          return instruction;
+        },
+      },
+    };
+
+    const result = await run(
+      [raw],
+      emptyLedger({ findings: candidateFindings }),
+      executionInput,
+    );
+
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(attempts).toHaveLength(3);
+    for (const instruction of attempts) {
+      const projection = sectionJson<{ findings: unknown[] }>(
+        instruction,
+        '## Relevant ledger projection',
+      );
+      expect(projection.findings).not.toHaveLength(0);
+    }
+    const coverages = attempts.map((instruction) => sectionJson<{
+      candidateFindingCount: number;
+      selectedFindingIds: string[];
+    }>(instruction, '## Context coverage'));
+    expect(coverages.map((coverage) => coverage.candidateFindingCount))
+      .toEqual([16, 16, 16]);
+    expect(coverages.map((coverage) => coverage.selectedFindingIds.length))
+      .toEqual([16, 8, 4]);
+    expect(result.rawFailures.get(raw.rawFindingId)?.kind)
+      .toBe('manager-input-overflow');
+    expect(result.taskAudits).toMatchObject([{
+      status: 'input_overflow',
+      inputBytes: expect.any(Number),
+    }]);
+    expect(result.taskAudits[0]?.inputBytes).toBeGreaterThan(
+      MAIN_MANAGER_INPUT_MAX_BYTES,
+    );
   });
 
   it.each([23_999, 24_000, 24_001])(
@@ -1119,7 +1202,6 @@ describe('main manager bounded task runner', () => {
           description?: string;
           suggestion?: string;
           target: unknown;
-          rawFindings?: Array<{ evidenceDetails: Array<{ verbatimExcerpt?: string }> }>;
         }>;
       }>(instruction, '## Relevant ledger projection');
       expect(ledger.findings).toEqual([expect.objectContaining({
@@ -1127,12 +1209,9 @@ describe('main manager bounded task runner', () => {
         description: 'The error branch leaks the acquired handle.',
         suggestion: 'Release the handle on every error branch.',
         target: { kind: 'code', paths: ['src/original.ts'] },
-        rawFindings: [expect.objectContaining({
-          evidenceDetails: [expect.objectContaining({
-            verbatimExcerpt: 'return withoutReleasing(handle);',
-          })],
-        })],
       })]);
+      expect(ledger.findings[0]).not.toHaveProperty('rawFindings');
+      expect(instruction).not.toContain('return withoutReleasing(handle);');
       return response({
         taskId: manifest.taskId,
         decisions: [{

--- a/src/__tests__/it-report-inheritance-task-resume.test.ts
+++ b/src/__tests__/it-report-inheritance-task-resume.test.ts
@@ -141,7 +141,7 @@ function buildWorkflowCallNamespace(projectDir: string, occurrence: number): str
 }
 
 function buildWorkflowCallAuthorityKey(projectDir: string, occurrence: number): string {
-  return buildWorkflowCallSite(projectDir, occurrence).key;
+  return buildWorkflowCallSite(projectDir, occurrence).runPathSegment;
 }
 
 function buildResumePoint(projectDir: string) {

--- a/src/__tests__/workflow-engine-structured-caller.integration.test.ts
+++ b/src/__tests__/workflow-engine-structured-caller.integration.test.ts
@@ -4169,9 +4169,8 @@ describe('WorkflowEngine structured caller defaults', () => {
     // により、2子の raw finding id は別々になる。衝突していれば重複排除で
     // 1件しか残らない。"#1" は呼び出し時点の親イテレーション（この走行では
     // fanout ステップが最初の1ステップのため1）。
-    expect(new Set(rawFindingIds).size).toBe(2);
-    expect(rawFindingIds.some((id) => id.includes('"step":"child-a"'))).toBe(true);
-    expect(rawFindingIds.some((id) => id.includes('"step":"child-b"'))).toBe(true);
+    expect(rawFindingIds).toHaveLength(2);
+    expect(new Set(rawFindingIds).size).toBe(rawFindingIds.length);
 
     // 内容（path+title+description）が完全一致するため、保存直前の再照合
     // （openFindingKeyIndex）で1件の finding に畳み込まれる。ただしその finding は両方の raw
@@ -4182,6 +4181,9 @@ describe('WorkflowEngine structured caller defaults', () => {
     const reportsRoot = join(cwd, '.takt', 'runs', 'test-report-dir', 'reports', 'subworkflows');
     const reportNamespaces = readdirSync(reportsRoot);
     expect(reportNamespaces).toHaveLength(2);
+    for (const namespace of reportNamespaces) {
+      expect(rawFindingIds.filter((id) => id.includes(namespace))).toHaveLength(1);
+    }
     expect(reportNamespaces.map((namespace) => (
       readFileSync(join(reportsRoot, namespace, 'review.md'), 'utf-8')
     ))).toEqual([

--- a/src/__tests__/workflow-engine-structured-caller.integration.test.ts
+++ b/src/__tests__/workflow-engine-structured-caller.integration.test.ts
@@ -4184,6 +4184,9 @@ describe('WorkflowEngine structured caller defaults', () => {
     for (const namespace of reportNamespaces) {
       expect(rawFindingIds.filter((id) => id.includes(namespace))).toHaveLength(1);
     }
+    for (const id of rawFindingIds) {
+      expect(reportNamespaces.filter((namespace) => id.includes(namespace))).toHaveLength(1);
+    }
     expect(reportNamespaces.map((namespace) => (
       readFileSync(join(reportsRoot, namespace, 'review.md'), 'utf-8')
     ))).toEqual([

--- a/src/core/workflow/engine/WorkflowCallExecutor.ts
+++ b/src/core/workflow/engine/WorkflowCallExecutor.ts
@@ -646,8 +646,8 @@ export class WorkflowCallExecutor {
       initialIteration: this.deps.state.iteration,
       reportDirName: this.deps.runPaths.slug,
       runPathNamespace: this.buildWorkflowCallNamespace(invocation),
-      findingCallNamespace: workflowCallSite.key,
-      workflowCallSiteIdentity: workflowCallSite.key,
+      findingCallNamespace: workflowCallSite.runPathSegment,
+      workflowCallSiteIdentity: workflowCallSite.runPathSegment,
       workflowCallVars: {
         ...options.workflowCallVars,
         ...request.step.vars,

--- a/src/core/workflow/findings/manager-agent.ts
+++ b/src/core/workflow/findings/manager-agent.ts
@@ -218,8 +218,15 @@ function compactEvidenceSummary(record: FindingEvidenceRecord | undefined, evide
  * 予算超過・解釈不能はすべて provisional として台帳へ着地し、run は継続する
  * （final gate は provisional が閉じ続ける）。
  */
-export function buildManagerInputLedger(ledger: FindingLedger, fullDetailFindingIds?: ReadonlySet<string>): unknown {
+export function buildManagerInputLedger(
+  ledger: FindingLedger,
+  fullDetailFindingIds?: ReadonlySet<string>,
+  options?: {
+    includeRawFindingDetails?: boolean;
+  },
+): unknown {
   const rawFindingsById = new Map(ledger.rawFindings.map((rawFinding) => [rawFinding.rawFindingId, rawFinding]));
+  const includeRawFindingDetails = options?.includeRawFindingDetails ?? true;
   const needsFullDetail = (finding: FindingLedger['findings'][number]): boolean => (
     fullDetailFindingIds === undefined
       ? finding.status === 'open'
@@ -246,10 +253,14 @@ export function buildManagerInputLedger(ledger: FindingLedger, fullDetailFinding
         suggestion: finding.suggestion,
         reviewers: finding.reviewers,
         rawFindingIds: finding.rawFindingIds,
-        rawFindings: finding.rawFindingIds
-          .map((rawFindingId) => rawFindingsById.get(rawFindingId))
-          .filter((rawFinding): rawFinding is RawFinding => rawFinding !== undefined)
-          .map((rawFinding) => managerRawFindingView(rawFinding, ledger.evidenceRecords)),
+        ...(includeRawFindingDetails
+          ? {
+              rawFindings: finding.rawFindingIds
+                .map((rawFindingId) => rawFindingsById.get(rawFindingId))
+                .filter((rawFinding): rawFinding is RawFinding => rawFinding !== undefined)
+                .map((rawFinding) => managerRawFindingView(rawFinding, ledger.evidenceRecords)),
+            }
+          : {}),
         evidenceDetails: finding.evidenceIds.map((evidenceId) => (
           ledger.evidenceRecords.find((record) => record.evidenceId === evidenceId) ?? {
             evidenceId,

--- a/src/core/workflow/findings/manager-task-runner.ts
+++ b/src/core/workflow/findings/manager-task-runner.ts
@@ -62,7 +62,7 @@ import type {
   ReviewerAnomalyEntry,
 } from './types.js';
 
-const CONTEXT_CANDIDATE_LIMITS = [16, 8, 4, 0] as const;
+const CONTEXT_CANDIDATE_LIMITS = [16, 8, 4] as const;
 const COMPACT_CONFLICT_COLLECTION_LIMIT = 16;
 const CONTROL_PRIOR_TEXT_LIMIT = 4_000;
 
@@ -110,7 +110,9 @@ function taskLedgerProjection(
   ledger: FindingLedger,
   fullDetailFindingIds: ReadonlySet<string>,
 ): unknown {
-  const projection = buildManagerInputLedger(ledger, fullDetailFindingIds) as {
+  const projection = buildManagerInputLedger(ledger, fullDetailFindingIds, {
+    includeRawFindingDetails: false,
+  }) as {
     workflowName: string;
     findings: unknown[];
     conflicts: unknown[];
@@ -665,7 +667,10 @@ async function executeRawTasks(input: {
       | { phase1Instruction: string; inputBytes: number }
       | undefined;
     let renderedInputBytes: number | undefined;
-    for (const candidateLimit of CONTEXT_CANDIDATE_LIMITS) {
+    const candidateLimits = item.rawFindings.length > 1
+      ? [CONTEXT_CANDIDATE_LIMITS[0]]
+      : CONTEXT_CANDIDATE_LIMITS;
+    for (const candidateLimit of candidateLimits) {
       const context = rawTaskContext(
         input.previousLedger,
         item.rawFindings,

--- a/src/core/workflow/workflow-call-site-identity.ts
+++ b/src/core/workflow/workflow-call-site-identity.ts
@@ -9,7 +9,6 @@ import { buildWorkflowCallNamespaceSegment } from './workflow-call-namespace.js'
 const MAX_READABLE_RUN_PATH_PREFIX_LENGTH = 160;
 
 export interface WorkflowCallSiteIdentity {
-  readonly key: string;
   readonly runPathSegment: string;
 }
 
@@ -33,18 +32,17 @@ export function buildWorkflowCallSiteIdentity(input: {
   if (currentFrame === undefined || currentFrame.kind !== 'workflow_call') {
     throw new Error('Canonical workflow call-site identity requires an active workflow_call frame');
   }
-  const key = JSON.stringify({
+  const canonicalJson = JSON.stringify({
     stack: input.stack.map(frameIdentity),
     childWorkflow: getWorkflowReference(input.childWorkflow),
   });
-  const digest = createHash('sha256').update(key).digest('hex');
+  const digest = createHash('sha256').update(canonicalJson).digest('hex');
   const readableRunPathPrefix = buildWorkflowCallNamespaceSegment(
     currentFrame.step,
     input.childWorkflow.name,
     currentFrame.occurrence,
   ).slice(0, MAX_READABLE_RUN_PATH_PREFIX_LENGTH);
   return {
-    key,
     runPathSegment: [
       readableRunPathPrefix,
       digest,


### PR DESCRIPTION
## 問題

workflow_call の call-site identity として `buildWorkflowCallSiteIdentity` の冗長形(スタック JSON 全文 ~1.2KB)が `findingCallNamespace` / 台帳 `authorityKey` に渡され、rawFindingId に丸ごと埋め込まれていた。manager raw 裁定タスクはこの ID をマニフェスト・射影・エコーに複数回掲載するため入力が 24,000B 上限を超え、射影候補を 16→8→4→**0** と削って**空の台帳射影のまま成功扱いで裁定**していた。実 run での帰結:

- 全 raw が new 判定 → 同一指摘が別 finding として重複増殖(同一タイトル×4 等)
- レビュアーの resolution_confirmation 21 件が 1 件も既存 finding に結びつかず resolved 停滞
- 1 raw でも超過するタスクは観測ごと喪失

#1271 は裁定側プロンプトの表示縮約で対処したが、根本(ID の採番)が冗長なままだった。

## 修正

**補償レイヤは追加しない。採番元を直す。**

1. **call-site identity を圧縮形へ**: `WorkflowCallExecutor` が渡す identity を、同じ構造体に最初から存在する `runPathSegment`(可読プレフィックス≤160字 + `--site-` + sha256、run ディレクトリ名で実績あり)に差し替え。ID は採番時点から ~150B になる。digest はスタック全体(全フレームの occurrence 含む)から算出されるため一意性・resume 決定性は不変。全消費者が置換済みのため `key` フィールド自体を削除。
2. **射影スリム化**: raw タスク射影から finding への埋め込み `rawFindings`(観測 raw 全文)を除外。同一性判定材料(title/description/target/locations/各 identityHash/evidence 要約)は維持し、入力が観測回数に比例して膨張する構造を解消。
3. **空射影の黙殺廃止**: 候補ラダー `[16,8,4,0]` → `[16,8,4]`。複数 raw タスクは候補フルのまま**分割を優先**し、縮小ラダーは 1 raw タスクのみ。それでも超過する場合は監査に載る可視の `manager-input-overflow` 失敗(候補4未満での裁定は実質盲目であり、黙殺の変種になるため失敗が正)。

24,000B 上限は据え置き。台帳の後方互換なし(SQLite リセットで再走可能な作りを維持)。

## 設計レビュー

codex sol (high) による設計判定済み: 根本方針・柱2/3とも妥当。指摘のうち `key` フィールド削除を採用。

## 検証

- 対象ユニット+IT 全緑(manager-task-runner 48 / entity binding 35 / ベースライン 4 / 継承 resume IT 7 / structured-caller IT 34 / workflow-call 系 45 / conflict-adjudication IT 24 / schemas 58 / step-executor 43 / releaseVerificationWiring 19)
- ベースライン fixture は不変(プロンプト文言を変えていないため)
- 並列2子呼び出しの raw ID 一意性は挙動検証(一意性+namespace 包含)として維持

## フォローアップ候補(既存挙動・スコープ外)

- `runPathSegment` 可読プレフィックスの 160 字切詰めは %XX エンコード途中で切れうる(非 ASCII step 名)。digest により一意性は保たれるが、切詰めを escape 単位に直す余地
- 射影 compact ビュー(locus/title/symbol 候補)は description を含まない — 同一性判定材料としての要否は別途判断

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 複数の検出結果を処理する際、候補の分割・絞り込みと入力上限の判定を改善しました。
  * 入力が大きすぎる場合に、不要な処理を行わず適切にエラーを報告するようにしました。
  * 台帳情報から不要な詳細や証拠抜粋を除外し、処理コンテキストを整理しました。
  * 並列ワークフロー実行時の検出結果とレポートの対応を安定化しました。

* **テスト**
  * 候補数、カバレッジ、入力上限、並列実行時の結果対応を検証するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->