### PR TITLE
fix(finding-contract): 保留した解消申告の記録をconflict裁定根拠に影響しない形へ変更する

### DIFF
--- a/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
+++ b/src/__tests__/finding-conflict-adjudication-runner.integration.test.ts
@@ -560,7 +560,24 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       status: 'open',
       provisional: expect.any(Object),
     });
-    expect(deferredHolding.rawFindingIds).toContain(deferredRaw.rawFindingId);
+    expect(deferredHolding.rawFindingIds).toEqual(holding.rawFindingIds);
+    expect(deferredHolding.evidenceIds).toEqual(holding.evidenceIds);
+    expect(deferredHolding.rejectedObservations).toEqual([
+      expect.objectContaining({
+        rawFindingId: deferredRaw.rawFindingId,
+        reason: expect.stringContaining('deferred while waiting for an unsettled conflict landing'),
+      }),
+    ]);
+    expect(deferredLedger.lifecycleReservations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        operation: 'record_rejected_observation',
+        authority: expect.objectContaining({
+          kind: 'rejected_observation',
+          rawFindingId: deferredRaw.rawFindingId,
+          rejectionCode: 'conflict_resolution_deferred',
+        }),
+      }),
+    ]));
 
     const adjudicationSnapshot = freshConflictAdjudicationSnapshot(
       deferredLedger,
@@ -704,9 +721,73 @@ describe('finding-conflict-adjudication runner registry contract', () => {
       lifecycle: 'resolved',
     });
     expect(resolvedHolding.rawFindingIds).toEqual(expect.arrayContaining([
-      deferredRaw.rawFindingId,
       afterAdjudicationRaw.rawFindingId,
     ]));
+    expect(resolvedHolding.rawFindingIds).not.toContain(deferredRaw.rawFindingId);
+  });
+
+  it('does not re-arm adjudication after deferring a resolution as an audit observation', async () => {
+    const initialLedger = ledgerStore.loadLedger();
+    const conflict = initialLedger.conflicts[0];
+    const landing = initialLedger.conflictRawClaimLandings[0];
+    const holding = initialLedger.findings.find((finding) => (
+      landing !== undefined
+      && finding.id === landing.holdingFindingId
+      && finding.provisional !== undefined
+    ));
+    if (conflict === undefined || landing === undefined || holding === undefined) {
+      throw new Error('Expected an active conflict with a provisional holding in the fixture');
+    }
+
+    const snapshot = freshConflictAdjudicationSnapshot(initialLedger, conflict.id);
+    executeAgentMock.mockResolvedValue({
+      persona: 'supervisor',
+      status: 'done',
+      content: '{}',
+      structuredOutput: {
+        proposal: {
+          kind: 'undetermined',
+          subjectIds: snapshot.subjects.map(({ subjectId }) => subjectId).sort(),
+          rationale: 'No verified terminal authority is available.',
+        },
+      },
+      timestamp: new Date(OBSERVATION.timestamp),
+    });
+    const adjudication = runner();
+    await adjudication.runner.run(adjudication.step, state());
+    const adjudicated = ledgerStore.loadLedger();
+    const priorSnapshot = freshConflictAdjudicationSnapshot(adjudicated, conflict.id);
+
+    executeAgentMock.mockReset();
+    executeAgentMock.mockImplementation(async (_persona, instruction) => (
+      managerResolutionResponse(String(instruction), holding.id)
+    ));
+    const resolutionRaw = reviewerRawExtractionFixture({
+      rawFindingId: 'resolution-deferred-audit-only',
+      familyTag: 'bug',
+      severity: 'high',
+      title: 'Disputed issue',
+      description: 'The materialized code no longer exhibits the reported failure mode.',
+      suggestion: null,
+      relation: 'resolution_confirmation',
+      targetFindingId: holding.id,
+      target: { kind: 'code', paths: ['src/a.ts'] },
+      evidence: [verifiedSourceQuoteFields(cwd, 'src/a.ts', 1)],
+    });
+    await managerRound([resolutionRaw], 1);
+
+    const deferred = ledgerStore.loadLedger();
+    const currentSnapshot = freshConflictAdjudicationSnapshot(deferred, conflict.id);
+    expect(sharesConflictAdjudicationBasis(deferred, priorSnapshot, currentSnapshot)).toBe(true);
+    expect(isActiveConflictUnadjudicated(deferred, conflict.id)).toBe(false);
+    const attemptCount = deferred.conflictAdjudicationAttempts.length;
+
+    executeAgentMock.mockClear();
+    const repeated = runner();
+    await repeated.runner.run(repeated.step, state());
+
+    expect(executeAgentMock).not.toHaveBeenCalled();
+    expect(ledgerStore.loadLedger().conflictAdjudicationAttempts).toHaveLength(attemptCount);
   });
 
   it('re-adjudicates when a fix changes the conflict target code with the same ledger projection', async () => {

--- a/src/core/models/finding-types.ts
+++ b/src/core/models/finding-types.ts
@@ -55,6 +55,7 @@ export type FindingLifecycleOperation =
 export const FINDING_REJECTED_OBSERVATION_CODES = [
   'evidence_admission_failed',
   'dismissed_same_round',
+  'conflict_resolution_deferred',
 ] as const;
 export type FindingRejectedObservationCode =
   typeof FINDING_REJECTED_OBSERVATION_CODES[number];

--- a/src/core/workflow/findings/manager-commit-finalization.ts
+++ b/src/core/workflow/findings/manager-commit-finalization.ts
@@ -426,6 +426,7 @@ export function reconcileCommitPlan(input: {
     settlement,
   });
   const rejectedObservationAttachments = [
+    ...reconciledPlan.rejectedObservationAttachments,
     ...settlement.rejectedObservationAttachments,
     ...terminalEntityResults.flatMap((result) => (
       result.sourceRawFindingIds.map((rawFindingId) => ({

--- a/src/core/workflow/findings/reconciler.ts
+++ b/src/core/workflow/findings/reconciler.ts
@@ -73,6 +73,7 @@ import type {
 } from './pre-admission-entity-binding-types.js';
 import { entityBindingDigest } from './pre-admission-entity-binding-identity.js';
 import { isEngineDerivedWaiverConflict } from './waiver-conflict.js';
+import type { RejectedObservationAttachment } from './manager-provisional-settlement.js';
 
 /**
  * provisional finding の upsert 指示。stableKey が同じ
@@ -683,6 +684,7 @@ export interface ReconcileFindingLedgerPlan {
   lifecycleCommands: FindingLifecycleCommand[];
   entityMutationResults: PreAdmissionEntityMutationResult[];
   deferredResolutionRejections: string[];
+  rejectedObservationAttachments: RejectedObservationAttachment[];
 }
 
 export function reconcileFindingLedgerPlan(
@@ -976,6 +978,7 @@ function reconcileFindingLedgerWithValidator(
     input.previousLedger,
   );
   const deferredResolutionRejections: string[] = [];
+  const rejectedObservationAttachments: RejectedObservationAttachment[] = [];
 
   const updatedById = new Map<string, FindingRecord>(
     input.previousLedger.findings.map((finding) => [finding.id, { ...finding }]),
@@ -1089,41 +1092,15 @@ function reconcileFindingLedgerWithValidator(
         (rawFindingId) => currentRawFindingsById.has(rawFindingId),
       );
       markRawFindingIdsUsed(usedRawFindingIds, observedRawFindingIds);
-      const evidence = foldFindingObservation({
-        finding,
-        rawFindings: getRawFindings(input.rawFindings, observedRawFindingIds),
-        observation: observationFromContext(input.context),
-      });
-      const updated: FindingRecord = {
-        ...finding,
-        revision: bumpRevision(finding),
-        evidenceIds: mergeBinarySortedUniqueStrings(
-          finding.evidenceIds,
-          evidenceIdsForRawFindings(
-            resolved.rawFindingIds,
-            input.verifiedEvidenceRecordsByRawFindingId,
-          ),
-        ),
-        ...evidence,
-      };
-      updatedById.set(resolved.findingId, updated);
-      findingCommand(
-        'update_provisional',
-        [updated],
-        rawFindingLifecycleAuthority({
-          operation: 'update_provisional',
-          rawFindingIds: finding.provisional.sourceRawFindingIds,
-          rawFindings: input.rawFindings,
-          adjudications: input.managerOutput.anchorAdjudications,
-        }),
-        verifiedFindingSources(
-          [finding.id],
-          finding.provisional.sourceRawFindingIds,
-        ),
-      );
-      deferredResolutionRejections.push(
-        `Resolution for provisional finding "${finding.id}" deferred while waiting for an unsettled conflict landing to settle (raw findings: ${resolved.rawFindingIds.join(', ')})`,
-      );
+      const deferredReason =
+        `Resolution for provisional finding "${finding.id}" deferred while waiting for an unsettled conflict landing to settle (raw findings: ${resolved.rawFindingIds.join(', ')})`;
+      deferredResolutionRejections.push(deferredReason);
+      rejectedObservationAttachments.push(...observedRawFindingIds.map((rawFindingId) => ({
+        targetFindingId: finding.id,
+        rawFindingId,
+        reason: `${deferredReason}; recorded without lifecycle or evidence authority`,
+        rejectionCode: 'conflict_resolution_deferred' as const,
+      })));
       continue;
     }
     assertFindingStatus(finding, 'open', 'resolve');
@@ -1539,6 +1516,7 @@ function reconcileFindingLedgerWithValidator(
     lifecycleCommands,
     entityMutationResults: entityMutationApplication.results,
     deferredResolutionRejections,
+    rejectedObservationAttachments,
   };
 }
 


### PR DESCRIPTION
## 問題(実 run で発生)

#1285 で入れた「保留した解消申告の記録」が、対象 finding の正準データ(観測の紐付け・evidence 追加)を更新する形だったため、conflict の裁定根拠が毎ラウンド「状態が変わった」扱いになり、裁定が毎ラウンド再実行され続けた。結果、reviewers と conflict 裁定の無限往復になり(8周以上、fix に一度も到達しない)、プロバイダ入力予算の枯渇で run が終了した。

## 修正

保留申告を、正準データを変更しない監査専用の添付(rejected observation と同じ既存機構、理由コード `conflict_resolution_deferred`)として保存する。

- 裁定根拠(台帳の射影+対象コードの digest)は保留記録で変化しなくなり、再裁定は本当に状態が変わったときだけ走る
- 裁定決着後の次ラウンドで保留申告を解消に使える動作は維持
- 検証レポートの保留理由フィールド(#1288)は維持

## 検証

- 回帰テスト追加: 保留記録後も裁定が再実行されない(裁定根拠が安定)/裁定決着後に解消できる
- conflict IT 26 / identity 2 / runner 49 / restatement slot 55 / schemas 58 / 配線 19 全通過、build・lint 通過

診断は codex sol(high)による(遷移経路の実コード追跡で因果を特定)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 未解決の競合に対する解決要求を延期し、関連する finding・evidence 情報を保持できるようになりました。
  * 延期された観測は拒否観測として監査記録に残り、`conflict_resolution_deferred` として追跡されます。
  * 競合解決後は新しい解決観測のみが反映され、延期された観測による意図しない再解決を防止します。
  * 監査記録後も競合状態が維持され、不必要な再 adjudication が発生しません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->