### PR TITLE
fix(workflow): retry companion failures without blocking

### DIFF
--- a/src/__tests__/companion-completion-coordinator.test.ts
+++ b/src/__tests__/companion-completion-coordinator.test.ts
@@ -101,6 +101,7 @@ describe('companion completion coordinator', () => {
     expect(workflowState.companion).toMatchObject({
       escalated: true,
       completionVerified: false,
+      completionFailure: true,
       openMustFixCount: 1,
     });
     expect(emit).toHaveBeenCalledWith('companion:complete', {
@@ -128,6 +129,7 @@ describe('companion completion coordinator', () => {
     expect(workflowState.companion).toMatchObject({
       escalated: true,
       completionVerified: false,
+      completionFailure: true,
       openMustFixCount: 0,
     });
     expect(emit).toHaveBeenCalledWith('companion:complete', {
@@ -159,6 +161,7 @@ describe('companion completion coordinator', () => {
     expect(workflowState.companion).toMatchObject({
       escalated: true,
       completionVerified: false,
+      completionFailure: true,
       openMustFixCount: 0,
     });
     expect(emit).toHaveBeenCalledWith('companion:complete', {
@@ -191,17 +194,48 @@ describe('companion completion coordinator', () => {
   it('should rethrow an abort without publishing completion', async () => {
     const current = detector();
     const emit = vi.fn();
+    const controller = new AbortController();
     const abort = new Error('cancelled');
     abort.name = 'AbortError';
     const coordinator = createCoordinator({
       current,
       emit,
-      readSnapshot: vi.fn().mockRejectedValue(abort),
+      abortSignal: controller.signal,
+      readSnapshot: vi.fn(async () => {
+        controller.abort();
+        throw abort;
+      }),
     });
 
     await expect(coordinator.complete(state(), { allowUnchangedDigest: () => false })).rejects.toBe(abort);
 
     expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('should fail soft for a provider abort when the parent signal is still active', async () => {
+    const current = detector();
+    const emit = vi.fn();
+    const providerAbort = new Error('provider cancelled');
+    providerAbort.name = 'AbortError';
+    const workflowState = state();
+    const coordinator = createCoordinator({
+      current,
+      emit,
+      readSnapshot: vi.fn().mockRejectedValue(providerAbort),
+      abortSignal: new AbortController().signal,
+    });
+
+    const result = await coordinator.complete(workflowState, { allowUnchangedDigest: () => false });
+
+    expect(result).toMatchObject({
+      escalated: true,
+      completionVerified: false,
+      openMustFix: [],
+    });
+    expect(workflowState.companion).toMatchObject({
+      completionVerified: false,
+      completionFailure: true,
+    });
   });
 
   it('should mark a loop-judge escalation as verified after a successful completion round', async () => {
@@ -268,6 +302,7 @@ function createCoordinator(input: {
   recordCompletionRound?: ReturnType<typeof vi.fn>;
   synchronizeSnapshot?: ReturnType<typeof vi.fn>;
   decision?: CompanionTerminalDecisionTracker;
+  abortSignal?: AbortSignal;
 }): CompanionCompletionCoordinator {
   const queue = input.queue ?? new CompanionReviewQueue({ runReview: vi.fn() });
   return new CompanionCompletionCoordinator({
@@ -280,6 +315,7 @@ function createCoordinator(input: {
     recordCompletionRound: input.recordCompletionRound ?? vi.fn(),
     decision: input.decision ?? new CompanionTerminalDecisionTracker(),
     events: new CompanionEventPublisher('implement', input.emit ?? vi.fn()),
+    abortSignal: input.abortSignal,
     onError: vi.fn(),
   });
 }

--- a/src/__tests__/companion-completion-gate.test.ts
+++ b/src/__tests__/companion-completion-gate.test.ts
@@ -132,7 +132,7 @@ describe('companion completion gate', () => {
     expect(result).toBe(original);
   });
 
-  it('should fail closed when completion review could not be verified', () => {
+  it('should fail closed for an unverified state without a recorded failure', () => {
     const result = guardCompanionCompletion(
       companionStep(),
       state({
@@ -147,4 +147,55 @@ describe('companion completion gate', () => {
 
     expect(result.status).toBe('blocked');
   });
+
+  it('should continue condition evaluation after an advisory completion failure', async () => {
+    const workflowState = state({
+      escalated: true,
+      completionVerified: false,
+      completionFailure: true,
+      openMustFixCount: 1,
+      openMustFix,
+      reason: 'completion review could not verify the final diff',
+    });
+    const executor = new StepExecutor({
+      structuredOutputNormalizers: createStructuredOutputNormalizerRegistry([]),
+      optionsBuilder: { buildPhaseRunnerContext: vi.fn() } as unknown as StepExecutorDeps['optionsBuilder'],
+      getInteractive: () => false,
+    } as unknown as StepExecutorDeps);
+
+    const result = await executor.applyPostExecutionPhases(
+      companionStep(),
+      workflowState,
+      1,
+      response(),
+      vi.fn(),
+    );
+
+    expect(result.status).toBe('done');
+    expect(result.matchedRuleIndex).toBe(0);
+    expect(workflowState.companion).toMatchObject({
+      completionVerified: false,
+      completionFailure: true,
+      openMustFixCount: 1,
+    });
+  });
+
+  it.each(['blocked', 'error', 'rate_limited'] as const)(
+    'should preserve a main %s response without applying companion conversion',
+    (status) => {
+      const original = { ...response(), status };
+      const result = guardCompanionCompletion(
+        companionStep(),
+        state({
+          escalated: false,
+          completionVerified: true,
+          openMustFixCount: 1,
+          openMustFix,
+        }),
+        original,
+      );
+
+      expect(result).toBe(original);
+    },
+  );
 });

--- a/src/__tests__/companion-review-moderator.integration.test.ts
+++ b/src/__tests__/companion-review-moderator.integration.test.ts
@@ -853,7 +853,9 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
             timestamp: new Date('2026-08-08T00:00:00.000Z'),
           };
           validateResponse?.(candidate);
-          validationCalls.push(purpose);
+          if (validateResponse !== undefined) {
+            validationCalls.push(purpose);
+          }
           return candidate;
         }),
         emitFinding: vi.fn(),

--- a/src/__tests__/companion-review-moderator.integration.test.ts
+++ b/src/__tests__/companion-review-moderator.integration.test.ts
@@ -790,6 +790,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       prompt: string;
       schema: Record<string, unknown>;
     }> = [];
+    const validationCalls: string[] = [];
     const evaluateRound = createEvaluateRound();
 
     try {
@@ -820,11 +821,19 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         mailboxPath: () => mailboxPath,
         systemPrompt: () => 'review',
         openFindings: () => [],
-        callStructured: vi.fn(async (purpose, _name, _system, prompt, schema) => {
+        callStructured: vi.fn(async (
+          purpose,
+          _name,
+          _system,
+          prompt,
+          schema,
+          _signal,
+          validateResponse,
+        ) => {
           calls.push({ purpose, prompt, schema });
-          return {
+          const candidate = {
             persona: purpose,
-            status: 'done',
+            status: 'done' as const,
             content: '',
             structuredOutput: purpose === 'reviewer'
               ? {
@@ -843,6 +852,9 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
                 },
             timestamp: new Date('2026-08-08T00:00:00.000Z'),
           };
+          validateResponse?.(candidate);
+          validationCalls.push(purpose);
+          return candidate;
         }),
         emitFinding: vi.fn(),
         markReviewed: vi.fn(),
@@ -858,6 +870,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         .toBe('The branch is required by the public API.');
       expect(() => assertStrictStructuredOutputSchema(calls[0]!.schema)).not.toThrow();
       expect(() => assertStrictStructuredOutputSchema(calls[1]!.schema)).not.toThrow();
+      expect(validationCalls).toEqual(['reviewer', 'moderator']);
       expect(evaluateRound).toHaveBeenCalledWith(
         'digest',
         '{"changedRegions":["src/a.ts:1-1"]}',

--- a/src/__tests__/companion-review-runner.test.ts
+++ b/src/__tests__/companion-review-runner.test.ts
@@ -65,6 +65,7 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
   it('should record failed usage before propagating an internal call failure to the fail-soft boundary', async () => {
     const failure = new Error('provider failed');
     const recordUsage = vi.fn();
+    const call = vi.fn().mockRejectedValue(failure);
 
     await expect(executeCompanionStructuredAgent({
       purpose: 'reviewer',
@@ -76,21 +77,132 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
       projectCwd: '/project',
       language: 'en',
       resolution: { provider: 'mock', model: 'mock-model', providerOptions: {} },
-      call: vi.fn().mockRejectedValue(failure),
+      call,
       recordUsage,
     })).rejects.toBe(failure);
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(recordUsage).toHaveBeenCalledTimes(2);
     expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({
       purpose: 'reviewer',
       success: false,
     }));
   });
 
+  it('should retry a transient internal failure and return the successful response', async () => {
+    const recordUsage = vi.fn();
+    const call = vi.fn()
+      .mockRejectedValueOnce(new Error('temporary provider failure'))
+      .mockResolvedValueOnce(response('done'));
+
+    const result = await executeCompanionStructuredAgent({
+      purpose: 'moderator',
+      agentName: 'companion-moderator',
+      systemPrompt: 'system',
+      prompt: 'prompt',
+      outputSchema: { type: 'object' },
+      cwd: '/worktree',
+      projectCwd: '/project',
+      language: 'en',
+      resolution: { provider: 'mock' },
+      call,
+      recordUsage,
+    });
+
+    expect(result.status).toBe('done');
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(recordUsage).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      purpose: 'moderator',
+      success: false,
+    }));
+    expect(recordUsage).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      purpose: 'moderator',
+      success: true,
+    }));
+  });
+
+  it('should retry a provider AbortError while the parent signal remains active', async () => {
+    const providerAbort = new Error('provider cancelled');
+    providerAbort.name = 'AbortError';
+    const recordUsage = vi.fn();
+    const call = vi.fn()
+      .mockRejectedValueOnce(providerAbort)
+      .mockResolvedValueOnce(response('done'));
+
+    const result = await executeCompanionStructuredAgent({
+      purpose: 'reviewer',
+      agentName: 'security-reviewer',
+      systemPrompt: 'system',
+      prompt: 'prompt',
+      outputSchema: { type: 'object' },
+      cwd: '/worktree',
+      projectCwd: '/project',
+      language: 'en',
+      resolution: { provider: 'mock' },
+      abortSignal: new AbortController().signal,
+      call,
+      recordUsage,
+    });
+
+    expect(result.status).toBe('done');
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(recordUsage).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      purpose: 'reviewer',
+      success: false,
+    }));
+    expect(recordUsage).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      purpose: 'reviewer',
+      success: true,
+    }));
+  });
+
+  it('should retry invalid semantic output and record the failed attempt usage', async () => {
+    const recordUsage = vi.fn();
+    const call = vi.fn()
+      .mockResolvedValueOnce(response('done'))
+      .mockResolvedValueOnce(response('done'));
+    const validateResponse = vi.fn()
+      .mockImplementationOnce(() => {
+        throw new Error('invalid semantic output');
+      })
+      .mockImplementationOnce(() => undefined);
+
+    const result = await executeCompanionStructuredAgent({
+      purpose: 'judge',
+      agentName: 'companion-judge',
+      systemPrompt: 'system',
+      prompt: 'prompt',
+      outputSchema: { type: 'object' },
+      cwd: '/worktree',
+      projectCwd: '/project',
+      language: 'en',
+      resolution: { provider: 'mock' },
+      call,
+      validateResponse,
+      recordUsage,
+    });
+
+    expect(result.status).toBe('done');
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(validateResponse).toHaveBeenCalledTimes(2);
+    expect(recordUsage).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      purpose: 'judge',
+      success: false,
+      usage: expect.objectContaining({ totalTokens: 30 }),
+    }));
+    expect(recordUsage).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      purpose: 'judge',
+      success: true,
+      usage: expect.objectContaining({ totalTokens: 30 }),
+    }));
+  });
+
   it.each(['error', 'blocked', 'rate_limited'] as const)(
-    'should record a resolved %s response as failed usage while retaining provider usage',
+    'should retry and then reject a resolved %s response as an internal failure',
     async (status) => {
       const recordUsage = vi.fn();
+      const call = vi.fn().mockResolvedValue(response(status));
 
-      const result = await executeCompanionStructuredAgent({
+      await expect(executeCompanionStructuredAgent({
         purpose: 'reviewer',
         agentName: 'security-reviewer',
         systemPrompt: 'system',
@@ -100,11 +212,12 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
         projectCwd: '/project',
         language: 'en',
         resolution: { provider: 'mock' },
-        call: vi.fn().mockResolvedValue(response(status)),
+        call,
         recordUsage,
-      });
+      })).rejects.toThrow(new RegExp(`returned status "${status}"`));
 
-      expect(result.status).toBe(status);
+      expect(call).toHaveBeenCalledTimes(2);
+      expect(recordUsage).toHaveBeenCalledTimes(2);
       expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({
         success: false,
         usage: expect.objectContaining({ totalTokens: 30 }),
@@ -136,10 +249,11 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
     resolveCall(response('done'));
 
     await expect(execution).rejects.toMatchObject({ name: 'AbortError' });
+    expect(call).toHaveBeenCalledOnce();
     expect(recordUsage).not.toHaveBeenCalled();
   });
 
-  it('should abort and record a failed usage event when one companion call reaches its timeout', async () => {
+  it('should retry and record failed usage when companion calls reach their timeout', async () => {
     vi.useFakeTimers();
     const recordUsage = vi.fn();
     const call = vi.fn((_system, _prompt, _schema, options: { abortSignal: AbortSignal }) => (
@@ -165,9 +279,13 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
         call,
         recordUsage,
       });
+      const rejection = expect(execution).rejects.toThrow(/timeout|timed out/i);
+      await vi.advanceTimersByTimeAsync(100);
       await vi.advanceTimersByTimeAsync(100);
 
-      await expect(execution).rejects.toThrow(/timeout|timed out/i);
+      await rejection;
+      expect(call).toHaveBeenCalledTimes(2);
+      expect(recordUsage).toHaveBeenCalledTimes(2);
       expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({
         purpose: 'reviewer',
         success: false,

--- a/src/__tests__/companion-runtime-lifecycle.integration.test.ts
+++ b/src/__tests__/companion-runtime-lifecycle.integration.test.ts
@@ -252,11 +252,18 @@ describe('companion runtime lifecycle', () => {
       ...step(),
       companion: { fixed: [], pool: ['security-reviewer'] },
     };
-    const callSpy = vi.spyOn(CompanionStructuredCaller.prototype, 'call').mockResolvedValue({
-      status: 'done',
-      content: '',
-      structuredOutput: { selected_ids: ['security-reviewer'], rationale: 'relevant' },
-    });
+    const callSpy = vi.spyOn(CompanionStructuredCaller.prototype, 'call').mockImplementation(
+      async (request) => {
+        const response = {
+          status: 'done' as const,
+          content: '',
+          structuredOutput: { selected_ids: ['security-reviewer'], rationale: 'relevant' },
+        };
+        expect(request.validateResponse).toBeDefined();
+        request.validateResponse!(response);
+        return response;
+      },
+    );
     let runtime: CompanionStepRuntime | undefined;
 
     try {
@@ -382,14 +389,17 @@ describe('companion runtime lifecycle', () => {
       async (request) => {
         schemas.push({ purpose: request.purpose, outputSchema: request.outputSchema });
         if (request.purpose === 'judge') {
-          return {
+          const response = {
             status: 'done',
             content: '',
             structuredOutput: { decision: 'continue', reason: 'continue' },
-          };
+          } as const;
+          expect(request.validateResponse).toBeDefined();
+          request.validateResponse!(response);
+          return response;
         }
         reviewerCalls += 1;
-        return {
+        const response = {
           status: 'done',
           content: '',
           structuredOutput: {
@@ -399,7 +409,10 @@ describe('companion runtime lifecycle', () => {
             updates: [],
             notes: null,
           },
-        };
+        } as const;
+        expect(request.validateResponse).toBeDefined();
+        request.validateResponse!(response);
+        return response;
       },
     );
     const readDiff = vi.fn().mockResolvedValue({ status: 'ok', snapshot });

--- a/src/__tests__/companion-step-executor.integration.test.ts
+++ b/src/__tests__/companion-step-executor.integration.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { WorkflowState } from '../core/models/types.js';
+import type { WorkflowRule, WorkflowState } from '../core/models/types.js';
 import type { CompanionDiffReader } from '../core/workflow/companion/diff-reader.js';
 import { buildCompanionMailboxPath } from '../core/workflow/companion/mailbox.js';
 import { CompanionReviewAuthority } from '../core/workflow/companion/review-state-store.js';
@@ -11,7 +11,7 @@ import { StepExecutor, type StepExecutorDeps } from '../core/workflow/engine/Ste
 import { createStructuredOutputNormalizerRegistry } from '../core/workflow/engine/structured-output-normalizer.js';
 import type { RunPaths } from '../core/workflow/run/run-paths.js';
 import { executeAgent } from '../agents/agent-usecases.js';
-import { makeStep } from './test-helpers.js';
+import { makeRule, makeStep } from './test-helpers.js';
 
 vi.mock('../agents/agent-usecases.js', () => ({
   executeAgent: vi.fn(),
@@ -101,9 +101,9 @@ function createFailingCompletionDiffReader(): CompanionDiffReader {
   };
 }
 
-function createFailingStartupDiffReader(): CompanionDiffReader {
+function createFailingStartupDiffReader(error = new Error('baseline failed')): CompanionDiffReader {
   return {
-    readBaselineSha: vi.fn().mockRejectedValue(new Error('baseline failed')),
+    readBaselineSha: vi.fn().mockRejectedValue(error),
     readDiff: vi.fn(),
   };
 }
@@ -121,13 +121,13 @@ function mockSuccessfulImplementer(): void {
   });
 }
 
-function createCompanionStep() {
+function createCompanionStep(rules: WorkflowRule[] = []) {
   return makeStep({
     name: 'implement',
     persona: 'coder',
     instruction: 'Implement.',
     companion: { fixed: ['security-reviewer'], pool: [] },
-    rules: [],
+    rules,
   });
 }
 
@@ -242,7 +242,7 @@ describe('companion StepExecutor lifecycle', () => {
     expect(getEventListeners(abortController.signal, 'abort')).toHaveLength(0);
   });
 
-  it('should block condition evaluation when companion startup fails', async () => {
+  it('should continue condition evaluation when companion startup fails', async () => {
     const abortController = new AbortController();
     mockSuccessfulImplementer();
     const state = makeState();
@@ -254,7 +254,7 @@ describe('companion StepExecutor lifecycle', () => {
       abortSignal: abortController.signal,
       emitEvent: vi.fn(),
     })).runNormalStep(
-      createCompanionStep(),
+      createCompanionStep([makeRule('Implementation is complete', 'COMPLETE')]),
       state,
       'task',
       5,
@@ -262,8 +262,71 @@ describe('companion StepExecutor lifecycle', () => {
       'Implement.',
     );
 
-    expect(result.response.status).toBe('blocked');
-    expect(state.companion).toBeUndefined();
+    expect(result.response.status).toBe('done');
+    expect(result.response.matchedRuleIndex).toBe(0);
+    expect(state.companion).toMatchObject({
+      completionVerified: false,
+      completionFailure: true,
+      openMustFixCount: 0,
+    });
+  });
+
+  it('should continue when required companion runtime configuration is unavailable', async () => {
+    const abortController = new AbortController();
+    mockSuccessfulImplementer();
+    const state = makeState();
+    const deps = createDeps({
+      cwd,
+      runPaths,
+      companionDiffReader: createCompanionDiffReader(),
+      abortSignal: abortController.signal,
+      emitEvent: vi.fn(),
+    });
+    const incompleteDeps = { ...deps, companionDefinitions: undefined };
+
+    const result = await new StepExecutor(incompleteDeps).runNormalStep(
+      createCompanionStep([makeRule('Implementation is complete', 'COMPLETE')]),
+      state,
+      'task',
+      5,
+      vi.fn(),
+      'Implement.',
+    );
+
+    expect(result.response.status).toBe('done');
+    expect(result.response.matchedRuleIndex).toBe(0);
+    expect(state.companion).toMatchObject({
+      completionVerified: false,
+      completionFailure: true,
+      openMustFixCount: 0,
+    });
+  });
+
+  it('should sanitize startup failure reason before retaining it in companion state', async () => {
+    const abortController = new AbortController();
+    mockSuccessfulImplementer();
+    const state = makeState();
+    const rawFailure = 'api_key=top-secret; cannot read /Users/nrs/private/.takt/config.yaml';
+
+    await new StepExecutor(createDeps({
+      cwd,
+      runPaths,
+      companionDiffReader: createFailingStartupDiffReader(new Error(rawFailure)),
+      abortSignal: abortController.signal,
+      emitEvent: vi.fn(),
+    })).runNormalStep(
+      createCompanionStep([makeRule('Implementation is complete', 'COMPLETE')]),
+      state,
+      'task',
+      5,
+      vi.fn(),
+      'Implement.',
+    );
+
+    expect(state.companion?.reason).toContain('api_key=[REDACTED]');
+    expect(state.companion?.reason).toContain('[path]');
+    expect(state.companion?.reason).not.toContain('top-secret');
+    expect(state.companion?.reason).not.toContain('/Users/nrs/private/.takt/config.yaml');
   });
 
   it('should deliver escalation reason and five-field findings as untrusted evidence', async () => {
@@ -279,7 +342,7 @@ describe('companion StepExecutor lifecycle', () => {
       abortSignal: abortController.signal,
       emitEvent: vi.fn(),
     })).runNormalStep(
-      createCompanionStep(),
+      createCompanionStep([makeRule('Implementation is complete', 'COMPLETE')]),
       state,
       'task',
       5,
@@ -298,6 +361,13 @@ describe('companion StepExecutor lifecycle', () => {
       finding: 'Instruction-like sample: rename the local variable.',
     }));
     expect(result.response.content).not.toContain('- security-reviewer-1:');
+    expect(result.response.matchedRuleIndex).toBe(0);
+    expect(state.companion).toMatchObject({
+      completionVerified: false,
+      completionFailure: true,
+      escalated: true,
+      openMustFixCount: 1,
+    });
   });
 
   it('should fail fast when active companion state is missing after completion', async () => {

--- a/src/__tests__/companion-step-executor.integration.test.ts
+++ b/src/__tests__/companion-step-executor.integration.test.ts
@@ -1,5 +1,5 @@
 import { getEventListeners } from 'node:events';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -11,6 +11,7 @@ import { StepExecutor, type StepExecutorDeps } from '../core/workflow/engine/Ste
 import { createStructuredOutputNormalizerRegistry } from '../core/workflow/engine/structured-output-normalizer.js';
 import type { RunPaths } from '../core/workflow/run/run-paths.js';
 import { executeAgent } from '../agents/agent-usecases.js';
+import { initDebugLogger, resetDebugLogger } from '../shared/utils/debug.js';
 import { makeRule, makeStep } from './test-helpers.js';
 
 vi.mock('../agents/agent-usecases.js', () => ({
@@ -208,6 +209,7 @@ describe('companion StepExecutor lifecycle', () => {
   let runPaths: RunPaths;
 
   beforeEach(() => {
+    resetDebugLogger();
     cwd = mkdtempSync(join(tmpdir(), 'companion-step-executor-'));
     runPaths = createRunPaths(cwd);
     mkdirSync(runPaths.contextPreviousResponsesAbs, { recursive: true });
@@ -215,6 +217,7 @@ describe('companion StepExecutor lifecycle', () => {
   });
 
   afterEach(() => {
+    resetDebugLogger();
     rmSync(cwd, { recursive: true, force: true });
   });
 
@@ -307,6 +310,8 @@ describe('companion StepExecutor lifecycle', () => {
     mockSuccessfulImplementer();
     const state = makeState();
     const rawFailure = 'api_key=top-secret; cannot read /Users/nrs/private/.takt/config.yaml';
+    const debugLogPath = join(cwd, 'debug.log');
+    initDebugLogger({ enabled: true, logFile: debugLogPath }, cwd);
 
     await new StepExecutor(createDeps({
       cwd,
@@ -327,6 +332,11 @@ describe('companion StepExecutor lifecycle', () => {
     expect(state.companion?.reason).toContain('[path]');
     expect(state.companion?.reason).not.toContain('top-secret');
     expect(state.companion?.reason).not.toContain('/Users/nrs/private/.takt/config.yaml');
+    const debugLog = readFileSync(debugLogPath, 'utf8');
+    expect(debugLog).toContain('api_key=[REDACTED]');
+    expect(debugLog).toContain('[path]');
+    expect(debugLog).not.toContain('top-secret');
+    expect(debugLog).not.toContain('/Users/nrs/private/.takt/config.yaml');
   });
 
   it('should deliver escalation reason and five-field findings as untrusted evidence', async () => {

--- a/src/core/models/companion-types.ts
+++ b/src/core/models/companion-types.ts
@@ -41,6 +41,7 @@ export type CompanionFindingEvidence = Pick<
 export interface CompanionWorkflowState {
   escalated: boolean;
   completionVerified: boolean;
+  completionFailure?: boolean;
   openMustFixCount: number;
   openMustFix: CompanionFindingEvidence[];
   reason?: string;

--- a/src/core/workflow/companion/completion-coordinator.ts
+++ b/src/core/workflow/companion/completion-coordinator.ts
@@ -1,7 +1,6 @@
 import type { CompanionFindingEvidence, WorkflowState } from '../../models/types.js';
 import type { CompanionChangeDetector } from './change-detector.js';
 import type { CompanionDiff } from './diff-reader.js';
-import { isAbortError } from './abort.js';
 import type { CompanionEventPublisher } from './event-publisher.js';
 import type { CompanionReviewQueue } from './review-queue.js';
 import type { CompanionTerminalDecisionTracker } from './terminal-decision.js';
@@ -39,13 +38,15 @@ export class CompanionCompletionCoordinator {
     ]));
     let reviewedSnapshot: CompanionDiff | undefined;
     let completionVerified = false;
+    let completionFailure = false;
     try {
       const snapshot = await this.input.readSnapshot();
       await this.completeQueues(snapshot, candidates);
       this.input.synchronizeSnapshot(snapshot);
       reviewedSnapshot = snapshot;
     } catch (error) {
-      if (isAbortError(error) || this.input.abortSignal?.aborted) throw error;
+      if (this.input.abortSignal?.aborted) throw error;
+      completionFailure = true;
       this.preserveCompletionFailure();
       await this.settleQueuesAfterFailure();
     }
@@ -56,7 +57,8 @@ export class CompanionCompletionCoordinator {
         await this.input.recordCompletionRound(reviewedSnapshot);
         completionVerified = true;
       } catch (error) {
-        if (isAbortError(error) || this.input.abortSignal?.aborted) throw error;
+        if (this.input.abortSignal?.aborted) throw error;
+        completionFailure = true;
         this.preserveCompletionFailure();
       }
     }
@@ -64,6 +66,7 @@ export class CompanionCompletionCoordinator {
     state.companion = {
       escalated: decision.decision === 'escalate',
       completionVerified,
+      ...(completionFailure ? { completionFailure: true } : {}),
       openMustFixCount: openMustFix.length,
       openMustFix,
       ...(decision.reason === undefined ? {} : { reason: decision.reason }),
@@ -115,7 +118,7 @@ export class CompanionCompletionCoordinator {
     try {
       await this.settleQueues();
     } catch (error) {
-      if (isAbortError(error) || this.input.abortSignal?.aborted) throw error;
+      if (this.input.abortSignal?.aborted) throw error;
       this.preserveCompletionFailure();
     }
   }

--- a/src/core/workflow/companion/completion-gate.ts
+++ b/src/core/workflow/companion/completion-gate.ts
@@ -3,9 +3,9 @@ import { isNormalAgentWorkflowStep } from '../../models/types.js';
 
 /**
  * Prevents a companion step from entering post-execution condition evaluation
- * while its completion review is unresolved or could not be verified. A
- * verified loop escalation is evidence for the step's ordinary condition
- * judgment, not a request for user intervention.
+ * while its completion review is unresolved. A recorded advisory review
+ * failure does not prevent the main workflow from evaluating its conditions.
+ * A verified loop escalation is also evidence for ordinary condition judgment.
  */
 export function guardCompanionCompletion(
   step: WorkflowStep,
@@ -13,6 +13,10 @@ export function guardCompanionCompletion(
   response: AgentResponse,
 ): AgentResponse {
   if (!isNormalAgentWorkflowStep(step) || step.companion === undefined) {
+    return response;
+  }
+
+  if (response.status === 'blocked' || response.status === 'error' || response.status === 'rate_limited') {
     return response;
   }
 
@@ -27,7 +31,7 @@ export function guardCompanionCompletion(
       status: 'blocked',
     };
   }
-  if (companion.completionVerified !== true) {
+  if (companion.completionVerified !== true && companion.completionFailure !== true) {
     return {
       ...response,
       status: 'blocked',

--- a/src/core/workflow/companion/moderator.ts
+++ b/src/core/workflow/companion/moderator.ts
@@ -1,7 +1,7 @@
 import type { CompanionFinding, CompanionFindingSeverity } from '../../models/companion-types.js';
 import type { CompanionReviewOutput } from './contracts.js';
 
-interface ModeratorResult {
+export interface ModeratorResult {
   readonly findings: readonly {
     action: 'accept' | 'reject' | 'merge' | 'downgrade';
     sourceIndex: number;
@@ -39,7 +39,7 @@ export async function moderateCompanionResult(input: {
       ? {}
       : { implementerExplanation: input.implementerExplanation }),
   });
-  validateDecisions(moderated, input.reviewerResult, input.openFindings);
+  validateModeratorDecisions(moderated, input.reviewerResult, input.openFindings);
   const findings = moderated.findings.flatMap((decision) => {
     const source = input.reviewerResult.findings[decision.sourceIndex]!;
     if (decision.action === 'reject') return [];
@@ -58,7 +58,7 @@ export async function moderateCompanionResult(input: {
   });
 }
 
-function validateDecisions(
+export function validateModeratorDecisions(
   moderated: ModeratorResult,
   reviewerResult: CompanionReviewOutput,
   openFindings: readonly CompanionFinding[],

--- a/src/core/workflow/companion/review-round.ts
+++ b/src/core/workflow/companion/review-round.ts
@@ -9,12 +9,15 @@ import {
 } from './contracts.js';
 import type { CompanionDiff } from './diff-reader.js';
 import type { CompanionLoopRound } from './loop-guard.js';
-import { moderateCompanionResult } from './moderator.js';
+import { moderateCompanionResult, validateModeratorDecisions } from './moderator.js';
 import {
   buildCompanionModeratorPrompt,
   buildCompanionReviewPrompt,
 } from './prompt.js';
-import type { CompanionAgentPurpose } from './review-runner.js';
+import type {
+  CompanionAgentPurpose,
+  CompanionStructuredResponseValidator,
+} from './review-runner.js';
 import type { CompanionReviewStateStore } from './review-state-store.js';
 import type { CompanionReviewOperation } from './review-state-store.js';
 import type { CompanionLoopDecision } from './terminal-decision.js';
@@ -47,6 +50,7 @@ interface CompanionReviewRoundInput {
     prompt: string,
     outputSchema: Record<string, unknown>,
     signal: AbortSignal,
+    validateResponse?: CompanionStructuredResponseValidator,
   ) => Promise<AgentResponse>;
   readonly emitFinding: (
     companionName: string,
@@ -98,6 +102,7 @@ export async function executeCompanionReviewRound(
     }
   }
   const state = input.stateStore.get(mailboxPath, input.companionName);
+  const ownersByFindingId = buildFindingOwnerIndex(input);
   const response = await input.callStructured(
     'reviewer',
     input.companionName,
@@ -116,6 +121,12 @@ export async function executeCompanionReviewRound(
     }),
     REVIEW_OUTPUT_JSON_SCHEMA,
     input.signal,
+    (candidate) => {
+      const reviewerResult = parseCompanionReviewOutput(candidate.structuredOutput);
+      if (input.moderatorName === undefined) {
+        validateUpdates(input, reviewerResult.updates, ownersByFindingId);
+      }
+    },
   );
   input.signal.throwIfAborted();
   const reviewerResult = parseCompanionReviewOutput(response.structuredOutput);
@@ -128,9 +139,10 @@ export async function executeCompanionReviewRound(
   if (moderatorName === undefined) {
     await commit(reviewerResult);
   } else {
+    const openFindings = input.openFindings();
     await moderateCompanionResult({
       reviewerResult,
-      openFindings: input.openFindings(),
+      openFindings,
       diffSummary: input.diffSummary,
       implementerExplanation: input.implementerExplanation,
       runModerator: async (request) => {
@@ -141,6 +153,11 @@ export async function executeCompanionReviewRound(
           buildCompanionModeratorPrompt(request),
           MODERATOR_OUTPUT_JSON_SCHEMA,
           input.signal,
+          (candidate) => {
+            const moderated = parseModeratorOutput(candidate.structuredOutput);
+            validateModeratorDecisions(moderated, reviewerResult, openFindings);
+            validateUpdates(input, moderated.updates, ownersByFindingId);
+          },
         );
         input.signal.throwIfAborted();
         return parseModeratorOutput(moderated.structuredOutput);

--- a/src/core/workflow/companion/review-runner.ts
+++ b/src/core/workflow/companion/review-runner.ts
@@ -2,6 +2,7 @@ import type { AgentResponse, PermissionMode, StepProviderOptions } from '../../m
 import type { ProviderType } from '../../../shared/types/provider.js';
 import { createAbortError } from './abort.js';
 import { appendCompanionEvidenceSystemGuard } from './evidence.js';
+import { safeExternalErrorMessage } from '../../../shared/utils/safeExternalErrorMessage.js';
 
 export type CompanionAgentPurpose = 'selector' | 'reviewer' | 'moderator' | 'judge';
 
@@ -23,9 +24,12 @@ interface CompanionCallOptions {
   abortSignal: AbortSignal;
 }
 
-const COMPANION_CALL_TIMEOUT_MS = 300_000;
+export type CompanionStructuredResponseValidator = (response: AgentResponse) => void;
 
-export function executeCompanionStructuredAgent(input: {
+const COMPANION_CALL_TIMEOUT_MS = 300_000;
+const MAX_COMPANION_CALL_ATTEMPTS = 2;
+
+export async function executeCompanionStructuredAgent(input: {
   purpose: CompanionAgentPurpose;
   agentName: string;
   systemPrompt: string;
@@ -43,6 +47,7 @@ export function executeCompanionStructuredAgent(input: {
     outputSchema: Record<string, unknown>,
     options: CompanionCallOptions,
   ) => Promise<AgentResponse>;
+  validateResponse?: CompanionStructuredResponseValidator;
   recordUsage: (event: {
     purpose: CompanionAgentPurpose;
     agentName: string;
@@ -50,9 +55,30 @@ export function executeCompanionStructuredAgent(input: {
     usage?: AgentResponse['providerUsage'];
   }) => void;
 }): Promise<AgentResponse> {
-  const execution = executeCompanionStructuredAgentInternal(input);
-  void execution.catch(() => undefined);
-  return execution;
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      const response = await executeCompanionStructuredAgentInternal(input);
+      if (response.status === 'done') return response;
+      if (attempt >= MAX_COMPANION_CALL_ATTEMPTS) {
+        throw new Error(companionResponseFailureMessage(input, response));
+      }
+    } catch (error) {
+      if (input.abortSignal?.aborted || attempt >= MAX_COMPANION_CALL_ATTEMPTS) {
+        throw error;
+      }
+    }
+  }
+}
+
+function companionResponseFailureMessage(
+  input: Parameters<typeof executeCompanionStructuredAgent>[0],
+  response: AgentResponse,
+): string {
+  const detail = safeExternalErrorMessage(response.error ?? response.content).trim();
+  return [
+    `Companion ${input.purpose} "${input.agentName}" returned status "${response.status}"`,
+    ...(detail.length === 0 ? [] : [detail]),
+  ].join(': ');
 }
 
 async function executeCompanionStructuredAgentInternal(input: Parameters<
@@ -72,6 +98,7 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
   if (input.abortSignal?.aborted) throw createAbortError(input.abortSignal.reason);
   input.abortSignal?.addEventListener('abort', abortFromParent, { once: true });
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let response: AgentResponse | undefined;
   try {
     const timeoutMs = input.timeoutMs ?? COMPANION_CALL_TIMEOUT_MS;
     const timeout = new Promise<never>((_resolve, reject) => {
@@ -80,6 +107,7 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
         controller.abort();
       }, timeoutMs);
     });
+    void timeout.catch(() => undefined);
     const call = input.call(
       appendCompanionEvidenceSystemGuard(input.systemPrompt),
       input.prompt,
@@ -97,11 +125,14 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
       },
     );
     void call.catch(() => undefined);
-    const response = await Promise.race([
+    response = await Promise.race([
       call,
       timeout,
       parentAbort,
     ]);
+    if (response.status === 'done') {
+      input.validateResponse?.(response);
+    }
     input.recordUsage({
       purpose: input.purpose,
       agentName: input.agentName,
@@ -115,6 +146,7 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
         purpose: input.purpose,
         agentName: input.agentName,
         success: false,
+        usage: response?.providerUsage,
       });
     }
     throw error;

--- a/src/core/workflow/companion/step-runtime.ts
+++ b/src/core/workflow/companion/step-runtime.ts
@@ -268,6 +268,14 @@ export class CompanionStepRuntime {
     const provider = this.deps.selectorProvider;
     if (provider === undefined) throw new Error('Companion pool selector has no resolved provider');
     const selectorContract = createSelectorContract(request.candidates, request.maxSelected);
+    const redact = (text: string): string => sanitizeCompanionSelectorRationale(text, request);
+    const validateSelection = (response: AgentResponse) => validateSelectorResponse(
+      response,
+      selectorContract.validationSchema,
+      this.deps.step.name,
+      redact,
+      { label: 'Companion' },
+    );
     const response = await this.structuredCaller.call({
       purpose: 'selector',
       agentName: 'companion-selector',
@@ -275,15 +283,9 @@ export class CompanionStepRuntime {
       systemPrompt: 'Select companion reviewer IDs relevant to this task. Do not select more than maxSelected.',
       prompt: JSON.stringify(request),
       outputSchema: selectorContract.providerSchema,
+      validateResponse: validateSelection,
     });
-    const redact = (text: string): string => sanitizeCompanionSelectorRationale(text, request);
-    const selected = validateSelectorResponse(
-      response,
-      selectorContract.validationSchema,
-      this.deps.step.name,
-      redact,
-      { label: 'Companion' },
-    );
+    const selected = validateSelection(response);
     const rationale = sanitizeCompanionSelectorRationale(selected.rationale, request);
     this.events.poolSelected(selected.selectedIds, rationale);
     return { selectedIds: [...selected.selectedIds], rationale };
@@ -317,7 +319,15 @@ export class CompanionStepRuntime {
         mailboxPath: (name) => this.mailboxPath(name),
         systemPrompt: (name) => this.definitionSystemPrompt(name),
         openFindings: () => this.openFindings(),
-        callStructured: async (purpose, agentName, systemPrompt, prompt, schema, reviewSignal) => (
+        callStructured: async (
+          purpose,
+          agentName,
+          systemPrompt,
+          prompt,
+          schema,
+          reviewSignal,
+          validateResponse,
+        ) => (
           this.structuredCaller.call({
             purpose,
             agentName,
@@ -326,6 +336,7 @@ export class CompanionStepRuntime {
             prompt,
             outputSchema: schema,
             abortSignal: reviewSignal,
+            validateResponse,
           })
         ),
         emitFinding: (ownerName, findingId, severity) => {
@@ -389,6 +400,9 @@ export class CompanionStepRuntime {
           prompt: buildCompanionLoopJudgePrompt(judgeHistory, signals),
           outputSchema: LOOP_JUDGE_OUTPUT_JSON_SCHEMA,
           abortSignal,
+          validateResponse: (candidate) => {
+            parseLoopJudgeOutput(candidate.structuredOutput);
+          },
         });
         return parseLoopJudgeOutput(response.structuredOutput);
       },

--- a/src/core/workflow/companion/structured-call.ts
+++ b/src/core/workflow/companion/structured-call.ts
@@ -1,7 +1,11 @@
 import { executeIsolatedStructuredInternalAgent } from '../../../agents/agent-usecases.js';
 import type { AgentResponse } from '../../models/types.js';
 import type { ProviderRoutingEntry } from '../../models/config-types.js';
-import { executeCompanionStructuredAgent, type CompanionAgentPurpose } from './review-runner.js';
+import {
+  executeCompanionStructuredAgent,
+  type CompanionAgentPurpose,
+  type CompanionStructuredResponseValidator,
+} from './review-runner.js';
 
 export class CompanionStructuredCaller {
   constructor(private readonly input: {
@@ -25,6 +29,7 @@ export class CompanionStructuredCaller {
     readonly prompt: string;
     readonly outputSchema: Record<string, unknown>;
     readonly abortSignal?: AbortSignal;
+    readonly validateResponse?: CompanionStructuredResponseValidator;
   }): Promise<AgentResponse> {
     if (request.provider.provider === undefined) {
       throw new Error(`Companion "${request.agentName}" has no provider`);
@@ -45,6 +50,7 @@ export class CompanionStructuredCaller {
         providerOptions: request.provider.providerOptions ?? {},
       },
       abortSignal: signal,
+      validateResponse: request.validateResponse,
       call: (systemPrompt, prompt, schema, options) => executeIsolatedStructuredInternalAgent(
         systemPrompt,
         prompt,

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -58,6 +58,7 @@ import type {
 import { buildSessionKey } from '../session-key.js';
 import { incrementStepIteration, getPreviousOutput } from './state-manager.js';
 import { createLogger, getErrorMessage, slugify } from '../../../shared/utils/index.js';
+import { safeExternalErrorMessage } from '../../../shared/utils/safeExternalErrorMessage.js';
 import type { OptionsBuilder } from './OptionsBuilder.js';
 import type { RunPaths } from '../run/run-paths.js';
 import { waitForStepDelay } from './step-delay.js';
@@ -2610,14 +2611,6 @@ export class StepExecutor {
       const companionProviders = this.deps.companionProviders;
       const companionDiffReader = this.deps.companionDiffReader;
       const companionReviewState = this.companionReviewState;
-      if (
-        companionDefinitions === undefined
-        || companionProviders === undefined
-        || companionDiffReader === undefined
-        || companionReviewState === undefined
-      ) {
-        throw new Error(`Companion runtime configuration is missing for step "${step.name}"`);
-      }
       state.companion = {
         escalated: false,
         completionVerified: false,
@@ -2625,6 +2618,14 @@ export class StepExecutor {
         openMustFix: [],
       };
       try {
+        if (
+          companionDefinitions === undefined
+          || companionProviders === undefined
+          || companionDiffReader === undefined
+          || companionReviewState === undefined
+        ) {
+          throw new Error(`Companion runtime configuration is missing for step "${step.name}"`);
+        }
         companionRuntime = await CompanionStepRuntime.create({
           cwd: this.deps.getCwd(),
           projectCwd: this.deps.getProjectCwd(),
@@ -2655,9 +2656,14 @@ export class StepExecutor {
         });
       } catch (error) {
         this.deps.abortSignal?.throwIfAborted();
-        delete state.companion;
+        const reason = safeExternalErrorMessage(error);
+        state.companion = {
+          ...requireActiveCompanionState(state, step.name),
+          completionFailure: true,
+          reason,
+        };
         log.warn(
-          `Companion startup failed for "${step.name}"; main step will continue but completion remains blocked: ${getErrorMessage(error)}`,
+          `Companion startup failed for "${step.name}"; main step will continue without completion review: ${reason}`,
         );
       }
     }


### PR DESCRIPTION
## 目的

Companionのreviewer・moderator・selector・judgeが一時失敗または不正なstructured outputを返したとき、再試行せず主workflowを`blocked`にしてしまう問題を修正します。

## 変更内容

- Companionの全structured internal agent callを最大2回まで再試行
- provider status、例外、parse/semantic validation失敗を同じ再試行境界で処理
- 親workflowのabortのみ即時伝播し、provider由来のAbortErrorは再試行
- 再試行後もCompanionが失敗した場合はadvisory failureとして記録し、主agentの条件評価を継続
- 主agent自身の`blocked`/`error`/`rate_limited`と、検証済みのmust-fix残存は従来どおり維持
- startup failure reasonをsanitizeして状態とログへ保存

## 検証

- 対象unit/heavy IT: 114件成功
- `npm test`: 6014件成功
- `npm run test:it`: 2356件成功
- `npm run build`: 成功
- `npm run lint`: 成功
- `npm run test:e2e:mock`: 成功
- `npm run test:prompt-evals`: 11ケース成功
- `git diff --check`: 成功

`npm run check:release`は実行していません。

## レビュー

Luna実装者と独立した敵対レビュアーで相互レビューを実施しました。初回指摘のsemantic validation境界、startup failure、AbortError分類、機密情報sanitizeを修正し、最終再レビューはAPPROVEでした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - コンパニオン処理の完了に失敗した場合も、失敗状態を記録してメイン処理を継続できるようになりました。
  - 応答の検証を強化し、不正な更新や無効な出力を適切に扱えるようになりました。
  - 呼び出し失敗、タイムアウト、一時的なエラー時に自動再試行します。
  - 中断操作は再試行せず、元の中断状態を維持します。
  - 起動失敗や設定不足時も安全なエラー情報を表示し、内部情報の漏えいを防ぎます。
  - `blocked`、`error`、`rate_limited` の応答は、元の状態を保持して返します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->