### PR TITLE
fix(companion): re-review unchanged diffs after fix rounds

### DIFF
--- a/src/__tests__/companion-change-detector.test.ts
+++ b/src/__tests__/companion-change-detector.test.ts
@@ -269,6 +269,7 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
     expect(live).toBeDefined();
     detector.markReviewed(diff('live-diff', 1), live!.observedGeneration);
 
+    expect(await evaluateCompletion(detector, diff('live-diff', 1))).toBeUndefined();
     expect(await detector.evaluateCandidate(
       detector.getCompletionCandidate(true),
       diff('live-diff', 1),

--- a/src/__tests__/companion-change-detector.test.ts
+++ b/src/__tests__/companion-change-detector.test.ts
@@ -35,7 +35,7 @@ async function evaluateCompletion(
   detector: CompanionChangeDetector,
   snapshot?: CompanionDiff,
 ) {
-  return detector.evaluateCandidate(detector.getCompletionCandidate(), snapshot);
+  return detector.evaluateCandidate(detector.getCompletionCandidate(false), snapshot);
 }
 
 describe('CT-COMP-05 event-driven companion change detection', () => {
@@ -232,6 +232,47 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
     now = 1_300;
 
     expect(await evaluateLive(detector)).toBeUndefined();
+  });
+
+  it('should allow an explicitly authorized unchanged-digest completion review without changing normal dedupe', async () => {
+    const detector = new CompanionChangeDetector({
+      intervalMs: 100,
+      minimumChangedLines: 10,
+      now: () => 1_000,
+      readDiff: vi.fn(),
+    });
+    detector.markReviewed(diff('same-diff', 10), 0);
+
+    expect(await evaluateCompletion(detector, diff('same-diff', 1))).toBeUndefined();
+    expect(await detector.evaluateCandidate(
+      detector.getCompletionCandidate(true),
+      diff('same-diff', 1),
+    )).toMatchObject({
+      reason: 'completion',
+      snapshot: { digest: 'same-diff' },
+    });
+    expect(await evaluateCompletion(detector, diff('same-diff', 1))).toBeUndefined();
+  });
+
+  it('should keep completion authorization explicit after a live review consumes its generation', async () => {
+    let now = 1_000;
+    const detector = new CompanionChangeDetector({
+      intervalMs: 100,
+      minimumChangedLines: 1,
+      now: () => now,
+      readDiff: vi.fn().mockResolvedValue(diff('live-diff', 1)),
+    });
+    detector.markReviewed(diff('initial-diff', 1), 0);
+    detector.observe(tool('Edit'));
+    now = 1_100;
+    const live = await evaluateLive(detector, diff('live-diff', 1));
+    expect(live).toBeDefined();
+    detector.markReviewed(diff('live-diff', 1), live!.observedGeneration);
+
+    expect(await detector.evaluateCandidate(
+      detector.getCompletionCandidate(true),
+      diff('live-diff', 1),
+    )).toBeDefined();
   });
 
   it('should retain an edit observed after the reviewed snapshot generation', async () => {

--- a/src/__tests__/companion-completion-coordinator.test.ts
+++ b/src/__tests__/companion-completion-coordinator.test.ts
@@ -68,7 +68,7 @@ describe('companion completion coordinator', () => {
     const coordinator = createCoordinator({ current, queue, emit, synchronizeSnapshot });
 
     const workflowState = state();
-    const result = await coordinator.complete(workflowState);
+    const result = await coordinator.complete(workflowState, { allowUnchangedDigest: () => false });
     await runningRejection;
 
     expect(result.completionVerified).toBe(true);
@@ -91,7 +91,7 @@ describe('companion completion coordinator', () => {
     });
     const workflowState = state();
 
-    const result = await coordinator.complete(workflowState);
+    const result = await coordinator.complete(workflowState, { allowUnchangedDigest: () => false });
 
     expect(result).toMatchObject({
       escalated: true,
@@ -122,7 +122,7 @@ describe('companion completion coordinator', () => {
     });
     const workflowState = state();
 
-    const result = await coordinator.complete(workflowState);
+    const result = await coordinator.complete(workflowState, { allowUnchangedDigest: () => false });
 
     expect(result).toMatchObject({ escalated: true, completionVerified: false, openMustFix: [] });
     expect(workflowState.companion).toMatchObject({
@@ -152,7 +152,7 @@ describe('companion completion coordinator', () => {
     });
     const workflowState = state();
 
-    const result = await coordinator.complete(workflowState);
+    const result = await coordinator.complete(workflowState, { allowUnchangedDigest: () => false });
 
     expect(current.isDirty()).toBe(true);
     expect(result).toMatchObject({ escalated: true, completionVerified: false, openMustFix: [] });
@@ -181,7 +181,7 @@ describe('companion completion coordinator', () => {
     const synchronizeSnapshot = vi.fn();
     const coordinator = createCoordinator({ current, queue, synchronizeSnapshot });
 
-    const result = await coordinator.complete(state());
+    const result = await coordinator.complete(state(), { allowUnchangedDigest: () => false });
 
     expect(current.isDirty()).toBe(true);
     expect(result).toMatchObject({ escalated: true, completionVerified: false, openMustFix: [] });
@@ -199,7 +199,7 @@ describe('companion completion coordinator', () => {
       readSnapshot: vi.fn().mockRejectedValue(abort),
     });
 
-    await expect(coordinator.complete(state())).rejects.toBe(abort);
+    await expect(coordinator.complete(state(), { allowUnchangedDigest: () => false })).rejects.toBe(abort);
 
     expect(emit).not.toHaveBeenCalled();
   });
@@ -216,7 +216,7 @@ describe('companion completion coordinator', () => {
       openMustFix: [openFinding],
     });
 
-    const result = await coordinator.complete(workflowState);
+    const result = await coordinator.complete(workflowState, { allowUnchangedDigest: () => false });
 
     expect(result).toMatchObject({
       escalated: true,

--- a/src/__tests__/companion-runtime-lifecycle.integration.test.ts
+++ b/src/__tests__/companion-runtime-lifecycle.integration.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { NormalAgentWorkflowStep } from '../core/models/types.js';
 import type { CompanionDiffReader } from '../core/workflow/companion/diff-reader.js';
+import { buildCompanionMailboxPath } from '../core/workflow/companion/mailbox.js';
 import { CompanionStepRuntime } from '../core/workflow/companion/step-runtime.js';
+import { runCompanionFixLoop } from '../core/workflow/companion/fix-loop.js';
 import { CompanionReviewStateStore } from '../core/workflow/companion/review-state-store.js';
 import { CompanionStructuredCaller } from '../core/workflow/companion/structured-call.js';
 import { assertStrictStructuredOutputSchema } from '../core/workflow/engine/structured-output-schema-validator.js';
@@ -35,7 +37,10 @@ const emptySnapshot = {
   truncated: false,
 };
 
-function step(allowGitCommit?: boolean): NormalAgentWorkflowStep {
+function step(
+  allowGitCommit?: boolean,
+  fixedCompanions: string[] = ['security-reviewer'],
+): NormalAgentWorkflowStep {
   return {
     name: 'implement',
     persona: 'coder',
@@ -43,7 +48,7 @@ function step(allowGitCommit?: boolean): NormalAgentWorkflowStep {
     instruction: 'implement',
     edit: true,
     passPreviousResponse: true,
-    companion: { fixed: ['security-reviewer'], pool: [] },
+    companion: { fixed: fixedCompanions, pool: [] },
     rules: [],
     ...(allowGitCommit === undefined ? {} : { allowGitCommit }),
   };
@@ -180,7 +185,11 @@ describe('companion runtime lifecycle', () => {
       runtime = await CompanionStepRuntime.create(dependencies({
         diffReader: { readBaselineSha: vi.fn().mockResolvedValue('baseline'), readDiff },
       }));
-      await runtime.complete({ companion: undefined } as unknown as WorkflowState, 'complete');
+      await runtime.complete(
+        { companion: undefined } as unknown as WorkflowState,
+        'complete',
+        { afterFix: false },
+      );
       runtime.beginFixRound(2, 0);
 
       runtime.observe({
@@ -410,16 +419,24 @@ describe('companion runtime lifecycle', () => {
         type: 'tool_use',
         data: { tool: 'Edit', input: { path: 'src/a.ts' }, id: 'first-edit' },
       });
-      await runtime.complete({ companion: undefined } as unknown as WorkflowState, 'first');
+      await runtime.complete(
+        { companion: undefined } as unknown as WorkflowState,
+        'first',
+        { afterFix: false },
+      );
       runtime.beginFixRound(3, 1);
       runtime.observe({
         type: 'tool_use',
         data: { tool: 'Edit', input: { path: 'src/a.ts' }, id: 'second-edit' },
       });
-      await runtime.complete({ companion: undefined } as unknown as WorkflowState, 'second');
+      await runtime.complete(
+        { companion: undefined } as unknown as WorkflowState,
+        'second',
+        { afterFix: true, fixRound: 2 },
+      );
 
-      expect(schemas.filter(({ purpose }) => purpose === 'reviewer')).toHaveLength(1);
-      expect(schemas.filter(({ purpose }) => purpose === 'judge')).toHaveLength(1);
+      expect(schemas.filter(({ purpose }) => purpose === 'reviewer')).toHaveLength(2);
+      expect(schemas.filter(({ purpose }) => purpose === 'judge')).toHaveLength(2);
       for (const { outputSchema } of schemas) {
         expect(() => assertStrictStructuredOutputSchema(outputSchema)).not.toThrow();
       }
@@ -427,6 +444,345 @@ describe('companion runtime lifecycle', () => {
       runtime?.stop();
       callSpy.mockRestore();
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('should re-review an unchanged diff after a fix explanation and resolve the prior finding', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'takt-companion-runtime-unchanged-fix-'));
+    const prompts: Array<{ purpose: string; prompt: string }> = [];
+    let reviewerCalls = 0;
+    const callSpy = vi.spyOn(CompanionStructuredCaller.prototype, 'call').mockImplementation(
+      async (request) => {
+        prompts.push({ purpose: request.purpose, prompt: request.prompt });
+        if (request.purpose === 'judge') {
+          return {
+            status: 'done',
+            content: '',
+            structuredOutput: { decision: 'continue', reason: 'continue' },
+          };
+        }
+        reviewerCalls += 1;
+        return {
+          status: 'done',
+          content: '',
+          structuredOutput: {
+            findings: reviewerCalls === 1
+              ? [{ severity: 'must_fix', file: 'src/a.ts', line: 1, finding: 'false positive' }]
+              : [],
+            updates: reviewerCalls === 2
+              ? [{ id: 'security-reviewer-1', status: 'resolved' }]
+              : [],
+            notes: null,
+          },
+        };
+      },
+    );
+    const readDiff = vi.fn().mockResolvedValue({ status: 'ok', snapshot });
+    const state = { companion: undefined } as unknown as WorkflowState;
+    const emitEvent = vi.fn();
+    let runtime: CompanionStepRuntime | undefined;
+
+    try {
+      const base = dependencies({
+        diffReader: { readBaselineSha: vi.fn().mockResolvedValue('baseline'), readDiff },
+      });
+      runtime = await CompanionStepRuntime.create({
+        ...base,
+        cwd: root,
+        projectCwd: root,
+        emitEvent,
+      });
+      const result = await runCompanionFixLoop({
+        initialResponse: {
+          persona: 'coder',
+          status: 'done',
+          content: 'initial implementation',
+          sessionId: 'session-1',
+          timestamp: new Date('2026-08-08T00:00:00.000Z'),
+        },
+        phase1Options: {},
+        completeReview: ({ implementerResponse, afterFix, fixRound }) => runtime!.complete(
+          state,
+          implementerResponse,
+          { afterFix, fixRound },
+        ),
+        executeFix: async (attempt) => {
+          runtime!.beginFixRound(attempt.sequence, state.companion?.openMustFixCount ?? 0);
+          return {
+            persona: 'coder',
+            status: 'done' as const,
+            content: 'The finding is a false positive; no code change was needed.',
+            sessionId: 'session-2',
+            timestamp: new Date('2026-08-08T00:00:00.000Z'),
+          };
+        },
+      });
+
+      const reviewerPrompts = prompts
+        .filter(({ purpose }) => purpose === 'reviewer')
+        .map(({ prompt }) => prompt);
+      expect(result.fixRounds).toBe(1);
+      expect(reviewerPrompts).toHaveLength(2);
+      expect(reviewerPrompts[1]).toContain('false positive; no code change was needed.');
+      expect(reviewerPrompts[1]).toContain('security-reviewer-1');
+      expect(emitEvent.mock.calls.filter(([event]) => event === 'companion:finding')).toHaveLength(1);
+      expect(state.companion).toMatchObject({
+        openMustFixCount: 0,
+        openMustFix: [],
+        completionVerified: true,
+      });
+      expect(base.stateStore.get(
+        buildCompanionMailboxPath({
+          cwd: root,
+          runSlug: 'run',
+          runPathNamespace: [],
+          stepName: 'implement',
+          companionName: 'security-reviewer',
+        }),
+        'security-reviewer',
+      ).mailbox.findings).toEqual([
+        expect.objectContaining({ id: 'security-reviewer-1', status: 'resolved' }),
+      ]);
+    } finally {
+      runtime?.stop();
+      callSpy.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('should authorize unchanged post-fix review only for the companion that owns an open finding', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'takt-companion-runtime-unchanged-scope-'));
+    const prompts: Array<{ purpose: string; agentName: string; prompt: string }> = [];
+    const reviewerCalls: string[] = [];
+    const callSpy = vi.spyOn(CompanionStructuredCaller.prototype, 'call').mockImplementation(
+      async (request) => {
+        prompts.push({ purpose: request.purpose, agentName: request.agentName, prompt: request.prompt });
+        if (request.purpose === 'judge') {
+          return {
+            status: 'done',
+            content: '',
+            structuredOutput: { decision: 'continue', reason: 'continue' },
+          };
+        }
+        reviewerCalls.push(request.agentName);
+        const companionCalls = reviewerCalls.filter((name) => name === request.agentName).length;
+        return {
+          status: 'done',
+          content: '',
+          structuredOutput: {
+            findings: request.agentName === 'security-reviewer' && companionCalls === 1
+              ? [{ severity: 'must_fix', file: 'src/a.ts', line: 1, finding: 'false positive' }]
+              : [],
+            updates: request.agentName === 'security-reviewer' && companionCalls === 2
+              ? [{ id: 'security-reviewer-1', status: 'resolved' }]
+              : [],
+            notes: null,
+          },
+        };
+      },
+    );
+    const state = { companion: undefined } as unknown as WorkflowState;
+    let runtime: CompanionStepRuntime | undefined;
+
+    try {
+      const workflowStep = step(undefined, ['security-reviewer', 'architecture-reviewer']);
+      const base = dependencies({
+        workflowStep,
+        providers: {
+          'security-reviewer': { provider: 'mock' },
+          'architecture-reviewer': { provider: 'mock' },
+        },
+        diffReader: {
+          readBaselineSha: vi.fn().mockResolvedValue('baseline'),
+          readDiff: vi.fn().mockResolvedValue({ status: 'ok', snapshot }),
+        },
+      });
+      runtime = await CompanionStepRuntime.create({
+        ...base,
+        cwd: root,
+        projectCwd: root,
+        definitions: {
+          ...base.definitions,
+          'architecture-reviewer': {
+            name: 'architecture-reviewer',
+            description: 'architecture review',
+            instruction: 'review architecture',
+            intervalMs: 60_000,
+          },
+        },
+      });
+
+      const result = await runCompanionFixLoop({
+        initialResponse: {
+          persona: 'coder',
+          status: 'done',
+          content: 'initial implementation',
+          sessionId: 'session-1',
+          timestamp: new Date('2026-08-08T00:00:00.000Z'),
+        },
+        phase1Options: {},
+        completeReview: ({ implementerResponse, afterFix, fixRound }) => runtime!.complete(
+          state,
+          implementerResponse,
+          { afterFix, fixRound },
+        ),
+        executeFix: async (attempt) => {
+          runtime!.beginFixRound(attempt.sequence, state.companion?.openMustFixCount ?? 0);
+          return {
+            persona: 'coder',
+            status: 'done' as const,
+            content: 'The finding is a false positive; no code change was needed.',
+            sessionId: 'session-2',
+            timestamp: new Date('2026-08-08T00:00:00.000Z'),
+          };
+        },
+      });
+
+      expect(result.fixRounds).toBe(1);
+      expect(reviewerCalls.filter((name) => name === 'security-reviewer')).toHaveLength(2);
+      expect(reviewerCalls.filter((name) => name === 'architecture-reviewer')).toHaveLength(1);
+      const securityPrompts = prompts
+        .filter(({ purpose, agentName }) => purpose === 'reviewer' && agentName === 'security-reviewer')
+        .map(({ prompt }) => prompt);
+      expect(securityPrompts[1]).toContain('false positive; no code change was needed.');
+      expect(securityPrompts[1]).toContain('security-reviewer-1');
+      expect(state.companion).toMatchObject({ openMustFixCount: 0, openMustFix: [] });
+    } finally {
+      runtime?.stop();
+      callSpy.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('should not bypass unchanged-digest dedupe when the Fix explanation is empty', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'takt-companion-runtime-empty-explanation-'));
+    let reviewerCalls = 0;
+    const callSpy = vi.spyOn(CompanionStructuredCaller.prototype, 'call').mockImplementation(
+      async (request) => {
+        if (request.purpose === 'judge') {
+          return {
+            status: 'done',
+            content: '',
+            structuredOutput: { decision: 'continue', reason: 'continue' },
+          };
+        }
+        reviewerCalls += 1;
+        return {
+          status: 'done',
+          content: '',
+          structuredOutput: {
+            findings: reviewerCalls === 1
+              ? [{ severity: 'must_fix', file: 'src/a.ts', line: 1, finding: 'candidate' }]
+              : [],
+            updates: [],
+            notes: null,
+          },
+        };
+      },
+    );
+    const state = { companion: undefined } as unknown as WorkflowState;
+    let runtime: CompanionStepRuntime | undefined;
+
+    try {
+      const base = dependencies({
+        diffReader: {
+          readBaselineSha: vi.fn().mockResolvedValue('baseline'),
+          readDiff: vi.fn().mockResolvedValue({ status: 'ok', snapshot }),
+        },
+      });
+      runtime = await CompanionStepRuntime.create({ ...base, cwd: root, projectCwd: root });
+
+      const first = await runtime.complete(state, 'initial', { afterFix: false });
+      runtime.beginFixRound(2, first.openMustFix.length);
+      const afterEmpty = await runtime.complete(state, '  \n\t', {
+        afterFix: true,
+        fixRound: 1,
+      });
+
+      expect(reviewerCalls).toBe(1);
+      expect(afterEmpty.openMustFix).toHaveLength(1);
+    } finally {
+      runtime?.stop();
+      callSpy.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('should re-review with the latest explanation even after a live review during the Fix round', async () => {
+    vi.useFakeTimers();
+    const root = mkdtempSync(join(tmpdir(), 'takt-companion-runtime-live-before-completion-'));
+    const liveSnapshot = {
+      ...snapshot,
+      digest: 'live-diff',
+      changedLines: 10,
+      content: '+live change\n',
+      fileFingerprints: { 'src/a.ts': 'live-diff' },
+      hunkFingerprints: { 'src/a.ts:1-1': 'live-diff' },
+    };
+    const readDiff = vi.fn()
+      .mockResolvedValueOnce({ status: 'ok', snapshot: emptySnapshot })
+      .mockResolvedValueOnce({ status: 'ok', snapshot })
+      .mockResolvedValue({ status: 'ok', snapshot: liveSnapshot });
+    const prompts: string[] = [];
+    let reviewerCalls = 0;
+    const callSpy = vi.spyOn(CompanionStructuredCaller.prototype, 'call').mockImplementation(
+      async (request) => {
+        if (request.purpose === 'judge') {
+          return {
+            status: 'done',
+            content: '',
+            structuredOutput: { decision: 'continue', reason: 'continue' },
+          };
+        }
+        prompts.push(request.prompt);
+        reviewerCalls += 1;
+        return {
+          status: 'done',
+          content: '',
+          structuredOutput: {
+            findings: reviewerCalls === 1
+              ? [{ severity: 'must_fix', file: 'src/a.ts', line: 1, finding: 'candidate' }]
+              : [],
+            updates: reviewerCalls === 3
+              ? [{ id: 'security-reviewer-1', status: 'resolved' }]
+              : [],
+            notes: null,
+          },
+        };
+      },
+    );
+    const state = { companion: undefined } as unknown as WorkflowState;
+    let runtime: CompanionStepRuntime | undefined;
+
+    try {
+      const base = dependencies({
+        diffReader: { readBaselineSha: vi.fn().mockResolvedValue('baseline'), readDiff },
+      });
+      runtime = await CompanionStepRuntime.create({ ...base, cwd: root, projectCwd: root });
+      const first = await runtime.complete(state, 'initial', { afterFix: false });
+      runtime.beginFixRound(2, first.openMustFix.length);
+      runtime.observe({
+        type: 'tool_use',
+        data: { tool: 'Edit', input: { path: 'src/a.ts' }, id: 'fix-edit' },
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.waitFor(() => expect(reviewerCalls).toBe(2));
+
+      const result = await runtime.complete(
+        state,
+        'The finding is a false positive; no code change was needed.',
+        { afterFix: true, fixRound: 1 },
+      );
+
+      expect(reviewerCalls).toBe(3);
+      expect(prompts[2]).toContain('false positive; no code change was needed.');
+      expect(prompts[2]).toContain('security-reviewer-1');
+      expect(result.openMustFix).toEqual([]);
+    } finally {
+      runtime?.stop();
+      callSpy.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+      vi.useRealTimers();
     }
   });
 
@@ -467,7 +823,7 @@ describe('companion runtime lifecycle', () => {
       });
       const state = { companion: undefined } as unknown as WorkflowState;
 
-      const result = await runtime.complete(state, 'complete');
+      const result = await runtime.complete(state, 'complete', { afterFix: false });
 
       expect(result).toMatchObject({
         escalated: true,
@@ -525,7 +881,7 @@ describe('companion runtime lifecycle', () => {
       });
       const state = { companion: undefined } as unknown as WorkflowState;
 
-      const result = await runtime.complete(state, 'complete');
+      const result = await runtime.complete(state, 'complete', { afterFix: false });
 
       expect(result).toMatchObject({
         escalated: true,

--- a/src/__tests__/it-companion-fix-loop.test.ts
+++ b/src/__tests__/it-companion-fix-loop.test.ts
@@ -79,8 +79,8 @@ describe('CT-COMP-08 same-session companion fix loop', () => {
     expect(result.latestSessionId).toBe('session-2');
     expect(result.fixRounds).toBe(1);
     expect(completeReview.mock.calls).toEqual([
-      [{ implementerResponse: 'original phase 1 result' }],
-      [{ implementerResponse: 'fixed the finding' }],
+      [{ implementerResponse: 'original phase 1 result', afterFix: false }],
+      [{ implementerResponse: 'fixed the finding', afterFix: true, fixRound: 1 }],
     ]);
   });
 
@@ -138,6 +138,26 @@ describe('CT-COMP-08 same-session companion fix loop', () => {
       expect(result.fixRounds).toBe(1);
     },
   );
+
+  it('should not claim a successful post-fix completion for a non-done fix response', async () => {
+    const completeReview = vi.fn().mockResolvedValue({
+      openMustFix: [finding('security-reviewer-1', 'a')],
+      escalated: false,
+    });
+    const result = await runCompanionFixLoop({
+      initialResponse: response('done', 'session-1'),
+      phase1Options: phase1Options(),
+      completeReview,
+      executeFix: vi.fn().mockResolvedValue(terminalResponse('blocked')),
+    });
+
+    expect(result.fixRounds).toBe(1);
+    expect(completeReview).toHaveBeenCalledOnce();
+    expect(completeReview).toHaveBeenCalledWith({
+      implementerResponse: 'done',
+      afterFix: false,
+    });
+  });
 });
 
 describe('CT-COMP-10 fail-soft and abort lifecycle', () => {

--- a/src/core/workflow/companion/change-detector.ts
+++ b/src/core/workflow/companion/change-detector.ts
@@ -9,6 +9,7 @@ export const COMPANION_CHANGE_DEBOUNCE_MS = 250;
 export interface CompanionChangeCandidate {
   readonly reason: 'quiet' | 'forced' | 'completion' | 'commit';
   readonly observedGeneration: number;
+  readonly allowUnchangedDigest?: boolean;
 }
 
 export interface CompanionChangeTrigger extends CompanionChangeCandidate {
@@ -112,8 +113,12 @@ export class CompanionChangeDetector {
     };
   }
 
-  getCompletionCandidate(): CompanionChangeCandidate {
-    return { reason: 'completion', observedGeneration: this.generation };
+  getCompletionCandidate(allowUnchangedDigest: boolean): CompanionChangeCandidate {
+    return {
+      reason: 'completion',
+      observedGeneration: this.generation,
+      ...(allowUnchangedDigest ? { allowUnchangedDigest: true } : {}),
+    };
   }
 
   async evaluateCandidate(
@@ -124,7 +129,10 @@ export class CompanionChangeDetector {
     const ignoreMinimum = candidate.reason === 'completion' || candidate.reason === 'commit';
     if (
       (snapshot.changedLines === 0 && snapshot.changedFiles.length === 0)
-      || snapshot.digest === this.lastReviewedDigest
+      || (
+        snapshot.digest === this.lastReviewedDigest
+        && candidate.allowUnchangedDigest !== true
+      )
       || (!ignoreMinimum && snapshot.changedLines < this.minimumChangedLines)
     ) {
       this.consumeThrough(candidate.observedGeneration);

--- a/src/core/workflow/companion/completion-coordinator.ts
+++ b/src/core/workflow/companion/completion-coordinator.ts
@@ -28,11 +28,14 @@ export class CompanionCompletionCoordinator {
     readonly onError: () => void;
   }) {}
 
-  async complete(state: WorkflowState): Promise<CompanionCompletionResult> {
+  async complete(
+    state: WorkflowState,
+    input: { readonly allowUnchangedDigest: (companionName: string) => boolean },
+  ): Promise<CompanionCompletionResult> {
     this.input.abortSignal?.throwIfAborted();
     const candidates = new Map([...this.input.detectors].map(([name, detector]) => [
       name,
-      detector.getCompletionCandidate(),
+      detector.getCompletionCandidate(input.allowUnchangedDigest(name)),
     ]));
     let reviewedSnapshot: CompanionDiff | undefined;
     let completionVerified = false;

--- a/src/core/workflow/companion/fix-loop.ts
+++ b/src/core/workflow/companion/fix-loop.ts
@@ -2,10 +2,15 @@ import type { AgentResponse, CompanionFindingEvidence } from '../../models/index
 import { createAbortError } from './abort.js';
 import { buildCompanionFixInstruction } from './evidence.js';
 
+export interface CompanionFixReviewContext {
+  readonly afterFix: boolean;
+  readonly fixRound?: number;
+}
+
 export async function runCompanionFixLoop<TOptions extends object>(input: {
   initialResponse: AgentResponse;
   phase1Options: TOptions;
-  completeReview: (context: { implementerResponse: string }) => Promise<{
+  completeReview: (context: CompanionFixReviewContext & { implementerResponse: string }) => Promise<{
     openMustFix: CompanionFindingEvidence[];
     escalated: boolean;
     reason?: string;
@@ -30,7 +35,11 @@ export async function runCompanionFixLoop<TOptions extends object>(input: {
   let fixRounds = 0;
   for (;;) {
     throwIfAborted(input.abortSignal);
-    const review = await input.completeReview({ implementerResponse: latestImplementerResponse });
+    const review = await input.completeReview({
+      implementerResponse: latestImplementerResponse,
+      afterFix: fixRounds > 0,
+      ...(fixRounds > 0 ? { fixRound: fixRounds } : {}),
+    });
     throwIfAborted(input.abortSignal);
     if (review.escalated || review.openMustFix.length === 0) {
       return terminal(

--- a/src/core/workflow/companion/step-runtime.ts
+++ b/src/core/workflow/companion/step-runtime.ts
@@ -32,6 +32,7 @@ import {
 import { createAbortError } from './abort.js';
 import { isCompanionCapacityError } from './limits.js';
 import { executeCompanionReviewRound } from './review-round.js';
+import type { CompanionFixReviewContext } from './fix-loop.js';
 import {
   CompanionEventPublisher,
   type CompanionEventEmitter,
@@ -133,17 +134,29 @@ export class CompanionStepRuntime {
     };
   }
 
-  async complete(state: WorkflowState, implementerResponse: string): Promise<{
+  async complete(
+    state: WorkflowState,
+    implementerResponse: string,
+    context: CompanionFixReviewContext,
+  ): Promise<{
     openMustFix: CompanionFindingEvidence[];
     escalated: boolean;
     reason?: string;
   }> {
-    this.latestImplementerExplanation = truncateUtf8(
+    const explanation = truncateUtf8(
       implementerResponse,
       ROUND_CONTEXT_MAX_BYTES,
-    ).value;
+    ).value.trim();
+    this.latestImplementerExplanation = explanation.length === 0 ? undefined : explanation;
     this.requireScheduler().beginCompletion();
-    return this.requireCompletionCoordinator().complete(state);
+    return this.requireCompletionCoordinator().complete(state, {
+      allowUnchangedDigest: (companionName) => (
+        context.afterFix
+        && context.fixRound === this.currentFixRound
+        && this.latestImplementerExplanation !== undefined
+        && this.hasOpenMustFix(companionName)
+      ),
+    });
   }
 
   beginFixRound(sequence: number, openMustFixCount: number): void {
@@ -423,6 +436,21 @@ export class CompanionStepRuntime {
       }
     }
     return open;
+  }
+
+  private hasOpenMustFix(companionName: string): boolean {
+    try {
+      return this.deps.stateStore.get(
+        this.mailboxPath(companionName),
+        companionName,
+      ).mailbox.findings.some(({ severity, status }) => (
+        severity === 'must_fix' && (status === 'open' || status === 'unresolved')
+      ));
+    } catch (error) {
+      if (!isCompanionCapacityError(error)) throw error;
+      this.recordCapacityExceeded(companionName);
+      return false;
+    }
   }
 
   private recordCapacityExceeded(companionName: string): void {

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -2790,8 +2790,11 @@ export class StepExecutor {
       const fixLoop = await runCompanionFixLoop({
         initialResponse: response,
         phase1Options: agentOptions,
-        completeReview: async ({ implementerResponse }) => {
-          const review = await activeCompanionRuntime.complete(state, implementerResponse);
+        completeReview: async ({ implementerResponse, afterFix, fixRound }) => {
+          const review = await activeCompanionRuntime.complete(state, implementerResponse, {
+            afterFix,
+            fixRound,
+          });
           requireActiveCompanionState(state, step.name);
           return review;
         },


### PR DESCRIPTION
## Summary

Fix Companion fix loops that could leave valid explanations unreviewed when a Fix agent made no code change and the cumulative diff digest stayed unchanged.

## Changes

- propagate explicit post-fix review context through the fix loop
- allow an unchanged-digest completion review only for a successful Fix round with a non-empty explanation
- scope the bypass to companions that own an open or unresolved must-fix finding
- preserve ordinary same-digest deduplication and reviewer-owned mailbox updates
- cover multiple companions, preceding live reviews, empty explanations, non-done fixes, and false-positive resolution

## Verification

- `npm run build`
- `npm run lint`
- `npm test` — 5998 tests passed
- `npm run test:it` — 2348 tests passed
- `npm run test:e2e:mock` — passed
- `npm run test:prompt-evals` — 11 smoke cases passed
- targeted heavy IT and release wiring — 49 tests passed
- `git diff --check`

## Review

A Luna Max implementer and a separate Luna Max adversarial reviewer iterated under the `$coding` criteria. The first review rejected a global mutable bypass; the revised per-companion, post-success design received final APPROVE.

`npm run check:release` and external-provider E2E were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 修正後のレビューで変更が検出されない場合でも、必要な指摘を再確認できるよう改善しました。
  - 同じ内容のレビューが不必要に繰り返される問題を抑制しました。
  - 修正内容が空の場合や修正が未完了の場合に、誤って完了レビューを実行しないよう修正しました。
  - 修正ラウンドの情報を正しく引き継ぎ、対象となる指摘を解決できるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->