### PR TITLE
fix(workflow): run unit gate after edits

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -8,36 +8,41 @@ workflow_overrides:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
-        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
-        - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
+        - "Run `npm test` after completing edits and verify the fast unit gate passes"
+        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     fix:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
-        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
-        - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
+        - "Run `npm test` after completing edits and verify the fast unit gate passes"
+        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     ai_fix:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
-        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
-        - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
+        - "Run `npm test` after completing edits and verify the fast unit gate passes"
+        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     ai-antipattern-fix:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
-        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
-        - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
+        - "Run `npm test` after completing edits and verify the fast unit gate passes"
+        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     fix_supervisor:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
-        - "Do not run the full suite or whole test groups, with two exceptions: (1) you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup) - run the affected group(s); (2) you are fixing a failure reported from a failed quality gate or final-gate run - re-run that exact failing command to reproduce and verify"
-        - "Run `npm run test:e2e:smoke` and verify the smoke E2E passes"
+        - "Run `npm test` after completing edits and verify the fast unit gate passes"
+        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     merge-readiness-review:
       quality_gates:
         - "Run `npm test` and verify unit tests pass. On failure, quote the failing output in your report and return needs_fix"


### PR DESCRIPTION
## Summary

- require `npm test` after edits for implementation and fix-oriented steps
- keep targeted test files mandatory while avoiding unrelated full suites and duplicate overlapping runs
- run smoke E2E only when the changed behavior affects its covered runtime surfaces

## Verification

- `takt workflow doctor takt-experimental`
- `npm run build`
- `npm run lint`
- `npm test` (93 files per shard, 5,971 tests total)
- `git diff --check`
