### PR TITLE
fix(finding-contract): active conflictの未決着landingを持つprovisionalの解消を保留する

### DIFF
--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -3,16 +3,21 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { executeAgent } from '../agents/agent-usecases.js';
+import { findingContentAddress } from '../core/models/finding-contract-identity.js';
 import {
   computeFileQuoteEvidenceRecordId,
   createEngineProofRecord,
 } from '../core/models/finding-evidence-record.js';
-import type { WorkflowState } from '../core/models/types.js';
+import type { AgentResponse, WorkflowState, WorkflowStep } from '../core/models/types.js';
 import {
   createFindingConflictAdjudicationRunner,
   serializeFindingConflictAdjudicationRequest,
 } from '../core/workflow/findings/adjudication-runner.js';
 import { buildFindingConflictAdjudicationStep } from '../core/workflow/findings/adjudication-step.js';
+import {
+  runFindingManagerForStep,
+  type FindingManagerSubStepResult,
+} from '../core/workflow/findings/manager-runner.js';
 import {
   buildConflictAdjudicationSnapshotReference,
   renderConflictAdjudicationInstruction,
@@ -38,9 +43,18 @@ import { initializeGitFixture } from './helpers/git-fixture.js';
 import {
   authorizeFindingLedgerFixture,
   canonicalRawFindingFixture,
+  reviewerRawExtractionFixture,
   rawCanonicalSnapshotFixture,
 } from './helpers/finding-lifecycle-fixture.js';
-import { verifiedFindingEvidenceFixture } from './helpers/finding-evidence.js';
+import {
+  findingManagerTaskManifest,
+  findingManagerTaskResponse,
+} from './helpers/finding-manager-task-response.js';
+import { findingReviewPublicationFixture } from './helpers/finding-review-publication.js';
+import {
+  verifiedFindingEvidenceFixture,
+  verifiedSourceQuoteFields,
+} from './helpers/finding-evidence.js';
 import {
   CONFLICT_ADJUDICATION_INPUT_MAX_BYTES,
   MANAGER_INTERPRETATION_LIMITS,
@@ -201,6 +215,90 @@ function seededLedger(
   });
 }
 
+function managerResolutionResponse(
+  instruction: string,
+  targetFindingId: string,
+): AgentResponse {
+  if (instruction.startsWith('Adjudicate the durable provisional finding below.')) {
+    return {
+      persona: 'findings-supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'undetermined',
+          rationale: 'The active conflict fixture supplies no terminal authority.',
+        },
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    };
+  }
+  if (instruction.includes('## Control task output override')) {
+    const manifest = findingManagerTaskManifest(instruction) as {
+      taskId: string;
+      candidateIntents?: Array<{ intentId: string }>;
+    };
+    return {
+      persona: 'findings-manager',
+      status: 'done',
+      content: '',
+      structuredOutput: {
+        taskId: manifest.taskId,
+        evaluations: (manifest.candidateIntents ?? []).map(({ intentId }) => ({
+          intentId,
+          result: {
+            kind: 'no_action',
+            reason: 'The fixture leaves conflict control to the adjudication runner.',
+          },
+        })),
+        selectedIntentId: null,
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    };
+  }
+  if (instruction.includes('entity-binding contract below replaces')) {
+    const manifest = findingManagerTaskManifest(instruction) as {
+      taskId: string;
+      ownedRawFindingIds: string[];
+    };
+    return {
+      persona: 'findings-manager',
+      status: 'done',
+      content: '',
+      structuredOutput: {
+        taskId: manifest.taskId,
+        decisions: manifest.ownedRawFindingIds.map((rawFindingId) => ({
+          rawFindingId,
+          decision: 'bind_existing',
+          findingId: targetFindingId,
+          groupRawFindingId: '',
+          reason: 'The resolution observation targets the existing conflict holding.',
+        })),
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    };
+  }
+
+  const match = /## Owned raw findings\n(`{3,})json\n([\s\S]*?)\n\1/.exec(instruction);
+  if (match?.[2] === undefined) {
+    throw new Error('Test setup error: manager resolution task input is missing');
+  }
+  const rawFindings = JSON.parse(match[2]) as Array<{ rawFindingId: string }>;
+  return findingManagerTaskResponse(instruction, {
+    rawDecisions: rawFindings.map(({ rawFindingId }) => ({
+      decision: 'resolved',
+      rawFindingId,
+      findingId: targetFindingId,
+      evidence: 'The materialized quote satisfies the original failure mode and required fix.',
+    })),
+    disputeDecisions: [],
+    conflictDecisions: [],
+    invalidateDecisions: [],
+    duplicateDecisions: [],
+    dismissDecisions: [],
+  });
+}
+
 describe('finding-conflict-adjudication runner registry contract', () => {
   let cwd: string;
   let ledgerStore: FindingLedgerStore;
@@ -261,6 +359,66 @@ describe('finding-conflict-adjudication runner registry contract', () => {
         guidance,
       }),
     };
+  }
+
+  function managerRound(
+    rawFindings: readonly unknown[],
+    stepIteration: number,
+  ) {
+    const parentStep: WorkflowStep = {
+      kind: 'agent',
+      name: 'reviewers',
+      persona: 'reviewer',
+      edit: false,
+    };
+    const subResults: FindingManagerSubStepResult[] = [{
+      subStep: {
+        kind: 'agent',
+        name: 'arch-review',
+        persona: 'arch',
+        edit: false,
+      },
+      publication: findingReviewPublicationFixture({
+        scopeIdentity: ledgerStore.ledgerIdentity,
+        parentStepName: parentStep.name,
+        stepIteration,
+        reviewerStepName: 'arch-review',
+        rawFindings,
+      }),
+    }];
+    return runFindingManagerForStep({
+      contract: contract(cwd),
+      ledgerStore,
+      optionsBuilder: {
+        buildAgentOptions: () => ({
+          provider: 'claude',
+          cwd,
+          providerOptions: { claude: {} },
+          resolvedProviderOptions: { claude: {} },
+        }),
+        resolveStepProviderModel: () => ({
+          provider: 'claude',
+          model: 'claude-sonnet',
+        }),
+      },
+      stepExecutor: {
+        buildPhase1Instruction: (instruction: string) => instruction,
+        normalizeStructuredOutput: (_step: WorkflowStep, response: AgentResponse) => response,
+        recordSynthesizedAgentUsage: () => {},
+      },
+      cwd,
+      parentStep,
+      stepIteration,
+      subResults,
+      workflowName: 'runner-test',
+      workflowTask: 'Review the implementation.',
+      runId: 'run-1',
+      callNamespace: '',
+      timestamp: stepIteration === 1
+        ? OBSERVATION.timestamp
+        : '2026-06-13T00:01:00.000Z',
+      managerAuthority: 'standard',
+    });
   }
 
   function reopenStore(runId = 'run-1'): FindingLedgerStore {
@@ -352,6 +510,203 @@ describe('finding-conflict-adjudication runner registry contract', () => {
 
     expect(executeAgentMock).not.toHaveBeenCalled();
     expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(2);
+  });
+
+  it('holds a clean resolution observation until conflict adjudication, then resolves it in the next manager round', async () => {
+    const initialLedger = ledgerStore.loadLedger();
+    const conflict = initialLedger.conflicts[0];
+    const landing = initialLedger.conflictRawClaimLandings[0];
+    const holding = initialLedger.findings.find((finding) => (
+      landing !== undefined
+      && finding.id === landing.holdingFindingId
+      && finding.provisional !== undefined
+    ));
+    if (conflict === undefined || landing === undefined || holding === undefined) {
+      throw new Error('Expected an active conflict with a provisional holding in the fixture');
+    }
+
+    const resolutionRaw = (rawFindingId: string) => reviewerRawExtractionFixture({
+      rawFindingId,
+      familyTag: 'bug',
+      severity: 'high',
+      title: 'Disputed issue',
+      description: 'The materialized code no longer exhibits the reported failure mode.',
+      suggestion: null,
+      relation: 'resolution_confirmation',
+      targetFindingId: holding.id,
+      target: { kind: 'code', paths: ['src/a.ts'] },
+      evidence: [verifiedSourceQuoteFields(cwd, 'src/a.ts', 1)],
+    });
+
+    const beforeAdjudicationRawId = 'resolution-before-adjudication';
+    executeAgentMock.mockImplementation(async (_persona, instruction) => (
+      managerResolutionResponse(String(instruction), holding.id)
+    ));
+    await managerRound([resolutionRaw(beforeAdjudicationRawId)], 1);
+
+    const deferredLedger = ledgerStore.loadLedger();
+    const deferredRaw = deferredLedger.rawFindings.find((rawFinding) => (
+      rawFinding.rawFindingId.endsWith(beforeAdjudicationRawId)
+    ));
+    const deferredHolding = deferredLedger.findings.find((finding) => finding.id === holding.id);
+    if (deferredRaw === undefined || deferredHolding === undefined) {
+      throw new Error('Expected the clean resolution observation to be admitted');
+    }
+    expect(deferredLedger.conflicts).toEqual([
+      expect.objectContaining({ id: conflict.id, status: 'active' }),
+    ]);
+    expect(deferredHolding).toMatchObject({
+      id: holding.id,
+      status: 'open',
+      provisional: expect.any(Object),
+    });
+    expect(deferredHolding.rawFindingIds).toContain(deferredRaw.rawFindingId);
+
+    const adjudicationSnapshot = freshConflictAdjudicationSnapshot(
+      deferredLedger,
+      conflict.id,
+    );
+    const holdingSubject = adjudicationSnapshot.subjects.find((subject) => (
+      subject.findingId === holding.id && subject.role === 'holding_provisional'
+    ));
+    const product = deferredLedger.findings.find((finding) => (
+      conflict.findingIds.includes(finding.id)
+      && finding.provisional === undefined
+    ));
+    const conflictRaw = deferredLedger.rawFindings.find((rawFinding) => (
+      rawFinding.rawFindingId === conflict.rawFindingIds[0]
+    ));
+    if (
+      holdingSubject === undefined
+      || product === undefined
+      || conflictRaw?.familyTag === null
+      || conflictRaw === undefined
+      || product.target === null
+      || product.targetIdentityHash === null
+      || product.claimIdentityHash === null
+      || product.semanticClaimIdentityHash === null
+      || product.severity === null
+      || product.title === null
+      || product.description === undefined
+    ) {
+      throw new Error('Expected complete product and holding projections for adjudication');
+    }
+    const proposedProduct = {
+      target: product.target,
+      targetIdentityHash: product.targetIdentityHash,
+      familyTag: conflictRaw.familyTag,
+      severity: product.severity,
+      title: product.title,
+      description: product.description,
+      suggestion: product.suggestion ?? null,
+      claimIdentityHash: product.claimIdentityHash,
+      semanticClaimIdentityHash: product.semanticClaimIdentityHash,
+      evidenceRecordIds: [...product.evidenceIds],
+    };
+    const proof = createEngineProofRecord({
+      kind: 'engine_proof',
+      purpose: 'lifecycle_authority',
+      verifierId: 'takt.finding-lifecycle-policy',
+      verifierVersion: '1',
+      workflowName: deferredLedger.workflowName,
+      runId: 'run-1',
+      scopeIdentity: SCOPE_IDENTITY,
+      snapshotId: adjudicationSnapshot.conflictSnapshotId,
+      claimIdentityHash: null,
+      targetFindingId: holdingSubject.findingId,
+      subject: {
+        kind: 'finding_claim_supported_after_verification',
+        adjudicationKind: 'conflict',
+        subjectId: holdingSubject.subjectId,
+        findingId: holdingSubject.findingId,
+        expectedHead: holdingSubject.expectedHead,
+        rawClaimRefIds: holdingSubject.rawClaimLandingIds,
+        productProjectionDigest: findingContentAddress(
+          'product-finding-projection',
+          proposedProduct,
+        ),
+      },
+      dependencyDigests: [adjudicationSnapshot.conflictSnapshotId],
+      resultDigest: '3'.repeat(64),
+      issuedAt: OBSERVATION.timestamp,
+    });
+    await ledgerStore.updateLedger((current) => ({
+      ledger: {
+        ...current,
+        evidenceRecords: [...current.evidenceRecords, proof],
+      },
+      result: undefined,
+    }));
+
+    executeAgentMock.mockReset();
+    executeAgentMock
+      .mockResolvedValueOnce({
+        persona: 'supervisor',
+        status: 'done',
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'undetermined',
+            subjectIds: adjudicationSnapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+            rationale: 'No verified terminal authority is available.',
+          },
+        },
+        timestamp: new Date(OBSERVATION.timestamp),
+      })
+      .mockResolvedValueOnce({
+        persona: 'supervisor',
+        status: 'done',
+        content: '{}',
+        structuredOutput: {
+          proposal: {
+            kind: 'promote_holding',
+            holdingSubjectId: holdingSubject.subjectId,
+            proposedProduct,
+            authorityRefIds: [proof.evidenceId],
+            rationale: 'The held claim is independently verified.',
+          },
+        },
+        timestamp: new Date(OBSERVATION.timestamp),
+      });
+    const adjudication = runner();
+    await adjudication.runner.run(adjudication.step, state());
+
+    const promotedLedger = ledgerStore.loadLedger();
+    const promotedHolding = promotedLedger.findings.find((finding) => finding.id === holding.id);
+    expect(promotedLedger.conflicts).toEqual([
+      expect.objectContaining({ id: conflict.id, status: 'resolved' }),
+    ]);
+    expect(promotedHolding).toMatchObject({
+      id: holding.id,
+      status: 'open',
+      lifecycle: 'persists',
+    });
+    expect(promotedHolding).not.toHaveProperty('provisional');
+
+    const afterAdjudicationRawId = 'resolution-after-adjudication';
+    executeAgentMock.mockReset();
+    executeAgentMock.mockImplementation(async (_persona, instruction) => (
+      managerResolutionResponse(String(instruction), holding.id)
+    ));
+    await managerRound([resolutionRaw(afterAdjudicationRawId)], 2);
+
+    const resolvedLedger = ledgerStore.loadLedger();
+    const afterAdjudicationRaw = resolvedLedger.rawFindings.find((rawFinding) => (
+      rawFinding.rawFindingId.endsWith(afterAdjudicationRawId)
+    ));
+    const resolvedHolding = resolvedLedger.findings.find((finding) => finding.id === holding.id);
+    if (afterAdjudicationRaw === undefined || resolvedHolding === undefined) {
+      throw new Error('Expected the post-adjudication resolution observation to be admitted');
+    }
+    expect(resolvedHolding).toMatchObject({
+      id: holding.id,
+      status: 'resolved',
+      lifecycle: 'resolved',
+    });
+    expect(resolvedHolding.rawFindingIds).toEqual(expect.arrayContaining([
+      deferredRaw.rawFindingId,
+      afterAdjudicationRaw.rawFindingId,
+    ]));
   });
 
   it('re-adjudicates when a fix changes the conflict target code with the same ledger projection', async () => {

--- a/src/__tests__/finding-identity-case-sensitivity.test.ts
+++ b/src/__tests__/finding-identity-case-sensitivity.test.ts
@@ -1,22 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { createEmptyFindingContractRegistries } from '../core/models/finding-contract-seed.js';
-import { computeConflictRawClaimLandingId } from '../core/models/finding-contract-identity.js';
-import { buildConflictAdjudicationSnapshot } from '../core/workflow/findings/conflict-adjudication-model.js';
-import {
-  applyProvisionalSettlement,
-  settleProvisionalsWithCleanEvidence,
-} from '../core/workflow/findings/manager-provisional-settlement.js';
+import { settleProvisionalsWithCleanEvidence } from '../core/workflow/findings/manager-provisional-settlement.js';
 import type {
   FindingLedger,
   FindingLedgerEntry,
   FindingManagerOutput,
-  FindingLifecycleEvent,
   RawFinding,
 } from '../core/workflow/findings/types.js';
-import {
-  canonicalRawFindingFixture,
-  rawCanonicalSnapshotFixture,
-} from './helpers/finding-lifecycle-fixture.js';
+import { canonicalRawFindingFixture } from './helpers/finding-lifecycle-fixture.js';
 
 const observation = { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-07-18T00:00:00.000Z' };
 
@@ -102,103 +93,6 @@ function emptyOutput(): FindingManagerOutput {
   };
 }
 
-function lifecycleEvent(
-  operation: FindingLifecycleEvent['operation'],
-  head: {
-    entityKind: 'finding' | 'conflict';
-    entityId: string;
-    revision: number;
-    eventId: string;
-    projectionDigest: string;
-  },
-): FindingLifecycleEvent {
-  return {
-    eventId: head.eventId,
-    mutationId: `mutation-${head.eventId}`,
-    reservationId: `reservation-${head.eventId}`,
-    operation,
-    transitions: [{ before: null, after: head }],
-    evidenceBindingIds: [],
-    outcome: { kind: 'projection_applied' },
-    resultDigest: `result-${head.eventId}`,
-    occurredAt: observation,
-  };
-}
-
-function conflictHoldingLedger(status: 'active' | 'resolved'): {
-  ledger: FindingLedger;
-  resolutionRaw: RawFinding;
-} {
-  const holding = finding('F-0001', 'Conflict holding', true);
-  const conflictRaw = raw('raw-conflict', 'Conflicting claim');
-  const resolutionRaw = {
-    ...raw('raw-resolution', 'Resolution confirmation'),
-    relation: 'resolution_confirmation' as const,
-    targetFindingId: holding.id,
-  };
-  const rawSnapshot = rawCanonicalSnapshotFixture(conflictRaw, observation);
-  const conflictId = 'C-0001';
-  const holdingHead = {
-    entityKind: 'finding' as const,
-    entityId: holding.id,
-    revision: holding.revision,
-    eventId: 'event-F-0001-1',
-    projectionDigest: 'projection-F-0001-1',
-  };
-  const conflictHead = {
-    entityKind: 'conflict' as const,
-    entityId: conflictId,
-    revision: 1,
-    eventId: 'event-C-0001-1',
-    projectionDigest: 'projection-C-0001-1',
-  };
-  const landingIdentity = {
-    conflictId,
-    rawFindingId: conflictRaw.rawFindingId,
-    rawCanonicalSnapshotId: rawSnapshot.rawCanonicalSnapshotId,
-    rawPayloadDigest: rawSnapshot.rawPayloadDigest,
-    claimSnapshotDigest: 'claim-snapshot-conflict',
-  };
-  const landing = {
-    rawClaimLandingId: computeConflictRawClaimLandingId(landingIdentity),
-    ...landingIdentity,
-    holdingAllocationId: 'allocation-F-0001',
-    holdingFindingId: holding.id,
-    holdingHeadAfterLanding: holdingHead,
-    landingEventId: holdingHead.eventId,
-    landedAt: observation,
-  };
-  return {
-    ledger: {
-      ...ledger([holding], [conflictRaw]),
-      updatedAt: observation.timestamp,
-      rawCanonicalSnapshots: [rawSnapshot],
-      conflicts: [{
-        id: conflictId,
-        status,
-        findingIds: [],
-        rawFindingIds: [conflictRaw.rawFindingId],
-        description: 'Conflicting claim requires adjudication.',
-        firstSeen: observation,
-        lastSeen: observation,
-        revision: 1,
-        ...(status === 'resolved'
-          ? {
-              resolvedAt: observation.timestamp,
-              resolvedEvidence: 'Conflict adjudication completed.',
-            }
-          : {}),
-      }],
-      conflictRawClaimLandings: [landing],
-      lifecycleEvents: [
-        lifecycleEvent('create_finding', holdingHead),
-        lifecycleEvent('create_conflict', conflictHead),
-      ],
-    },
-    resolutionRaw,
-  };
-}
-
 describe('finding identity case sensitivity', () => {
   it('should not promote a provisional from a clean new finding that differs only by case', () => {
     const wire = raw('raw-new', 'Parser Path');
@@ -237,75 +131,4 @@ describe('finding identity case sensitivity', () => {
 
     expect(result.resolvedByMapping.size).toBe(0);
   });
-
-  it('should keep an unsettled active conflict holding provisional until adjudication finishes', () => {
-    const fixture = conflictHoldingLedger('active');
-    const output = {
-      ...emptyOutput(),
-      resolvedFindings: [{
-        findingId: 'F-0001',
-        rawFindingIds: [fixture.resolutionRaw.rawFindingId],
-        evidence: 'The finding is no longer present.',
-      }],
-    };
-    const settlement = settleProvisionalsWithCleanEvidence({
-      output,
-      cleanRawIds: new Set([fixture.resolutionRaw.rawFindingId]),
-      wireById: new Map([[fixture.resolutionRaw.rawFindingId, fixture.resolutionRaw]]),
-      freshLedger: {
-        ...fixture.ledger,
-        rawFindings: [...fixture.ledger.rawFindings, fixture.resolutionRaw],
-      },
-      explicitResolvedByMapping: new Map(),
-      explicitPromotedFindingIds: new Set(),
-      healthyReviewerStableKeys: new Set(),
-    });
-    const settled = applyProvisionalSettlement(
-      fixture.ledger,
-      settlement,
-      observation.timestamp,
-    );
-
-    expect(settlement.resolvedByEvidence.size).toBe(0);
-    expect(settled.findings[0]).toMatchObject({
-      id: 'F-0001',
-      status: 'open',
-      provisional: expect.any(Object),
-    });
-    expect(() => buildConflictAdjudicationSnapshot({
-      ledger: settled,
-      conflictId: 'C-0001',
-      originStep: 'reviewer',
-      createdAt: observation,
-    })).not.toThrow();
-  });
-
-  it('should settle the same provisional after the conflict is adjudicated', () => {
-    const fixture = conflictHoldingLedger('resolved');
-    const resolutionRaw = fixture.resolutionRaw;
-    const settlement = settleProvisionalsWithCleanEvidence({
-      output: {
-        ...emptyOutput(),
-        resolvedFindings: [{
-          findingId: 'F-0001',
-          rawFindingIds: [resolutionRaw.rawFindingId],
-          evidence: 'The finding is no longer present.',
-        }],
-      },
-      cleanRawIds: new Set([resolutionRaw.rawFindingId]),
-      wireById: new Map([[resolutionRaw.rawFindingId, resolutionRaw]]),
-      freshLedger: {
-        ...fixture.ledger,
-        rawFindings: [...fixture.ledger.rawFindings, resolutionRaw],
-      },
-      explicitResolvedByMapping: new Map(),
-      explicitPromotedFindingIds: new Set(),
-      healthyReviewerStableKeys: new Set(),
-    });
-
-    expect(settlement.resolvedByEvidence).toEqual(new Map([
-      ['F-0001', 'The finding is no longer present.'],
-    ]));
-  });
-
 });

--- a/src/__tests__/finding-identity-case-sensitivity.test.ts
+++ b/src/__tests__/finding-identity-case-sensitivity.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from 'vitest';
-import { settleProvisionalsWithCleanEvidence } from '../core/workflow/findings/manager-provisional-settlement.js';
+import { createEmptyFindingContractRegistries } from '../core/models/finding-contract-seed.js';
+import { computeConflictRawClaimLandingId } from '../core/models/finding-contract-identity.js';
+import { buildConflictAdjudicationSnapshot } from '../core/workflow/findings/conflict-adjudication-model.js';
+import {
+  applyProvisionalSettlement,
+  settleProvisionalsWithCleanEvidence,
+} from '../core/workflow/findings/manager-provisional-settlement.js';
 import type {
   FindingLedger,
   FindingLedgerEntry,
   FindingManagerOutput,
+  FindingLifecycleEvent,
   RawFinding,
 } from '../core/workflow/findings/types.js';
-import { canonicalRawFindingFixture } from './helpers/finding-lifecycle-fixture.js';
+import {
+  canonicalRawFindingFixture,
+  rawCanonicalSnapshotFixture,
+} from './helpers/finding-lifecycle-fixture.js';
 
 const observation = { runId: 'run-1', stepName: 'reviewers', timestamp: '2026-07-18T00:00:00.000Z' };
 
@@ -52,8 +62,10 @@ function ledger(findings: FindingLedgerEntry[], rawFindings: RawFinding[] = []):
     updatedAt: observation.timestamp,
     findings,
     evidenceRecords: [],
+    evidenceBindings: [],
     rawFindings,
     conflicts: [],
+    ...createEmptyFindingContractRegistries(),
   };
 }
 
@@ -87,6 +99,103 @@ function emptyOutput(): FindingManagerOutput {
     invalidatedFindings: [],
     duplicateFindings: [],
     dismissedFindings: [],
+  };
+}
+
+function lifecycleEvent(
+  operation: FindingLifecycleEvent['operation'],
+  head: {
+    entityKind: 'finding' | 'conflict';
+    entityId: string;
+    revision: number;
+    eventId: string;
+    projectionDigest: string;
+  },
+): FindingLifecycleEvent {
+  return {
+    eventId: head.eventId,
+    mutationId: `mutation-${head.eventId}`,
+    reservationId: `reservation-${head.eventId}`,
+    operation,
+    transitions: [{ before: null, after: head }],
+    evidenceBindingIds: [],
+    outcome: { kind: 'projection_applied' },
+    resultDigest: `result-${head.eventId}`,
+    occurredAt: observation,
+  };
+}
+
+function conflictHoldingLedger(status: 'active' | 'resolved'): {
+  ledger: FindingLedger;
+  resolutionRaw: RawFinding;
+} {
+  const holding = finding('F-0001', 'Conflict holding', true);
+  const conflictRaw = raw('raw-conflict', 'Conflicting claim');
+  const resolutionRaw = {
+    ...raw('raw-resolution', 'Resolution confirmation'),
+    relation: 'resolution_confirmation' as const,
+    targetFindingId: holding.id,
+  };
+  const rawSnapshot = rawCanonicalSnapshotFixture(conflictRaw, observation);
+  const conflictId = 'C-0001';
+  const holdingHead = {
+    entityKind: 'finding' as const,
+    entityId: holding.id,
+    revision: holding.revision,
+    eventId: 'event-F-0001-1',
+    projectionDigest: 'projection-F-0001-1',
+  };
+  const conflictHead = {
+    entityKind: 'conflict' as const,
+    entityId: conflictId,
+    revision: 1,
+    eventId: 'event-C-0001-1',
+    projectionDigest: 'projection-C-0001-1',
+  };
+  const landingIdentity = {
+    conflictId,
+    rawFindingId: conflictRaw.rawFindingId,
+    rawCanonicalSnapshotId: rawSnapshot.rawCanonicalSnapshotId,
+    rawPayloadDigest: rawSnapshot.rawPayloadDigest,
+    claimSnapshotDigest: 'claim-snapshot-conflict',
+  };
+  const landing = {
+    rawClaimLandingId: computeConflictRawClaimLandingId(landingIdentity),
+    ...landingIdentity,
+    holdingAllocationId: 'allocation-F-0001',
+    holdingFindingId: holding.id,
+    holdingHeadAfterLanding: holdingHead,
+    landingEventId: holdingHead.eventId,
+    landedAt: observation,
+  };
+  return {
+    ledger: {
+      ...ledger([holding], [conflictRaw]),
+      updatedAt: observation.timestamp,
+      rawCanonicalSnapshots: [rawSnapshot],
+      conflicts: [{
+        id: conflictId,
+        status,
+        findingIds: [],
+        rawFindingIds: [conflictRaw.rawFindingId],
+        description: 'Conflicting claim requires adjudication.',
+        firstSeen: observation,
+        lastSeen: observation,
+        revision: 1,
+        ...(status === 'resolved'
+          ? {
+              resolvedAt: observation.timestamp,
+              resolvedEvidence: 'Conflict adjudication completed.',
+            }
+          : {}),
+      }],
+      conflictRawClaimLandings: [landing],
+      lifecycleEvents: [
+        lifecycleEvent('create_finding', holdingHead),
+        lifecycleEvent('create_conflict', conflictHead),
+      ],
+    },
+    resolutionRaw,
   };
 }
 
@@ -127,6 +236,76 @@ describe('finding identity case sensitivity', () => {
     });
 
     expect(result.resolvedByMapping.size).toBe(0);
+  });
+
+  it('should keep an unsettled active conflict holding provisional until adjudication finishes', () => {
+    const fixture = conflictHoldingLedger('active');
+    const output = {
+      ...emptyOutput(),
+      resolvedFindings: [{
+        findingId: 'F-0001',
+        rawFindingIds: [fixture.resolutionRaw.rawFindingId],
+        evidence: 'The finding is no longer present.',
+      }],
+    };
+    const settlement = settleProvisionalsWithCleanEvidence({
+      output,
+      cleanRawIds: new Set([fixture.resolutionRaw.rawFindingId]),
+      wireById: new Map([[fixture.resolutionRaw.rawFindingId, fixture.resolutionRaw]]),
+      freshLedger: {
+        ...fixture.ledger,
+        rawFindings: [...fixture.ledger.rawFindings, fixture.resolutionRaw],
+      },
+      explicitResolvedByMapping: new Map(),
+      explicitPromotedFindingIds: new Set(),
+      healthyReviewerStableKeys: new Set(),
+    });
+    const settled = applyProvisionalSettlement(
+      fixture.ledger,
+      settlement,
+      observation.timestamp,
+    );
+
+    expect(settlement.resolvedByEvidence.size).toBe(0);
+    expect(settled.findings[0]).toMatchObject({
+      id: 'F-0001',
+      status: 'open',
+      provisional: expect.any(Object),
+    });
+    expect(() => buildConflictAdjudicationSnapshot({
+      ledger: settled,
+      conflictId: 'C-0001',
+      originStep: 'reviewer',
+      createdAt: observation,
+    })).not.toThrow();
+  });
+
+  it('should settle the same provisional after the conflict is adjudicated', () => {
+    const fixture = conflictHoldingLedger('resolved');
+    const resolutionRaw = fixture.resolutionRaw;
+    const settlement = settleProvisionalsWithCleanEvidence({
+      output: {
+        ...emptyOutput(),
+        resolvedFindings: [{
+          findingId: 'F-0001',
+          rawFindingIds: [resolutionRaw.rawFindingId],
+          evidence: 'The finding is no longer present.',
+        }],
+      },
+      cleanRawIds: new Set([resolutionRaw.rawFindingId]),
+      wireById: new Map([[resolutionRaw.rawFindingId, resolutionRaw]]),
+      freshLedger: {
+        ...fixture.ledger,
+        rawFindings: [...fixture.ledger.rawFindings, resolutionRaw],
+      },
+      explicitResolvedByMapping: new Map(),
+      explicitPromotedFindingIds: new Set(),
+      healthyReviewerStableKeys: new Set(),
+    });
+
+    expect(settlement.resolvedByEvidence).toEqual(new Map([
+      ['F-0001', 'The finding is no longer present.'],
+    ]));
   });
 
 });

--- a/src/__tests__/finding-provisional-target-landing.test.ts
+++ b/src/__tests__/finding-provisional-target-landing.test.ts
@@ -13,6 +13,7 @@ import {
   findIndependentProvisionalDestination,
   independentProvisionalIdentity,
 } from '../core/workflow/findings/independent-provisional-identity.js';
+import { collectUnsettledActiveConflictHoldingFindingIds } from '../core/workflow/findings/conflict-ownership.js';
 import { applyFindingLifecycleCommands } from '../core/workflow/findings/lifecycle-transaction.js';
 import { captureFindingLifecycleHead } from '../core/workflow/findings/lifecycle-mutation.js';
 import { landUnownedConflictRawClaims } from '../core/workflow/findings/conflict-claim-landing.js';
@@ -212,6 +213,7 @@ describe('provisional target landing', () => {
     expect(() => findIndependentProvisionalDestination({
       ledger: { ...ledger, findings: [...ledger.findings, duplicate] },
       stableKey: ledger.findings[0]!.provisional!.stableKey,
+      unsettledConflictHoldingFindingIds: collectUnsettledActiveConflictHoldingFindingIds(ledger),
     })).toThrow(/multiple open owners/);
   });
 

--- a/src/core/workflow/findings/conflict-ownership.ts
+++ b/src/core/workflow/findings/conflict-ownership.ts
@@ -48,27 +48,30 @@ export function validConflictLandingSettlements(
   ));
 }
 
-export function hasUnsettledActiveConflictOwnership(
+export function collectUnsettledActiveConflictHoldingFindingIds(
   ledger: FindingLedger,
-  findingId: string,
-): boolean {
-  const owners = new Set(ledger.conflictRawClaimLandings.flatMap((landing) => {
-    if (landing.holdingFindingId !== findingId) {
-      return [];
-    }
+): Set<string> {
+  const ownersByFindingId = new Map<string, Set<string>>();
+  for (const landing of ledger.conflictRawClaimLandings) {
     const conflict = ledger.conflicts.find((candidate) => candidate.id === landing.conflictId);
     if (
       conflict?.status !== 'active'
       || validConflictLandingSettlements(ledger, landing.rawClaimLandingId).length === 1
     ) {
-      return [];
+      continue;
     }
-    return [landing.conflictId];
-  }));
-  if (owners.size > 1) {
-    throw new Error(
-      `Conflict holding "${findingId}" has multiple unsettled active owners`,
-    );
+    const owners = ownersByFindingId.get(landing.holdingFindingId) ?? new Set<string>();
+    owners.add(landing.conflictId);
+    ownersByFindingId.set(landing.holdingFindingId, owners);
   }
-  return owners.size === 1;
+  const findingIds = new Set<string>();
+  for (const [findingId, owners] of ownersByFindingId) {
+    if (owners.size > 1) {
+      throw new Error(
+        `Conflict holding "${findingId}" has multiple unsettled active owners`,
+      );
+    }
+    findingIds.add(findingId);
+  }
+  return findingIds;
 }

--- a/src/core/workflow/findings/independent-provisional-identity.ts
+++ b/src/core/workflow/findings/independent-provisional-identity.ts
@@ -13,7 +13,6 @@ import type {
 } from './types.js';
 import type { ProvisionalFindingSpec } from './reconciler.js';
 import { captureFindingLifecycleHead } from './lifecycle-mutation.js';
-import { hasUnsettledActiveConflictOwnership } from './conflict-ownership.js';
 
 export interface IndependentProvisionalIdentity {
   independentClaimKey: string;
@@ -72,12 +71,13 @@ export function independentProvisionalIdentity(
 export function findIndependentProvisionalDestination(input: {
   ledger: FindingLedger;
   stableKey: string;
+  unsettledConflictHoldingFindingIds: ReadonlySet<string>;
 }): { finding: ProvisionalFindingEntry; expectedHead: FindingLifecycleEntityHead } | null {
   const matches = input.ledger.findings.filter((finding): finding is ProvisionalFindingEntry => (
     finding.status === 'open'
     && finding.provisional?.kind === 'raw-adjudication-unresolved'
     && finding.provisional.stableKey === input.stableKey
-    && !hasUnsettledActiveConflictOwnership(input.ledger, finding.id)
+    && !input.unsettledConflictHoldingFindingIds.has(finding.id)
   )).sort((left, right) => compareBinaryStrings(left.id, right.id));
   if (matches.length > 1) {
     throw new Error(

--- a/src/core/workflow/findings/interpretation-origin-attachment.ts
+++ b/src/core/workflow/findings/interpretation-origin-attachment.ts
@@ -6,7 +6,7 @@ import type {
 } from './types.js';
 import type { CanonicalIntakeItem } from './manager-admission.js';
 import { captureFindingLifecycleHead } from './lifecycle-mutation.js';
-import { hasUnsettledActiveConflictOwnership } from './conflict-ownership.js';
+import { collectUnsettledActiveConflictHoldingFindingIds } from './conflict-ownership.js';
 
 const FRESH_SETTLEMENT_KINDS = new Set<FindingProvisionalKind>([
   'raw-meaning-ambiguous',
@@ -100,10 +100,11 @@ export function planInterpretationOriginAttachments(input: {
     throw new Error('Interpretation origin attachment round must be a positive safe integer');
   }
   const activeOrigins = activeBoundOriginIds(input.ledger);
+  const unsettledConflictHoldingFindingIds = collectUnsettledActiveConflictHoldingFindingIds(input.ledger);
   const candidates = input.ledger.findings.flatMap((finding) => {
     if (
       activeOrigins.has(finding.id)
-      || hasUnsettledActiveConflictOwnership(input.ledger, finding.id)
+      || unsettledConflictHoldingFindingIds.has(finding.id)
     ) {
       return [];
     }

--- a/src/core/workflow/findings/manager-commit-finalization.ts
+++ b/src/core/workflow/findings/manager-commit-finalization.ts
@@ -443,7 +443,10 @@ export function reconcileCommitPlan(input: {
     managerOutput: settledOutput,
     landedSpecs,
     entityMutationResults,
-    normalizationRejections,
+    normalizationRejections: [
+      ...normalizationRejections,
+      ...reconciledPlan.deferredResolutionRejections,
+    ],
     rejectedObservationAttachments,
     settlementCommands,
   };

--- a/src/core/workflow/findings/manager-commit-plan.ts
+++ b/src/core/workflow/findings/manager-commit-plan.ts
@@ -63,6 +63,7 @@ import { applyFindingLifecycleCommands } from './lifecycle-transaction.js';
 import { landUnownedConflictRawClaims } from './conflict-claim-landing.js';
 import { computeConflictReactivationDigest } from '../../models/finding-contract-identity.js';
 import { collectRestatementRequestBindings } from './review-publication.js';
+import { collectUnsettledActiveConflictHoldingFindingIds } from './conflict-ownership.js';
 
 export function attachCapturedConflictHeads(input: {
   commands: readonly FindingLifecycleCommand[];
@@ -242,6 +243,7 @@ function prepareProvisionalTargetLandings(input: {
   const itemsByRawFindingId = new Map(
     input.intake.items.map((item) => [item.wire.rawFindingId, item]),
   );
+  const unsettledConflictHoldingFindingIds = collectUnsettledActiveConflictHoldingFindingIds(input.ledger);
   return input.candidates.flatMap((candidate): PreparedProvisionalTargetLanding[] => {
     if (!input.retainedRawFindingIds.has(candidate.rawFindingId)) {
       return [];
@@ -290,6 +292,7 @@ function prepareProvisionalTargetLandings(input: {
     const existing = findIndependentProvisionalDestination({
       ledger: input.ledger,
       stableKey: identity.independentStableKey,
+      unsettledConflictHoldingFindingIds,
     });
     return [{
       candidate,
@@ -1228,6 +1231,9 @@ export function buildFindingManagerCommitMutation(
     healthyReviewerStableKeys: params.intake.healthyReviewerStableKeys,
     verifiedEvidenceRecordsByRawFindingId: admission.verifiedEvidenceRecordsByRawFindingId,
   };
+  const unsettledConflictHoldingFindingIds = collectUnsettledActiveConflictHoldingFindingIds(
+    recoveryLedger,
+  );
   const interpretationProvisionalTargetLandings = interpretationPrepared.cases.flatMap(
     (preparedCase): PreparedProvisionalTargetLanding[] => {
       if (preparedCase.action.kind !== 'land_provisional_target') {
@@ -1250,6 +1256,7 @@ export function buildFindingManagerCommitMutation(
           : findIndependentProvisionalDestination({
               ledger: recoveryLedger,
               stableKey: spec.stableKey,
+              unsettledConflictHoldingFindingIds,
             })?.finding.id ?? null;
         return {
           candidate: {

--- a/src/core/workflow/findings/manager-provisional-settlement.ts
+++ b/src/core/workflow/findings/manager-provisional-settlement.ts
@@ -28,7 +28,7 @@ import {
   isProvisionalFindingEntry,
   materializeProvisionalFinding,
 } from './finding-entry.js';
-import { hasUnsettledActiveConflictOwnership } from './conflict-ownership.js';
+import { collectUnsettledActiveConflictHoldingFindingIds } from './conflict-ownership.js';
 
 export interface ProvisionalSettlement {
   output: FindingManagerOutput;
@@ -113,11 +113,7 @@ export function settleProvisionalsWithCleanEvidence(input: {
     };
   }
   const provisionalById = new Map(openProvisionals.map((finding) => [finding.id, finding]));
-  const unsettledConflictHoldingFindingIds = new Set(
-    openProvisionals
-      .filter((finding) => hasUnsettledActiveConflictOwnership(input.freshLedger, finding.id))
-      .map((finding) => finding.id),
-  );
+  const unsettledConflictHoldingFindingIds = collectUnsettledActiveConflictHoldingFindingIds(input.freshLedger);
   const ineligibleConfirmationRawIds = new Set(
     input.output.resolvedFindings.flatMap((resolved) => {
       const provisional = provisionalById.get(resolved.findingId);

--- a/src/core/workflow/findings/manager-provisional-settlement.ts
+++ b/src/core/workflow/findings/manager-provisional-settlement.ts
@@ -28,6 +28,7 @@ import {
   isProvisionalFindingEntry,
   materializeProvisionalFinding,
 } from './finding-entry.js';
+import { hasUnsettledActiveConflictOwnership } from './conflict-ownership.js';
 
 export interface ProvisionalSettlement {
   output: FindingManagerOutput;
@@ -112,6 +113,11 @@ export function settleProvisionalsWithCleanEvidence(input: {
     };
   }
   const provisionalById = new Map(openProvisionals.map((finding) => [finding.id, finding]));
+  const unsettledConflictHoldingFindingIds = new Set(
+    openProvisionals
+      .filter((finding) => hasUnsettledActiveConflictOwnership(input.freshLedger, finding.id))
+      .map((finding) => finding.id),
+  );
   const ineligibleConfirmationRawIds = new Set(
     input.output.resolvedFindings.flatMap((resolved) => {
       const provisional = provisionalById.get(resolved.findingId);
@@ -259,9 +265,11 @@ export function settleProvisionalsWithCleanEvidence(input: {
   };
 
   let promotedFindingIds = new Set(input.explicitPromotedFindingIds);
-  let resolvedByMapping = new Map<string, string>([
-    ...input.explicitResolvedByMapping,
-  ]);
+  let resolvedByMapping = new Map(
+    [...input.explicitResolvedByMapping].filter(([findingId]) => (
+      !unsettledConflictHoldingFindingIds.has(findingId)
+    )),
+  );
   let resolvedByEvidence = new Map<string, string>();
   for (const resolved of settlementOutput.resolvedFindings) {
     const provisional = provisionalById.get(resolved.findingId);
@@ -269,6 +277,9 @@ export function settleProvisionalsWithCleanEvidence(input: {
       provisional === undefined
       || !canResolveProvisionalByExplicitConfirmation(provisional)
     ) {
+      continue;
+    }
+    if (unsettledConflictHoldingFindingIds.has(provisional.id)) {
       continue;
     }
     const hasCleanConfirmation = resolved.rawFindingIds.some((rawFindingId) => {
@@ -285,7 +296,10 @@ export function settleProvisionalsWithCleanEvidence(input: {
     }
   }
   for (const finding of openProvisionals) {
-    if (finding.provisional?.kind !== 'reviewer-output-overflow') {
+    if (
+      finding.provisional?.kind !== 'reviewer-output-overflow'
+      || unsettledConflictHoldingFindingIds.has(finding.id)
+    ) {
       continue;
     }
     const reviewerStableKey = finding.provisional.recoveryReviewerStableKey;
@@ -347,7 +361,12 @@ export function settleProvisionalsWithCleanEvidence(input: {
         continue;
       }
       const provisional = byUniqueIdentity.get(identity);
-      if (provisional === undefined || provisional.id === match.findingId || promotedFindingIds.has(provisional.id)) {
+      if (
+        provisional === undefined
+        || provisional.id === match.findingId
+        || promotedFindingIds.has(provisional.id)
+        || unsettledConflictHoldingFindingIds.has(provisional.id)
+      ) {
         continue;
       }
       if (targetHasExactIdentity(match.findingId, identity)) {
@@ -358,6 +377,9 @@ export function settleProvisionalsWithCleanEvidence(input: {
 
   const promotionSourceRawFindingIds = new Map<string, string[]>();
   promotedFindingIds = new Set([...promotedFindingIds].filter((findingId) => {
+    if (unsettledConflictHoldingFindingIds.has(findingId)) {
+      return false;
+    }
     const provisional = provisionalById.get(findingId);
     if (provisional === undefined || !isProvisionalFindingEntry(provisional)) {
       return false;

--- a/src/core/workflow/findings/reconciler.ts
+++ b/src/core/workflow/findings/reconciler.ts
@@ -65,7 +65,7 @@ import {
   mergeProvisionalClaimProjection,
 } from './finding-entry.js';
 import { isProvisionalReopenSource } from './provisional-promotion-eligibility.js';
-import { hasUnsettledActiveConflictOwnership } from './conflict-ownership.js';
+import { collectUnsettledActiveConflictHoldingFindingIds } from './conflict-ownership.js';
 import { findingMatchesMutationPrecondition } from './finding-preconditions.js';
 import type {
   PreAdmissionEntityMutationResult,
@@ -682,6 +682,7 @@ export interface ReconcileFindingLedgerPlan {
   ledger: FindingLedger;
   lifecycleCommands: FindingLifecycleCommand[];
   entityMutationResults: PreAdmissionEntityMutationResult[];
+  deferredResolutionRejections: string[];
 }
 
 export function reconcileFindingLedgerPlan(
@@ -971,6 +972,10 @@ function reconcileFindingLedgerWithValidator(
   const currentRawFindingsById = new Map(input.rawFindings.map((finding) => [finding.rawFindingId, finding]));
   let nextId = input.previousLedger.nextId;
   const usedRawFindingIds = new Set<string>();
+  const unsettledConflictHoldingFindingIds = collectUnsettledActiveConflictHoldingFindingIds(
+    input.previousLedger,
+  );
+  const deferredResolutionRejections: string[] = [];
 
   const updatedById = new Map<string, FindingRecord>(
     input.previousLedger.findings.map((finding) => [finding.id, { ...finding }]),
@@ -1071,8 +1076,54 @@ function reconcileFindingLedgerWithValidator(
     const finding = updatedById.get(resolved.findingId)!;
     if (
       finding.provisional !== undefined
-      && hasUnsettledActiveConflictOwnership(input.previousLedger, finding.id)
+      && unsettledConflictHoldingFindingIds.has(finding.id)
     ) {
+      assertFindingStatus(finding, 'open', 'resolve');
+      assertResolvedEvidenceRawFindings({
+        finding,
+        resolvedRawFindingIds: resolved.rawFindingIds,
+        previousRawFindingsById,
+        currentRawFindingsById,
+      });
+      const observedRawFindingIds = resolved.rawFindingIds.filter(
+        (rawFindingId) => currentRawFindingsById.has(rawFindingId),
+      );
+      markRawFindingIdsUsed(usedRawFindingIds, observedRawFindingIds);
+      const evidence = foldFindingObservation({
+        finding,
+        rawFindings: getRawFindings(input.rawFindings, observedRawFindingIds),
+        observation: observationFromContext(input.context),
+      });
+      const updated: FindingRecord = {
+        ...finding,
+        revision: bumpRevision(finding),
+        evidenceIds: mergeBinarySortedUniqueStrings(
+          finding.evidenceIds,
+          evidenceIdsForRawFindings(
+            resolved.rawFindingIds,
+            input.verifiedEvidenceRecordsByRawFindingId,
+          ),
+        ),
+        ...evidence,
+      };
+      updatedById.set(resolved.findingId, updated);
+      findingCommand(
+        'update_provisional',
+        [updated],
+        rawFindingLifecycleAuthority({
+          operation: 'update_provisional',
+          rawFindingIds: finding.provisional.sourceRawFindingIds,
+          rawFindings: input.rawFindings,
+          adjudications: input.managerOutput.anchorAdjudications,
+        }),
+        verifiedFindingSources(
+          [finding.id],
+          finding.provisional.sourceRawFindingIds,
+        ),
+      );
+      deferredResolutionRejections.push(
+        `Resolution for provisional finding "${finding.id}" deferred while waiting for an unsettled conflict landing to settle (raw findings: ${resolved.rawFindingIds.join(', ')})`,
+      );
       continue;
     }
     assertFindingStatus(finding, 'open', 'resolve');
@@ -1487,6 +1538,7 @@ function reconcileFindingLedgerWithValidator(
     ledger,
     lifecycleCommands,
     entityMutationResults: entityMutationApplication.results,
+    deferredResolutionRejections,
   };
 }
 

--- a/src/core/workflow/findings/reconciler.ts
+++ b/src/core/workflow/findings/reconciler.ts
@@ -65,6 +65,7 @@ import {
   mergeProvisionalClaimProjection,
 } from './finding-entry.js';
 import { isProvisionalReopenSource } from './provisional-promotion-eligibility.js';
+import { hasUnsettledActiveConflictOwnership } from './conflict-ownership.js';
 import { findingMatchesMutationPrecondition } from './finding-preconditions.js';
 import type {
   PreAdmissionEntityMutationResult,
@@ -1068,6 +1069,12 @@ function reconcileFindingLedgerWithValidator(
   for (const resolved of input.managerOutput.resolvedFindings) {
     assertKnownFinding(knownFindingIds, resolved.findingId);
     const finding = updatedById.get(resolved.findingId)!;
+    if (
+      finding.provisional !== undefined
+      && hasUnsettledActiveConflictOwnership(input.previousLedger, finding.id)
+    ) {
+      continue;
+    }
     assertFindingStatus(finding, 'open', 'resolve');
     assertResolvedEvidenceRawFindings({
       finding,

--- a/src/core/workflow/findings/terminal-adjudication-candidates.ts
+++ b/src/core/workflow/findings/terminal-adjudication-candidates.ts
@@ -14,7 +14,7 @@ import type {
   FindingProvisionalKind,
 } from './types.js';
 import { captureFindingLifecycleHead } from './lifecycle-mutation.js';
-import { hasUnsettledActiveConflictOwnership } from './conflict-ownership.js';
+import { collectUnsettledActiveConflictHoldingFindingIds } from './conflict-ownership.js';
 
 const ENTITY_ADJUDICATION_PROVISIONAL_KINDS = new Set<FindingProvisionalKind>([
   'raw-meaning-ambiguous',
@@ -124,11 +124,12 @@ function targetCandidates(
   }).sort((left, right) => compareBinaryStrings(left.targetRefId, right.targetRefId));
 }
 
-export function buildTerminalAdjudicationCandidateSnapshot(input: {
+function buildTerminalAdjudicationCandidateSnapshotWithOwnership(input: {
   ledger: FindingLedger;
   finding: FindingLedgerEntry;
   currentRound: number;
   allowExistingEpisode?: boolean;
+  unsettledConflictHoldingFindingIds: ReadonlySet<string>;
 }): TerminalAdjudicationCandidateSnapshot | undefined {
   const finding = input.finding;
   if (
@@ -136,7 +137,7 @@ export function buildTerminalAdjudicationCandidateSnapshot(input: {
     || !ENTITY_ADJUDICATION_PROVISIONAL_KINDS.has(finding.provisional.kind)
     || finding.provisional.firstObservedRound >= input.currentRound
     || finding.provisional.sourceRawFindingIds.length === 0
-    || hasUnsettledActiveConflictOwnership(input.ledger, finding.id)
+    || input.unsettledConflictHoldingFindingIds.has(finding.id)
   ) {
     return undefined;
   }
@@ -178,12 +179,29 @@ export function buildTerminalAdjudicationCandidateSnapshot(input: {
   return { candidateSnapshotDigest, ...withoutDigest };
 }
 
+export function buildTerminalAdjudicationCandidateSnapshot(input: {
+  ledger: FindingLedger;
+  finding: FindingLedgerEntry;
+  currentRound: number;
+  allowExistingEpisode?: boolean;
+}): TerminalAdjudicationCandidateSnapshot | undefined {
+  return buildTerminalAdjudicationCandidateSnapshotWithOwnership({
+    ...input,
+    unsettledConflictHoldingFindingIds: collectUnsettledActiveConflictHoldingFindingIds(input.ledger),
+  });
+}
+
 export function selectTerminalAdjudicationCandidates(input: {
   ledger: FindingLedger;
   currentRound: number;
 }): TerminalAdjudicationCandidateSnapshot[] {
+  const unsettledConflictHoldingFindingIds = collectUnsettledActiveConflictHoldingFindingIds(input.ledger);
   return input.ledger.findings.flatMap((finding) => {
-    const candidate = buildTerminalAdjudicationCandidateSnapshot({ ...input, finding });
+    const candidate = buildTerminalAdjudicationCandidateSnapshotWithOwnership({
+      ...input,
+      finding,
+      unsettledConflictHoldingFindingIds,
+    });
     return candidate === undefined ? [] : [candidate];
   }).sort((left, right) => compareBinaryStrings(left.findingId, right.findingId));
 }


### PR DESCRIPTION
## 問題(実 run で発生)

sol-lead ベンチ run が『Unsettled conflict holding "F-0017" is not an open provisional』(conflict-adjudication-model.ts:240)で abort した。

原因: 通常の provisional 解消経路(clean evidence 決着と reconciler)が、active conflict の未決着 conflictRawClaimLanding を保有している finding を、landing を決着させないまま resolution / promotion できてしまう。landing の決着は conflict 裁定経路(applyResolvedConflictAdjudication)だけの責務なので、直後の conflict 裁定スナップショットが不変条件違反で run 全体を落とす。resume しても同じ場所で再発する。

## 修正

- 通常の解消経路にガードを追加: 未決着 landing を保有する finding は解消を**保留**し provisional のまま維持する(拒否エラーにしない — conflict 裁定が決着すれば次ラウンドで通常どおり解消される。新しい停止点は作らない)
- 保留した解消申告は黙って消費しない: 申告 raw を finding の観測(rawFindingIds)として残し、検証レポートに保留理由を記録
- 保有判定は「未決着 landing を持つ findingId の Set」を処理単位ごとに1回だけ構築して参照(finding ごとの全履歴再走査をやめる)
- スナップショット側の不変条件検査は緩和しない

## 検証

- 回帰テスト(実 fixture・実 manager ラウンド): active conflict 中は provisional 維持 → 申告 raw が観測に残る → 裁定決着後の次ラウンドで解消
- conflict IT 25 / identity 2 / runner 49 / restatement slot 55 / determinism 7 / step-executor 43 / 配線 19 全通過、build・lint 通過

診断・設計は codex(読み取り専用診断→最小修正案)によるレビュー済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 競合解決中のFindingが、誤って解決・昇格・移行される問題を修正しました。
  * 未解決の競合を保持しているFindingを、暫定移行や終端判定の候補から適切に除外します。
  * 競合解消後の次回処理で、Findingが正しく解決されるよう改善しました。
  * 遅延された解決処理の拒否理由を記録し、処理結果の可視性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->