### PR TITLE
docs: add Pi to provider lists

### DIFF
--- a/docs/ci-cd.ja.md
+++ b/docs/ci-cd.ja.md
@@ -173,7 +173,7 @@ takt --pipeline --task "Fix bug" --auto-pr --repo owner/repo
 
 ## 環境変数
 
-CI 環境での認証には、選択した provider に必要な認証情報を設定してください。以下の API キー環境変数は、他のツールとの衝突を避けるため TAKT 固有のプレフィックスを使用しています。
+CI 環境での認証には、適切な API キー環境変数を設定してください。これらは他のツールとの衝突を避けるため TAKT 固有のプレフィックスを使用しています。
 
 ```bash
 # Claude（Anthropic）用

--- a/docs/ci-cd.ja.md
+++ b/docs/ci-cd.ja.md
@@ -173,7 +173,7 @@ takt --pipeline --task "Fix bug" --auto-pr --repo owner/repo
 
 ## 環境変数
 
-CI 環境での認証には、適切な API キー環境変数を設定してください。これらは他のツールとの衝突を避けるため TAKT 固有のプレフィックスを使用しています。
+CI 環境での認証には、該当する場合は適切な API キー環境変数を設定してください。これらは他のツールとの衝突を避けるため TAKT 固有のプレフィックスを使用しています。
 
 ```bash
 # Claude（Anthropic）用
@@ -185,7 +185,8 @@ export TAKT_OPENAI_API_KEY=sk-...
 # OpenCode 用
 export TAKT_OPENCODE_API_KEY=...
 
-# Pi は Pi SDK の credential store または provider-native 環境変数を使用
+# Pi 用
+# Pi SDK の credential store または provider-native 環境変数を使用
 
 # Cursor Agent 用（cursor-agent login 済みなら省略可）
 export TAKT_CURSOR_API_KEY=...

--- a/docs/ci-cd.ja.md
+++ b/docs/ci-cd.ja.md
@@ -173,7 +173,7 @@ takt --pipeline --task "Fix bug" --auto-pr --repo owner/repo
 
 ## 環境変数
 
-CI 環境での認証には、適切な API キー環境変数を設定してください。これらは他のツールとの衝突を避けるため TAKT 固有のプレフィックスを使用しています。
+CI 環境での認証には、選択した provider に必要な認証情報を設定してください。以下の API キー環境変数は、他のツールとの衝突を避けるため TAKT 固有のプレフィックスを使用しています。
 
 ```bash
 # Claude（Anthropic）用
@@ -184,6 +184,8 @@ export TAKT_OPENAI_API_KEY=sk-...
 
 # OpenCode 用
 export TAKT_OPENCODE_API_KEY=...
+
+# Pi は Pi SDK の credential store または provider-native 環境変数を使用
 
 # Cursor Agent 用（cursor-agent login 済みなら省略可）
 export TAKT_CURSOR_API_KEY=...

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -173,7 +173,7 @@ This approach works with any CI system that supports Node.js, including GitLab C
 
 ## Environment Variables
 
-For authentication in CI environments, set the appropriate API key environment variable. These use TAKT-specific prefixes to avoid conflicts with other tools.
+For authentication in CI environments, set the appropriate API key environment variable where applicable. These use TAKT-specific prefixes to avoid conflicts with other tools.
 
 ```bash
 # For Claude (Anthropic)
@@ -185,7 +185,8 @@ export TAKT_OPENAI_API_KEY=sk-...
 # For OpenCode
 export TAKT_OPENCODE_API_KEY=...
 
-# For Pi, use the Pi SDK credential store or provider-native environment variables
+# For Pi
+# Use the Pi SDK credential store or provider-native environment variables
 
 # For Cursor Agent (optional if cursor-agent login session exists)
 export TAKT_CURSOR_API_KEY=...

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -173,7 +173,7 @@ This approach works with any CI system that supports Node.js, including GitLab C
 
 ## Environment Variables
 
-For authentication in CI environments, configure the credentials required by the selected provider. The API key environment variables below use TAKT-specific prefixes to avoid conflicts with other tools.
+For authentication in CI environments, set the appropriate API key environment variable. These use TAKT-specific prefixes to avoid conflicts with other tools.
 
 ```bash
 # For Claude (Anthropic)

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -173,7 +173,7 @@ This approach works with any CI system that supports Node.js, including GitLab C
 
 ## Environment Variables
 
-For authentication in CI environments, set the appropriate API key environment variable. These use TAKT-specific prefixes to avoid conflicts with other tools.
+For authentication in CI environments, configure the credentials required by the selected provider. The API key environment variables below use TAKT-specific prefixes to avoid conflicts with other tools.
 
 ```bash
 # For Claude (Anthropic)
@@ -184,6 +184,8 @@ export TAKT_OPENAI_API_KEY=sk-...
 
 # For OpenCode
 export TAKT_OPENCODE_API_KEY=...
+
+# For Pi, use the Pi SDK credential store or provider-native environment variables
 
 # For Cursor Agent (optional if cursor-agent login session exists)
 export TAKT_CURSOR_API_KEY=...

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -444,6 +444,8 @@ export TAKT_OPENAI_API_KEY=sk-...
 # OpenCode 用
 export TAKT_OPENCODE_API_KEY=...
 
+# Pi は Pi SDK の credential store または provider-native 環境変数を使用
+
 # Cursor Agent 用（cursor-agent login 済みなら省略可）
 export TAKT_CURSOR_API_KEY=...
 
@@ -475,6 +477,7 @@ kiro_api_key: ...              # Kiro CLI 用
 | Claude (Anthropic) | `TAKT_ANTHROPIC_API_KEY` | `anthropic_api_key` |
 | Codex (OpenAI) | `TAKT_OPENAI_API_KEY` | `openai_api_key` |
 | OpenCode | `TAKT_OPENCODE_API_KEY` | `opencode_api_key` |
+| Pi | Pi SDK credential store または provider-native 環境変数 | - |
 | Cursor Agent | `TAKT_CURSOR_API_KEY` | `cursor_api_key` |
 | GitHub Copilot CLI | `TAKT_COPILOT_GITHUB_TOKEN` | `copilot_github_token` |
 | Kiro CLI | `TAKT_KIRO_API_KEY`（`KIRO_API_KEY` フォールバック） | `kiro_api_key` |
@@ -550,6 +553,8 @@ workflow YAML では、通常 step、parallel sub-step、`loop_monitors.judge` �
 **Codex** は Codex SDK を通じてモデル文字列をそのまま使用します。未指定の場合、デフォルトは `codex` です。利用可能なモデルについては Codex のドキュメントを参照してください。
 
 **OpenCode** は `provider/model` 形式のモデル（例: `opencode/big-pickle`）が必要です。OpenCode provider でモデルを省略すると設定エラーになります。
+
+**Pi** は `provider/model` 形式と、設定済みの Pi model に一意に一致する model ID を受け付けます。認識可能な `:<thinking-level>` サフィックスで Pi の thinking level を指定できます。省略時は Pi SDK が選択した model を使用します。
 
 **Cursor Agent** は `model` を `cursor-agent --model <model>` にそのまま渡します。省略時は Cursor CLI のデフォルトが使用されます。
 
@@ -1222,6 +1227,7 @@ provider:
 | `claude-terminal` | 可 | ターン後に再生 |
 | `mock` | 可 | scenario に依存 |
 | `opencode` | 不可 | ライブ |
+| `pi` | 不可 | ライブ |
 | `cursor`、`copilot`、`kiro` | 不可 | 利用不可 |
 
 `不可` の provider を指定した workflow はロード時に拒否され、隔離を弱めた縮退実行は行いません。

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -554,7 +554,7 @@ workflow YAML では、通常 step、parallel sub-step、`loop_monitors.judge` �
 
 **OpenCode** は `provider/model` 形式のモデル（例: `opencode/big-pickle`）が必要です。OpenCode provider でモデルを省略すると設定エラーになります。
 
-**Pi** は `provider/model` 形式と、設定済みの Pi model に一意に一致する model ID を受け付けます。認識可能な `:<thinking-level>` サフィックスで Pi の thinking level を指定できます。省略時は Pi SDK が選択した model を使用します。
+**Pi** は `provider/model` 形式と、設定済みの Pi model に一意に一致する model ID を受け付けます。認識可能な `:<thinking-level>` サフィックスで Pi の thinking level を指定できます。省略時は Pi session の現在の model を維持します。
 
 **Cursor Agent** は `model` を `cursor-agent --model <model>` にそのまま渡します。省略時は Cursor CLI のデフォルトが使用されます。
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -444,7 +444,8 @@ export TAKT_OPENAI_API_KEY=sk-...
 # OpenCode 用
 export TAKT_OPENCODE_API_KEY=...
 
-# Pi は Pi SDK の credential store または provider-native 環境変数を使用
+# Pi 用
+# Pi SDK の credential store または provider-native 環境変数を使用
 
 # Cursor Agent 用（cursor-agent login 済みなら省略可）
 export TAKT_CURSOR_API_KEY=...

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -454,7 +454,8 @@ export TAKT_OPENAI_API_KEY=sk-...
 # For OpenCode
 export TAKT_OPENCODE_API_KEY=...
 
-# For Pi, use the Pi SDK credential store or provider-native environment variables
+# For Pi
+# Use the Pi SDK credential store or provider-native environment variables
 
 # For Cursor Agent (optional if cursor-agent login session exists)
 export TAKT_CURSOR_API_KEY=...

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -564,7 +564,7 @@ In workflow YAML, `model: null` is an explicit model omission for a normal step,
 
 **OpenCode** requires a model in `provider/model` format (e.g., `opencode/big-pickle`). Omitting the model for the OpenCode provider will result in a configuration error.
 
-**Pi** accepts `provider/model` references and bare model IDs that uniquely match a configured Pi model. A recognized `:<thinking-level>` suffix selects the Pi thinking level. If omitted, the Pi SDK-selected model is used.
+**Pi** accepts `provider/model` references and bare model IDs that uniquely match a configured Pi model. A recognized `:<thinking-level>` suffix selects the Pi thinking level. If omitted, TAKT keeps the Pi session's current model.
 
 **Cursor Agent** forwards `model` directly to `cursor-agent --model <model>`. If omitted, Cursor CLI default is used.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -454,6 +454,8 @@ export TAKT_OPENAI_API_KEY=sk-...
 # For OpenCode
 export TAKT_OPENCODE_API_KEY=...
 
+# For Pi, use the Pi SDK credential store or provider-native environment variables
+
 # For Cursor Agent (optional if cursor-agent login session exists)
 export TAKT_CURSOR_API_KEY=...
 
@@ -485,6 +487,7 @@ Environment variables take precedence over `config.yaml` settings.
 | Claude (Anthropic) | `TAKT_ANTHROPIC_API_KEY` | `anthropic_api_key` |
 | Codex (OpenAI) | `TAKT_OPENAI_API_KEY` | `openai_api_key` |
 | OpenCode | `TAKT_OPENCODE_API_KEY` | `opencode_api_key` |
+| Pi | Pi SDK credential store or provider-native environment variables | - |
 | Cursor Agent | `TAKT_CURSOR_API_KEY` | `cursor_api_key` |
 | GitHub Copilot CLI | `TAKT_COPILOT_GITHUB_TOKEN` | `copilot_github_token` |
 | Kiro CLI | `TAKT_KIRO_API_KEY` (`KIRO_API_KEY` fallback) | `kiro_api_key` |
@@ -560,6 +563,8 @@ In workflow YAML, `model: null` is an explicit model omission for a normal step,
 **Codex** uses the model string as-is via the Codex SDK. If unspecified, defaults to `codex`. Refer to Codex documentation for available models.
 
 **OpenCode** requires a model in `provider/model` format (e.g., `opencode/big-pickle`). Omitting the model for the OpenCode provider will result in a configuration error.
+
+**Pi** accepts `provider/model` references and bare model IDs that uniquely match a configured Pi model. A recognized `:<thinking-level>` suffix selects the Pi thinking level. If omitted, the Pi SDK-selected model is used.
 
 **Cursor Agent** forwards `model` directly to `cursor-agent --model <model>`. If omitted, Cursor CLI default is used.
 
@@ -1233,6 +1238,7 @@ provider:
 | `claude-terminal` | Yes | Replayed after the turn |
 | `mock` | Yes | Scenario-dependent |
 | `opencode` | No | Live |
+| `pi` | No | Live |
 | `cursor`, `copilot`, `kiro` | No | Unavailable |
 
 `No` means the workflow is rejected during loading; TAKT does not run a degraded, non-isolated companion.


### PR DESCRIPTION
## 概要

- #1283 で追加された `pi` provider を、既存ドキュメント内の provider 一覧へ反映しました
- Configuration と CI/CD の英語版・日本語版を同時に更新し、Pi の認証、model 解決、Companion 対応状況を実装と揃えました
- 新しい Pi 専用ガイドや設定例は追加せず、Pi が抜けていた既存箇所だけを更新しました

## 主な変更

- 認証一覧へ Pi SDK credential store / provider-native environment variables を追加
- Provider-specific Model Notes へ Pi の `provider/model`、一意な model ID、thinking level suffix、model 省略時の挙動を追加
- Companion provider 対応表へ Pi の strict isolation 非対応 / live tool events を追加
- CI/CD の認証一覧へ Pi の credential source を追加
- `docs/configuration.md` / `docs/configuration.ja.md` と `docs/ci-cd.md` / `docs/ci-cd.ja.md` の英日記載を同期

## 変更範囲

- Pi 専用ドキュメントや `provider: pi` の YAML 例は追加していません
- README、workflow、tutorial、testing、CHANGELOG は変更していません
- provider 実装、設定 schema、既に Pi が記載されている箇所は変更していません

## 検証

成功:

- `npm ci`
- `npm run build`
- `git diff --check`
- 英語版・日本語版の記載内容を照合
- Pi client/provider 実装と認証、model、Companion の記載を照合
- provider 一覧を再監査し、追加の変更対象がないことを確認
- pre-landing review: findings なし

Closes #1301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - CI環境で、TAKT固有および選択したプロバイダーに応じた認証情報の設定方法を更新しました。
  - Pi SDKの認証情報ストアとプロバイダー固有の環境変数による認証方法を追加しました。
  - Piのモデル指定形式、thinking level、APIキーの優先順位を説明しました。
  - モデル未指定時のセッション内モデル維持や、Companionの厳密な分離実行に関する制約を明記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->