### PR TITLE
fix: isolate fallback operation journal lineage

### DIFF
--- a/src/__tests__/workflowExecution-claude-terminal.test.ts
+++ b/src/__tests__/workflowExecution-claude-terminal.test.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'node:fs';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { WorkflowConfig } from '../core/models/index.js';
+import type { WorkflowConfig, WorkflowResumePoint } from '../core/models/index.js';
+import { buildWorkflowStepParticipationIdentity } from '../core/workflow/workflow-step-participation-index.js';
 import { normalizeRule } from '../infra/config/loaders/workflowRuleNormalizer.js';
 import { FindingDatabase } from '../infra/finding-storage/database.js';
 import { createTestFindingLedgerStore } from './helpers/finding-storage.js';
@@ -95,6 +96,31 @@ function makeMultiRuleConfig(): WorkflowConfig {
           normalizeRule({ condition: 'done', next: 'COMPLETE' }),
           normalizeRule({ condition: 'fix', next: 'implement' }),
         ],
+      },
+    ],
+  };
+}
+
+function makeReviewFixConfig(): WorkflowConfig {
+  return {
+    name: 'claude-terminal-workflow-review-fix',
+    maxSteps: 3,
+    initialStep: 'review',
+    steps: [
+      {
+        name: 'review',
+        personaDisplayName: 'review',
+        instruction: 'Review {task}',
+        provider: 'claude-terminal',
+        outputContracts: [{ name: 'review.md', format: '# Review' }],
+        rules: [normalizeRule({ condition: 'done', next: 'fix' })],
+      },
+      {
+        name: 'fix',
+        personaDisplayName: 'fix',
+        instruction: 'Fix using {report:review.md}',
+        provider: 'claude-terminal',
+        rules: [normalizeRule({ condition: 'done', next: 'COMPLETE' })],
       },
     ],
   };
@@ -310,6 +336,218 @@ describe('executeWorkflow claude-terminal integration', () => {
       'utf-8',
     )) as { workflow: string };
     expect(resumedMeta.workflow).toBe('claude-terminal-workflow-phase3');
+  });
+
+  it.each([
+    {
+      label: 'missing source',
+      sourceRunSlug: '20260801-lineage-source-missing',
+      fallbackRunSlug: '20260801-lineage-missing-fallback',
+      resumedRunSlug: '20260801-lineage-missing-resumed',
+      seedIncompleteSource: false,
+    },
+    {
+      label: 'incomplete source',
+      sourceRunSlug: '20260801-lineage-source-incomplete',
+      fallbackRunSlug: '20260801-lineage-incomplete-fallback',
+      resumedRunSlug: '20260801-lineage-incomplete-resumed',
+      seedIncompleteSource: true,
+    },
+  ])('operation lineage unavailable時もartifact sourceを公開せず後続requeueを同一journalで実行する ($label)', async ({
+    sourceRunSlug,
+    fallbackRunSlug,
+    resumedRunSlug,
+    seedIncompleteSource,
+  }) => {
+    const { executeWorkflow } = await import('../features/tasks/execute/workflowExecution.js');
+
+    if (seedIncompleteSource) {
+      await executeWorkflow(makeConfig(), 'incomplete source task', projectDir, {
+        projectCwd: projectDir,
+        provider: 'claude-terminal',
+        reportDirName: sourceRunSlug,
+      });
+      const sourceMetaPath = join(projectDir, '.takt', 'runs', sourceRunSlug, 'meta.json');
+      const sourceMeta = JSON.parse(await readFile(sourceMetaPath, 'utf-8')) as Record<string, unknown>;
+      delete sourceMeta.operation_claim_token;
+      await writeFile(sourceMetaPath, JSON.stringify(sourceMeta), 'utf-8');
+    }
+
+    const fallback = await executeWorkflow(makeConfig(), 'fallback source task', projectDir, {
+      projectCwd: projectDir,
+      provider: 'claude-terminal',
+      reportDirName: fallbackRunSlug,
+      resumeSource: {
+        sourceRunSlug,
+        resumeMode: 'requeue',
+      },
+    });
+    expect(fallback.success).toBe(true);
+
+    const fallbackMeta = JSON.parse(await readFile(
+      join(projectDir, '.takt', 'runs', fallbackRunSlug, 'meta.json'),
+      'utf-8',
+    )) as Record<string, unknown>;
+    expect(fallbackMeta).toMatchObject({
+      operation_journal_run_slug: fallbackRunSlug,
+      operation_claim_token: expect.any(String),
+    });
+    expect(fallbackMeta).not.toHaveProperty('source_run_slug');
+    expect(fallbackMeta).not.toHaveProperty('resume_mode');
+
+    const resumed = await executeWorkflow(makeConfig(), 'resumed fallback task', projectDir, {
+      projectCwd: projectDir,
+      provider: 'claude-terminal',
+      reportDirName: resumedRunSlug,
+      resumeSource: {
+        sourceRunSlug: fallbackRunSlug,
+        resumeMode: 'requeue',
+      },
+    });
+    expect(resumed.success).toBe(true);
+
+    const resumedMeta = JSON.parse(await readFile(
+      join(projectDir, '.takt', 'runs', resumedRunSlug, 'meta.json'),
+      'utf-8',
+    )) as Record<string, unknown>;
+    expect(resumedMeta).toMatchObject({
+      source_run_slug: fallbackRunSlug,
+      operation_journal_run_slug: fallbackRunSlug,
+      operation_claim_token: expect.any(String),
+    });
+  });
+
+  it('fallback時のbootstrap失敗でもsourceを公開せず、後続requeueを同一journalで実行する', async () => {
+    const { executeWorkflow } = await import('../features/tasks/execute/workflowExecution.js');
+    const fallbackRunSlug = '20260801-lineage-terminal-fallback';
+    const resumedRunSlug = '20260801-lineage-terminal-resumed';
+
+    await expect(executeWorkflow(makeConfig(), 'fallback bootstrap failure', projectDir, {
+      projectCwd: projectDir,
+      provider: 'claude-terminal',
+      reportDirName: fallbackRunSlug,
+      resumeSource: {
+        sourceRunSlug: '20260801-lineage-terminal-source-missing',
+        resumeMode: 'requeue',
+      },
+      taskSpec: {
+        runSlug: fallbackRunSlug,
+        sourceTaskDir: join(projectDir, 'missing-task-source'),
+        attachmentManifest: [{
+          relativePath: 'attachments/missing.png',
+          kind: 'file',
+          contentSha256: 'a'.repeat(64),
+        }],
+        taskPrompt: 'missing task prompt',
+        orderContent: 'missing task',
+        stagedOrderContent: 'missing task',
+      },
+    })).rejects.toThrow();
+
+    const fallbackMeta = JSON.parse(await readFile(
+      join(projectDir, '.takt', 'runs', fallbackRunSlug, 'meta.json'),
+      'utf-8',
+    )) as Record<string, unknown>;
+    expect(fallbackMeta).toMatchObject({
+      status: 'failed',
+      operation_journal_run_slug: fallbackRunSlug,
+      operation_claim_token: expect.any(String),
+    });
+    expect(fallbackMeta).not.toHaveProperty('source_run_slug');
+    expect(fallbackMeta).not.toHaveProperty('resume_mode');
+
+    const resumed = await executeWorkflow(makeConfig(), 'resumed terminal fallback', projectDir, {
+      projectCwd: projectDir,
+      provider: 'claude-terminal',
+      reportDirName: resumedRunSlug,
+      resumeSource: {
+        sourceRunSlug: fallbackRunSlug,
+        resumeMode: 'requeue',
+      },
+    });
+    expect(resumed.success).toBe(true);
+
+    const resumedMeta = JSON.parse(await readFile(
+      join(projectDir, '.takt', 'runs', resumedRunSlug, 'meta.json'),
+      'utf-8',
+    )) as Record<string, unknown>;
+    expect(resumedMeta).toMatchObject({
+      source_run_slug: fallbackRunSlug,
+      operation_journal_run_slug: fallbackRunSlug,
+      operation_claim_token: expect.any(String),
+    });
+  });
+
+  it('snapshot失敗時もartifact専用sourceでEngineのreview report継承を継続する', async () => {
+    const { executeWorkflow } = await import('../features/tasks/execute/workflowExecution.js');
+    const workflow = makeReviewFixConfig();
+    const sourceRunSlug = '20260801-engine-artifact-source';
+    const targetRunSlug = '20260801-engine-artifact-target';
+    const sourceRunRoot = join(projectDir, '.takt', 'runs', sourceRunSlug);
+    const sourceReports = join(sourceRunRoot, 'reports');
+    await mkdir(sourceReports, { recursive: true });
+    await writeFile(join(sourceReports, 'review.md'), '# valid review\n', 'utf-8');
+    const outsideReport = join(projectDir, 'outside-review.md');
+    await writeFile(outsideReport, 'outside', 'utf-8');
+    await symlink(outsideReport, join(sourceReports, 'invalid-link.md'));
+    await writeFile(join(sourceRunRoot, 'meta.json'), JSON.stringify({
+      task: 'source task',
+      workflow: workflow.name,
+      runSlug: sourceRunSlug,
+      runRoot: `.takt/runs/${sourceRunSlug}`,
+      reportDirectory: `.takt/runs/${sourceRunSlug}/reports`,
+      contextDirectory: `.takt/runs/${sourceRunSlug}/context`,
+      logsDirectory: `.takt/runs/${sourceRunSlug}/logs`,
+      status: 'failed',
+      startTime: '2026-08-01T00:00:00.000Z',
+      operation_journal_run_slug: sourceRunSlug,
+    }), 'utf-8');
+
+    const resumePoint: WorkflowResumePoint = {
+      version: 2,
+      stack: [{
+        workflow: workflow.name,
+        workflow_ref: workflow.name,
+        step: 'fix',
+        kind: 'agent',
+        occurrence: 1,
+        step_iterations: { review: 1 },
+      }],
+      iteration: 1,
+      elapsed_ms: 0,
+      workflow_call_invocations: {},
+      workflow_step_participations: {
+        [buildWorkflowStepParticipationIdentity(workflow.name, 'review', [])]: {
+          report_names: ['review.md'],
+        },
+      },
+    };
+    const result = await executeWorkflow(workflow, 'resume artifact task', projectDir, {
+      projectCwd: projectDir,
+      provider: 'claude-terminal',
+      reportDirName: targetRunSlug,
+      startStep: 'fix',
+      resumePoint,
+      resumeSource: { sourceRunSlug, resumeMode: 'requeue' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(await readFile(
+      join(projectDir, '.takt', 'runs', targetRunSlug, 'reports', 'review.md'),
+      'utf-8',
+    )).toBe('# valid review\n');
+    expect(existsSync(
+      join(projectDir, '.takt', 'runs', targetRunSlug, 'reports', 'resume-artifacts.json'),
+    )).toBe(false);
+    const targetMeta = JSON.parse(await readFile(
+      join(projectDir, '.takt', 'runs', targetRunSlug, 'meta.json'),
+      'utf-8',
+    )) as Record<string, unknown>;
+    expect(targetMeta).not.toHaveProperty('source_run_slug');
+    expect(targetMeta).toMatchObject({
+      operation_journal_run_slug: targetRunSlug,
+      operation_claim_token: expect.any(String),
+    });
   });
 
   it('FC非使用workflowのrequeueはsource finding DBを検証せず成功する', async () => {

--- a/src/__tests__/workflowExecution-claude-terminal.test.ts
+++ b/src/__tests__/workflowExecution-claude-terminal.test.ts
@@ -421,6 +421,12 @@ describe('executeWorkflow claude-terminal integration', () => {
     const { executeWorkflow } = await import('../features/tasks/execute/workflowExecution.js');
     const fallbackRunSlug = '20260801-lineage-terminal-fallback';
     const resumedRunSlug = '20260801-lineage-terminal-resumed';
+    const missingAttachmentPath = join(
+      projectDir,
+      'missing-task-source',
+      'attachments',
+      'missing.png',
+    );
 
     await expect(executeWorkflow(makeConfig(), 'fallback bootstrap failure', projectDir, {
       projectCwd: projectDir,
@@ -442,7 +448,7 @@ describe('executeWorkflow claude-terminal integration', () => {
         orderContent: 'missing task',
         stagedOrderContent: 'missing task',
       },
-    })).rejects.toThrow();
+    })).rejects.toThrow(`Task attachment is missing: ${missingAttachmentPath}`);
 
     const fallbackMeta = JSON.parse(await readFile(
       join(projectDir, '.takt', 'runs', fallbackRunSlug, 'meta.json'),
@@ -536,6 +542,9 @@ describe('executeWorkflow claude-terminal integration', () => {
       join(projectDir, '.takt', 'runs', targetRunSlug, 'reports', 'review.md'),
       'utf-8',
     )).toBe('# valid review\n');
+    expect(existsSync(
+      join(projectDir, '.takt', 'runs', targetRunSlug, 'reports', 'invalid-link.md'),
+    )).toBe(false);
     expect(existsSync(
       join(projectDir, '.takt', 'runs', targetRunSlug, 'reports', 'resume-artifacts.json'),
     )).toBe(false);

--- a/src/features/tasks/execute/workflowExecution.ts
+++ b/src/features/tasks/execute/workflowExecution.ts
@@ -229,13 +229,14 @@ async function executeWorkflowInternal(
       ? {}
       : { resumeSource: options.resumeSource }),
   });
-  const publishedResumeSource = options.resumeSource;
   const resumeLineage: WorkflowExecutionResumeLineage =
     availableSourceLineage ?? resolveWorkflowExecutionResumeLineage(
       cwd,
       activeRun.runSlug,
       options.resumeSource,
     );
+  const artifactResumeSource = resumeLineage.artifactResumeSource;
+  const publishedResumeSource = resumeLineage.publishedResumeSource;
   let bootstrap: WorkflowExecutionBootstrap;
   try {
     publishWorkflowExecutionBundle(activeRun.runPaths, preparedBundle);
@@ -264,9 +265,6 @@ async function executeWorkflowInternal(
       projectCwd: options.projectCwd,
       primaryError: bootstrapError,
       resumeLineage,
-      ...(publishedResumeSource === undefined
-        ? {}
-        : { resumeSource: publishedResumeSource }),
     });
   }
   const executionBundle = loadWorkflowExecutionBundle(activeRun.runPaths);
@@ -427,7 +425,7 @@ async function executeWorkflowInternal(
         retryNote: options.retryNote,
         resumePoint: options.resumePoint,
         restartPoint: options.restartPoint,
-        resumeSource: publishedResumeSource,
+        resumeSource: artifactResumeSource,
         operationJournal: bootstrap.operationJournal,
         reportDirName: bootstrap.runSlug,
         taskPrefix: options.taskPrefix,
@@ -631,19 +629,19 @@ async function terminalizeBootstrapFailure(input: {
   readonly task: string;
   readonly projectCwd: string;
   readonly primaryError: unknown;
-  readonly resumeSource?: WorkflowExecutionOptions['resumeSource'];
   readonly resumeLineage?: WorkflowExecutionResumeLineage;
 }): Promise<never> {
   const reason = getErrorMessage(input.primaryError);
   const finalizationErrors: unknown[] = [];
+  const publishedResumeSource = input.resumeLineage?.publishedResumeSource;
   try {
     input.activeRun.bootstrap.publishRunMeta({
         runPaths: input.activeRun.runPaths,
         task: input.task,
         workflowName: input.workflowConfig.name,
-        ...(input.resumeSource === undefined
+        ...(publishedResumeSource === undefined
           ? {}
-          : { resumeSource: input.resumeSource }),
+          : { resumeSource: publishedResumeSource }),
         ...(input.resumeLineage === undefined
           ? {}
           : {

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -141,7 +141,11 @@ export interface WorkflowExecutionBootstrap {
 }
 
 export interface WorkflowExecutionResumeLineage {
+  /** Best-effort report/artifact inheritance source, not operation ancestry. */
   readonly sourceRunSlug?: string;
+  /** Runtime-only resume source for report/artifact fallback in the engine. */
+  readonly artifactResumeSource?: WorkflowExecutionOptions['resumeSource'];
+  /** Verified operation ancestry source to persist in run metadata. */
   readonly publishedResumeSource?: WorkflowExecutionOptions['resumeSource'];
   readonly operationJournalRunSlug: string;
   readonly operationClaimToken: string;
@@ -270,7 +274,10 @@ export function resolveWorkflowExecutionResumeLineage(
     return {
       operationJournalRunSlug: runSlug,
       operationClaimToken: randomUUID(),
-      ...(resumeSource === undefined ? {} : { publishedResumeSource: resumeSource }),
+      ...(resumeSource === undefined ? {} : {
+        artifactResumeSource: resumeSource,
+        publishedResumeSource: resumeSource,
+      }),
     };
   }
 
@@ -290,7 +297,7 @@ export function resolveWorkflowExecutionResumeLineage(
     );
     return {
       sourceRunSlug,
-      publishedResumeSource: resumeSource,
+      artifactResumeSource: resumeSource,
       operationJournalRunSlug: runSlug,
       operationClaimToken: randomUUID(),
     };
@@ -311,6 +318,7 @@ export function resolveWorkflowExecutionResumeSourceLineage(
   const sourceClaims = resolveOperationJournalSourceClaims(cwd, sourceRunSlug);
   return {
     sourceRunSlug,
+    artifactResumeSource: resumeSource,
     publishedResumeSource: resumeSource,
     operationJournalRunSlug: sourceClaims.journalRunSlug,
     operationClaimToken: randomUUID(),


### PR DESCRIPTION
## 概要

operation lineage を復元できない resume で、新しい journal を開始したにもかかわらず旧 source を run metadata に保存し、次回 requeue が cross-journal error になる問題を修正します。

## 変更内容

- operation ancestry と report/artifact 継承用 source を分離
- fallback run の metadata には未検証の source を公開しない
- snapshot 失敗時も engine の best-effort report 継承を維持
- missing/incomplete lineage、bootstrap failure、後続 requeue、snapshot fallback の実行回帰テストを追加

## 検証

- npm test
- npm run test:it
- npm test -- src/__tests__/workflowExecution-claude-terminal.test.ts
- npm test -- src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
- npm test -- src/__tests__/releaseVerificationWiring.test.ts
- npm run build
- npm run lint

## レビュー

Luna Max の実装担当と敵対レビュー担当を分離して確認し、1件の report inheritance regression を修正後、再レビューで APPROVE を確認しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ワークフロー再開時に、実行継続に必要な成果物と公開情報を適切に分離するよう改善しました。
  * 系譜の復元やブートストラップに失敗した場合でも、不要なソース情報を公開せず、同じ記録上で処理を再試行できるようにしました。
  * スナップショットに失敗した際は、有効なレビュー成果物のみを引き継ぎ、不完全な再開情報を生成しないようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->