### PR TITLE
chore: persist release check output

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "test:e2e:opencode": "npm run test:e2e:provider:opencode",
     "test:e2e:cursor": "npm run test:e2e:provider:cursor",
     "lint": "eslint src/",
-    "check:release": "npm run build && npm run lint && npm run test && npm run test:it:all && npm run test:e2e:all; code=$?; if [ \"$code\" -eq 0 ]; then msg='check:release passed'; else msg=\"check:release failed (exit=$code)\"; fi; if command -v osascript >/dev/null 2>&1; then osascript -e \"display notification \\\"$msg\\\" with title \\\"takt\\\" subtitle \\\"Release Check\\\"\" >/dev/null 2>&1 || true; fi; echo \"[takt] $msg\"; exit $code",
+    "check:release": "node scripts/run-release-check.mjs",
     "prepublishOnly": "npm run lint && npm run build",
     "canary:coder": "node scripts/canary-coder.mjs"
   },

--- a/scripts/run-release-check.mjs
+++ b/scripts/run-release-check.mjs
@@ -1,0 +1,143 @@
+import { createWriteStream, mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { resolveNpmInvocation } from './npm-invocation.mjs';
+import { runTeedCommand } from './teed-command.mjs';
+
+export const RELEASE_GATE_SCRIPTS = Object.freeze([
+  'build',
+  'lint',
+  'test',
+  'test:it:all',
+  'test:e2e:all',
+]);
+export const RELEASE_LOG_RELATIVE_PATH = '.takt/quality-gates/logs/check-release.log';
+const RELEASE_LOG_MESSAGE = `[takt] check:release log: ${RELEASE_LOG_RELATIVE_PATH}`;
+const releaseLogErrors = new WeakMap();
+
+function writeMessage(message, logStream, output) {
+  const line = `${message}\n`;
+  logStream.write(line);
+  output.write(line);
+}
+
+function openReleaseLog() {
+  const logPath = join(process.cwd(), RELEASE_LOG_RELATIVE_PATH);
+  mkdirSync(dirname(logPath), { recursive: true });
+  return new Promise((resolve, reject) => {
+    const logStream = createWriteStream(logPath, { flags: 'w' });
+    releaseLogErrors.set(logStream, null);
+    logStream.on('error', (error) => {
+      if (releaseLogErrors.get(logStream) === null) {
+        releaseLogErrors.set(logStream, error);
+      }
+    });
+    logStream.once('open', () => resolve(logStream));
+    logStream.once('error', reject);
+  });
+}
+
+function getReleaseLogError(logStream) {
+  return releaseLogErrors.get(logStream);
+}
+
+function closeReleaseLog(logStream) {
+  if (logStream.destroyed || logStream.errored) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    logStream.once('finish', resolve);
+    logStream.once('error', reject);
+    logStream.end();
+  });
+}
+
+function notifyReleaseResult(message) {
+  spawnSync(
+    'osascript',
+    ['-e', `display notification "${message}" with title "takt" subtitle "Release Check"`],
+    { stdio: 'ignore' },
+  );
+}
+
+async function runNpmCommand(npmArgs, logStream) {
+  try {
+    const invocation = resolveNpmInvocation(process.execPath, process.env.npm_execpath);
+    return await runTeedCommand(invocation.executable, [...invocation.args, ...npmArgs], {
+      logStream,
+    });
+  } catch (error) {
+    writeMessage(
+      `[takt] Failed to run npm ${npmArgs.join(' ')}: ${error.message}`,
+      logStream,
+      process.stderr,
+    );
+    return {
+      code: 1,
+      signal: null,
+      output: '',
+    };
+  }
+}
+
+export async function runReleaseCheck(runCommand = runNpmCommand) {
+  let logStream;
+  try {
+    logStream = await openReleaseLog();
+  } catch (error) {
+    process.stdout.write(`${RELEASE_LOG_MESSAGE}\n`);
+    process.stderr.write(`[takt] Failed to open release log: ${error.message}\n`);
+    const message = '[takt] check:release failed (exit=1)';
+    notifyReleaseResult(message.replace('[takt] ', ''));
+    process.stdout.write(`${message}\n`);
+    return 1;
+  }
+  writeMessage(RELEASE_LOG_MESSAGE, logStream, process.stdout);
+
+  let code = 0;
+  try {
+    for (const script of RELEASE_GATE_SCRIPTS) {
+      const result = await runCommand(['run', script], logStream);
+      if (result.code !== 0) {
+        code = result.code;
+        break;
+      }
+      const logError = getReleaseLogError(logStream);
+      if (logError !== null) {
+        code = 1;
+        process.stderr.write(`[takt] Release log failed: ${logError.message}\n`);
+        break;
+      }
+    }
+  } catch (error) {
+    code = 1;
+    writeMessage(`[takt] Release check failed: ${error.message}`, logStream, process.stderr);
+  }
+
+  const message = code === 0
+    ? '[takt] check:release passed'
+    : `[takt] check:release failed (exit=${code})`;
+  if (getReleaseLogError(logStream) === null) {
+    logStream.write(`${message}\n`);
+  }
+  let closeError;
+  try {
+    await closeReleaseLog(logStream);
+  } catch (error) {
+    closeError = error;
+    process.stderr.write(`[takt] Failed to close release log: ${error.message}\n`);
+  }
+  const finalCode = code === 0 && closeError !== undefined ? 1 : code;
+  const finalMessage = finalCode === 0
+    ? '[takt] check:release passed'
+    : `[takt] check:release failed (exit=${finalCode})`;
+  notifyReleaseResult(finalMessage.replace('[takt] ', ''));
+  process.stdout.write(`${finalMessage}\n`);
+  return finalCode;
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  const code = await runReleaseCheck();
+  process.exitCode = code;
+}

--- a/scripts/run-release-check.mjs
+++ b/scripts/run-release-check.mjs
@@ -27,14 +27,17 @@ function openReleaseLog() {
   mkdirSync(dirname(logPath), { recursive: true });
   return new Promise((resolve, reject) => {
     const logStream = createWriteStream(logPath, { flags: 'w' });
-    releaseLogErrors.set(logStream, null);
-    logStream.on('error', (error) => {
-      if (releaseLogErrors.get(logStream) === null) {
-        releaseLogErrors.set(logStream, error);
-      }
-    });
     logStream.once('open', () => resolve(logStream));
     logStream.once('error', reject);
+  });
+}
+
+function trackReleaseLogErrors(logStream) {
+  releaseLogErrors.set(logStream, null);
+  logStream.on('error', (error) => {
+    if (releaseLogErrors.get(logStream) === null) {
+      releaseLogErrors.set(logStream, error);
+    }
   });
 }
 
@@ -43,7 +46,11 @@ function getReleaseLogError(logStream) {
 }
 
 function closeReleaseLog(logStream) {
-  if (logStream.destroyed || logStream.errored) {
+  const logError = getReleaseLogError(logStream) ?? logStream.errored;
+  if (logError) {
+    return Promise.reject(logError);
+  }
+  if (logStream.destroyed) {
     return Promise.resolve();
   }
   return new Promise((resolve, reject) => {
@@ -81,10 +88,10 @@ async function runNpmCommand(npmArgs, logStream) {
   }
 }
 
-export async function runReleaseCheck(runCommand = runNpmCommand) {
+export async function runReleaseCheck(runCommand = runNpmCommand, openLog = openReleaseLog) {
   let logStream;
   try {
-    logStream = await openReleaseLog();
+    logStream = await openLog();
   } catch (error) {
     process.stdout.write(`${RELEASE_LOG_MESSAGE}\n`);
     process.stderr.write(`[takt] Failed to open release log: ${error.message}\n`);
@@ -93,6 +100,7 @@ export async function runReleaseCheck(runCommand = runNpmCommand) {
     process.stdout.write(`${message}\n`);
     return 1;
   }
+  trackReleaseLogErrors(logStream);
   writeMessage(RELEASE_LOG_MESSAGE, logStream, process.stdout);
 
   let code = 0;
@@ -128,7 +136,10 @@ export async function runReleaseCheck(runCommand = runNpmCommand) {
     closeError = error;
     process.stderr.write(`[takt] Failed to close release log: ${error.message}\n`);
   }
-  const finalCode = code === 0 && closeError !== undefined ? 1 : code;
+  const finalCode = code === 0
+    && (getReleaseLogError(logStream) !== null || closeError !== undefined)
+    ? 1
+    : code;
   const finalMessage = finalCode === 0
     ? '[takt] check:release passed'
     : `[takt] check:release failed (exit=${finalCode})`;

--- a/scripts/teed-command.mjs
+++ b/scripts/teed-command.mjs
@@ -9,43 +9,85 @@ const STDIO_DRAIN_DEADLINE_MS = 3000;
 /**
  * Runs a command with its stdout/stderr forwarded to this process as they
  * arrive, and resolves with the exit status plus everything that was forwarded.
- * Rejects when the command cannot be started.
+ * When a log stream is provided, the same chunks are written to it as they
+ * arrive. Rejects when the command or log stream cannot be used.
  */
-export function runTeedCommand(executable, args) {
+export function runTeedCommand(executable, args, options) {
+  const logStream = options?.logStream;
   return new Promise((resolve, reject) => {
-    const child = spawn(executable, args, {
+    let child = spawn(executable, args, {
       stdio: ['inherit', 'pipe', 'pipe'],
       shell: false,
     });
-    const chunks = [];
+    let chunks = [];
     let exitStatus;
     let stdioClosed = false;
     let drainTimer;
     let isSettled = false;
+    let pendingLogWrites = 0;
 
-    const settle = () => {
-      if (isSettled || exitStatus === undefined) {
+    const rejectWithError = (error) => {
+      if (isSettled) {
         return;
       }
       isSettled = true;
       clearTimeout(drainTimer);
+      child.kill();
+      child = null;
+      chunks = [];
+      reject(error);
+    };
+
+    const settle = () => {
+      if (isSettled || exitStatus === undefined || pendingLogWrites > 0) {
+        return;
+      }
+      isSettled = true;
+      clearTimeout(drainTimer);
+      const output = Buffer.concat(chunks).toString('utf8');
+      child = null;
+      chunks = [];
       resolve({
         code: exitStatus.code ?? 1,
         signal: exitStatus.signal,
-        output: Buffer.concat(chunks).toString('utf8'),
+        output,
       });
     };
 
     const tee = (source, sink) => {
       source.on('data', (chunk) => {
-        chunks.push(chunk);
         sink.write(chunk);
+        if (isSettled) {
+          return;
+        }
+        chunks.push(chunk);
+        if (logStream === undefined) {
+          return;
+        }
+        pendingLogWrites += 1;
+        try {
+          logStream.write(chunk, (error) => {
+            pendingLogWrites -= 1;
+            if (error) {
+              rejectWithError(error);
+              return;
+            }
+            settle();
+          });
+        } catch (error) {
+          pendingLogWrites -= 1;
+          rejectWithError(error);
+        }
       });
     };
+    logStream?.on('error', rejectWithError);
     tee(child.stdout, process.stdout);
     tee(child.stderr, process.stderr);
 
     child.on('exit', (code, signal) => {
+      if (isSettled) {
+        return;
+      }
       exitStatus = { code, signal };
       if (stdioClosed) {
         settle();
@@ -60,12 +102,7 @@ export function runTeedCommand(executable, args) {
     });
 
     child.on('error', (error) => {
-      if (isSettled) {
-        return;
-      }
-      isSettled = true;
-      clearTimeout(drainTimer);
-      reject(error);
+      rejectWithError(error);
     });
   });
 }

--- a/src/__tests__/it-teed-command.test.ts
+++ b/src/__tests__/it-teed-command.test.ts
@@ -92,7 +92,7 @@ describe('teed command execution', () => {
   });
 
   it('should reject and stop the child when the log stream fails', async () => {
-    captureStdout();
+    const written = captureStdout();
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     const logStream = new Writable({
       write(_chunk, _encoding, callback) {
@@ -100,10 +100,15 @@ describe('teed command execution', () => {
       },
     });
 
-    await expect(runTeedCommand(process.execPath, [
+    const pending = runTeedCommand(process.execPath, [
       '-e',
-      "setInterval(() => process.stdout.write('still-running\\n'), 10);",
-    ], { logStream })).rejects.toThrow('log stream failed');
+      "process.on('SIGTERM', () => process.stdout.write('received-sigterm\\n', () => process.exit(0)));"
+      + " process.stdout.write('trigger-log-failure\\n');"
+      + ' setInterval(() => {}, 1000);',
+    ], { logStream });
+
+    await expect(pending).rejects.toThrow('log stream failed');
+    await waitUntil(() => written.join('').includes('received-sigterm'), 5000);
   });
 
   it('should settle within the drain deadline when a grandchild still holds the pipe', async () => {

--- a/src/__tests__/it-teed-command.test.ts
+++ b/src/__tests__/it-teed-command.test.ts
@@ -102,9 +102,9 @@ describe('teed command execution', () => {
 
     const pending = runTeedCommand(process.execPath, [
       '-e',
-      "process.on('SIGTERM', () => process.stdout.write('received-sigterm\\n', () => process.exit(0)));"
+      "const fallback = setTimeout(() => process.exit(0), 1000);"
+      + " process.on('SIGTERM', () => { clearTimeout(fallback); process.stdout.write('received-sigterm\\n', () => process.exit(0)); });"
       + " process.stdout.write('trigger-log-failure\\n');"
-      + ' setInterval(() => {}, 1000);',
     ], { logStream });
 
     await expect(pending).rejects.toThrow('log stream failed');

--- a/src/__tests__/it-teed-command.test.ts
+++ b/src/__tests__/it-teed-command.test.ts
@@ -1,3 +1,8 @@
+import { once } from 'node:events';
+import { createWriteStream, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Writable } from 'node:stream';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { runTeedCommand } from '../../scripts/teed-command.mjs';
 
@@ -57,6 +62,48 @@ describe('teed command execution', () => {
     expect(result.code).toBe(3);
     expect(result.output).toContain('on-stdout');
     expect(result.output).toContain('on-stderr');
+  });
+
+  it('should write forwarded stdout and stderr to the provided log stream', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'takt-teed-command-log-'));
+    const logPath = join(tempRoot, 'command.log');
+    const logStream = createWriteStream(logPath, { flags: 'w' });
+    captureStdout();
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      await once(logStream, 'open');
+      await runTeedCommand(process.execPath, [
+        '-e',
+        "process.stdout.write('logged-stdout\\n'); process.stderr.write('logged-stderr\\n');",
+      ], { logStream });
+      logStream.end();
+      await once(logStream, 'finish');
+
+      const log = readFileSync(logPath, 'utf8');
+      expect(log).toContain('logged-stdout');
+      expect(log).toContain('logged-stderr');
+    } finally {
+      if (!logStream.closed) {
+        logStream.destroy();
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('should reject and stop the child when the log stream fails', async () => {
+    captureStdout();
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const logStream = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback(new Error('log stream failed'));
+      },
+    });
+
+    await expect(runTeedCommand(process.execPath, [
+      '-e',
+      "setInterval(() => process.stdout.write('still-running\\n'), 10);",
+    ], { logStream })).rejects.toThrow('log stream failed');
   });
 
   it('should settle within the drain deadline when a grandchild still holds the pipe', async () => {

--- a/src/__tests__/releaseVerificationWiring.test.ts
+++ b/src/__tests__/releaseVerificationWiring.test.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from 'node:child_process';
 import {
-  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -11,7 +10,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, join, relative } from 'node:path';
+import { basename, dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
@@ -35,6 +34,10 @@ import serialGitConfig from '../../vitest.config.it.serial.git.js';
 import serialWorkflowConfig from '../../vitest.config.it.serial.workflow.js';
 import unitConfig from '../../vitest.config.unit.parallel.js';
 import { selectNpmTestRuns } from '../../scripts/run-npm-test.mjs';
+import {
+  RELEASE_GATE_SCRIPTS,
+  RELEASE_LOG_RELATIVE_PATH,
+} from '../../scripts/run-release-check.mjs';
 
 interface PackageManifest {
   scripts: Record<string, string>;
@@ -178,44 +181,49 @@ function hasIntegrationFileName(filePath: string): boolean {
     || fileName.endsWith('.performance.test.ts');
 }
 
-function releaseCommands(): string[] {
-  const [gateCommands, notification] = manifest.scripts['check:release'].split('; code=$?;');
-  expect(notification).toContain('exit $code');
-  return gateCommands.split(' && ');
-}
-
 function executeReleaseScript(failingCommand: string | undefined): {
   commands: string[];
   status: number | null;
   stdout: string;
+  log: string;
 } {
   const tempRoot = mkdtempSync(join(tmpdir(), 'takt-release-verification-'));
   const binDir = join(tempRoot, 'bin');
   const logPath = join(tempRoot, 'npm.log');
-  const npmStubPath = join(binDir, 'npm');
+  const releaseLogPath = join(process.cwd(), RELEASE_LOG_RELATIVE_PATH);
+  const npmStubPath = join(binDir, 'npm-cli.js');
   mkdirSync(binDir);
-  writeFileSync(npmStubPath, `#!/bin/sh
-printf '%s\\n' "$*" >> "$TAKT_RELEASE_LOG"
-if [ "$*" = "$TAKT_FAIL_COMMAND" ]; then
-  exit 23
-fi
-`);
-  chmodSync(npmStubPath, 0o755);
+  writeFileSync(npmStubPath, `
+import { appendFileSync } from 'node:fs';
+
+const command = process.argv.slice(2).join(' ');
+appendFileSync(process.env.TAKT_RELEASE_LOG, command + '\\n');
+process.stdout.write('stdout:' + command + '\\n');
+process.stderr.write('stderr:' + command + '\\n');
+if (command === process.env.TAKT_FAIL_COMMAND) {
+  process.exit(23);
+}
+  `);
+  mkdirSync(dirname(releaseLogPath), { recursive: true });
+  writeFileSync(releaseLogPath, 'stale log entry\\n');
 
   try {
     const result = spawnSync('/bin/sh', ['-c', manifest.scripts['check:release']], {
       encoding: 'utf8',
       env: {
         ...process.env,
-        PATH: binDir,
+        PATH: `${binDir}:${process.env.PATH}`,
+        npm_execpath: npmStubPath,
         TAKT_FAIL_COMMAND: failingCommand === undefined ? '' : failingCommand,
         TAKT_RELEASE_LOG: logPath,
       },
     });
     const commands = readFileSync(logPath, 'utf8').trim().split('\n');
-    return { commands, status: result.status, stdout: result.stdout };
+    const log = readFileSync(releaseLogPath, 'utf8');
+    return { commands, status: result.status, stdout: result.stdout, log };
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
+    rmSync(releaseLogPath, { force: true });
   }
 }
 
@@ -240,16 +248,15 @@ describe('release verification wiring', () => {
   });
 
   it('should run every release gate once', () => {
-    const commands = releaseCommands();
-
-    expect(commands).toEqual([
-      'npm run build',
-      'npm run lint',
-      'npm run test',
-      'npm run test:it:all',
-      'npm run test:e2e:all',
+    expect(manifest.scripts['check:release']).toBe('node scripts/run-release-check.mjs');
+    expect(RELEASE_GATE_SCRIPTS).toEqual([
+      'build',
+      'lint',
+      'test',
+      'test:it:all',
+      'test:e2e:all',
     ]);
-    expect(new Set(commands).size).toBe(commands.length);
+    expect(new Set(RELEASE_GATE_SCRIPTS).size).toBe(RELEASE_GATE_SCRIPTS.length);
   });
 
   it('should run light integration and isolated heavy integration shards as pull-request gates', () => {
@@ -313,7 +320,12 @@ describe('release verification wiring', () => {
       'run test:e2e:all',
     ]);
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`[takt] check:release log: ${RELEASE_LOG_RELATIVE_PATH}`);
     expect(result.stdout).toContain('[takt] check:release passed');
+    expect(result.log).toContain(`[takt] check:release log: ${RELEASE_LOG_RELATIVE_PATH}`);
+    expect(result.log).toContain('stdout:run build');
+    expect(result.log).toContain('stderr:run build');
+    expect(result.log).not.toContain('stale log entry');
   });
 
   it.each([
@@ -343,7 +355,10 @@ describe('release verification wiring', () => {
 
     expect(result.commands).toEqual(expectedCommands);
     expect(result.status).toBe(23);
+    expect(result.stdout).toContain(`[takt] check:release log: ${RELEASE_LOG_RELATIVE_PATH}`);
     expect(result.stdout).toContain('[takt] check:release failed (exit=23)');
+    expect(result.log).toContain('[takt] check:release failed (exit=23)');
+    expect(result.log).not.toContain('stale log entry');
   });
 
   it('should keep fast unit and integration classifications disjoint', () => {

--- a/src/__tests__/releaseVerificationWiring.test.ts
+++ b/src/__tests__/releaseVerificationWiring.test.ts
@@ -11,9 +11,10 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, relative } from 'node:path';
+import { Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 import {
   auditedIntegrationBoundaryTestFiles,
@@ -37,6 +38,7 @@ import { selectNpmTestRuns } from '../../scripts/run-npm-test.mjs';
 import {
   RELEASE_GATE_SCRIPTS,
   RELEASE_LOG_RELATIVE_PATH,
+  runReleaseCheck,
 } from '../../scripts/run-release-check.mjs';
 
 interface PackageManifest {
@@ -188,9 +190,10 @@ function executeReleaseScript(failingCommand: string | undefined): {
   log: string;
 } {
   const tempRoot = mkdtempSync(join(tmpdir(), 'takt-release-verification-'));
+  const repositoryRoot = process.cwd();
   const binDir = join(tempRoot, 'bin');
   const logPath = join(tempRoot, 'npm.log');
-  const releaseLogPath = join(process.cwd(), RELEASE_LOG_RELATIVE_PATH);
+  const releaseLogPath = join(tempRoot, RELEASE_LOG_RELATIVE_PATH);
   const npmStubPath = join(binDir, 'npm-cli.js');
   mkdirSync(binDir);
   writeFileSync(npmStubPath, `
@@ -208,11 +211,11 @@ if (command === process.env.TAKT_FAIL_COMMAND) {
   writeFileSync(releaseLogPath, 'stale log entry\\n');
 
   try {
-    const result = spawnSync('/bin/sh', ['-c', manifest.scripts['check:release']], {
+    const result = spawnSync(process.execPath, [join(repositoryRoot, 'scripts/run-release-check.mjs')], {
       encoding: 'utf8',
+      cwd: tempRoot,
       env: {
         ...process.env,
-        PATH: `${binDir}:${process.env.PATH}`,
         npm_execpath: npmStubPath,
         TAKT_FAIL_COMMAND: failingCommand === undefined ? '' : failingCommand,
         TAKT_RELEASE_LOG: logPath,
@@ -223,7 +226,6 @@ if (command === process.env.TAKT_FAIL_COMMAND) {
     return { commands, status: result.status, stdout: result.stdout, log };
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
-    rmSync(releaseLogPath, { force: true });
   }
 }
 
@@ -326,6 +328,23 @@ describe('release verification wiring', () => {
     expect(result.log).toContain('stdout:run build');
     expect(result.log).toContain('stderr:run build');
     expect(result.log).not.toContain('stale log entry');
+  });
+
+  it('should fail when the release log rejects the final result write', async () => {
+    const logStream = new Writable({
+      write(chunk, _encoding, callback) {
+        const error = chunk.toString().includes('check:release passed')
+          ? new Error('final release log write failed')
+          : undefined;
+        callback(error);
+      },
+    });
+    const runCommand = vi.fn().mockResolvedValue({ code: 0, signal: null, output: '' });
+
+    const code = await runReleaseCheck(runCommand, async () => logStream);
+
+    expect(runCommand).toHaveBeenCalledTimes(RELEASE_GATE_SCRIPTS.length);
+    expect(code).toBe(1);
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- `npm run check:release` の stdout / stderr を端末へリアルタイム表示しながら、`.takt/quality-gates/logs/check-release.log` に保存します。
- ログは実行開始時に上書きし、失敗途中の出力と最終結果を後から確認できるようにします。
- 既存のゲート順序、fail-fast、終了コード、macOS 通知を維持します。
- ログ書き込み失敗時は子プロセスを停止し、release check 自体を失敗させます。

## Validation

- `npm run build`
- `npm run lint`
- `npm test`
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts`
- `npm test -- src/__tests__/it-teed-command.test.ts`

`npm run check:release` 全体と実 provider E2E は実行していません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * リリース前にビルド、Lint、各種テストを順番に実行し、失敗時は後続処理を停止するようになりました。
  * 実行結果を画面とログファイルへ同時に記録し、ログの作成・書き込みエラーを検知します。
  * 実行結果を終了コードに反映し、失敗時にはmacOS通知を表示します。
* **テスト**
  * コマンド出力の記録、書き込みエラー、失敗時の処理停止を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->