### PR TITLE
fix(kiro): reject compaction-only responses

### DIFF
--- a/src/__tests__/kiro-client.test.ts
+++ b/src/__tests__/kiro-client.test.ts
@@ -662,6 +662,35 @@ describe('callKiro', () => {
     expect(result.content).toBe(output);
   });
 
+  it('Given only a context compaction notice, When command succeeds, Then returns an error so the caller can retry', async () => {
+    const notice = 'The context window has overflowed, summarizing the history...';
+    mockSpawnWithScenario({
+      stdout: notice,
+      code: 0,
+    });
+
+    const onStream = vi.fn();
+    const result = await callKiro('planner', 'write the report', {
+      cwd: '/repo',
+      onStream,
+      sessionId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toBe(
+      'kiro-cli compacted the context without returning a response',
+    );
+    expect(onStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'result',
+        data: expect.objectContaining({ success: false }),
+      }),
+    );
+    expect(onStream).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'text' }),
+    );
+  });
+
   it('Given onStream callback, When command succeeds, Then emits text and successful result events', async () => {
     mockSpawnWithScenario({
       stdout: 'stream content',

--- a/src/infra/kiro/client.ts
+++ b/src/infra/kiro/client.ts
@@ -14,6 +14,10 @@ const KIRO_AGENT_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 // Matches only a leading prompt-echo marker (absolute start of the cleaned
 // output), so a Markdown blockquote ("> ") later in the body is left intact.
 const KIRO_LEADING_PROMPT_PATTERN = /^\s*> /;
+const KIRO_CONTEXT_COMPACTION_NOTICE =
+  'The context window has overflowed, summarizing the history...';
+const KIRO_CONTEXT_COMPACTION_ERROR =
+  'kiro-cli compacted the context without returning a response';
 // UUID emitted by `kiro-cli chat --list-sessions` for each listed session.
 // No `g` flag: RegExp#exec always returns the first (most recent) match.
 const KIRO_SESSION_UUID_PATTERN = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
@@ -251,14 +255,19 @@ export class KiroClient {
       const args = buildArgs(effectiveOptions, promptText);
       const { stdout } = await execKiro(args, effectiveOptions);
       const content = cleanKiroOutput(stdout);
-      if (!content) {
-        const message = 'kiro-cli returned empty output';
-        emitResult(options, '', false, message, options.sessionId);
+      const outputError = content.length === 0
+        ? 'kiro-cli returned empty output'
+        : content === KIRO_CONTEXT_COMPACTION_NOTICE
+          ? KIRO_CONTEXT_COMPACTION_ERROR
+          : undefined;
+
+      if (outputError !== undefined) {
+        emitResult(options, '', false, outputError, options.sessionId);
         return {
           persona: agentType,
           status: 'error',
-          content: message,
-          error: message,
+          content: outputError,
+          error: outputError,
           timestamp: new Date(),
           sessionId: options.sessionId,
         };


### PR DESCRIPTION
## Background

Kiro CLI can exit with code 0 while returning only its context-compaction notice. takt currently accepts any non-empty cleaned stdout as a successful assistant response, so a report phase can persist that notice as valid workflow output and a later phase can make an incorrect transition decision.

Closes #1297.

## Purpose

Treat compaction-only Kiro output as a provider failure so the existing report-phase recovery path can retry in a fresh session instead of persisting an invalid report.

## Proposed Specification

- Recognize the exact cleaned Kiro compaction notice at the provider boundary.
- Return `AgentResponse.status = 'error'` with an actionable provider error.
- Emit a failed result event and no assistant text event.
- Preserve successful handling for every other non-empty Kiro response.

## Constraints

- Match the complete cleaned notice, not a substring, to avoid rejecting valid responses that mention compaction.
- Keep provider-specific normalization in `src/infra/kiro/`.
- Reuse the existing report-phase provider-error retry behavior rather than adding workflow-level special cases.

## Non-scope

- Matching undocumented variants of the Kiro notice.
- Changing workflow transition or report persistence logic.
- Retrying non-report provider calls.

## Validation Requirements

- [x] `npm test -- src/__tests__/kiro-client.test.ts` — 57 passed
- [x] `npm test -- src/__tests__/report-phase-retry.test.ts` — 47 passed
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run test:it` — 160 files, 2384 tests passed
- [x] `git diff --check`
- [x] Independent code review — approved with no blocking findings

## Acceptance Criteria

- [x] Exact compaction-only output returns provider error status.
- [x] The notice is not emitted as assistant text or persisted as a successful report.
- [x] Report-phase provider errors remain eligible for a fresh-session retry.
- [x] Normal non-empty Kiro output remains successful.
- [x] A regression test covers the compaction-only response and stream events.

## Use Cases

1. During report generation, Kiro compacts context and returns only the notice: takt reports a provider error and the report runner retries in a fresh session.
2. Kiro returns a normal report: takt continues to emit text and a successful result exactly as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * コンテキスト圧縮に関する通知だけが返された場合に、処理が適切に失敗として扱われるようになりました。
  * 再試行可能なエラーとして案内されるため、必要に応じて再度実行できます。
  * 不完全な応答時に、誤ってテキスト結果が表示される問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->