### PR TITLE
fix: make companion review execution auditable

### DIFF
--- a/src/__tests__/companion-change-detector.test.ts
+++ b/src/__tests__/companion-change-detector.test.ts
@@ -149,6 +149,27 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
     expect(await evaluateLive(detector)).toBeUndefined();
   });
 
+  it('should report the concrete live skip reason once when a candidate is consumed', async () => {
+    let now = 1_000;
+    const detector = new CompanionChangeDetector({
+      intervalMs: 100,
+      minimumChangedLines: 10,
+      now: () => now,
+      readDiff: vi.fn(),
+    });
+    detector.observe(tool('Edit'));
+    now = 1_100;
+    const candidate = detector.getTriggerCandidate(100);
+    const skipped: string[] = [];
+
+    expect(await detector.evaluateCandidate(candidate!, diff('small', 1), (reason) => {
+      skipped.push(reason);
+    })).toBeUndefined();
+    expect(skipped).toEqual(['below_minimum_changed_lines']);
+    expect(await evaluateLive(detector, diff('small', 1))).toBeUndefined();
+    expect(skipped).toEqual(['below_minimum_changed_lines']);
+  });
+
   it('should force a trigger after four intervals even when edits never become quiet', async () => {
     let now = 1_000;
     const detector = new CompanionChangeDetector({
@@ -549,6 +570,62 @@ describe('CT-COMP-05 event-driven companion change detection', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('should suppress a live skip when completion starts during candidate evaluation', async () => {
+    let now = 1_000;
+    let resolveSnapshot!: (snapshot: CompanionDiff) => void;
+    let releaseCandidate!: () => void;
+    let candidateStarted!: () => void;
+    const candidateStartedPromise = new Promise<void>((resolve) => {
+      candidateStarted = resolve;
+    });
+    const candidateGate = new Promise<void>((resolve) => {
+      releaseCandidate = resolve;
+    });
+    const readSnapshot = vi.fn(() => new Promise<CompanionDiff>((resolve) => {
+      resolveSnapshot = resolve;
+    }));
+    const detector = new CompanionChangeDetector({
+      intervalMs: 15_000,
+      minimumChangedLines: 10,
+      now: () => now,
+      readDiff: readSnapshot,
+    });
+    detector.observe(tool('Edit'));
+    now = 1_250;
+    const originalEvaluateCandidate = detector.evaluateCandidate.bind(detector);
+    vi.spyOn(detector, 'evaluateCandidate').mockImplementation(async (...args) => {
+      candidateStarted();
+      await candidateGate;
+      return originalEvaluateCandidate(...args);
+    });
+    const enqueue = vi.fn().mockResolvedValue(undefined);
+    const onSkipped = vi.fn();
+    const scheduler = new CompanionTriggerScheduler({
+      detectors: new Map([['security-reviewer', detector]]),
+      intervals: [15_000],
+      allowGitCommit: false,
+      queue: { enqueue } as unknown as CompanionReviewQueue,
+      initialSnapshot: diff('initial', 0),
+      readSnapshot,
+      isAborted: () => false,
+      onError: vi.fn(),
+      onSkipped,
+    });
+
+    const evaluation = scheduler.evaluateNow();
+    await Promise.resolve();
+    expect(readSnapshot).toHaveBeenCalledOnce();
+    resolveSnapshot(diff('small', 1));
+    await candidateStartedPromise;
+    scheduler.beginCompletion();
+    releaseCandidate();
+    await evaluation;
+
+    expect(onSkipped).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+    scheduler.stop();
   });
 
   it('should detect a Bash mutation from before/after diff snapshots without parsing the command', async () => {

--- a/src/__tests__/companion-review-moderator.integration.test.ts
+++ b/src/__tests__/companion-review-moderator.integration.test.ts
@@ -258,12 +258,97 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
 
       expect(result.findingCount).toBe(1);
       expect(onRoundCompleted).toHaveBeenCalledOnce();
-      expect(onRoundCompleted).toHaveBeenCalledWith({
+      expect(onRoundCompleted).toHaveBeenCalledWith(expect.objectContaining({
         snapshot: expect.objectContaining({ digest: 'digest' }),
         trigger: 'quiet',
         findingCount: 1,
-      });
+      }));
       expect(stateStore.get(mailboxPath, 'security-reviewer').mailbox.findings).toHaveLength(2);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('should record reviewer candidates, moderator decisions, and the accepted zero-finding result', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'takt-companion-review-audit-'));
+    const mailboxPath = join(root, 'security-reviewer.jsonl');
+    const stateStore = new CompanionReviewStateStore();
+    const onRoundCompleted = vi.fn();
+    const callStructured = vi.fn(async (purpose: string) => purpose === 'reviewer'
+      ? {
+          status: 'done' as const,
+          content: '',
+          structuredOutput: {
+            findings: [{ severity: 'must_fix' as const, file: 'src/a.ts', line: 1, finding: 'candidate' }],
+            updates: [],
+            notes: null,
+          },
+        }
+      : {
+          status: 'done' as const,
+          content: '',
+          structuredOutput: {
+            findings: [{
+              action: 'reject' as const,
+              sourceIndex: 0,
+              severity: null,
+              finding: null,
+              targetId: null,
+            }],
+            updates: [],
+          },
+        });
+
+    try {
+      await executeCompanionReviewRound({
+        companionName: 'security-reviewer',
+        moderatorName: 'moderator',
+        trigger: 'completion',
+        diff: {
+          content: 'diff',
+          digest: 'digest',
+          changedLines: 10,
+          changedFiles: ['src/a.ts'],
+          fileFingerprints: {},
+          hunkFingerprints: {},
+          omittedBytes: 0,
+          truncated: false,
+        },
+        observedGeneration: 1,
+        changedRegionsSincePreviousReview: [],
+        diffSummary: 'summary',
+        signal: new AbortController().signal,
+        task: 'task',
+        stepName: 'implement',
+        stepInstruction: 'implement',
+        activeNames: ['security-reviewer'],
+        stateStore,
+        mailboxPath: () => mailboxPath,
+        systemPrompt: () => 'review',
+        openFindings: () => [],
+        callStructured,
+        emitFinding: vi.fn(),
+        markReviewed: vi.fn(),
+        evaluateRound: createEvaluateRound(),
+        applyRoundDecision: vi.fn(),
+        onRoundCompleted,
+      });
+
+      expect(onRoundCompleted).toHaveBeenCalledWith(expect.objectContaining({
+        trigger: 'completion',
+        reviewerResult: expect.objectContaining({
+          findings: [expect.objectContaining({ finding: 'candidate' })],
+        }),
+        moderator: expect.objectContaining({
+          invoked: true,
+          result: expect.objectContaining({
+            findings: [expect.objectContaining({ action: 'reject', sourceIndex: 0 })],
+          }),
+        }),
+        accepted: { findings: [], updates: [] },
+        findingCount: 0,
+        zeroReason: 'moderator_rejected_or_merged_all_findings',
+      }));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -961,11 +1046,33 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
     const firstController = new AbortController();
     const evaluateRound = createEvaluateRound();
     const markReviewed = vi.fn();
-    const callStructured = vi.fn().mockResolvedValue({
-      status: 'done',
-      content: '',
-      structuredOutput: { findings: [], updates: [] },
+    const onRoundCompleted = vi.fn();
+    stateStore.apply({
+      path: mailboxPath,
+      companionName: 'security-reviewer',
+      maxOpenMustFix: 5,
+      result: {
+        findings: [{ severity: 'must_fix', file: 'src/existing.ts', line: 2, finding: 'existing' }],
+        updates: [],
+      },
     });
+    const callStructured = vi.fn(async (purpose: string) => purpose === 'reviewer'
+      ? {
+          status: 'done' as const,
+          content: '',
+          structuredOutput: {
+            findings: [{ severity: 'must_fix' as const, file: 'src/a.ts', line: 1, finding: 'candidate' }],
+            updates: [{ id: 'security-reviewer-1', status: 'resolved' as const }],
+          },
+        }
+      : {
+          status: 'done' as const,
+          content: '',
+          structuredOutput: {
+            findings: [{ action: 'accept' as const, sourceIndex: 0 }],
+            updates: [{ id: 'security-reviewer-1', status: 'resolved' as const }],
+          },
+        });
     const base = {
       companionName: 'security-reviewer',
       trigger: 'quiet' as const,
@@ -986,15 +1093,16 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       stepName: 'implement',
       stepInstruction: 'implement',
       activeNames: ['security-reviewer'],
+      moderatorName: 'moderator',
       stateStore,
       mailboxPath: () => mailboxPath,
       systemPrompt: () => 'review',
-      openFindings: () => [],
+      openFindings: () => stateStore.get(mailboxPath, 'security-reviewer').mailbox.findings,
       callStructured,
       emitFinding: vi.fn(),
       markReviewed,
       evaluateRound,
-      onRoundCompleted: vi.fn(),
+      onRoundCompleted,
     };
 
     try {
@@ -1009,7 +1117,24 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
         applyRoundDecision: vi.fn(),
       });
 
-      expect(callStructured).toHaveBeenCalledOnce();
+      expect(callStructured).toHaveBeenCalledTimes(2);
+      expect(onRoundCompleted).toHaveBeenCalledWith(expect.objectContaining({
+        reviewerResult: expect.objectContaining({
+          findings: [expect.objectContaining({ finding: 'candidate' })],
+          updates: [{ id: 'security-reviewer-1', status: 'resolved' }],
+        }),
+        accepted: expect.objectContaining({
+          findings: [expect.objectContaining({ finding: 'candidate' })],
+          updates: [{ id: 'security-reviewer-1', status: 'resolved' }],
+        }),
+        findingCount: 1,
+        moderator: expect.objectContaining({
+          invoked: true,
+          result: expect.objectContaining({
+            findings: [expect.objectContaining({ action: 'accept', sourceIndex: 0 })],
+          }),
+        }),
+      }));
       expect(evaluateRound).toHaveBeenCalledOnce();
       expect(markReviewed).toHaveBeenCalledOnce();
       expect(stateStore.previewRound('history', {
@@ -1217,16 +1342,16 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
       expect(callStructured).toHaveBeenCalledTimes(2);
       expect(markReviewed).toHaveBeenNthCalledWith(1, pendingDiff, 1);
       expect(markReviewed).toHaveBeenNthCalledWith(2, currentDiff, currentGeneration);
-      expect(onRoundCompleted).toHaveBeenNthCalledWith(1, {
+      expect(onRoundCompleted).toHaveBeenNthCalledWith(1, expect.objectContaining({
         snapshot: pendingDiff,
         trigger: 'quiet',
         findingCount: 0,
-      });
-      expect(onRoundCompleted).toHaveBeenNthCalledWith(2, {
+      }));
+      expect(onRoundCompleted).toHaveBeenNthCalledWith(2, expect.objectContaining({
         snapshot: currentDiff,
         trigger: 'quiet',
         findingCount: 0,
-      });
+      }));
       expect(evaluateRound).toHaveBeenCalledTimes(3);
       expect(stateStore.previewRound('history', {
         diffDigest: 'probe',

--- a/src/__tests__/companion-review-moderator.integration.test.ts
+++ b/src/__tests__/companion-review-moderator.integration.test.ts
@@ -258,7 +258,7 @@ describe('CT-COMP-10 companion review terminal lifecycle', () => {
 
       expect(result.findingCount).toBe(1);
       expect(onRoundCompleted).toHaveBeenCalledOnce();
-      expect(onRoundCompleted).toHaveBeenCalledWith(expect.objectContaining({
+      expect(onRoundCompleted).toHaveBeenNthCalledWith(1, expect.objectContaining({
         snapshot: expect.objectContaining({ digest: 'digest' }),
         trigger: 'quiet',
         findingCount: 1,

--- a/src/__tests__/companion-review-runner.test.ts
+++ b/src/__tests__/companion-review-runner.test.ts
@@ -94,6 +94,7 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
       outputSchema: { type: 'object' },
       cwd: '/worktree',
       projectCwd: '/project',
+      failureDir: '/project/.takt/runs/run/failures',
       language: 'en',
       resolution: { provider: 'mock', model: 'mock-model', providerOptions: {} },
       call,
@@ -131,6 +132,7 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
       outputSchema: { type: 'object' },
       cwd: '/worktree',
       projectCwd: '/project',
+      failureDir: '/project/.takt/runs/run/failures',
       language: 'en',
       resolution: { provider: 'mock' },
       call: vi.fn().mockRejectedValue(failure),
@@ -157,7 +159,9 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
       throw new Error('audit write failed');
     });
     const recordUsage = vi.fn();
-    const onCallAuditPersistenceFailure = vi.fn();
+    const onCallAuditPersistenceFailure = vi.fn(() => {
+      throw new Error('audit diagnostic failed');
+    });
 
     const result = await executeCompanionStructuredAgent({
       purpose: 'reviewer',
@@ -167,6 +171,7 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
       outputSchema: { type: 'object' },
       cwd: '/worktree',
       projectCwd: '/project',
+      failureDir: '/project/.takt/runs/run/failures',
       language: 'en',
       resolution: { provider: 'mock' },
       call,
@@ -199,6 +204,7 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
       outputSchema: { type: 'object' },
       cwd: '/worktree',
       projectCwd: '/project',
+      failureDir: '/project/.takt/runs/run/failures',
       language: 'en',
       resolution: { provider: 'mock' },
       call: vi.fn().mockRejectedValue(failure),
@@ -255,6 +261,7 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
       outputSchema: { type: 'object' },
       cwd: '/worktree',
       projectCwd: '/project',
+      failureDir: '/project/.takt/runs/run/failures',
       language: 'en',
       resolution: { provider: 'mock' },
       call,
@@ -348,6 +355,7 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
       outputSchema: { type: 'object' },
       cwd: '/worktree',
       projectCwd: '/project',
+      failureDir: '/project/.takt/runs/run/failures',
       language: 'en',
       resolution: { provider: 'mock' },
       abortSignal: new AbortController().signal,
@@ -386,6 +394,7 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
       outputSchema: { type: 'object' },
       cwd: '/worktree',
       projectCwd: '/project',
+      failureDir: '/project/.takt/runs/run/failures',
       language: 'en',
       resolution: { provider: 'mock' },
       call,

--- a/src/__tests__/companion-review-runner.test.ts
+++ b/src/__tests__/companion-review-runner.test.ts
@@ -68,6 +68,152 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
     },
   );
 
+  it('should record the resolved prompt, response, session, and attempt outcome for each internal call', async () => {
+    const recordCall = vi.fn();
+    const call = vi.fn(async (
+      _systemPrompt: string,
+      _prompt: string,
+      _schema: Record<string, unknown>,
+      options: { onPromptResolved?: (parts: { systemPrompt: string; userInstruction: string }) => void },
+    ) => {
+      options.onPromptResolved?.({
+        systemPrompt: 'resolved system prompt',
+        userInstruction: 'resolved user prompt',
+      });
+      return {
+        ...response('done'),
+        sessionId: 'provider-session-1',
+      };
+    });
+
+    await executeCompanionStructuredAgent({
+      purpose: 'selector',
+      agentName: 'companion-selector',
+      systemPrompt: 'system',
+      prompt: 'prompt',
+      outputSchema: { type: 'object' },
+      cwd: '/worktree',
+      projectCwd: '/project',
+      language: 'en',
+      resolution: { provider: 'mock', model: 'mock-model', providerOptions: {} },
+      call,
+      recordUsage: vi.fn(),
+      recordCall,
+    });
+
+    expect(call.mock.calls[0]?.[3]).toMatchObject({ sessionId: undefined });
+    expect(recordCall).toHaveBeenCalledWith(expect.objectContaining({
+      purpose: 'selector',
+      agentName: 'companion-selector',
+      attempt: 1,
+      status: 'completed',
+      provider: 'mock',
+      model: 'mock-model',
+      systemPrompt: 'resolved system prompt',
+      prompt: 'resolved user prompt',
+      promptResolved: true,
+      response: expect.objectContaining({
+        sessionId: 'provider-session-1',
+        structuredOutput: { findings: [], updates: [] },
+      }),
+    }));
+  });
+
+  it('should record failed attempts when the provider rejects before returning a response', async () => {
+    const recordCall = vi.fn();
+    const failure = new Error('provider failed');
+
+    await expect(executeCompanionStructuredAgent({
+      purpose: 'reviewer',
+      agentName: 'security-reviewer',
+      systemPrompt: 'system',
+      prompt: 'prompt',
+      outputSchema: { type: 'object' },
+      cwd: '/worktree',
+      projectCwd: '/project',
+      language: 'en',
+      resolution: { provider: 'mock' },
+      call: vi.fn().mockRejectedValue(failure),
+      recordUsage: vi.fn(),
+      recordCall,
+    })).rejects.toBe(failure);
+
+    expect(recordCall).toHaveBeenCalledTimes(2);
+    expect(recordCall).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      purpose: 'reviewer',
+      attempt: 1,
+      status: 'failed',
+    }));
+    expect(recordCall).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      purpose: 'reviewer',
+      attempt: 2,
+      status: 'failed',
+    }));
+  });
+
+  it('should retain a provider response when persisting its call audit fails', async () => {
+    const call = vi.fn().mockResolvedValue(response('done'));
+    const recordCall = vi.fn(() => {
+      throw new Error('audit write failed');
+    });
+    const recordUsage = vi.fn();
+    const onCallAuditPersistenceFailure = vi.fn();
+
+    const result = await executeCompanionStructuredAgent({
+      purpose: 'reviewer',
+      agentName: 'security-reviewer',
+      systemPrompt: 'system',
+      prompt: 'prompt',
+      outputSchema: { type: 'object' },
+      cwd: '/worktree',
+      projectCwd: '/project',
+      language: 'en',
+      resolution: { provider: 'mock' },
+      call,
+      recordUsage,
+      recordCall,
+      onCallAuditPersistenceFailure,
+    });
+
+    expect(result.status).toBe('done');
+    expect(call).toHaveBeenCalledOnce();
+    expect(recordCall).toHaveBeenCalledOnce();
+    expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    expect(onCallAuditPersistenceFailure).toHaveBeenCalledWith(expect.objectContaining({
+      purpose: 'reviewer',
+      agentName: 'security-reviewer',
+      attempt: 1,
+      error: expect.any(Error),
+    }));
+  });
+
+  it('should omit prompts when the provider fails before prompt resolution', async () => {
+    const recordCall = vi.fn();
+    const failure = new Error('capability resolution failed');
+
+    await expect(executeCompanionStructuredAgent({
+      purpose: 'selector',
+      agentName: 'companion-selector',
+      systemPrompt: 'guarded system prompt',
+      prompt: 'initial prompt',
+      outputSchema: { type: 'object' },
+      cwd: '/worktree',
+      projectCwd: '/project',
+      language: 'en',
+      resolution: { provider: 'mock' },
+      call: vi.fn().mockRejectedValue(failure),
+      recordUsage: vi.fn(),
+      recordCall,
+    })).rejects.toBe(failure);
+
+    expect(recordCall).toHaveBeenCalledWith(expect.objectContaining({
+      promptResolved: false,
+      status: 'failed',
+    }));
+    expect(recordCall.mock.calls[0]?.[0]).not.toHaveProperty('systemPrompt');
+    expect(recordCall.mock.calls[0]?.[0]).not.toHaveProperty('prompt');
+  });
+
   it('should record failed usage before propagating an internal call failure to the fail-soft boundary', async () => {
     const failure = new Error('provider failed');
     const recordUsage = vi.fn();

--- a/src/__tests__/companion-runtime-lifecycle.integration.test.ts
+++ b/src/__tests__/companion-runtime-lifecycle.integration.test.ts
@@ -61,6 +61,7 @@ function dependencies(input: {
   providers?: Record<string, { provider: 'mock' }>;
   selectorProvider?: SelectorProviderInfo;
   intervalMs?: number;
+  emitEvent?: ReturnType<typeof vi.fn>;
 }) {
   return {
     cwd: '/project',
@@ -84,7 +85,7 @@ function dependencies(input: {
     diffReader: input.diffReader,
     abortSignal: input.abortSignal,
     stateStore: new CompanionReviewStateStore(),
-    emitEvent: vi.fn(),
+    emitEvent: input.emitEvent ?? vi.fn(),
     recordUsage: vi.fn(),
   };
 }
@@ -246,6 +247,29 @@ describe('companion runtime lifecycle', () => {
     expect(addListener).not.toHaveBeenCalled();
     expect(setIntervalSpy).not.toHaveBeenCalled();
     setIntervalSpy.mockRestore();
+  });
+
+  it('should record an initial selector-empty skip for an empty companion selection', async () => {
+    const emitEvent = vi.fn();
+    const runtime = await CompanionStepRuntime.create(dependencies({
+      workflowStep: {
+        ...step(),
+        companion: { fixed: [], pool: [] },
+      },
+      diffReader: {
+        readBaselineSha: vi.fn().mockResolvedValue('baseline'),
+        readDiff: vi.fn().mockResolvedValue({ status: 'ok', snapshot: emptySnapshot }),
+      },
+      emitEvent,
+    }));
+
+    runtime.stop();
+
+    expect(emitEvent).toHaveBeenCalledWith('companion:review_skipped', {
+      step: 'implement',
+      phase: 'initial',
+      reason: 'selector_empty',
+    });
   });
 
   it('should send a provider-compatible schema when selecting companion reviewers', async () => {

--- a/src/__tests__/companion-step-executor.integration.test.ts
+++ b/src/__tests__/companion-step-executor.integration.test.ts
@@ -250,7 +250,9 @@ describe('companion StepExecutor lifecycle', () => {
     const companionDiffReader = createCompanionDiffReader();
     mockSuccessfulImplementer();
     const state = makeState();
-    const emitEvent = vi.fn();
+    const emitEvent = vi.fn(() => {
+      throw new Error('audit listener unavailable');
+    });
     const deps = createDeps({
       cwd,
       runPaths,
@@ -273,9 +275,11 @@ describe('companion StepExecutor lifecycle', () => {
     expect(companionDiffReader.readBaselineSha).not.toHaveBeenCalled();
     expect(executeAgent).toHaveBeenCalledOnce();
     expect(executeAgent.mock.calls[0]?.[1]).not.toContain('mailbox');
-    expect(emitEvent.mock.calls.filter(([event]) => (
-      typeof event === 'string' && event.startsWith('companion:')
-    ))).toHaveLength(0);
+    expect(emitEvent).toHaveBeenCalledWith('companion:review_skipped', expect.objectContaining({
+      step: 'implement',
+      phase: 'initial',
+      reason: 'companion_disabled',
+    }));
     expect(vi.mocked(deps.recordSynthesizedAgentUsage).mock.calls.filter(([stepName]) => (
       typeof stepName === 'string' && stepName.startsWith('companion:')
     ))).toHaveLength(0);
@@ -286,12 +290,13 @@ describe('companion StepExecutor lifecycle', () => {
     mockSuccessfulImplementer();
     const state = makeState();
 
+    const emitEvent = vi.fn();
     const result = await new StepExecutor(createDeps({
       cwd,
       runPaths,
       companionDiffReader: createFailingStartupDiffReader(),
       abortSignal: abortController.signal,
-      emitEvent: vi.fn(),
+      emitEvent,
     })).runNormalStep(
       createCompanionStep([makeRule('Implementation is complete', 'COMPLETE')]),
       state,
@@ -308,6 +313,10 @@ describe('companion StepExecutor lifecycle', () => {
       completionFailure: true,
       openMustFixCount: 0,
     });
+    expect(emitEvent).toHaveBeenCalledWith('companion:review_skipped', expect.objectContaining({
+      phase: 'initial',
+      reason: 'companion_runtime_unavailable',
+    }));
   });
 
   it('should continue when required companion runtime configuration is unavailable', async () => {

--- a/src/__tests__/sessionLogger.test.ts
+++ b/src/__tests__/sessionLogger.test.ts
@@ -41,7 +41,11 @@ describe('SessionLogger', () => {
       trigger: 'quiet',
       digest: 'digest-2',
       changedLines: 12,
-      findingCount: 2,
+      findingCount: 0,
+      reviewerFindings: [],
+      reviewerUpdates: [],
+      acceptedFindings: [],
+      acceptedUpdates: [],
     });
     logger.onCompanionQueueCoalesced({
       step: 'implement',
@@ -73,7 +77,7 @@ describe('SessionLogger', () => {
         trigger: 'quiet',
         digest: 'digest-2',
         changedLines: 12,
-        findingCount: 2,
+        findingCount: 0,
       }),
       expect.objectContaining({
         type: 'companion_queue_coalesced',
@@ -81,6 +85,112 @@ describe('SessionLogger', () => {
         replacement: expect.objectContaining({ digest: 'digest-2' }),
       }),
     ]));
+  });
+
+  it('Companion の実呼び出し、採否結果、skip理由を run NDJSON に永続化する', () => {
+    const logsDir = createTempLogsDir();
+    const ndjsonPath = initNdjsonLog('session-companion-audit', 'task', 'workflow', { logsDir });
+    const logger = new SessionLogger(ndjsonPath, false);
+
+    logger.onCompanionCall({
+      step: 'implement',
+      agent: 'security-reviewer',
+      purpose: 'reviewer',
+      attempt: 1,
+      status: 'completed',
+      provider: 'mock',
+      model: 'mock-model',
+      systemPrompt: 'system token=super-secret',
+      prompt: 'prompt password=super-secret',
+      promptResolved: true,
+      response: {
+        persona: 'security-reviewer',
+        status: 'done',
+        content: 'review response',
+        structuredOutput: {
+          findings: [{ severity: 'must_fix', file: 'src/a.ts', line: 1, finding: 'candidate' }],
+          updates: [],
+          apiKey: 'sk-companion-actual-secret',
+          nested: { accessToken: 'nested-access-token-value' },
+        },
+        sessionId: 'provider-session-1',
+        providerUsage: { inputTokens: 10, outputTokens: 2, usageMissing: false },
+        timestamp: new Date('2026-08-13T00:00:00.000Z'),
+      },
+    });
+    logger.onCompanionReviewRound({
+      step: 'implement',
+      companion: 'security-reviewer',
+      trigger: 'completion',
+      digest: 'digest-1',
+      changedLines: 4,
+      reviewerFindings: [{
+        severity: 'must_fix',
+        file: 'src/a.ts',
+        line: 1,
+        finding: 'candidate',
+      }],
+      reviewerUpdates: [],
+      moderator: {
+        name: 'moderator',
+        invoked: true,
+        decisions: [{ action: 'accept', sourceIndex: 0 }],
+      },
+      acceptedFindings: [{
+        severity: 'must_fix',
+        file: 'src/a.ts',
+        line: 1,
+        finding: 'candidate',
+      }],
+      acceptedUpdates: [],
+      findingCount: 1,
+    });
+    logger.onCompanionReviewSkipped({
+      step: 'implement',
+      companion: 'security-reviewer',
+      phase: 'live',
+      reason: 'unchanged_digest',
+      observedGeneration: 3,
+    });
+
+    const records = readFileSync(ndjsonPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .map(parseNdjsonRecord);
+    const call = records.find((record) => record.type === 'companion_call');
+    const round = records.find((record) => (
+      record.type === 'companion_review_round' && record.digest === 'digest-1'
+    ));
+    const skipped = records.find((record) => record.type === 'companion_review_skipped');
+
+    expect(call).toMatchObject({
+      purpose: 'reviewer',
+      attempt: 1,
+      status: 'completed',
+      provider: 'mock',
+      sessionIdAvailable: true,
+      sessionId: 'provider-session-1',
+      response: 'review response',
+      structuredOutput: expect.stringContaining('candidate'),
+      promptResolved: true,
+      usage: expect.objectContaining({ inputTokens: 10, outputTokens: 2, usageMissing: false }),
+      systemPrompt: expect.stringContaining('[REDACTED]'),
+      prompt: expect.stringContaining('[REDACTED]'),
+    });
+    expect(call?.type).toBe('companion_call');
+    expect(call?.structuredOutput).not.toContain('sk-companion-actual-secret');
+    expect(call?.structuredOutput).not.toContain('nested-access-token-value');
+    expect(round).toMatchObject({
+      reviewerFindings: [expect.objectContaining({ finding: 'candidate' })],
+      moderator: expect.objectContaining({ invoked: true }),
+      acceptedFindings: [expect.objectContaining({ finding: 'candidate' })],
+      findingCount: 1,
+    });
+    expect(skipped).toMatchObject({
+      phase: 'live',
+      reason: 'unchanged_digest',
+      observedGeneration: 3,
+    });
   });
 
   it.each([

--- a/src/__tests__/sessionLogger.test.ts
+++ b/src/__tests__/sessionLogger.test.ts
@@ -178,6 +178,8 @@ describe('SessionLogger', () => {
       prompt: expect.stringContaining('[REDACTED]'),
     });
     expect(call?.type).toBe('companion_call');
+    expect(call?.systemPrompt).not.toContain('sk-companion-actual-secret');
+    expect(call?.prompt).not.toContain('nested-access-token-value');
     expect(call?.structuredOutput).not.toContain('sk-companion-actual-secret');
     expect(call?.structuredOutput).not.toContain('nested-access-token-value');
     expect(round).toMatchObject({

--- a/src/__tests__/type-contracts/companion-events.ts
+++ b/src/__tests__/type-contracts/companion-events.ts
@@ -39,6 +39,10 @@ emitCompanionEvent('companion:review_round', {
   digest: 'digest-1',
   changedLines: 12,
   findingCount: 1,
+  reviewerFindings: [],
+  reviewerUpdates: [],
+  acceptedFindings: [],
+  acceptedUpdates: [],
 });
 
 emitCompanionEvent('companion:queue_coalesced', {
@@ -66,6 +70,10 @@ emitCompanionEvent('companion:review_round', {
   digest: 'digest-1',
   changedLines: 12,
   findingCount: 1,
+  reviewerFindings: [],
+  reviewerUpdates: [],
+  acceptedFindings: [],
+  acceptedUpdates: [],
 });
 
 // @ts-expect-error Companion queue coalescing requires the replacement payload.

--- a/src/__tests__/workflowExecutionEvents.test.ts
+++ b/src/__tests__/workflowExecutionEvents.test.ts
@@ -255,6 +255,22 @@ describe('bindWorkflowExecutionEvents', () => {
         reason: 'unchanged_digest',
         observedGeneration: 2,
       })).not.toThrow();
+      expect(() => engine.emit('companion:queue_coalesced', {
+        step: 'review',
+        companion: 'security-reviewer',
+        replaced: {
+          trigger: 'quiet',
+          digest: 'digest-1',
+          changedLines: 1,
+          observedGeneration: 1,
+        },
+        replacement: {
+          trigger: 'quiet',
+          digest: 'digest-2',
+          changedLines: 2,
+          observedGeneration: 2,
+        },
+      })).not.toThrow();
 
       expect(sessionLogger.getNdjsonRecords()).toEqual([]);
     } finally {

--- a/src/__tests__/workflowExecutionEvents.test.ts
+++ b/src/__tests__/workflowExecutionEvents.test.ts
@@ -100,6 +100,8 @@ function createBridgeHarness(options?: {
     onWorkflowAbort: vi.fn(),
     onCompanionReviewRound: vi.fn(),
     onCompanionQueueCoalesced: vi.fn(),
+    onCompanionCall: vi.fn(),
+    onCompanionReviewSkipped: vi.fn(),
   };
   const sessionLog = {
     task: 'task',
@@ -197,6 +199,69 @@ describe('bindWorkflowExecutionEvents', () => {
     expect(sessionLogger.onWorkflowCallComplete).toHaveBeenCalledWith(complete);
   });
 
+  it('Companion監査のSessionLogger失敗をワークフローへ伝播させない', () => {
+    const sessionLogger = {
+      onCompanionCall: vi.fn(() => { throw new Error('call audit append failed'); }),
+      onCompanionReviewRound: vi.fn(() => { throw new Error('review audit append failed'); }),
+      onCompanionReviewSkipped: vi.fn(() => { throw new Error('skip audit append failed'); }),
+    } as unknown as SessionLogger;
+    const { engine } = createBridgeHarness({ sessionLogger });
+
+    expect(() => {
+      engine.emit('companion:call', {
+        step: 'review',
+        agent: 'security-reviewer',
+        purpose: 'reviewer',
+        attempt: 1,
+        status: 'completed',
+        provider: 'mock',
+        promptResolved: false,
+      });
+      engine.emit('companion:review_round', {
+        step: 'review',
+        companion: 'security-reviewer',
+        trigger: 'quiet',
+        digest: 'digest',
+        changedLines: 1,
+        findingCount: 0,
+        reviewerFindings: [],
+        reviewerUpdates: [],
+        acceptedFindings: [],
+        acceptedUpdates: [],
+      });
+      engine.emit('companion:review_skipped', {
+        step: 'review',
+        companion: 'security-reviewer',
+        phase: 'live',
+        reason: 'unchanged_digest',
+      });
+    }).not.toThrow();
+
+    expect(sessionLogger.onCompanionCall).toHaveBeenCalledOnce();
+    expect(sessionLogger.onCompanionReviewRound).toHaveBeenCalledOnce();
+    expect(sessionLogger.onCompanionReviewSkipped).toHaveBeenCalledOnce();
+  });
+
+  it('SessionLoggerの監査NDJSON失敗時に未永続レコードをメモリへ残さない', () => {
+    const logsDir = mkdtempSync(join(tmpdir(), 'takt-companion-audit-failure-'));
+    try {
+      const sessionLogger = new SessionLogger(logsDir, false);
+      const { engine } = createBridgeHarness({ sessionLogger });
+
+      expect(() => engine.emit('companion:review_skipped', {
+        step: 'review',
+        companion: 'security-reviewer',
+        phase: 'live',
+        reason: 'unchanged_digest',
+        observedGeneration: 2,
+      })).not.toThrow();
+
+      expect(sessionLogger.getNdjsonRecords()).toEqual([]);
+    } finally {
+      rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
+
   it('child workflow の companion review event を relay と親 bridge 経由で run NDJSON に記録する', async () => {
     const logsDir = mkdtempSync(join(tmpdir(), 'takt-companion-relay-'));
     try {
@@ -242,17 +307,24 @@ describe('bindWorkflowExecutionEvents', () => {
         status: 'completed',
       };
       const listeners = new Map<string, (...args: unknown[]) => void>();
+      const childScope = ['subworkflows', 'iteration-1--step-delegate--workflow-child'];
       const reviewRoundPayload = {
         step: 'review',
         companion: 'security-reviewer',
         trigger: 'quiet',
         digest: 'child-digest',
         changedLines: 12,
-        findingCount: 2,
+        findingCount: 0,
+        reviewerFindings: [],
+        reviewerUpdates: [],
+        acceptedFindings: [],
+        acceptedUpdates: [],
+        runPathNamespace: childScope,
       };
       const queueCoalescedPayload = {
         step: 'review',
         companion: 'security-reviewer',
+        runPathNamespace: childScope,
         replaced: {
           trigger: 'quiet',
           digest: 'child-digest',
@@ -266,6 +338,23 @@ describe('bindWorkflowExecutionEvents', () => {
           observedGeneration: 2,
         },
       };
+      const callPayload = {
+        step: 'review',
+        agent: 'security-reviewer',
+        purpose: 'reviewer' as const,
+        attempt: 1,
+        status: 'completed' as const,
+        provider: 'mock' as const,
+        promptResolved: false,
+        runPathNamespace: childScope,
+      };
+      const skippedPayload = {
+        step: 'review',
+        companion: 'security-reviewer',
+        phase: 'fix' as const,
+        reason: 'unchanged_digest' as const,
+        runPathNamespace: childScope,
+      };
       const childEngine = {
         on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
           listeners.set(event, listener);
@@ -273,6 +362,8 @@ describe('bindWorkflowExecutionEvents', () => {
         runWithResult: vi.fn().mockImplementation(async () => {
           listeners.get('companion:review_round')?.(reviewRoundPayload);
           listeners.get('companion:queue_coalesced')?.(queueCoalescedPayload);
+          listeners.get('companion:call')?.(callPayload);
+          listeners.get('companion:review_skipped')?.(skippedPayload);
           return { state: childState };
         }),
       };
@@ -319,7 +410,18 @@ describe('bindWorkflowExecutionEvents', () => {
         trigger: 'quiet',
         digest: 'child-digest',
         changedLines: 12,
-        findingCount: 2,
+        findingCount: 0,
+        runPathNamespace: childScope,
+      }));
+      expect(records).toContainEqual(expect.objectContaining({
+        type: 'companion_call',
+        promptResolved: false,
+        runPathNamespace: childScope,
+      }));
+      expect(records).toContainEqual(expect.objectContaining({
+        type: 'companion_review_skipped',
+        phase: 'fix',
+        runPathNamespace: childScope,
       }));
       expect(records).toContainEqual(expect.objectContaining({
         type: 'companion_queue_coalesced',
@@ -327,6 +429,7 @@ describe('bindWorkflowExecutionEvents', () => {
         companion: 'security-reviewer',
         replaced: expect.objectContaining({ digest: 'child-digest' }),
         replacement: expect.objectContaining({ digest: 'child-digest-2' }),
+        runPathNamespace: childScope,
       }));
     } finally {
       rmSync(logsDir, { recursive: true, force: true });
@@ -1975,7 +2078,26 @@ describe('bindWorkflowExecutionEvents', () => {
         trigger: 'quiet',
         digest: 'digest-2',
         changedLines: 12,
-        findingCount: 2,
+        findingCount: 1,
+        reviewerFindings: [{
+          severity: 'must_fix',
+          file: 'src/private.ts',
+          line: 7,
+          finding: 'candidate-private-detail',
+        }],
+        reviewerUpdates: [],
+        moderator: {
+          name: 'moderator',
+          invoked: true,
+          decisions: [{ action: 'accept', sourceIndex: 0 }],
+        },
+        acceptedFindings: [{
+          severity: 'must_fix',
+          file: 'src/private.ts',
+          line: 7,
+          finding: 'candidate-private-detail',
+        }],
+        acceptedUpdates: [],
       }],
       ['companion:queue_coalesced', {
         step: 'implement',
@@ -2039,7 +2161,7 @@ describe('bindWorkflowExecutionEvents', () => {
         trigger: 'quiet',
         digest: 'digest-2',
         changedLines: 12,
-        findingCount: 2,
+        findingCount: 1,
       },
       {
         type: 'companion',
@@ -2062,8 +2184,18 @@ describe('bindWorkflowExecutionEvents', () => {
     ]);
     expect(sessionLogger.onCompanionReviewRound).toHaveBeenCalledWith(events[5][1]);
     expect(sessionLogger.onCompanionQueueCoalesced).toHaveBeenCalledWith(events[6][1]);
-    expect(analyticsEmitter.onCompanionEvent.mock.calls.map(([name, payload]) => [name, payload]))
-      .toEqual(events);
+    expect(analyticsEmitter.onCompanionEvent.mock.calls.map(([name]) => name))
+      .toEqual(events.map(([name]) => name));
+    expect(analyticsEmitter.onCompanionEvent).toHaveBeenNthCalledWith(6, 'companion:review_round', {
+      step: 'implement',
+      companion: 'security-reviewer',
+      trigger: 'quiet',
+      digest: 'digest-2',
+      changedLines: 12,
+      findingCount: 1,
+    });
+    expect(JSON.stringify(eventSink.mock.calls)).not.toContain('candidate-private-detail');
+    expect(JSON.stringify(analyticsEmitter.onCompanionEvent.mock.calls)).not.toContain('candidate-private-detail');
     expect(out.info.mock.calls.map(([message]) => message)).toEqual([
       'Companion start for step "implement"',
       'Companion pool_selected for step "implement"',
@@ -2072,4 +2204,5 @@ describe('bindWorkflowExecutionEvents', () => {
       'Companion complete for step "implement"',
     ]);
   });
+
 });

--- a/src/agents/agent-usecases.ts
+++ b/src/agents/agent-usecases.ts
@@ -39,6 +39,7 @@ export interface ResolvedInternalAgentOptions {
   readonly language?: Language;
   readonly childProcessEnv?: Readonly<Record<string, string>>;
   readonly sessionId?: string;
+  readonly onPromptResolved?: RunAgentOptions['onPromptResolved'];
   readonly resolution: {
     readonly provider: ProviderType;
     readonly model: string | undefined;
@@ -63,6 +64,7 @@ export async function executeIsolatedStructuredInternalAgent(
     ...(resolution.provider === 'opencode' ? { executionProfile: 'isolated-structured' } : {}),
     ...(agentName === undefined ? {} : { internalAgentName: agentName }),
     sessionId: undefined,
+    onPromptResolved: options.onPromptResolved,
     internalSystemPrompt: systemPrompt,
     internalAgentIsolation: 'strict-readonly',
     allowedTools: [],

--- a/src/core/workflow/companion/change-detector.ts
+++ b/src/core/workflow/companion/change-detector.ts
@@ -16,6 +16,11 @@ export interface CompanionChangeTrigger extends CompanionChangeCandidate {
   readonly snapshot: CompanionDiff;
 }
 
+export type CompanionChangeSkipReason =
+  | 'empty_diff'
+  | 'unchanged_digest'
+  | 'below_minimum_changed_lines';
+
 export class CompanionChangeDetector {
   private readonly intervalMs: number;
   private readonly minimumChangedLines: number;
@@ -124,18 +129,20 @@ export class CompanionChangeDetector {
   async evaluateCandidate(
     candidate: CompanionChangeCandidate,
     providedSnapshot?: CompanionDiff,
+    onSkipped?: (reason: CompanionChangeSkipReason) => void,
   ): Promise<CompanionChangeTrigger | undefined> {
     const snapshot = providedSnapshot ?? await this.readDiff();
     const ignoreMinimum = candidate.reason === 'completion' || candidate.reason === 'commit';
-    if (
-      (snapshot.changedLines === 0 && snapshot.changedFiles.length === 0)
-      || (
-        snapshot.digest === this.lastReviewedDigest
-        && candidate.allowUnchangedDigest !== true
-      )
-      || (!ignoreMinimum && snapshot.changedLines < this.minimumChangedLines)
-    ) {
+    const skipReason = snapshot.changedLines === 0 && snapshot.changedFiles.length === 0
+      ? 'empty_diff'
+      : snapshot.digest === this.lastReviewedDigest && candidate.allowUnchangedDigest !== true
+        ? 'unchanged_digest'
+        : !ignoreMinimum && snapshot.changedLines < this.minimumChangedLines
+          ? 'below_minimum_changed_lines'
+          : undefined;
+    if (skipReason !== undefined) {
       this.consumeThrough(candidate.observedGeneration);
+      onSkipped?.(skipReason);
       return undefined;
     }
     return { snapshot, ...candidate };

--- a/src/core/workflow/companion/completion-coordinator.ts
+++ b/src/core/workflow/companion/completion-coordinator.ts
@@ -1,5 +1,9 @@
 import type { CompanionFindingEvidence, WorkflowState } from '../../models/types.js';
-import type { CompanionChangeDetector } from './change-detector.js';
+import type {
+  CompanionChangeDetector,
+  CompanionChangeSkipReason,
+  CompanionChangeCandidate,
+} from './change-detector.js';
 import type { CompanionDiff } from './diff-reader.js';
 import type { CompanionEventPublisher } from './event-publisher.js';
 import type { CompanionReviewQueue } from './review-queue.js';
@@ -25,6 +29,11 @@ export class CompanionCompletionCoordinator {
     readonly events: CompanionEventPublisher;
     readonly abortSignal?: AbortSignal;
     readonly onError: () => void;
+    readonly onSkipped?: (input: {
+      readonly companionName: string;
+      readonly reason: CompanionChangeSkipReason;
+      readonly candidate: CompanionChangeCandidate;
+    }) => void;
   }) {}
 
   async complete(
@@ -92,7 +101,17 @@ export class CompanionCompletionCoordinator {
       if (detector === undefined || candidate === undefined) {
         throw new Error(`Missing completion state for companion "${name}"`);
       }
-      const trigger = await detector.evaluateCandidate(candidate, snapshot);
+      let skippedReason: CompanionChangeSkipReason | undefined;
+      const trigger = await detector.evaluateCandidate(candidate, snapshot, (reason) => {
+        skippedReason = reason;
+      });
+      if (skippedReason !== undefined) {
+        this.input.onSkipped?.({
+          companionName: name,
+          reason: skippedReason,
+          candidate,
+        });
+      }
       if (trigger === undefined) {
         await this.input.queue.settle(name);
         return;

--- a/src/core/workflow/companion/event-publisher.ts
+++ b/src/core/workflow/companion/event-publisher.ts
@@ -1,8 +1,18 @@
 import type {
   CompanionQueueAuditEntry,
+  CompanionCallPurpose,
+  CompanionCallStatus,
+  CompanionModeratorAudit,
+  CompanionAcceptedFindingAudit,
+  CompanionAcceptedUpdateAudit,
   CompanionReviewTrigger,
+  CompanionReviewPhase,
+  CompanionReviewSkipReason,
+  CompanionReviewZeroReason,
   WorkflowEvents,
 } from '../types.js';
+import type { AgentResponse } from '../../models/index.js';
+import type { ProviderType } from '../../../shared/types/provider.js';
 
 type CompanionEventName = Extract<keyof WorkflowEvents, `companion:${string}`>;
 type CompanionEventArguments<TEvent extends CompanionEventName> = Parameters<WorkflowEvents[TEvent]>;
@@ -17,6 +27,7 @@ export class CompanionEventPublisher {
   constructor(
     private readonly step: string,
     private readonly emit: CompanionEventEmitter,
+    private readonly runPathNamespace: readonly string[] = [],
   ) {}
 
   start(companion: string): void {
@@ -56,8 +67,18 @@ export class CompanionEventPublisher {
     digest: string;
     changedLines: number;
     findingCount: number;
+    reviewerFindings: readonly CompanionAcceptedFindingAudit[];
+    reviewerUpdates: readonly CompanionAcceptedUpdateAudit[];
+    moderator?: CompanionModeratorAudit;
+    acceptedFindings: readonly CompanionAcceptedFindingAudit[];
+    acceptedUpdates: readonly CompanionAcceptedUpdateAudit[];
+    zeroReason?: CompanionReviewZeroReason;
   }): void {
-    this.emit('companion:review_round', { step: this.step, ...input });
+    this.emit('companion:review_round', {
+      step: this.step,
+      ...input,
+      ...this.scopePayload(),
+    });
   }
 
   queueCoalesced(input: {
@@ -65,6 +86,42 @@ export class CompanionEventPublisher {
     replaced: CompanionQueueAuditEntry;
     replacement: CompanionQueueAuditEntry;
   }): void {
-    this.emit('companion:queue_coalesced', { step: this.step, ...input });
+    this.emit('companion:queue_coalesced', {
+      step: this.step,
+      ...input,
+      ...this.scopePayload(),
+    });
+  }
+
+  call(input: {
+    agent: string;
+    purpose: CompanionCallPurpose;
+    attempt: number;
+    status: CompanionCallStatus;
+    provider: ProviderType;
+    model?: string;
+    systemPrompt?: string;
+    prompt?: string;
+    promptResolved: boolean;
+    response?: AgentResponse;
+    error?: string;
+  }): void {
+    this.emit('companion:call', { step: this.step, ...input, ...this.scopePayload() });
+  }
+
+  reviewSkipped(input: {
+    companion?: string;
+    phase: CompanionReviewPhase;
+    reason: CompanionReviewSkipReason;
+    fixRound?: number;
+    observedGeneration?: number;
+  }): void {
+    this.emit('companion:review_skipped', { step: this.step, ...input, ...this.scopePayload() });
+  }
+
+  private scopePayload(): { runPathNamespace?: string[] } {
+    return this.runPathNamespace.length === 0
+      ? {}
+      : { runPathNamespace: [...this.runPathNamespace] };
   }
 }

--- a/src/core/workflow/companion/moderator.ts
+++ b/src/core/workflow/companion/moderator.ts
@@ -1,5 +1,6 @@
 import type { CompanionFinding, CompanionFindingSeverity } from '../../models/companion-types.js';
 import type { CompanionReviewOutput } from './contracts.js';
+import type { CompanionReviewAuditSnapshot } from './review-state-store.js';
 
 export interface ModeratorResult {
   readonly findings: readonly {
@@ -10,6 +11,11 @@ export interface ModeratorResult {
     targetId?: string;
   }[];
   readonly updates: CompanionReviewOutput['updates'];
+}
+
+export interface ModeratedCompanionResult {
+  readonly moderator: ModeratorResult;
+  readonly accepted: CompanionReviewOutput;
 }
 
 export async function moderateCompanionResult(input: {
@@ -24,12 +30,21 @@ export async function moderateCompanionResult(input: {
     implementerExplanation?: string;
   }) => Promise<ModeratorResult>;
   commit: (result: CompanionReviewOutput) => Promise<void>;
-}): Promise<void> {
+  moderatorName?: string;
+  onCommitAudit?: (audit: CompanionReviewAuditSnapshot) => void;
+}): Promise<ModeratedCompanionResult | undefined> {
+  const moderatorName = input.moderatorName ?? 'moderator';
   if (input.reviewerResult.findings.length === 0 && input.reviewerResult.updates.length === 0) {
     if (input.reviewerResult.notes !== undefined) {
-      await input.commit({ findings: [], updates: [], notes: input.reviewerResult.notes });
+      const accepted = { findings: [], updates: [], notes: input.reviewerResult.notes };
+      input.onCommitAudit?.({
+        reviewerResult: input.reviewerResult,
+        accepted,
+        moderator: { name: moderatorName, invoked: false, reason: 'reviewer_result_empty' },
+      });
+      await input.commit(accepted);
     }
-    return;
+    return undefined;
   }
   const moderated = await input.runModerator({
     reviewerResult: input.reviewerResult,
@@ -51,11 +66,18 @@ export async function moderateCompanionResult(input: {
       ...(decision.finding === undefined ? {} : { finding: decision.finding }),
     }];
   });
-  await input.commit({
+  const accepted: CompanionReviewOutput = {
     findings,
     updates: moderated.updates,
     ...(input.reviewerResult.notes === undefined ? {} : { notes: input.reviewerResult.notes }),
+  };
+  input.onCommitAudit?.({
+    reviewerResult: input.reviewerResult,
+    accepted,
+    moderator: { name: moderatorName, invoked: true, result: moderated },
   });
+  await input.commit(accepted);
+  return { moderator: moderated, accepted };
 }
 
 export function validateModeratorDecisions(

--- a/src/core/workflow/companion/review-round.ts
+++ b/src/core/workflow/companion/review-round.ts
@@ -9,7 +9,11 @@ import {
 } from './contracts.js';
 import type { CompanionDiff } from './diff-reader.js';
 import type { CompanionLoopRound } from './loop-guard.js';
-import { moderateCompanionResult, validateModeratorDecisions } from './moderator.js';
+import {
+  moderateCompanionResult,
+  validateModeratorDecisions,
+  type ModeratorResult,
+} from './moderator.js';
 import {
   buildCompanionModeratorPrompt,
   buildCompanionReviewPrompt,
@@ -18,7 +22,10 @@ import type {
   CompanionAgentPurpose,
   CompanionStructuredResponseValidator,
 } from './review-runner.js';
-import type { CompanionReviewStateStore } from './review-state-store.js';
+import type {
+  CompanionReviewAuditSnapshot,
+  CompanionReviewStateStore,
+} from './review-state-store.js';
 import type { CompanionReviewOperation } from './review-state-store.js';
 import type { CompanionLoopDecision } from './terminal-decision.js';
 import type { CompanionReviewRequest } from './review-queue.js';
@@ -73,6 +80,19 @@ interface CompanionReviewRoundInput {
     readonly snapshot: CompanionDiff;
     readonly trigger: CompanionReviewRequest['reason'];
     readonly findingCount: number;
+    readonly reviewerResult: CompanionReviewOutput;
+    readonly moderator?: {
+      readonly name: string;
+      readonly invoked: boolean;
+      readonly reason?: 'reviewer_result_empty' | 'not_configured';
+      readonly result?: ModeratorResult;
+    };
+    readonly accepted: CompanionReviewOutput;
+    readonly zeroReason?:
+      | 'reviewer_returned_no_findings'
+      | 'moderator_not_invoked_for_empty_reviewer_result'
+      | 'moderator_rejected_or_merged_all_findings'
+      | 'no_new_finding_records';
   }) => void;
 }
 
@@ -89,10 +109,20 @@ export async function executeCompanionReviewRound(
   if (pending !== undefined) {
     const findingCount = await commitOperation(input, pending);
     await finalizeOperation(input, mailboxPath);
+    const audit = pending.audit ?? reconstructAuditSnapshot(pending);
     input.onRoundCompleted({
       snapshot: pending.snapshot,
       trigger: pending.trigger,
+      reviewerResult: audit.reviewerResult,
+      ...(audit.moderator === undefined ? {} : { moderator: audit.moderator }),
+      accepted: audit.accepted,
       findingCount,
+      zeroReason: resolveZeroReason({
+        reviewerResult: audit.reviewerResult,
+        moderatorAudit: audit.moderator,
+        accepted: audit.accepted,
+        findingCount,
+      }),
     });
     if (
       pending.snapshot.digest === input.diff.digest
@@ -131,16 +161,30 @@ export async function executeCompanionReviewRound(
   input.signal.throwIfAborted();
   const reviewerResult = parseCompanionReviewOutput(response.structuredOutput);
   let findingCount = 0;
+  let accepted: CompanionReviewOutput = { findings: [], updates: [] };
+  let moderatorAudit: {
+    readonly name: string;
+    readonly invoked: boolean;
+    readonly reason?: 'reviewer_result_empty' | 'not_configured';
+    readonly result?: ModeratorResult;
+  } | undefined;
+  let pendingCommitAudit: CompanionReviewAuditSnapshot | undefined;
   const commit = createCommit(input, mailboxPath, (count) => {
     findingCount = count;
-  });
+  }, () => pendingCommitAudit);
   const moderatorName = input.moderatorName;
 
   if (moderatorName === undefined) {
-    await commit(reviewerResult);
+    moderatorAudit = { name: 'not-configured', invoked: false, reason: 'not_configured' };
+    accepted = reviewerResult;
+    await commit(reviewerResult, {
+      reviewerResult,
+      accepted: reviewerResult,
+      moderator: moderatorAudit,
+    });
   } else {
     const openFindings = input.openFindings();
-    await moderateCompanionResult({
+    const moderated = await moderateCompanionResult({
       reviewerResult,
       openFindings,
       diffSummary: input.diffSummary,
@@ -162,8 +206,30 @@ export async function executeCompanionReviewRound(
         input.signal.throwIfAborted();
         return parseModeratorOutput(moderated.structuredOutput);
       },
+      moderatorName,
       commit,
+      onCommitAudit: (audit) => {
+        pendingCommitAudit = audit;
+      },
     });
+    if (moderated === undefined) {
+      moderatorAudit = {
+        name: moderatorName,
+        invoked: false,
+        reason: 'reviewer_result_empty',
+      };
+      accepted = reviewerResult.notes === undefined
+        ? { findings: [], updates: [] }
+        : { findings: [], updates: [], notes: reviewerResult.notes };
+      pendingCommitAudit = {
+        reviewerResult,
+        accepted,
+        moderator: moderatorAudit,
+      };
+    } else {
+      moderatorAudit = { name: moderatorName, invoked: true, result: moderated.moderator };
+      accepted = moderated.accepted;
+    }
   }
   if (input.stateStore.getPendingOperation(mailboxPath) === undefined) {
     await commit({ findings: [], updates: [] });
@@ -172,17 +238,74 @@ export async function executeCompanionReviewRound(
   input.onRoundCompleted({
     snapshot: input.diff,
     trigger: input.trigger,
+    reviewerResult,
+    ...(moderatorAudit === undefined ? {} : { moderator: moderatorAudit }),
+    accepted,
     findingCount,
+    zeroReason: resolveZeroReason({
+      reviewerResult,
+      moderatorAudit,
+      accepted,
+      findingCount,
+    }),
   });
   return { findingCount };
+}
+
+function resolveZeroReason(input: {
+  readonly reviewerResult: CompanionReviewOutput;
+  readonly moderatorAudit?: {
+    readonly name: string;
+    readonly invoked: boolean;
+    readonly reason?: 'reviewer_result_empty' | 'not_configured';
+  };
+  readonly accepted: CompanionReviewOutput;
+  readonly findingCount: number;
+}):
+  | 'reviewer_returned_no_findings'
+  | 'moderator_not_invoked_for_empty_reviewer_result'
+  | 'moderator_rejected_or_merged_all_findings'
+  | 'no_new_finding_records'
+  | undefined {
+  if (input.findingCount !== 0) return undefined;
+  if (input.reviewerResult.findings.length === 0) {
+    return input.moderatorAudit?.reason === 'reviewer_result_empty'
+      ? 'moderator_not_invoked_for_empty_reviewer_result'
+      : 'reviewer_returned_no_findings';
+  }
+  if (
+    input.moderatorAudit?.invoked === true
+    && input.accepted.findings.length === 0
+  ) {
+    return 'moderator_rejected_or_merged_all_findings';
+  }
+  return 'no_new_finding_records';
+}
+
+function reconstructAuditSnapshot(operation: CompanionReviewOperation): CompanionReviewAuditSnapshot {
+  const result = operation.owners.reduce<CompanionReviewOutput>(
+    (combined, owner) => ({
+      findings: [...combined.findings, ...owner.result.findings],
+      updates: [...combined.updates, ...owner.result.updates],
+      ...(combined.notes === undefined && owner.result.notes === undefined
+        ? {}
+        : { notes: owner.result.notes ?? combined.notes }),
+    }),
+    { findings: [], updates: [] },
+  );
+  return { reviewerResult: result, accepted: result };
 }
 
 function createCommit(
   input: CompanionReviewRoundInput,
   scope: string,
   onFindingCount: (count: number) => void,
-): (accepted: CompanionReviewOutput) => Promise<void> {
-  return async (accepted) => {
+  getAudit: () => CompanionReviewAuditSnapshot | undefined = () => undefined,
+): (
+  accepted: CompanionReviewOutput,
+  audit?: CompanionReviewAuditSnapshot,
+) => Promise<void> {
+  return async (accepted, audit) => {
     input.signal.throwIfAborted();
     const ownersByFindingId = buildFindingOwnerIndex(input);
     validateUpdates(input, accepted.updates, ownersByFindingId);
@@ -197,6 +320,7 @@ function createCommit(
         ? [{ ownerName, path: input.mailboxPath(ownerName), result }]
         : [];
     });
+    const committedAudit = audit ?? getAudit();
     input.stateStore.beginOperation({
       scope,
       snapshot: input.diff,
@@ -207,6 +331,7 @@ function createCommit(
         ? {}
         : { implementerExplanation: input.implementerExplanation }),
       owners,
+      ...(committedAudit === undefined ? {} : { audit: committedAudit }),
     });
     const operation = input.stateStore.getPendingOperation(scope);
     if (operation === undefined) {

--- a/src/core/workflow/companion/review-round.ts
+++ b/src/core/workflow/companion/review-round.ts
@@ -110,6 +110,12 @@ export async function executeCompanionReviewRound(
     const findingCount = await commitOperation(input, pending);
     await finalizeOperation(input, mailboxPath);
     const audit = pending.audit ?? reconstructAuditSnapshot(pending);
+    const zeroReason = resolveZeroReason({
+      reviewerResult: audit.reviewerResult,
+      moderatorAudit: audit.moderator,
+      accepted: audit.accepted,
+      findingCount,
+    });
     input.onRoundCompleted({
       snapshot: pending.snapshot,
       trigger: pending.trigger,
@@ -117,12 +123,7 @@ export async function executeCompanionReviewRound(
       ...(audit.moderator === undefined ? {} : { moderator: audit.moderator }),
       accepted: audit.accepted,
       findingCount,
-      zeroReason: resolveZeroReason({
-        reviewerResult: audit.reviewerResult,
-        moderatorAudit: audit.moderator,
-        accepted: audit.accepted,
-        findingCount,
-      }),
+      ...(zeroReason === undefined ? {} : { zeroReason }),
     });
     if (
       pending.snapshot.digest === input.diff.digest
@@ -235,6 +236,12 @@ export async function executeCompanionReviewRound(
     await commit({ findings: [], updates: [] });
   }
   await finalizeOperation(input, mailboxPath);
+  const zeroReason = resolveZeroReason({
+    reviewerResult,
+    moderatorAudit,
+    accepted,
+    findingCount,
+  });
   input.onRoundCompleted({
     snapshot: input.diff,
     trigger: input.trigger,
@@ -242,12 +249,7 @@ export async function executeCompanionReviewRound(
     ...(moderatorAudit === undefined ? {} : { moderator: moderatorAudit }),
     accepted,
     findingCount,
-    zeroReason: resolveZeroReason({
-      reviewerResult,
-      moderatorAudit,
-      accepted,
-      findingCount,
-    }),
+    ...(zeroReason === undefined ? {} : { zeroReason }),
   });
   return { findingCount };
 }

--- a/src/core/workflow/companion/review-runner.ts
+++ b/src/core/workflow/companion/review-runner.ts
@@ -225,7 +225,9 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
       } : { promptResolved: false }),
       status: response.status === 'done' ? 'completed' : 'failed',
       response,
-      ...(response.status === 'done' ? {} : { error: response.error ?? response.content }),
+      ...(response.status === 'done'
+        ? {}
+        : { error: safeExternalErrorMessage(response.error ?? response.content) }),
     });
     input.recordUsage({
       purpose: input.purpose,

--- a/src/core/workflow/companion/review-runner.ts
+++ b/src/core/workflow/companion/review-runner.ts
@@ -28,6 +28,21 @@ interface CompanionCallOptions {
   mcpServers: Record<string, never>;
   sessionId: undefined;
   abortSignal: AbortSignal;
+  onPromptResolved?: (prompt: { systemPrompt: string; userInstruction: string }) => void;
+}
+
+export interface CompanionCallAudit {
+  readonly purpose: CompanionAgentPurpose;
+  readonly agentName: string;
+  readonly attempt: number;
+  readonly status: 'completed' | 'failed';
+  readonly provider: ProviderType;
+  readonly model?: string;
+  readonly systemPrompt?: string;
+  readonly prompt?: string;
+  readonly promptResolved: boolean;
+  readonly response?: AgentResponse;
+  readonly error?: string;
 }
 
 export type CompanionStructuredResponseValidator = (response: AgentResponse) => void;
@@ -61,10 +76,17 @@ export async function executeCompanionStructuredAgent(input: {
     success: boolean;
     usage?: AgentResponse['providerUsage'];
   }) => void;
+  recordCall?: (event: CompanionCallAudit) => void;
+  onCallAuditPersistenceFailure?: (failure: {
+    purpose: CompanionAgentPurpose;
+    agentName: string;
+    attempt: number;
+    error: unknown;
+  }) => void;
 }): Promise<AgentResponse> {
   for (let attempt = 1; ; attempt += 1) {
     try {
-      const response = await executeCompanionStructuredAgentInternal(input);
+      const response = await executeCompanionStructuredAgentInternal(input, attempt);
       if (response.status === 'done') return response;
       if (response.failureCategory === AGENT_FAILURE_CATEGORIES.PROVIDER_STREAM_PARSE_ERROR) {
         throw createProviderStreamParseError(response.error ?? response.content ?? response.status);
@@ -94,7 +116,7 @@ function companionResponseFailureMessage(
 
 async function executeCompanionStructuredAgentInternal(input: Parameters<
   typeof executeCompanionStructuredAgent
->[0]): Promise<AgentResponse> {
+>[0], attempt: number): Promise<AgentResponse> {
   const controller = new AbortController();
   let rejectParentAbort: ((error: Error) => void) | undefined;
   let parentAborted = false;
@@ -110,6 +132,51 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
   input.abortSignal?.addEventListener('abort', abortFromParent, { once: true });
   let timer: ReturnType<typeof setTimeout> | undefined;
   let response: AgentResponse | undefined;
+  let callAuditRecorded = false;
+  const guardedSystemPrompt = appendCompanionEvidenceSystemGuard(input.systemPrompt);
+  let actualSystemPrompt: string | undefined;
+  let actualPrompt: string | undefined;
+  let promptResolved = false;
+  const recordCall = (audit: Omit<CompanionCallAudit, 'purpose' | 'agentName' | 'attempt' | 'provider' | 'model' | 'systemPrompt'> & {
+    readonly systemPrompt?: string;
+  }): void => {
+    if (input.recordCall === undefined) return;
+    callAuditRecorded = true;
+    try {
+      input.recordCall({
+        purpose: input.purpose,
+        agentName: input.agentName,
+        attempt,
+        provider: input.resolution.provider,
+        ...(input.resolution.model === undefined ? {} : { model: input.resolution.model }),
+        ...(audit.promptResolved
+          ? {
+            promptResolved: true,
+            ...(audit.systemPrompt === undefined && actualSystemPrompt === undefined
+              ? {}
+              : { systemPrompt: audit.systemPrompt ?? actualSystemPrompt }),
+            ...(audit.prompt === undefined && actualPrompt === undefined
+              ? {}
+              : { prompt: audit.prompt ?? actualPrompt }),
+          }
+          : { promptResolved: false }),
+        status: audit.status,
+        ...(audit.response === undefined ? {} : { response: audit.response }),
+        ...(audit.error === undefined ? {} : { error: audit.error }),
+      });
+    } catch (error) {
+      try {
+        input.onCallAuditPersistenceFailure?.({
+          purpose: input.purpose,
+          agentName: input.agentName,
+          attempt,
+          error,
+        });
+      } catch {
+        // Audit diagnostics must not change the provider result or retry policy.
+      }
+    }
+  };
   try {
     const timeoutMs = input.timeoutMs ?? COMPANION_CALL_TIMEOUT_MS;
     const timeout = new Promise<never>((_resolve, reject) => {
@@ -120,7 +187,7 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
     });
     void timeout.catch(() => undefined);
     const call = input.call(
-      appendCompanionEvidenceSystemGuard(input.systemPrompt),
+      guardedSystemPrompt,
       input.prompt,
       input.outputSchema,
       {
@@ -134,6 +201,11 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
         mcpServers: {},
         sessionId: undefined,
         abortSignal: controller.signal,
+        onPromptResolved: ({ systemPrompt, userInstruction }) => {
+          actualSystemPrompt = systemPrompt;
+          actualPrompt = userInstruction;
+          promptResolved = true;
+        },
       },
     );
     void call.catch(() => undefined);
@@ -145,6 +217,16 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
     if (response.status === 'done') {
       input.validateResponse?.(response);
     }
+    recordCall({
+      ...(promptResolved ? {
+        promptResolved: true,
+        systemPrompt: actualSystemPrompt,
+        prompt: actualPrompt,
+      } : { promptResolved: false }),
+      status: response.status === 'done' ? 'completed' : 'failed',
+      response,
+      ...(response.status === 'done' ? {} : { error: response.error ?? response.content }),
+    });
     input.recordUsage({
       purpose: input.purpose,
       agentName: input.agentName,
@@ -153,6 +235,18 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
     });
     return response;
   } catch (error) {
+    if (!callAuditRecorded) {
+      recordCall({
+        ...(promptResolved ? {
+          promptResolved: true,
+          systemPrompt: actualSystemPrompt,
+          prompt: actualPrompt,
+        } : { promptResolved: false }),
+        status: 'failed',
+        ...(response === undefined ? {} : { response }),
+        error: safeExternalErrorMessage(error),
+      });
+    }
     if (!parentAborted) {
       input.recordUsage({
         purpose: input.purpose,

--- a/src/core/workflow/companion/review-state-store.ts
+++ b/src/core/workflow/companion/review-state-store.ts
@@ -15,6 +15,7 @@ import {
 import { appendCompanionMailboxRecords } from './mailbox-projection.js';
 import type { CompanionLoopDecision } from './terminal-decision.js';
 import type { CompanionReviewRequest } from './review-queue.js';
+import type { ModeratorResult } from './moderator.js';
 
 interface CompanionReviewState {
   mailbox: CompanionMailbox;
@@ -27,6 +28,17 @@ export interface CompanionReviewOwnerOperation {
   readonly ownerName: string;
   readonly path: string;
   readonly result: CompanionReviewOutput;
+}
+
+export interface CompanionReviewAuditSnapshot {
+  readonly reviewerResult: CompanionReviewOutput;
+  readonly accepted: CompanionReviewOutput;
+  readonly moderator?: {
+    readonly name: string;
+    readonly invoked: boolean;
+    readonly reason?: 'reviewer_result_empty' | 'not_configured';
+    readonly result?: ModeratorResult;
+  };
 }
 
 export interface CompanionReviewOperation {
@@ -42,6 +54,7 @@ export interface CompanionReviewOperation {
   readonly findingEvents: readonly CompanionFindingEvent[];
   readonly attemptedFindingEvents: ReadonlySet<string>;
   readonly roundDecision?: CompanionLoopDecision;
+  readonly audit?: CompanionReviewAuditSnapshot;
 }
 
 export interface CompanionFindingEvent {
@@ -349,6 +362,7 @@ function cloneOperationInput(
       path: owner.path,
       result: cloneReviewOutput(owner.result),
     })),
+    ...(operation.audit === undefined ? {} : { audit: cloneAuditSnapshot(operation.audit) }),
   };
 }
 
@@ -362,6 +376,26 @@ function cloneOperation(operation: CompanionReviewOperation): CompanionReviewOpe
     ...(operation.roundDecision === undefined
       ? {}
       : { roundDecision: cloneDecision(operation.roundDecision) }),
+  };
+}
+
+function cloneAuditSnapshot(audit: CompanionReviewAuditSnapshot): CompanionReviewAuditSnapshot {
+  return {
+    reviewerResult: cloneReviewOutput(audit.reviewerResult),
+    accepted: cloneReviewOutput(audit.accepted),
+    ...(audit.moderator === undefined ? {} : {
+      moderator: {
+        name: audit.moderator.name,
+        invoked: audit.moderator.invoked,
+        ...(audit.moderator.reason === undefined ? {} : { reason: audit.moderator.reason }),
+        ...(audit.moderator.result === undefined ? {} : {
+          result: {
+            findings: audit.moderator.result.findings.map((finding) => ({ ...finding })),
+            updates: audit.moderator.result.updates.map((update) => ({ ...update })),
+          },
+        }),
+      },
+    }),
   };
 }
 

--- a/src/core/workflow/companion/step-runtime.ts
+++ b/src/core/workflow/companion/step-runtime.ts
@@ -9,9 +9,12 @@ import type {
 } from '../../models/index.js';
 import { truncateUtf8 } from '../../../shared/utils/utf8.js';
 import type { StreamEvent } from '../../../shared/types/provider.js';
-import type { SelectorProviderInfo } from '../types.js';
+import type { CompanionReviewPhase, SelectorProviderInfo } from '../types.js';
 import { createLogger } from '../../../shared/utils/index.js';
-import { CompanionChangeDetector } from './change-detector.js';
+import {
+  CompanionChangeDetector,
+  type CompanionChangeSkipReason,
+} from './change-detector.js';
 import {
   LOOP_JUDGE_OUTPUT_JSON_SCHEMA,
   parseLoopJudgeOutput,
@@ -38,6 +41,7 @@ import {
   type CompanionEventEmitter,
 } from './event-publisher.js';
 import { CompanionStructuredCaller } from './structured-call.js';
+import type { CompanionCallAudit } from './review-runner.js';
 import { CompanionTriggerScheduler } from './trigger-scheduler.js';
 import { CompanionCompletionCoordinator } from './completion-coordinator.js';
 import { CompanionTerminalDecisionTracker } from './terminal-decision.js';
@@ -85,9 +89,15 @@ export class CompanionStepRuntime {
   private currentFixRound: number | undefined;
   private stopped = false;
   private latestImplementerExplanation: string | undefined;
+  private readonly emittedReviewSkips = new Set<string>();
+  private companionAuditWriteFailureReported = false;
 
   private constructor(private readonly deps: CompanionStepRuntimeDeps) {
-    this.events = new CompanionEventPublisher(deps.step.name, deps.emitEvent);
+    this.events = new CompanionEventPublisher(
+      deps.step.name,
+      deps.emitEvent,
+      deps.runPathNamespace,
+    );
     this.structuredCaller = new CompanionStructuredCaller({
       cwd: deps.cwd,
       projectCwd: deps.projectCwd,
@@ -95,6 +105,30 @@ export class CompanionStepRuntime {
       language: deps.language,
       abortSignal: deps.abortSignal,
       recordUsage: deps.recordUsage,
+      recordCall: (call: CompanionCallAudit) => {
+        this.events.call({
+          agent: call.agentName,
+          purpose: call.purpose,
+          attempt: call.attempt,
+          status: call.status,
+          provider: call.provider,
+          ...(call.model === undefined ? {} : { model: call.model }),
+          ...(call.promptResolved ? {
+            promptResolved: true,
+            systemPrompt: call.systemPrompt,
+            prompt: call.prompt,
+          } : { promptResolved: false }),
+          ...(call.response === undefined ? {} : { response: call.response }),
+          ...(call.error === undefined ? {} : { error: call.error }),
+        });
+      },
+      onCallAuditPersistenceFailure: ({ purpose, agentName, attempt, error }) => {
+        this.reportCompanionAuditWriteFailure('companion_call', error, {
+          purpose,
+          agent: agentName,
+          attempt,
+        });
+      },
     });
     this.queue = new CompanionReviewQueue({
       runReview: async (request) => {
@@ -200,6 +234,12 @@ export class CompanionStepRuntime {
       },
       runSelector: async (request) => this.runSelector(request),
     });
+    if (selected.length === 0) {
+      this.emitReviewSkipped({
+        phase: 'initial',
+        reason: 'selector_empty',
+      });
+    }
     const resolved = selected.map((item) => {
       const definition = definitions.get(item.name);
       if (definition === undefined) throw new Error(`Undefined companion "${item.name}"`);
@@ -234,6 +274,15 @@ export class CompanionStepRuntime {
       onError: () => log.warn('Companion live review failed; the change remains unreviewed', {
         step: this.deps.step.name,
       }),
+      onSkipped: ({ companionName, reason, candidate }) => this.emitReviewSkipped({
+        companion: companionName,
+        phase: candidate.reason === 'completion'
+          ? 'completion'
+          : this.currentFixRound === undefined ? 'live' : 'fix',
+        reason,
+        ...(this.currentFixRound === undefined ? {} : { fixRound: this.currentFixRound }),
+        observedGeneration: candidate.observedGeneration,
+      }),
     });
     this.completionCoordinator = new CompanionCompletionCoordinator({
       activeNames: () => [...this.active.keys()],
@@ -255,6 +304,13 @@ export class CompanionStepRuntime {
       abortSignal: this.deps.abortSignal,
       onError: () => log.warn('Companion completion review failed; confirmed findings were retained', {
         step: this.deps.step.name,
+      }),
+      onSkipped: ({ companionName, reason, candidate }) => this.emitReviewSkipped({
+        companion: companionName,
+        phase: 'completion',
+        reason,
+        ...(this.currentFixRound === undefined ? {} : { fixRound: this.currentFixRound }),
+        observedGeneration: candidate.observedGeneration,
       }),
     });
     this.scheduler.start();
@@ -356,13 +412,34 @@ export class CompanionStepRuntime {
           )
         ),
         applyRoundDecision: (decision) => this.terminalDecision.update(decision),
-        onRoundCompleted: (round) => this.events.reviewRound({
-          companion: companionName,
-          trigger: round.trigger,
-          digest: round.snapshot.digest,
-          changedLines: round.snapshot.changedLines,
-          findingCount: round.findingCount,
-        }),
+        onRoundCompleted: (round) => {
+          try {
+            this.events.reviewRound({
+              companion: companionName,
+              trigger: round.trigger,
+              digest: round.snapshot.digest,
+              changedLines: round.snapshot.changedLines,
+              findingCount: round.findingCount,
+              reviewerFindings: round.reviewerResult.findings,
+              reviewerUpdates: round.reviewerResult.updates,
+              ...(round.moderator === undefined ? {} : {
+                moderator: {
+                  name: round.moderator.name,
+                  invoked: round.moderator.invoked,
+                  ...(round.moderator.reason === undefined ? {} : { reason: round.moderator.reason }),
+                  decisions: round.moderator.result?.findings ?? [],
+                },
+              }),
+              acceptedFindings: round.accepted.findings,
+              acceptedUpdates: round.accepted.updates,
+              ...(round.zeroReason === undefined ? {} : { zeroReason: round.zeroReason }),
+            });
+          } catch (error) {
+            this.reportCompanionAuditWriteFailure('companion_review_round', error, {
+              companion: companionName,
+            });
+          }
+        },
       });
     } catch (error) {
       if (!isCompanionCapacityError(error)) throw error;
@@ -536,6 +613,51 @@ export class CompanionStepRuntime {
       throw new Error('Companion completion coordinator is not initialized');
     }
     return this.completionCoordinator;
+  }
+
+  private emitReviewSkipped(input: {
+    readonly companion?: string;
+    readonly phase: CompanionReviewPhase;
+    readonly reason: CompanionChangeSkipReason | 'selector_empty';
+    readonly fixRound?: number;
+    readonly observedGeneration?: number;
+  }): void {
+    if (this.stopped) return;
+    const key = input.companion === undefined || input.observedGeneration === undefined
+      ? undefined
+      : `${input.companion}\0${input.observedGeneration}`;
+    if (key !== undefined) {
+      if (this.emittedReviewSkips.has(key)) return;
+      this.emittedReviewSkips.add(key);
+    }
+    try {
+      this.events.reviewSkipped({
+        ...(input.companion === undefined ? {} : { companion: input.companion }),
+        phase: input.phase,
+        reason: input.reason,
+        ...(input.fixRound === undefined ? {} : { fixRound: input.fixRound }),
+        ...(input.observedGeneration === undefined
+          ? {}
+          : { observedGeneration: input.observedGeneration }),
+      });
+    } catch (error) {
+      this.reportCompanionAuditWriteFailure('companion_review_skipped', error);
+    }
+  }
+
+  private reportCompanionAuditWriteFailure(
+    recordType: 'companion_call' | 'companion_review_round' | 'companion_review_skipped',
+    error: unknown,
+    context: Record<string, unknown> = {},
+  ): void {
+    if (this.companionAuditWriteFailureReported) return;
+    this.companionAuditWriteFailureReported = true;
+    log.warn('Companion audit record could not be persisted; continuing workflow', {
+      step: this.deps.step.name,
+      recordType,
+      ...context,
+      error: safeExternalErrorMessage(error),
+    });
   }
 }
 

--- a/src/core/workflow/companion/structured-call.ts
+++ b/src/core/workflow/companion/structured-call.ts
@@ -4,6 +4,7 @@ import type { ProviderRoutingEntry } from '../../models/config-types.js';
 import {
   executeCompanionStructuredAgent,
   type CompanionAgentPurpose,
+  type CompanionCallAudit,
   type CompanionStructuredResponseValidator,
 } from './review-runner.js';
 
@@ -20,6 +21,13 @@ export class CompanionStructuredCaller {
       success: boolean,
       usage: AgentResponse['providerUsage'],
     ) => void;
+    readonly recordCall: (event: CompanionCallAudit) => void;
+    readonly onCallAuditPersistenceFailure?: (failure: {
+      purpose: CompanionAgentPurpose;
+      agentName: string;
+      attempt: number;
+      error: unknown;
+    }) => void;
   }) {}
 
   call(request: {
@@ -64,6 +72,7 @@ export class CompanionStructuredCaller {
           agentName: request.agentName,
           language: this.input.language,
           abortSignal: options.abortSignal,
+          onPromptResolved: options.onPromptResolved,
           resolution: {
             provider: options.resolution.provider,
             model: options.resolution.model,
@@ -74,6 +83,10 @@ export class CompanionStructuredCaller {
       recordUsage: ({ success, usage }) => {
         this.input.recordUsage(request.agentName, request.provider, success, usage);
       },
+      recordCall: (event) => {
+        this.input.recordCall(event);
+      },
+      onCallAuditPersistenceFailure: this.input.onCallAuditPersistenceFailure,
     });
   }
 }

--- a/src/core/workflow/companion/structured-call.ts
+++ b/src/core/workflow/companion/structured-call.ts
@@ -86,7 +86,9 @@ export class CompanionStructuredCaller {
       recordCall: (event) => {
         this.input.recordCall(event);
       },
-      onCallAuditPersistenceFailure: this.input.onCallAuditPersistenceFailure,
+      ...(this.input.onCallAuditPersistenceFailure === undefined
+        ? {}
+        : { onCallAuditPersistenceFailure: this.input.onCallAuditPersistenceFailure }),
     });
   }
 }

--- a/src/core/workflow/companion/trigger-scheduler.ts
+++ b/src/core/workflow/companion/trigger-scheduler.ts
@@ -3,6 +3,7 @@ import type { CompanionDiff } from './diff-reader.js';
 import {
   CompanionChangeDetector,
   COMPANION_CHANGE_DEBOUNCE_MS,
+  type CompanionChangeSkipReason,
   type CompanionChangeCandidate,
 } from './change-detector.js';
 import { isGitCommitCommand } from './git-command.js';
@@ -19,6 +20,7 @@ export class CompanionTriggerScheduler {
   private readonly knownSnapshotGenerations = new Map<string, number>();
   private snapshotOperation: Promise<void> = Promise.resolve();
   private evaluationEpoch = 0;
+  private lifecycleGeneration = 0;
   private readonly pendingBash = new Map<string, {
     readonly detectors: ReadonlyMap<string, {
       readonly dirty: boolean;
@@ -38,6 +40,11 @@ export class CompanionTriggerScheduler {
     readonly readSnapshot: () => Promise<CompanionDiff>;
     readonly isAborted: () => boolean;
     readonly onError: () => void;
+    readonly onSkipped?: (input: {
+      readonly companionName: string;
+      readonly reason: CompanionChangeSkipReason;
+      readonly candidate: CompanionChangeCandidate;
+    }) => void;
   }) {
     this.knownSnapshot = input.initialSnapshot;
     for (const [name, detector] of input.detectors) {
@@ -78,13 +85,13 @@ export class CompanionTriggerScheduler {
 
   start(): void {
     this.completing = false;
+    this.lifecycleGeneration += 1;
     if (this.pollTimer !== undefined || this.input.intervals.length === 0) return;
     const interval = Math.max(250, Math.min(...this.input.intervals));
     this.pollTimer = setInterval(() => void this.evaluateNow(), interval);
   }
 
   beginCompletion(): void {
-    this.completing = true;
     this.stop();
   }
 
@@ -96,6 +103,8 @@ export class CompanionTriggerScheduler {
   }
 
   stop(): void {
+    this.completing = true;
+    this.lifecycleGeneration += 1;
     if (this.pollTimer !== undefined) {
       clearInterval(this.pollTimer);
       this.pollTimer = undefined;
@@ -118,6 +127,7 @@ export class CompanionTriggerScheduler {
     if (candidates.length === 0) return;
     this.evaluating = true;
     this.evaluationEpoch += 1;
+    const lifecycleGeneration = this.lifecycleGeneration;
     const evaluationGenerations = new Map([...this.input.detectors].map(([name, detector]) => [
       name,
       detector.getObservedGeneration(),
@@ -125,7 +135,11 @@ export class CompanionTriggerScheduler {
     try {
       const snapshot = await this.runSnapshotOperation(async () => {
         const current = await this.input.readSnapshot();
-        if (this.completing || this.input.isAborted()) return undefined;
+        if (
+          this.completing
+          || this.input.isAborted()
+          || this.lifecycleGeneration !== lifecycleGeneration
+        ) return undefined;
         this.knownSnapshot = current;
         for (const [name, generation] of evaluationGenerations) {
           this.knownSnapshotGenerations.set(name, generation);
@@ -134,8 +148,21 @@ export class CompanionTriggerScheduler {
       });
       if (snapshot === undefined) return;
       await Promise.all(candidates.map(async ({ name, detector, candidate }) => {
-        const trigger = await detector.evaluateCandidate(candidate, snapshot);
-        if (trigger === undefined || this.completing) return;
+        let skippedReason: CompanionChangeSkipReason | undefined;
+        const trigger = await detector.evaluateCandidate(candidate, snapshot, (reason) => {
+          skippedReason = reason;
+        });
+        const staleEvaluation = this.completing
+          || this.input.isAborted()
+          || this.lifecycleGeneration !== lifecycleGeneration;
+        if (skippedReason !== undefined && !staleEvaluation) {
+          this.input.onSkipped?.({
+            companionName: name,
+            reason: skippedReason,
+            candidate,
+          });
+        }
+        if (trigger === undefined || staleEvaluation) return;
         await this.input.queue.enqueue({ companionName: name, ...trigger });
       }));
     } catch (error) {

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -105,6 +105,19 @@ import {
 
 const log = createLogger('step-executor');
 
+function emitCompanionReviewSkippedSafely(
+  emitEvent: StepExecutorDeps['emitEvent'],
+  payload: Record<string, unknown>,
+): void {
+  try {
+    emitEvent('companion:review_skipped', payload);
+  } catch (error) {
+    log.warn('Companion skip audit could not be emitted; continuing workflow', {
+      error: safeExternalErrorMessage(error),
+    });
+  }
+}
+
 function requireActiveCompanionState(
   state: WorkflowState,
   stepName: string,
@@ -866,6 +879,23 @@ export class StepExecutor {
 
     // Phase 1: main execution (Write excluded if step has report)
     let companionRuntime: CompanionStepRuntime | undefined;
+    if (isNormalAgentWorkflowStep(executableStep)) {
+      if (!this.deps.companionEnabled && executableStep.companion !== undefined) {
+        emitCompanionReviewSkippedSafely(this.deps.emitEvent, {
+          step: step.name,
+          phase: 'initial',
+          reason: 'companion_disabled',
+          runPathNamespace: [...this.deps.getRunPathNamespace()],
+        });
+      } else if (this.deps.companionEnabled && executableStep.companion === undefined) {
+        emitCompanionReviewSkippedSafely(this.deps.emitEvent, {
+          step: step.name,
+          phase: 'initial',
+          reason: 'companion_not_configured',
+          runPathNamespace: [...this.deps.getRunPathNamespace()],
+        });
+      }
+    }
     if (
       this.deps.companionEnabled
       && isNormalAgentWorkflowStep(executableStep)
@@ -927,6 +957,12 @@ export class StepExecutor {
           completionFailure: true,
           reason,
         };
+        emitCompanionReviewSkippedSafely(this.deps.emitEvent, {
+          step: step.name,
+          phase: 'initial',
+          reason: 'companion_runtime_unavailable',
+          runPathNamespace: [...this.deps.getRunPathNamespace()],
+        });
         log.warn(
           `Companion startup failed for "${step.name}"; main step will continue without completion review: ${reason}`,
         );

--- a/src/core/workflow/engine/WorkflowCallExecutor.ts
+++ b/src/core/workflow/engine/WorkflowCallExecutor.ts
@@ -456,6 +456,8 @@ export class WorkflowCallExecutor {
       'companion:complete',
       'companion:review_round',
       'companion:queue_coalesced',
+      'companion:call',
+      'companion:review_skipped',
       'step:blocked',
       'step:rate_limited',
       'step:user_input',

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -313,6 +313,50 @@ export interface CompanionQueueAuditEntry {
   readonly observedGeneration: number;
 }
 
+export type CompanionCallPurpose = 'selector' | 'reviewer' | 'moderator' | 'judge';
+export type CompanionCallStatus = 'completed' | 'failed';
+export type CompanionReviewPhase = 'initial' | 'live' | 'fix' | 'completion';
+export type CompanionReviewSkipReason =
+  | 'companion_disabled'
+  | 'companion_not_configured'
+  | 'companion_runtime_unavailable'
+  | 'selector_empty'
+  | 'empty_diff'
+  | 'unchanged_digest'
+  | 'below_minimum_changed_lines';
+export type CompanionReviewZeroReason =
+  | 'reviewer_returned_no_findings'
+  | 'moderator_not_invoked_for_empty_reviewer_result'
+  | 'moderator_rejected_or_merged_all_findings'
+  | 'no_new_finding_records';
+
+export interface CompanionModeratorDecisionAudit {
+  readonly action: 'accept' | 'reject' | 'merge' | 'downgrade';
+  readonly sourceIndex: number;
+  readonly severity?: 'must_fix' | 'should_fix' | 'nit';
+  readonly finding?: string;
+  readonly targetId?: string;
+}
+
+export interface CompanionAcceptedFindingAudit {
+  readonly severity: 'must_fix' | 'should_fix' | 'nit';
+  readonly file: string;
+  readonly line: number;
+  readonly finding: string;
+}
+
+export interface CompanionAcceptedUpdateAudit {
+  readonly id: string;
+  readonly status: 'resolved' | 'unresolved' | 'wontfix_accepted';
+}
+
+export interface CompanionModeratorAudit {
+  readonly name: string;
+  readonly invoked: boolean;
+  readonly reason?: 'reviewer_result_empty' | 'not_configured';
+  readonly decisions: readonly CompanionModeratorDecisionAudit[];
+}
+
 export interface WorkflowEvents {
   'workflow_call:start': (lifecycle: WorkflowCallLifecycle) => void;
   'workflow_call:complete': (lifecycle: WorkflowCallCompleteLifecycle) => void;
@@ -381,12 +425,44 @@ export interface WorkflowEvents {
     digest: string;
     changedLines: number;
     findingCount: number;
+    reviewerFindings: readonly CompanionAcceptedFindingAudit[];
+    reviewerUpdates: readonly CompanionAcceptedUpdateAudit[];
+    moderator?: CompanionModeratorAudit;
+    acceptedFindings: readonly CompanionAcceptedFindingAudit[];
+    acceptedUpdates: readonly CompanionAcceptedUpdateAudit[];
+    zeroReason?: CompanionReviewZeroReason;
+    runPathNamespace?: string[];
   }) => void;
   'companion:queue_coalesced': (payload: {
     step: string;
     companion: string;
     replaced: CompanionQueueAuditEntry;
     replacement: CompanionQueueAuditEntry;
+    runPathNamespace?: string[];
+  }) => void;
+  'companion:call': (payload: {
+    step: string;
+    agent: string;
+    purpose: CompanionCallPurpose;
+    attempt: number;
+    status: CompanionCallStatus;
+    provider: ProviderType;
+    model?: string;
+    systemPrompt?: string;
+    prompt?: string;
+    promptResolved: boolean;
+    runPathNamespace?: string[];
+    response?: AgentResponse;
+    error?: string;
+  }) => void;
+  'companion:review_skipped': (payload: {
+    step: string;
+    companion?: string;
+    phase: CompanionReviewPhase;
+    reason: CompanionReviewSkipReason;
+    fixRound?: number;
+    observedGeneration?: number;
+    runPathNamespace?: string[];
   }) => void;
   'step:blocked': (step: WorkflowStep, response: AgentResponse) => void;
   'step:rate_limited': (step: WorkflowStep, response: AgentResponse, rateLimitInfo: AgentResponse['rateLimitInfo']) => void;

--- a/src/features/tasks/execute/sessionLogger.ts
+++ b/src/features/tasks/execute/sessionLogger.ts
@@ -409,7 +409,10 @@ export class SessionLogger {
   onCompanionQueueCoalesced(
     input: Omit<NdjsonCompanionQueueCoalesced, 'type' | 'timestamp'>,
   ): void {
-    this.appendRecord(buildCompanionQueueCoalescedRecord(input));
+    this.appendCompanionAuditRecord(
+      'companion_queue_coalesced',
+      () => buildCompanionQueueCoalescedRecord(input),
+    );
   }
 
   onCompanionCall(
@@ -442,7 +445,8 @@ export class SessionLogger {
 
   private appendCompanionAuditRecord(
     recordType: Extract<NdjsonRecord, {
-      type: 'companion_call' | 'companion_review_round' | 'companion_review_skipped';
+      type: 'companion_call' | 'companion_review_round' | 'companion_review_skipped'
+        | 'companion_queue_coalesced';
     }>['type'],
     buildRecord: () => NdjsonRecord,
   ): void {

--- a/src/features/tasks/execute/sessionLogger.ts
+++ b/src/features/tasks/execute/sessionLogger.ts
@@ -9,7 +9,7 @@ import {
   parseNdjsonRecord,
 } from '../../../infra/fs/index.js';
 import type { InteractiveMetadata } from './types.js';
-import { isDebugEnabled, writePromptLog } from '../../../shared/utils/index.js';
+import { createLogger, isDebugEnabled, writePromptLog } from '../../../shared/utils/index.js';
 import type { PromptLogRecord, NdjsonRecord } from '../../../shared/utils/index.js';
 import type { WorkflowResumePointEntry, WorkflowStep, AgentResponse, WorkflowState } from '../../../core/models/index.js';
 import type {
@@ -18,11 +18,13 @@ import type {
   StepProviderInfo,
   WorkflowCallCompleteLifecycle,
   WorkflowCallLifecycle,
+  WorkflowEvents,
 } from '../../../core/workflow/types.js';
 import { parsePhaseExecutionId } from '../../../shared/utils/phaseExecutionId.js';
 import { sanitizeTextForStorage } from './traceReportRedaction.js';
 import { buildWorkflowStepScopeKey } from './workflowStepScope.js';
 import { SessionLoggerPhaseTracker } from './sessionLoggerPhaseTracker.js';
+import { safeExternalErrorMessage } from '../../../shared/utils/safeExternalErrorMessage.js';
 import {
   buildInteractiveRecords,
   buildPhaseCompleteRecord,
@@ -37,8 +39,11 @@ import {
   buildWorkflowCompleteRecord,
   buildCompanionReviewRoundRecord,
   buildCompanionQueueCoalescedRecord,
+  buildCompanionCallRecord,
+  buildCompanionReviewSkippedRecord,
 } from './sessionLoggerRecordFactory.js';
 import type {
+  NdjsonCompanionReviewSkipped,
   NdjsonCompanionQueueCoalesced,
   NdjsonCompanionReviewRound,
 } from '../../../shared/utils/types.js';
@@ -49,6 +54,7 @@ import {
 } from '../../../shared/utils/private-file.js';
 
 const SESSION_LOG_MODE = 0o600;
+const log = createLogger('session-logger');
 
 type TerminalSessionRecord = Extract<
   NdjsonRecord,
@@ -171,6 +177,7 @@ export class SessionLogger {
   private readonly ndjsonRecords: NdjsonRecord[] = [];
   private readonly promptRecords: PromptLogRecord[] = [];
   private workflowTerminalLogged = false;
+  private companionAuditWriteFailureReported = false;
 
   constructor(ndjsonLogPath: string, allowSensitiveData: boolean) {
     this.ndjsonLogPath = ndjsonLogPath;
@@ -393,13 +400,31 @@ export class SessionLogger {
   onCompanionReviewRound(
     input: Omit<NdjsonCompanionReviewRound, 'type' | 'timestamp'>,
   ): void {
-    this.appendRecord(buildCompanionReviewRoundRecord(input));
+    this.appendCompanionAuditRecord('companion_review_round', () => buildCompanionReviewRoundRecord(
+      input,
+      this.sanitizeText.bind(this),
+    ));
   }
 
   onCompanionQueueCoalesced(
     input: Omit<NdjsonCompanionQueueCoalesced, 'type' | 'timestamp'>,
   ): void {
     this.appendRecord(buildCompanionQueueCoalescedRecord(input));
+  }
+
+  onCompanionCall(
+    input: Parameters<WorkflowEvents['companion:call']>[0],
+  ): void {
+    this.appendCompanionAuditRecord('companion_call', () => buildCompanionCallRecord(
+      input,
+      this.sanitizeText.bind(this),
+    ));
+  }
+
+  onCompanionReviewSkipped(
+    input: Omit<NdjsonCompanionReviewSkipped, 'type' | 'timestamp'>,
+  ): void {
+    this.appendCompanionAuditRecord('companion_review_skipped', () => buildCompanionReviewSkippedRecord(input));
   }
 
   getNdjsonRecords(): NdjsonRecord[] {
@@ -413,6 +438,26 @@ export class SessionLogger {
   private appendRecord(record: NdjsonRecord): void {
     this.ndjsonRecords.push(record);
     appendNdjsonLine(this.ndjsonLogPath, record);
+  }
+
+  private appendCompanionAuditRecord(
+    recordType: Extract<NdjsonRecord, {
+      type: 'companion_call' | 'companion_review_round' | 'companion_review_skipped';
+    }>['type'],
+    buildRecord: () => NdjsonRecord,
+  ): void {
+    try {
+      const record = buildRecord();
+      appendNdjsonLine(this.ndjsonLogPath, record);
+      this.ndjsonRecords.push(record);
+    } catch (error) {
+      if (this.companionAuditWriteFailureReported) return;
+      this.companionAuditWriteFailureReported = true;
+      log.warn('Companion audit record could not be persisted; continuing workflow', {
+        recordType,
+        error: safeExternalErrorMessage(error),
+      });
+    }
   }
 
   private sanitizeText(text: string): string {

--- a/src/features/tasks/execute/sessionLoggerRecordFactory.ts
+++ b/src/features/tasks/execute/sessionLoggerRecordFactory.ts
@@ -12,6 +12,8 @@ import type {
   NdjsonWorkflowComplete,
   NdjsonCompanionReviewRound,
   NdjsonCompanionQueueCoalesced,
+  NdjsonCompanionCall,
+  NdjsonCompanionReviewSkipped,
   NdjsonCompanionReviewTrigger,
 } from '../../../infra/fs/index.js';
 import type { PromptLogRecord } from '../../../shared/utils/index.js';
@@ -27,6 +29,14 @@ import type {
   StepProviderInfo,
   WorkflowCallCompleteLifecycle,
   WorkflowCallLifecycle,
+  CompanionCallPurpose,
+  CompanionCallStatus,
+  CompanionModeratorAudit,
+  CompanionAcceptedFindingAudit,
+  CompanionAcceptedUpdateAudit,
+  CompanionReviewPhase,
+  CompanionReviewSkipReason,
+  CompanionReviewZeroReason,
 } from '../../../core/workflow/types.js';
 import { redactProviderOptions } from '../../../core/workflow/providerOptionsRedaction.js';
 import { toJudgmentMatchMethod } from '../../../core/logging/contracts.js';
@@ -34,8 +44,15 @@ import {
   parseCanonicalWorkflowResumeFrame,
 } from '../../../shared/types/workflow-resume.js';
 import type { InteractiveMetadata } from './types.js';
+import { truncateUtf8 } from '../../../shared/utils/utf8.js';
+import { isSensitiveKeyName } from '../../../shared/utils/sensitiveText.js';
+import { COMPANION_CUMULATIVE_LIMITS } from '../../../core/workflow/companion/limits.js';
+import { COMPANION_OUTPUT_LIMITS } from '../../../core/workflow/companion/output-envelope.js';
 
 type SanitizeText = (text: string) => string;
+
+const COMPANION_AUDIT_PROMPT_MAX_BYTES = COMPANION_CUMULATIVE_LIMITS.maxPromptBytes;
+const COMPANION_AUDIT_RESPONSE_MAX_BYTES = COMPANION_OUTPUT_LIMITS.maxSerializedBytes;
 
 function serializeWorkflowStack(stack: WorkflowResumePointEntry[] | undefined): {
   workflow?: string;
@@ -308,10 +325,33 @@ export function buildCompanionReviewRoundRecord(input: {
   readonly digest: string;
   readonly changedLines: number;
   readonly findingCount: number;
-}): NdjsonCompanionReviewRound {
+  readonly reviewerFindings: readonly CompanionAcceptedFindingAudit[];
+  readonly reviewerUpdates: readonly CompanionAcceptedUpdateAudit[];
+  readonly moderator?: CompanionModeratorAudit;
+  readonly acceptedFindings: readonly CompanionAcceptedFindingAudit[];
+  readonly acceptedUpdates: readonly CompanionAcceptedUpdateAudit[];
+  readonly zeroReason?: CompanionReviewZeroReason;
+  readonly runPathNamespace?: readonly string[];
+}, sanitizeText: SanitizeText): NdjsonCompanionReviewRound {
   return {
     type: 'companion_review_round',
-    ...input,
+    step: input.step,
+    companion: input.companion,
+    trigger: input.trigger,
+    digest: input.digest,
+    changedLines: input.changedLines,
+    findingCount: input.findingCount,
+    reviewerFindings: sanitizeAcceptedFindings(input.reviewerFindings, sanitizeText),
+    reviewerUpdates: sanitizeAcceptedUpdates(input.reviewerUpdates, sanitizeText),
+    ...(input.moderator === undefined ? {} : {
+      moderator: sanitizeModeratorAudit(input.moderator, sanitizeText),
+    }),
+    acceptedFindings: sanitizeAcceptedFindings(input.acceptedFindings, sanitizeText),
+    acceptedUpdates: sanitizeAcceptedUpdates(input.acceptedUpdates, sanitizeText),
+    ...(input.zeroReason === undefined ? {} : { zeroReason: input.zeroReason }),
+    ...(input.runPathNamespace === undefined || input.runPathNamespace.length === 0
+      ? {}
+      : { runPathNamespace: [...input.runPathNamespace] }),
     timestamp: new Date().toISOString(),
   };
 }
@@ -321,10 +361,241 @@ export function buildCompanionQueueCoalescedRecord(input: {
   readonly companion: string;
   readonly replaced: NdjsonCompanionQueueCoalesced['replaced'];
   readonly replacement: NdjsonCompanionQueueCoalesced['replacement'];
+  readonly runPathNamespace?: readonly string[];
 }): NdjsonCompanionQueueCoalesced {
+  const { runPathNamespace, ...record } = input;
   return {
     type: 'companion_queue_coalesced',
-    ...input,
+    ...record,
+    ...(runPathNamespace === undefined || runPathNamespace.length === 0
+      ? {}
+      : { runPathNamespace: [...runPathNamespace] }),
     timestamp: new Date().toISOString(),
+  };
+}
+
+export function buildCompanionCallRecord(
+  input: {
+    readonly step: string;
+    readonly agent: string;
+    readonly purpose: CompanionCallPurpose;
+    readonly attempt: number;
+    readonly status: CompanionCallStatus;
+    readonly provider: string;
+    readonly model?: string;
+    readonly systemPrompt?: string;
+    readonly prompt?: string;
+    readonly promptResolved: boolean;
+    readonly runPathNamespace?: readonly string[];
+    readonly response?: AgentResponse;
+    readonly error?: string;
+  },
+  sanitizeText: SanitizeText,
+): NdjsonCompanionCall {
+  const promptResolved = input.promptResolved;
+  const systemPrompt = !promptResolved || input.systemPrompt === undefined
+    ? undefined
+    : truncateAuditText(input.systemPrompt, sanitizeText, COMPANION_AUDIT_PROMPT_MAX_BYTES);
+  const prompt = !promptResolved || input.prompt === undefined
+    ? undefined
+    : truncateAuditText(input.prompt, sanitizeText, COMPANION_AUDIT_PROMPT_MAX_BYTES);
+  const response = input.response === undefined
+    ? undefined
+    : truncateAuditText(input.response.content, sanitizeText, COMPANION_AUDIT_RESPONSE_MAX_BYTES);
+  const structuredOutput = input.response?.structuredOutput === undefined
+    ? undefined
+    : serializeStructuredOutput(
+      input.response.structuredOutput,
+      sanitizeText,
+      COMPANION_AUDIT_RESPONSE_MAX_BYTES,
+    );
+  const usage = serializeCompanionUsage(input.response?.providerUsage, sanitizeText);
+  const sessionId = typeof input.response?.sessionId === 'string'
+    ? input.response.sessionId.trim()
+    : undefined;
+  const error = (input.error ?? input.response?.error) === undefined
+    ? undefined
+    : truncateAuditText(
+      input.error ?? input.response?.error ?? '',
+      sanitizeText,
+      COMPANION_AUDIT_RESPONSE_MAX_BYTES,
+    );
+  return {
+    type: 'companion_call',
+    step: input.step,
+    agent: input.agent,
+    purpose: input.purpose,
+    attempt: input.attempt,
+    status: input.status,
+    provider: input.provider,
+    ...(input.model === undefined ? {} : { model: input.model }),
+    ...(input.runPathNamespace === undefined || input.runPathNamespace.length === 0
+      ? {}
+      : { runPathNamespace: [...input.runPathNamespace] }),
+    sessionIdAvailable: sessionId !== undefined && sessionId.length > 0,
+    ...(sessionId === undefined || sessionId.length === 0
+      ? {}
+      : { sessionId: sanitizeText(sessionId) }),
+    promptResolved,
+    ...(systemPrompt === undefined ? {} : {
+      systemPrompt: systemPrompt.value,
+      systemPromptTruncated: systemPrompt.truncated,
+    }),
+    ...(prompt === undefined ? {} : {
+      prompt: prompt.value,
+      promptTruncated: prompt.truncated,
+    }),
+    ...(response === undefined
+      ? {}
+      : { response: response.value, responseTruncated: response.truncated }),
+    ...(structuredOutput === undefined
+      ? {}
+      : { structuredOutput: structuredOutput.value, structuredOutputTruncated: structuredOutput.truncated }),
+    usage,
+    ...(error === undefined
+      ? {}
+      : { error: error.value, errorTruncated: error.truncated }),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function sanitizeAcceptedFindings(
+  findings: readonly CompanionAcceptedFindingAudit[],
+  sanitizeText: SanitizeText,
+): NdjsonCompanionReviewRound['acceptedFindings'] {
+  return findings.map((finding) => ({
+    severity: finding.severity,
+    file: sanitizeText(finding.file),
+    line: finding.line,
+    finding: sanitizeText(finding.finding),
+  }));
+}
+
+function sanitizeAcceptedUpdates(
+  updates: readonly CompanionAcceptedUpdateAudit[],
+  sanitizeText: SanitizeText,
+): NdjsonCompanionReviewRound['acceptedUpdates'] {
+  return updates.map((update) => ({
+    id: sanitizeText(update.id),
+    status: update.status,
+  }));
+}
+
+export function buildCompanionReviewSkippedRecord(
+  input: {
+    readonly step: string;
+    readonly companion?: string;
+    readonly phase: CompanionReviewPhase;
+    readonly reason: CompanionReviewSkipReason;
+    readonly fixRound?: number;
+    readonly observedGeneration?: number;
+    readonly runPathNamespace?: readonly string[];
+  },
+): NdjsonCompanionReviewSkipped {
+  return {
+    type: 'companion_review_skipped',
+    step: input.step,
+    ...(input.companion === undefined ? {} : { companion: input.companion }),
+    ...(input.runPathNamespace === undefined || input.runPathNamespace.length === 0
+      ? {}
+      : { runPathNamespace: [...input.runPathNamespace] }),
+    phase: input.phase,
+    reason: input.reason,
+    ...(input.fixRound === undefined ? {} : { fixRound: input.fixRound }),
+    ...(input.observedGeneration === undefined
+      ? {}
+      : { observedGeneration: input.observedGeneration }),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function truncateAuditText(
+  value: string,
+  sanitizeText: SanitizeText,
+  maxBytes: number,
+): { value: string; truncated: boolean } {
+  const sanitized = sanitizeText(value);
+  const truncated = truncateUtf8(sanitized, maxBytes);
+  return { value: truncated.value, truncated: truncated.bytes < Buffer.byteLength(sanitized, 'utf8') };
+}
+
+function sanitizeStructuredOutput(
+  value: Record<string, unknown>,
+  sanitizeText: SanitizeText,
+): Record<string, unknown> {
+  return sanitizeStructuredValue(value, sanitizeText) as Record<string, unknown>;
+}
+
+function serializeStructuredOutput(
+  value: Record<string, unknown>,
+  sanitizeText: SanitizeText,
+  maxBytes: number,
+): { value: string; truncated: boolean } {
+  const sanitized = sanitizeStructuredOutput(value, sanitizeText);
+  const serialized = JSON.stringify(sanitized);
+  if (serialized === undefined) {
+    throw new Error('Companion structured output is not serializable');
+  }
+  // Re-sanitize the serialized envelope so embedded assignment-style secrets
+  // are covered in addition to key-aware nested redaction.
+  return truncateAuditText(serialized, sanitizeText, maxBytes);
+}
+
+function sanitizeStructuredValue(
+  value: unknown,
+  sanitizeText: SanitizeText,
+  key?: string,
+): unknown {
+  if (key !== undefined && isSensitiveKeyName(key)) return '[REDACTED]';
+  if (typeof value === 'string') return sanitizeText(value);
+  if (Array.isArray(value)) return value.map((item) => sanitizeStructuredValue(item, sanitizeText));
+  if (value === null || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([nestedKey, nested]) => [
+      nestedKey,
+      sanitizeStructuredValue(nested, sanitizeText, nestedKey),
+    ]),
+  );
+}
+
+function sanitizeModeratorAudit(
+  moderator: CompanionModeratorAudit,
+  sanitizeText: SanitizeText,
+): NonNullable<NdjsonCompanionReviewRound['moderator']> {
+  return {
+    name: moderator.name,
+    invoked: moderator.invoked,
+    ...(moderator.reason === undefined ? {} : { reason: moderator.reason }),
+    decisions: moderator.decisions.map((decision) => ({
+      action: decision.action,
+      sourceIndex: decision.sourceIndex,
+      ...(decision.severity === undefined ? {} : { severity: decision.severity }),
+      ...(decision.finding === undefined ? {} : { finding: sanitizeText(decision.finding) }),
+      ...(decision.targetId === undefined ? {} : { targetId: sanitizeText(decision.targetId) }),
+    })),
+  };
+}
+
+function serializeCompanionUsage(
+  usage: AgentResponse['providerUsage'],
+  sanitizeText: SanitizeText,
+): NdjsonCompanionCall['usage'] {
+  if (usage === undefined) {
+    return {
+      usageMissing: true,
+      reason: 'provider_did_not_return_usage',
+    };
+  }
+  return {
+    usageMissing: usage.usageMissing ?? true,
+    ...(usage.inputTokens === undefined ? {} : { inputTokens: usage.inputTokens }),
+    ...(usage.outputTokens === undefined ? {} : { outputTokens: usage.outputTokens }),
+    ...(usage.totalTokens === undefined ? {} : { totalTokens: usage.totalTokens }),
+    ...(usage.cachedInputTokens === undefined ? {} : { cachedInputTokens: usage.cachedInputTokens }),
+    ...(usage.cacheCreationInputTokens === undefined ? {} : {
+      cacheCreationInputTokens: usage.cacheCreationInputTokens,
+    }),
+    ...(usage.cacheReadInputTokens === undefined ? {} : { cacheReadInputTokens: usage.cacheReadInputTokens }),
+    ...(usage.reason === undefined ? {} : { reason: sanitizeText(usage.reason) }),
   };
 }

--- a/src/features/tasks/execute/workflowExecutionEvents.ts
+++ b/src/features/tasks/execute/workflowExecutionEvents.ts
@@ -19,7 +19,8 @@ import {
   sanitizeTerminalTextWithinBytes,
 } from '../../../shared/utils/text.js';
 import { isDebugEnabled, isVerboseConsole } from '../../../shared/utils/debug.js';
-import { notifyWarning, playWarningSound } from '../../../shared/utils/index.js';
+import { createLogger, notifyWarning, playWarningSound } from '../../../shared/utils/index.js';
+import { safeExternalErrorMessage } from '../../../shared/utils/safeExternalErrorMessage.js';
 import type { ExceededInfo, WorkflowExecutionEvent, WorkflowExecutionOptions } from './types.js';
 import type { AnalyticsStepContext } from './analyticsEmitter.js';
 import { detectStepType, isQuietMode } from './workflowExecutionBootstrap.js';
@@ -135,6 +136,7 @@ type WorkflowTerminalIntent =
     };
 
 type OutInfo = { info: (line: string) => void };
+const log = createLogger('workflow-execution-events');
 
 function resolveStepProviderContext(
   providerInfo: StepProviderInfo,
@@ -409,12 +411,28 @@ export function bindWorkflowExecutionEvents(
   let preparedTerminalPublication:
     WorkflowTerminalPublicationPayload | undefined;
   let confirmationSequence = 0;
+  let companionAuditWriteFailureReported = false;
   const nextConfirmationId = (): string => {
     confirmationSequence += 1;
     return `confirmation-${confirmationSequence}`;
   };
   const onEventSinkFailure = (error: unknown): void => {
     finalizationIssues.push(new RunLiveDeliveryError(error));
+  };
+  const persistCompanionAudit = (
+    recordType: 'companion_call' | 'companion_review_round' | 'companion_review_skipped',
+    persist: () => void,
+  ): void => {
+    try {
+      persist();
+    } catch (error) {
+      if (companionAuditWriteFailureReported) return;
+      companionAuditWriteFailureReported = true;
+      log.warn('Companion audit record could not be persisted; continuing workflow', {
+        recordType,
+        error: safeExternalErrorMessage(error),
+      });
+    }
   };
   const syncLatestResumePoint = (): void => {
     if (!canReadResumePoint()) {
@@ -843,11 +861,22 @@ export function bindWorkflowExecutionEvents(
     );
   });
   deps.engine.on('companion:review_round', (payload) => {
-    deps.analyticsEmitter.onCompanionEvent('companion:review_round', payload);
-    deps.sessionLogger.onCompanionReviewRound(payload);
+    const summary = {
+      step: payload.step,
+      companion: payload.companion,
+      trigger: payload.trigger,
+      digest: payload.digest,
+      changedLines: payload.changedLines,
+      findingCount: payload.findingCount,
+      ...(payload.runPathNamespace === undefined
+        ? {}
+        : { runPathNamespace: payload.runPathNamespace }),
+    };
+    deps.analyticsEmitter.onCompanionEvent('companion:review_round', summary);
+    persistCompanionAudit('companion_review_round', () => deps.sessionLogger.onCompanionReviewRound(payload));
     emitWorkflowExecutionEvent(
       deps.eventSink,
-      { type: 'companion', action: 'review_round', ...payload },
+      { type: 'companion', action: 'review_round', ...summary },
       onEventSinkFailure,
       eventSinkDispatchState,
     );
@@ -861,6 +890,12 @@ export function bindWorkflowExecutionEvents(
       onEventSinkFailure,
       eventSinkDispatchState,
     );
+  });
+  deps.engine.on('companion:call', (payload) => {
+    persistCompanionAudit('companion_call', () => deps.sessionLogger.onCompanionCall(payload));
+  });
+  deps.engine.on('companion:review_skipped', (payload) => {
+    persistCompanionAudit('companion_review_skipped', () => deps.sessionLogger.onCompanionReviewSkipped(payload));
   });
 
   deps.engine.on('workflow:complete', (workflowState) => {

--- a/src/infra/fs/index.ts
+++ b/src/infra/fs/index.ts
@@ -18,6 +18,8 @@ export type {
   NdjsonInteractiveEnd,
   NdjsonCompanionReviewRound,
   NdjsonCompanionQueueCoalesced,
+  NdjsonCompanionCall,
+  NdjsonCompanionReviewSkipped,
   NdjsonCompanionReviewTrigger,
   NdjsonRecord,
 } from './session.js';

--- a/src/infra/fs/session.ts
+++ b/src/infra/fs/session.ts
@@ -563,7 +563,7 @@ function requireCompanionCallFields(
     throw new Error('NDJSON companion call status is invalid');
   }
   requireNdjsonInteger(record.attempt, 'attempt');
-  if ((record.attempt as number) < 1) {
+  if (record.attempt < 1) {
     throw new Error('NDJSON companion call attempt must be positive');
   }
   requireNdjsonString(record.provider, 'provider');
@@ -784,7 +784,7 @@ function requireOptionalNdjsonBoolean(value: unknown, field: string): void {
   if (value !== undefined) requireNdjsonBoolean(value, field);
 }
 
-function requireNdjsonInteger(value: unknown, field: string): void {
+function requireNdjsonInteger(value: unknown, field: string): asserts value is number {
   if (!Number.isSafeInteger(value) || (value as number) < 0) {
     throw new Error(`NDJSON ${field} must be a non-negative integer`);
   }

--- a/src/infra/fs/session.ts
+++ b/src/infra/fs/session.ts
@@ -37,6 +37,8 @@ export type {
   NdjsonInteractiveEnd,
   NdjsonCompanionReviewRound,
   NdjsonCompanionQueueCoalesced,
+  NdjsonCompanionCall,
+  NdjsonCompanionReviewSkipped,
   NdjsonCompanionReviewTrigger,
   NdjsonRecord,
 } from '../../shared/utils/index.js';
@@ -480,6 +482,12 @@ function assertNdjsonRecordShape(
     case 'companion_queue_coalesced':
       requireCompanionQueueCoalescedFields(record);
       return;
+    case 'companion_call':
+      requireCompanionCallFields(record);
+      return;
+    case 'companion_review_skipped':
+      requireCompanionReviewSkippedFields(record);
+      return;
     default:
       throw new Error(`Unknown NDJSON session record type: ${String(record.type)}`);
   }
@@ -500,6 +508,13 @@ function requireCompanionReviewRoundFields(
   requireNdjsonString(record.digest, 'digest');
   requireNdjsonInteger(record.changedLines, 'changedLines');
   requireNdjsonInteger(record.findingCount, 'findingCount');
+  requireCompanionAcceptedFindings(record.reviewerFindings);
+  requireCompanionAcceptedUpdates(record.reviewerUpdates);
+  requireOptionalCompanionModeratorAudit(record.moderator);
+  requireCompanionAcceptedFindings(record.acceptedFindings);
+  requireCompanionAcceptedUpdates(record.acceptedUpdates);
+  requireOptionalCompanionZeroReason(record.zeroReason);
+  requireOptionalNdjsonStringArray(record.runPathNamespace, 'runPathNamespace');
   requireNdjsonString(record.timestamp, 'timestamp');
 }
 
@@ -508,6 +523,7 @@ function requireCompanionQueueCoalescedFields(
 ): void {
   requireNdjsonString(record.step, 'step');
   requireNdjsonString(record.companion, 'companion');
+  requireOptionalNdjsonStringArray(record.runPathNamespace, 'runPathNamespace');
   requireCompanionQueueRequest(record.replaced, 'replaced');
   requireCompanionQueueRequest(record.replacement, 'replacement');
   requireNdjsonString(record.timestamp, 'timestamp');
@@ -530,6 +546,202 @@ function requireCompanionReviewTrigger(value: unknown): void {
   }
 }
 
+function requireCompanionCallFields(
+  record: Readonly<Record<string, unknown>>,
+): void {
+  requireNdjsonString(record.step, 'step');
+  requireNdjsonString(record.agent, 'agent');
+  if (
+    record.purpose !== 'selector'
+    && record.purpose !== 'reviewer'
+    && record.purpose !== 'moderator'
+    && record.purpose !== 'judge'
+  ) {
+    throw new Error('NDJSON companion call purpose is invalid');
+  }
+  if (record.status !== 'completed' && record.status !== 'failed') {
+    throw new Error('NDJSON companion call status is invalid');
+  }
+  requireNdjsonInteger(record.attempt, 'attempt');
+  if ((record.attempt as number) < 1) {
+    throw new Error('NDJSON companion call attempt must be positive');
+  }
+  requireNdjsonString(record.provider, 'provider');
+  requireOptionalNdjsonString(record.model, 'model');
+  requireOptionalNdjsonStringArray(record.runPathNamespace, 'runPathNamespace');
+  requireNdjsonBoolean(record.sessionIdAvailable, 'sessionIdAvailable');
+  requireOptionalNdjsonString(record.sessionId, 'sessionId');
+  if (record.sessionIdAvailable !== (typeof record.sessionId === 'string' && record.sessionId.length > 0)) {
+    throw new Error('NDJSON companion session ID availability does not match session ID');
+  }
+  requireNdjsonBoolean(record.promptResolved, 'promptResolved');
+  if (record.promptResolved) {
+    requireNdjsonString(record.systemPrompt, 'systemPrompt');
+    requireNdjsonBoolean(record.systemPromptTruncated, 'systemPromptTruncated');
+    requireNdjsonString(record.prompt, 'prompt');
+    requireNdjsonBoolean(record.promptTruncated, 'promptTruncated');
+  } else if (
+    record.systemPrompt !== undefined
+    || record.systemPromptTruncated !== undefined
+    || record.prompt !== undefined
+    || record.promptTruncated !== undefined
+  ) {
+    throw new Error('NDJSON unresolved companion prompt must be omitted');
+  }
+  requireOptionalNdjsonString(record.response, 'response');
+  requireOptionalNdjsonBoolean(record.responseTruncated, 'responseTruncated');
+  requireOptionalNdjsonString(record.structuredOutput, 'structuredOutput');
+  requireOptionalNdjsonBoolean(record.structuredOutputTruncated, 'structuredOutputTruncated');
+  requireCompanionUsage(record.usage);
+  requireOptionalNdjsonString(record.error, 'error');
+  requireOptionalNdjsonBoolean(record.errorTruncated, 'errorTruncated');
+  requireNdjsonString(record.timestamp, 'timestamp');
+}
+
+function requireCompanionUsage(value: unknown): void {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('NDJSON companion usage must be an object');
+  }
+  const usage = value as Record<string, unknown>;
+  requireNdjsonBoolean(usage.usageMissing, 'usage.usageMissing');
+  for (const field of [
+    'inputTokens',
+    'outputTokens',
+    'totalTokens',
+    'cachedInputTokens',
+    'cacheCreationInputTokens',
+    'cacheReadInputTokens',
+  ]) {
+    requireOptionalNdjsonInteger(usage[field], `usage.${field}`);
+  }
+  requireOptionalNdjsonString(usage.reason, 'usage.reason');
+}
+
+function requireCompanionAcceptedFindings(value: unknown): void {
+  if (!Array.isArray(value)) {
+    throw new Error('NDJSON companion accepted findings must be an array');
+  }
+  value.forEach((finding, index) => {
+    if (finding === null || typeof finding !== 'object' || Array.isArray(finding)) {
+      throw new Error(`NDJSON companion accepted finding[${index}] must be an object`);
+    }
+    const item = finding as Record<string, unknown>;
+    if (
+      item.severity !== 'must_fix'
+      && item.severity !== 'should_fix'
+      && item.severity !== 'nit'
+    ) {
+      throw new Error(`NDJSON companion accepted finding[${index}] severity is invalid`);
+    }
+    requireNdjsonString(item.file, `acceptedFindings[${index}].file`);
+    requireNdjsonInteger(item.line, `acceptedFindings[${index}].line`);
+    requireNdjsonString(item.finding, `acceptedFindings[${index}].finding`);
+  });
+}
+
+function requireCompanionAcceptedUpdates(value: unknown): void {
+  if (!Array.isArray(value)) {
+    throw new Error('NDJSON companion accepted updates must be an array');
+  }
+  value.forEach((update, index) => {
+    if (update === null || typeof update !== 'object' || Array.isArray(update)) {
+      throw new Error(`NDJSON companion accepted update[${index}] must be an object`);
+    }
+    const item = update as Record<string, unknown>;
+    requireNdjsonString(item.id, `acceptedUpdates[${index}].id`);
+    if (
+      item.status !== 'resolved'
+      && item.status !== 'unresolved'
+      && item.status !== 'wontfix_accepted'
+    ) {
+      throw new Error(`NDJSON companion accepted update[${index}] status is invalid`);
+    }
+  });
+}
+
+function requireOptionalCompanionModeratorAudit(value: unknown): void {
+  if (value === undefined) return;
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('NDJSON companion moderator must be an object');
+  }
+  const moderator = value as Record<string, unknown>;
+  requireNdjsonString(moderator.name, 'moderator.name');
+  requireNdjsonBoolean(moderator.invoked, 'moderator.invoked');
+  if (moderator.reason !== undefined
+    && moderator.reason !== 'reviewer_result_empty'
+    && moderator.reason !== 'not_configured') {
+    throw new Error('NDJSON companion moderator reason is invalid');
+  }
+  if (!Array.isArray(moderator.decisions)) {
+    throw new Error('NDJSON companion moderator decisions must be an array');
+  }
+  moderator.decisions.forEach((decision, index) => {
+    if (decision === null || typeof decision !== 'object' || Array.isArray(decision)) {
+      throw new Error(`NDJSON companion moderator decision[${index}] must be an object`);
+    }
+    const item = decision as Record<string, unknown>;
+    if (
+      item.action !== 'accept'
+      && item.action !== 'reject'
+      && item.action !== 'merge'
+      && item.action !== 'downgrade'
+    ) {
+      throw new Error(`NDJSON companion moderator decision[${index}] action is invalid`);
+    }
+    requireNdjsonInteger(item.sourceIndex, `moderator.decisions[${index}].sourceIndex`);
+    if (item.severity !== undefined
+      && item.severity !== 'must_fix'
+      && item.severity !== 'should_fix'
+      && item.severity !== 'nit') {
+      throw new Error(`NDJSON companion moderator decision[${index}] severity is invalid`);
+    }
+    requireOptionalNdjsonString(item.finding, `moderator.decisions[${index}].finding`);
+    requireOptionalNdjsonString(item.targetId, `moderator.decisions[${index}].targetId`);
+  });
+}
+
+function requireOptionalCompanionZeroReason(value: unknown): void {
+  if (value === undefined) return;
+  if (
+    value !== 'reviewer_returned_no_findings'
+    && value !== 'moderator_not_invoked_for_empty_reviewer_result'
+    && value !== 'moderator_rejected_or_merged_all_findings'
+    && value !== 'no_new_finding_records'
+  ) {
+    throw new Error('NDJSON companion zero reason is invalid');
+  }
+}
+
+function requireCompanionReviewSkippedFields(
+  record: Readonly<Record<string, unknown>>,
+): void {
+  requireNdjsonString(record.step, 'step');
+  requireOptionalNdjsonString(record.companion, 'companion');
+  if (
+    record.phase !== 'initial'
+    && record.phase !== 'live'
+    && record.phase !== 'fix'
+    && record.phase !== 'completion'
+  ) {
+    throw new Error('NDJSON companion review skipped phase is invalid');
+  }
+  if (
+    record.reason !== 'companion_disabled'
+    && record.reason !== 'companion_not_configured'
+    && record.reason !== 'companion_runtime_unavailable'
+    && record.reason !== 'selector_empty'
+    && record.reason !== 'empty_diff'
+    && record.reason !== 'unchanged_digest'
+    && record.reason !== 'below_minimum_changed_lines'
+  ) {
+    throw new Error('NDJSON companion review skipped reason is invalid');
+  }
+  requireOptionalNdjsonInteger(record.fixRound, 'fixRound');
+  requireOptionalNdjsonInteger(record.observedGeneration, 'observedGeneration');
+  requireOptionalNdjsonStringArray(record.runPathNamespace, 'runPathNamespace');
+  requireNdjsonString(record.timestamp, 'timestamp');
+}
+
 function requireNdjsonWorkflowCallIdentity(
   record: Readonly<Record<string, unknown>>,
 ): void {
@@ -549,10 +761,27 @@ function requireNdjsonString(value: unknown, field: string): void {
   }
 }
 
+function requireNdjsonBoolean(value: unknown, field: string): void {
+  if (typeof value !== 'boolean') {
+    throw new Error(`NDJSON ${field} must be a boolean`);
+  }
+}
+
 function requireOptionalNdjsonString(value: unknown, field: string): void {
   if (value !== undefined) {
     requireNdjsonString(value, field);
   }
+}
+
+function requireOptionalNdjsonStringArray(value: unknown, field: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`NDJSON ${field} must be an array of strings`);
+  }
+}
+
+function requireOptionalNdjsonBoolean(value: unknown, field: string): void {
+  if (value !== undefined) requireNdjsonBoolean(value, field);
 }
 
 function requireNdjsonInteger(value: unknown, field: string): void {

--- a/src/shared/utils/types.ts
+++ b/src/shared/utils/types.ts
@@ -257,6 +257,8 @@ export interface NdjsonCompanionCall {
   promptTruncated?: boolean;
   response?: string;
   responseTruncated?: boolean;
+  structuredOutput?: string;
+  structuredOutputTruncated?: boolean;
   usage: NdjsonCompanionUsage;
   error?: string;
   errorTruncated?: boolean;

--- a/src/shared/utils/types.ts
+++ b/src/shared/utils/types.ts
@@ -194,6 +194,13 @@ export interface NdjsonCompanionReviewRound {
   digest: string;
   changedLines: number;
   findingCount: number;
+  reviewerFindings: NdjsonCompanionAcceptedFinding[];
+  reviewerUpdates: NdjsonCompanionAcceptedUpdate[];
+  moderator?: NdjsonCompanionModeratorAudit;
+  acceptedFindings: NdjsonCompanionAcceptedFinding[];
+  acceptedUpdates: NdjsonCompanionAcceptedUpdate[];
+  zeroReason?: NdjsonCompanionZeroReason;
+  runPathNamespace?: string[];
   timestamp: string;
 }
 
@@ -213,6 +220,101 @@ export interface NdjsonCompanionQueueCoalesced {
     changedLines: number;
     observedGeneration: number;
   };
+  runPathNamespace?: string[];
+  timestamp: string;
+}
+
+export type NdjsonCompanionCallPurpose = 'selector' | 'reviewer' | 'moderator' | 'judge';
+export type NdjsonCompanionCallStatus = 'completed' | 'failed';
+
+export interface NdjsonCompanionUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  usageMissing: boolean;
+  reason?: string;
+}
+
+export interface NdjsonCompanionCall {
+  type: 'companion_call';
+  step: string;
+  agent: string;
+  purpose: NdjsonCompanionCallPurpose;
+  attempt: number;
+  status: NdjsonCompanionCallStatus;
+  provider: string;
+  model?: string;
+  runPathNamespace?: string[];
+  sessionIdAvailable: boolean;
+  sessionId?: string;
+  promptResolved: boolean;
+  systemPrompt?: string;
+  systemPromptTruncated?: boolean;
+  prompt?: string;
+  promptTruncated?: boolean;
+  response?: string;
+  responseTruncated?: boolean;
+  usage: NdjsonCompanionUsage;
+  error?: string;
+  errorTruncated?: boolean;
+  timestamp: string;
+}
+
+export type NdjsonCompanionZeroReason =
+  | 'reviewer_returned_no_findings'
+  | 'moderator_not_invoked_for_empty_reviewer_result'
+  | 'moderator_rejected_or_merged_all_findings'
+  | 'no_new_finding_records';
+
+export interface NdjsonCompanionModeratorDecision {
+  action: 'accept' | 'reject' | 'merge' | 'downgrade';
+  sourceIndex: number;
+  severity?: 'must_fix' | 'should_fix' | 'nit';
+  finding?: string;
+  targetId?: string;
+}
+
+export interface NdjsonCompanionModeratorAudit {
+  name: string;
+  invoked: boolean;
+  reason?: 'reviewer_result_empty' | 'not_configured';
+  decisions: NdjsonCompanionModeratorDecision[];
+}
+
+export interface NdjsonCompanionAcceptedFinding {
+  severity: 'must_fix' | 'should_fix' | 'nit';
+  file: string;
+  line: number;
+  finding: string;
+}
+
+export interface NdjsonCompanionAcceptedUpdate {
+  id: string;
+  status: 'resolved' | 'unresolved' | 'wontfix_accepted';
+}
+
+export type NdjsonCompanionReviewPhase = 'initial' | 'live' | 'fix' | 'completion';
+export type NdjsonCompanionReviewSkipReason =
+  | 'companion_disabled'
+  | 'companion_not_configured'
+  | 'companion_runtime_unavailable'
+  | 'selector_empty'
+  | 'empty_diff'
+  | 'unchanged_digest'
+  | 'below_minimum_changed_lines';
+
+export interface NdjsonCompanionReviewSkipped {
+  type: 'companion_review_skipped';
+  step: string;
+  companion?: string;
+  phase: NdjsonCompanionReviewPhase;
+  reason: NdjsonCompanionReviewSkipReason;
+  fixRound?: number;
+  observedGeneration?: number;
+  runPathNamespace?: string[];
   timestamp: string;
 }
 
@@ -230,7 +332,9 @@ export type NdjsonRecord =
   | NdjsonInteractiveStart
   | NdjsonInteractiveEnd
   | NdjsonCompanionReviewRound
-  | NdjsonCompanionQueueCoalesced;
+  | NdjsonCompanionQueueCoalesced
+  | NdjsonCompanionCall
+  | NdjsonCompanionReviewSkipped;
 
 /** Record for debug prompt/response log (debug-*-prompts.jsonl) */
 export interface PromptLogRecord {


### PR DESCRIPTION
## 目的

Companionのround完了集計だけでは、実際のモデル呼び出し、moderator判断、0件理由、レビュー非実行理由を検証できなかったため、run NDJSONへ監査可能な記録を追加します。

## 変更内容

- selector/reviewer/moderator/judgeの実呼び出しごとに、解決済みprompt、応答、provider/model、session、usage、試行結果を記録
- 既存companion_review_roundへreviewer候補、moderator判断、確定結果、0件理由を追加
- disabled、未設定、起動失敗、選択0件、差分0件、同一差分、閾値未満のskip理由を記録
- workflow-call配下のrun namespaceを保持
- 機密値のredactionとサイズ上限を適用し、監査ログ失敗はworkflow結果へ影響させない
- 詳細findingはrun NDJSONだけに保存し、analytics/event sinkは従来の集計payloadを維持

## 過剰実装の監査

当初案にあった独立companion_review_auditイベント、配列から導出する重複件数、agentと常に同値のcompanionフィールドは削除しました。

## 検証

- npm run lint
- npm run build
- npm test: 5,358 tests passed
- 対象7ファイル: 211 tests passed
- npm test -- src/__tests__/releaseVerificationWiring.test.ts: 17 tests passed
- npm run test:it: 1,986 passed / 1 failed
  - worktreeのnode_modules symlinkをvite-nodeが辿れずwanakanaを解決できない環境固有失敗
  - 同じmcp-entrypoint.integration.test.tsはmain checkoutで1 test passed

実providerを使うcheck:releaseは実行していません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * コンパニオンの呼び出し、レビュー結果、モデレーター判断、採用結果を監査ログに記録できるようになりました。
  * レビュー未実行時の理由や実行経路を記録します。
  * プロンプト、応答、構造化データの機密情報をマスキングして保存します。
  * レビュー結果がない場合の理由を確認できるようになりました。
* **改善**
  * 監査ログの保存に失敗しても、ワークフローは継続します。
  * 中断後の再開時にレビュー結果を保持・再利用します。
  * 実行中の状態変更による古い結果の通知やキュー登録を防止します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->