### PR TITLE
fix(workflow): route experimental rework through replan

### DIFF
--- a/builtins/en/workflows/experimental-core.yaml
+++ b/builtins/en/workflows/experimental-core.yaml
@@ -22,6 +22,10 @@ subworkflow:
       type: facet_ref
       facet_kind: instruction
       default: plan
+    replan_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: replan-implementation
     testing_policy:
       type: facet_ref[]
       facet_kind: policy
@@ -125,6 +129,29 @@ steps:
       - condition: Requirements are unclear or information is insufficient
         next: ABORT
 
+  - name: replan
+    tags: [plan]
+    edit: false
+    persona: planner
+    policy:
+      - contract-change
+      - $param: plan_policy
+    knowledge:
+      $param: plan_knowledge
+    instruction:
+      $param: replan_instruction
+    output_contracts:
+      report:
+        - name: plan.md
+          format: plan
+    rules:
+      - condition: An actionable, untried project-scoped change or investigation and its verification steps were defined
+        next: implement
+      - condition: The current implementation satisfies the requirements and acceptance criteria, required project-scoped verification is complete, and no untried change or investigation remains
+        next: review
+      - condition: Confirmed evidence shows that project-scoped changes or investigation cannot resolve the blocker, leaving only an external action or mutually incompatible requirements
+        next: ABORT
+
   - name: write_tests
     capabilities: [edit, enable-skills]
     uses: development-core-write-tests
@@ -167,7 +194,7 @@ steps:
       - condition: No implementation was started (report only)
         next: review
       - condition: Implementation cannot proceed
-        next: plan
+        next: replan
       - condition: User input is required
         next: implement
         requires_user_input: true
@@ -229,9 +256,9 @@ steps:
       - condition: Fix is complete
         next: follow-up-review
       - condition: The fix approach needs to be reconsidered
-        next: plan
+        next: replan
       - condition: The task needs to be replanned
-        next: plan
+        next: replan
       - condition: Fix cannot proceed
         next: ABORT
 
@@ -251,6 +278,6 @@ steps:
       - condition: approved
         next: COMPLETE
       - condition: need_replan
-        next: plan
+        next: replan
       - condition: needs_fix
         next: fix

--- a/builtins/ja/workflows/experimental-core.yaml
+++ b/builtins/ja/workflows/experimental-core.yaml
@@ -22,6 +22,10 @@ subworkflow:
       type: facet_ref
       facet_kind: instruction
       default: plan
+    replan_instruction:
+      type: facet_ref
+      facet_kind: instruction
+      default: replan-implementation
     testing_policy:
       type: facet_ref[]
       facet_kind: policy
@@ -125,6 +129,29 @@ steps:
       - condition: 要件が不明確、情報不足
         next: ABORT
 
+  - name: replan
+    tags: [plan]
+    edit: false
+    persona: planner
+    policy:
+      - contract-change
+      - $param: plan_policy
+    knowledge:
+      $param: plan_knowledge
+    instruction:
+      $param: replan_instruction
+    output_contracts:
+      report:
+        - name: plan.md
+          format: plan
+    rules:
+      - condition: プロジェクト内で実行可能な未試行の変更または原因調査と、その検証手順を具体化した
+        next: implement
+      - condition: 現行実装が要件・受入条件を満たし、必要なプロジェクト内検証が完了し、未試行の変更・調査が残っていない
+        next: review
+      - condition: 確認済みの根拠により、プロジェクト内の変更や調査では解消できず、外部操作だけが残るか要件が両立不能である
+        next: ABORT
+
   - name: write_tests
     capabilities: [edit, enable-skills]
     uses: development-core-write-tests
@@ -167,7 +194,7 @@ steps:
       - condition: 実装未着手（レポートのみ）
         next: review
       - condition: 実装を進行できない
-        next: plan
+        next: replan
       - condition: ユーザー入力が必要
         next: implement
         requires_user_input: true
@@ -229,9 +256,9 @@ steps:
       - condition: 修正完了
         next: follow-up-review
       - condition: 修正方針の見直しが必要
-        next: plan
+        next: replan
       - condition: タスク全体の再計画が必要
-        next: plan
+        next: replan
       - condition: 修正を進行できない
         next: ABORT
 
@@ -251,6 +278,6 @@ steps:
       - condition: approved
         next: COMPLETE
       - condition: need_replan
-        next: plan
+        next: replan
       - condition: needs_fix
         next: fix

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -153,6 +153,23 @@ function response(
   };
 }
 
+function responseForNext(
+  workflow: WorkflowConfig,
+  stepName: string,
+  persona: string,
+  nextStep: string,
+): ScenarioEntry {
+  const step = findWorkflowStep(workflow, stepName);
+  const rule = step.rules?.find((candidate) => candidate.next === nextStep);
+  const ruleLabel = rule === undefined
+    ? undefined
+    : semanticRuleCandidatesOf([rule], false)[0]?.label;
+  if (ruleLabel === undefined) {
+    throw new Error(`Semantic rule not found for transition "${stepName}" -> "${nextStep}"`);
+  }
+  return response(workflow, stepName, persona, ruleLabel);
+}
+
 function selection(selectedIds: string[], rationale: string): ScenarioEntry {
   return {
     persona: 'takt-internal',
@@ -364,35 +381,25 @@ steps:
       const scenarioWorkflow = loadCoreForWrapper(language, workflow, projectDir);
       const reviewWorkflow = loadReviewForCore(language, scenarioWorkflow, projectDir);
       setMockScenario([
-        response(scenarioWorkflow, 'plan', 'planner', 'Requirements are clear and implementation is feasible'),
-        response(scenarioWorkflow, 'write_tests', 'coder', 'Test creation is complete'),
+        responseForNext(scenarioWorkflow, 'plan', 'planner', 'write_tests'),
+        responseForNext(scenarioWorkflow, 'write_tests', 'coder', 'implement'),
         selection(['testing'], 'Testing implementation facets are required.'),
-        response(scenarioWorkflow, 'implement', 'coder', 'Implementation cannot proceed'),
-        response(
-          scenarioWorkflow,
-          'replan',
-          'planner',
-          'An actionable, untried project-scoped change or investigation and its verification steps were defined',
-        ),
+        responseForNext(scenarioWorkflow, 'implement', 'coder', 'replan'),
+        responseForNext(scenarioWorkflow, 'replan', 'planner', 'implement'),
         selection(['testing'], 'The replanned implementation still changes test boundaries.'),
-        response(scenarioWorkflow, 'implement', 'coder', 'Implementation is complete'),
+        responseForNext(scenarioWorkflow, 'implement', 'coder', 'review'),
         selection([], 'The fixed TAKT reviewers cover the changed path.'),
         response(reviewWorkflow, 'coding-review', 'coding-reviewer', 'needs_fix'),
         response(reviewWorkflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'needs_fix'),
         selection([], 'No additional remediation facets are needed.'),
-        response(scenarioWorkflow, 'fix', 'coder', 'The task needs to be replanned'),
-        response(
-          scenarioWorkflow,
-          'replan',
-          'planner',
-          'An actionable, untried project-scoped change or investigation and its verification steps were defined',
-        ),
+        responseForNext(scenarioWorkflow, 'fix', 'coder', 'replan'),
+        responseForNext(scenarioWorkflow, 'replan', 'planner', 'implement'),
         selection(['testing'], 'The second replanned implementation changes test boundaries.'),
-        response(scenarioWorkflow, 'implement', 'coder', 'Implementation is complete'),
+        responseForNext(scenarioWorkflow, 'implement', 'coder', 'review'),
         selection([], 'The fixed TAKT reviewers cover the replanned path.'),
         response(reviewWorkflow, 'coding-review', 'coding-reviewer', 'approved'),
         response(reviewWorkflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'approved'),
-        response(scenarioWorkflow, 'supervise', 'supervisor', 'approved'),
+        responseForNext(scenarioWorkflow, 'supervise', 'supervisor', 'COMPLETE'),
       ]);
       const engine = new WorkflowEngine(workflow, projectDir, 'Implement a TAKT change that requires replanning', {
         projectCwd: projectDir,

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -352,6 +352,81 @@ steps:
   );
 
   it(
+    'should route blocked implementation and fix replanning through replan before reviewing again',
+    async () => {
+      const language = 'en';
+      writeFileSync(join(projectDir, '.takt', 'config.yaml'), `language: ${language}\n`);
+      invalidateAllResolvedConfigCache();
+      const workflow = loadWorkflowFromFile(
+        join(getBuiltinWorkflowsDir(language), 'takt-experimental.yaml'),
+        projectDir,
+      );
+      const scenarioWorkflow = loadCoreForWrapper(language, workflow, projectDir);
+      const reviewWorkflow = loadReviewForCore(language, scenarioWorkflow, projectDir);
+      setMockScenario([
+        response(scenarioWorkflow, 'plan', 'planner', 'Requirements are clear and implementation is feasible'),
+        response(scenarioWorkflow, 'write_tests', 'coder', 'Test creation is complete'),
+        selection(['testing'], 'Testing implementation facets are required.'),
+        response(scenarioWorkflow, 'implement', 'coder', 'Implementation cannot proceed'),
+        response(
+          scenarioWorkflow,
+          'replan',
+          'planner',
+          'An actionable, untried project-scoped change or investigation and its verification steps were defined',
+        ),
+        selection(['testing'], 'The replanned implementation still changes test boundaries.'),
+        response(scenarioWorkflow, 'implement', 'coder', 'Implementation is complete'),
+        selection([], 'The fixed TAKT reviewers cover the changed path.'),
+        response(reviewWorkflow, 'coding-review', 'coding-reviewer', 'needs_fix'),
+        response(reviewWorkflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'needs_fix'),
+        selection([], 'No additional remediation facets are needed.'),
+        response(scenarioWorkflow, 'fix', 'coder', 'The task needs to be replanned'),
+        response(
+          scenarioWorkflow,
+          'replan',
+          'planner',
+          'An actionable, untried project-scoped change or investigation and its verification steps were defined',
+        ),
+        selection(['testing'], 'The second replanned implementation changes test boundaries.'),
+        response(scenarioWorkflow, 'implement', 'coder', 'Implementation is complete'),
+        selection([], 'The fixed TAKT reviewers cover the replanned path.'),
+        response(reviewWorkflow, 'coding-review', 'coding-reviewer', 'approved'),
+        response(reviewWorkflow, 'ai-antipattern-review', 'ai-antipattern-reviewer', 'approved'),
+        response(scenarioWorkflow, 'supervise', 'supervisor', 'approved'),
+      ]);
+      const engine = new WorkflowEngine(workflow, projectDir, 'Implement a TAKT change that requires replanning', {
+        projectCwd: projectDir,
+        provider: 'mock',
+        selectorProvider: SELECTOR_PROVIDER,
+        selectorGitCommandRunner: SELECTOR_GIT_COMMAND_RUNNER,
+        companionProviders: {
+          'ai-antipattern-review-companion': { provider: 'mock' },
+        },
+        companionDiffReader: COMPANION_DIFF_READER,
+        structuredCaller: new DefaultStructuredCaller(),
+        workflowCallResolver: ({ parentWorkflow, step, projectCwd, lookupCwd }) =>
+          resolveWorkflowCallTarget(parentWorkflow, step, projectCwd, lookupCwd),
+      });
+      engines.push(engine);
+      const visitedSteps: string[] = [];
+      engine.on('step:start', (step) => visitedSteps.push(step.name));
+
+      const state = await engine.run();
+
+      expect(state.status, JSON.stringify({
+        currentStep: state.currentStep,
+        iteration: state.iteration,
+        remainingScenarios: getScenarioQueue()?.remaining,
+        visitedSteps,
+      })).toBe('completed');
+      expect(getScenarioQueue()?.remaining).toBe(0);
+      expect(visitedSteps.filter((step) => step === 'replan')).toHaveLength(2);
+      expect(visitedSteps.filter((step) => step === 'plan')).toHaveLength(1);
+    },
+    60_000,
+  );
+
+  it(
     'should abort the Japanese experimental wrapper when review findings cannot be remediated',
     async () => {
       const language = 'ja';

--- a/src/__tests__/workflow-step-fragment-builtin-runtime.test.ts
+++ b/src/__tests__/workflow-step-fragment-builtin-runtime.test.ts
@@ -863,6 +863,40 @@ describe('builtin workflow step fragment migration', () => {
     expect(fcReplan?.instruction?.trim().length ?? 0).toBeGreaterThan(0);
   });
 
+  it.each(LANGUAGES)('routes %s experimental-core rework through replan instead of the initial plan', (lang) => {
+    mkdirSync(join(projectDir, '.takt'), { recursive: true });
+    writeFileSync(join(projectDir, '.takt', 'config.yaml'), 'language: ' + lang + '\n', 'utf-8');
+    invalidateAllResolvedConfigCache();
+
+    const raw = readBuiltinWorkflow(lang, 'experimental-core');
+    const replan = getStep(raw, 'replan');
+    expect(replan).toMatchObject({
+      persona: 'planner',
+      edit: false,
+      instruction: { $param: 'replan_instruction' },
+      knowledge: { $param: 'plan_knowledge' },
+      output_contracts: { report: [{ name: 'plan.md', format: 'plan' }] },
+    });
+    expect(replan.policy).toEqual(['contract-change', { $param: 'plan_policy' }]);
+    expect((replan.rules as RawRule[]).map((rule) => rule.next))
+      .toEqual(['implement', 'review', 'ABORT']);
+
+    const nextTargets = (stepName: string): (string | undefined)[] =>
+      (getStep(raw, stepName).rules as RawRule[]).map((rule) => rule.next);
+    for (const stepName of ['implement', 'fix', 'supervise']) {
+      expect(nextTargets(stepName), stepName).toContain('replan');
+      expect(nextTargets(stepName), stepName).not.toContain('plan');
+    }
+    expect(nextTargets('write_tests')).toContain('plan');
+
+    const workflowPath = join(getBuiltinWorkflowsDir(lang), 'experimental-core.yaml');
+    const loaded = loadWorkflowFromFile(workflowPath, projectDir);
+    const loadedReplan = loaded.steps.find((step) => step.name === 'replan');
+    expect(loadedReplan).toMatchObject({ persona: 'planner', edit: false });
+    expect(loadedReplan?.outputContracts?.[0]).toMatchObject({ name: 'plan.md', formatRef: 'plan' });
+    expect(loadedReplan?.instruction?.trim().length ?? 0).toBeGreaterThan(0);
+  });
+
   it.each(LANGUAGES)('loads %s lightweight development routines with resolved runtime report contracts', (lang) => {
     mkdirSync(join(projectDir, '.takt'), { recursive: true });
     writeFileSync(join(projectDir, '.takt', 'config.yaml'), 'language: ' + lang + '\n', 'utf-8');

--- a/src/__tests__/workflow-step-fragment-builtin-runtime.test.ts
+++ b/src/__tests__/workflow-step-fragment-builtin-runtime.test.ts
@@ -864,23 +864,7 @@ describe('builtin workflow step fragment migration', () => {
   });
 
   it.each(LANGUAGES)('routes %s experimental-core rework through replan instead of the initial plan', (lang) => {
-    mkdirSync(join(projectDir, '.takt'), { recursive: true });
-    writeFileSync(join(projectDir, '.takt', 'config.yaml'), 'language: ' + lang + '\n', 'utf-8');
-    invalidateAllResolvedConfigCache();
-
     const raw = readBuiltinWorkflow(lang, 'experimental-core');
-    const replan = getStep(raw, 'replan');
-    expect(replan).toMatchObject({
-      persona: 'planner',
-      edit: false,
-      instruction: { $param: 'replan_instruction' },
-      knowledge: { $param: 'plan_knowledge' },
-      output_contracts: { report: [{ name: 'plan.md', format: 'plan' }] },
-    });
-    expect(replan.policy).toEqual(['contract-change', { $param: 'plan_policy' }]);
-    expect((replan.rules as RawRule[]).map((rule) => rule.next))
-      .toEqual(['implement', 'review', 'ABORT']);
-
     const nextTargets = (stepName: string): (string | undefined)[] =>
       (getStep(raw, stepName).rules as RawRule[]).map((rule) => rule.next);
     for (const stepName of ['implement', 'fix', 'supervise']) {
@@ -888,13 +872,6 @@ describe('builtin workflow step fragment migration', () => {
       expect(nextTargets(stepName), stepName).not.toContain('plan');
     }
     expect(nextTargets('write_tests')).toContain('plan');
-
-    const workflowPath = join(getBuiltinWorkflowsDir(lang), 'experimental-core.yaml');
-    const loaded = loadWorkflowFromFile(workflowPath, projectDir);
-    const loadedReplan = loaded.steps.find((step) => step.name === 'replan');
-    expect(loadedReplan).toMatchObject({ persona: 'planner', edit: false });
-    expect(loadedReplan?.outputContracts?.[0]).toMatchObject({ name: 'plan.md', formatRef: 'plan' });
-    expect(loadedReplan?.instruction?.trim().length ?? 0).toBeGreaterThan(0);
   });
 
   it.each(LANGUAGES)('loads %s lightweight development routines with resolved runtime report contracts', (lang) => {


### PR DESCRIPTION
## 目的

experimental / takt-experimental の実装・修正後の再計画が初回用 plan に戻る経路をなくし、default と同様に専用 replan へ分離する。

## 変更内容

- experimental-core に replan_instruction パラメータと replan ステップを追加
- implement、fix、supervise の再計画経路を replan へ変更
- 再計画後に変更が不要な場合は初回 review から再検証
- 日英定義を同時更新
- 実エンジンで implement と fix から replan へ遷移し、plan が再実行されない回帰テストを追加
- 日英のロード済み遷移契約テストを追加

## 検証

- npm run build
- npm run lint
- npm test
- npm run test:it
- npm test -- src/__tests__/it-experimental-workflow.test.ts
- npm test -- src/__tests__/workflow-step-fragment-builtin-runtime.test.ts
- npm test -- src/__tests__/releaseVerificationWiring.test.ts
- node bin/takt workflow doctor builtins/ja/workflows/takt-experimental.yaml
- node bin/takt workflow doctor builtins/en/workflows/takt-experimental.yaml
- npm run test:e2e:mock -- e2e/specs/cycle-detection.e2e.ts

mock E2E 全体は無関係な cycle-detection の1件が並列実行時に一度失敗したが、同specの単独再実行は2件とも成功。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 実装や修正が困難な場合に、計画を自動で再生成できる再計画機能を追加しました。
  * 再計画後は、変更の再実装、レビュー、または中止へ適切に分岐します。
  * 再計画の指示を設定できるようになりました。
  * 英語・日本語の実験ワークフローに対応しています。

* **テスト**
  * 実装失敗や修正失敗後の再計画から、再実装・再レビューまでの動作を検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->