### PR TITLE
fix(companion): improve incremental review scheduling

### DIFF
--- a/src/__tests__/companion-change-detector.test.ts
+++ b/src/__tests__/companion-change-detector.test.ts
@@ -27,7 +27,7 @@ async function evaluateLive(
   detector: CompanionChangeDetector,
   snapshot?: CompanionDiff,
 ) {
-  const candidate = detector.getTriggerCandidate();
+  const candidate = detector.getTriggerCandidate(100);
   return candidate === undefined ? undefined : detector.evaluateCandidate(candidate, snapshot);
 }
 
@@ -39,7 +39,7 @@ async function evaluateCompletion(
 }
 
 describe('CT-COMP-05 event-driven companion change detection', () => {
-  it('should mark Write, Edit, and mutating Bash events dirty without reading Git synchronously', () => {
+  it('should mark explicit write tools dirty without reading Git synchronously', () => {
     const readDiff = vi.fn();
     const detector = new CompanionChangeDetector({
       intervalMs: 100,
@@ -79,7 +79,7 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
     expect(detector.isDirty()).toBe(true);
   });
 
-  it('should recognize an OpenCode lowercase bash event only when it carries a command', () => {
+  it('should ignore OpenCode Bash events even when they carry a command', () => {
     const detector = new CompanionChangeDetector({
       intervalMs: 100,
       minimumChangedLines: 10,
@@ -101,7 +101,7 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
         id: 'opencode-bash-command',
       },
     });
-    expect(detector.isDirty()).toBe(true);
+    expect(detector.isDirty()).toBe(false);
   });
 
   it('should ignore read-only tool events', () => {
@@ -127,7 +127,7 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
       readDiff,
     });
     detector.observe(tool('Edit'));
-    now = 1_100;
+    now = 1_250;
 
     const trigger = await evaluateLive(detector);
 
@@ -144,7 +144,7 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
       readDiff: vi.fn().mockResolvedValue(diff('diff-a', 9)),
     });
     detector.observe(tool('Edit'));
-    now = 1_100;
+    now = 1_250;
 
     expect(await evaluateLive(detector)).toBeUndefined();
   });
@@ -244,7 +244,7 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
     });
     detector.observe(tool('Edit'));
     now = 1_100;
-    const candidate = detector.getTriggerCandidate();
+    const candidate = detector.getTriggerCandidate(100);
     expect(candidate).toBeDefined();
     const trigger = await detector.evaluateCandidate(candidate!, diff('first', 10));
     now = 1_101;
@@ -254,10 +254,10 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
     now = 1_201;
 
     expect(detector.isDirty()).toBe(true);
-    expect(detector.getTriggerCandidate()).toMatchObject({ reason: 'quiet' });
+    expect(detector.getTriggerCandidate(100)).toMatchObject({ reason: 'quiet' });
   });
 
-  it('should consume an empty Bash candidate once and still inspect completion snapshots', async () => {
+  it('should leave read-only Bash events available for completion snapshots', async () => {
     let now = 1_000;
     const empty = { ...diff('empty', 0), changedFiles: [], content: '' };
     const readDiff = vi.fn().mockResolvedValue(empty);
@@ -275,7 +275,7 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
 
     expect(await evaluateLive(detector)).toBeUndefined();
     expect(await evaluateLive(detector)).toBeUndefined();
-    expect(readDiff).toHaveBeenCalledOnce();
+    expect(readDiff).not.toHaveBeenCalled();
     expect(detector.isDirty()).toBe(false);
     expect(await evaluateCompletion(detector, diff('completion-change', 1))).toMatchObject({
       reason: 'completion',
@@ -373,7 +373,7 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
     'git apply change.patch',
     'node scripts/write-file.js',
     'git diff -- src/a.ts',
-  ])('should treat Bash as a dirty candidate and defer read-only filtering to the diff digest: %s', (command) => {
+  ])('should not extend the debounce for Bash commands: %s', (command) => {
     const detector = new CompanionChangeDetector({
       intervalMs: 100,
       minimumChangedLines: 10,
@@ -386,7 +386,499 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
       data: { tool: 'Bash', input: { command }, id: 'tool-bash' },
     });
 
-    expect(detector.isDirty()).toBe(true);
+    expect(detector.isDirty()).toBe(false);
+  });
+
+  it('should not postpone an edit review when a read-only Bash command follows it', async () => {
+    let now = 1_000;
+    const detector = new CompanionChangeDetector({
+      intervalMs: 15_000,
+      minimumChangedLines: 1,
+      now: () => now,
+      readDiff: vi.fn().mockResolvedValue(diff('edited', 1)),
+    });
+
+    detector.observe(tool('Edit'));
+    now = 1_100;
+    detector.observe({
+      type: 'tool_use',
+      data: { tool: 'Bash', input: { command: 'npm test' }, id: 'test-command' },
+    });
+    now = 1_250;
+
+    await expect(evaluateLive(detector, diff('edited', 1))).resolves.toMatchObject({
+      reason: 'quiet',
+    });
+  });
+
+  it('should review shortly after an explicit edit without waiting for the poll interval', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 10,
+        now: () => now,
+        readDiff: vi.fn(),
+      });
+      const enqueue = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue } as unknown as CompanionReviewQueue,
+        initialSnapshot: diff('initial', 0),
+        readSnapshot: vi.fn().mockResolvedValue(diff('edited', 10)),
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.start();
+      scheduler.observe(tool('Edit'));
+      now = 1_250;
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(enqueue).toHaveBeenCalledWith(expect.objectContaining({
+        reason: 'quiet',
+        snapshot: expect.objectContaining({ digest: 'edited' }),
+      }));
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should re-evaluate an edit that arrives while a prior evaluation is in flight', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      let resolveFirst!: (snapshot: CompanionDiff) => void;
+      let resolveSecond!: (snapshot: CompanionDiff) => void;
+      const readSnapshot = vi.fn()
+        .mockImplementationOnce(() => new Promise<CompanionDiff>((resolve) => {
+          resolveFirst = resolve;
+        }))
+        .mockImplementationOnce(() => new Promise<CompanionDiff>((resolve) => {
+          resolveSecond = resolve;
+        }));
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => now,
+        readDiff: readSnapshot,
+      });
+      const enqueue = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue } as unknown as CompanionReviewQueue,
+        initialSnapshot: diff('initial', 0),
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.observe(tool('Edit'));
+      now = 1_250;
+      await vi.advanceTimersByTimeAsync(250);
+      expect(readSnapshot).toHaveBeenCalledOnce();
+
+      now = 1_260;
+      scheduler.observe(tool('Edit'));
+      now = 1_510;
+      await vi.advanceTimersByTimeAsync(250);
+      resolveFirst(diff('first', 10));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueue).toHaveBeenCalledTimes(1);
+
+      now = 1_760;
+      await vi.advanceTimersByTimeAsync(250);
+      expect(readSnapshot).toHaveBeenCalledTimes(2);
+      resolveSecond(diff('second', 10));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(enqueue).toHaveBeenCalledTimes(2);
+      expect(enqueue.mock.calls.map(([request]) => request.snapshot.digest)).toEqual([
+        'first',
+        'second',
+      ]);
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should detect a Bash mutation from before/after diff snapshots without parsing the command', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      const before = diff('before', 0);
+      const after = diff('after', 10);
+      let resolveAfter!: (snapshot: CompanionDiff) => void;
+      const readSnapshot = vi.fn()
+        .mockImplementationOnce(() => new Promise<CompanionDiff>((resolve) => {
+          resolveAfter = resolve;
+        }))
+        .mockResolvedValueOnce(after);
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => now,
+        readDiff: readSnapshot,
+      });
+      const enqueue = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue } as unknown as CompanionReviewQueue,
+        initialSnapshot: before,
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.observe({
+        type: 'tool_use',
+        data: { tool: 'bash', input: { command: 'node scripts/write-file.js' }, id: 'bash-1' },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(readSnapshot).not.toHaveBeenCalled();
+      scheduler.observe({
+        type: 'tool_result',
+        data: { id: 'bash-1', content: '', isError: false },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(readSnapshot).toHaveBeenCalledOnce();
+      resolveAfter(after);
+      await vi.advanceTimersByTimeAsync(0);
+      now = 1_250;
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(enqueue).toHaveBeenCalledWith(expect.objectContaining({
+        reason: 'quiet',
+        snapshot: expect.objectContaining({ digest: 'after' }),
+      }));
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should not postpone an explicit Edit review after a read-only Bash result', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      const initial = diff('baseline', 0);
+      const unchanged = diff('edited', 1);
+      const readSnapshot = vi.fn()
+        .mockResolvedValueOnce(unchanged)
+        .mockResolvedValueOnce(unchanged);
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => now,
+        readDiff: readSnapshot,
+      });
+      const enqueue = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue } as unknown as CompanionReviewQueue,
+        initialSnapshot: initial,
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.observe(tool('Edit'));
+      now = 1_100;
+      scheduler.observe({
+        type: 'tool_use',
+        data: { tool: 'Bash', input: { command: 'npm test' }, id: 'bash-read' },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      scheduler.observe({
+        type: 'tool_result',
+        data: { id: 'bash-read', content: '', isError: false },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      now = 1_250;
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(enqueue).toHaveBeenCalledTimes(1);
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should not attribute an Edit after a clean Bash start to that Bash result', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      const initial = diff('baseline', 0);
+      const afterEdit = diff('edited', 10);
+      const readSnapshot = vi.fn().mockResolvedValue(afterEdit);
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => now,
+        readDiff: readSnapshot,
+      });
+      const enqueue = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue } as unknown as CompanionReviewQueue,
+        initialSnapshot: initial,
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.observe({
+        type: 'tool_use',
+        data: { tool: 'Bash', input: { command: 'npm test' }, id: 'bash-read' },
+      });
+      now = 1_100;
+      scheduler.observe(tool('Edit'));
+      await vi.advanceTimersByTimeAsync(100);
+      scheduler.observe({
+        type: 'tool_result',
+        data: { id: 'bash-read', content: '', isError: false },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      now = 1_350;
+      await vi.advanceTimersByTimeAsync(150);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(detector.getObservedGeneration()).toBe(1);
+      expect(enqueue).toHaveBeenCalledOnce();
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should probe an ID-less Bash result when a preceding Read result is missing', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      const initial = diff('baseline', 0);
+      const after = diff('bash-change', 10);
+      const readSnapshot = vi.fn().mockResolvedValueOnce(after).mockResolvedValueOnce(after);
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => now,
+        readDiff: readSnapshot,
+      });
+      const enqueue = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue } as unknown as CompanionReviewQueue,
+        initialSnapshot: initial,
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.observe({
+        type: 'tool_use',
+        data: { tool: 'Read', input: { path: 'src/a.ts' }, id: 'read-1' },
+      });
+      scheduler.observe({
+        type: 'tool_use',
+        data: { tool: 'Bash', input: { command: 'npm run format' }, id: 'bash-1' },
+      });
+      scheduler.observe({
+        type: 'tool_result',
+        data: { content: '', isError: false },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      now = 1_250;
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(enqueue).toHaveBeenCalledWith(expect.objectContaining({
+        snapshot: expect.objectContaining({ digest: 'bash-change' }),
+      }));
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should match an identified tool result only to its Bash request', async () => {
+    vi.useFakeTimers();
+    try {
+      const initial = diff('baseline', 0);
+      const after = diff('bash-change', 10);
+      const readSnapshot = vi.fn().mockResolvedValue(after);
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => 1_000,
+        readDiff: readSnapshot,
+      });
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue: vi.fn().mockResolvedValue(undefined) } as unknown as CompanionReviewQueue,
+        initialSnapshot: initial,
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.observe({
+        type: 'tool_use',
+        data: { tool: 'Bash', input: { command: 'npm run format' }, id: 'bash-1' },
+      });
+      scheduler.observe({
+        type: 'tool_result',
+        data: { id: 'read-1', content: '', isError: false },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(readSnapshot).not.toHaveBeenCalled();
+
+      scheduler.observe({
+        type: 'tool_result',
+        data: { id: 'bash-1', content: '', isError: false },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(readSnapshot).toHaveBeenCalledOnce();
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should retain a Bash change observed while its Edit review is still evaluating', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      const initial = diff('baseline', 0);
+      const edited = diff('edited', 10);
+      const bashChanged = diff('bash-changed', 12);
+      const readSnapshot = vi.fn()
+        .mockResolvedValueOnce(edited)
+        .mockResolvedValueOnce(bashChanged);
+      let resolveQueue!: () => void;
+      const queuePromise = new Promise<void>((resolve) => {
+        resolveQueue = resolve;
+      });
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => now,
+        readDiff: readSnapshot,
+      });
+      const enqueue = vi.fn().mockReturnValue(queuePromise);
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue } as unknown as CompanionReviewQueue,
+        initialSnapshot: initial,
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.observe(tool('Edit'));
+      now = 1_250;
+      await vi.advanceTimersByTimeAsync(250);
+      expect(enqueue).toHaveBeenCalledOnce();
+
+      scheduler.observe({
+        type: 'tool_use',
+        data: { tool: 'Bash', input: { command: 'npm run format' }, id: 'bash-in-flight' },
+      });
+      scheduler.observe({
+        type: 'tool_result',
+        data: { id: 'bash-in-flight', content: '', isError: false },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(detector.getObservedGeneration()).toBe(2);
+      resolveQueue();
+      await vi.advanceTimersByTimeAsync(0);
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should retain a Bash change after an Edit snapshot crosses the evaluation boundary', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      const initial = diff('baseline', 0);
+      const edited = diff('edited', 10);
+      const bashChanged = diff('bash-changed', 12);
+      let resolveEvaluationSnapshot!: (snapshot: CompanionDiff) => void;
+      const readSnapshot = vi.fn()
+        .mockImplementationOnce(() => new Promise<CompanionDiff>((resolve) => {
+          resolveEvaluationSnapshot = resolve;
+        }))
+        .mockResolvedValueOnce(bashChanged);
+      let resolveQueue!: () => void;
+      const queuePromise = new Promise<void>((resolve) => {
+        resolveQueue = resolve;
+      });
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => now,
+        readDiff: readSnapshot,
+      });
+      const enqueue = vi.fn().mockReturnValue(queuePromise);
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue } as unknown as CompanionReviewQueue,
+        initialSnapshot: initial,
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.observe({
+        type: 'tool_use',
+        data: { tool: 'Bash', input: { command: 'npm test' }, id: 'bash-before-edit' },
+      });
+      now = 1_100;
+      scheduler.observe(tool('Edit'));
+      now = 1_350;
+      await vi.advanceTimersByTimeAsync(250);
+      expect(readSnapshot).toHaveBeenCalledOnce();
+
+      resolveEvaluationSnapshot(edited);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(enqueue).toHaveBeenCalledOnce();
+
+      scheduler.observe({
+        type: 'tool_result',
+        data: { id: 'bash-before-edit', content: '', isError: false },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(detector.getObservedGeneration()).toBe(2);
+      resolveQueue();
+      await vi.advanceTimersByTimeAsync(0);
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([
@@ -401,13 +893,14 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
       readDiff: vi.fn(),
     });
     detector.observe(tool('Edit'));
-    now = 1_100;
+    now = 1_250;
     const onError = vi.fn();
     const scheduler = new CompanionTriggerScheduler({
       detectors: new Map([['security-reviewer', detector]]),
       intervals: [100],
       allowGitCommit: false,
       queue: { enqueue: vi.fn().mockRejectedValue(error) } as unknown as CompanionReviewQueue,
+      initialSnapshot: diff('initial', 0),
       readSnapshot: vi.fn().mockResolvedValue(diff('current', 10)),
       isAborted: () => false,
       onError,

--- a/src/__tests__/companion-change-detector.test.ts
+++ b/src/__tests__/companion-change-detector.test.ts
@@ -770,7 +770,8 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
       const bashChanged = diff('bash-changed', 12);
       const readSnapshot = vi.fn()
         .mockResolvedValueOnce(edited)
-        .mockResolvedValueOnce(bashChanged);
+        .mockResolvedValueOnce(bashChanged)
+        .mockResolvedValue(bashChanged);
       let resolveQueue!: () => void;
       const queuePromise = new Promise<void>((resolve) => {
         resolveQueue = resolve;
@@ -811,6 +812,12 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
       expect(detector.getObservedGeneration()).toBe(2);
       resolveQueue();
       await vi.advanceTimersByTimeAsync(0);
+      now = 1_500;
+      await vi.advanceTimersByTimeAsync(250);
+      expect(enqueue).toHaveBeenCalledTimes(2);
+      expect(enqueue).toHaveBeenLastCalledWith(expect.objectContaining({
+        snapshot: expect.objectContaining({ digest: 'bash-changed' }),
+      }));
       scheduler.stop();
     } finally {
       vi.useRealTimers();
@@ -829,7 +836,8 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
         .mockImplementationOnce(() => new Promise<CompanionDiff>((resolve) => {
           resolveEvaluationSnapshot = resolve;
         }))
-        .mockResolvedValueOnce(bashChanged);
+        .mockResolvedValueOnce(bashChanged)
+        .mockResolvedValue(bashChanged);
       let resolveQueue!: () => void;
       const queuePromise = new Promise<void>((resolve) => {
         resolveQueue = resolve;
@@ -875,6 +883,127 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
       expect(detector.getObservedGeneration()).toBe(2);
       resolveQueue();
       await vi.advanceTimersByTimeAsync(0);
+      now = 1_600;
+      await vi.advanceTimersByTimeAsync(250);
+      expect(enqueue).toHaveBeenCalledTimes(2);
+      expect(enqueue).toHaveBeenLastCalledWith(expect.objectContaining({
+        snapshot: expect.objectContaining({ digest: 'bash-changed' }),
+      }));
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should serialize overlapping Bash snapshot probes', async () => {
+    vi.useFakeTimers();
+    try {
+      const initial = diff('baseline', 0);
+      const changed = diff('bash-changed', 12);
+      let resolveFirstProbe!: (snapshot: CompanionDiff) => void;
+      const readSnapshot = vi.fn()
+        .mockImplementationOnce(() => new Promise<CompanionDiff>((resolve) => {
+          resolveFirstProbe = resolve;
+        }))
+        .mockResolvedValueOnce(changed);
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => 1_000,
+        readDiff: readSnapshot,
+      });
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue: vi.fn().mockResolvedValue(undefined) } as unknown as CompanionReviewQueue,
+        initialSnapshot: initial,
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      for (const id of ['bash-1', 'bash-2']) {
+        scheduler.observe({
+          type: 'tool_use',
+          data: { tool: 'Bash', input: { command: 'npm run format' }, id },
+        });
+      }
+      for (const id of ['bash-1', 'bash-2']) {
+        scheduler.observe({
+          type: 'tool_result',
+          data: { id, content: '', isError: false },
+        });
+      }
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(readSnapshot).toHaveBeenCalledOnce();
+      resolveFirstProbe(changed);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(readSnapshot).toHaveBeenCalledTimes(2);
+      expect(detector.getObservedGeneration()).toBe(1);
+      scheduler.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should serialize a Bash snapshot probe with a scheduled evaluation snapshot', async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      const initial = diff('baseline', 0);
+      const bashChanged = diff('bash-changed', 8);
+      const edited = diff('edited-after-bash', 12);
+      let resolveProbe!: (snapshot: CompanionDiff) => void;
+      const readSnapshot = vi.fn()
+        .mockImplementationOnce(() => new Promise<CompanionDiff>((resolve) => {
+          resolveProbe = resolve;
+        }))
+        .mockResolvedValueOnce(edited);
+      const detector = new CompanionChangeDetector({
+        intervalMs: 15_000,
+        minimumChangedLines: 1,
+        now: () => now,
+        readDiff: readSnapshot,
+      });
+      const enqueue = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new CompanionTriggerScheduler({
+        detectors: new Map([['security-reviewer', detector]]),
+        intervals: [15_000],
+        allowGitCommit: false,
+        queue: { enqueue } as unknown as CompanionReviewQueue,
+        initialSnapshot: initial,
+        readSnapshot,
+        isAborted: () => false,
+        onError: vi.fn(),
+      });
+
+      scheduler.observe({
+        type: 'tool_use',
+        data: { tool: 'Bash', input: { command: 'npm run format' }, id: 'bash-1' },
+      });
+      scheduler.observe({
+        type: 'tool_result',
+        data: { id: 'bash-1', content: '', isError: false },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      now = 1_100;
+      scheduler.observe(tool('Edit'));
+      now = 1_350;
+      await vi.advanceTimersByTimeAsync(250);
+      expect(readSnapshot).toHaveBeenCalledOnce();
+
+      resolveProbe(bashChanged);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(readSnapshot).toHaveBeenCalledTimes(2);
+      expect(enqueue).toHaveBeenCalledOnce();
+      expect(enqueue).toHaveBeenCalledWith(expect.objectContaining({
+        snapshot: expect.objectContaining({ digest: 'edited-after-bash' }),
+      }));
       scheduler.stop();
     } finally {
       vi.useRealTimers();

--- a/src/__tests__/companion-completion-coordinator.test.ts
+++ b/src/__tests__/companion-completion-coordinator.test.ts
@@ -226,6 +226,7 @@ function createCoordinator(input: {
     detectors: new Map([['security-reviewer', input.current]]),
     queue,
     readSnapshot: input.readSnapshot ?? vi.fn().mockResolvedValue(snapshot),
+    synchronizeSnapshot: vi.fn(),
     openMustFix: () => input.openMustFix ?? [],
     recordCompletionRound: input.recordCompletionRound ?? vi.fn(),
     decision: new CompanionTerminalDecisionTracker(),

--- a/src/__tests__/companion-completion-coordinator.test.ts
+++ b/src/__tests__/companion-completion-coordinator.test.ts
@@ -64,13 +64,16 @@ describe('companion completion coordinator', () => {
     const runningRejection = expect(running).rejects.toMatchObject({ name: 'AbortError' });
     await Promise.resolve();
     const emit = vi.fn();
-    const coordinator = createCoordinator({ current, queue, emit });
+    const synchronizeSnapshot = vi.fn();
+    const coordinator = createCoordinator({ current, queue, emit, synchronizeSnapshot });
 
     await coordinator.complete(state());
     await runningRejection;
 
     expect(order).toEqual(['started', 'aborted']);
     expect(emit).toHaveBeenCalledOnce();
+    expect(synchronizeSnapshot).toHaveBeenCalledOnce();
+    expect(synchronizeSnapshot).toHaveBeenCalledWith(snapshot);
   });
 
   it('should retain open must_fix and escalate when loop adjudication fails', async () => {
@@ -159,12 +162,14 @@ describe('companion completion coordinator', () => {
     const queue = new CompanionReviewQueue({
       runReview: vi.fn().mockRejectedValue(new Error('review failed')),
     });
-    const coordinator = createCoordinator({ current, queue });
+    const synchronizeSnapshot = vi.fn();
+    const coordinator = createCoordinator({ current, queue, synchronizeSnapshot });
 
     const result = await coordinator.complete(state());
 
     expect(current.isDirty()).toBe(true);
     expect(result).toMatchObject({ escalated: true, openMustFix: [] });
+    expect(synchronizeSnapshot).not.toHaveBeenCalled();
   });
 
   it('should rethrow an abort without publishing completion', async () => {
@@ -219,6 +224,7 @@ function createCoordinator(input: {
   openMustFix?: CompanionFindingEvidence[];
   readSnapshot?: ReturnType<typeof vi.fn>;
   recordCompletionRound?: ReturnType<typeof vi.fn>;
+  synchronizeSnapshot?: ReturnType<typeof vi.fn>;
 }): CompanionCompletionCoordinator {
   const queue = input.queue ?? new CompanionReviewQueue({ runReview: vi.fn() });
   return new CompanionCompletionCoordinator({
@@ -226,7 +232,7 @@ function createCoordinator(input: {
     detectors: new Map([['security-reviewer', input.current]]),
     queue,
     readSnapshot: input.readSnapshot ?? vi.fn().mockResolvedValue(snapshot),
-    synchronizeSnapshot: vi.fn(),
+    synchronizeSnapshot: input.synchronizeSnapshot ?? vi.fn(),
     openMustFix: () => input.openMustFix ?? [],
     recordCompletionRound: input.recordCompletionRound ?? vi.fn(),
     decision: new CompanionTerminalDecisionTracker(),

--- a/src/__tests__/companion-review-moderator.integration.test.ts
+++ b/src/__tests__/companion-review-moderator.integration.test.ts
@@ -213,6 +213,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       },
     });
 
+    const onRoundCompleted = vi.fn();
     try {
       const result = await executeCompanionReviewRound({
         companionName: 'security-reviewer',
@@ -252,10 +253,16 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         markReviewed: vi.fn(),
         evaluateRound: createEvaluateRound(),
         applyRoundDecision: vi.fn(),
-        onRoundCompleted: vi.fn(),
+        onRoundCompleted,
       });
 
       expect(result.findingCount).toBe(1);
+      expect(onRoundCompleted).toHaveBeenCalledOnce();
+      expect(onRoundCompleted).toHaveBeenCalledWith({
+        snapshot: expect.objectContaining({ digest: 'digest' }),
+        trigger: 'quiet',
+        findingCount: 1,
+      });
       expect(stateStore.get(mailboxPath, 'security-reviewer').mailbox.findings).toHaveLength(2);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/src/__tests__/companion-review-moderator.integration.test.ts
+++ b/src/__tests__/companion-review-moderator.integration.test.ts
@@ -97,6 +97,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     try {
       await expect(executeCompanionReviewRound({
         companionName: 'security-reviewer',
+        trigger: 'quiet',
         diff: {
           content: 'diff',
           digest: 'digest',
@@ -129,6 +130,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         markReviewed: vi.fn(),
         evaluateRound: createEvaluateRound(),
         applyRoundDecision: vi.fn(),
+        onRoundCompleted: vi.fn(),
       })).rejects.toThrow(`${actor} references unknown companion finding "missing-1"`);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -156,6 +158,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     try {
       await executeCompanionReviewRound({
         companionName: 'security-reviewer',
+        trigger: 'quiet',
         diff: {
           content: 'diff',
           digest: 'digest',
@@ -184,12 +187,76 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         markReviewed,
         evaluateRound,
         applyRoundDecision: vi.fn(),
+        onRoundCompleted: vi.fn(),
       });
 
       expect(callStructured).toHaveBeenCalledOnce();
       expect(markReviewed).toHaveBeenCalledOnce();
       expect(evaluateRound).toHaveBeenCalledOnce();
       expect(existsSync(mailboxPath)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('should return the findings accepted by this round instead of the mailbox open count', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'takt-companion-finding-count-'));
+    const mailboxPath = join(root, 'security-reviewer.jsonl');
+    const stateStore = new CompanionReviewStateStore();
+    stateStore.apply({
+      path: mailboxPath,
+      companionName: 'security-reviewer',
+      maxOpenMustFix: 5,
+      result: {
+        findings: [{ severity: 'should_fix', file: 'src/existing.ts', line: 1, finding: 'existing' }],
+        updates: [],
+      },
+    });
+
+    try {
+      const result = await executeCompanionReviewRound({
+        companionName: 'security-reviewer',
+        trigger: 'quiet',
+        diff: {
+          content: 'diff',
+          digest: 'digest',
+          changedLines: 1,
+          changedFiles: ['src/a.ts'],
+          fileFingerprints: {},
+          hunkFingerprints: {},
+          omittedBytes: 0,
+          truncated: false,
+        },
+        observedGeneration: 1,
+        changedRegionsSincePreviousReview: [],
+        diffSummary: 'summary',
+        signal: new AbortController().signal,
+        task: 'task',
+        stepName: 'implement',
+        stepInstruction: 'implement',
+        activeNames: ['security-reviewer'],
+        stateStore,
+        mailboxPath: () => mailboxPath,
+        systemPrompt: () => 'review',
+        openFindings: () => stateStore.get(mailboxPath, 'security-reviewer').mailbox.findings,
+        callStructured: vi.fn().mockResolvedValue({
+          status: 'done',
+          content: '',
+          structuredOutput: {
+            findings: [{ severity: 'nit', file: 'src/a.ts', line: 2, finding: 'new' }],
+            updates: [],
+            notes: null,
+          },
+        }),
+        emitFinding: vi.fn(),
+        markReviewed: vi.fn(),
+        evaluateRound: createEvaluateRound(),
+        applyRoundDecision: vi.fn(),
+        onRoundCompleted: vi.fn(),
+      });
+
+      expect(result.findingCount).toBe(1);
+      expect(stateStore.get(mailboxPath, 'security-reviewer').mailbox.findings).toHaveLength(2);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -226,6 +293,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     });
     const roundInput = {
       companionName: 'security-reviewer',
+      trigger: 'quiet' as const,
       diff: {
         content: 'diff',
         digest: 'digest',
@@ -253,6 +321,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       markReviewed,
       evaluateRound,
       applyRoundDecision: vi.fn(),
+      onRoundCompleted: vi.fn(),
     };
     mailboxPublicationInjection.path = mailboxPath;
     mailboxPublicationInjection.failAfterGuard = true;
@@ -310,6 +379,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     try {
       await expect(executeCompanionReviewRound({
         companionName: 'security-reviewer',
+        trigger: 'quiet',
         diff: {
           content: 'diff',
           digest: 'digest',
@@ -347,6 +417,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         markReviewed: vi.fn(),
         evaluateRound: createEvaluateRound(),
         applyRoundDecision: vi.fn(),
+        onRoundCompleted: vi.fn(),
       })).rejects.toThrow(/changed outside the engine/);
 
       expect(readFileSync(mailboxPath)).toEqual(Buffer.concat([bytesBefore, externalRecord]));
@@ -406,6 +477,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     });
     const roundInput = {
       companionName: 'security-reviewer',
+      trigger: 'quiet' as const,
       diff: {
         content: 'diff',
         digest: 'digest',
@@ -437,6 +509,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       markReviewed,
       evaluateRound,
       applyRoundDecision: vi.fn(),
+      onRoundCompleted: vi.fn(),
     };
     mailboxPublicationInjection.path = designPath;
     mailboxPublicationInjection.failAfterGuard = true;
@@ -510,6 +583,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     try {
       await executeCompanionReviewRound({
         companionName: shortOwner,
+        trigger: 'quiet',
         diff: {
           content: 'diff',
           digest: 'digest',
@@ -551,6 +625,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         markReviewed: vi.fn(),
         evaluateRound: createEvaluateRound(),
         applyRoundDecision: vi.fn(),
+        onRoundCompleted: vi.fn(),
       });
 
       expect(stateStore.get(shortPath, shortOwner).mailbox.findings[0]?.status).toBe('open');
@@ -588,6 +663,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     });
     const roundInput = {
       companionName: 'security-reviewer',
+      trigger: 'quiet' as const,
       diff: {
         content: 'diff',
         digest: 'digest',
@@ -615,6 +691,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       markReviewed,
       evaluateRound,
       applyRoundDecision: vi.fn(),
+      onRoundCompleted: vi.fn(),
     };
 
     try {
@@ -649,6 +726,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     try {
       await expect(executeCompanionReviewRound({
         companionName: 'security-reviewer',
+        trigger: 'quiet',
         diff: {
           content: 'diff',
           digest: 'digest',
@@ -686,6 +764,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         markReviewed,
         evaluateRound,
         applyRoundDecision: vi.fn(),
+        onRoundCompleted: vi.fn(),
       })).rejects.toMatchObject({ name: 'AbortError' });
 
       expect(emitFinding).not.toHaveBeenCalled();
@@ -709,6 +788,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     try {
       await executeCompanionReviewRound({
         companionName: 'security-reviewer',
+        trigger: 'quiet',
         diff: {
           content: 'diff',
           digest: 'digest',
@@ -761,6 +841,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         markReviewed: vi.fn(),
         evaluateRound,
         applyRoundDecision: vi.fn(),
+        onRoundCompleted: vi.fn(),
       });
 
       expect(calls[0]?.prompt).toContain('The branch is required by the public API.');
@@ -800,6 +881,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     });
     const input = {
       companionName: 'security-reviewer',
+      trigger: 'quiet' as const,
       diff: {
         content: 'diff',
         digest: 'digest',
@@ -827,6 +909,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       markReviewed,
       evaluateRound,
       applyRoundDecision: vi.fn(),
+      onRoundCompleted: vi.fn(),
     };
 
     try {
@@ -863,6 +946,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     });
     const base = {
       companionName: 'security-reviewer',
+      trigger: 'quiet' as const,
       diff: {
         content: 'diff',
         digest: 'digest',
@@ -888,6 +972,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       emitFinding: vi.fn(),
       markReviewed,
       evaluateRound,
+      onRoundCompleted: vi.fn(),
     };
 
     try {
@@ -971,6 +1056,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     });
     const input = {
       companionName: 'security-reviewer',
+      trigger: 'quiet' as const,
       diff: {
         content: 'diff',
         digest: 'digest',
@@ -998,6 +1084,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       markReviewed: vi.fn(),
       evaluateRound,
       applyRoundDecision: vi.fn(),
+      onRoundCompleted: vi.fn(),
     };
 
     try {
@@ -1033,6 +1120,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     const mailboxPath = join(root, 'security-reviewer.jsonl');
     const stateStore = new CompanionReviewStateStore();
     const markReviewed = vi.fn();
+    const onRoundCompleted = vi.fn();
     let evaluationAttempt = 0;
     const evaluateRound = vi.fn(async (
       digest: string,
@@ -1061,6 +1149,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     });
     const common = {
       companionName: 'security-reviewer',
+      trigger: 'quiet' as const,
       changedRegionsSincePreviousReview: [],
       diffSummary: 'summary',
       signal: new AbortController().signal,
@@ -1077,6 +1166,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       markReviewed,
       evaluateRound,
       applyRoundDecision: vi.fn(),
+      onRoundCompleted,
     };
     const pendingDiff = {
       content: 'pending',
@@ -1105,6 +1195,16 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       expect(callStructured).toHaveBeenCalledTimes(2);
       expect(markReviewed).toHaveBeenNthCalledWith(1, pendingDiff, 1);
       expect(markReviewed).toHaveBeenNthCalledWith(2, currentDiff, currentGeneration);
+      expect(onRoundCompleted).toHaveBeenNthCalledWith(1, {
+        snapshot: pendingDiff,
+        trigger: 'quiet',
+        findingCount: 0,
+      });
+      expect(onRoundCompleted).toHaveBeenNthCalledWith(2, {
+        snapshot: currentDiff,
+        trigger: 'quiet',
+        findingCount: 0,
+      });
       expect(evaluateRound).toHaveBeenCalledTimes(3);
       expect(stateStore.previewRound('history', {
         diffDigest: 'probe',

--- a/src/__tests__/companion-review-queue.test.ts
+++ b/src/__tests__/companion-review-queue.test.ts
@@ -33,11 +33,15 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
   it('should serialize rounds for one companion and batch changes into the next round', async () => {
     const first = deferred<void>();
     const starts: string[] = [];
+    const coalesced: unknown[] = [];
     const runReview = vi.fn(async (request: { companionName: string; snapshot: { digest: string } }) => {
       starts.push(request.snapshot.digest);
       if (request.snapshot.digest === 'diff-1') await first.promise;
     });
-    const queue = new CompanionReviewQueue({ runReview });
+    const queue = new CompanionReviewQueue({
+      runReview,
+      onCoalesced: (event) => coalesced.push(event),
+    });
 
     const round1 = queue.enqueue(request('diff-1'));
     const round2 = queue.enqueue(request('diff-2'));
@@ -48,6 +52,21 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
     await Promise.all([round1, round2, round3]);
 
     expect(starts).toEqual(['diff-1', 'diff-3']);
+    expect(coalesced).toEqual([{
+      companionName: 'security-reviewer',
+      replaced: {
+        trigger: 'quiet',
+        digest: 'diff-2',
+        changedLines: 1,
+        observedGeneration: 1,
+      },
+      replacement: {
+        trigger: 'quiet',
+        digest: 'diff-3',
+        changedLines: 1,
+        observedGeneration: 1,
+      },
+    }]);
   });
 
   it('should allow different companions to review concurrently', async () => {

--- a/src/__tests__/companion-runtime-lifecycle.integration.test.ts
+++ b/src/__tests__/companion-runtime-lifecycle.integration.test.ts
@@ -24,6 +24,17 @@ const snapshot = {
   truncated: false,
 };
 
+const emptySnapshot = {
+  digest: 'empty',
+  changedLines: 0,
+  content: '',
+  changedFiles: [],
+  fileFingerprints: {},
+  hunkFingerprints: {},
+  omittedBytes: 0,
+  truncated: false,
+};
+
 function step(allowGitCommit?: boolean): NormalAgentWorkflowStep {
   return {
     name: 'implement',
@@ -74,7 +85,7 @@ function dependencies(input: {
 
 describe('companion runtime lifecycle', () => {
   it('should preserve the diff failure code and sanitized message in its error', async () => {
-    const runtime = await CompanionStepRuntime.create(dependencies({
+    await expect(CompanionStepRuntime.create(dependencies({
       diffReader: {
         readBaselineSha: vi.fn().mockResolvedValue('baseline'),
         readDiff: vi.fn().mockResolvedValue({
@@ -85,17 +96,9 @@ describe('companion runtime lifecycle', () => {
           },
         }),
       },
-    }));
-
-    try {
-      const readSnapshot = (runtime as unknown as { readSnapshot: () => Promise<unknown> }).readSnapshot
-        .bind(runtime);
-      await expect(readSnapshot()).rejects.toThrow(
-        'Companion diff unavailable (git_failure): git diff failed in [path]',
-      );
-    } finally {
-      runtime.stop();
-    }
+    }))).rejects.toThrow(
+      'Companion diff unavailable (git_failure): git diff failed in [path]',
+    );
   });
 
   it('should pass the maximum platform-safe interval to the scheduler unchanged', async () => {
@@ -104,7 +107,10 @@ describe('companion runtime lifecycle', () => {
     let runtime: CompanionStepRuntime | undefined;
     try {
       runtime = await CompanionStepRuntime.create(dependencies({
-        diffReader: { readBaselineSha: vi.fn().mockResolvedValue('baseline'), readDiff: vi.fn() },
+        diffReader: {
+          readBaselineSha: vi.fn().mockResolvedValue('baseline'),
+          readDiff: vi.fn().mockResolvedValue({ status: 'ok', snapshot: emptySnapshot }),
+        },
         intervalMs: MAX_COMPANION_INTERVAL_MS,
       }));
 
@@ -132,7 +138,7 @@ describe('companion runtime lifecycle', () => {
       await Promise.resolve();
       runtime.stop();
 
-      expect(readDiff).not.toHaveBeenCalled();
+      expect(readDiff).toHaveBeenCalledOnce();
     },
   );
 
@@ -147,8 +153,53 @@ describe('companion runtime lifecycle', () => {
       type: 'tool_use',
       data: { tool: 'Bash', input: { command: 'git commit -m change' }, id: 'commit' },
     });
-    await vi.waitFor(() => expect(readDiff).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(readDiff).toHaveBeenCalledTimes(2));
     runtime.stop();
+  });
+
+  it('should synchronize the completion snapshot before an unchanged Bash in a fix round', async () => {
+    vi.useFakeTimers();
+    const readDiff = vi.fn()
+      .mockResolvedValueOnce({ status: 'ok', snapshot: emptySnapshot })
+      .mockResolvedValue({ status: 'ok', snapshot });
+    const callSpy = vi.spyOn(CompanionStructuredCaller.prototype, 'call').mockImplementation(
+      async (request) => request.purpose === 'judge'
+        ? {
+            status: 'done',
+            content: '',
+            structuredOutput: { decision: 'continue', reason: 'continue' },
+          }
+        : {
+            status: 'done',
+            content: '',
+            structuredOutput: { findings: [], updates: [], notes: null },
+          },
+    );
+    let runtime: CompanionStepRuntime | undefined;
+    try {
+      runtime = await CompanionStepRuntime.create(dependencies({
+        diffReader: { readBaselineSha: vi.fn().mockResolvedValue('baseline'), readDiff },
+      }));
+      await runtime.complete({ companion: undefined } as unknown as WorkflowState, 'complete');
+      runtime.beginFixRound(2, 0);
+
+      runtime.observe({
+        type: 'tool_use',
+        data: { tool: 'Bash', input: { command: 'npm test' }, id: 'bash-read' },
+      });
+      runtime.observe({
+        type: 'tool_result',
+        data: { id: 'bash-read', content: '', isError: false },
+      });
+      await vi.waitFor(() => expect(readDiff).toHaveBeenCalledTimes(3));
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(callSpy.mock.calls.filter(([request]) => request.purpose === 'reviewer')).toHaveLength(1);
+    } finally {
+      runtime?.stop();
+      callSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it('should leave no listener or timer when baseline initialization fails', async () => {
@@ -202,7 +253,10 @@ describe('companion runtime lifecycle', () => {
     try {
       runtime = await CompanionStepRuntime.create(dependencies({
         workflowStep,
-        diffReader: { readBaselineSha: vi.fn().mockResolvedValue('baseline'), readDiff: vi.fn() },
+        diffReader: {
+          readBaselineSha: vi.fn().mockResolvedValue('baseline'),
+          readDiff: vi.fn().mockResolvedValue({ status: 'ok', snapshot: emptySnapshot }),
+        },
         selectorProvider: {
           provider: 'mock',
           model: undefined,
@@ -249,7 +303,10 @@ describe('companion runtime lifecycle', () => {
     };
     const base = dependencies({
       workflowStep,
-      diffReader: { readBaselineSha: vi.fn().mockResolvedValue('baseline'), readDiff: vi.fn() },
+      diffReader: {
+        readBaselineSha: vi.fn().mockResolvedValue('baseline'),
+        readDiff: vi.fn().mockResolvedValue({ status: 'ok', snapshot: emptySnapshot }),
+      },
       providers: {
         'security-reviewer': { provider: 'mock' },
         adjudicator: { provider: 'mock' },

--- a/src/__tests__/companion-step-executor.integration.test.ts
+++ b/src/__tests__/companion-step-executor.integration.test.ts
@@ -77,13 +77,27 @@ function createCompanionDiffReader(): CompanionDiffReader {
 function createFailingCompletionDiffReader(): CompanionDiffReader {
   return {
     readBaselineSha: vi.fn().mockResolvedValue('baseline-sha'),
-    readDiff: vi.fn().mockResolvedValue({
-      status: 'error',
-      failure: {
-        code: 'git_failure',
-        message: 'safe injected completion failure',
-      },
-    }),
+    readDiff: vi.fn()
+      .mockResolvedValueOnce({
+        status: 'ok',
+        snapshot: {
+          digest: 'empty-diff',
+          changedLines: 0,
+          content: '',
+          changedFiles: [],
+          fileFingerprints: {},
+          hunkFingerprints: {},
+          omittedBytes: 0,
+          truncated: false,
+        },
+      })
+      .mockResolvedValue({
+        status: 'error',
+        failure: {
+          code: 'git_failure',
+          message: 'safe injected completion failure',
+        },
+      }),
   };
 }
 

--- a/src/__tests__/sessionLogger.test.ts
+++ b/src/__tests__/sessionLogger.test.ts
@@ -30,6 +30,59 @@ afterEach(() => {
 });
 
 describe('SessionLogger', () => {
+  it('companion review round と queue coalescing を run NDJSON に永続化する', () => {
+    const logsDir = createTempLogsDir();
+    const ndjsonPath = initNdjsonLog('session-companion', 'task', 'workflow', { logsDir });
+    const logger = new SessionLogger(ndjsonPath, false);
+
+    logger.onCompanionReviewRound({
+      step: 'implement',
+      companion: 'security-reviewer',
+      trigger: 'quiet',
+      digest: 'digest-2',
+      changedLines: 12,
+      findingCount: 2,
+    });
+    logger.onCompanionQueueCoalesced({
+      step: 'implement',
+      companion: 'security-reviewer',
+      replaced: {
+        trigger: 'quiet',
+        digest: 'digest-1',
+        changedLines: 10,
+        observedGeneration: 1,
+      },
+      replacement: {
+        trigger: 'quiet',
+        digest: 'digest-2',
+        changedLines: 12,
+        observedGeneration: 2,
+      },
+    });
+
+    const records = readFileSync(ndjsonPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .map(parseNdjsonRecord);
+
+    expect(records).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'companion_review_round',
+        step: 'implement',
+        companion: 'security-reviewer',
+        trigger: 'quiet',
+        digest: 'digest-2',
+        changedLines: 12,
+        findingCount: 2,
+      }),
+      expect.objectContaining({
+        type: 'companion_queue_coalesced',
+        replaced: expect.objectContaining({ digest: 'digest-1' }),
+        replacement: expect.objectContaining({ digest: 'digest-2' }),
+      }),
+    ]));
+  });
+
   it.each([
     {
       name: 'completed',

--- a/src/__tests__/type-contracts/companion-events.ts
+++ b/src/__tests__/type-contracts/companion-events.ts
@@ -32,6 +32,32 @@ emitCompanionEvent('companion:complete', {
   escalated: false,
 });
 
+emitCompanionEvent('companion:review_round', {
+  step: 'implement',
+  companion: 'security-reviewer',
+  trigger: 'quiet',
+  digest: 'digest-1',
+  changedLines: 12,
+  findingCount: 1,
+});
+
+emitCompanionEvent('companion:queue_coalesced', {
+  step: 'implement',
+  companion: 'security-reviewer',
+  replaced: {
+    trigger: 'quiet',
+    digest: 'digest-1',
+    changedLines: 10,
+    observedGeneration: 1,
+  },
+  replacement: {
+    trigger: 'quiet',
+    digest: 'digest-2',
+    changedLines: 12,
+    observedGeneration: 2,
+  },
+});
+
 emitCompanionEvent('companion:complete', {
   step: 'implement',
   openMustFixCount: 0,

--- a/src/__tests__/type-contracts/companion-events.ts
+++ b/src/__tests__/type-contracts/companion-events.ts
@@ -58,6 +58,28 @@ emitCompanionEvent('companion:queue_coalesced', {
   },
 });
 
+emitCompanionEvent('companion:review_round', {
+  step: 'implement',
+  companion: 'security-reviewer',
+  // @ts-expect-error Companion review rounds require a declared trigger value.
+  trigger: 'manual',
+  digest: 'digest-1',
+  changedLines: 12,
+  findingCount: 1,
+});
+
+// @ts-expect-error Companion queue coalescing requires the replacement payload.
+emitCompanionEvent('companion:queue_coalesced', {
+  step: 'implement',
+  companion: 'security-reviewer',
+  replaced: {
+    trigger: 'quiet',
+    digest: 'digest-1',
+    changedLines: 10,
+    observedGeneration: 1,
+  },
+});
+
 emitCompanionEvent('companion:complete', {
   step: 'implement',
   openMustFixCount: 0,

--- a/src/__tests__/workflowExecutionEvents.test.ts
+++ b/src/__tests__/workflowExecutionEvents.test.ts
@@ -256,11 +256,39 @@ describe('bindWorkflowExecutionEvents', () => {
         status: 'completed',
       };
       const listeners = new Map<string, (...args: unknown[]) => void>();
+      const reviewRoundPayload = {
+        step: 'review',
+        companion: 'security-reviewer',
+        trigger: 'quiet',
+        digest: 'child-digest',
+        changedLines: 12,
+        findingCount: 2,
+      };
+      const queueCoalescedPayload = {
+        step: 'review',
+        companion: 'security-reviewer',
+        replaced: {
+          trigger: 'quiet',
+          digest: 'child-digest',
+          changedLines: 12,
+          observedGeneration: 1,
+        },
+        replacement: {
+          trigger: 'forced',
+          digest: 'child-digest-2',
+          changedLines: 18,
+          observedGeneration: 2,
+        },
+      };
       const childEngine = {
         on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
           listeners.set(event, listener);
         }),
-        runWithResult: vi.fn().mockResolvedValue({ state: childState }),
+        runWithResult: vi.fn().mockImplementation(async () => {
+          listeners.get('companion:review_round')?.(reviewRoundPayload);
+          listeners.get('companion:queue_coalesced')?.(queueCoalescedPayload);
+          return { state: childState };
+        }),
       };
       const sharedRuntime = { startedAtMs: Date.now(), maxSteps: 10 };
       const executor = new WorkflowCallExecutor({
@@ -295,15 +323,6 @@ describe('bindWorkflowExecutionEvents', () => {
         providerEscalation: undefined,
       } as never, { syncParentState: true });
 
-      listeners.get('companion:review_round')?.({
-        step: 'review',
-        companion: 'security-reviewer',
-        trigger: 'quiet',
-        digest: 'child-digest',
-        changedLines: 12,
-        findingCount: 2,
-      });
-
       const records = readFileSync(ndjsonPath, 'utf8')
         .trim()
         .split('\n')
@@ -316,6 +335,13 @@ describe('bindWorkflowExecutionEvents', () => {
         digest: 'child-digest',
         changedLines: 12,
         findingCount: 2,
+      }));
+      expect(records).toContainEqual(expect.objectContaining({
+        type: 'companion_queue_coalesced',
+        step: 'review',
+        companion: 'security-reviewer',
+        replaced: expect.objectContaining({ digest: 'child-digest' }),
+        replacement: expect.objectContaining({ digest: 'child-digest-2' }),
       }));
     } finally {
       rmSync(logsDir, { recursive: true, force: true });

--- a/src/__tests__/workflowExecutionEvents.test.ts
+++ b/src/__tests__/workflowExecutionEvents.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -8,7 +8,10 @@ import { initAnalyticsWriter } from '../features/analytics/index.js';
 import { resetAnalyticsWriter } from '../features/analytics/writer.js';
 import { AnalyticsEmitter } from '../features/tasks/execute/analyticsEmitter.js';
 import { bindWorkflowExecutionEvents } from '../features/tasks/execute/workflowExecutionEvents.js';
+import { SessionLogger } from '../features/tasks/execute/sessionLogger.js';
 import { createWorkflowTerminalPayloadFactory } from '../features/tasks/execute/workflowTerminalPayload.js';
+import { initNdjsonLog, parseNdjsonRecord } from '../infra/fs/session.js';
+import { WorkflowCallExecutor } from '../core/workflow/engine/WorkflowCallExecutor.js';
 import { resetDebugLogger, setVerboseConsole } from '../shared/utils/debug.js';
 import { normalizeRule } from '../infra/config/loaders/workflowRuleNormalizer.js';
 import type { ProviderType } from '../shared/types/provider.js';
@@ -47,6 +50,8 @@ function createBridgeHarness(options?: {
   eventSink?: ReturnType<typeof vi.fn>;
   shouldNotifyRateLimit?: boolean;
   display?: { flush: ReturnType<typeof vi.fn> };
+  engine?: TestEngine;
+  sessionLogger?: SessionLogger;
 }) {
   const resumePoint = options?.resumePoint ?? {
     version: 2,
@@ -62,7 +67,7 @@ function createBridgeHarness(options?: {
     workflow_call_invocations: {},
     workflow_step_participations: {},
   } satisfies WorkflowResumePoint;
-  const engine = new TestEngine(resumePoint, options?.findingIds);
+  const engine = options?.engine ?? new TestEngine(resumePoint, options?.findingIds);
   const out = {
     info: vi.fn(),
     blankLine: vi.fn(),
@@ -96,7 +101,7 @@ function createBridgeHarness(options?: {
   const usageEventLogger = {
     logUsageFor: vi.fn(),
   };
-  const sessionLogger = {
+  const sessionLogger = options?.sessionLogger ?? {
     onPhaseStart: vi.fn(),
     onPhaseComplete: vi.fn(),
     onJudgeStage: vi.fn(),
@@ -106,6 +111,8 @@ function createBridgeHarness(options?: {
     onStepComplete: vi.fn(),
     onWorkflowComplete: vi.fn(),
     onWorkflowAbort: vi.fn(),
+    onCompanionReviewRound: vi.fn(),
+    onCompanionQueueCoalesced: vi.fn(),
   };
   const sessionLog = {
     task: 'task',
@@ -201,6 +208,118 @@ describe('bindWorkflowExecutionEvents', () => {
 
     expect(sessionLogger.onWorkflowCallStart).toHaveBeenCalledWith(lifecycle);
     expect(sessionLogger.onWorkflowCallComplete).toHaveBeenCalledWith(complete);
+  });
+
+  it('child workflow の companion review event を relay と親 bridge 経由で run NDJSON に記録する', async () => {
+    const logsDir = mkdtempSync(join(tmpdir(), 'takt-companion-relay-'));
+    try {
+      const ndjsonPath = initNdjsonLog('session-relay', 'task', 'parent', { logsDir });
+      const sessionLogger = new SessionLogger(ndjsonPath, false);
+      const bridgeHarness = createBridgeHarness({ sessionLogger });
+      const parentConfig = {
+        name: 'parent',
+        initialStep: 'delegate',
+        maxSteps: 10,
+        steps: [],
+      };
+      const childConfig = {
+        name: 'child',
+        initialStep: 'review',
+        maxSteps: 10,
+        steps: [{ name: 'review' }],
+      };
+      const step = {
+        name: 'delegate',
+        call: 'child',
+        personaDisplayName: 'delegate',
+        instruction: '',
+      };
+      const state = {
+        workflowName: 'parent',
+        currentStep: 'delegate',
+        iteration: 1,
+        stepOutputs: new Map(),
+        structuredOutputs: new Map(),
+        systemContexts: new Map(),
+        effectResults: new Map(),
+        userInputs: [],
+        personaSessions: new Map(),
+        stepIterations: new Map([['delegate', 1]]),
+        dynamicParallelSelections: new Map(),
+        resumedDynamicParallelSteps: new Set(),
+        status: 'running',
+      };
+      const childState = {
+        ...state,
+        workflowName: 'child',
+        currentStep: 'review',
+        status: 'completed',
+      };
+      const listeners = new Map<string, (...args: unknown[]) => void>();
+      const childEngine = {
+        on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+          listeners.set(event, listener);
+        }),
+        runWithResult: vi.fn().mockResolvedValue({ state: childState }),
+      };
+      const sharedRuntime = { startedAtMs: Date.now(), maxSteps: 10 };
+      const executor = new WorkflowCallExecutor({
+        getConfig: () => parentConfig as never,
+        getOptions: () => ({ projectCwd: '/tmp/project', reportDirName: 'run' }),
+        getMaxSteps: () => 10,
+        updateMaxSteps: vi.fn(),
+        getCwd: () => '/tmp/project',
+        projectCwd: '/tmp/project',
+        task: 'task',
+        sharedRuntime: sharedRuntime as never,
+        resumeStackPrefix: [],
+        consumeWorkflowCallContinuation: vi.fn(),
+        runPaths: { slug: 'run' } as never,
+        resolveWorkflowCall: vi.fn(),
+        createEngine: vi.fn().mockReturnValue(childEngine),
+        emit: (event: string, ...args: unknown[]) => bridgeHarness.engine.emit(event, ...args),
+        state: state as never,
+        setActiveResumePoint: vi.fn(),
+        refreshFindingsState: vi.fn(),
+      });
+
+      const prepared = executor.prepare(step as never, childConfig as never, 1, []);
+      await executor.execute({
+        step: step as never,
+        preparedExecution: prepared,
+        childProviderInfo: { provider: 'mock', model: 'test-model' },
+        parentProviderOptions: undefined,
+        personaProviders: undefined,
+        providerRouting: undefined,
+        providerLadders: undefined,
+        providerEscalation: undefined,
+      } as never, { syncParentState: true });
+
+      listeners.get('companion:review_round')?.({
+        step: 'review',
+        companion: 'security-reviewer',
+        trigger: 'quiet',
+        digest: 'child-digest',
+        changedLines: 12,
+        findingCount: 2,
+      });
+
+      const records = readFileSync(ndjsonPath, 'utf8')
+        .trim()
+        .split('\n')
+        .map(parseNdjsonRecord);
+      expect(records).toContainEqual(expect.objectContaining({
+        type: 'companion_review_round',
+        step: 'review',
+        companion: 'security-reviewer',
+        trigger: 'quiet',
+        digest: 'child-digest',
+        changedLines: 12,
+        findingCount: 2,
+      }));
+    } finally {
+      rmSync(logsDir, { recursive: true, force: true });
+    }
   });
 
   it('event bridge が run meta と実行結果を同期する', () => {
@@ -1775,7 +1894,7 @@ describe('bindWorkflowExecutionEvents', () => {
 
   it('CT-COMP-11 should preserve all companion actions in event sink and analytics payloads', async () => {
     const eventSink = vi.fn().mockResolvedValue(undefined);
-    const { bridge, engine, analyticsEmitter, out } = createBridgeHarness({ eventSink });
+    const { bridge, engine, analyticsEmitter, out, sessionLogger } = createBridgeHarness({ eventSink });
     const events = [
       ['companion:start', { step: 'implement', companion: 'security-reviewer' }],
       ['companion:pool_selected', {
@@ -1791,6 +1910,30 @@ describe('bindWorkflowExecutionEvents', () => {
       }],
       ['companion:fix_round', { step: 'implement', sequence: 2, openMustFixCount: 1 }],
       ['companion:complete', { step: 'implement', openMustFixCount: 0, escalated: false }],
+      ['companion:review_round', {
+        step: 'implement',
+        companion: 'security-reviewer',
+        trigger: 'quiet',
+        digest: 'digest-2',
+        changedLines: 12,
+        findingCount: 2,
+      }],
+      ['companion:queue_coalesced', {
+        step: 'implement',
+        companion: 'security-reviewer',
+        replaced: {
+          trigger: 'quiet',
+          digest: 'digest-1',
+          changedLines: 10,
+          observedGeneration: 1,
+        },
+        replacement: {
+          trigger: 'quiet',
+          digest: 'digest-2',
+          changedLines: 12,
+          observedGeneration: 2,
+        },
+      }],
     ] as const;
 
     for (const [name, payload] of events) {
@@ -1829,7 +1972,37 @@ describe('bindWorkflowExecutionEvents', () => {
         openMustFixCount: 0,
         escalated: false,
       },
+      {
+        type: 'companion',
+        action: 'review_round',
+        step: 'implement',
+        companion: 'security-reviewer',
+        trigger: 'quiet',
+        digest: 'digest-2',
+        changedLines: 12,
+        findingCount: 2,
+      },
+      {
+        type: 'companion',
+        action: 'queue_coalesced',
+        step: 'implement',
+        companion: 'security-reviewer',
+        replaced: {
+          trigger: 'quiet',
+          digest: 'digest-1',
+          changedLines: 10,
+          observedGeneration: 1,
+        },
+        replacement: {
+          trigger: 'quiet',
+          digest: 'digest-2',
+          changedLines: 12,
+          observedGeneration: 2,
+        },
+      },
     ]);
+    expect(sessionLogger.onCompanionReviewRound).toHaveBeenCalledWith(events[5][1]);
+    expect(sessionLogger.onCompanionQueueCoalesced).toHaveBeenCalledWith(events[6][1]);
     expect(analyticsEmitter.onCompanionEvent.mock.calls.map(([name, payload]) => [name, payload]))
       .toEqual(events);
     expect(out.info.mock.calls.map(([message]) => message)).toEqual([

--- a/src/core/workflow/companion/change-detector.ts
+++ b/src/core/workflow/companion/change-detector.ts
@@ -4,6 +4,8 @@ import type { CompanionDiff } from './diff-reader.js';
 const FORCE_INTERVAL_MULTIPLIER = 4;
 const MUTATING_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'apply_patch', 'write', 'edit']);
 
+export const COMPANION_CHANGE_DEBOUNCE_MS = 250;
+
 export interface CompanionChangeCandidate {
   readonly reason: 'quiet' | 'forced' | 'completion' | 'commit';
   readonly observedGeneration: number;
@@ -38,12 +40,13 @@ export class CompanionChangeDetector {
     this.readDiff = input.readDiff;
   }
 
-  observe(event: StreamEvent): void {
-    if (event.type !== 'tool_use' || !this.isMutatingTool(event.data.tool, event.data.input)) return;
+  observe(event: StreamEvent): boolean {
+    if (event.type !== 'tool_use' || !this.isMutatingTool(event.data.tool)) return false;
     const timestamp = this.now();
     this.generation += 1;
     this.dirtySince ??= timestamp;
     this.lastChangeAt = timestamp;
+    return true;
   }
 
   observeCommit(): void {
@@ -54,8 +57,21 @@ export class CompanionChangeDetector {
     this.immediateGeneration = this.generation;
   }
 
+  observeSnapshotChange(before: CompanionDiff, after: CompanionDiff): boolean {
+    if (before.digest === after.digest) return false;
+    const timestamp = this.now();
+    this.generation += 1;
+    this.dirtySince ??= timestamp;
+    this.lastChangeAt = timestamp;
+    return true;
+  }
+
   isDirty(): boolean {
     return this.dirtySince !== undefined;
+  }
+
+  getObservedGeneration(): number {
+    return this.generation;
   }
 
   markReviewed(snapshot: CompanionDiff, observedGeneration: number): void {
@@ -83,10 +99,10 @@ export class CompanionChangeDetector {
     return [...changedHunks, ...changedFilesWithoutHunks];
   }
 
-  getTriggerCandidate(): CompanionChangeCandidate | undefined {
+  getTriggerCandidate(quietIntervalMs: number): CompanionChangeCandidate | undefined {
     if (this.dirtySince === undefined || this.lastChangeAt === undefined) return undefined;
     const elapsed = this.now() - this.dirtySince;
-    const quiet = this.now() - this.lastChangeAt >= this.intervalMs;
+    const quiet = this.now() - this.lastChangeAt >= quietIntervalMs;
     const forced = elapsed >= this.intervalMs * FORCE_INTERVAL_MULTIPLIER;
     const immediate = this.immediateGeneration !== undefined;
     if (!quiet && !forced && !immediate) return undefined;
@@ -133,9 +149,8 @@ export class CompanionChangeDetector {
     }
   }
 
-  private isMutatingTool(tool: string, input: Record<string, unknown>): boolean {
-    if (MUTATING_TOOLS.has(tool)) return true;
-    return (tool === 'Bash' || tool === 'bash') && typeof input.command === 'string';
+  private isMutatingTool(tool: string): boolean {
+    return MUTATING_TOOLS.has(tool);
   }
 }
 

--- a/src/core/workflow/companion/completion-coordinator.ts
+++ b/src/core/workflow/companion/completion-coordinator.ts
@@ -18,6 +18,7 @@ export class CompanionCompletionCoordinator {
     readonly detectors: ReadonlyMap<string, CompanionChangeDetector>;
     readonly queue: CompanionReviewQueue;
     readonly readSnapshot: () => Promise<CompanionDiff>;
+    readonly synchronizeSnapshot: (snapshot: CompanionDiff) => void;
     readonly openMustFix: () => CompanionFindingEvidence[];
     readonly recordCompletionRound: (snapshot: CompanionDiff) => Promise<void>;
     readonly decision: CompanionTerminalDecisionTracker;
@@ -36,6 +37,7 @@ export class CompanionCompletionCoordinator {
     try {
       const snapshot = await this.input.readSnapshot();
       await this.completeQueues(snapshot, candidates);
+      this.input.synchronizeSnapshot(snapshot);
       reviewedSnapshot = snapshot;
     } catch (error) {
       if (isAbortError(error) || this.input.abortSignal?.aborted) throw error;

--- a/src/core/workflow/companion/event-publisher.ts
+++ b/src/core/workflow/companion/event-publisher.ts
@@ -1,4 +1,8 @@
-import type { WorkflowEvents } from '../types.js';
+import type {
+  CompanionQueueAuditEntry,
+  CompanionReviewTrigger,
+  WorkflowEvents,
+} from '../types.js';
 
 type CompanionEventName = Extract<keyof WorkflowEvents, `companion:${string}`>;
 type CompanionEventArguments<TEvent extends CompanionEventName> = Parameters<WorkflowEvents[TEvent]>;
@@ -48,7 +52,7 @@ export class CompanionEventPublisher {
 
   reviewRound(input: {
     companion: string;
-    trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+    trigger: CompanionReviewTrigger;
     digest: string;
     changedLines: number;
     findingCount: number;
@@ -58,18 +62,8 @@ export class CompanionEventPublisher {
 
   queueCoalesced(input: {
     companion: string;
-    replaced: {
-      trigger: 'quiet' | 'forced' | 'completion' | 'commit';
-      digest: string;
-      changedLines: number;
-      observedGeneration: number;
-    };
-    replacement: {
-      trigger: 'quiet' | 'forced' | 'completion' | 'commit';
-      digest: string;
-      changedLines: number;
-      observedGeneration: number;
-    };
+    replaced: CompanionQueueAuditEntry;
+    replacement: CompanionQueueAuditEntry;
   }): void {
     this.emit('companion:queue_coalesced', { step: this.step, ...input });
   }

--- a/src/core/workflow/companion/event-publisher.ts
+++ b/src/core/workflow/companion/event-publisher.ts
@@ -45,4 +45,32 @@ export class CompanionEventPublisher {
     this.completed = true;
     this.emit('companion:complete', { step: this.step, openMustFixCount, escalated });
   }
+
+  reviewRound(input: {
+    companion: string;
+    trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+    digest: string;
+    changedLines: number;
+    findingCount: number;
+  }): void {
+    this.emit('companion:review_round', { step: this.step, ...input });
+  }
+
+  queueCoalesced(input: {
+    companion: string;
+    replaced: {
+      trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+      digest: string;
+      changedLines: number;
+      observedGeneration: number;
+    };
+    replacement: {
+      trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+      digest: string;
+      changedLines: number;
+      observedGeneration: number;
+    };
+  }): void {
+    this.emit('companion:queue_coalesced', { step: this.step, ...input });
+  }
 }

--- a/src/core/workflow/companion/review-queue.ts
+++ b/src/core/workflow/companion/review-queue.ts
@@ -8,6 +8,22 @@ export interface CompanionReviewRequest {
   readonly observedGeneration: number;
 }
 
+export interface CompanionReviewQueueCoalesced {
+  readonly companionName: string;
+  readonly replaced: {
+    readonly trigger: CompanionReviewRequest['reason'];
+    readonly digest: string;
+    readonly changedLines: number;
+    readonly observedGeneration: number;
+  };
+  readonly replacement: {
+    readonly trigger: CompanionReviewRequest['reason'];
+    readonly digest: string;
+    readonly changedLines: number;
+    readonly observedGeneration: number;
+  };
+}
+
 interface QueueWaiter {
   readonly resolve: () => void;
   readonly reject: (error: unknown) => void;
@@ -31,6 +47,7 @@ export class CompanionReviewQueue {
 
   constructor(private readonly input: {
     runReview: (request: CompanionReviewRequest & { signal: AbortSignal }) => Promise<void>;
+    onCoalesced?: (event: CompanionReviewQueueCoalesced) => void;
   }) {}
 
   enqueue(request: CompanionReviewRequest): Promise<void> {
@@ -39,8 +56,14 @@ export class CompanionReviewQueue {
     const waiter = promiseWaiter();
     const last = state.pending.at(-1);
     if (last !== undefined && last.request.reason !== 'completion') {
+      const replaced = toQueueAuditRequest(last.request);
       last.request = request;
       last.waiters.push(waiter.waiter);
+      this.input.onCoalesced?.({
+        companionName: request.companionName,
+        replaced,
+        replacement: toQueueAuditRequest(request),
+      });
     } else {
       state.pending.push({ request, waiters: [waiter.waiter] });
     }
@@ -128,6 +151,15 @@ export class CompanionReviewQueue {
   private throwIfStopped(): void {
     if (this.stopped) throw createAbortError();
   }
+}
+
+function toQueueAuditRequest(request: CompanionReviewRequest): CompanionReviewQueueCoalesced['replaced'] {
+  return {
+    trigger: request.reason,
+    digest: request.snapshot.digest,
+    changedLines: request.snapshot.changedLines,
+    observedGeneration: request.observedGeneration,
+  };
 }
 
 function promiseWaiter(): { promise: Promise<void>; waiter: QueueWaiter } {

--- a/src/core/workflow/companion/review-round.ts
+++ b/src/core/workflow/companion/review-round.ts
@@ -18,12 +18,14 @@ import type { CompanionAgentPurpose } from './review-runner.js';
 import type { CompanionReviewStateStore } from './review-state-store.js';
 import type { CompanionReviewOperation } from './review-state-store.js';
 import type { CompanionLoopDecision } from './terminal-decision.js';
+import type { CompanionReviewRequest } from './review-queue.js';
 
 const MAX_OPEN_MUST_FIX = 5;
 
 interface CompanionReviewRoundInput {
   readonly companionName: string;
   readonly diff: CompanionDiff;
+  readonly trigger: CompanionReviewRequest['reason'];
   readonly observedGeneration: number;
   readonly changedRegionsSincePreviousReview: readonly string[];
   readonly diffSummary: string;
@@ -63,22 +65,36 @@ interface CompanionReviewRoundInput {
     decision: CompanionLoopDecision;
   }>;
   readonly applyRoundDecision: (decision: CompanionLoopDecision) => void;
+  readonly onRoundCompleted: (round: {
+    readonly snapshot: CompanionDiff;
+    readonly trigger: CompanionReviewRequest['reason'];
+    readonly findingCount: number;
+  }) => void;
+}
+
+export interface CompanionReviewRoundResult {
+  readonly findingCount: number;
 }
 
 export async function executeCompanionReviewRound(
   input: CompanionReviewRoundInput,
-): Promise<void> {
+): Promise<CompanionReviewRoundResult> {
   input.signal.throwIfAborted();
   const mailboxPath = input.mailboxPath(input.companionName);
   const pending = input.stateStore.getPendingOperation(mailboxPath);
   if (pending !== undefined) {
-    await commitOperation(input, pending);
+    const findingCount = await commitOperation(input, pending);
     await finalizeOperation(input, mailboxPath);
+    input.onRoundCompleted({
+      snapshot: pending.snapshot,
+      trigger: pending.trigger,
+      findingCount,
+    });
     if (
       pending.snapshot.digest === input.diff.digest
       && pending.observedGeneration === input.observedGeneration
     ) {
-      return;
+      return { findingCount };
     }
   }
   const state = input.stateStore.get(mailboxPath, input.companionName);
@@ -103,7 +119,10 @@ export async function executeCompanionReviewRound(
   );
   input.signal.throwIfAborted();
   const reviewerResult = parseCompanionReviewOutput(response.structuredOutput);
-  const commit = createCommit(input, mailboxPath);
+  let findingCount = 0;
+  const commit = createCommit(input, mailboxPath, (count) => {
+    findingCount = count;
+  });
   const moderatorName = input.moderatorName;
 
   if (moderatorName === undefined) {
@@ -133,11 +152,18 @@ export async function executeCompanionReviewRound(
     await commit({ findings: [], updates: [] });
   }
   await finalizeOperation(input, mailboxPath);
+  input.onRoundCompleted({
+    snapshot: input.diff,
+    trigger: input.trigger,
+    findingCount,
+  });
+  return { findingCount };
 }
 
 function createCommit(
   input: CompanionReviewRoundInput,
   scope: string,
+  onFindingCount: (count: number) => void,
 ): (accepted: CompanionReviewOutput) => Promise<void> {
   return async (accepted) => {
     input.signal.throwIfAborted();
@@ -157,6 +183,7 @@ function createCommit(
     input.stateStore.beginOperation({
       scope,
       snapshot: input.diff,
+      trigger: input.trigger,
       observedGeneration: input.observedGeneration,
       diffSummary: input.diffSummary,
       ...(input.implementerExplanation === undefined
@@ -168,14 +195,15 @@ function createCommit(
     if (operation === undefined) {
       throw new Error(`Companion review operation was not created: ${scope}`);
     }
-    await commitOperation(input, operation);
+    onFindingCount(await commitOperation(input, operation));
   };
 }
 
 async function commitOperation(
   input: CompanionReviewRoundInput,
   operation: CompanionReviewOperation,
-): Promise<void> {
+): Promise<number> {
+  let findingCount = operation.findingEvents.length;
   publishPendingFindingEvents(input, operation.scope);
   for (const owner of operation.owners) {
     const current = input.stateStore.getPendingOperation(operation.scope);
@@ -190,7 +218,7 @@ async function commitOperation(
       owner.ownerName,
       owner.result,
     );
-    input.stateStore.applyOwner(operation.scope, owner.ownerName, transitions, {
+    findingCount += input.stateStore.applyOwner(operation.scope, owner.ownerName, transitions, {
       path: owner.path,
       companionName: owner.ownerName,
       maxOpenMustFix: MAX_OPEN_MUST_FIX,
@@ -198,6 +226,7 @@ async function commitOperation(
     });
     publishPendingFindingEvents(input, operation.scope);
   }
+  return findingCount;
 }
 
 function publishPendingFindingEvents(

--- a/src/core/workflow/companion/review-state-store.ts
+++ b/src/core/workflow/companion/review-state-store.ts
@@ -14,6 +14,7 @@ import {
 } from './mailbox.js';
 import { appendCompanionMailboxRecords } from './mailbox-projection.js';
 import type { CompanionLoopDecision } from './terminal-decision.js';
+import type { CompanionReviewRequest } from './review-queue.js';
 
 interface CompanionReviewState {
   mailbox: CompanionMailbox;
@@ -31,6 +32,7 @@ export interface CompanionReviewOwnerOperation {
 export interface CompanionReviewOperation {
   readonly scope: string;
   readonly snapshot: CompanionDiff;
+  readonly trigger: CompanionReviewRequest['reason'];
   readonly observedGeneration: number;
   readonly diffSummary: string;
   readonly implementerExplanation?: string;
@@ -159,7 +161,7 @@ export class CompanionReviewStateStore {
     ownerName: string,
     transitions: CompanionLoopRound['transitions'],
     input: CompanionReviewStateApplyInput,
-  ): void {
+  ): number {
     const operation = this.requireOperation(scope);
     const owner = operation.owners.find((candidate) => candidate.ownerName === ownerName);
     if (
@@ -192,6 +194,7 @@ export class CompanionReviewStateStore {
       ],
       findingEvents: [...operation.findingEvents, ...findingEvents],
     });
+    return findingEvents.length;
   }
 
   takeNextFindingEvent(scope: string): CompanionFindingEvent | undefined {
@@ -335,6 +338,7 @@ function cloneOperationInput(
   return {
     scope: operation.scope,
     snapshot: cloneDiff(operation.snapshot),
+    trigger: operation.trigger,
     observedGeneration: operation.observedGeneration,
     diffSummary: operation.diffSummary,
     ...(operation.implementerExplanation === undefined

--- a/src/core/workflow/companion/step-runtime.ts
+++ b/src/core/workflow/companion/step-runtime.ts
@@ -97,6 +97,11 @@ export class CompanionStepRuntime {
       runReview: async (request) => {
         await this.runReview(request);
       },
+      onCoalesced: (event) => this.events.queueCoalesced({
+        companion: event.companionName,
+        replaced: event.replaced,
+        replacement: event.replacement,
+      }),
     });
   }
 
@@ -186,6 +191,7 @@ export class CompanionStepRuntime {
       this.requireProvider(item.name);
       return { name: item.name, definition };
     });
+    const initialSnapshot = await this.readSnapshot();
     for (const { name, definition } of resolved) {
       this.active.set(name, definition);
       try {
@@ -207,6 +213,7 @@ export class CompanionStepRuntime {
       intervals: [...this.active.values()].map(({ intervalMs }) => intervalMs),
       allowGitCommit: this.deps.step.allowGitCommit === true,
       queue: this.queue,
+      initialSnapshot,
       readSnapshot: () => this.readSnapshot(),
       isAborted: () => this.deps.abortSignal?.aborted === true,
       onError: () => log.warn('Companion live review failed; the change remains unreviewed', {
@@ -218,6 +225,7 @@ export class CompanionStepRuntime {
       detectors: this.detectors,
       queue: this.queue,
       readSnapshot: () => this.readSnapshot(),
+      synchronizeSnapshot: (snapshot) => this.requireScheduler().synchronizeSnapshot(snapshot),
       openMustFix: () => this.openMustFix(),
       recordCompletionRound: async (snapshot) => this.recordStandaloneRound(
         snapshot.digest,
@@ -281,6 +289,7 @@ export class CompanionStepRuntime {
       await executeCompanionReviewRound({
         companionName,
         diff,
+        trigger: request.reason,
         observedGeneration,
         changedRegionsSincePreviousReview: detector.changedRegionsSinceLastReview(diff),
         diffSummary: summarizeDiff(diff),
@@ -321,6 +330,13 @@ export class CompanionStepRuntime {
           )
         ),
         applyRoundDecision: (decision) => this.terminalDecision.update(decision),
+        onRoundCompleted: (round) => this.events.reviewRound({
+          companion: companionName,
+          trigger: round.trigger,
+          digest: round.snapshot.digest,
+          changedLines: round.snapshot.changedLines,
+          findingCount: round.findingCount,
+        }),
       });
     } catch (error) {
       if (!isCompanionCapacityError(error)) throw error;

--- a/src/core/workflow/companion/trigger-scheduler.ts
+++ b/src/core/workflow/companion/trigger-scheduler.ts
@@ -2,6 +2,7 @@ import type { StreamEvent } from '../../../shared/types/provider.js';
 import type { CompanionDiff } from './diff-reader.js';
 import {
   CompanionChangeDetector,
+  COMPANION_CHANGE_DEBOUNCE_MS,
   type CompanionChangeCandidate,
 } from './change-detector.js';
 import { isGitCommitCommand } from './git-command.js';
@@ -9,39 +10,76 @@ import type { CompanionReviewQueue } from './review-queue.js';
 import { isAbortError } from './abort.js';
 
 export class CompanionTriggerScheduler {
-  private timer: ReturnType<typeof setInterval> | undefined;
+  private pollTimer: ReturnType<typeof setInterval> | undefined;
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
   private evaluating = false;
+  private pendingEvaluation = false;
   private completing = false;
+  private knownSnapshot: CompanionDiff;
+  private readonly knownSnapshotGenerations = new Map<string, number>();
+  private evaluationEpoch = 0;
+  private readonly pendingBash = new Map<string, {
+    readonly detectors: ReadonlyMap<string, {
+      readonly dirty: boolean;
+      readonly generation: number;
+      readonly snapshotGeneration: number;
+    }>;
+    readonly evaluationEpoch: number;
+  }>();
+  private readonly pendingBashIds: string[] = [];
 
   constructor(private readonly input: {
     readonly detectors: ReadonlyMap<string, CompanionChangeDetector>;
     readonly intervals: readonly number[];
     readonly allowGitCommit: boolean;
     readonly queue: CompanionReviewQueue;
+    readonly initialSnapshot: CompanionDiff;
     readonly readSnapshot: () => Promise<CompanionDiff>;
     readonly isAborted: () => boolean;
     readonly onError: () => void;
-  }) {}
+  }) {
+    this.knownSnapshot = input.initialSnapshot;
+    for (const [name, detector] of input.detectors) {
+      this.knownSnapshotGenerations.set(name, detector.getObservedGeneration());
+    }
+  }
 
   observe(event: StreamEvent): void {
-    const command = event.type === 'tool_use' && event.data.tool === 'Bash'
+    if (event.type === 'tool_result') {
+      this.observeBashResult(event.data.id);
+      return;
+    }
+    const command = event.type === 'tool_use' && isBashTool(event.data.tool)
       ? event.data.input.command
       : undefined;
+    const gitCommit = typeof command === 'string' && isGitCommitCommand(command);
+    if (
+      event.type === 'tool_use'
+      && isBashTool(event.data.tool)
+      && !(this.input.allowGitCommit && gitCommit)
+    ) {
+      this.observeBashUse(event.data.id);
+    }
     const commit = this.input.allowGitCommit
-      && typeof command === 'string'
-      && isGitCommitCommand(command);
+      && gitCommit;
+    let observedChange = false;
     for (const detector of this.input.detectors.values()) {
-      if (commit) detector.observeCommit();
-      else detector.observe(event);
+      if (commit) {
+        detector.observeCommit();
+        observedChange = true;
+      } else {
+        observedChange = detector.observe(event) || observedChange;
+      }
     }
     if (commit) void this.evaluateNow();
+    else if (observedChange) this.scheduleDebouncedEvaluation();
   }
 
   start(): void {
     this.completing = false;
-    if (this.timer !== undefined || this.input.intervals.length === 0) return;
+    if (this.pollTimer !== undefined || this.input.intervals.length === 0) return;
     const interval = Math.max(250, Math.min(...this.input.intervals));
-    this.timer = setInterval(() => void this.evaluateNow(), interval);
+    this.pollTimer = setInterval(() => void this.evaluateNow(), interval);
   }
 
   beginCompletion(): void {
@@ -49,19 +87,46 @@ export class CompanionTriggerScheduler {
     this.stop();
   }
 
+  synchronizeSnapshot(snapshot: CompanionDiff): void {
+    this.knownSnapshot = snapshot;
+    for (const [name, detector] of this.input.detectors) {
+      this.knownSnapshotGenerations.set(name, detector.getObservedGeneration());
+    }
+  }
+
   stop(): void {
-    if (this.timer === undefined) return;
-    clearInterval(this.timer);
-    this.timer = undefined;
+    if (this.pollTimer !== undefined) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = undefined;
+    }
+    if (this.debounceTimer !== undefined) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+    this.pendingBash.clear();
+    this.pendingBashIds.splice(0);
   }
 
   async evaluateNow(): Promise<void> {
-    if (this.evaluating || this.completing || this.input.isAborted()) return;
+    if (this.evaluating) {
+      this.pendingEvaluation = true;
+      return;
+    }
+    if (this.completing || this.input.isAborted()) return;
     const candidates = this.liveCandidates();
     if (candidates.length === 0) return;
     this.evaluating = true;
+    this.evaluationEpoch += 1;
+    const evaluationGenerations = new Map([...this.input.detectors].map(([name, detector]) => [
+      name,
+      detector.getObservedGeneration(),
+    ]));
     try {
       const snapshot = await this.input.readSnapshot();
+      this.knownSnapshot = snapshot;
+      for (const [name, generation] of evaluationGenerations) {
+        this.knownSnapshotGenerations.set(name, generation);
+      }
       await Promise.all(candidates.map(async ({ name, detector, candidate }) => {
         const trigger = await detector.evaluateCandidate(candidate, snapshot);
         if (trigger === undefined || this.completing) return;
@@ -71,6 +136,10 @@ export class CompanionTriggerScheduler {
       if (!this.input.isAborted() && !isAbortError(error)) this.input.onError();
     } finally {
       this.evaluating = false;
+      if (this.pendingEvaluation) {
+        this.pendingEvaluation = false;
+        this.scheduleDebouncedEvaluation();
+      }
     }
   }
 
@@ -80,8 +149,92 @@ export class CompanionTriggerScheduler {
     readonly candidate: CompanionChangeCandidate;
   }> {
     return [...this.input.detectors].flatMap(([name, detector]) => {
-      const candidate = detector.getTriggerCandidate();
+      const candidate = detector.getTriggerCandidate(COMPANION_CHANGE_DEBOUNCE_MS);
       return candidate === undefined ? [] : [{ name, detector, candidate }];
     });
   }
+
+  private scheduleDebouncedEvaluation(): void {
+    if (this.completing || this.input.isAborted()) return;
+    if (this.debounceTimer !== undefined) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      void this.evaluateNow();
+    }, COMPANION_CHANGE_DEBOUNCE_MS);
+  }
+
+  private observeBashUse(id: string): void {
+    this.pendingBash.set(id, {
+      detectors: new Map([...this.input.detectors].map(([name, detector]) => [
+        name,
+        {
+          dirty: detector.isDirty(),
+          generation: detector.getObservedGeneration(),
+          snapshotGeneration: this.knownSnapshotGenerations.get(name)!,
+        },
+      ])),
+      evaluationEpoch: this.evaluationEpoch,
+    });
+    this.pendingBashIds.push(id);
+  }
+
+  private observeBashResult(id: string | undefined): void {
+    const matchedId = id === undefined
+      ? this.pendingBashIds[0]
+      : this.pendingBash.has(id) ? id : undefined;
+    if (matchedId === undefined) return;
+    const pending = this.pendingBash.get(matchedId);
+    if (pending === undefined) return;
+    this.pendingBash.delete(matchedId);
+    removePendingBashId(this.pendingBashIds, matchedId);
+    void this.probeBashCompletion(pending).catch((error) => {
+      if (!this.input.isAborted() && !isAbortError(error)) this.input.onError();
+    });
+  }
+
+  private async probeBashCompletion(pending: {
+    readonly detectors: ReadonlyMap<string, {
+      readonly dirty: boolean;
+      readonly generation: number;
+      readonly snapshotGeneration: number;
+    }>;
+    readonly evaluationEpoch: number;
+  }): Promise<void> {
+    const snapshotBefore = this.knownSnapshot;
+    const snapshotAfter = await this.input.readSnapshot();
+    this.knownSnapshot = snapshotAfter;
+    const snapshotChanged = snapshotBefore.digest !== snapshotAfter.digest;
+    const evaluationCrossed = this.evaluating || this.evaluationEpoch !== pending.evaluationEpoch;
+    let observedChange = false;
+    for (const [name, detector] of this.input.detectors) {
+      const pendingDetector = pending.detectors.get(name)!;
+      const cacheCoversDirtyGeneration = pendingDetector.snapshotGeneration
+        >= pendingDetector.generation;
+      const explicitChangeAfterBash = detector.getObservedGeneration() > pendingDetector.generation;
+      if (
+        snapshotChanged
+        && (
+          evaluationCrossed
+          || (
+            !explicitChangeAfterBash
+            && !(pendingDetector.dirty && detector.isDirty() && !cacheCoversDirtyGeneration)
+          )
+        )
+      ) {
+        observedChange = detector.observeSnapshotChange(snapshotBefore, snapshotAfter)
+          || observedChange;
+      }
+      this.knownSnapshotGenerations.set(name, detector.getObservedGeneration());
+    }
+    if (observedChange) this.scheduleDebouncedEvaluation();
+  }
+}
+
+function removePendingBashId(ids: string[], id: string): void {
+  const index = ids.indexOf(id);
+  if (index !== -1) ids.splice(index, 1);
+}
+
+function isBashTool(tool: string): boolean {
+  return tool === 'Bash' || tool === 'bash';
 }

--- a/src/core/workflow/companion/trigger-scheduler.ts
+++ b/src/core/workflow/companion/trigger-scheduler.ts
@@ -17,6 +17,7 @@ export class CompanionTriggerScheduler {
   private completing = false;
   private knownSnapshot: CompanionDiff;
   private readonly knownSnapshotGenerations = new Map<string, number>();
+  private snapshotOperation: Promise<void> = Promise.resolve();
   private evaluationEpoch = 0;
   private readonly pendingBash = new Map<string, {
     readonly detectors: ReadonlyMap<string, {
@@ -122,11 +123,16 @@ export class CompanionTriggerScheduler {
       detector.getObservedGeneration(),
     ]));
     try {
-      const snapshot = await this.input.readSnapshot();
-      this.knownSnapshot = snapshot;
-      for (const [name, generation] of evaluationGenerations) {
-        this.knownSnapshotGenerations.set(name, generation);
-      }
+      const snapshot = await this.runSnapshotOperation(async () => {
+        const current = await this.input.readSnapshot();
+        if (this.completing || this.input.isAborted()) return undefined;
+        this.knownSnapshot = current;
+        for (const [name, generation] of evaluationGenerations) {
+          this.knownSnapshotGenerations.set(name, generation);
+        }
+        return current;
+      });
+      if (snapshot === undefined) return;
       await Promise.all(candidates.map(async ({ name, detector, candidate }) => {
         const trigger = await detector.evaluateCandidate(candidate, snapshot);
         if (trigger === undefined || this.completing) return;
@@ -164,15 +170,22 @@ export class CompanionTriggerScheduler {
   }
 
   private observeBashUse(id: string): void {
+    const detectors = new Map<string, {
+      readonly dirty: boolean;
+      readonly generation: number;
+      readonly snapshotGeneration: number;
+    }>();
+    for (const [name, detector] of this.input.detectors) {
+      const snapshotGeneration = this.knownSnapshotGenerations.get(name);
+      if (snapshotGeneration === undefined) continue;
+      detectors.set(name, {
+        dirty: detector.isDirty(),
+        generation: detector.getObservedGeneration(),
+        snapshotGeneration,
+      });
+    }
     this.pendingBash.set(id, {
-      detectors: new Map([...this.input.detectors].map(([name, detector]) => [
-        name,
-        {
-          dirty: detector.isDirty(),
-          generation: detector.getObservedGeneration(),
-          snapshotGeneration: this.knownSnapshotGenerations.get(name)!,
-        },
-      ])),
+      detectors,
       evaluationEpoch: this.evaluationEpoch,
     });
     this.pendingBashIds.push(id);
@@ -187,7 +200,7 @@ export class CompanionTriggerScheduler {
     if (pending === undefined) return;
     this.pendingBash.delete(matchedId);
     removePendingBashId(this.pendingBashIds, matchedId);
-    void this.probeBashCompletion(pending).catch((error) => {
+    void this.runSnapshotOperation(() => this.probeBashCompletion(pending)).catch((error) => {
       if (!this.input.isAborted() && !isAbortError(error)) this.input.onError();
     });
   }
@@ -200,14 +213,17 @@ export class CompanionTriggerScheduler {
     }>;
     readonly evaluationEpoch: number;
   }): Promise<void> {
+    if (this.completing || this.input.isAborted()) return;
     const snapshotBefore = this.knownSnapshot;
     const snapshotAfter = await this.input.readSnapshot();
+    if (this.completing || this.input.isAborted()) return;
     this.knownSnapshot = snapshotAfter;
     const snapshotChanged = snapshotBefore.digest !== snapshotAfter.digest;
     const evaluationCrossed = this.evaluating || this.evaluationEpoch !== pending.evaluationEpoch;
     let observedChange = false;
     for (const [name, detector] of this.input.detectors) {
-      const pendingDetector = pending.detectors.get(name)!;
+      const pendingDetector = pending.detectors.get(name);
+      if (pendingDetector === undefined) continue;
       const cacheCoversDirtyGeneration = pendingDetector.snapshotGeneration
         >= pendingDetector.generation;
       const explicitChangeAfterBash = detector.getObservedGeneration() > pendingDetector.generation;
@@ -227,6 +243,15 @@ export class CompanionTriggerScheduler {
       this.knownSnapshotGenerations.set(name, detector.getObservedGeneration());
     }
     if (observedChange) this.scheduleDebouncedEvaluation();
+  }
+
+  private runSnapshotOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.snapshotOperation.then(operation);
+    this.snapshotOperation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 }
 

--- a/src/core/workflow/engine/WorkflowCallExecutor.ts
+++ b/src/core/workflow/engine/WorkflowCallExecutor.ts
@@ -488,6 +488,8 @@ export class WorkflowCallExecutor {
       'companion:finding',
       'companion:fix_round',
       'companion:complete',
+      'companion:review_round',
+      'companion:queue_coalesced',
       'step:blocked',
       'step:rate_limited',
       'step:user_input',

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -388,6 +388,30 @@ export interface WorkflowEvents {
     openMustFixCount: number;
     escalated: boolean;
   }) => void;
+  'companion:review_round': (payload: {
+    step: string;
+    companion: string;
+    trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+    digest: string;
+    changedLines: number;
+    findingCount: number;
+  }) => void;
+  'companion:queue_coalesced': (payload: {
+    step: string;
+    companion: string;
+    replaced: {
+      trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+      digest: string;
+      changedLines: number;
+      observedGeneration: number;
+    };
+    replacement: {
+      trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+      digest: string;
+      changedLines: number;
+      observedGeneration: number;
+    };
+  }) => void;
   'step:blocked': (step: WorkflowStep, response: AgentResponse) => void;
   'step:rate_limited': (step: WorkflowStep, response: AgentResponse, rateLimitInfo: AgentResponse['rateLimitInfo']) => void;
   'step:user_input': (step: WorkflowStep, userInput: string) => void;

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -317,6 +317,15 @@ export interface WorkflowCallCompleteLifecycle extends WorkflowCallLifecycle {
 }
 
 /** Events emitted by workflow engine */
+export type CompanionReviewTrigger = 'quiet' | 'forced' | 'completion' | 'commit';
+
+export interface CompanionQueueAuditEntry {
+  readonly trigger: CompanionReviewTrigger;
+  readonly digest: string;
+  readonly changedLines: number;
+  readonly observedGeneration: number;
+}
+
 export interface WorkflowEvents {
   'workflow_call:start': (lifecycle: WorkflowCallLifecycle) => void;
   'workflow_call:complete': (lifecycle: WorkflowCallCompleteLifecycle) => void;
@@ -391,7 +400,7 @@ export interface WorkflowEvents {
   'companion:review_round': (payload: {
     step: string;
     companion: string;
-    trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+    trigger: CompanionReviewTrigger;
     digest: string;
     changedLines: number;
     findingCount: number;
@@ -399,18 +408,8 @@ export interface WorkflowEvents {
   'companion:queue_coalesced': (payload: {
     step: string;
     companion: string;
-    replaced: {
-      trigger: 'quiet' | 'forced' | 'completion' | 'commit';
-      digest: string;
-      changedLines: number;
-      observedGeneration: number;
-    };
-    replacement: {
-      trigger: 'quiet' | 'forced' | 'completion' | 'commit';
-      digest: string;
-      changedLines: number;
-      observedGeneration: number;
-    };
+    replaced: CompanionQueueAuditEntry;
+    replacement: CompanionQueueAuditEntry;
   }) => void;
   'step:blocked': (step: WorkflowStep, response: AgentResponse) => void;
   'step:rate_limited': (step: WorkflowStep, response: AgentResponse, rateLimitInfo: AgentResponse['rateLimitInfo']) => void;

--- a/src/features/analytics/events.ts
+++ b/src/features/analytics/events.ts
@@ -101,7 +101,7 @@ export interface RoutingDecisionEvent {
 
 export interface CompanionAnalyticsEvent {
   type: 'companion';
-  action: 'start' | 'pool_selected' | 'finding' | 'fix_round' | 'complete';
+  action: 'start' | 'pool_selected' | 'finding' | 'fix_round' | 'complete' | 'review_round' | 'queue_coalesced';
   step: string;
   companion?: string;
   selected?: string[];
@@ -111,6 +111,22 @@ export interface CompanionAnalyticsEvent {
   sequence?: number;
   openMustFixCount?: number;
   escalated?: boolean;
+  trigger?: 'quiet' | 'forced' | 'completion' | 'commit';
+  digest?: string;
+  changedLines?: number;
+  findingCount?: number;
+  replaced?: {
+    trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+    digest: string;
+    changedLines: number;
+    observedGeneration: number;
+  };
+  replacement?: {
+    trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+    digest: string;
+    changedLines: number;
+    observedGeneration: number;
+  };
   runId: string;
   timestamp: string;
 }

--- a/src/features/tasks/execute/analyticsEmitter.ts
+++ b/src/features/tasks/execute/analyticsEmitter.ts
@@ -267,13 +267,13 @@ export class AnalyticsEmitter {
   }
 
   onCompanionEvent(
-    eventName: 'companion:start' | 'companion:pool_selected' | 'companion:finding' | 'companion:fix_round' | 'companion:complete',
+    eventName: 'companion:start' | 'companion:pool_selected' | 'companion:finding' | 'companion:fix_round' | 'companion:complete' | 'companion:review_round' | 'companion:queue_coalesced',
     payload: Record<string, unknown> & { step: string },
   ): void {
     writeAnalyticsEvent({
       type: 'companion',
       action: eventName.slice('companion:'.length) as
-        'start' | 'pool_selected' | 'finding' | 'fix_round' | 'complete',
+        'start' | 'pool_selected' | 'finding' | 'fix_round' | 'complete' | 'review_round' | 'queue_coalesced',
       ...payload,
       runId: this.runSlug,
       timestamp: new Date().toISOString(),

--- a/src/features/tasks/execute/sessionLogger.ts
+++ b/src/features/tasks/execute/sessionLogger.ts
@@ -35,7 +35,13 @@ import {
   buildWorkflowCallCompleteRecord,
   buildWorkflowCallStartRecord,
   buildWorkflowCompleteRecord,
+  buildCompanionReviewRoundRecord,
+  buildCompanionQueueCoalescedRecord,
 } from './sessionLoggerRecordFactory.js';
+import type {
+  NdjsonCompanionQueueCoalesced,
+  NdjsonCompanionReviewRound,
+} from '../../../shared/utils/types.js';
 import {
   PrivateArtifactPublicationConflictError,
   readPrivateFileState,
@@ -373,6 +379,18 @@ export class SessionLogger {
     }
     this.appendRecord(buildWorkflowAbortRecord(state, reason, this.sanitizeText.bind(this)));
     this.workflowTerminalLogged = true;
+  }
+
+  onCompanionReviewRound(
+    input: Omit<NdjsonCompanionReviewRound, 'type' | 'timestamp'>,
+  ): void {
+    this.appendRecord(buildCompanionReviewRoundRecord(input));
+  }
+
+  onCompanionQueueCoalesced(
+    input: Omit<NdjsonCompanionQueueCoalesced, 'type' | 'timestamp'>,
+  ): void {
+    this.appendRecord(buildCompanionQueueCoalescedRecord(input));
   }
 
   getNdjsonRecords(): NdjsonRecord[] {

--- a/src/features/tasks/execute/sessionLoggerRecordFactory.ts
+++ b/src/features/tasks/execute/sessionLoggerRecordFactory.ts
@@ -10,6 +10,9 @@ import type {
   NdjsonStepStart,
   NdjsonWorkflowAbort,
   NdjsonWorkflowComplete,
+  NdjsonCompanionReviewRound,
+  NdjsonCompanionQueueCoalesced,
+  NdjsonCompanionReviewTrigger,
 } from '../../../infra/fs/index.js';
 import type { PromptLogRecord } from '../../../shared/utils/index.js';
 import type {
@@ -293,5 +296,33 @@ export function buildWorkflowAbortRecord(
     iterations: state.iteration,
     reason: sanitizeText(reason),
     endTime: new Date().toISOString(),
+  };
+}
+
+export function buildCompanionReviewRoundRecord(input: {
+  readonly step: string;
+  readonly companion: string;
+  readonly trigger: NdjsonCompanionReviewTrigger;
+  readonly digest: string;
+  readonly changedLines: number;
+  readonly findingCount: number;
+}): NdjsonCompanionReviewRound {
+  return {
+    type: 'companion_review_round',
+    ...input,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function buildCompanionQueueCoalescedRecord(input: {
+  readonly step: string;
+  readonly companion: string;
+  readonly replaced: NdjsonCompanionQueueCoalesced['replaced'];
+  readonly replacement: NdjsonCompanionQueueCoalesced['replacement'];
+}): NdjsonCompanionQueueCoalesced {
+  return {
+    type: 'companion_queue_coalesced',
+    ...input,
+    timestamp: new Date().toISOString(),
   };
 }

--- a/src/features/tasks/execute/types.ts
+++ b/src/features/tasks/execute/types.ts
@@ -152,6 +152,34 @@ export type WorkflowExecutionEvent =
       step: string;
       openMustFixCount: number;
       escalated: boolean;
+    }
+  | {
+      type: 'companion';
+      action: 'review_round';
+      step: string;
+      companion: string;
+      trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+      digest: string;
+      changedLines: number;
+      findingCount: number;
+    }
+  | {
+      type: 'companion';
+      action: 'queue_coalesced';
+      step: string;
+      companion: string;
+      replaced: {
+        trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+        digest: string;
+        changedLines: number;
+        observedGeneration: number;
+      };
+      replacement: {
+        trigger: 'quiet' | 'forced' | 'completion' | 'commit';
+        digest: string;
+        changedLines: number;
+        observedGeneration: number;
+      };
     };
 
 /** Live-only workflow feedback. Delivery failure never changes run outcome. */

--- a/src/features/tasks/execute/workflowExecutionEvents.ts
+++ b/src/features/tasks/execute/workflowExecutionEvents.ts
@@ -836,6 +836,26 @@ export function bindWorkflowExecutionEvents(
       eventSinkDispatchState,
     );
   });
+  deps.engine.on('companion:review_round', (payload) => {
+    deps.analyticsEmitter.onCompanionEvent('companion:review_round', payload);
+    deps.sessionLogger.onCompanionReviewRound(payload);
+    emitWorkflowExecutionEvent(
+      deps.eventSink,
+      { type: 'companion', action: 'review_round', ...payload },
+      onEventSinkFailure,
+      eventSinkDispatchState,
+    );
+  });
+  deps.engine.on('companion:queue_coalesced', (payload) => {
+    deps.analyticsEmitter.onCompanionEvent('companion:queue_coalesced', payload);
+    deps.sessionLogger.onCompanionQueueCoalesced(payload);
+    emitWorkflowExecutionEvent(
+      deps.eventSink,
+      { type: 'companion', action: 'queue_coalesced', ...payload },
+      onEventSinkFailure,
+      eventSinkDispatchState,
+    );
+  });
 
   deps.engine.on('workflow:complete', (workflowState) => {
     if (terminalIntent === undefined) {

--- a/src/infra/fs/index.ts
+++ b/src/infra/fs/index.ts
@@ -16,6 +16,9 @@ export type {
   NdjsonPhaseJudgeStage,
   NdjsonInteractiveStart,
   NdjsonInteractiveEnd,
+  NdjsonCompanionReviewRound,
+  NdjsonCompanionQueueCoalesced,
+  NdjsonCompanionReviewTrigger,
   NdjsonRecord,
 } from './session.js';
 

--- a/src/infra/fs/session.ts
+++ b/src/infra/fs/session.ts
@@ -34,6 +34,9 @@ export type {
   NdjsonPhaseJudgeStage,
   NdjsonInteractiveStart,
   NdjsonInteractiveEnd,
+  NdjsonCompanionReviewRound,
+  NdjsonCompanionQueueCoalesced,
+  NdjsonCompanionReviewTrigger,
   NdjsonRecord,
 } from '../../shared/utils/index.js';
 
@@ -468,8 +471,53 @@ function assertNdjsonRecordShape(
       }
       requireNdjsonString(record.timestamp, 'timestamp');
       return;
+    case 'companion_review_round':
+      requireCompanionReviewRoundFields(record);
+      return;
+    case 'companion_queue_coalesced':
+      requireCompanionQueueCoalescedFields(record);
+      return;
     default:
       throw new Error(`Unknown NDJSON session record type: ${String(record.type)}`);
+  }
+}
+
+function requireCompanionReviewRoundFields(
+  record: Readonly<Record<string, unknown>>,
+): void {
+  requireNdjsonString(record.step, 'step');
+  requireNdjsonString(record.companion, 'companion');
+  requireCompanionReviewTrigger(record.trigger);
+  requireNdjsonString(record.digest, 'digest');
+  requireNdjsonInteger(record.changedLines, 'changedLines');
+  requireNdjsonInteger(record.findingCount, 'findingCount');
+  requireNdjsonString(record.timestamp, 'timestamp');
+}
+
+function requireCompanionQueueCoalescedFields(
+  record: Readonly<Record<string, unknown>>,
+): void {
+  requireNdjsonString(record.step, 'step');
+  requireNdjsonString(record.companion, 'companion');
+  requireCompanionQueueRequest(record.replaced, 'replaced');
+  requireCompanionQueueRequest(record.replacement, 'replacement');
+  requireNdjsonString(record.timestamp, 'timestamp');
+}
+
+function requireCompanionQueueRequest(value: unknown, field: string): void {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`NDJSON ${field} must be an object`);
+  }
+  const request = value as Record<string, unknown>;
+  requireCompanionReviewTrigger(request.trigger);
+  requireNdjsonString(request.digest, `${field}.digest`);
+  requireNdjsonInteger(request.changedLines, `${field}.changedLines`);
+  requireNdjsonInteger(request.observedGeneration, `${field}.observedGeneration`);
+}
+
+function requireCompanionReviewTrigger(value: unknown): void {
+  if (value !== 'quiet' && value !== 'forced' && value !== 'completion' && value !== 'commit') {
+    throw new Error('NDJSON companion review trigger is invalid');
   }
 }
 

--- a/src/shared/utils/types.ts
+++ b/src/shared/utils/types.ts
@@ -183,6 +183,38 @@ export interface NdjsonInteractiveEnd {
   timestamp: string;
 }
 
+export type NdjsonCompanionReviewTrigger = 'quiet' | 'forced' | 'completion' | 'commit';
+
+export interface NdjsonCompanionReviewRound {
+  type: 'companion_review_round';
+  step: string;
+  companion: string;
+  trigger: NdjsonCompanionReviewTrigger;
+  digest: string;
+  changedLines: number;
+  findingCount: number;
+  timestamp: string;
+}
+
+export interface NdjsonCompanionQueueCoalesced {
+  type: 'companion_queue_coalesced';
+  step: string;
+  companion: string;
+  replaced: {
+    trigger: NdjsonCompanionReviewTrigger;
+    digest: string;
+    changedLines: number;
+    observedGeneration: number;
+  };
+  replacement: {
+    trigger: NdjsonCompanionReviewTrigger;
+    digest: string;
+    changedLines: number;
+    observedGeneration: number;
+  };
+  timestamp: string;
+}
+
 export type NdjsonRecord =
   | NdjsonWorkflowStart
   | NdjsonWorkflowCallStart
@@ -195,7 +227,9 @@ export type NdjsonRecord =
   | NdjsonPhaseComplete
   | NdjsonPhaseJudgeStage
   | NdjsonInteractiveStart
-  | NdjsonInteractiveEnd;
+  | NdjsonInteractiveEnd
+  | NdjsonCompanionReviewRound
+  | NdjsonCompanionQueueCoalesced;
 
 /** Record for debug prompt/response log (debug-*-prompts.jsonl) */
 export interface PromptLogRecord {


### PR DESCRIPTION
## 概要

Companion が実装中の変更を逐次レビューできるよう、変更検出・デバウンス・レビューキューの世代管理を改善します。

## 主な変更

- 明示的な編集操作を短いデバウンスでレビューへ送る
- レビュー実行中に発生した後続変更を保持し、最新世代として再評価する
- Bash コマンド文字列を解析せず、既知スナップショットとの差分から実変更を検出する
- step 完了時のスナップショット同期により、fix ラウンド前の不要な再レビューを防ぐ
- 完了したレビューラウンドとキュー統合を workflow event / session NDJSON に記録する
- nested workflow の companion event を親のイベント経路へ中継する
- 競合・世代境界・永続化経路の回帰テストを追加する

## 検証

- `npm run build`
- `npm run lint`
- `npm test -- src/__tests__/companion-change-detector.test.ts src/__tests__/companion-completion-coordinator.test.ts src/__tests__/companion-runtime-lifecycle.integration.test.ts`
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts`
- Luna 実装レビューを反復し、最終 APPROVE を確認

`npm run check:release` は実プロバイダー E2E を含むため実行していません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - コンパニオンレビューの実行結果やトリガー情報を、イベント・分析データ・セッションログに記録できるようになりました。
  - レビュー待ち項目の統合時に、置換前後の変更情報を追跡できるようになりました。

- **改善**
  - ファイル変更の検出精度を向上し、読み取り専用の Bash 操作では不要なレビューを発生させないようにしました。
  - レビュー中に発生した変更を保持し、完了後に再評価できるようになりました。
  - スナップショット同期とエラー処理を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->