### PR TITLE
fix(finding-contract): 保留した解消申告を専用フィールドで報告する

### DIFF
--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -543,6 +543,19 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       managerResolutionResponse(String(instruction), holding.id)
     ));
     await managerRound([resolutionRaw(beforeAdjudicationRawId)], 1);
+
+    const validationReport = JSON.parse(readFileSync(
+      join(cwd, '.takt', 'runs', 'run-1', 'reports', 'findings-manager-validation.reviewers.json'),
+      'utf8',
+    )) as {
+      attempts: Array<{ validationErrors: string[] }>;
+      deferredResolutionRejections: string[];
+    };
+    expect(validationReport.deferredResolutionRejections).toEqual([
+      expect.stringContaining('deferred while waiting for an unsettled conflict landing to settle'),
+    ]);
+    expect(validationReport.attempts.flatMap((attempt) => attempt.validationErrors).join(' '))
+      .not.toContain('deferred while waiting for an unsettled conflict landing to settle');
 
     const deferredLedger = ledgerStore.loadLedger();
     const deferredRaw = deferredLedger.rawFindings.find((rawFinding) => (

--- a/src/__tests__/finding-provisional-target-landing.test.ts
+++ b/src/__tests__/finding-provisional-target-landing.test.ts
@@ -239,6 +239,7 @@ describe('provisional target landing', () => {
       landedSpecs: [],
       entityMutationResults: [],
       normalizationRejections: [],
+      deferredResolutionRejections: [],
       rejectedObservationAttachments: [],
       settlementCommands: [],
     };
@@ -312,6 +313,7 @@ describe('provisional target landing', () => {
       landedSpecs: [],
       entityMutationResults: [],
       normalizationRejections: [],
+      deferredResolutionRejections: [],
       rejectedObservationAttachments: [],
       settlementCommands: [],
     };

--- a/src/core/models/finding-schemas.ts
+++ b/src/core/models/finding-schemas.ts
@@ -2269,6 +2269,7 @@ const FindingManagerValidationReportSchema = z.object({
   ledgerUpdated: z.boolean(),
   finalErrors: z.array(z.string()),
   attempts: z.array(FindingManagerValidationAttemptReportSchema),
+  deferredResolutionRejections: z.array(z.string()).optional(),
   rawAdmissionRejections: z.array(RawAdmissionRejectionReportSchema).optional(),
   unsupportedRawFindings: z.array(UnsupportedRawFindingReportSchema).optional(),
   reviewerOutputOverflows: z.array(ReviewerOutputOverflowReportSchema).optional(),

--- a/src/core/models/finding-types.ts
+++ b/src/core/models/finding-types.ts
@@ -1164,6 +1164,7 @@ export interface FindingManagerValidationReport {
   ledgerUpdated: boolean;
   finalErrors: string[];
   attempts: FindingManagerValidationAttemptReport[];
+  deferredResolutionRejections?: string[];
   rawAdmissionRejections?: RawAdmissionRejectionReport[];
   unsupportedRawFindings?: UnsupportedRawFindingReport[];
   reviewerOutputOverflows?: ReviewerOutputOverflowReport[];

--- a/src/core/workflow/findings/manager-commit-finalization.ts
+++ b/src/core/workflow/findings/manager-commit-finalization.ts
@@ -312,6 +312,7 @@ export function reconcileCommitPlan(input: {
   landedSpecs: ProvisionalFindingSpec[];
   entityMutationResults: PreAdmissionEntityMutationResult[];
   normalizationRejections: string[];
+  deferredResolutionRejections: string[];
   rejectedObservationAttachments: RejectedObservationAttachment[];
   settlementCommands: FindingLifecycleCommand[];
 } {
@@ -443,10 +444,8 @@ export function reconcileCommitPlan(input: {
     managerOutput: settledOutput,
     landedSpecs,
     entityMutationResults,
-    normalizationRejections: [
-      ...normalizationRejections,
-      ...reconciledPlan.deferredResolutionRejections,
-    ],
+    normalizationRejections,
+    deferredResolutionRejections: reconciledPlan.deferredResolutionRejections,
     rejectedObservationAttachments,
     settlementCommands,
   };

--- a/src/core/workflow/findings/manager-commit-plan.ts
+++ b/src/core/workflow/findings/manager-commit-plan.ts
@@ -119,6 +119,7 @@ export interface CommitMutationResult {
   managerDecisionCommands: FindingLifecycleCommand[];
   lifecycleManagerOutput: FindingManagerOutput;
   staleRejections: string[];
+  deferredResolutionRejections: string[];
   unsupportedRawFindingReports: UnsupportedRawFindingReport[];
   admissionRejections: RawAdmissionEvaluation['admissionRejections'];
   provisionalLandings: ProvisionalLandingReport[];
@@ -1079,6 +1080,7 @@ export function buildFindingManagerCommitMutation(
         managerDecisionCommands: [],
         lifecycleManagerOutput: params.managerDecision.managerOutput,
         staleRejections: [],
+        deferredResolutionRejections: [],
         unsupportedRawFindingReports: [],
         admissionRejections: [],
         provisionalLandings: [],
@@ -1424,6 +1426,7 @@ export function buildFindingManagerCommitMutation(
         ...reconcilePlan.normalizationRejections,
         ...finalized.adjudicationRejections,
       ],
+      deferredResolutionRejections: reconcilePlan.deferredResolutionRejections,
       unsupportedRawFindingReports: revalidated.unsupportedRawFindingReports,
       admissionRejections: admission.admissionRejections,
       provisionalLandings,

--- a/src/core/workflow/findings/manager-commit.ts
+++ b/src/core/workflow/findings/manager-commit.ts
@@ -234,6 +234,7 @@ function buildCommitReport(
       ...managerDecision.invalidAttempts,
     ],
     staleRejections: committed.staleRejections,
+    deferredResolutionRejections: committed.deferredResolutionRejections,
     admissionRejections: committed.admissionRejections,
     unsupportedRawFindingReports: [
       ...managerDecision.unsupportedRawFindingReports,

--- a/src/core/workflow/findings/manager-report-content.ts
+++ b/src/core/workflow/findings/manager-report-content.ts
@@ -59,6 +59,9 @@ function canonicalizeReport(
     ...(report.rawAdmissionRejections === undefined
       ? {}
       : { rawAdmissionRejections: [...report.rawAdmissionRejections] }),
+    ...(report.deferredResolutionRejections === undefined
+      ? {}
+      : { deferredResolutionRejections: [...report.deferredResolutionRejections] }),
     ...(report.unsupportedRawFindings === undefined
       ? {}
       : { unsupportedRawFindings: [...report.unsupportedRawFindings] }),

--- a/src/core/workflow/findings/manager-report.ts
+++ b/src/core/workflow/findings/manager-report.ts
@@ -21,6 +21,7 @@ interface ManagerCommitReportInput {
   managerOutput: FindingManagerOutput;
   invalidAttempts: FindingManagerValidationAttemptReport[];
   staleRejections: string[];
+  deferredResolutionRejections: string[];
   admissionRejections: RawAdmissionRejectionReport[];
   unsupportedRawFindingReports: UnsupportedRawFindingReport[];
   overflowReports: ReviewerOutputOverflowReport[];
@@ -38,6 +39,7 @@ export function buildManagerCommitReport(
 ): FindingManagerValidationReport | undefined {
   const reportNeeded = input.invalidAttempts.length > 0
     || input.staleRejections.length > 0
+    || input.deferredResolutionRejections.length > 0
     || input.admissionRejections.length > 0
     || input.unsupportedRawFindingReports.length > 0
     || input.overflowReports.length > 0
@@ -74,6 +76,9 @@ export function buildManagerCommitReport(
       : {}),
     ...(input.managerTaskAudits.length > 0
       ? { managerTaskAudits: input.managerTaskAudits }
+      : {}),
+    ...(input.deferredResolutionRejections.length > 0
+      ? { deferredResolutionRejections: input.deferredResolutionRejections }
       : {}),
     interpretationStats: input.interpretationStats,
     attempts: input.staleRejections.length > 0


### PR DESCRIPTION
## 内容

PR #1285 の CodeRabbit 指摘2件への対応。

- 保留(未決着 conflict 待ち)の解消申告が stale rejection と同じ配列に合流して区別できなかったため、検証レポート内に専用フィールドとして分離
- 保留回帰テストに「保留理由がレポートで観測でき、stale 側に混入しない」検証を追加

スキーマバージョン・テーブル変更なし。conflict IT 25 / schemas 58 / runner 49 / 配線 19 全通過。