### PR TITLE
fix(finding-contract): 候補ラダーを0まで戻しrequired付きlifecycle観測のドロップを解消する

### DIFF
--- a/src/__tests__/finding-manager-task-runner.test.ts
+++ b/src/__tests__/finding-manager-task-runner.test.ts
@@ -903,7 +903,7 @@ describe('main manager bounded task runner', () => {
     expect(result.taskAudits).toMatchObject([{ status: 'input_overflow' }]);
   });
 
-  it('fails a one-raw input after the 16-to-8-to-4 candidates without an empty projection success', async () => {
+  it('fails a one-raw input after the 16-to-8-to-4-to-2-to-1 candidates without an empty projection success', async () => {
     const raw = rawFinding(1, {
       title: 'Candidate issue 1',
       description: `Candidate description 1 ${'x'.repeat(MAIN_MANAGER_INPUT_MAX_BYTES)}`,
@@ -933,7 +933,7 @@ describe('main manager bounded task runner', () => {
     );
 
     expect(executeAgentMock).not.toHaveBeenCalled();
-    expect(attempts).toHaveLength(3);
+    expect(attempts).toHaveLength(5);
     for (const instruction of attempts) {
       const projection = sectionJson<{ findings: unknown[] }>(
         instruction,
@@ -946,9 +946,9 @@ describe('main manager bounded task runner', () => {
       selectedFindingIds: string[];
     }>(instruction, '## Context coverage'));
     expect(coverages.map((coverage) => coverage.candidateFindingCount))
-      .toEqual([16, 16, 16]);
+      .toEqual([16, 16, 16, 16, 16]);
     expect(coverages.map((coverage) => coverage.selectedFindingIds.length))
-      .toEqual([16, 8, 4]);
+      .toEqual([16, 8, 4, 2, 1]);
     expect(result.rawFailures.get(raw.rawFindingId)?.kind)
       .toBe('manager-input-overflow');
     expect(result.taskAudits).toMatchObject([{
@@ -958,6 +958,74 @@ describe('main manager bounded task runner', () => {
     expect(result.taskAudits[0]?.inputBytes).toBeGreaterThan(
       MAIN_MANAGER_INPUT_MAX_BYTES,
     );
+  });
+
+  it('lands a required lifecycle raw with only its required finding after candidate reduction', async () => {
+    const raw = rawFinding(1, {
+      relation: 'persists',
+      targetFindingId: 'F-0001',
+      title: 'Candidate issue 1',
+      description: `Raw observation candidateSymbolShared ${'x'.repeat(4_000)}`,
+    });
+    // optional 候補は圧縮ビューに載る title で予算を圧迫させる（description は
+    // 圧縮ビューに描画されない）。候補資格は共有シンボルで維持する。
+    const candidateFindings = Array.from({ length: 4 }, (_, index) => (
+      index === 0
+        ? {
+            ...ledgerFinding(1),
+            title: 'Candidate issue 1',
+            description: `Candidate description ${'x'.repeat(7_000)}`,
+          }
+        : {
+            ...ledgerFinding(index + 1),
+            title: `Optional candidateSymbolShared ${'y'.repeat(22_000)}`,
+            description: 'Optional candidate candidateSymbolShared',
+          }
+    ));
+    const attempts: string[] = [];
+    const executionInput = {
+      ...runInput,
+      stepExecutor: {
+        ...runInput.stepExecutor,
+        buildPhase1Instruction: (instruction: string) => {
+          if (!instruction.includes('__manager-prefix-check__')) {
+            attempts.push(instruction);
+          }
+          return instruction;
+        },
+      },
+    };
+    executeAgentMock.mockImplementation(async (_persona, instruction) => (
+      successfulRawResponse(instruction, 'same')
+    ));
+
+    const result = await run(
+      [raw],
+      emptyLedger({ findings: candidateFindings }),
+      executionInput,
+    );
+
+    const coverages = attempts.map((instruction) => sectionJson<{
+      candidateFindingCount: number;
+      selectedFindingIds: string[];
+    }>(instruction, '## Context coverage'));
+    expect(coverages).toHaveLength(6);
+    expect(coverages.map((coverage) => coverage.candidateFindingCount))
+      .toEqual([4, 4, 4, 4, 4, 4]);
+    expect(coverages.map((coverage) => coverage.selectedFindingIds.length))
+      .toEqual([4, 4, 4, 3, 2, 1]);
+    expect(coverages.at(-1)).toMatchObject({
+      candidateFindingCount: 4,
+      selectedFindingIds: ['F-0001'],
+    });
+    expect(executeAgentMock).toHaveBeenCalledTimes(1);
+    expect(result.decisions.rawDecisions).toEqual([expect.objectContaining({
+      rawFindingId: raw.rawFindingId,
+      decision: 'same',
+      findingId: 'F-0001',
+    })]);
+    expect(result.rawFailures.size).toBe(0);
+    expect(result.taskAudits).toMatchObject([{ status: 'succeeded' }]);
   });
 
   it.each([23_999, 24_000, 24_001])(

--- a/src/core/workflow/findings/manager-task-runner.ts
+++ b/src/core/workflow/findings/manager-task-runner.ts
@@ -62,7 +62,8 @@ import type {
   ReviewerAnomalyEntry,
 } from './types.js';
 
-const CONTEXT_CANDIDATE_LIMITS = [16, 8, 4] as const;
+// required target は常に含め、単一 raw の optional 候補だけを段階的に削る。
+const CONTEXT_CANDIDATE_LIMITS = [16, 8, 4, 2, 1, 0] as const;
 const COMPACT_CONFLICT_COLLECTION_LIMIT = 16;
 const CONTROL_PRIOR_TEXT_LIMIT = 4_000;
 
@@ -676,6 +677,12 @@ async function executeRawTasks(input: {
         item.rawFindings,
         candidateLimit,
       );
+      if (
+        context.coverage.candidateFindingCount > 0
+        && context.coverage.selectedFindingIds.length === 0
+      ) {
+        break;
+      }
       const baseInstruction = buildRawTaskInstruction({
         contract: input.contract,
         task: item.task,


### PR DESCRIPTION
## 問題(実測)

#1278 で候補ラダーを `[16,8,4,0]` → `[16,8,4]` にした際の床4が過補正だった。requiredIds(raw が明示参照する targetFindingId)は candidateLimit に関係なく常に射影へ含まれる仕様のため、旧 limit 0 は lifecycle raw(persists / resolution_confirmation)には盲目ではなかった。床4の結果、候補4件の evidence 込みで 24,000B を僅かに超える 1 raw タスク(実測 24,175〜25,377B)が `manager-input-overflow` で**観測ごとドロップ**し、レビュアーの解消申告が台帳に届かず resolved が停滞する。

## 修正

- `CONTEXT_CANDIDATE_LIMITS` を `[16,8,4,2,1,0]` に拡張(optional 候補を段階的に落とす。required は常に残る)
- **『候補が存在するのに射影が空になる』呼び出しは行わない**ガードを追加 — その場合はラダーを打ち切り従来の可視 overflow 失敗へ。#1278 で封じた空射影裁定(黙殺)の不変条件は維持
- required 持ち raw は selected が空にならないため必ず着地する

## 検証

- manager-task-runner 49件全緑(required-only 射影での着地・空射影防止の両テスト含む)、ベースライン4件、lint 通過
- 追加テストは圧縮ビューに実際に描画されるフィールド(title)で予算超過を構成(description は圧縮ビュー非描画のため不発だった codex 初版を修正)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * コンテキスト候補を段階的に最大0件まで削減できるようになりました。
  * 候補がない場合は不要な追加処理を行わず、コンテキスト準備を適切に中断します。
  * 必須対象を含む検出結果が候補削減後も正しく保持されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->