### PR TITLE
fix(tasks): retry start picker をツリー選択に作り直し、Resume 消失と stale frame を修正する (#1223)

### DIFF
--- a/src/__tests__/it-task-restart-point.test.ts
+++ b/src/__tests__/it-task-restart-point.test.ts
@@ -328,20 +328,54 @@ function buildNestedRestartPoint(projectDir: string): WorkflowRestartPoint {
 async function selectRestartPath(
   root: NonNullable<ReturnType<typeof loadWorkflowByIdentifier>>,
   projectDir: string,
-  labels: string[],
+  leaf: string,
+  occurrence = 0,
 ): Promise<WorkflowRestartPoint> {
-  let labelIndex = 0;
+  let branchLabel: string | undefined;
   const selected = await selectTaskRetryStart(root, {
     projectCwd: projectDir,
     lookupCwd: projectDir,
   }, async (_message, options) => {
-    const label = labels[labelIndex]!;
-    labelIndex += 1;
-    const option = options.find((candidate) => candidate.label === label);
-    if (option === undefined) {
-      throw new Error(`Expected retry option: ${label}`);
+    if (options.length === 0) {
+      throw new Error('Retry picker returned no options');
     }
-    return option.value;
+    const option = options.filter((candidate) => candidate.label.trim() === leaf)[occurrence];
+    if (option !== undefined) {
+      return option.value;
+    }
+
+    const navigationOptions = options.filter((candidate) => (
+      candidate.indent === (candidate.leadingLines?.length ?? 0) + 1
+    ));
+    if (branchLabel === undefined) {
+      const rootNavigation = navigationOptions.filter((candidate) => (
+        (candidate.leadingLines?.length ?? 0) === 1
+      ))[occurrence];
+      if (rootNavigation !== undefined) {
+        branchLabel = rootNavigation.label.trim();
+        return rootNavigation.value;
+      }
+    }
+    const branchNavigationOptions = branchLabel === undefined
+      ? navigationOptions
+      : navigationOptions.filter((candidate) => (
+        candidate.leadingLines?.some((line) => line.trim() === branchLabel) === true
+      ));
+    const deepestNavigationDepth = Math.max(
+      ...branchNavigationOptions.map((candidate) => candidate.leadingLines?.length ?? 0),
+      0,
+    );
+    const navigation = deepestNavigationDepth > 1
+      ? branchNavigationOptions.find((candidate) => (
+        (candidate.leadingLines?.length ?? 0) === deepestNavigationDepth
+      ))
+      : branchNavigationOptions.filter((candidate) => (
+        (candidate.leadingLines?.length ?? 0) === 1
+      ))[occurrence];
+    if (navigation === undefined) {
+      throw new Error(`Expected retry option: ${leaf} (#${occurrence})`);
+    }
+    return navigation.value;
   });
   if (selected?.selection.kind !== 'restart') {
     throw new Error('Expected restart selection');
@@ -926,7 +960,7 @@ describe('task restart persistence and execution resolution', () => {
     await expect(resolveTaskExecution(pending, projectDir)).rejects.toThrow(/restart.*publish/i);
   });
 
-  it('should fail queued revalidation when a selected terminal workflow_call target disappears', async () => {
+  it('should fail queued revalidation when the selected child workflow disappears', async () => {
     const projectDir = createProject();
     writeNestedWorkflows(projectDir, 'review');
     writeFailedTask(projectDir);
@@ -934,16 +968,14 @@ describe('task restart persistence and execution resolution', () => {
     if (root === null) {
       throw new Error('Expected default workflow');
     }
-    const restartPoint = await selectRestartPath(root, projectDir, [
-      'Restart from: "default" > "delegate"',
-    ]);
+    const restartPoint = await selectRestartPath(root, projectDir, 'review');
     const runner = new TaskRunner(projectDir);
     runner.requeueTask(
       'nested-retry',
       ['failed'],
       {
         startStep: undefined,
-        retryNote: 'restart terminal call',
+        retryNote: 'restart child review',
         resumePoint: undefined,
         workflow: undefined,
         taskDir: undefined,
@@ -958,7 +990,7 @@ describe('task restart persistence and execution resolution', () => {
     await expect(resolveTaskExecution(pending, projectDir)).rejects.toThrow(/unknown workflow.*coding/i);
   });
 
-  it('should fail queued revalidation when a selected terminal workflow_call target becomes non-callable', async () => {
+  it('should fail queued revalidation when the selected child workflow becomes non-callable', async () => {
     const projectDir = createProject();
     writeNestedWorkflows(projectDir, 'review');
     writeFailedTask(projectDir);
@@ -966,16 +998,14 @@ describe('task restart persistence and execution resolution', () => {
     if (root === null) {
       throw new Error('Expected default workflow');
     }
-    const restartPoint = await selectRestartPath(root, projectDir, [
-      'Restart from: "default" > "delegate"',
-    ]);
+    const restartPoint = await selectRestartPath(root, projectDir, 'review');
     const runner = new TaskRunner(projectDir);
     runner.requeueTask(
       'nested-retry',
       ['failed'],
       {
         startStep: undefined,
-        retryNote: 'restart terminal call',
+        retryNote: 'restart child review',
         resumePoint: undefined,
         workflow: undefined,
         taskDir: undefined,
@@ -1047,11 +1077,7 @@ describe('task restart persistence and execution resolution', () => {
 
     const restartPoints = [];
     for (const [rootStep, leaf] of [['left', 'leaf-a'], ['right', 'leaf-b']] as const) {
-      restartPoints.push(await selectRestartPath(root, projectDir, [
-        `Browse child workflow from: "args-root" > "${rootStep}"`,
-        `Browse child workflow from: "args-root" > "${rootStep}" > "router" > "route"`,
-        `Restart from: "args-root" > "${rootStep}" > "router" > "route" > "${leaf}" > "finish"`,
-      ]));
+      restartPoints.push(await selectRestartPath(root, projectDir, 'finish', rootStep === 'right' ? 1 : 0));
     }
     expect(restartPoints.map((point) => point.stack[2]?.workflow)).toEqual(['leaf-a', 'leaf-b']);
     for (const restartPoint of restartPoints) {
@@ -1093,14 +1119,8 @@ describe('task restart persistence and execution resolution', () => {
     if (root === null) {
       throw new Error('Expected identity-root workflow');
     }
-    const leftRestartPoint = await selectRestartPath(root, projectDir, [
-      'Browse child workflow from: "identity-root" > "left"',
-      'Restart from: "identity-root" > "left" > "shared" > "review"',
-    ]);
-    const rightRestartPoint = await selectRestartPath(root, projectDir, [
-      'Browse child workflow from: "identity-root" > "right"',
-      'Restart from: "identity-root" > "right" > "shared" > "review"',
-    ]);
+    const leftRestartPoint = await selectRestartPath(root, projectDir, 'review', 0);
+    const rightRestartPoint = await selectRestartPath(root, projectDir, 'review', 1);
     const runner = new TaskRunner(projectDir);
     runner.requeueTask(
       'nested-retry',

--- a/src/__tests__/prompt.test.ts
+++ b/src/__tests__/prompt.test.ts
@@ -13,9 +13,13 @@ import {
   handleKeyInput,
   readMultilineFromStream,
 } from '../shared/prompt/index.js';
+import { renderSingleOption } from '../shared/prompt/select-menu.js';
+import { getDisplayWidth, stripAnsi } from '../shared/utils/text.js';
 
 // Disable chalk colors for predictable test output
 chalk.level = 0;
+
+type TreeOption = SelectOptionItem<string> & { leadingLines?: string[] };
 
 describe('prompt', () => {
   describe('renderMenu', () => {
@@ -118,6 +122,25 @@ describe('prompt', () => {
       expect(lines).toHaveLength(1);
       expect(lines[0]).toContain('Cancel');
     });
+
+    it('should render leading tree headings without adding selectable cursor positions', () => {
+      const options: TreeOption[] = [
+        { label: 'plan', value: 'plan', leadingLines: ['development-core'] },
+        { label: 'reviewers', value: 'reviewers', leadingLines: ['peer-review'] },
+      ];
+
+      const lines = renderMenu(options, 1, false);
+
+      expect(lines).toHaveLength(4);
+      expect(lines[0]).toContain('development-core');
+      expect(lines[0]).not.toContain('❯');
+      expect(lines[1]).toContain('plan');
+      expect(lines[1]).not.toContain('❯');
+      expect(lines[2]).toContain('peer-review');
+      expect(lines[2]).not.toContain('❯');
+      expect(lines[3]).toContain('❯');
+      expect(lines[3]).toContain('reviewers');
+    });
   });
 
   describe('countRenderedLines', () => {
@@ -185,6 +208,86 @@ describe('prompt', () => {
 
     it('should return 1 for empty options with cancel', () => {
       expect(countRenderedLines([], true)).toBe(1);
+    });
+
+    it('should count leading tree headings in the rendered line total', () => {
+      const options: TreeOption[] = [
+        { label: 'plan', value: 'plan', leadingLines: ['development-core'] },
+        { label: 'reviewers', value: 'reviewers', leadingLines: ['peer-review'] },
+      ];
+
+      expect(countRenderedLines(options, true)).toBe(5);
+    });
+
+    it('should count shared tree headings only once across consecutive leaves', () => {
+      const options: TreeOption[] = [
+        { label: 'plan', value: 'plan', leadingLines: ['root', 'child'] },
+        { label: 'review', value: 'review', leadingLines: ['root', 'child'] },
+        { label: 'fix', value: 'fix', leadingLines: ['root', 'child'] },
+      ];
+
+      expect(countRenderedLines(options, false)).toBe(5);
+    });
+  });
+
+  describe('renderSingleOption', () => {
+    it('should include indent in every truncation width budget', () => {
+      const maxWidth = 16;
+      const lines = renderSingleOption({
+        label: 'ABCDEFGHIJK',
+        value: 'item',
+        description: 'description',
+        details: ['detail'],
+        indent: 2,
+      }, false, maxWidth);
+
+      expect(lines).toHaveLength(3);
+      for (const line of lines) {
+        expect(getDisplayWidth(stripAnsi(line))).toBeLessThanOrEqual(maxWidth);
+      }
+    });
+
+    it('should keep a deeply indented narrow option within max width', () => {
+      const maxWidth = 10;
+      const lines = renderSingleOption({
+        label: '選択肢ABC',
+        value: 'item',
+        description: '説明文',
+        details: ['詳細情報'],
+        indent: 4,
+      }, false, maxWidth);
+
+      expect(lines).toHaveLength(3);
+      for (const line of lines) {
+        expect(getDisplayWidth(stripAnsi(line))).toBeLessThanOrEqual(maxWidth);
+      }
+    });
+
+    it('should keep leading heading lines within max width', () => {
+      const maxWidth = 20;
+      const lines = renderSingleOption({
+        label: 'review',
+        value: 'item',
+        leadingLines: [
+          `${'  '.repeat(3)}${'A'.repeat(100)}`,
+          '日本語'.repeat(20),
+        ],
+      }, false, maxWidth);
+
+      expect(lines).toHaveLength(3);
+      for (const line of lines) {
+        expect(getDisplayWidth(stripAnsi(line))).toBeLessThanOrEqual(maxWidth);
+      }
+    });
+
+    it('should truncate the heading prefix when max width is narrower than the prefix', () => {
+      const lines = renderSingleOption({
+        label: 'review',
+        value: 'item',
+        leadingLines: ['heading'],
+      }, false, 1);
+
+      expect(getDisplayWidth(stripAnsi(lines[0]!))).toBeLessThanOrEqual(1);
     });
   });
 
@@ -396,6 +499,55 @@ describe('prompt', () => {
 
       // defaultValue not found → falls back to index 0
       expect(result).toBe('plan');
+    });
+
+    it('should preserve leading tree headings while marking the selected default', async () => {
+      setupRawStdin(['\r']);
+
+      const { selectOptionWithDefault } = await import('../shared/prompt/index.js');
+      const options: TreeOption[] = [
+        { label: 'plan', value: 'plan', leadingLines: ['development-core'] },
+        { label: 'reviewers', value: 'reviewers', leadingLines: ['peer-review'] },
+      ];
+
+      const result = await selectOptionWithDefault('Start position:', options, 'reviewers');
+      const writes = (process.stdout.write as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+      const output = writes.map((call) => String(call[0] ?? '')).join('');
+
+      expect(result).toBe('reviewers');
+      expect(output).toContain('peer-review');
+      expect(output).toMatch(/❯ reviewers \(default\)/);
+    });
+
+    it('should show a deep default leaf and its cursor in the initial viewport', async () => {
+      const rowsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'rows');
+      Object.defineProperty(process.stdout, 'rows', { value: 10, configurable: true });
+
+      try {
+        setupRawStdin(['\r']);
+
+        const { selectOptionWithDefault } = await import('../shared/prompt/index.js');
+        const options: TreeOption[] = Array.from({ length: 60 }, (_, index) => ({
+          label: `leaf-${index}`,
+          value: `leaf-${index}`,
+          leadingLines: ['root', 'branch'],
+        }));
+
+        const result = await selectOptionWithDefault('Start position:', options, 'leaf-59');
+        const writes = (process.stdout.write as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+        const output = writes.map((call) => String(call[0] ?? '')).join('');
+        const defaultLine = output.split('\n').find((line) => line.includes('leaf-59'));
+
+        expect(defaultLine).toContain('❯');
+        expect(defaultLine).toContain('(default)');
+        expect(result).toBe('leaf-59');
+      } finally {
+        if (rowsDescriptor) {
+          Object.defineProperty(process.stdout, 'rows', rowsDescriptor);
+        } else {
+          Reflect.deleteProperty(process.stdout, 'rows');
+        }
+      }
     });
   });
 

--- a/src/__tests__/select-viewport.test.ts
+++ b/src/__tests__/select-viewport.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect } from 'vitest';
 import chalk from 'chalk';
 import type { SelectOptionItem } from '../shared/prompt/select-menu.js';
-import { countItemLines } from '../shared/prompt/select-menu.js';
+import { countItemLines, countRenderedLines } from '../shared/prompt/select-menu.js';
 import {
   createViewportState,
   adjustScrollOffset,
@@ -16,6 +16,8 @@ import {
 } from '../shared/prompt/select-viewport.js';
 
 chalk.level = 0;
+
+type TreeOption = SelectOptionItem<string> & { leadingLines?: string[] };
 
 // ── Test fixtures ────────────────────────────────────────────────────
 
@@ -40,6 +42,14 @@ function withDescAndDetails(
   return { label, value, description, details };
 }
 
+function withLeadingLines(
+  label: string,
+  value: string,
+  leadingLines: string[],
+): TreeOption {
+  return { label, value, leadingLines };
+}
+
 // ── countItemLines ───────────────────────────────────────────────────
 
 describe('countItemLines', () => {
@@ -57,6 +67,21 @@ describe('countItemLines', () => {
 
   it('should count description + details', () => {
     expect(countItemLines(withDescAndDetails('A', 'a', 'desc', ['d1', 'd2', 'd3']))).toBe(5);
+  });
+
+  it('should count non-selectable leading tree headings', () => {
+    expect(countItemLines(withLeadingLines('review', 'review', ['development-core', 'peer-review']))).toBe(3);
+  });
+
+  it('should count shared headings according to the rendered suffixes', () => {
+    const options = [
+      withLeadingLines('plan', 'plan', ['root', 'child']),
+      withLeadingLines('review', 'review', ['root', 'child']),
+      withLeadingLines('fix', 'fix', ['root', 'child']),
+    ];
+
+    expect(countRenderedLines(options, false)).toBe(5);
+    expect(countItemLines(options[1]!, options[0]!.leadingLines)).toBe(1);
   });
 });
 
@@ -111,6 +136,42 @@ describe('createViewportState', () => {
 
     expect(state.active).toBe(true);
     expect(state.maxOptionLines).toBe(4);
+  });
+
+  it('should activate the viewport using tree heading lines', () => {
+    const options = [
+      withLeadingLines('plan', 'plan', ['development-core']),
+      withLeadingLines('review', 'review', ['development-core', 'peer-review']),
+      withLeadingLines('fix', 'fix', ['development-core', 'peer-review']),
+    ];
+    const state = createViewportState(8, options, false);
+
+    expect(state.active).toBe(true);
+    expect(state.maxOptionLines).toBe(4);
+  });
+
+  it('should align shared heading count, viewport state, and rendered lines', () => {
+    const options = [
+      withLeadingLines('plan', 'plan', ['root', 'child']),
+      withLeadingLines('review', 'review', ['root', 'child']),
+      withLeadingLines('fix', 'fix', ['root', 'child']),
+    ];
+    const state = createViewportState(8, options, false);
+    const lines = renderMenuWithViewport(
+      options,
+      1,
+      false,
+      1,
+      state.maxOptionLines,
+      'Cancel',
+    );
+
+    expect(countRenderedLines(options, false)).toBe(5);
+    expect(state.active).toBe(true);
+    expect(lines.filter((line) => line.includes('root'))).toHaveLength(1);
+    expect(lines.filter((line) => line.includes('child'))).toHaveLength(1);
+    expect(lines.find((line) => line.includes('❯'))).toContain('review');
+    expect(lines).toHaveLength(countItemLines(options[1]!) + 2);
   });
 });
 
@@ -174,6 +235,19 @@ describe('adjustScrollOffset', () => {
     // scrollOffset=0, selected=3 (below visible)
     const result = adjustScrollOffset(3, 0, multiLineOpts, false, 4);
     expect(result).toBeGreaterThan(0);
+  });
+
+  it('should scroll by selectable leaf index while accounting for heading lines', () => {
+    const options = [
+      withLeadingLines('plan', 'plan', ['development-core']),
+      withLeadingLines('review', 'review', ['development-core', 'peer-review']),
+      withLeadingLines('fix', 'fix', ['development-core', 'peer-review']),
+    ];
+
+    const result = adjustScrollOffset(2, 0, options, false, 4);
+
+    expect(result).toBeGreaterThan(0);
+    expect(adjustScrollOffset(2, result, options, false, 4)).toBe(result);
   });
 });
 
@@ -277,5 +351,36 @@ describe('renderMenuWithViewport', () => {
     expect(lines.join('\n')).toContain('A');
     expect(lines.join('\n')).toContain('desc a');
     expect(lines.join('\n')).toContain('↓ 2 more');
+  });
+
+  it('should render tree headings without cursors and keep the leaf cursor aligned', () => {
+    const options = [
+      withLeadingLines('plan', 'plan', ['development-core']),
+      withLeadingLines('review', 'review', ['development-core', 'peer-review']),
+    ];
+
+    const lines = renderMenuWithViewport(options, 1, false, 0, 5, 'Cancel');
+
+    expect(lines.join('\n')).toContain('development-core');
+    expect(lines.join('\n')).toContain('peer-review');
+    expect(lines.filter((line) => line.includes('❯'))).toHaveLength(1);
+    expect(lines.find((line) => line.includes('❯'))).toContain('review');
+  });
+
+  it('should repeat all headings for the first option in a scrolled viewport', () => {
+    const options = [
+      withLeadingLines('plan', 'plan', ['root', 'child']),
+      withLeadingLines('review', 'review', ['root', 'child']),
+      withLeadingLines('fix', 'fix', ['root', 'other']),
+    ];
+
+    const lines = renderMenuWithViewport(options, 1, false, 1, 5, 'Cancel');
+
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toContain('↑ 1 more');
+    expect(lines.filter((line) => line.includes('root'))).toHaveLength(1);
+    expect(lines.filter((line) => line.includes('child'))).toHaveLength(1);
+    expect(lines.find((line) => line.includes('❯'))).toContain('review');
+    expect(lines[lines.length - 1]).toContain('↓ 1 more');
   });
 });

--- a/src/__tests__/taskRetryActions.test.ts
+++ b/src/__tests__/taskRetryActions.test.ts
@@ -271,20 +271,12 @@ function makeNestedCheckpoint() {
 function configureNestedReviewRestart(): TaskListItem {
   mockFindRunForTask.mockImplementationOnce(() => null);
   mockLoadWorkflowByIdentifier.mockReturnValue(nestedRootWorkflowConfig);
-  selectStartCandidate('Restart from: default > delegate > coding > review');
-  return makeFailedTask({
-    data: {
-      task: 'Do something',
-      workflow: 'default',
-      resume_point: makeNestedCheckpoint(),
-    },
-  });
-}
-
-function configureRootCallRestart(): TaskListItem {
-  mockFindRunForTask.mockImplementationOnce(() => null);
-  mockLoadWorkflowByIdentifier.mockReturnValue(nestedRootWorkflowConfig);
-  selectStartCandidate('Restart from: default > delegate');
+  mockSelectOptionWithDefault.mockImplementationOnce(
+    (_message: string, options: Array<{ label: string; value: string }>) => (
+      options.find((option) => option.label.trim() === 'delegate')?.value ?? null
+    ),
+  );
+  selectStartCandidate('review');
   return makeFailedTask({
     data: {
       task: 'Do something',
@@ -310,16 +302,6 @@ const nestedReviewRestartPoint = {
       kind: 'agent' as const,
     },
   ],
-};
-
-const rootCallRestartPoint = {
-  stack: [{
-    workflow: 'default',
-    workflow_ref: 'default',
-    step: 'delegate',
-    kind: 'workflow_call' as const,
-    call_instance: 1 as const,
-  }],
 };
 
 const defaultPlanRestartPoint = {
@@ -355,32 +337,10 @@ function makeFailedTask(overrides?: Partial<TaskListItem>): TaskListItem {
   };
 }
 
-function selectStartCandidate(label: string): void {
-  const normalizeLabel = (candidateLabel: string): string => candidateLabel.replace(
-    /^(Restart from: |Resume failed position: )(.*?)( \[default\])?$/,
-    (_match, prefix: string, path: string, suffix: string | undefined) => (
-      `${prefix}${path.split(' > ').map((segment) => JSON.stringify(segment)).join(' > ')}${suffix ?? ''}`
-    ),
-  );
-  const normalizedLabel = normalizeLabel(label);
-  const path = label.replace(/^(Restart from: |Resume failed position: )/, '').replace(/ \[default\]$/, '');
-  const segments = path.split(' > ');
-  if (label.startsWith('Restart from: ') && segments.length > 2) {
-    for (let stepIndex = 1; stepIndex < segments.length - 1; stepIndex += 2) {
-      const browsePath = segments.slice(0, stepIndex + 1)
-        .map((segment) => JSON.stringify(segment))
-        .join(' > ');
-      const browseLabel = `Browse child workflow from: ${browsePath}`;
-      mockSelectOptionWithDefault.mockImplementationOnce(
-        (_message: string, options: Array<{ label: string; value: string }>) => (
-          options.find((option) => option.label === browseLabel)?.value ?? null
-        ),
-      );
-    }
-  }
+function selectStartCandidate(leaf: string): void {
   mockSelectOptionWithDefault.mockImplementationOnce(
     (_message: string, options: Array<{ label: string; value: string }>) => (
-      options.find((option) => option.label === normalizedLabel)?.value ?? null
+      options.find((option) => option.label.trim() === leaf)?.value ?? null
     ),
   );
 }
@@ -411,17 +371,17 @@ function expectResumeCandidateIsDefault(): void {
   const call = mockSelectOptionWithDefault.mock.calls.at(-1);
   const options = call?.[1] as Array<{ label: string; value: string }>;
   const defaultValue = call?.[2];
-  const resumeCandidate = options.find((option) => option.label.startsWith('Resume failed position:'));
+  const resumeCandidate = options.find((option) => option.value === defaultValue);
   expect(resumeCandidate).toBeDefined();
-  expect(defaultValue).toBe(resumeCandidate?.value);
+  expect(resumeCandidate?.label.trim()).toBe('review');
 }
 
 function expectRestartCandidateIsDefault(path: string): void {
   const call = mockSelectOptionWithDefault.mock.calls.at(-1);
   const options = call?.[1] as Array<{ label: string; value: string }>;
   const defaultValue = call?.[2];
-  const formattedPath = path.split(' > ').map((segment) => JSON.stringify(segment)).join(' > ');
-  const restartCandidate = options.find((option) => option.label === `Restart from: ${formattedPath}`);
+  const leafSegment = path.split(' > ').at(-1)!;
+  const restartCandidate = options.find((option) => option.label.trim() === leafSegment);
   expect(restartCandidate).toBeDefined();
   expect(defaultValue).toBe(restartCandidate?.value);
 }
@@ -429,9 +389,7 @@ function expectRestartCandidateIsDefault(path: string): void {
 function expectEffectRestartCandidateIsHidden(): void {
   const call = mockSelectOptionWithDefault.mock.calls.at(-1);
   const options = call?.[1] as Array<{ label: string; value: string }>;
-  expect(options.map((option) => option.label)).toEqual([
-    'Restart from: "default" > "plan"',
-  ]);
+  expect(options.map((option) => option.label.trim())).toEqual(['plan']);
 }
 
 const autoRequeueNote = [
@@ -471,8 +429,13 @@ beforeEach(() => {
   mockIsWorkflowPath.mockImplementation((workflow: string) => workflow.startsWith('/') || workflow.startsWith('~') || workflow.startsWith('./') || workflow.startsWith('../') || workflow.endsWith('.yaml') || workflow.endsWith('.yml'));
   mockLoadAllStandaloneWorkflowsWithSources.mockReturnValue(new Map<string, unknown>([['default', {}], ['selected-workflow', {}]]));
   mockSelectOptionWithDefault.mockImplementation(
-    (_message: string, options: Array<{ label: string; value: string }>) => (
-      options.find((option) => option.label === 'Restart from: "default" > "plan"')?.value
+    (
+      _message: string,
+      options: Array<{ label: string; value: string }>,
+      defaultValue: string,
+    ) => (
+      options.find((option) => option.label.trim() === 'plan')?.value
+      ?? options.find((option) => option.value === defaultValue)?.value
       ?? options[0]?.value
       ?? null
     ),
@@ -733,7 +696,7 @@ describe('requeueFailedTask', () => {
         resume_point: resumePoint,
       },
     });
-    selectStartCandidate('Resume failed position: default > implement [default]');
+    selectStartCandidate('implement');
 
     await requeueFailedTask(task, '/project');
 
@@ -791,7 +754,7 @@ describe('requeueFailedTask', () => {
 
   it('should pass a non-initial selected step only through restartPoint', async () => {
     const task = makeFailedTask();
-    selectStartCandidate('Restart from: default > implement');
+    selectStartCandidate('implement');
 
     await requeueFailedTask(task, '/project');
 
@@ -872,7 +835,7 @@ describe('requeueFailedTask', () => {
         { name: 'final_review', persona: 'supervisor', instruction: '', personaDisplayName: 'supervisor', passPreviousResponse: true },
       ],
     });
-    selectStartCandidate('Resume failed position: default > delegate > takt/coding > review [default]');
+    selectStartCandidate('review');
     const task = makeFailedTask({
       data: {
         task: 'Do something',
@@ -916,29 +879,7 @@ describe('requeueFailedTask', () => {
         restartPoint: nestedReviewRestartPoint,
       },
     );
-    expect(mockInfo).toHaveBeenCalledWith(
-      'Selected start position: Restart from: "default" > "delegate" > "coding" > "review"',
-    );
-  });
-
-  it('should preserve a terminal root workflow_call restart path for Requeue', async () => {
-    const task = configureRootCallRestart();
-
-    await requeueFailedTask(task, '/project');
-
-    expectRequeueTaskCalledWith(
-      'my-task',
-      ['failed'],
-      {
-        startStep: undefined,
-        retryNote: autoRequeueNote,
-        resumePoint: undefined,
-        workflow: undefined,
-        taskDir: undefined,
-        sourceRunSlug: undefined,
-        restartPoint: rootCallRestartPoint,
-      },
-    );
+    expect(mockInfo).toHaveBeenCalledWith('Selected start position: review');
   });
 
   it('should not expose an effect-backed system step through Requeue selection', async () => {
@@ -964,8 +905,7 @@ describe('requeueFailedTask', () => {
     );
   });
 
-  it('should confirm the same collision-safe path label shown in the start selection', async () => {
-    const selectedLabel = 'Restart from: "default" > "line\\\\n"';
+  it('should preserve a collision-safe selected leaf value', async () => {
     mockFindRunForTask.mockImplementationOnce(() => null);
     mockLoadWorkflowByIdentifier.mockReturnValue({
       ...defaultWorkflowConfig,
@@ -977,11 +917,9 @@ describe('requeueFailedTask', () => {
     });
     mockSelectOptionWithDefault.mockImplementationOnce(
       (_message: string, options: Array<{ label: string; value: string }>) => {
-        expect(options.map((option) => option.label)).toEqual([
-          'Restart from: "default" > "line\\n"',
-          selectedLabel,
-        ]);
-        return options.find((option) => option.label === selectedLabel)?.value ?? null;
+        expect(options.map((option) => option.label.trim())).toEqual(['line\\n', 'line\\n']);
+        expect(options.every((option) => !/[\n\r\x1b]/.test(option.label))).toBe(true);
+        return options[1]?.value ?? null;
       },
     );
     const task = makeFailedTask({ data: { task: 'Do something', workflow: 'default' } });
@@ -1003,7 +941,7 @@ describe('requeueFailedTask', () => {
       },
       },
     );
-    expect(mockInfo).toHaveBeenCalledWith(`Selected start position: ${selectedLabel}`);
+    expect(mockInfo).toHaveBeenCalledWith('Selected start position: line\\n');
   });
 
   it('should return false when workflow selection is cancelled', async () => {
@@ -1374,11 +1312,11 @@ describe('retryFailedTask', () => {
     await retryFailedTask(task, '/project');
 
     const call = mockSelectOptionWithDefault.mock.calls.at(-1);
-    expect(call?.[0]).toBe('Start position — "default" (page 1/1):');
+    expect(call?.[0]).not.toContain('page');
     expect(call?.[1]).toEqual(expect.arrayContaining([
-      expect.objectContaining({ label: 'Restart from: "default" > "plan"', description: 'Initial step' }),
-      expect.objectContaining({ label: 'Restart from: "default" > "implement"' }),
-      expect.objectContaining({ label: 'Restart from: "default" > "review"' }),
+      expect.objectContaining({ label: 'plan', description: 'Initial step' }),
+      expect.objectContaining({ label: 'implement' }),
+      expect.objectContaining({ label: 'review' }),
     ]));
     expectRestartCandidateIsDefault('default > review');
   });
@@ -1488,7 +1426,7 @@ describe('retryFailedTask', () => {
     );
   });
 
-  it('should keep root workflow_call step as retry default when child step was renamed', async () => {
+  it('should choose the child initial leaf when the preferred step is a workflow_call', async () => {
     mockFindRunForTask.mockReturnValue('run-1');
     mockLoadWorkflowByIdentifier.mockReturnValue({
       ...defaultWorkflowConfig,
@@ -1541,7 +1479,7 @@ describe('retryFailedTask', () => {
 
     await retryFailedTask(makeFailedTask(), '/project');
 
-    expectRestartCandidateIsDefault('default > delegate');
+    expectRestartCandidateIsDefault('default > delegate > takt/coding > fix');
   });
 
   it('should reject retry selection when a workflow_call target no longer resolves', async () => {
@@ -1600,7 +1538,7 @@ describe('retryFailedTask', () => {
 
   it('should pass a non-initial selected step only through restartPoint', async () => {
     const task = makeFailedTask();
-    selectStartCandidate('Restart from: default > implement');
+    selectStartCandidate('implement');
 
     await retryFailedTask(task, '/project');
 
@@ -1668,7 +1606,7 @@ describe('retryFailedTask', () => {
         { name: 'review', persona: 'reviewer', instruction: '' },
       ],
     });
-    selectStartCandidate('Resume failed position: default > implement > takt/coding > review [default]');
+    selectStartCandidate('review');
     const task = makeFailedTask();
 
     await retryFailedTask(task, '/project');
@@ -1714,27 +1652,6 @@ describe('retryFailedTask', () => {
       startStep: undefined,
       restartPoint: nestedReviewRestartPoint,
     });
-  });
-
-  it('should preserve a terminal root workflow_call restart path for immediate Retry execution', async () => {
-    const task = configureRootCallRestart();
-
-    await retryFailedTask(task, '/project');
-
-    expectStartReExecutionCalledWith(
-      'my-task',
-      ['failed'],
-      'retry',
-      {
-        startStep: undefined,
-        retryNote: '追加指示A',
-        resumePoint: undefined,
-        workflow: undefined,
-        taskDir: undefined,
-        sourceRunSlug: undefined,
-        restartPoint: rootCallRestartPoint,
-      },
-    );
   });
 
   it('should not expose an effect-backed system step through immediate Retry selection', async () => {
@@ -1799,7 +1716,7 @@ describe('retryFailedTask', () => {
       startTime: '2026-04-13T00:00:00.000Z',
       resumePoint,
     });
-    selectStartCandidate('Restart from: default > review');
+    selectStartCandidate('review');
     const task = makeFailedTask();
 
     await retryFailedTask(task, '/project');
@@ -1952,15 +1869,14 @@ describe('retryFailedTask', () => {
     mockLoadWorkflowByIdentifier.mockReturnValue(workflow);
 
     await expect(retryFailedTask(makeFailedTask(), '/project')).resolves.toBe(true);
-    expect(mockSelectOptionWithDefault).toHaveBeenCalledWith(
-      'Start position — "selected-workflow" (page 1/1):',
-      expect.arrayContaining([
-        expect.objectContaining({ label: 'Restart from: "selected-workflow" > "plan"' }),
-        expect.objectContaining({ label: 'Restart from: "selected-workflow" > "implement"' }),
-        expect.objectContaining({ label: 'Restart from: "selected-workflow" > "review"' }),
-      ]),
-      expect.any(String),
-    );
+    const call = mockSelectOptionWithDefault.mock.calls.at(-1);
+    expect(call?.[0]).not.toContain('page');
+    expect(call?.[1]).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: 'plan' }),
+      expect.objectContaining({ label: 'implement' }),
+      expect.objectContaining({ label: 'review' }),
+    ]));
+    expect(call?.[2]).toEqual(expect.any(String));
   });
 
   it('should allow allow_git_commit worktree workflows during retry and continue to step selection', async () => {
@@ -1988,15 +1904,14 @@ describe('retryFailedTask', () => {
     mockLoadWorkflowByIdentifier.mockReturnValue(workflow);
 
     await expect(retryFailedTask(makeFailedTask(), '/project')).resolves.toBe(true);
-    expect(mockSelectOptionWithDefault).toHaveBeenCalledWith(
-      'Start position — "selected-workflow" (page 1/1):',
-      expect.arrayContaining([
-        expect.objectContaining({ label: 'Restart from: "selected-workflow" > "plan"' }),
-        expect.objectContaining({ label: 'Restart from: "selected-workflow" > "implement"' }),
-        expect.objectContaining({ label: 'Restart from: "selected-workflow" > "review"' }),
-      ]),
-      expect.any(String),
-    );
+    const call = mockSelectOptionWithDefault.mock.calls.at(-1);
+    expect(call?.[0]).not.toContain('page');
+    expect(call?.[1]).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: 'plan' }),
+      expect.objectContaining({ label: 'implement' }),
+      expect.objectContaining({ label: 'review' }),
+    ]));
+    expect(call?.[2]).toEqual(expect.any(String));
   });
 
   it('should show deprecated config warning when selected run order uses legacy provider fields', async () => {
@@ -2212,7 +2127,7 @@ describe('retryFailedTask', () => {
         { name: 'final_review', persona: 'supervisor', instruction: '', personaDisplayName: 'supervisor', passPreviousResponse: true },
       ],
     });
-    selectStartCandidate('Resume failed position: default > delegate > takt/coding > review [default]');
+    selectStartCandidate('review');
     mockRunTaskRetryMode.mockResolvedValue({ action: 'save_task', task: '追加指示A' });
 
     const task = makeFailedTask({
@@ -2260,27 +2175,6 @@ describe('retryFailedTask', () => {
         taskDir: undefined,
         sourceRunSlug: undefined,
         restartPoint: nestedReviewRestartPoint,
-      },
-    );
-  });
-
-  it('should preserve a terminal root workflow_call restart path for Retry save_task', async () => {
-    const task = configureRootCallRestart();
-    mockRunTaskRetryMode.mockResolvedValue({ action: 'save_task', task: '追加指示A' });
-
-    await retryFailedTask(task, '/project');
-
-    expectRequeueTaskCalledWith(
-      'my-task',
-      ['failed'],
-      {
-        startStep: undefined,
-        retryNote: '追加指示A',
-        resumePoint: undefined,
-        workflow: undefined,
-        taskDir: undefined,
-        sourceRunSlug: undefined,
-        restartPoint: rootCallRestartPoint,
       },
     );
   });

--- a/src/__tests__/taskRetryStartSelection.test.ts
+++ b/src/__tests__/taskRetryStartSelection.test.ts
@@ -9,12 +9,9 @@ import type {
 import { MAX_WORKFLOW_CALL_DEPTH } from '../core/workflow/workflow-call-depth.js';
 import {
   selectTaskRetryStart,
-  type TaskRetryStartOptionSelector,
 } from '../features/tasks/list/taskRetryStartSelection.js';
-import {
-  TASK_RETRY_START_PAGE_SIZE,
-  validateTaskRetryRestartPoint,
-} from '../features/tasks/taskRetryStartPath.js';
+import { validateTaskRetryRestartPoint } from '../features/tasks/taskRetryStartPath.js';
+import type { SelectOptionItem } from '../shared/prompt/index.js';
 import { attachWorkflowOpaqueRef } from '../infra/config/loaders/workflowSourceMetadata.js';
 
 const mockResolveWorkflowCallTarget = vi.hoisted(() => vi.fn());
@@ -29,10 +26,13 @@ const pathContext = {
   lookupCwd: '/project/worktree',
 };
 
+type TreeOption = SelectOptionItem<string> & { leadingLines?: string[] };
+
 function agentStep(name: string): WorkflowStep {
   return {
     name,
     persona: `${name}-persona`,
+    personaDisplayName: name,
     instruction: `${name} instruction`,
   };
 }
@@ -46,6 +46,7 @@ function callStep(name: string, call: string): WorkflowCallStep {
     name,
     kind: 'workflow_call',
     call,
+    personaDisplayName: name,
     instruction: `${name} instruction`,
   };
 }
@@ -57,6 +58,13 @@ function systemStep(name: string, effects?: WorkflowStep['effects']): WorkflowSt
     personaDisplayName: name,
     instruction: `${name} instruction`,
     ...(effects === undefined ? {} : { effects }),
+  };
+}
+
+function parallelStep(name: string, parallel: WorkflowStep[] = [agentStep(`${name}-worker`)]): WorkflowStep {
+  return {
+    ...agentStep(name),
+    parallel,
   };
 }
 
@@ -76,17 +84,25 @@ function makeWorkflow(options: {
   }, options.ref);
 }
 
-function chooseLabels(labels: string[]): TaskRetryStartOptionSelector {
-  let index = 0;
-  return vi.fn(async (_message, options) => {
-    const expected = labels[index];
-    index += 1;
-    const selected = options.find((option) => option.label === expected);
-    if (selected === undefined) {
-      throw new Error(`Missing scripted option: ${expected}`);
-    }
-    return selected.value;
-  });
+function asTreeOptions(options: SelectOptionItem<string>[]): TreeOption[] {
+  return options as TreeOption[];
+}
+
+function optionLabel(option: TreeOption): string {
+  return option.label.trim();
+}
+
+function findLeaf(
+  options: SelectOptionItem<string>[],
+  label: string,
+  occurrence = 0,
+): SelectOptionItem<string> {
+  const matches = options.filter((option) => option.label.trim() === label);
+  const match = matches[occurrence];
+  if (match === undefined) {
+    throw new Error(`Missing leaf option: ${label} (#${occurrence})`);
+  }
+  return match;
 }
 
 function rootRestartPoint(step: string, kind: 'agent' | 'system' = 'agent'): WorkflowRestartPoint {
@@ -100,15 +116,10 @@ function rootRestartPoint(step: string, kind: 'agent' | 'system' = 'agent'): Wor
   };
 }
 
-function rootResumePoint(step: string, kind: 'agent' | 'system'): WorkflowResumePoint {
+function resumePointWithStack(stack: WorkflowResumePoint['stack']): WorkflowResumePoint {
   return {
     version: 2,
-    stack: [{
-      workflow: 'default',
-      workflow_ref: 'project:root',
-      step,
-      kind,
-    }],
+    stack,
     iteration: 4,
     elapsed_ms: 1_000,
     workflow_call_invocations: {},
@@ -116,114 +127,1211 @@ function rootResumePoint(step: string, kind: 'agent' | 'system'): WorkflowResume
   };
 }
 
+function rootResumePoint(
+  step: string,
+  kind: 'agent' | 'system' | 'parallel',
+): WorkflowResumePoint {
+  return resumePointWithStack([{
+    workflow: 'default',
+    workflow_ref: 'project:root',
+    step,
+    kind,
+    occurrence: 1,
+  }]);
+}
+
 beforeEach(() => {
   mockResolveWorkflowCallTarget.mockReset();
 });
 
-describe('task retry start browser contracts', () => {
-
-  it('should select a grandchild restart with a complete stateless path', async () => {
-    const grandchild = makeWorkflow({
-      name: 'review-loop',
-      ref: 'project:grandchild',
-      callable: true,
-      steps: [agentStep('review'), agentStep('fix')],
+describe('task retry start tree selection', () => {
+  it('should keep the initial picker window bounded for a large root workflow', async () => {
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: Array.from({ length: 100_000 }, (_, index) => agentStep(`step-${index}`)),
     });
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    const result = await selectTaskRetryStart(root, pathContext, async (
+      _message,
+      options,
+      defaultValue,
+    ) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    expect(observedOptions.length).toBeLessThanOrEqual(50);
+    expect(observedOptions).toHaveLength(50);
+    expect(observedOptions.at(-1)?.label.trim()).toBe('step-49');
+    expect(observedDefault).toBe(observedOptions[0]?.value);
+    expect(mockResolveWorkflowCallTarget).not.toHaveBeenCalled();
+    expect(result?.selection.kind).toBe('restart');
+  });
+
+  it('should include the preferred child leaf within the shared initial window', async () => {
     const child = makeWorkflow({
-      name: 'coding',
+      name: 'child',
       ref: 'project:child',
       callable: true,
-      steps: [agentStep('implement'), callStep('delegate-review', 'review-loop')],
+      steps: Array.from({ length: 6 }, (_, index) => agentStep(`review-${index}`)),
     });
     const root = makeWorkflow({
       name: 'default',
       ref: 'project:root',
-      steps: [agentStep('plan'), callStep('delegate', 'coding')],
+      steps: [
+        ...Array.from({ length: 49 }, (_, index) => agentStep(`step-${index}`)),
+        callStep('delegate', 'child'),
+      ],
     });
-    mockResolveWorkflowCallTarget.mockImplementation(
-      (_parent: WorkflowConfig, step: { call: string }) => ({
-        coding: child,
-        'review-loop': grandchild,
-      })[step.call] ?? null,
-    );
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
 
-    const result = await selectTaskRetryStart(root, pathContext, chooseLabels([
-      'Browse child workflow from: "default" > "delegate"',
-      'Browse child workflow from: "default" > "delegate" > "coding" > "delegate-review"',
-      'Restart from: "default" > "delegate" > "coding" > "delegate-review" > "review-loop" > "fix"',
-    ]));
-
-    expect(result?.label).toBe(
-      'Restart from: "default" > "delegate" > "coding" > "delegate-review" > "review-loop" > "fix"',
-    );
-    expect(result?.selection).toEqual({
-      kind: 'restart',
-      restartPoint: {
-        stack: [
-          expect.objectContaining({ workflow_ref: 'project:root', step: 'delegate', call_instance: 1 }),
-          expect.objectContaining({ workflow_ref: 'project:child', step: 'delegate-review', call_instance: 1 }),
-          expect.objectContaining({ workflow_ref: 'project:grandchild', step: 'fix', kind: 'agent' }),
-        ],
-      },
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      preferredRootStep: 'delegate',
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
     });
-    expect(mockResolveWorkflowCallTarget).toHaveBeenCalledTimes(2);
+
+    const preferredLeaf = findLeaf(observedOptions, 'review-0');
+    expect(observedOptions.length).toBeLessThanOrEqual(50);
+    expect(new Set(observedOptions.map((option) => option.value)).size).toBe(observedOptions.length);
+    expect(observedDefault).toBe(preferredLeaf.value);
+    expect(result?.selection.kind).toBe('restart');
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.at(-1)?.step
+      : undefined).toBe('review-0');
   });
 
-  it('should restart from a terminal workflow_call without resolving its child during selection', async () => {
+  it('should reserve the late Resume leaf when earlier root leaves fill the window', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: Array.from({ length: 100 }, (_, index) => agentStep(`review-${index}`)),
+    });
     const root = makeWorkflow({
       name: 'default',
       ref: 'project:root',
-      steps: [callStep('delegate', 'coding')],
+      steps: [
+        ...Array.from({ length: 49 }, (_, index) => agentStep(`step-${index}`)),
+        callStep('delegate', 'child'),
+      ],
     });
-
-    const result = await selectTaskRetryStart(root, pathContext, chooseLabels([
-      'Restart from: "default" > "delegate"',
-    ]));
-
-    expect(result?.selection).toEqual({
-      kind: 'restart',
-      restartPoint: {
-        stack: [expect.objectContaining({ step: 'delegate', call_instance: 1 })],
-      },
-    });
-    expect(mockResolveWorkflowCallTarget).not.toHaveBeenCalled();
-  });
-
-  it('should keep a synthesized checkpoint available only through Resume', async () => {
-    const root = makeWorkflow({
-      name: 'default',
-      ref: 'project:root',
-      steps: [synthesizedAgentStep('engine-step'), agentStep('finish')],
-    });
-    const resumePoint: WorkflowResumePoint = {
-      version: 2,
-      stack: [{
+    const resumePoint = resumePointWithStack([
+      {
         workflow: 'default',
         workflow_ref: 'project:root',
-        step: 'engine-step',
+        step: 'delegate',
+        kind: 'workflow_call',
+        occurrence: 1,
+        call_instance: 1,
+      },
+      {
+        workflow: 'child',
+        workflow_ref: 'project:child',
+        step: 'review-99',
         kind: 'agent',
-      }],
-      iteration: 4,
-      elapsed_ms: 1_000,
-      workflow_call_invocations: {},
-      workflow_step_participations: {},
-    };
-    let observedOptions: string[] = [];
+        occurrence: 1,
+      },
+    ]);
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      expect(options.some((option) => option.value === 'resume-checkpoint')).toBe(true);
+      expect(defaultValue).toBe('resume-checkpoint');
+      return defaultValue;
+    });
+
+    expect(observedOptions.length).toBeLessThanOrEqual(50);
+    expect(observedOptions.some((option) => option.label.trim() === 'delegate')).toBe(true);
+    expect(observedOptions.some((option) => option.label.trim() === 'review-99')).toBe(true);
+    expect(result?.selection).toEqual({ kind: 'resume', resumePoint });
+  });
+
+  it('should reserve the late preferred child leaf when earlier root leaves fill the window', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      initialStep: 'review-99',
+      steps: Array.from({ length: 100 }, (_, index) => agentStep(`review-${index}`)),
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        ...Array.from({ length: 49 }, (_, index) => agentStep(`step-${index}`)),
+        callStep('delegate', 'child'),
+      ],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      preferredRootStep: 'delegate',
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      const preferredLeaf = findLeaf(options, 'review-99');
+      expect(defaultValue).toBe(preferredLeaf.value);
+      return defaultValue;
+    });
+
+    expect(observedOptions.length).toBeLessThanOrEqual(50);
+    expect(observedOptions.some((option) => option.label.trim() === 'delegate')).toBe(true);
+    expect(observedOptions.some((option) => option.label.trim() === 'review-99')).toBe(true);
+    expect(result?.selection.kind).toBe('restart');
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.at(-1)?.step
+      : undefined).toBe('review-99');
+  });
+
+  it('should reserve every ancestor navigation for a late nested Resume leaf', async () => {
+    const grandchild = makeWorkflow({
+      name: 'grandchild',
+      ref: 'project:grandchild',
+      callable: true,
+      steps: [agentStep('review-99')],
+    });
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [
+        ...Array.from({ length: 48 }, (_, index) => agentStep(`child-${index}`)),
+        callStep('delegate-grandchild', 'grandchild'),
+      ],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        ...Array.from({ length: 49 }, (_, index) => agentStep(`step-${index}`)),
+        callStep('delegate-child', 'child'),
+      ],
+    });
+    const resumePoint = resumePointWithStack([
+      {
+        workflow: 'default',
+        workflow_ref: 'project:root',
+        step: 'delegate-child',
+        kind: 'workflow_call',
+        occurrence: 1,
+        call_instance: 1,
+      },
+      {
+        workflow: 'child',
+        workflow_ref: 'project:child',
+        step: 'delegate-grandchild',
+        kind: 'workflow_call',
+        occurrence: 1,
+        call_instance: 1,
+      },
+      {
+        workflow: 'grandchild',
+        workflow_ref: 'project:grandchild',
+        step: 'review-99',
+        kind: 'agent',
+        occurrence: 1,
+      },
+    ]);
+    mockResolveWorkflowCallTarget.mockImplementation(
+      (_parent: WorkflowConfig, step: { call: string }) => (
+        step.call === 'child' ? child : grandchild
+      ),
+    );
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      expect(options.some((option) => option.value === 'resume-checkpoint')).toBe(true);
+      expect(defaultValue).toBe('resume-checkpoint');
+      return defaultValue;
+    });
+
+    expect(observedOptions.length).toBeLessThanOrEqual(50);
+    expect(observedOptions.some((option) => option.label.trim() === 'delegate-child')).toBe(true);
+    expect(observedOptions.some((option) => option.label.trim() === 'delegate-grandchild')).toBe(true);
+    expect(observedOptions.some((option) => option.label.trim() === 'review-99')).toBe(true);
+    expect(result?.selection).toEqual({ kind: 'resume', resumePoint });
+  });
+
+  it('should keep a static parallel fanout within the initial picker window', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        parallelStep(
+          'reviewers',
+          Array.from({ length: 100 }, (_, index) => callStep(`delegate-${index}`, 'child')),
+        ),
+        agentStep('finish'),
+      ],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, pathContext, async (
+      _message,
+      options,
+      defaultValue,
+    ) => {
+      observedOptions = asTreeOptions(options);
+      return defaultValue;
+    });
+
+    expect(observedOptions.length).toBeLessThanOrEqual(50);
+    expect(observedOptions.map(optionLabel)).toEqual(['reviewers', 'finish']);
+    expect(mockResolveWorkflowCallTarget).not.toHaveBeenCalled();
+    expect(result?.selection.kind).toBe('restart');
+  });
+
+  it('should expose multiple static parallel parents without resolving their children', async () => {
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        parallelStep('reviewers-a', [callStep('delegate-a', 'child')]),
+        parallelStep('reviewers-b', [callStep('delegate-b', 'child')]),
+        agentStep('finish'),
+      ],
+    });
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, pathContext, async (
+      _message,
+      options,
+      defaultValue,
+      callbacks,
+    ) => {
+      observedOptions = asTreeOptions(options);
+      const firstParent = findLeaf(options, 'reviewers-a');
+      const withFirstChildren = callbacks?.onKeyPress?.(
+        '\x1B[B',
+        firstParent.value,
+        options.indexOf(firstParent),
+      );
+      expect(withFirstChildren?.some((option) => option.label.trim() === 'delegate-a')).toBe(true);
+      const secondParent = withFirstChildren?.find((option) => option.label.trim() === 'reviewers-b');
+      expect(secondParent).toBeDefined();
+      const withSecondChildren = callbacks?.onKeyPress?.(
+        '\x1B[B',
+        secondParent!.value,
+        withFirstChildren!.indexOf(secondParent!),
+      );
+      expect(withSecondChildren?.some((option) => option.label.trim() === 'delegate-b')).toBe(true);
+      return defaultValue;
+    });
+
+    expect(observedOptions.map(optionLabel)).toEqual(['reviewers-a', 'reviewers-b', 'finish']);
+    expect(mockResolveWorkflowCallTarget).not.toHaveBeenCalled();
+    expect(result?.selection.kind).toBe('restart');
+  });
+
+  it('should keep static parallel child leaves out of authored restart selections', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [parallelStep('reviewers', [callStep('delegate', 'child')]), agentStep('finish')],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let promptCount = 0;
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, pathContext, async (
+      _message,
+      options,
+      _defaultValue,
+      callbacks,
+    ) => {
+      promptCount += 1;
+      observedOptions = asTreeOptions(options);
+      if (promptCount === 1) {
+        const parent = findLeaf(options, 'reviewers');
+        const updatedOptions = callbacks?.onKeyPress?.(
+          '\x1B[B',
+          parent.value,
+          options.indexOf(parent),
+        );
+        expect(updatedOptions?.some((option) => option.label.trim() === 'delegate')).toBe(true);
+        return updatedOptions!.find((option) => option.label.trim() === 'delegate')!.value;
+      }
+
+      expect(observedOptions.some((option) => option.label.trim() === 'review')).toBe(false);
+      return findLeaf(options, 'reviewers').value;
+    });
+
+    expect(promptCount).toBe(2);
+    expect(result?.selection.kind).toBe('restart');
+    if (result?.selection.kind !== 'restart') {
+      throw new Error('Expected an authored restart selection');
+    }
+    expect(result.selection.restartPoint.stack).toHaveLength(1);
+    expect(() => validateTaskRetryRestartPoint(
+      root,
+      result.selection.restartPoint,
+      pathContext,
+    )).not.toThrow();
+  });
+
+  it('should keep a late static parallel Resume leaf in the initial window', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        parallelStep(
+          'reviewers',
+          Array.from({ length: 100 }, (_, index) => callStep(`delegate-${index}`, 'child')),
+        ),
+      ],
+    });
+    const resumePoint = resumePointWithStack([
+      {
+        workflow: 'default',
+        workflow_ref: 'project:root',
+        step: 'reviewers',
+        kind: 'parallel',
+        occurrence: 1,
+      },
+      {
+        workflow: 'default',
+        workflow_ref: 'project:root',
+        step: 'delegate-99',
+        kind: 'workflow_call',
+        occurrence: 1,
+        call_instance: 1,
+      },
+      {
+        workflow: 'child',
+        workflow_ref: 'project:child',
+        step: 'review',
+        kind: 'agent',
+        occurrence: 1,
+      },
+    ]);
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
     let observedDefault = '';
 
     const result = await selectTaskRetryStart(root, {
       ...pathContext,
       resumePoint,
     }, async (_message, options, defaultValue) => {
-      observedOptions = options.map((option) => option.label);
+      observedOptions = asTreeOptions(options);
       observedDefault = defaultValue;
       return defaultValue;
     });
 
-    expect(result?.selection).toEqual({ kind: 'resume', resumePoint });
-    expect(observedOptions).toContain('Resume failed position: "default" > "engine-step" [default]');
-    expect(observedOptions).not.toContain('Restart from: "default" > "engine-step"');
+    expect(observedOptions.length).toBeLessThanOrEqual(50);
+    expect(observedOptions.some((option) => option.value === 'resume-checkpoint')).toBe(true);
     expect(observedDefault).toBe('resume-checkpoint');
+    expect(result?.selection).toEqual({ kind: 'resume', resumePoint });
+  });
+
+  it('should choose a single initial window when Resume and default target different windows', async () => {
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: Array.from({ length: 100 }, (_, index) => agentStep(`step-${index}`)),
+    });
+    const resumePoint = rootResumePoint('step-10', 'agent');
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+      preferredRootStep: 'step-90',
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    expect(observedOptions).toHaveLength(50);
+    expect(observedOptions.some((option) => option.label.trim() === 'step-10')).toBe(true);
+    expect(observedOptions.some((option) => option.label.trim() === 'step-90')).toBe(false);
+    expect(observedDefault).toBe('resume-checkpoint');
+    expect(result?.selection).toEqual({ kind: 'resume', resumePoint });
+  });
+
+  it('should not resolve an unopened workflow call in the initial picker window', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [agentStep('plan'), callStep('delegate', 'child'), agentStep('finish')],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, pathContext, async (
+      _message,
+      options,
+      defaultValue,
+    ) => {
+      observedOptions = asTreeOptions(options);
+      return defaultValue;
+    });
+
+    expect(observedOptions.map(optionLabel)).toEqual(['plan', 'delegate', 'finish']);
+    expect(observedOptions.some((option) => option.label.trim() === 'review')).toBe(false);
+    expect(mockResolveWorkflowCallTarget).not.toHaveBeenCalled();
+    expect(result?.selection.kind).toBe('restart');
+  });
+
+  it('should show workflow calls as headings and expose only leaves in one tree', async () => {
+    const child = makeWorkflow({
+      name: 'peer-review',
+      ref: 'project:peer-review',
+      callable: true,
+      steps: [agentStep('initial-reviewers'), agentStep('reviewers')],
+    });
+    const root = makeWorkflow({
+      name: 'development-core',
+      ref: 'project:root',
+      steps: [agentStep('plan'), callStep('peer-review', 'peer-review')],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+    let observedMessage = '';
+
+    let promptCount = 0;
+    const result = await selectTaskRetryStart(root, pathContext, async (message, options) => {
+      observedMessage = message;
+      observedOptions = asTreeOptions(options);
+      promptCount += 1;
+      if (promptCount === 1) {
+        return options.find((option) => option.label.trim() === 'peer-review')!.value;
+      }
+      return findLeaf(options, 'reviewers').value;
+    });
+
+    expect(observedMessage).not.toContain('page');
+    expect(observedOptions.map(optionLabel)).toEqual([
+      'plan',
+      'peer-review',
+      'initial-reviewers',
+      'reviewers',
+    ]);
+    expect(observedOptions.some((option) => (
+      option.leadingLines?.some((line) => line.trim() === 'peer-review') === true
+    ))).toBe(true);
+    expect(observedOptions.map((option) => option.label).join('\n'))
+      .not.toMatch(/Restart from:|Browse child workflow from:| > /);
+    expect(result?.selection.kind).toBe('restart');
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.at(-1)
+      : undefined).toEqual(expect.objectContaining({
+      workflow_ref: 'project:peer-review',
+      step: 'reviewers',
+      kind: 'agent',
+    }));
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.at(-1)?.kind
+      : undefined).not.toBe('workflow_call');
+  });
+
+  it('should use the matching nested leaf as the default when the preferred step is a call', async () => {
+    const child = makeWorkflow({
+      name: 'coding',
+      ref: 'project:child',
+      callable: true,
+      initialStep: 'implement',
+      steps: [agentStep('implement'), agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      initialStep: 'delegate',
+      steps: [callStep('delegate', 'coding'), agentStep('review')],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      preferredRootStep: 'delegate',
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    const childInitial = findLeaf(observedOptions, 'implement');
+    expect(observedDefault).toBe(childInitial.value);
+    expect(result?.selection.kind).toBe('restart');
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.at(-1)?.step
+      : undefined).toBe('implement');
+  });
+
+  it('should use the first restartable leaf after an unrestartable child initial step', async () => {
+    const child = makeWorkflow({
+      name: 'delegate-workflow',
+      ref: 'project:child',
+      callable: true,
+      initialStep: 'publish',
+      steps: [
+        agentStep('prepare'),
+        systemStep('publish', [{ type: 'merge_pr', pr: 42 }]),
+        agentStep('implement'),
+      ],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      initialStep: 'delegate',
+      steps: [agentStep('plan'), callStep('delegate', 'delegate-workflow'), agentStep('finish')],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    await selectTaskRetryStart(root, {
+      ...pathContext,
+      preferredRootStep: 'delegate',
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    const plan = findLeaf(observedOptions, 'plan');
+    const prepare = findLeaf(observedOptions, 'prepare');
+    const implement = findLeaf(observedOptions, 'implement');
+    expect(observedDefault).toBe(implement.value);
+    expect(observedDefault).not.toBe(plan.value);
+    expect(observedDefault).not.toBe(prepare.value);
+  });
+
+  it('should fall back to the first leaf when a preferred child has no later restartable leaf', async () => {
+    const child = makeWorkflow({
+      name: 'delegate-workflow',
+      ref: 'project:child',
+      callable: true,
+      initialStep: 'publish',
+      steps: [agentStep('prepare'), systemStep('publish', [{ type: 'merge_pr', pr: 42 }])],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      initialStep: 'delegate',
+      steps: [agentStep('plan'), callStep('delegate', 'delegate-workflow'), agentStep('finish')],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    await selectTaskRetryStart(root, {
+      ...pathContext,
+      preferredRootStep: 'delegate',
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    const plan = findLeaf(observedOptions, 'plan');
+    const prepare = observedOptions.find((option) => option.label.trim() === 'prepare');
+    const finish = findLeaf(observedOptions, 'finish');
+    expect(observedDefault).toBe(plan.value);
+    expect(prepare).toBeUndefined();
+    expect(observedDefault).not.toBe(finish.value);
+  });
+
+  it('should align a valid resume checkpoint with the default leaf', async () => {
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [agentStep('plan'), agentStep('review')],
+    });
+    const resumePoint = rootResumePoint('review', 'agent');
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    const review = findLeaf(observedOptions, 'review');
+    expect(observedDefault).toBe(review.value);
+    expect(result).toEqual({
+      label: review.label,
+      selection: { kind: 'resume', resumePoint },
+    });
+  });
+
+  it('should align a static parallel resume frame with its leaf', async () => {
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [parallelStep('reviewers'), agentStep('finish')],
+    });
+    const resumePoint = rootResumePoint('reviewers', 'parallel');
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    const reviewers = findLeaf(observedOptions, 'reviewers');
+    expect(observedDefault).toBe(reviewers.value);
+    expect(result).toEqual({
+      label: reviewers.label,
+      selection: { kind: 'resume', resumePoint },
+    });
+  });
+
+  it('should align a static parallel workflow-call descendant with its Resume leaf', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('review'), agentStep('finish')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [parallelStep('reviewers', [callStep('delegate', 'child')]), agentStep('finish')],
+    });
+    const resumePoint = resumePointWithStack([
+      {
+        workflow: 'default',
+        workflow_ref: 'project:root',
+        step: 'reviewers',
+        kind: 'parallel',
+        occurrence: 1,
+      },
+      {
+        workflow: 'default',
+        workflow_ref: 'project:root',
+        step: 'delegate',
+        kind: 'workflow_call',
+        occurrence: 1,
+        call_instance: 1,
+      },
+      {
+        workflow: 'child',
+        workflow_ref: 'project:child',
+        step: 'review',
+        kind: 'agent',
+        occurrence: 1,
+      },
+    ]);
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    const review = findLeaf(observedOptions, 'review');
+    expect(review.value).toBe('resume-checkpoint');
+    expect(observedDefault).toBe(review.value);
+    expect(result).toEqual({
+      label: review.label,
+      selection: { kind: 'resume', resumePoint },
+    });
+  });
+
+  it('should not expose a static parallel descendant for a non-parallel Resume frame', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [parallelStep('reviewers', [callStep('delegate', 'child')]), agentStep('finish')],
+    });
+    const resumePoint = resumePointWithStack([
+      {
+        workflow: 'default',
+        workflow_ref: 'project:root',
+        step: 'reviewers',
+        kind: 'agent',
+        occurrence: 1,
+      },
+      {
+        workflow: 'default',
+        workflow_ref: 'project:root',
+        step: 'delegate',
+        kind: 'workflow_call',
+        occurrence: 1,
+        call_instance: 1,
+      },
+      {
+        workflow: 'child',
+        workflow_ref: 'project:child',
+        step: 'review',
+        kind: 'agent',
+        occurrence: 1,
+      },
+    ]);
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    expect(observedOptions.some((option) => option.label.trim() === 'review')).toBe(false);
+    const reviewers = findLeaf(observedOptions, 'reviewers');
+    expect(observedDefault).toBe(reviewers.value);
+    expect(reviewers.value).not.toBe('resume-checkpoint');
+  });
+
+  it('should not treat an agent resume frame as a static parallel Resume', async () => {
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [parallelStep('reviewers'), agentStep('finish')],
+    });
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint: rootResumePoint('reviewers', 'agent'),
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      return defaultValue;
+    });
+
+    expect(observedOptions.find((option) => option.label.trim() === 'reviewers')?.value)
+      .not.toBe('resume-checkpoint');
+    expect(result?.selection.kind).toBe('restart');
+  });
+
+  it('should align a terminal workflow call checkpoint with the child initial leaf', async () => {
+    const grandchild = makeWorkflow({
+      name: 'grandchild',
+      ref: 'project:grandchild',
+      callable: true,
+      initialStep: 'review',
+      steps: [agentStep('review'), agentStep('finish')],
+    });
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      initialStep: 'delegate',
+      steps: [callStep('delegate', 'grandchild'), agentStep('finish')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [agentStep('plan'), callStep('delegate', 'child')],
+    });
+    const resumePoint = resumePointWithStack([{
+      workflow: 'default',
+      workflow_ref: 'project:root',
+      step: 'delegate',
+      kind: 'workflow_call',
+      occurrence: 1,
+      call_instance: 1,
+    }]);
+    mockResolveWorkflowCallTarget.mockImplementation(
+      (_parent: WorkflowConfig, step: { call: string }) => (
+        step.call === 'child' ? child : grandchild
+      ),
+    );
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    const childInitial = findLeaf(observedOptions, 'review');
+    expect(observedDefault).toBe(childInitial.value);
+    expect(childInitial.leadingLines?.map((line) => line.trim())).toEqual([
+      'default',
+      'delegate',
+      'child',
+      'delegate',
+      'grandchild',
+    ]);
+    expect(result).toEqual({
+      label: childInitial.label,
+      selection: { kind: 'resume', resumePoint },
+    });
+  });
+
+  it('should not fall back to an unrelated first leaf for a terminal workflow call', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      initialStep: 'review',
+      steps: [agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [agentStep('plan'), callStep('delegate', 'child')],
+    });
+    const resumePoint = resumePointWithStack([{
+      workflow: 'default',
+      workflow_ref: 'project:root',
+      step: 'delegate',
+      kind: 'workflow_call',
+      occurrence: 1,
+      call_instance: 1,
+    }]);
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return defaultValue;
+    });
+
+    const firstLeaf = findLeaf(observedOptions, 'plan');
+    const childInitial = findLeaf(observedOptions, 'review');
+    expect(observedDefault).toBe(childInitial.value);
+    expect(observedDefault).not.toBe(firstLeaf.value);
+    expect(result?.selection.kind).toBe('resume');
+  });
+
+  it('should replace bounded windows while reaching a deep leaf without page actions', async () => {
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: Array.from({ length: 10_000 }, (_, index) => agentStep(`step-${index}`)),
+    });
+    let observedOptions: TreeOption[] = [];
+    let promptCount = 0;
+
+    const assertBoundedAndUnique = (options: SelectOptionItem<string>[]): void => {
+      expect(options.length).toBeLessThanOrEqual(50);
+      expect(new Set(options.map((option) => option.value)).size).toBe(options.length);
+    };
+
+    const result = await selectTaskRetryStart(root, pathContext, async (_message, options, _defaultValue, callbacks) => {
+      promptCount += 1;
+      observedOptions = asTreeOptions(options);
+      assertBoundedAndUnique(options);
+      let currentOptions = options;
+      while (!currentOptions.some((option) => option.label.trim() === 'step-9999')) {
+        const lastIndex = currentOptions.length - 1;
+        const updatedOptions = callbacks?.onKeyPress?.(
+          '\x1B[B',
+          currentOptions[lastIndex]!.value,
+          lastIndex,
+        );
+        if (updatedOptions === null || updatedOptions === undefined) {
+          throw new Error('Expected the next retry start window');
+        }
+        currentOptions = updatedOptions;
+        observedOptions = asTreeOptions(currentOptions);
+        assertBoundedAndUnique(currentOptions);
+      }
+      return findLeaf(currentOptions, 'step-9999').value;
+    });
+
+    expect(promptCount).toBe(1);
+    expect(observedOptions.length).toBeLessThanOrEqual(50);
+    expect(result?.selection.kind).toBe('restart');
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.at(-1)?.step
+      : undefined).toBe('step-9999');
+  });
+
+  it('should load the parent window after reaching the end of an expanded child', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('child-review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        ...Array.from({ length: 49 }, (_, index) => agentStep(`step-${index}`)),
+        callStep('delegate', 'child'),
+        ...Array.from({ length: 51 }, (_, index) => agentStep(`step-${index + 49}`)),
+      ],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let promptCount = 0;
+    let observedOptions: SelectOptionItem<string>[] = [];
+
+    const result = await selectTaskRetryStart(root, pathContext, async (
+      _message,
+      options,
+      _defaultValue,
+      callbacks,
+    ) => {
+      promptCount += 1;
+      observedOptions = options;
+      if (promptCount === 1) {
+        return options.find((option) => option.label.trim() === 'delegate')!.value;
+      }
+      const lastOption = options.at(-1)!;
+      const updatedOptions = callbacks?.onKeyPress?.('\x1B[B', lastOption.value, options.length - 1);
+      expect(updatedOptions).not.toBeNull();
+      expect(updatedOptions?.some((option) => option.label.trim() === 'step-50')).toBe(true);
+      return updatedOptions!.find((option) => option.label.trim() === 'step-50')!.value;
+    });
+
+    expect(promptCount).toBe(2);
+    expect(observedOptions.some((option) => option.label.trim() === 'child-review')).toBe(true);
+    expect(result?.selection.kind).toBe('restart');
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.at(-1)?.step
+      : undefined).toBe('step-50');
+  });
+
+  it('should load the parent next window when a child ends before the parent window', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('child-review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        ...Array.from({ length: 20 }, (_, index) => agentStep(`step-${index}`)),
+        callStep('delegate', 'child'),
+        ...Array.from({ length: 79 }, (_, index) => agentStep(`step-${index + 21}`)),
+      ],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let promptCount = 0;
+
+    const result = await selectTaskRetryStart(root, pathContext, async (
+      _message,
+      options,
+      _defaultValue,
+      callbacks,
+    ) => {
+      promptCount += 1;
+      if (promptCount === 1) {
+        return options.find((option) => option.label.trim() === 'delegate')!.value;
+      }
+
+      const childReview = options.find((option) => option.label.trim() === 'child-review')!;
+      const childReviewIndex = options.indexOf(childReview);
+      const updatedOptions = callbacks?.onKeyPress?.(
+        '\x1B[B',
+        childReview.value,
+        childReviewIndex,
+      );
+      expect(updatedOptions?.some((option) => option.label.trim() === 'step-50')).toBe(true);
+      return updatedOptions!.find((option) => option.label.trim() === 'step-50')!.value;
+    });
+
+    expect(promptCount).toBe(2);
+    expect(result?.selection.kind).toBe('restart');
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.at(-1)?.step
+      : undefined).toBe('step-50');
+  });
+
+  it('should preserve the selected branch when leaf labels collide', async () => {
+    const left = makeWorkflow({
+      name: 'shared',
+      ref: 'project:left',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    const right = makeWorkflow({
+      name: 'shared',
+      ref: 'project:right',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [callStep('left', 'left'), callStep('right', 'right')],
+    });
+    mockResolveWorkflowCallTarget.mockImplementation(
+      (_parent: WorkflowConfig, step: { call: string }) => ({ left, right }[step.call] ?? null),
+    );
+
+    let observedOptions: TreeOption[] = [];
+    let promptCount = 0;
+    const result = await selectTaskRetryStart(root, pathContext, async (_message, options) => {
+      observedOptions = asTreeOptions(options);
+      promptCount += 1;
+      if (promptCount === 1) {
+        return options.find((option) => option.label.trim() === 'right')!.value;
+      }
+      const reviews = options.filter((option) => option.label.trim() === 'review');
+      expect(reviews).toHaveLength(2);
+      expect(reviews[0]?.value).not.toBe(reviews[1]?.value);
+      return reviews[1]!.value;
+    });
+
+    expect(result?.selection.kind).toBe('restart');
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.map((entry) => entry.workflow_ref)
+      : undefined).toEqual(['project:root', 'project:right']);
+    const reviewHeadings = observedOptions
+      .filter((option) => option.label.trim() === 'review')
+      .map((option) => option.leadingLines?.map((line) => line.trim()));
+    expect(reviewHeadings).toEqual([
+      ['default', 'left', 'shared'],
+      ['default', 'right', 'shared'],
+    ]);
+  });
+
+  it('should not finalize a workflow call when its child leaf has the same label', async () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('delegate')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      initialStep: 'plan',
+      steps: [agentStep('plan'), callStep('delegate', 'child'), agentStep('finish')],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let promptCount = 0;
+
+    const result = await selectTaskRetryStart(root, pathContext, async (_message, options) => {
+      promptCount += 1;
+      const delegateOptions = options.filter((option) => option.label.trim() === 'delegate');
+      if (promptCount === 1) {
+        const navigation = delegateOptions.find((option) => (
+          option.indent === (option.leadingLines?.length ?? 0) + 1
+        ));
+        expect(navigation).toBeDefined();
+        return navigation!.value;
+      }
+
+      const leaf = delegateOptions.find((option) => (
+        option.indent === (option.leadingLines?.length ?? 0)
+      ));
+      expect(leaf).toBeDefined();
+      return leaf!.value;
+    });
+
+    expect(promptCount).toBe(2);
+    expect(result?.selection.kind).toBe('restart');
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.map((entry) => entry.workflow_ref)
+      : undefined).toEqual(['project:root', 'project:child']);
+    expect(result?.selection.kind === 'restart'
+      ? result.selection.restartPoint.stack.at(-1)?.step
+      : undefined).toBe('delegate');
+  });
+
+  it('should keep a synthesized checkpoint available as Resume but not Restart', async () => {
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [synthesizedAgentStep('engine-step'), agentStep('finish')],
+    });
+    const resumePoint = rootResumePoint('engine-step', 'agent');
+    let observedOptions: TreeOption[] = [];
+    let observedDefault = '';
+
+    const result = await selectTaskRetryStart(root, {
+      ...pathContext,
+      resumePoint,
+    }, async (_message, options, defaultValue) => {
+      observedOptions = asTreeOptions(options);
+      observedDefault = defaultValue;
+      return findLeaf(options, 'engine-step').value;
+    });
+
+    const checkpoint = findLeaf(observedOptions, 'engine-step');
+    expect(observedDefault).toBe(checkpoint.value);
+    expect(result).toEqual({
+      label: checkpoint.label,
+      selection: { kind: 'resume', resumePoint },
+    });
   });
 
   it.each([
@@ -237,7 +1345,7 @@ describe('task retry start browser contracts', () => {
       step: systemStep('publish', [{ type: 'merge_pr', pr: 42 }]),
       resumePoint: rootResumePoint('publish', 'system'),
     },
-  ])('should offer only Resume when a $description checkpoint is the only position', async ({
+  ])('should offer a resume-only leaf for a $description checkpoint', async ({
     step,
     resumePoint,
   }) => {
@@ -246,26 +1354,22 @@ describe('task retry start browser contracts', () => {
       ref: 'project:root',
       steps: [step],
     });
-    let observedOptions: string[] = [];
-    let observedDefault = '';
+    let observedOptions: TreeOption[] = [];
 
     const result = await selectTaskRetryStart(root, {
       ...pathContext,
       resumePoint,
     }, async (_message, options, defaultValue) => {
-      observedOptions = options.map((option) => option.label);
-      observedDefault = defaultValue;
+      observedOptions = asTreeOptions(options);
+      expect(defaultValue).toBe(options[0]?.value);
       return defaultValue;
     });
 
+    expect(observedOptions).toHaveLength(1);
     expect(result?.selection).toEqual({ kind: 'resume', resumePoint });
-    expect(observedOptions).toEqual([
-      `Resume failed position: "default" > "${resumePoint.stack[0]!.step}" [default]`,
-    ]);
-    expect(observedDefault).toBe('resume-checkpoint');
   });
 
-  it('should return no selection when a Resume-only prompt is cancelled', async () => {
+  it('should return no selection when a resume-only prompt is cancelled', async () => {
     const root = makeWorkflow({
       name: 'default',
       ref: 'project:root',
@@ -280,7 +1384,7 @@ describe('task retry start browser contracts', () => {
     expect(result).toBeNull();
   });
 
-  it('should reject a workflow with neither Resume nor authored Restart positions', async () => {
+  it('should reject a workflow with neither resume nor authored restart positions', async () => {
     const root = makeWorkflow({
       name: 'default',
       ref: 'project:root',
@@ -290,333 +1394,70 @@ describe('task retry start browser contracts', () => {
     await expect(selectTaskRetryStart(root, pathContext, async () => null)).rejects.toThrow();
   });
 
-  it('should omit synthesized and effect-backed siblings at root and child levels', async () => {
+  it('should fail once when an expanded child has no selectable leaf', async () => {
     const child = makeWorkflow({
-      name: 'coding',
+      name: 'child',
       ref: 'project:child',
       callable: true,
-      steps: [
-        synthesizedAgentStep('child-synthetic-first'),
-        agentStep('child-agent-middle'),
-        systemStep('child-effect-last', [{ type: 'merge_pr', pr: 42 }]),
-      ],
+      steps: [systemStep('publish', [{ type: 'merge_pr', pr: 42 }])],
     });
     const root = makeWorkflow({
       name: 'default',
       ref: 'project:root',
-      steps: [
-        synthesizedAgentStep('root-synthetic-first'),
-        callStep('delegate', 'coding'),
-        systemStep('root-effect-last', [{ type: 'close_pr', pr: 42 }]),
-      ],
-      initialStep: 'delegate',
+      steps: [callStep('delegate', 'child')],
     });
     mockResolveWorkflowCallTarget.mockReturnValue(child);
-    const promptLabels: string[][] = [];
+    let selectorCalls = 0;
 
-    await selectTaskRetryStart(root, pathContext, async (_message, options) => {
-      promptLabels.push(options.map((option) => option.label));
-      if (promptLabels.length === 1) {
-        return options.find((option) => option.value.startsWith('open-child-'))!.value;
-      }
-      return options.find((option) => option.value.startsWith('restart-step-'))!.value;
-    });
+    await expect(selectTaskRetryStart(root, pathContext, async (_message, options) => {
+      selectorCalls += 1;
+      return options.find((option) => option.label.trim() === 'delegate')!.value;
+    })).rejects.toThrow();
 
-    expect(promptLabels[0]).toEqual([
-      'Restart from: "default" > "delegate"',
-      'Browse child workflow from: "default" > "delegate"',
-    ]);
-    expect(promptLabels[1]).toEqual([
-      'Restart from: "default" > "delegate" > "coding" > "child-agent-middle"',
-      'Back to parent workflow',
-    ]);
+    expect(selectorCalls).toBe(1);
   });
 
-  it('should default to the child initial step when the root preferred step has the same name', async () => {
-    const child = makeWorkflow({
-      name: 'coding',
-      ref: 'project:child',
-      callable: true,
-      initialStep: 'implement',
-      steps: [agentStep('review'), agentStep('implement')],
-    });
-    const root = makeWorkflow({
-      name: 'default',
-      ref: 'project:root',
-      steps: [callStep('delegate', 'coding'), agentStep('review')],
-    });
-    mockResolveWorkflowCallTarget.mockReturnValue(child);
-    let promptCount = 0;
-
-    const result = await selectTaskRetryStart(root, {
-      ...pathContext,
-      preferredRootStep: 'review',
-    }, async (_message, options, defaultValue) => {
-      promptCount += 1;
-      if (promptCount === 1) {
-        return options.find((option) => option.value.startsWith('open-child-'))!.value;
-      }
-      return defaultValue;
-    });
-
-    expect(result?.label).toBe(
-      'Restart from: "default" > "delegate" > "coding" > "implement"',
-    );
-  });
-
-  it('should bound a 250,000-step prompt to the current page', async () => {
-    const root = makeWorkflow({
-      name: 'default',
-      ref: 'project:root',
-      steps: Array.from({ length: 250_000 }, (_, index) => agentStep(`step-${index}`)),
-    });
-    let optionCount = 0;
-
-    const result = await selectTaskRetryStart(root, pathContext, async (_message, options) => {
-      optionCount = options.length;
-      return options.find((option) => option.value === `restart-step-${TASK_RETRY_START_PAGE_SIZE - 1}`)!.value;
-    });
-
-    expect(optionCount).toBe(TASK_RETRY_START_PAGE_SIZE + 1);
-    expect(result?.label).toBe(`Restart from: "default" > "step-${TASK_RETRY_START_PAGE_SIZE - 1}"`);
-  });
-
-  it('should reach every one of 1,001 root steps through Next pages', async () => {
-    const root = makeWorkflow({
-      name: 'default',
-      ref: 'project:root',
-      steps: Array.from({ length: 1_001 }, (_, index) => agentStep(`step-${index}`)),
-    });
-    const observedRestartValues: string[] = [];
-
-    const result = await selectTaskRetryStart(root, pathContext, async (_message, options) => {
-      observedRestartValues.push(
-        ...options.filter((option) => option.value.startsWith('restart-step-')).map((option) => option.value),
-      );
-      const next = options.find((option) => option.value === 'next-page');
-      return next?.value ?? options.find((option) => option.value === 'restart-step-1000')!.value;
-    });
-
-    expect(observedRestartValues).toEqual(
-      Array.from({ length: 1_001 }, (_, index) => `restart-step-${index}`),
-    );
-    expect(result?.label).toBe('Restart from: "default" > "step-1000"');
-  });
-
-  it('should return from a middle page through Previous without losing the first page', async () => {
-    const root = makeWorkflow({
-      name: 'default',
-      ref: 'project:root',
-      steps: Array.from({ length: 101 }, (_, index) => agentStep(`step-${index}`)),
-    });
-    const selections = ['next-page', 'previous-page', 'restart-step-0'];
-    let callIndex = 0;
-
-    const result = await selectTaskRetryStart(root, pathContext, async (_message, options) => {
-      const value = selections[callIndex]!;
-      callIndex += 1;
-      expect(options.some((option) => option.value === value)).toBe(true);
-      return value;
-    });
-
-    expect(result?.label).toBe('Restart from: "default" > "step-0"');
-  });
-
-  it('should return from a child level and select a root sibling', async () => {
-    const child = makeWorkflow({
-      name: 'coding', ref: 'project:child', callable: true, steps: [agentStep('implement')],
-    });
-    const root = makeWorkflow({
-      name: 'default',
-      ref: 'project:root',
-      steps: [callStep('delegate', 'coding'), agentStep('finish')],
-    });
-    mockResolveWorkflowCallTarget.mockReturnValue(child);
-
-    const result = await selectTaskRetryStart(root, pathContext, chooseLabels([
-      'Browse child workflow from: "default" > "delegate"',
-      'Back to parent workflow',
-      'Restart from: "default" > "finish"',
-    ]));
-
-    expect(result?.label).toBe('Restart from: "default" > "finish"');
-    expect(mockResolveWorkflowCallTarget).toHaveBeenCalledTimes(1);
-  });
-
-  it('should discard visited root and child branches after returning to their parent', async () => {
-    const leafA = makeWorkflow({
-      name: 'leaf-a', ref: 'project:leaf-a', callable: true, steps: [agentStep('finish-a')],
-    });
-    const leafB = makeWorkflow({
-      name: 'leaf-b', ref: 'project:leaf-b', callable: true, steps: [agentStep('finish-b')],
-    });
-    const parent = makeWorkflow({
-      name: 'parent',
-      ref: 'project:parent',
-      callable: true,
-      steps: [
-        callStep('open-a', 'leaf-a'),
-        callStep('open-b', 'leaf-b'),
-        agentStep('finish-parent'),
-      ],
-    });
-    const root = makeWorkflow({
-      name: 'default', ref: 'project:root', steps: [callStep('open-parent', 'parent')],
-    });
-    const workflows = new Map([
-      ['parent', parent],
-      ['leaf-a', leafA],
-      ['leaf-b', leafB],
-    ]);
-    mockResolveWorkflowCallTarget.mockImplementation(
-      (_workflow: WorkflowConfig, step: { call: string }) => workflows.get(step.call) ?? null,
-    );
-    const selections = [
-      'open-child-0',
-      'open-child-0',
-      'parent-level',
-      'open-child-1',
-      'parent-level',
-      'open-child-0',
-      'parent-level',
-      'parent-level',
-      'open-child-0',
-      'restart-step-2',
-    ];
-    let selectionIndex = 0;
-
-    const result = await selectTaskRetryStart(root, pathContext, async (_message, options) => {
-      const value = selections[selectionIndex]!;
-      selectionIndex += 1;
-      expect(options.some((option) => option.value === value)).toBe(true);
-      return value;
-    });
-
-    expect(result?.label).toBe(
-      'Restart from: "default" > "open-parent" > "parent" > "finish-parent"',
-    );
-    expect(mockResolveWorkflowCallTarget.mock.calls.map((call) => call[1].name)).toEqual([
-      'open-parent',
-      'open-a',
-      'open-b',
-      'open-a',
-      'open-parent',
-    ]);
-  });
-
-  it('should resolve only the selected child in a 10,000-call fan-out', async () => {
-    const root = makeWorkflow({
-      name: 'default',
-      ref: 'project:root',
-      steps: Array.from({ length: 10_000 }, (_, index) => callStep(`call-${index}`, `child-${index}`)),
-    });
-    const child = makeWorkflow({
-      name: 'selected-child',
-      ref: 'project:selected-child',
-      callable: true,
-      steps: [agentStep('finish')],
-    });
-    mockResolveWorkflowCallTarget.mockReturnValue(child);
-    let promptCount = 0;
-
-    const result = await selectTaskRetryStart(root, pathContext, async (_message, options) => {
-      promptCount += 1;
-      if (promptCount === 1) {
-        expect(mockResolveWorkflowCallTarget).not.toHaveBeenCalled();
-        expect(options.length).toBe(TASK_RETRY_START_PAGE_SIZE * 2 + 1);
-        return 'open-child-49';
-      }
-      expect(mockResolveWorkflowCallTarget).toHaveBeenCalledTimes(1);
-      return 'restart-step-0';
-    });
-
-    expect(result?.label).toBe(
-      'Restart from: "default" > "call-49" > "selected-child" > "finish"',
-    );
-    expect(mockResolveWorkflowCallTarget).toHaveBeenCalledTimes(1);
-  });
-
-  it('should fail explicitly when the selected child is unknown', async () => {
+  it('should fail explicitly when an expanded child is unknown', async () => {
     const root = makeWorkflow({
       name: 'default', ref: 'project:root', steps: [callStep('route', 'missing')],
     });
     mockResolveWorkflowCallTarget.mockReturnValue(null);
 
-    await expect(selectTaskRetryStart(root, pathContext, chooseLabels([
-      'Browse child workflow from: "default" > "route"',
-    ]))).rejects.toThrow(/route.*missing/i);
+    await expect(selectTaskRetryStart(root, pathContext, async (_message, options) => (
+      options.find((option) => option.label.trim() === 'route')!.value
+    )))
+      .rejects.toThrow(/route.*missing/i);
   });
 
-  it('should fail explicitly when the selected child is not callable', async () => {
+  it('should fail explicitly when an expanded child is not callable', async () => {
     const root = makeWorkflow({
       name: 'default', ref: 'project:root', steps: [callStep('route', 'child')],
     });
-    const child = makeWorkflow({
+    mockResolveWorkflowCallTarget.mockReturnValue(makeWorkflow({
       name: 'child', ref: 'project:child', steps: [agentStep('finish')],
-    });
-    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    }));
 
-    await expect(selectTaskRetryStart(root, pathContext, chooseLabels([
-      'Browse child workflow from: "default" > "route"',
-    ]))).rejects.toThrow(/child.*not callable/i);
+    await expect(selectTaskRetryStart(root, pathContext, async (_message, options) => (
+      options.find((option) => option.label.trim() === 'route')!.value
+    )))
+      .rejects.toThrow(/child.*not callable/i);
   });
 
-  it('should detect a cycle only when browsing the selected edge', async () => {
+  it('should fail explicitly when the expanded tree contains a cycle', async () => {
     const root = makeWorkflow({
       name: 'default', ref: 'project:root', steps: [callStep('route', 'default')],
     });
-    const recursive = makeWorkflow({
+    mockResolveWorkflowCallTarget.mockReturnValue(makeWorkflow({
       name: 'default', ref: 'project:root', callable: true, steps: [agentStep('finish')],
-    });
-    mockResolveWorkflowCallTarget.mockReturnValue(recursive);
-
-    await expect(selectTaskRetryStart(root, pathContext, chooseLabels([
-      'Browse child workflow from: "default" > "route"',
-    ]))).rejects.toThrow(/cycle/i);
-  });
-
-  it('should select an authored step at the runtime workflow-call depth limit', async () => {
-    const workflows = Array.from({ length: MAX_WORKFLOW_CALL_DEPTH }, (_, index) => makeWorkflow({
-      name: `workflow-${index}`,
-      ref: `project:workflow-${index}`,
-      callable: index > 0,
-      steps: index === MAX_WORKFLOW_CALL_DEPTH - 1
-        ? [agentStep('finish')]
-        : [callStep(`call-${index}`, `workflow-${index + 1}`)],
     }));
-    mockResolveWorkflowCallTarget.mockImplementation(
-      (_parent: WorkflowConfig, step: { call: string }) => (
-        workflows.find((workflow) => workflow.name === step.call) ?? null
-      ),
-    );
 
-    const result = await selectTaskRetryStart(
-      workflows[0]!,
-      pathContext,
-      async (_message, options) => (
-        options.find((option) => option.value.startsWith('open-child-'))?.value
-        ?? options.find((option) => option.value.startsWith('restart-step-'))!.value
-      ),
-    );
-
-    if (result?.selection.kind !== 'restart') {
-      throw new Error('Expected a restart selection at the workflow-call depth limit');
-    }
-    expect(result.selection.restartPoint.stack).toHaveLength(MAX_WORKFLOW_CALL_DEPTH);
-    expect(result.selection.restartPoint.stack.map((entry) => entry.workflow_ref)).toEqual(
-      Array.from({ length: MAX_WORKFLOW_CALL_DEPTH }, (_, index) => `project:workflow-${index}`),
-    );
-    expect(result.selection.restartPoint.stack.map((entry) => entry.step)).toEqual([
-      ...Array.from(
-        { length: MAX_WORKFLOW_CALL_DEPTH - 1 },
-        (_, index) => `call-${index}`,
-      ),
-      'finish',
-    ]);
-    expect(mockResolveWorkflowCallTarget).toHaveBeenCalledTimes(MAX_WORKFLOW_CALL_DEPTH - 1);
+    await expect(selectTaskRetryStart(root, pathContext, async (_message, options) => (
+      options.find((option) => option.label.trim() === 'route')!.value
+    )))
+      .rejects.toThrow(/cycle/i);
   });
 
-  it('should reject browsing beyond the runtime workflow-call depth', async () => {
+  it('should fail explicitly when the expanded tree exceeds call depth', async () => {
     const workflows = Array.from({ length: MAX_WORKFLOW_CALL_DEPTH + 1 }, (_, index) => makeWorkflow({
       name: `workflow-${index}`,
       ref: `project:workflow-${index}`,
@@ -632,8 +1473,54 @@ describe('task retry start browser contracts', () => {
     );
 
     await expect(selectTaskRetryStart(workflows[0]!, pathContext, async (_message, options) => (
-      options.find((option) => option.value.startsWith('open-child-'))!.value
-    ))).rejects.toThrow(/depth exceeds/i);
+      options[0]!.value
+    )))
+      .rejects.toThrow(/depth exceeds/i);
+  });
+
+  it('should sanitize control characters in workflow step labels', async () => {
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [agentStep('line\n\x1b[31m'), agentStep('literal\\n')],
+    });
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, pathContext, async (_message, options) => {
+      observedOptions = asTreeOptions(options);
+      return options[0]!.value;
+    });
+
+    const labels = observedOptions.map((option) => option.label);
+    expect(labels.every((label) => !/[\n\r\x1b]/.test(label))).toBe(true);
+    expect(labels.some((label) => label.includes('\\n'))).toBe(true);
+    expect(result?.label).not.toMatch(/[\n\r\x1b]/);
+  });
+
+  it('should sanitize control characters in nested workflow headings', async () => {
+    const child = makeWorkflow({
+      name: 'child\nname\r\x1b[31m',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [callStep('delegate', 'child')],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    let observedOptions: TreeOption[] = [];
+
+    const result = await selectTaskRetryStart(root, pathContext, async (_message, options) => {
+      observedOptions = asTreeOptions(options);
+      return findLeaf(options, 'review').value;
+    });
+
+    const headings = observedOptions.flatMap((option) => option.leadingLines ?? []);
+    expect(headings.length).toBeGreaterThan(0);
+    expect(headings.every((heading) => !/[\n\r\x1b]/.test(heading))).toBe(true);
+    expect(result?.label).toBe('review');
   });
 });
 
@@ -733,14 +1620,10 @@ describe('persisted task retry restart validation', () => {
 
   it('should reject a nested restart path when the resolved child workflow is not callable', () => {
     const root = makeWorkflow({
-      name: 'default',
-      ref: 'project:root',
-      steps: [callStep('delegate', 'coding')],
+      name: 'default', ref: 'project:root', steps: [callStep('delegate', 'coding')],
     });
     const child = makeWorkflow({
-      name: 'coding',
-      ref: 'project:child',
-      steps: [agentStep('finish')],
+      name: 'coding', ref: 'project:child', steps: [agentStep('finish')],
     });
     const restartPoint: WorkflowRestartPoint = {
       stack: [
@@ -762,15 +1645,10 @@ describe('persisted task retry restart validation', () => {
 
   it('should reject a nested restart path when the child workflow_ref no longer matches', () => {
     const root = makeWorkflow({
-      name: 'default',
-      ref: 'project:root',
-      steps: [callStep('delegate', 'coding')],
+      name: 'default', ref: 'project:root', steps: [callStep('delegate', 'coding')],
     });
     const child = makeWorkflow({
-      name: 'coding',
-      ref: 'project:child',
-      callable: true,
-      steps: [agentStep('finish')],
+      name: 'coding', ref: 'project:child', callable: true, steps: [agentStep('finish')],
     });
     const restartPoint: WorkflowRestartPoint = {
       stack: [

--- a/src/__tests__/taskRetryStartTreeInvariants.test.ts
+++ b/src/__tests__/taskRetryStartTreeInvariants.test.ts
@@ -1,0 +1,450 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  WorkflowCallStep,
+  WorkflowConfig,
+  WorkflowRestartPoint,
+  WorkflowStep,
+} from '../core/models/index.js';
+import { attachWorkflowOpaqueRef } from '../infra/config/loaders/workflowSourceMetadata.js';
+import {
+  TASK_RETRY_START_WINDOW_SIZE,
+  TaskRetryRestartTree,
+  type TaskRetryRestartTreeNode,
+} from '../features/tasks/taskRetryStartPath.js';
+
+const mockResolveWorkflowCallTarget = vi.hoisted(() => vi.fn());
+
+vi.mock('../infra/config/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveWorkflowCallTarget: (...args: unknown[]) => mockResolveWorkflowCallTarget(...args),
+}));
+
+const pathContext = {
+  projectCwd: '/project',
+  lookupCwd: '/project/worktree',
+};
+
+interface InspectedWindow {
+  start: number;
+  end: number;
+}
+
+interface InspectedNodeUiState {
+  id: string;
+  expanded: boolean;
+  childFrame?: InspectedFrameState;
+}
+
+interface InspectedFrameState {
+  activeStepWindow: InspectedWindow | undefined;
+  activeParallelWindows: Map<number, InspectedWindow>;
+  nodeStates: Map<string, InspectedNodeUiState>;
+}
+
+function agentStep(name: string): WorkflowStep {
+  return {
+    name,
+    persona: `${name}-persona`,
+    personaDisplayName: name,
+    instruction: `${name} instruction`,
+  };
+}
+
+function callStep(name: string, call: string): WorkflowCallStep {
+  return {
+    name,
+    kind: 'workflow_call',
+    call,
+    personaDisplayName: name,
+    instruction: `${name} instruction`,
+  };
+}
+
+function parallelStep(name: string, parallel: WorkflowStep[]): WorkflowStep {
+  return {
+    ...agentStep(name),
+    parallel,
+  };
+}
+
+function makeWorkflow(options: {
+  name: string;
+  ref: string;
+  steps: WorkflowStep[];
+  callable?: boolean;
+}): WorkflowConfig {
+  return attachWorkflowOpaqueRef({
+    name: options.name,
+    initialStep: options.steps[0]!.name,
+    maxSteps: 20,
+    steps: options.steps,
+    ...(options.callable ? { subworkflow: { callable: true } } : {}),
+  }, options.ref);
+}
+
+function rootRestartPoint(step: string): WorkflowRestartPoint {
+  return {
+    stack: [{
+      workflow: 'default',
+      workflow_ref: 'project:root',
+      step,
+      kind: 'agent',
+    }],
+  };
+}
+
+function findNodeByStep(
+  tree: TaskRetryRestartTree,
+  stepName: string,
+): TaskRetryRestartTreeNode {
+  const node = tree.getVisibleNodes().find((candidate) => candidate.step.name === stepName);
+  if (node === undefined) throw new Error(`Missing tree node: ${stepName}`);
+  return node;
+}
+
+function registerDeepCallChain(
+  workflowsByCall: Map<string, WorkflowConfig>,
+  prefix: string,
+): WorkflowCallStep {
+  workflowsByCall.set(`${prefix}-workflow-4`, makeWorkflow({
+    name: `${prefix}-workflow-4`,
+    ref: `project:${prefix}-workflow-4`,
+    callable: true,
+    steps: [agentStep(`${prefix}-leaf`)],
+  }));
+  for (let level = 3; level >= 1; level -= 1) {
+    workflowsByCall.set(`${prefix}-workflow-${level}`, makeWorkflow({
+      name: `${prefix}-workflow-${level}`,
+      ref: `project:${prefix}-workflow-${level}`,
+      callable: true,
+      steps: [callStep(`${prefix}-call-${level + 1}`, `${prefix}-workflow-${level + 1}`)],
+    }));
+  }
+  return callStep(prefix, `${prefix}-workflow-1`);
+}
+
+function expandDeepCallChain(tree: TaskRetryRestartTree, prefix: string): void {
+  for (const stepName of [
+    prefix,
+    `${prefix}-call-2`,
+    `${prefix}-call-3`,
+    `${prefix}-call-4`,
+  ]) {
+    const node = findNodeByStep(tree, stepName);
+    expect(node.kind).toBe('navigation');
+    if (node.kind !== 'navigation') throw new Error(`Expected navigation node: ${stepName}`);
+    tree.toggleNavigation(node);
+  }
+}
+
+function inspectRootFrame(tree: TaskRetryRestartTree): InspectedFrameState {
+  return (tree as unknown as { rootFrame: InspectedFrameState }).rootFrame;
+}
+
+function expectNodeStateKeysActive(frame: InspectedFrameState): void {
+  const stepWindow = frame.activeStepWindow;
+  expect(stepWindow).toBeDefined();
+  for (const key of frame.nodeStates.keys()) {
+    const parts = key.split(':');
+    if (parts[0] === 'step') {
+      const stepIndex = Number(parts[1]);
+      expect(stepIndex).toBeGreaterThanOrEqual(stepWindow!.start);
+      expect(stepIndex).toBeLessThan(stepWindow!.end);
+      continue;
+    }
+    const parentStepIndex = Number(parts[1]);
+    const parallelStepIndex = Number(parts[2]);
+    const parallelWindow = frame.activeParallelWindows.get(parentStepIndex);
+    expect(parentStepIndex).toBeGreaterThanOrEqual(stepWindow!.start);
+    expect(parentStepIndex).toBeLessThan(stepWindow!.end);
+    expect(parallelWindow).toBeDefined();
+    expect(parallelStepIndex).toBeGreaterThanOrEqual(parallelWindow!.start);
+    expect(parallelStepIndex).toBeLessThan(parallelWindow!.end);
+  }
+  for (const state of frame.nodeStates.values()) {
+    if (state.childFrame !== undefined) expectNodeStateKeysActive(state.childFrame);
+  }
+}
+
+beforeEach(() => {
+  mockResolveWorkflowCallTarget.mockReset();
+});
+
+describe('TaskRetryRestartTree invariants', () => {
+  it('keeps Resume and the expanded unrelated child projected within the shared budget', () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('child-review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        agentStep('resume'),
+        ...Array.from({ length: 48 }, (_, index) => agentStep(`step-${index}`)),
+        callStep('unrelated', 'child'),
+        ...Array.from({ length: 50 }, (_, index) => agentStep(`later-${index}`)),
+      ],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    const tree = new TaskRetryRestartTree(
+      root,
+      pathContext,
+      undefined,
+      { resumeRestartPoint: rootRestartPoint('resume') },
+    );
+    const resumeValue = tree.getDefaultValue();
+    const navigation = findNodeByStep(tree, 'unrelated');
+    expect(navigation.kind).toBe('navigation');
+    if (navigation.kind !== 'navigation') throw new Error('Expected navigation node');
+
+    tree.toggleNavigation(navigation);
+
+    const visible = tree.getVisibleNodes();
+    expect(visible).toHaveLength(TASK_RETRY_START_WINDOW_SIZE);
+    expect(new Set(visible.map((node) => node.value)).size).toBe(visible.length);
+    expect(visible.some((node) => node.step.name === 'resume')).toBe(true);
+    expect(visible.some((node) => node.step.name === 'child-review')).toBe(true);
+    expect(tree.getDefaultValue()).toBe(resumeValue);
+  });
+
+  it('recaptures a visible Resume when an over-budget expansion structurally moves the root window', () => {
+    const workflowsByCall = new Map<string, WorkflowConfig>();
+    const beforeTriggerBranches = Array.from({ length: 9 }, (_, index) => (
+      registerDeepCallChain(workflowsByCall, `before-${index}`)
+    ));
+    const afterTriggerBranches = Array.from({ length: 2 }, (_, index) => (
+      registerDeepCallChain(workflowsByCall, `after-${index}`)
+    ));
+    for (const call of ['normal-a-child', 'normal-b-child', 'trigger-child']) {
+      workflowsByCall.set(call, makeWorkflow({
+        name: call,
+        ref: `project:${call}`,
+        callable: true,
+        steps: [agentStep(`${call}-leaf`)],
+      }));
+    }
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        parallelStep('reviewers', [
+          ...beforeTriggerBranches,
+          callStep('normal-a', 'normal-a-child'),
+          callStep('normal-b', 'normal-b-child'),
+          callStep('structural-trigger', 'trigger-child'),
+          ...afterTriggerBranches,
+        ]),
+        ...Array.from({ length: 48 }, (_, index) => agentStep(`root-step-${index + 1}`)),
+        agentStep('resume'),
+      ],
+    });
+    mockResolveWorkflowCallTarget.mockImplementation(
+      (_parent: WorkflowConfig, step: WorkflowCallStep) => {
+        const workflow = workflowsByCall.get(step.call);
+        if (workflow === undefined) throw new Error(`Missing workflow fixture: ${step.call}`);
+        return workflow;
+      },
+    );
+    const tree = new TaskRetryRestartTree(
+      root,
+      pathContext,
+      undefined,
+      { resumeRestartPoint: rootRestartPoint('resume') },
+    );
+    const resumeValue = tree.getDefaultValue();
+    const parallelParent = findNodeByStep(tree, 'reviewers');
+    expect(tree.handleKeyPress(parallelParent.value, '\x1B[B')).toBe(true);
+
+    for (const prefix of ['after-0', 'after-1']) expandDeepCallChain(tree, prefix);
+    for (const prefix of Array.from({ length: 9 }, (_, index) => `before-${index}`)) {
+      expandDeepCallChain(tree, prefix);
+    }
+
+    const before = tree.getVisibleNodes();
+    const beforeLeadingSteps = before.slice(0, 5).map((node) => node.step.name);
+    expect(beforeLeadingSteps[0]).toBe('reviewers');
+    expect(before.some((node) => node.step.name === 'structural-trigger')).toBe(true);
+    expect(before.some((node) => node.step.name === 'resume')).toBe(true);
+    const trigger = findNodeByStep(tree, 'structural-trigger');
+    expect(trigger.kind).toBe('navigation');
+    if (trigger.kind !== 'navigation') throw new Error('Expected structural trigger navigation');
+
+    tree.toggleNavigation(trigger);
+
+    const after = tree.getVisibleNodes();
+    const afterLeadingSteps = after.slice(0, 5).map((node) => node.step.name);
+    expect(afterLeadingSteps).not.toEqual(beforeLeadingSteps);
+    expect(afterLeadingSteps[0]).toBe('root-step-1');
+    expect(after.some((node) => node.step.name === 'reviewers')).toBe(false);
+    expect(after).toHaveLength(TASK_RETRY_START_WINDOW_SIZE - 1);
+    expect(new Set(after.map((node) => node.value)).size).toBe(after.length);
+    const resume = findNodeByStep(tree, 'resume');
+    expect(resume.kind).toBe('leaf');
+    expect(resume.kind === 'leaf' && resume.isResumeCandidate).toBe(true);
+    expect(tree.getDefaultValue()).toBe(resumeValue);
+  });
+
+  it('keeps a preferred leaf as the default while expanding and collapsing an unrelated branch', () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('child-review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        agentStep('preferred'),
+        ...Array.from({ length: 48 }, (_, index) => agentStep(`step-${index}`)),
+        callStep('unrelated', 'child'),
+        ...Array.from({ length: 50 }, (_, index) => agentStep(`later-${index}`)),
+      ],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    const tree = new TaskRetryRestartTree(root, pathContext, 'preferred', {});
+    const preferredValue = tree.getDefaultValue();
+    const navigation = findNodeByStep(tree, 'unrelated');
+    expect(navigation.kind).toBe('navigation');
+    if (navigation.kind !== 'navigation') throw new Error('Expected navigation node');
+
+    tree.toggleNavigation(navigation);
+    const expanded = tree.getVisibleNodes();
+    expect(expanded).toHaveLength(TASK_RETRY_START_WINDOW_SIZE);
+    expect(expanded.some((node) => node.step.name === 'preferred')).toBe(true);
+    expect(expanded.some((node) => node.step.name === 'child-review')).toBe(true);
+    expect(tree.getDefaultValue()).toBe(preferredValue);
+
+    const expandedNavigation = findNodeByStep(tree, 'unrelated');
+    expect(expandedNavigation.kind).toBe('navigation');
+    if (expandedNavigation.kind !== 'navigation') throw new Error('Expected navigation node');
+    tree.toggleNavigation(expandedNavigation);
+    expect(tree.getVisibleNodes().some((node) => node.step.name === 'preferred')).toBe(true);
+    expect(tree.getDefaultValue()).toBe(preferredValue);
+  });
+
+  it('prunes a parallel child atomically and recreates a fresh child frame', () => {
+    const grandchild = makeWorkflow({
+      name: 'grandchild',
+      ref: 'project:grandchild',
+      callable: true,
+      steps: [agentStep('grandchild-review')],
+    });
+    const childV1 = makeWorkflow({
+      name: 'child-v1',
+      ref: 'project:child-v1',
+      callable: true,
+      steps: [callStep('nested', 'grandchild'), agentStep('child-v1-finish')],
+    });
+    const childV2 = makeWorkflow({
+      name: 'child-v2',
+      ref: 'project:child-v2',
+      callable: true,
+      steps: [agentStep('child-v2-review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        parallelStep('reviewers', [callStep('delegate', 'child')]),
+        ...Array.from({ length: 99 }, (_, index) => agentStep(`step-${index + 1}`)),
+      ],
+    });
+    let delegateChild = childV1;
+    mockResolveWorkflowCallTarget.mockImplementation(
+      (_parent: WorkflowConfig, step: WorkflowCallStep) => {
+        if (step.call === 'child') return delegateChild;
+        if (step.call === 'grandchild') return grandchild;
+        throw new Error(`Missing workflow fixture: ${step.call}`);
+      },
+    );
+    const tree = new TaskRetryRestartTree(root, pathContext, undefined, {});
+    const parent = findNodeByStep(tree, 'reviewers');
+    expect(tree.handleKeyPress(parent.value, '\x1B[B')).toBe(true);
+    const delegate = findNodeByStep(tree, 'delegate');
+    expect(delegate.kind).toBe('navigation');
+    if (delegate.kind !== 'navigation') throw new Error('Expected navigation node');
+    tree.toggleNavigation(delegate);
+    const nested = findNodeByStep(tree, 'nested');
+    expect(nested.kind).toBe('navigation');
+    if (nested.kind !== 'navigation') throw new Error('Expected nested navigation node');
+    tree.toggleNavigation(nested);
+    expect(findNodeByStep(tree, 'grandchild-review')).toBeDefined();
+    expect(findNodeByStep(tree, 'child-v1-finish')).toBeDefined();
+    expect(mockResolveWorkflowCallTarget).toHaveBeenCalledTimes(2);
+
+    const rootFrame = inspectRootFrame(tree);
+    const lastRootNode = tree.getVisibleNodes().findLast((node) => node.frame.workflow === root);
+    if (lastRootNode === undefined) throw new Error('Missing root boundary node');
+    expect(tree.handleKeyPress(lastRootNode.value, '\x1B[B')).toBe(true);
+
+    expect(rootFrame.activeParallelWindows.size).toBe(0);
+    expect([...rootFrame.nodeStates.keys()].some((key) => key.startsWith('parallel:0:'))).toBe(false);
+    expectNodeStateKeysActive(rootFrame);
+    delegateChild = childV2;
+
+    const firstRootNode = tree.getVisibleNodes().find((node) => node.frame.workflow === root);
+    if (firstRootNode === undefined) throw new Error('Missing root boundary node');
+    expect(tree.handleKeyPress(firstRootNode.value, '\x1B[A')).toBe(true);
+    const restoredParent = findNodeByStep(tree, 'reviewers');
+    expect(tree.handleKeyPress(restoredParent.value, '\x1B[B')).toBe(true);
+    const restoredDelegate = findNodeByStep(tree, 'delegate');
+    expect(restoredDelegate.kind).toBe('navigation');
+    if (restoredDelegate.kind !== 'navigation') throw new Error('Expected navigation node');
+    tree.toggleNavigation(restoredDelegate);
+
+    expect(mockResolveWorkflowCallTarget).toHaveBeenCalledTimes(3);
+    expect(findNodeByStep(tree, 'child-v2-review')).toBeDefined();
+    expect(tree.getVisibleNodes().some((node) => node.step.name === 'child-v1-finish')).toBe(false);
+    expect(tree.getVisibleNodes().some((node) => node.step.name === 'nested')).toBe(false);
+    expect(tree.getVisibleNodes().some((node) => node.step.name === 'grandchild-review')).toBe(false);
+    expectNodeStateKeysActive(rootFrame);
+  });
+
+  it('allows explicit scrolling to hide the target and restores it on reverse scrolling', () => {
+    const child = makeWorkflow({
+      name: 'child',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('child-review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [
+        agentStep('resume'),
+        ...Array.from({ length: 48 }, (_, index) => agentStep(`step-${index}`)),
+        callStep('unrelated', 'child'),
+        ...Array.from({ length: 50 }, (_, index) => agentStep(`later-${index}`)),
+      ],
+    });
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+    const tree = new TaskRetryRestartTree(
+      root,
+      pathContext,
+      undefined,
+      { resumeRestartPoint: rootRestartPoint('resume') },
+    );
+    const resumeValue = tree.getDefaultValue();
+    const navigation = findNodeByStep(tree, 'unrelated');
+    expect(navigation.kind).toBe('navigation');
+    if (navigation.kind !== 'navigation') throw new Error('Expected navigation node');
+    tree.toggleNavigation(navigation);
+    const childLeaf = findNodeByStep(tree, 'child-review');
+
+    expect(tree.handleKeyPress(childLeaf.value, '\x1B[B')).toBe(true);
+    expect(tree.getVisibleNodes().some((node) => node.step.name === 'resume')).toBe(false);
+    expect(tree.getDefaultValue()).not.toBe(resumeValue);
+
+    const firstNode = tree.getVisibleNodes()[0];
+    if (firstNode === undefined) throw new Error('Missing first scrolled node');
+    expect(tree.handleKeyPress(firstNode.value, '\x1B[A')).toBe(true);
+    const restoredResume = findNodeByStep(tree, 'resume');
+    expect(restoredResume.kind).toBe('leaf');
+    expect(restoredResume.kind === 'leaf' && restoredResume.isResumeCandidate).toBe(true);
+    expect(tree.getDefaultValue()).toBe(restoredResume.value);
+  });
+});

--- a/src/features/tasks/list/taskRetryActions.ts
+++ b/src/features/tasks/list/taskRetryActions.ts
@@ -122,10 +122,11 @@ async function selectRetryStart(
   const result = await selectTaskRetryStart(
     workflowConfig,
     options,
-    (message, candidates, defaultValue) => selectOptionWithDefault(
+    (message, candidates, defaultValue, callbacks) => selectOptionWithDefault(
       message,
       candidates,
       defaultValue,
+      callbacks,
     ),
   );
   if (result === null) {

--- a/src/features/tasks/list/taskRetryStartSelection.ts
+++ b/src/features/tasks/list/taskRetryStartSelection.ts
@@ -3,29 +3,20 @@ import {
   type WorkflowRestartPoint,
   type WorkflowResumePoint,
 } from '../../../core/models/index.js';
-import { isWorkflowCallStep } from '../../../core/workflow/step-kind.js';
-import { isWorkflowRestartTarget } from '../../../core/workflow/workflow-restart-target.js';
-import type { SelectOptionItem } from '../../../shared/prompt/index.js';
+import type {
+  InteractiveSelectCallbacks,
+  SelectOptionItem,
+} from '../../../shared/prompt/index.js';
+import { sanitizeTerminalText } from '../../../shared/utils/text.js';
 import {
-  formatTaskRetryPath,
   resolveTaskRetryStackPath,
-  TASK_RETRY_START_PAGE_SIZE,
-  TaskRetryRestartBrowser,
-  type TaskRetryRestartLevel,
-  type TaskRetryRestartPage,
-  type TaskRetryRestartPageItem,
+  TaskRetryRestartTree,
+  type ResolvedTaskRetryPath,
+  type TaskRetryRestartTreeNode,
   type TaskRetryStartPathContext,
 } from '../taskRetryStartPath.js';
 
 const RESUME_SELECTION_VALUE = 'resume-checkpoint';
-const RESTART_SELECTION_VALUE_PREFIX = 'restart-step-';
-const OPEN_CHILD_SELECTION_VALUE_PREFIX = 'open-child-';
-const PREVIOUS_PAGE_VALUE = 'previous-page';
-const NEXT_PAGE_VALUE = 'next-page';
-const PARENT_LEVEL_VALUE = 'parent-level';
-const RESUME_LABEL_PREFIX = 'Resume failed position: ';
-const RESTART_LABEL_PREFIX = 'Restart from: ';
-const OPEN_CHILD_LABEL_PREFIX = 'Browse child workflow from: ';
 
 export type TaskRetryStartSelection =
   | { kind: 'resume'; resumePoint: WorkflowResumePoint }
@@ -40,6 +31,7 @@ export type TaskRetryStartOptionSelector = (
   message: string,
   options: SelectOptionItem<string>[],
   defaultValue: string,
+  callbacks?: InteractiveSelectCallbacks<string>,
 ) => Promise<string | null>;
 
 interface SelectTaskRetryStartOptions extends TaskRetryStartPathContext {
@@ -47,163 +39,85 @@ interface SelectTaskRetryStartOptions extends TaskRetryStartPathContext {
   preferredRootStep?: string;
 }
 
-type BrowserAction =
-  | { kind: 'resume'; value: string; label: string; resumePoint: WorkflowResumePoint }
-  | { kind: 'restart'; value: string; label: string; restartPoint: WorkflowRestartPoint }
-  | { kind: 'open_child'; value: string; item: TaskRetryRestartPageItem }
-  | { kind: 'previous_page'; value: string; startIndex: number }
-  | { kind: 'next_page'; value: string; startIndex: number }
-  | { kind: 'parent_level'; value: string };
-
-interface BrowserFrame {
-  level: TaskRetryRestartLevel;
-  startIndex: number;
+interface SelectableResumePath {
+  resumePoint: WorkflowResumePoint;
+  resolvedPath: ResolvedTaskRetryPath;
 }
 
-function findInitialPageStart(
-  level: TaskRetryRestartLevel,
-  preferredStep: string | undefined,
-): number | undefined {
-  const preferredIndex = preferredStep === undefined
-    ? -1
-    : level.workflow.steps.findIndex((step) => (
-      step.name === preferredStep && isWorkflowRestartTarget(step)
-    ));
-  const firstRestartIndex = preferredIndex >= 0
-    ? preferredIndex
-    : level.workflow.steps.findIndex(isWorkflowRestartTarget);
-  return firstRestartIndex < 0
-    ? undefined
-    : Math.floor(firstRestartIndex / TASK_RETRY_START_PAGE_SIZE) * TASK_RETRY_START_PAGE_SIZE;
+interface ProjectedTree {
+  options: SelectOptionItem<string>[];
+  selections: Map<string, TaskRetryStartSelection>;
 }
 
-function requireInitialPageStart(
-  level: TaskRetryRestartLevel,
-  preferredStep: string | undefined,
-): number {
-  const startIndex = findInitialPageStart(level, preferredStep);
-  if (startIndex === undefined) {
-    throw new Error(`Workflow "${level.workflow.name}" has no authored steps to restart from`);
-  }
-  return startIndex;
-}
-
-function createResumeAction(
+function resolveSelectableResumePoint(
   rootWorkflow: WorkflowConfig,
   options: SelectTaskRetryStartOptions,
-): BrowserAction | undefined {
-  if (options.resumePoint === undefined) {
-    return undefined;
-  }
-  const resolved = resolveTaskRetryStackPath(
+): SelectableResumePath | undefined {
+  const resumePoint = options.resumePoint;
+  if (resumePoint === undefined) return undefined;
+
+  const resolvedPath = resolveTaskRetryStackPath(
     rootWorkflow,
-    options.resumePoint.stack,
+    resumePoint.stack,
     options,
     true,
   );
-  if (resolved === undefined) {
+  if (resolvedPath === undefined) {
+    if (resumePoint.stack.at(-1)?.kind === 'workflow_call') {
+      throw new Error('Task retry resume path cannot be resolved');
+    }
     return undefined;
   }
-  return {
-    kind: 'resume',
-    value: RESUME_SELECTION_VALUE,
-    label: `${RESUME_LABEL_PREFIX}${formatTaskRetryPath(resolved.segments)} [default]`,
-    resumePoint: options.resumePoint,
-  };
+  return { resumePoint, resolvedPath };
 }
 
-function createPageActions(
-  page: TaskRetryRestartPage,
-  includeParent: boolean,
-): BrowserAction[] {
-  const actions: BrowserAction[] = [];
-  for (const item of page.items) {
-    const path = formatTaskRetryPath(item.segments);
-    actions.push({
-      kind: 'restart',
-      value: `${RESTART_SELECTION_VALUE_PREFIX}${item.stepIndex}`,
-      label: `${RESTART_LABEL_PREFIX}${path}`,
-      restartPoint: item.restartPoint,
-    });
-    if (isWorkflowCallStep(item.step)) {
-      actions.push({
-        kind: 'open_child',
-        value: `${OPEN_CHILD_SELECTION_VALUE_PREFIX}${item.stepIndex}`,
-        item,
+function formatWorkflowHeading(name: string): string {
+  return sanitizeTerminalText(name);
+}
+
+function getNodeLabel(node: TaskRetryRestartTreeNode): string {
+  return sanitizeTerminalText(node.step.name);
+}
+
+function projectTree(
+  rootWorkflow: WorkflowConfig,
+  nodes: readonly TaskRetryRestartTreeNode[],
+  resumePath: SelectableResumePath | undefined,
+): ProjectedTree {
+  const options: SelectOptionItem<string>[] = [];
+  const selections = new Map<string, TaskRetryStartSelection>();
+
+  for (const node of nodes) {
+    const label = getNodeLabel(node);
+    if (node.kind === 'navigation') {
+      options.push({
+        label,
+        value: node.value,
+        leadingLines: node.workflowPath.map(formatWorkflowHeading),
+        indent: node.workflowPath.length + 1,
       });
+      continue;
     }
-  }
-  if (page.previousStartIndex !== undefined) {
-    actions.push({
-      kind: 'previous_page',
-      value: PREVIOUS_PAGE_VALUE,
-      startIndex: page.previousStartIndex,
+    if (!node.isRestartable && !node.isResumeCandidate) continue;
+
+    const value = node.isResumeCandidate ? RESUME_SELECTION_VALUE : node.value;
+    const selection = node.isResumeCandidate
+      ? { kind: 'resume' as const, resumePoint: resumePath!.resumePoint }
+      : { kind: 'restart' as const, restartPoint: node.restartPoint };
+    options.push({
+      label,
+      value,
+      leadingLines: node.workflowPath.map(formatWorkflowHeading),
+      indent: node.workflowPath.length,
+      ...(node.restartPoint.stack.length === 1
+        && node.step.name === rootWorkflow.initialStep
+        ? { description: 'Initial step' }
+        : {}),
     });
+    selections.set(value, selection);
   }
-  if (page.nextStartIndex !== undefined) {
-    actions.push({
-      kind: 'next_page',
-      value: NEXT_PAGE_VALUE,
-      startIndex: page.nextStartIndex,
-    });
-  }
-  if (includeParent) {
-    actions.push({ kind: 'parent_level', value: PARENT_LEVEL_VALUE });
-  }
-  return actions;
-}
 
-function getActionLabel(action: BrowserAction, page: TaskRetryRestartPage): string {
-  switch (action.kind) {
-    case 'resume':
-    case 'restart':
-      return action.label;
-    case 'open_child':
-      return `${OPEN_CHILD_LABEL_PREFIX}${formatTaskRetryPath(action.item.segments)}`;
-    case 'previous_page':
-      return `Previous page (${page.pageNumber - 1}/${page.pageCount})`;
-    case 'next_page':
-      return `Next page (${page.pageNumber + 1}/${page.pageCount})`;
-    case 'parent_level':
-      return 'Back to parent workflow';
-  }
-}
-
-function getDefaultValue(
-  actions: BrowserAction[],
-  resumeAction: BrowserAction | undefined,
-  preferredStep: string | undefined,
-): string {
-  if (resumeAction?.kind === 'resume') {
-    return resumeAction.value;
-  }
-  const preferred = actions.find((action) => (
-    action.kind === 'restart'
-    && action.restartPoint.stack.at(-1)?.step === preferredStep
-  ));
-  return preferred?.value ?? actions[0]!.value;
-}
-
-async function selectResumeOnly(
-  level: TaskRetryRestartLevel,
-  resumeAction: Extract<BrowserAction, { kind: 'resume' }>,
-  selectOption: TaskRetryStartOptionSelector,
-): Promise<TaskRetryStartSelectionResult | null> {
-  const selectedValue = await selectOption(
-    `Start position — ${formatTaskRetryPath(level.segments)}:`,
-    [{ label: resumeAction.label, value: resumeAction.value }],
-    resumeAction.value,
-  );
-  if (selectedValue === null) {
-    return null;
-  }
-  if (selectedValue !== resumeAction.value) {
-    throw new Error(`Unknown task retry start selection: ${selectedValue}`);
-  }
-  return {
-    label: resumeAction.label,
-    selection: { kind: 'resume', resumePoint: resumeAction.resumePoint },
-  };
+  return { options, selections };
 }
 
 export async function selectTaskRetryStart(
@@ -211,76 +125,70 @@ export async function selectTaskRetryStart(
   options: SelectTaskRetryStartOptions,
   selectOption: TaskRetryStartOptionSelector,
 ): Promise<TaskRetryStartSelectionResult | null> {
-  const browser = new TaskRetryRestartBrowser(options);
-  const rootLevel = browser.createRootLevel(rootWorkflow);
-  const resumeAction = createResumeAction(rootWorkflow, options);
-  const rootStartIndex = findInitialPageStart(rootLevel, options.preferredRootStep);
-  if (rootStartIndex === undefined) {
-    if (resumeAction?.kind !== 'resume') {
-      throw new Error(`Workflow "${rootWorkflow.name}" has no authored steps to restart from`);
-    }
-    return selectResumeOnly(rootLevel, resumeAction, selectOption);
-  }
-  const frames: BrowserFrame[] = [{
-    level: rootLevel,
-    startIndex: rootStartIndex,
-  }];
+  const resumePath = resolveSelectableResumePoint(rootWorkflow, options);
+  const tree = new TaskRetryRestartTree(
+    rootWorkflow,
+    options,
+    options.preferredRootStep,
+    { resumeRestartPoint: resumePath?.resolvedPath.restartPoint },
+  );
 
-  while (frames.length > 0) {
-    const frame = frames.at(-1)!;
-    const page = browser.getPage(frame.level, frame.startIndex);
-    const pageActions = createPageActions(page, frames.length > 1);
-    const actions = frames.length === 1 && resumeAction !== undefined
-      ? [resumeAction, ...pageActions]
-      : pageActions;
-    if (actions.length === 0) {
-      throw new Error(`Workflow "${frame.level.workflow.name}" has no selectable retry positions`);
+  let projected = projectTree(rootWorkflow, tree.getVisibleNodes(), resumePath);
+  if (projected.options.length === 0) {
+    throw new Error(`Workflow "${rootWorkflow.name}" has no selectable retry positions`);
+  }
+
+  const message = `Start position — ${sanitizeTerminalText(rootWorkflow.name)}:`;
+  while (true) {
+    const defaultNodeValue = tree.getDefaultValue();
+    const defaultNode = defaultNodeValue === undefined
+      ? undefined
+      : tree.findNode(defaultNodeValue);
+    const defaultValue = defaultNode?.kind === 'leaf' && defaultNode.isResumeCandidate
+      ? RESUME_SELECTION_VALUE
+      : defaultNodeValue;
+    if (defaultValue === undefined) {
+      throw new Error(`Workflow "${rootWorkflow.name}" has no selectable retry positions`);
     }
-    const promptOptions = actions.map((action): SelectOptionItem<string> => ({
-      label: getActionLabel(action, page),
-      value: action.value,
-      ...(action.kind === 'restart'
-        && action.restartPoint.stack.length === 1
-        && action.restartPoint.stack[0]?.step === rootWorkflow.initialStep
-        ? { description: 'Initial step' }
-        : {}),
-    }));
-    const preferredStep = frames.length === 1
-      ? options.preferredRootStep
-      : frame.level.workflow.initialStep;
     const selectedValue = await selectOption(
-      `Start position — ${formatTaskRetryPath(frame.level.segments)} (page ${page.pageNumber}/${page.pageCount}):`,
-      promptOptions,
-      getDefaultValue(actions, frames.length === 1 ? resumeAction : undefined, preferredStep),
+      message,
+      projected.options,
+      defaultValue,
+      {
+        onKeyPress: (key, value) => {
+          const treeValue = value === RESUME_SELECTION_VALUE
+            ? tree.getVisibleNodes().find((node) => (
+              node.kind === 'leaf' && node.isResumeCandidate
+            ))?.value ?? value
+            : value;
+          if (!tree.handleKeyPress(treeValue, key)) {
+            return null;
+          }
+          projected = projectTree(rootWorkflow, tree.getVisibleNodes(), resumePath);
+          return projected.options;
+        },
+      },
     );
-    if (selectedValue === null) {
-      return null;
+    if (selectedValue === null) return null;
+
+    if (tree.isNavigation(selectedValue)) {
+      const navigation = tree.findNode(selectedValue);
+      if (navigation?.kind !== 'navigation') {
+        throw new Error(`Unknown task retry start selection: ${selectedValue}`);
+      }
+      tree.toggleNavigation(navigation);
+      projected = projectTree(rootWorkflow, tree.getVisibleNodes(), resumePath);
+      continue;
     }
-    const action = actions.find((candidate) => candidate.value === selectedValue);
-    if (action === undefined) {
+
+    const selection = projected.selections.get(selectedValue);
+    if (selection === undefined) {
       throw new Error(`Unknown task retry start selection: ${selectedValue}`);
     }
-    switch (action.kind) {
-      case 'resume':
-        return { label: action.label, selection: { kind: 'resume', resumePoint: action.resumePoint } };
-      case 'restart':
-        return { label: action.label, selection: { kind: 'restart', restartPoint: action.restartPoint } };
-      case 'open_child': {
-        const childLevel = browser.openChild(frame.level, action.item);
-        frames.push({
-          level: childLevel,
-          startIndex: requireInitialPageStart(childLevel, childLevel.workflow.initialStep),
-        });
-        break;
-      }
-      case 'previous_page':
-      case 'next_page':
-        frame.startIndex = action.startIndex;
-        break;
-      case 'parent_level':
-        frames.pop();
-        break;
+    const selectedOption = projected.options.find((option) => option.value === selectedValue);
+    if (selectedOption === undefined) {
+      throw new Error(`Unknown task retry start selection: ${selectedValue}`);
     }
+    return { label: selectedOption.label, selection };
   }
-  throw new Error('Task retry start browser exited without a selection');
 }

--- a/src/features/tasks/taskRetryStartPath.ts
+++ b/src/features/tasks/taskRetryStartPath.ts
@@ -81,6 +81,8 @@ interface TaskRetryStartWindow {
   end: number;
 }
 
+type TaskRetryStartWindowChange = 'structural' | 'scroll';
+
 function resolveCallableChild(
   parent: WorkflowConfig,
   step: Extract<WorkflowStep, { kind: 'workflow_call' }>,
@@ -203,15 +205,21 @@ function resolvePreferredRestartPoint(
   ) ?? findFirstAuthoredRestartPoint(rootWorkflow, []);
 }
 
+type TaskRetryRestartTreeNodeUiState =
+  | { readonly id: string; readonly expanded: false }
+  | {
+    readonly id: string;
+    readonly expanded: true;
+    readonly childFrame: TaskRetryRestartTreeFrameState;
+  };
+
 interface TaskRetryRestartTreeFrameState extends TaskRetryRestartTreeFrame {
   readonly parent?: TaskRetryRestartTreeFrameState;
   readonly parentStepIndex?: number;
   readonly parentParallelStepIndex?: number;
   activeStepWindow: TaskRetryStartWindow | undefined;
   readonly activeParallelWindows: Map<number, TaskRetryStartWindow>;
-  readonly expandedCallKeys: Set<string>;
-  readonly childFrames: Map<string, TaskRetryRestartTreeFrameState>;
-  readonly nodeIds: Map<string, string>;
+  readonly nodeStates: Map<string, TaskRetryRestartTreeNodeUiState>;
 }
 
 export interface TaskRetryRestartTreeOptions {
@@ -299,7 +307,7 @@ export class TaskRetryRestartTree {
     }
     if (this.isDownKey(key) && node.kind === 'leaf' && this.isStaticParallelCallStep(node.step)) {
       const stepIndex = node.frame.workflow.steps.indexOf(node.step);
-      if (stepIndex >= 0 && this.loadParallelWindow(node.frame, stepIndex, 0)) {
+      if (stepIndex >= 0 && this.loadParallelWindow(node.frame, stepIndex, 0, TASK_RETRY_START_WINDOW_SIZE, 'scroll')) {
         return true;
       }
     }
@@ -332,14 +340,12 @@ export class TaskRetryRestartTree {
 
   toggleNavigation(node: TaskRetryRestartTreeNavigation): void {
     if (node.expanded) {
-      node.frame.expandedCallKeys.delete(node.key);
-      node.frame.childFrames.delete(node.key);
+      this.deleteNodeState(node.frame, node.key);
       return;
     }
 
     const child = this.resolveChildFrame(node);
-    node.frame.childFrames.set(node.key, child);
-    node.frame.expandedCallKeys.add(node.key);
+    this.setExpandedNodeState(node.frame, node.key, child);
     const activeWindow = node.frame.activeStepWindow;
     const visibleNodes = this.getVisibleNodes();
     const childHasVisibleNode = this.getVisibleNodesForFrame(child).length > 0;
@@ -351,7 +357,7 @@ export class TaskRetryRestartTree {
       && !childIsProjected
     ) {
       const windowSize = activeWindow.end - activeWindow.start - 1;
-      this.loadWindow(node.frame, node.parentStepIndex - windowSize + 1, windowSize);
+      this.loadWindow(node.frame, node.parentStepIndex - windowSize + 1, windowSize, 'structural');
     }
   }
 
@@ -374,14 +380,12 @@ export class TaskRetryRestartTree {
       ...(parentParallelStepIndex === undefined ? {} : { parentParallelStepIndex }),
       activeStepWindow: undefined,
       activeParallelWindows: new Map<number, TaskRetryStartWindow>(),
-      expandedCallKeys: new Set<string>(),
-      childFrames: new Map<string, TaskRetryRestartTreeFrameState>(),
-      nodeIds: new Map<string, string>(),
+      nodeStates: new Map<string, TaskRetryRestartTreeNodeUiState>(),
     };
   }
 
   private loadInitialWindow(frame: TaskRetryRestartTreeFrameState): void {
-    const target = this.resumeRestartPoint ?? this.defaultRestartPoint;
+    const target = this.getTargetRestartPoint();
     const targetIndex = this.findTargetStepIndex(frame, target);
     const firstVisibleIndex = targetIndex ?? this.findFirstVisibleStepIndex(frame.workflow);
     if (firstVisibleIndex === undefined) return;
@@ -405,7 +409,7 @@ export class TaskRetryRestartTree {
         ? Math.floor(firstVisibleIndex / TASK_RETRY_START_WINDOW_SIZE)
           * TASK_RETRY_START_WINDOW_SIZE
         : Math.max(0, firstVisibleIndex - windowSize + 1);
-      this.loadWindow(frame, windowStart, windowSize);
+      this.loadWindow(frame, windowStart, windowSize, 'structural');
       return;
     }
 
@@ -423,32 +427,46 @@ export class TaskRetryRestartTree {
       parallelStepIndex,
     );
     if (targetParallelIndex === undefined) {
-      this.loadWindow(frame, windowStart, topLevelSize);
+      this.loadWindow(frame, windowStart, topLevelSize, 'structural');
       return;
     }
-    this.loadWindow(frame, windowStart, topLevelSize);
+    this.loadWindow(frame, windowStart, topLevelSize, 'structural');
     this.loadParallelWindow(
       frame,
       parallelStepIndex,
       targetParallelIndex,
       Math.max(1, TASK_RETRY_START_WINDOW_SIZE - topLevelSize - nestedContentCount),
+      'structural',
     );
   }
 
   private loadWindow(
     frame: TaskRetryRestartTreeFrameState,
     startIndex: number,
-    windowSize = TASK_RETRY_START_WINDOW_SIZE,
+    windowSize: number,
+    change: TaskRetryStartWindowChange,
   ): boolean {
     if (frame.workflow.steps.length === 0 || windowSize <= 0) return false;
-    const normalizedStart = Math.max(
+    let normalizedStart = Math.max(
       0,
       Math.min(startIndex, frame.workflow.steps.length - 1),
     );
-    const endIndex = Math.min(
+    let endIndex = Math.min(
       frame.workflow.steps.length,
       normalizedStart + windowSize,
     );
+    const targetIndex = this.findTargetStepIndex(frame, this.getTargetRestartPoint());
+    if (
+      change === 'structural'
+      && targetIndex !== undefined
+      && this.isStepIndexActive(frame, targetIndex)
+      && (targetIndex < normalizedStart || targetIndex >= endIndex)
+    ) {
+      normalizedStart = targetIndex < normalizedStart
+        ? targetIndex
+        : Math.max(0, targetIndex - windowSize + 1);
+      endIndex = Math.min(frame.workflow.steps.length, normalizedStart + windowSize);
+    }
     const previous = frame.activeStepWindow;
     const changed = previous?.start !== normalizedStart || previous.end !== endIndex;
     frame.activeStepWindow = { start: normalizedStart, end: endIndex };
@@ -460,7 +478,8 @@ export class TaskRetryRestartTree {
     frame: TaskRetryRestartTreeFrameState,
     parentStepIndex: number,
     startIndex: number,
-    windowSize = TASK_RETRY_START_WINDOW_SIZE,
+    windowSize: number,
+    change: TaskRetryStartWindowChange,
   ): boolean {
     const parentStep = frame.workflow.steps[parentStepIndex];
     if (
@@ -473,15 +492,32 @@ export class TaskRetryRestartTree {
     }
 
     if (parentStep.parallel.length === 0) return false;
-    const normalizedStart = Math.max(
+    let normalizedStart = Math.max(
       0,
       Math.min(startIndex, parentStep.parallel.length - 1),
     );
-    const endIndex = Math.min(
+    let endIndex = Math.min(
       parentStep.parallel.length,
       normalizedStart + windowSize,
     );
+    const targetIndex = this.findTargetParallelStepIndex(
+      frame,
+      this.getTargetRestartPoint(),
+      parentStepIndex,
+    );
     const previous = frame.activeParallelWindows.get(parentStepIndex);
+    if (
+      change === 'structural'
+      && targetIndex !== undefined
+      && previous !== undefined
+      && this.isParallelIndexActive(previous, targetIndex)
+      && (targetIndex < normalizedStart || targetIndex >= endIndex)
+    ) {
+      normalizedStart = targetIndex < normalizedStart
+        ? targetIndex
+        : Math.max(0, targetIndex - windowSize + 1);
+      endIndex = Math.min(parentStep.parallel.length, normalizedStart + windowSize);
+    }
     const changed = previous?.start !== normalizedStart || previous.end !== endIndex;
     frame.activeParallelWindows.set(parentStepIndex, {
       start: normalizedStart,
@@ -492,35 +528,19 @@ export class TaskRetryRestartTree {
   }
 
   private pruneFrameState(frame: TaskRetryRestartTreeFrameState): void {
-    for (const [parentStepIndex, window] of frame.activeParallelWindows) {
+    for (const parentStepIndex of frame.activeParallelWindows.keys()) {
       if (!this.isStepIndexActive(frame, parentStepIndex)) {
         frame.activeParallelWindows.delete(parentStepIndex);
-        continue;
-      }
-      for (const key of frame.childFrames.keys()) {
-        if (this.isParallelNodeKeyForParent(key, parentStepIndex)
-          && !this.isParallelIndexActive(window, this.getParallelNodeIndex(key))) {
-          frame.childFrames.delete(key);
-          frame.expandedCallKeys.delete(key);
-          frame.nodeIds.delete(key);
-        }
       }
     }
 
-    for (const key of frame.childFrames.keys()) {
-      if (this.isStepNodeKey(key) && !this.isStepIndexActive(frame, this.getStepNodeIndex(key))) {
-        frame.childFrames.delete(key);
-        frame.expandedCallKeys.delete(key);
-        frame.nodeIds.delete(key);
-      }
+    for (const key of frame.nodeStates.keys()) {
+      if (!this.isNodeKeyActive(frame, key)) this.deleteNodeState(frame, key);
     }
+  }
 
-    for (const key of frame.expandedCallKeys) {
-      if (!this.isNodeKeyActive(frame, key)) frame.expandedCallKeys.delete(key);
-    }
-    for (const key of frame.nodeIds.keys()) {
-      if (!this.isNodeKeyActive(frame, key)) frame.nodeIds.delete(key);
-    }
+  private deleteNodeState(frame: TaskRetryRestartTreeFrameState, key: string): void {
+    frame.nodeStates.delete(key);
   }
 
   private isNodeKeyActive(frame: TaskRetryRestartTreeFrameState, key: string): boolean {
@@ -549,14 +569,6 @@ export class TaskRetryRestartTree {
     return Number(key.slice('step:'.length));
   }
 
-  private getParallelNodeIndex(key: string): number {
-    return Number(key.split(':').at(-1));
-  }
-
-  private isParallelNodeKeyForParent(key: string, parentStepIndex: number): boolean {
-    return key.startsWith(`parallel:${parentStepIndex}:`);
-  }
-
   private isStepIndexActive(frame: TaskRetryRestartTreeFrameState, index: number): boolean {
     const window = frame.activeStepWindow;
     return window !== undefined && index >= window.start && index < window.end;
@@ -564,6 +576,10 @@ export class TaskRetryRestartTree {
 
   private isParallelIndexActive(window: TaskRetryStartWindow, index: number): boolean {
     return index >= window.start && index < window.end;
+  }
+
+  private getTargetRestartPoint(): WorkflowRestartPoint | undefined {
+    return this.resumeRestartPoint ?? this.defaultRestartPoint;
   }
 
   private findTargetStaticParallelCallIndex(
@@ -644,7 +660,11 @@ export class TaskRetryRestartTree {
     const stepWindow = frame.activeStepWindow;
     if (stepWindow === undefined) return nodes;
     const targetBranch = this.getTargetBranch(frame);
-    let remainingRequiredNodes = this.getRequiredVisibleNodeCount(frame);
+    const reserveExpandedBranches = this.getRequiredVisibleNodeCount(frame, true) <= budget;
+    let remainingRequiredNodes = this.getRequiredVisibleNodeCount(
+      frame,
+      reserveExpandedBranches,
+    );
     for (
       let stepIndex = stepWindow.start;
       stepIndex < stepWindow.end && nodes.length < budget;
@@ -653,8 +673,14 @@ export class TaskRetryRestartTree {
       const step = frame.workflow.steps[stepIndex];
       if (step === undefined) continue;
       const isTargetStep = targetBranch?.stepIndex === stepIndex;
+      const requiredStepNodes = this.getRequiredVisibleNodeCountForStep(
+        frame,
+        stepIndex,
+        targetBranch,
+        reserveExpandedBranches,
+      );
       if (
-        !isTargetStep
+        requiredStepNodes === 0
         && nodes.length + 1 + remainingRequiredNodes > budget
       ) {
         continue;
@@ -672,14 +698,13 @@ export class TaskRetryRestartTree {
           stepIndex,
         );
         nodes.push(navigation);
-        if (isTargetStep) remainingRequiredNodes -= 1;
+        if (requiredStepNodes > 0) remainingRequiredNodes -= 1;
         if (navigation.expanded) {
-          const child = frame.childFrames.get(key);
+          const child = this.getExpandedChildFrame(frame, key);
           if (child !== undefined) {
-            const requiredChildNodes = isTargetStep ? remainingRequiredNodes : 0;
-            const childBudget = budget - nodes.length - (
-              isTargetStep ? 0 : remainingRequiredNodes
-            );
+            const requiredChildNodes = Math.max(0, requiredStepNodes - 1);
+            const childBudget = budget - nodes.length
+              - (remainingRequiredNodes - requiredChildNodes);
             nodes.push(...this.getVisibleNodesForFrame(child, childBudget));
             remainingRequiredNodes -= requiredChildNodes;
           }
@@ -701,7 +726,7 @@ export class TaskRetryRestartTree {
           isResumeCandidate,
           frame,
         });
-        if (isTargetStep) remainingRequiredNodes -= 1;
+        if (requiredStepNodes > 0) remainingRequiredNodes -= 1;
       }
 
       if (step.parallel !== undefined && !isDynamicParallelSubSteps(step.parallel)) {
@@ -718,8 +743,14 @@ export class TaskRetryRestartTree {
           const key = `parallel:${stepIndex}:${subStepIndex}`;
           const isTargetParallelStep = isTargetStep
             && targetBranch.parallelStepIndex === subStepIndex;
+          const requiredParallelNodes = this.getRequiredVisibleNodeCountForParallelNode(
+            frame,
+            key,
+            isTargetParallelStep,
+            reserveExpandedBranches,
+          );
           if (
-            !isTargetParallelStep
+            requiredParallelNodes === 0
             && nodes.length + 1 + remainingRequiredNodes > budget
           ) {
             continue;
@@ -735,14 +766,13 @@ export class TaskRetryRestartTree {
             subStepIndex,
           );
           nodes.push(navigation);
-          if (isTargetParallelStep) remainingRequiredNodes -= 1;
+          if (requiredParallelNodes > 0) remainingRequiredNodes -= 1;
           if (navigation.expanded) {
-            const child = frame.childFrames.get(key);
+            const child = this.getExpandedChildFrame(frame, key);
             if (child !== undefined) {
-              const requiredChildNodes = isTargetParallelStep ? remainingRequiredNodes : 0;
-              const childBudget = budget - nodes.length - (
-                isTargetParallelStep ? 0 : remainingRequiredNodes
-              );
+              const requiredChildNodes = Math.max(0, requiredParallelNodes - 1);
+              const childBudget = budget - nodes.length
+                - (remainingRequiredNodes - requiredChildNodes);
               nodes.push(...this.getVisibleNodesForFrame(child, childBudget));
               remainingRequiredNodes -= requiredChildNodes;
             }
@@ -756,7 +786,7 @@ export class TaskRetryRestartTree {
   private getTargetBranch(
     frame: TaskRetryRestartTreeFrameState,
   ): { stepIndex: number; parallelStepIndex?: number } | undefined {
-    const target = this.resumeRestartPoint ?? this.defaultRestartPoint;
+    const target = this.getTargetRestartPoint();
     if (target === undefined || !matchesFrameStack(frame.stack, target.stack)) {
       return undefined;
     }
@@ -772,25 +802,85 @@ export class TaskRetryRestartTree {
 
   private getRequiredVisibleNodeCount(
     frame: TaskRetryRestartTreeFrameState,
+    reserveExpandedBranches: boolean,
   ): number {
     const targetBranch = this.getTargetBranch(frame);
-    if (targetBranch === undefined) return 0;
+    const window = frame.activeStepWindow;
+    if (window === undefined) return 0;
+    let count = 0;
+    for (let stepIndex = window.start; stepIndex < window.end; stepIndex += 1) {
+      count += this.getRequiredVisibleNodeCountForStep(
+        frame,
+        stepIndex,
+        targetBranch,
+        reserveExpandedBranches,
+      );
+    }
+    return count;
+  }
 
-    const step = frame.workflow.steps[targetBranch.stepIndex];
+  private getRequiredVisibleNodeCountForStep(
+    frame: TaskRetryRestartTreeFrameState,
+    stepIndex: number,
+    targetBranch: { stepIndex: number; parallelStepIndex?: number } | undefined,
+    reserveExpandedBranches: boolean,
+  ): number {
+    const step = frame.workflow.steps[stepIndex];
     if (step === undefined) return 0;
-
-    if (targetBranch.parallelStepIndex !== undefined) {
-      const key = `parallel:${targetBranch.stepIndex}:${targetBranch.parallelStepIndex}`;
-      const child = frame.childFrames.get(key);
-      return 1 + 1 + (child === undefined ? 0 : this.getRequiredVisibleNodeCount(child));
-    }
-
+    const isTargetStep = targetBranch?.stepIndex === stepIndex;
     if (isWorkflowCallStep(step)) {
-      const child = frame.childFrames.get(`step:${targetBranch.stepIndex}`);
-      return 1 + (child === undefined ? 0 : this.getRequiredVisibleNodeCount(child));
+      const state = frame.nodeStates.get(`step:${stepIndex}`);
+      if (!isTargetStep && (!reserveExpandedBranches || state?.expanded !== true)) return 0;
+      return 1 + this.getRequiredExpandedChildNodeCount(
+        state?.expanded === true ? state.childFrame : undefined,
+        reserveExpandedBranches,
+      );
     }
 
-    return 1;
+    let parallelNodeCount = 0;
+    const parallelWindow = frame.activeParallelWindows.get(stepIndex);
+    if (
+      parallelWindow !== undefined
+      && step.parallel !== undefined
+      && !isDynamicParallelSubSteps(step.parallel)
+    ) {
+      for (
+        let parallelStepIndex = parallelWindow.start;
+        parallelStepIndex < parallelWindow.end;
+        parallelStepIndex += 1
+      ) {
+        parallelNodeCount += this.getRequiredVisibleNodeCountForParallelNode(
+          frame,
+          `parallel:${stepIndex}:${parallelStepIndex}`,
+          isTargetStep && targetBranch.parallelStepIndex === parallelStepIndex,
+          reserveExpandedBranches,
+        );
+      }
+    }
+    return isTargetStep || parallelNodeCount > 0 ? 1 + parallelNodeCount : 0;
+  }
+
+  private getRequiredVisibleNodeCountForParallelNode(
+    frame: TaskRetryRestartTreeFrameState,
+    key: string,
+    isTarget: boolean,
+    reserveExpandedBranches: boolean,
+  ): number {
+    const state = frame.nodeStates.get(key);
+    if (!isTarget && (!reserveExpandedBranches || state?.expanded !== true)) return 0;
+    return 1 + this.getRequiredExpandedChildNodeCount(
+      state?.expanded === true ? state.childFrame : undefined,
+      reserveExpandedBranches,
+    );
+  }
+
+  private getRequiredExpandedChildNodeCount(
+    childFrame: TaskRetryRestartTreeFrameState | undefined,
+    reserveExpandedBranches: boolean,
+  ): number {
+    return childFrame === undefined
+      ? 0
+      : Math.max(1, this.getRequiredVisibleNodeCount(childFrame, reserveExpandedBranches));
   }
 
   private isStaticParallelCallStep(step: WorkflowStep): boolean {
@@ -824,7 +914,7 @@ export class TaskRetryRestartTree {
       step,
       restartPoint,
       workflowPath: [...workflowPath],
-      expanded: frame.expandedCallKeys.has(key),
+      expanded: frame.nodeStates.get(key)?.expanded === true,
       frame,
       key,
       parentStepIndex,
@@ -834,16 +924,33 @@ export class TaskRetryRestartTree {
   }
 
   private getNodeValue(frame: TaskRetryRestartTreeFrameState, key: string): string {
-    const existing = frame.nodeIds.get(key);
-    if (existing !== undefined) return existing;
+    const existing = frame.nodeStates.get(key);
+    if (existing !== undefined) return existing.id;
     const value = `retry-tree-${this.nextNodeId}`;
     this.nextNodeId += 1;
-    frame.nodeIds.set(key, value);
+    frame.nodeStates.set(key, { id: value, expanded: false });
     return value;
   }
 
+  private setExpandedNodeState(
+    frame: TaskRetryRestartTreeFrameState,
+    key: string,
+    childFrame: TaskRetryRestartTreeFrameState,
+  ): void {
+    const id = this.getNodeValue(frame, key);
+    frame.nodeStates.set(key, { id, expanded: true, childFrame });
+  }
+
+  private getExpandedChildFrame(
+    frame: TaskRetryRestartTreeFrameState,
+    key: string,
+  ): TaskRetryRestartTreeFrameState | undefined {
+    const state = frame.nodeStates.get(key);
+    return state?.expanded === true ? state.childFrame : undefined;
+  }
+
   private resolveChildFrame(node: TaskRetryRestartTreeNavigation): TaskRetryRestartTreeFrameState {
-    const existing = node.frame.childFrames.get(node.key);
+    const existing = this.getExpandedChildFrame(node.frame, node.key);
     if (existing !== undefined) return existing;
     const child = resolveCallableChild(node.frame.workflow, node.step, this.context);
     assertCallableChildBoundary(child, node.frame.ancestors);
@@ -881,7 +988,7 @@ export class TaskRetryRestartTree {
           1,
           TASK_RETRY_START_WINDOW_SIZE - nestedContentCount,
         );
-        this.loadWindow(frame, stepIndex - windowSize + 1, windowSize);
+        this.loadWindow(frame, stepIndex - windowSize + 1, windowSize, 'structural');
       }
       const step = frame.workflow.steps[stepIndex]!;
       if (isWorkflowCallStep(step)) {
@@ -893,9 +1000,8 @@ export class TaskRetryRestartTree {
           frame.workflowPath,
           stepIndex,
         );
-        frame.expandedCallKeys.add(node.key);
         const child = this.resolveChildFrame(node);
-        frame.childFrames.set(node.key, child);
+        this.setExpandedNodeState(frame, node.key, child);
         frame = child;
         index += 1;
         continue;
@@ -909,7 +1015,7 @@ export class TaskRetryRestartTree {
       const subStep = subStepIndex < 0 ? undefined : step.parallel[subStepIndex];
       if (subStep === undefined || !isWorkflowCallStep(subStep)) return;
       const key = `parallel:${stepIndex}:${subStepIndex}`;
-      this.loadParallelWindow(frame, stepIndex, subStepIndex, 1);
+      this.loadParallelWindow(frame, stepIndex, subStepIndex, 1, 'structural');
       const node = this.createNavigationNode(
         frame,
         key,
@@ -920,9 +1026,8 @@ export class TaskRetryRestartTree {
         step.name,
         subStepIndex,
       );
-      frame.expandedCallKeys.add(key);
       const child = this.resolveChildFrame(node);
-      frame.childFrames.set(key, child);
+      this.setExpandedNodeState(frame, key, child);
       frame = child;
       index += 2;
     }
@@ -948,7 +1053,13 @@ export class TaskRetryRestartTree {
       && this.isStaticParallelCallStep(node.step)
     ) {
       const stepIndex = node.frame.workflow.steps.indexOf(node.step);
-      if (stepIndex >= 0 && this.loadParallelWindow(node.frame, stepIndex, 0)) {
+      if (stepIndex >= 0 && this.loadParallelWindow(
+        node.frame,
+        stepIndex,
+        0,
+        TASK_RETRY_START_WINDOW_SIZE,
+        'scroll',
+      )) {
         return true;
       }
     }
@@ -963,9 +1074,9 @@ export class TaskRetryRestartTree {
         const windowSize = Math.max(1, window.end - window.start);
         const changed = direction === 'up'
           ? currentStepIndex > 0
-            && this.loadWindow(frame, currentStepIndex - windowSize + 1, windowSize)
+            && this.loadWindow(frame, currentStepIndex - windowSize + 1, windowSize, 'scroll')
           : currentStepIndex + 1 < frame.workflow.steps.length
-            && this.loadWindow(frame, currentStepIndex, windowSize);
+            && this.loadWindow(frame, currentStepIndex, windowSize, 'scroll');
         if (changed) return true;
       }
 
@@ -995,7 +1106,13 @@ export class TaskRetryRestartTree {
   ): boolean {
     const window = frame.activeParallelWindows.get(parentStepIndex);
     if (window === undefined) {
-      return direction === 'down' && this.loadParallelWindow(frame, parentStepIndex, 0);
+      return direction === 'down' && this.loadParallelWindow(
+        frame,
+        parentStepIndex,
+        0,
+        TASK_RETRY_START_WINDOW_SIZE,
+        'scroll',
+      );
     }
 
     const windowSize = Math.max(1, window.end - window.start);
@@ -1004,14 +1121,14 @@ export class TaskRetryRestartTree {
       : currentIndex;
     return direction === 'up'
       ? currentIndex > 0
-        && this.loadParallelWindow(frame, parentStepIndex, adjacentIndex, windowSize)
+        && this.loadParallelWindow(frame, parentStepIndex, adjacentIndex, windowSize, 'scroll')
       : (() => {
         const parentStep = frame.workflow.steps[parentStepIndex];
         const parallel = parentStep?.parallel;
         return parallel !== undefined
           && !isDynamicParallelSubSteps(parallel)
           && currentIndex + 1 < parallel.length
-          && this.loadParallelWindow(frame, parentStepIndex, adjacentIndex, windowSize);
+          && this.loadParallelWindow(frame, parentStepIndex, adjacentIndex, windowSize, 'scroll');
       })();
   }
 

--- a/src/features/tasks/taskRetryStartPath.ts
+++ b/src/features/tasks/taskRetryStartPath.ts
@@ -7,7 +7,11 @@ import {
   type WorkflowStep,
 } from '../../core/models/index.js';
 import { WorkflowRestartNavigator } from '../../core/workflow/engine/WorkflowRestartNavigator.js';
-import { getWorkflowStepKind, isWorkflowCallStep } from '../../core/workflow/step-kind.js';
+import {
+  getWorkflowResumeFrameKind,
+  getWorkflowStepKind,
+  isWorkflowCallStep,
+} from '../../core/workflow/step-kind.js';
 import { MAX_WORKFLOW_CALL_DEPTH } from '../../core/workflow/workflow-call-depth.js';
 import { isWorkflowRestartTarget } from '../../core/workflow/workflow-restart-target.js';
 import {
@@ -17,10 +21,6 @@ import {
   workflowRestartEntryMatchesWorkflow,
 } from '../../core/workflow/workflow-reference.js';
 import { resolveWorkflowCallTarget } from '../../infra/config/index.js';
-import { sanitizeTerminalText } from '../../shared/utils/text.js';
-
-const TASK_RETRY_PATH_SEPARATOR = ' > ';
-export const TASK_RETRY_START_PAGE_SIZE = 50;
 
 export interface TaskRetryStartPathContext {
   projectCwd: string;
@@ -28,35 +28,57 @@ export interface TaskRetryStartPathContext {
 }
 
 export interface ResolvedTaskRetryPath {
-  segments: string[];
+  restartPoint: WorkflowRestartPoint;
 }
 
-export interface TaskRetryRestartLevel {
-  workflow: WorkflowConfig;
-  stack: WorkflowRestartPointEntry[];
-  segments: string[];
-  ancestors: string[];
-}
+export const TASK_RETRY_START_WINDOW_SIZE = 50;
 
-export interface TaskRetryRestartPageItem {
-  stepIndex: number;
+export type TaskRetryRestartTreeNode =
+  | TaskRetryRestartTreeLeaf
+  | TaskRetryRestartTreeNavigation;
+
+export interface TaskRetryRestartTreeLeaf {
+  kind: 'leaf';
+  value: string;
   step: WorkflowStep;
   restartPoint: WorkflowRestartPoint;
-  segments: string[];
+  workflowPath: readonly string[];
+  isRestartable: boolean;
+  isDefaultCandidate: boolean;
+  isResumeCandidate: boolean;
+  frame: TaskRetryRestartTreeFrameState;
 }
 
-export interface TaskRetryRestartPage {
-  items: TaskRetryRestartPageItem[];
-  pageNumber: number;
-  pageCount: number;
-  previousStartIndex?: number;
-  nextStartIndex?: number;
+export interface TaskRetryRestartTreeNavigation {
+  kind: 'navigation';
+  value: string;
+  step: Extract<WorkflowStep, { kind: 'workflow_call' }>;
+  restartPoint: WorkflowRestartPoint;
+  workflowPath: readonly string[];
+  expanded: boolean;
+  frame: TaskRetryRestartTreeFrameState;
+  key: string;
+  parentStepIndex: number;
+  parallelStepName?: string;
+  parallelStepIndex?: number;
+}
+
+export interface TaskRetryRestartTreeFrame {
+  readonly workflow: WorkflowConfig;
+  readonly stack: readonly WorkflowRestartPointEntry[];
+  readonly workflowPath: readonly string[];
+  readonly ancestors: readonly string[];
 }
 
 interface ResolveTaskRetryStackOptions {
   allowParallelEntries: boolean;
   requireRestartTarget: boolean;
   requireRestartIdentity: boolean;
+}
+
+interface TaskRetryStartWindow {
+  start: number;
+  end: number;
 }
 
 function resolveCallableChild(
@@ -108,87 +130,897 @@ function createRestartEntry(
   );
 }
 
-function serializeTaskRetryPathSegment(segment: string): string {
-  return sanitizeTerminalText(JSON.stringify(segment));
+function sameRestartPoint(
+  left: WorkflowRestartPoint | undefined,
+  right: WorkflowRestartPoint | undefined,
+): boolean {
+  if (left === undefined || right === undefined || left.stack.length !== right.stack.length) {
+    return false;
+  }
+  return left.stack.every((leftEntry, index) => {
+    const rightEntry = right.stack[index];
+    return rightEntry !== undefined
+      && leftEntry.workflow_ref === rightEntry.workflow_ref
+      && leftEntry.step === rightEntry.step
+      && leftEntry.kind === rightEntry.kind
+      && leftEntry.call_instance === rightEntry.call_instance;
+  });
 }
 
-export function formatTaskRetryPath(segments: readonly string[]): string {
-  return segments
-    .map(serializeTaskRetryPathSegment)
-    .join(TASK_RETRY_PATH_SEPARATOR);
-}
-
-export class TaskRetryRestartBrowser {
-  private readonly context: TaskRetryStartPathContext;
-
-  constructor(context: TaskRetryStartPathContext) {
-    this.context = context;
-  }
-
-  createRootLevel(rootWorkflow: WorkflowConfig): TaskRetryRestartLevel {
-    return {
-      workflow: rootWorkflow,
-      stack: [],
-      segments: [rootWorkflow.name],
-      ancestors: [getWorkflowReference(rootWorkflow)],
-    };
-  }
-
-  getPage(level: TaskRetryRestartLevel, startIndex: number): TaskRetryRestartPage {
-    if (!Number.isInteger(startIndex) || startIndex < 0 || startIndex >= level.workflow.steps.length) {
-      throw new Error(`Invalid task retry page start index: ${startIndex}`);
+function findFirstAuthoredRestartPoint(
+  workflow: WorkflowConfig,
+  stack: readonly WorkflowRestartPointEntry[],
+): WorkflowRestartPoint | undefined {
+  for (const step of workflow.steps) {
+    if (!isWorkflowCallStep(step) && isWorkflowRestartTarget(step)) {
+      return { stack: [...stack, createRestartEntry(workflow, step)] };
     }
-    const pageCount = Math.ceil(level.workflow.steps.length / TASK_RETRY_START_PAGE_SIZE);
-    const pageNumber = Math.floor(startIndex / TASK_RETRY_START_PAGE_SIZE) + 1;
-    const normalizedStart = (pageNumber - 1) * TASK_RETRY_START_PAGE_SIZE;
-    const pageSteps = level.workflow.steps.slice(
-      normalizedStart,
-      normalizedStart + TASK_RETRY_START_PAGE_SIZE,
-    );
-    const items = pageSteps.flatMap((step, offset): TaskRetryRestartPageItem[] => {
-      if (!isWorkflowRestartTarget(step)) {
-        return [];
+  }
+  return undefined;
+}
+
+function resolvePreferredRestartPoint(
+  rootWorkflow: WorkflowConfig,
+  context: TaskRetryStartPathContext,
+  preferredRootStep: string,
+): WorkflowRestartPoint | undefined {
+  const rootStepIndex = rootWorkflow.steps.findIndex((step) => step.name === preferredRootStep);
+  if (rootStepIndex < 0) {
+    return findFirstAuthoredRestartPoint(rootWorkflow, []);
+  }
+
+  const findFrom = (
+    workflow: WorkflowConfig,
+    stack: readonly WorkflowRestartPointEntry[],
+    ancestors: readonly string[],
+    startIndex: number,
+  ): WorkflowRestartPoint | undefined => {
+    for (let index = startIndex; index < workflow.steps.length; index += 1) {
+      const step = workflow.steps[index]!;
+      const nextStack = [...stack, createRestartEntry(workflow, step)];
+      if (isWorkflowCallStep(step)) {
+        const child = resolveCallableChild(workflow, step, context);
+        assertCallableChildBoundary(child, ancestors);
+        return findFrom(
+          child,
+          nextStack,
+          [...ancestors, getWorkflowReference(child)],
+          child.steps.findIndex((candidate) => candidate.name === child.initialStep),
+        );
       }
-      const entry = createRestartEntry(level.workflow, step);
-      return [{
-        stepIndex: normalizedStart + offset,
-        step,
-        restartPoint: {
-          stack: [...level.stack, entry],
-        },
-        segments: [...level.segments, step.name],
-      }];
-    });
-    const previousStartIndex = normalizedStart === 0
-      ? undefined
-      : normalizedStart - TASK_RETRY_START_PAGE_SIZE;
-    const nextStartIndex = pageNumber === pageCount
-      ? undefined
-      : normalizedStart + TASK_RETRY_START_PAGE_SIZE;
+      if (isWorkflowRestartTarget(step)) {
+        return { stack: nextStack };
+      }
+    }
+    return undefined;
+  };
+
+  return findFrom(
+    rootWorkflow,
+    [],
+    [getWorkflowReference(rootWorkflow)],
+    rootStepIndex,
+  ) ?? findFirstAuthoredRestartPoint(rootWorkflow, []);
+}
+
+interface TaskRetryRestartTreeFrameState extends TaskRetryRestartTreeFrame {
+  readonly parent?: TaskRetryRestartTreeFrameState;
+  readonly parentStepIndex?: number;
+  readonly parentParallelStepIndex?: number;
+  activeStepWindow: TaskRetryStartWindow | undefined;
+  readonly activeParallelWindows: Map<number, TaskRetryStartWindow>;
+  readonly expandedCallKeys: Set<string>;
+  readonly childFrames: Map<string, TaskRetryRestartTreeFrameState>;
+  readonly nodeIds: Map<string, string>;
+}
+
+export interface TaskRetryRestartTreeOptions {
+  defaultRestartPoint?: WorkflowRestartPoint;
+  resumeRestartPoint?: WorkflowRestartPoint;
+}
+
+function matchesFrameStack(
+  frameStack: readonly WorkflowRestartPointEntry[],
+  targetStack: readonly WorkflowRestartPointEntry[],
+): boolean {
+  return frameStack.every((entry, index) => {
+    const targetEntry = targetStack[index];
+    return targetEntry !== undefined
+      && entry.workflow_ref === targetEntry.workflow_ref
+      && entry.step === targetEntry.step
+      && entry.kind === targetEntry.kind
+      && entry.call_instance === targetEntry.call_instance;
+  });
+}
+
+export class TaskRetryRestartTree {
+  private readonly rootFrame: TaskRetryRestartTreeFrameState;
+  private readonly context: TaskRetryStartPathContext;
+  private readonly defaultRestartPoint: WorkflowRestartPoint | undefined;
+  private readonly resumeRestartPoint: WorkflowRestartPoint | undefined;
+  private nextNodeId = 0;
+
+  constructor(
+    rootWorkflow: WorkflowConfig,
+    context: TaskRetryStartPathContext,
+    preferredRootStep: string | undefined,
+    options: TaskRetryRestartTreeOptions,
+  ) {
+    this.context = context;
+    this.defaultRestartPoint = options.defaultRestartPoint
+      ?? resolvePreferredRestartPoint(rootWorkflow, context, preferredRootStep ?? rootWorkflow.initialStep);
+    this.resumeRestartPoint = options.resumeRestartPoint;
+    this.rootFrame = this.createFrame(
+      rootWorkflow,
+      [],
+      [rootWorkflow.name],
+      [getWorkflowReference(rootWorkflow)],
+    );
+    this.loadInitialWindow(this.rootFrame);
+    if (this.resumeRestartPoint !== undefined) {
+      this.ensureRestartPointVisible(this.resumeRestartPoint);
+    } else if (this.defaultRestartPoint !== undefined) {
+      this.ensureRestartPointVisible(this.defaultRestartPoint);
+    }
+  }
+
+  getRootWorkflow(): WorkflowConfig {
+    return this.rootFrame.workflow;
+  }
+
+  getVisibleNodes(): TaskRetryRestartTreeNode[] {
+    return this.getVisibleNodesForFrame(this.rootFrame);
+  }
+
+  getDefaultValue(): string | undefined {
+    const nodes = this.getVisibleNodes();
+    const resume = nodes.find((node) => node.kind === 'leaf' && node.isResumeCandidate);
+    if (resume !== undefined) return resume.value;
+    const preferred = nodes.find((node) => node.kind === 'leaf' && node.isDefaultCandidate);
+    if (preferred !== undefined) return preferred.value;
+    const leaf = nodes.find((node) => node.kind === 'leaf');
+    if (leaf !== undefined) return leaf.value;
+    return nodes.find((node) => node.kind === 'navigation' && !node.expanded)?.value;
+  }
+
+  findNode(value: string): TaskRetryRestartTreeNode | undefined {
+    return this.getVisibleNodes().find((node) => node.value === value);
+  }
+
+  handleKeyPress(
+    value: string,
+    key: string,
+  ): boolean {
+    const node = this.findNode(value);
+    if (node === undefined) return false;
+    if (node.kind === 'navigation' && (key === '\r' || key === '\n')) {
+      this.toggleNavigation(node);
+      return true;
+    }
+    if (this.isDownKey(key) && node.kind === 'leaf' && this.isStaticParallelCallStep(node.step)) {
+      const stepIndex = node.frame.workflow.steps.indexOf(node.step);
+      if (stepIndex >= 0 && this.loadParallelWindow(node.frame, stepIndex, 0)) {
+        return true;
+      }
+    }
+    if (this.isUpKey(key) && this.isFrameBoundary(node, 'up')) {
+      const changed = this.loadAdjacentWindow(node, 'up');
+      return changed;
+    }
+    if (this.isDownKey(key) && this.isFrameBoundary(node, 'down')) {
+      const changed = this.loadAdjacentWindow(node, 'down');
+      return changed;
+    }
+    return false;
+  }
+
+  private isFrameBoundary(
+    node: TaskRetryRestartTreeNode,
+    direction: 'up' | 'down',
+  ): boolean {
+    const nodes = this.getVisibleNodesForFrame(node.frame);
+    const nodeIndex = nodes.findIndex((candidate) => candidate.value === node.value);
+    if (nodeIndex < 0) return false;
+    return direction === 'up'
+      ? nodeIndex === 0
+      : nodeIndex === nodes.length - 1;
+  }
+
+  isNavigation(value: string): boolean {
+    return this.findNode(value)?.kind === 'navigation';
+  }
+
+  toggleNavigation(node: TaskRetryRestartTreeNavigation): void {
+    if (node.expanded) {
+      node.frame.expandedCallKeys.delete(node.key);
+      node.frame.childFrames.delete(node.key);
+      return;
+    }
+
+    const child = this.resolveChildFrame(node);
+    node.frame.childFrames.set(node.key, child);
+    node.frame.expandedCallKeys.add(node.key);
+    const activeWindow = node.frame.activeStepWindow;
+    const visibleNodes = this.getVisibleNodes();
+    const childHasVisibleNode = this.getVisibleNodesForFrame(child).length > 0;
+    const childIsProjected = visibleNodes.some((visibleNode) => visibleNode.frame === child);
+    if (
+      activeWindow !== undefined
+      && activeWindow.end - activeWindow.start > 1
+      && childHasVisibleNode
+      && !childIsProjected
+    ) {
+      const windowSize = activeWindow.end - activeWindow.start - 1;
+      this.loadWindow(node.frame, node.parentStepIndex - windowSize + 1, windowSize);
+    }
+  }
+
+  private createFrame(
+    workflow: WorkflowConfig,
+    stack: readonly WorkflowRestartPointEntry[],
+    workflowPath: readonly string[],
+    ancestors: readonly string[],
+    parent?: TaskRetryRestartTreeFrameState,
+    parentStepIndex?: number,
+    parentParallelStepIndex?: number,
+  ): TaskRetryRestartTreeFrameState {
     return {
-      items,
-      pageNumber,
-      pageCount,
-      ...(previousStartIndex === undefined ? {} : { previousStartIndex }),
-      ...(nextStartIndex === undefined ? {} : { nextStartIndex }),
+      workflow,
+      stack: [...stack],
+      workflowPath: [...workflowPath],
+      ancestors: [...ancestors],
+      ...(parent === undefined ? {} : { parent }),
+      ...(parentStepIndex === undefined ? {} : { parentStepIndex }),
+      ...(parentParallelStepIndex === undefined ? {} : { parentParallelStepIndex }),
+      activeStepWindow: undefined,
+      activeParallelWindows: new Map<number, TaskRetryStartWindow>(),
+      expandedCallKeys: new Set<string>(),
+      childFrames: new Map<string, TaskRetryRestartTreeFrameState>(),
+      nodeIds: new Map<string, string>(),
     };
   }
 
-  openChild(
-    level: TaskRetryRestartLevel,
-    item: TaskRetryRestartPageItem,
-  ): TaskRetryRestartLevel {
-    if (!isWorkflowCallStep(item.step)) {
-      throw new Error(`Task retry path step "${item.step.name}" is not a workflow_call`);
+  private loadInitialWindow(frame: TaskRetryRestartTreeFrameState): void {
+    const target = this.resumeRestartPoint ?? this.defaultRestartPoint;
+    const targetIndex = this.findTargetStepIndex(frame, target);
+    const firstVisibleIndex = targetIndex ?? this.findFirstVisibleStepIndex(frame.workflow);
+    if (firstVisibleIndex === undefined) return;
+    const parallelStepIndex = targetIndex === undefined
+      ? undefined
+      : this.findTargetStaticParallelCallIndex(
+        frame,
+        target,
+        0,
+        frame.workflow.steps.length,
+      );
+    if (parallelStepIndex === undefined) {
+      const nestedContentCount = target === undefined || targetIndex === undefined
+        ? 0
+        : Math.max(0, target.stack.length - frame.stack.length - 1);
+      const windowSize = Math.max(
+        1,
+        TASK_RETRY_START_WINDOW_SIZE - nestedContentCount,
+      );
+      const windowStart = targetIndex === undefined
+        ? Math.floor(firstVisibleIndex / TASK_RETRY_START_WINDOW_SIZE)
+          * TASK_RETRY_START_WINDOW_SIZE
+        : Math.max(0, firstVisibleIndex - windowSize + 1);
+      this.loadWindow(frame, windowStart, windowSize);
+      return;
     }
-    const child = resolveCallableChild(level.workflow, item.step, this.context);
-    assertCallableChildBoundary(child, level.ancestors);
+
+    const nestedContentCount = target === undefined
+      ? 0
+      : Math.max(0, target.stack.length - frame.stack.length - 2);
+    const topLevelSize = Math.max(
+      1,
+      TASK_RETRY_START_WINDOW_SIZE - 1 - nestedContentCount,
+    );
+    const windowStart = Math.max(0, parallelStepIndex - topLevelSize + 1);
+    const targetParallelIndex = this.findTargetParallelStepIndex(
+      frame,
+      target,
+      parallelStepIndex,
+    );
+    if (targetParallelIndex === undefined) {
+      this.loadWindow(frame, windowStart, topLevelSize);
+      return;
+    }
+    this.loadWindow(frame, windowStart, topLevelSize);
+    this.loadParallelWindow(
+      frame,
+      parallelStepIndex,
+      targetParallelIndex,
+      Math.max(1, TASK_RETRY_START_WINDOW_SIZE - topLevelSize - nestedContentCount),
+    );
+  }
+
+  private loadWindow(
+    frame: TaskRetryRestartTreeFrameState,
+    startIndex: number,
+    windowSize = TASK_RETRY_START_WINDOW_SIZE,
+  ): boolean {
+    if (frame.workflow.steps.length === 0 || windowSize <= 0) return false;
+    const normalizedStart = Math.max(
+      0,
+      Math.min(startIndex, frame.workflow.steps.length - 1),
+    );
+    const endIndex = Math.min(
+      frame.workflow.steps.length,
+      normalizedStart + windowSize,
+    );
+    const previous = frame.activeStepWindow;
+    const changed = previous?.start !== normalizedStart || previous.end !== endIndex;
+    frame.activeStepWindow = { start: normalizedStart, end: endIndex };
+    this.pruneFrameState(frame);
+    return changed;
+  }
+
+  private loadParallelWindow(
+    frame: TaskRetryRestartTreeFrameState,
+    parentStepIndex: number,
+    startIndex: number,
+    windowSize = TASK_RETRY_START_WINDOW_SIZE,
+  ): boolean {
+    const parentStep = frame.workflow.steps[parentStepIndex];
+    if (
+      parentStep === undefined
+      || parentStep.parallel === undefined
+      || isDynamicParallelSubSteps(parentStep.parallel)
+      || windowSize <= 0
+    ) {
+      return false;
+    }
+
+    if (parentStep.parallel.length === 0) return false;
+    const normalizedStart = Math.max(
+      0,
+      Math.min(startIndex, parentStep.parallel.length - 1),
+    );
+    const endIndex = Math.min(
+      parentStep.parallel.length,
+      normalizedStart + windowSize,
+    );
+    const previous = frame.activeParallelWindows.get(parentStepIndex);
+    const changed = previous?.start !== normalizedStart || previous.end !== endIndex;
+    frame.activeParallelWindows.set(parentStepIndex, {
+      start: normalizedStart,
+      end: endIndex,
+    });
+    this.pruneFrameState(frame);
+    return changed;
+  }
+
+  private pruneFrameState(frame: TaskRetryRestartTreeFrameState): void {
+    for (const [parentStepIndex, window] of frame.activeParallelWindows) {
+      if (!this.isStepIndexActive(frame, parentStepIndex)) {
+        frame.activeParallelWindows.delete(parentStepIndex);
+        continue;
+      }
+      for (const key of frame.childFrames.keys()) {
+        if (this.isParallelNodeKeyForParent(key, parentStepIndex)
+          && !this.isParallelIndexActive(window, this.getParallelNodeIndex(key))) {
+          frame.childFrames.delete(key);
+          frame.expandedCallKeys.delete(key);
+          frame.nodeIds.delete(key);
+        }
+      }
+    }
+
+    for (const key of frame.childFrames.keys()) {
+      if (this.isStepNodeKey(key) && !this.isStepIndexActive(frame, this.getStepNodeIndex(key))) {
+        frame.childFrames.delete(key);
+        frame.expandedCallKeys.delete(key);
+        frame.nodeIds.delete(key);
+      }
+    }
+
+    for (const key of frame.expandedCallKeys) {
+      if (!this.isNodeKeyActive(frame, key)) frame.expandedCallKeys.delete(key);
+    }
+    for (const key of frame.nodeIds.keys()) {
+      if (!this.isNodeKeyActive(frame, key)) frame.nodeIds.delete(key);
+    }
+  }
+
+  private isNodeKeyActive(frame: TaskRetryRestartTreeFrameState, key: string): boolean {
+    if (this.isStepNodeKey(key)) {
+      return this.isStepIndexActive(frame, this.getStepNodeIndex(key));
+    }
+    if (!key.startsWith('parallel:')) return false;
+    const separatorIndex = key.indexOf(':', 'parallel:'.length);
+    if (separatorIndex < 0) return false;
+    const parentStepIndexText = key.slice('parallel:'.length, separatorIndex);
+    const parallelStepIndexText = key.slice(separatorIndex + 1);
+    if (parentStepIndexText.length === 0 || parallelStepIndexText.length === 0) return false;
+    const parentStepIndex = Number(parentStepIndexText);
+    const parallelStepIndex = Number(parallelStepIndexText);
+    const window = frame.activeParallelWindows.get(parentStepIndex);
+    return window !== undefined
+      && this.isStepIndexActive(frame, parentStepIndex)
+      && this.isParallelIndexActive(window, parallelStepIndex);
+  }
+
+  private isStepNodeKey(key: string): boolean {
+    return key.startsWith('step:');
+  }
+
+  private getStepNodeIndex(key: string): number {
+    return Number(key.slice('step:'.length));
+  }
+
+  private getParallelNodeIndex(key: string): number {
+    return Number(key.split(':').at(-1));
+  }
+
+  private isParallelNodeKeyForParent(key: string, parentStepIndex: number): boolean {
+    return key.startsWith(`parallel:${parentStepIndex}:`);
+  }
+
+  private isStepIndexActive(frame: TaskRetryRestartTreeFrameState, index: number): boolean {
+    const window = frame.activeStepWindow;
+    return window !== undefined && index >= window.start && index < window.end;
+  }
+
+  private isParallelIndexActive(window: TaskRetryStartWindow, index: number): boolean {
+    return index >= window.start && index < window.end;
+  }
+
+  private findTargetStaticParallelCallIndex(
+    frame: TaskRetryRestartTreeFrameState,
+    target: WorkflowRestartPoint | undefined,
+    startIndex: number,
+    endIndex: number,
+  ): number | undefined {
+    for (let index = startIndex; index < endIndex; index += 1) {
+      const step = frame.workflow.steps[index];
+      if (step === undefined || !this.isStaticParallelCallStep(step)) continue;
+      if (this.findTargetParallelStepIndex(frame, target, index) !== undefined) {
+        return index;
+      }
+    }
+    return undefined;
+  }
+
+  private findTargetParallelStepIndex(
+    frame: TaskRetryRestartTreeFrameState,
+    target: WorkflowRestartPoint | undefined,
+    parentStepIndex: number,
+  ): number | undefined {
+    if (
+      target === undefined
+      || !matchesFrameStack(frame.stack, target.stack.slice(0, frame.stack.length))
+    ) {
+      return undefined;
+    }
+    const parentEntry = target.stack[frame.stack.length];
+    const nextEntry = target.stack[frame.stack.length + 1];
+    const parentStep = frame.workflow.steps[parentStepIndex];
+    if (
+      parentEntry === undefined
+      || nextEntry === undefined
+      || parentStep === undefined
+      || parentStep.name !== parentEntry.step
+      || parentStep.parallel === undefined
+      || isDynamicParallelSubSteps(parentStep.parallel)
+    ) {
+      return undefined;
+    }
+    const index = parentStep.parallel.findIndex((subStep) => (
+      subStep.name === nextEntry.step
+      && getWorkflowStepKind(subStep) === nextEntry.kind
+    ));
+    return index < 0 ? undefined : index;
+  }
+
+  private findFirstVisibleStepIndex(workflow: WorkflowConfig): number | undefined {
+    const index = workflow.steps.findIndex((step) => (
+      isWorkflowCallStep(step) || isWorkflowRestartTarget(step)
+    ));
+    return index < 0 ? undefined : index;
+  }
+
+  private findTargetStepIndex(
+    frame: TaskRetryRestartTreeFrameState,
+    target: WorkflowRestartPoint | undefined,
+  ): number | undefined {
+    if (target === undefined || !matchesFrameStack(frame.stack, target.stack)) return undefined;
+    const targetEntry = target.stack[frame.stack.length];
+    if (targetEntry === undefined || targetEntry.workflow_ref !== getWorkflowReference(frame.workflow)) {
+      return undefined;
+    }
+    const index = frame.workflow.steps.findIndex((step) => (
+      step.name === targetEntry.step && getWorkflowStepKind(step) === targetEntry.kind
+    ));
+    return index < 0 ? undefined : index;
+  }
+
+  private getVisibleNodesForFrame(
+    frame: TaskRetryRestartTreeFrameState,
+    budget = TASK_RETRY_START_WINDOW_SIZE,
+  ): TaskRetryRestartTreeNode[] {
+    if (budget <= 0) return [];
+    const nodes: TaskRetryRestartTreeNode[] = [];
+    const stepWindow = frame.activeStepWindow;
+    if (stepWindow === undefined) return nodes;
+    const targetBranch = this.getTargetBranch(frame);
+    let remainingRequiredNodes = this.getRequiredVisibleNodeCount(frame);
+    for (
+      let stepIndex = stepWindow.start;
+      stepIndex < stepWindow.end && nodes.length < budget;
+      stepIndex += 1
+    ) {
+      const step = frame.workflow.steps[stepIndex];
+      if (step === undefined) continue;
+      const isTargetStep = targetBranch?.stepIndex === stepIndex;
+      if (
+        !isTargetStep
+        && nodes.length + 1 + remainingRequiredNodes > budget
+      ) {
+        continue;
+      }
+      const entry = createRestartEntry(frame.workflow, step);
+      const restartPoint = { stack: [...frame.stack, entry] };
+      if (isWorkflowCallStep(step)) {
+        const key = `step:${stepIndex}`;
+        const navigation = this.createNavigationNode(
+          frame,
+          key,
+          step,
+          restartPoint,
+          frame.workflowPath,
+          stepIndex,
+        );
+        nodes.push(navigation);
+        if (isTargetStep) remainingRequiredNodes -= 1;
+        if (navigation.expanded) {
+          const child = frame.childFrames.get(key);
+          if (child !== undefined) {
+            const requiredChildNodes = isTargetStep ? remainingRequiredNodes : 0;
+            const childBudget = budget - nodes.length - (
+              isTargetStep ? 0 : remainingRequiredNodes
+            );
+            nodes.push(...this.getVisibleNodesForFrame(child, childBudget));
+            remainingRequiredNodes -= requiredChildNodes;
+          }
+        }
+        continue;
+      }
+
+      const isResumeCandidate = sameRestartPoint(restartPoint, this.resumeRestartPoint);
+      if (isWorkflowRestartTarget(step) || isResumeCandidate) {
+        nodes.push({
+          kind: 'leaf',
+          value: this.getNodeValue(frame, `step:${stepIndex}`),
+          step,
+          restartPoint,
+          workflowPath: frame.workflowPath,
+          isRestartable: !this.isStaticParallelDescendant(frame)
+            && isWorkflowRestartTarget(step),
+          isDefaultCandidate: sameRestartPoint(restartPoint, this.defaultRestartPoint),
+          isResumeCandidate,
+          frame,
+        });
+        if (isTargetStep) remainingRequiredNodes -= 1;
+      }
+
+      if (step.parallel !== undefined && !isDynamicParallelSubSteps(step.parallel)) {
+        const parallelWindow = frame.activeParallelWindows.get(stepIndex);
+        if (parallelWindow === undefined) continue;
+        for (
+          let subStepIndex = parallelWindow.start;
+          subStepIndex < parallelWindow.end && nodes.length < budget;
+          subStepIndex += 1
+        ) {
+          const subStep = step.parallel[subStepIndex];
+          if (subStep === undefined) continue;
+          if (!isWorkflowCallStep(subStep)) continue;
+          const key = `parallel:${stepIndex}:${subStepIndex}`;
+          const isTargetParallelStep = isTargetStep
+            && targetBranch.parallelStepIndex === subStepIndex;
+          if (
+            !isTargetParallelStep
+            && nodes.length + 1 + remainingRequiredNodes > budget
+          ) {
+            continue;
+          }
+          const navigation = this.createNavigationNode(
+            frame,
+            key,
+            subStep,
+            { stack: [...restartPoint.stack, createRestartEntry(frame.workflow, subStep)] },
+            [...frame.workflowPath, step.name],
+            stepIndex,
+            step.name,
+            subStepIndex,
+          );
+          nodes.push(navigation);
+          if (isTargetParallelStep) remainingRequiredNodes -= 1;
+          if (navigation.expanded) {
+            const child = frame.childFrames.get(key);
+            if (child !== undefined) {
+              const requiredChildNodes = isTargetParallelStep ? remainingRequiredNodes : 0;
+              const childBudget = budget - nodes.length - (
+                isTargetParallelStep ? 0 : remainingRequiredNodes
+              );
+              nodes.push(...this.getVisibleNodesForFrame(child, childBudget));
+              remainingRequiredNodes -= requiredChildNodes;
+            }
+          }
+        }
+      }
+    }
+    return nodes;
+  }
+
+  private getTargetBranch(
+    frame: TaskRetryRestartTreeFrameState,
+  ): { stepIndex: number; parallelStepIndex?: number } | undefined {
+    const target = this.resumeRestartPoint ?? this.defaultRestartPoint;
+    if (target === undefined || !matchesFrameStack(frame.stack, target.stack)) {
+      return undefined;
+    }
+    const stepIndex = this.findTargetStepIndex(frame, target);
+    if (stepIndex === undefined || !this.isStepIndexActive(frame, stepIndex)) {
+      return undefined;
+    }
+    const parallelStepIndex = this.findTargetParallelStepIndex(frame, target, stepIndex);
+    return parallelStepIndex === undefined
+      ? { stepIndex }
+      : { stepIndex, parallelStepIndex };
+  }
+
+  private getRequiredVisibleNodeCount(
+    frame: TaskRetryRestartTreeFrameState,
+  ): number {
+    const targetBranch = this.getTargetBranch(frame);
+    if (targetBranch === undefined) return 0;
+
+    const step = frame.workflow.steps[targetBranch.stepIndex];
+    if (step === undefined) return 0;
+
+    if (targetBranch.parallelStepIndex !== undefined) {
+      const key = `parallel:${targetBranch.stepIndex}:${targetBranch.parallelStepIndex}`;
+      const child = frame.childFrames.get(key);
+      return 1 + 1 + (child === undefined ? 0 : this.getRequiredVisibleNodeCount(child));
+    }
+
+    if (isWorkflowCallStep(step)) {
+      const child = frame.childFrames.get(`step:${targetBranch.stepIndex}`);
+      return 1 + (child === undefined ? 0 : this.getRequiredVisibleNodeCount(child));
+    }
+
+    return 1;
+  }
+
+  private isStaticParallelCallStep(step: WorkflowStep): boolean {
+    return step.parallel !== undefined
+      && !isDynamicParallelSubSteps(step.parallel)
+      && step.parallel.some((subStep) => isWorkflowCallStep(subStep));
+  }
+
+  private isStaticParallelDescendant(frame: TaskRetryRestartTreeFrameState): boolean {
+    let current: TaskRetryRestartTreeFrameState | undefined = frame;
+    while (current?.parent !== undefined) {
+      if (current.parentParallelStepIndex !== undefined) return true;
+      current = current.parent;
+    }
+    return false;
+  }
+
+  private createNavigationNode(
+    frame: TaskRetryRestartTreeFrameState,
+    key: string,
+    step: Extract<WorkflowStep, { kind: 'workflow_call' }>,
+    restartPoint: WorkflowRestartPoint,
+    workflowPath: readonly string[],
+    parentStepIndex: number,
+    parallelStepName?: string,
+    parallelStepIndex?: number,
+  ): TaskRetryRestartTreeNavigation {
     return {
-      workflow: child,
-      stack: item.restartPoint.stack,
-      segments: [...item.segments, child.name],
-      ancestors: [...level.ancestors, getWorkflowReference(child)],
+      kind: 'navigation',
+      value: this.getNodeValue(frame, key),
+      step,
+      restartPoint,
+      workflowPath: [...workflowPath],
+      expanded: frame.expandedCallKeys.has(key),
+      frame,
+      key,
+      parentStepIndex,
+      ...(parallelStepName === undefined ? {} : { parallelStepName }),
+      ...(parallelStepIndex === undefined ? {} : { parallelStepIndex }),
     };
+  }
+
+  private getNodeValue(frame: TaskRetryRestartTreeFrameState, key: string): string {
+    const existing = frame.nodeIds.get(key);
+    if (existing !== undefined) return existing;
+    const value = `retry-tree-${this.nextNodeId}`;
+    this.nextNodeId += 1;
+    frame.nodeIds.set(key, value);
+    return value;
+  }
+
+  private resolveChildFrame(node: TaskRetryRestartTreeNavigation): TaskRetryRestartTreeFrameState {
+    const existing = node.frame.childFrames.get(node.key);
+    if (existing !== undefined) return existing;
+    const child = resolveCallableChild(node.frame.workflow, node.step, this.context);
+    assertCallableChildBoundary(child, node.frame.ancestors);
+    const workflowPath = node.parallelStepName === undefined
+      ? [...node.frame.workflowPath, node.step.name, child.name]
+      : [...node.workflowPath, node.step.name, child.name];
+    const childFrame = this.createFrame(
+      child,
+      node.restartPoint.stack,
+      workflowPath,
+      [...node.frame.ancestors, getWorkflowReference(child)],
+      node.frame,
+      node.parentStepIndex,
+      node.parallelStepIndex,
+    );
+    this.loadInitialWindow(childFrame);
+    return childFrame;
+  }
+
+  private ensureRestartPointVisible(target: WorkflowRestartPoint): void {
+    let frame = this.rootFrame;
+    let index = 0;
+    while (index < target.stack.length) {
+      const entry = target.stack[index]!;
+      if (!matchesFrameStack(frame.stack, target.stack.slice(0, frame.stack.length))) {
+        return;
+      }
+      const stepIndex = frame.workflow.steps.findIndex((step) => (
+        step.name === entry.step && getWorkflowStepKind(step) === entry.kind
+      ));
+      if (stepIndex < 0) return;
+      if (!this.isStepIndexActive(frame, stepIndex)) {
+        const nestedContentCount = Math.max(0, target.stack.length - frame.stack.length - 1);
+        const windowSize = Math.max(
+          1,
+          TASK_RETRY_START_WINDOW_SIZE - nestedContentCount,
+        );
+        this.loadWindow(frame, stepIndex - windowSize + 1, windowSize);
+      }
+      const step = frame.workflow.steps[stepIndex]!;
+      if (isWorkflowCallStep(step)) {
+        const node = this.createNavigationNode(
+          frame,
+          `step:${stepIndex}`,
+          step,
+          { stack: [...frame.stack, createRestartEntry(frame.workflow, step)] },
+          frame.workflowPath,
+          stepIndex,
+        );
+        frame.expandedCallKeys.add(node.key);
+        const child = this.resolveChildFrame(node);
+        frame.childFrames.set(node.key, child);
+        frame = child;
+        index += 1;
+        continue;
+      }
+      if (index === target.stack.length - 1) return;
+      const nextEntry = target.stack[index + 1]!;
+      if (step.parallel === undefined || isDynamicParallelSubSteps(step.parallel)) return;
+      const subStepIndex = step.parallel.findIndex((subStep) => (
+        subStep.name === nextEntry.step && getWorkflowStepKind(subStep) === nextEntry.kind
+      ));
+      const subStep = subStepIndex < 0 ? undefined : step.parallel[subStepIndex];
+      if (subStep === undefined || !isWorkflowCallStep(subStep)) return;
+      const key = `parallel:${stepIndex}:${subStepIndex}`;
+      this.loadParallelWindow(frame, stepIndex, subStepIndex, 1);
+      const node = this.createNavigationNode(
+        frame,
+        key,
+        subStep,
+        { stack: [...frame.stack, createRestartEntry(frame.workflow, step), createRestartEntry(frame.workflow, subStep)] },
+        [...frame.workflowPath, step.name],
+        stepIndex,
+        step.name,
+        subStepIndex,
+      );
+      frame.expandedCallKeys.add(key);
+      const child = this.resolveChildFrame(node);
+      frame.childFrames.set(key, child);
+      frame = child;
+      index += 2;
+    }
+  }
+
+  private loadAdjacentWindow(
+    node: TaskRetryRestartTreeNode,
+    direction: 'up' | 'down',
+  ): boolean {
+    if (node.kind === 'navigation' && node.parallelStepIndex !== undefined) {
+      const changed = this.loadAdjacentParallelWindow(
+        node.frame,
+        node.parentStepIndex,
+        node.parallelStepIndex,
+        direction,
+      );
+      if (changed) return true;
+    }
+
+    if (
+      node.kind === 'leaf'
+      && direction === 'down'
+      && this.isStaticParallelCallStep(node.step)
+    ) {
+      const stepIndex = node.frame.workflow.steps.indexOf(node.step);
+      if (stepIndex >= 0 && this.loadParallelWindow(node.frame, stepIndex, 0)) {
+        return true;
+      }
+    }
+
+    let frame: TaskRetryRestartTreeFrameState | undefined = node.frame;
+    let currentStepIndex = node.kind === 'navigation'
+      ? node.parentStepIndex
+      : frame.workflow.steps.indexOf(node.step);
+    while (frame !== undefined) {
+      const window = frame.activeStepWindow;
+      if (window !== undefined && currentStepIndex >= 0) {
+        const windowSize = Math.max(1, window.end - window.start);
+        const changed = direction === 'up'
+          ? currentStepIndex > 0
+            && this.loadWindow(frame, currentStepIndex - windowSize + 1, windowSize)
+          : currentStepIndex + 1 < frame.workflow.steps.length
+            && this.loadWindow(frame, currentStepIndex, windowSize);
+        if (changed) return true;
+      }
+
+      const parent: TaskRetryRestartTreeFrameState | undefined = frame.parent;
+      if (parent === undefined || frame.parentStepIndex === undefined) return false;
+      const parentStepIndex = frame.parentStepIndex;
+      if (frame.parentParallelStepIndex !== undefined) {
+        const changed = this.loadAdjacentParallelWindow(
+          parent,
+          parentStepIndex,
+          frame.parentParallelStepIndex,
+          direction,
+        );
+        if (changed) return true;
+      }
+      frame = parent;
+      currentStepIndex = parentStepIndex;
+    }
+    return false;
+  }
+
+  private loadAdjacentParallelWindow(
+    frame: TaskRetryRestartTreeFrameState,
+    parentStepIndex: number,
+    currentIndex: number,
+    direction: 'up' | 'down',
+  ): boolean {
+    const window = frame.activeParallelWindows.get(parentStepIndex);
+    if (window === undefined) {
+      return direction === 'down' && this.loadParallelWindow(frame, parentStepIndex, 0);
+    }
+
+    const windowSize = Math.max(1, window.end - window.start);
+    const adjacentIndex = direction === 'up'
+      ? currentIndex - windowSize + 1
+      : currentIndex;
+    return direction === 'up'
+      ? currentIndex > 0
+        && this.loadParallelWindow(frame, parentStepIndex, adjacentIndex, windowSize)
+      : (() => {
+        const parentStep = frame.workflow.steps[parentStepIndex];
+        const parallel = parentStep?.parallel;
+        return parallel !== undefined
+          && !isDynamicParallelSubSteps(parallel)
+          && currentIndex + 1 < parallel.length
+          && this.loadParallelWindow(frame, parentStepIndex, adjacentIndex, windowSize);
+      })();
+  }
+
+  private isUpKey(key: string): boolean {
+    return key === '\x1B[A' || key === '\x1BOA' || key === 'k';
+  }
+
+  private isDownKey(key: string): boolean {
+    return key === '\x1B[B' || key === '\x1BOB' || key === 'j';
   }
 }
 
@@ -201,7 +1033,41 @@ function resolveTaskRetryStackPathWithOptions(
   let workflow = rootWorkflow;
   let steps = rootWorkflow.steps;
   const ancestors = [getWorkflowReference(rootWorkflow)];
-  const segments = [rootWorkflow.name];
+  let restartStack: WorkflowRestartPointEntry[] = [];
+
+  const resolveInitialRestartLeaf = (
+    initialWorkflow: WorkflowConfig,
+    initialAncestors: readonly string[],
+    initialStack: readonly WorkflowRestartPointEntry[],
+  ): ResolvedTaskRetryPath => {
+    let workflowToVisit = initialWorkflow;
+    let ancestorsToVisit = [...initialAncestors];
+    const resolvedStack = [...initialStack];
+
+    while (true) {
+      const initialStep = workflowToVisit.steps.find(
+        (candidate) => candidate.name === workflowToVisit.initialStep,
+      );
+      if (initialStep === undefined) {
+        throw new Error(
+          `Workflow "${workflowToVisit.name}" initial step "${workflowToVisit.initialStep}" cannot be resolved`,
+        );
+      }
+
+      resolvedStack.push(createRestartEntry(workflowToVisit, initialStep));
+      if (!isWorkflowCallStep(initialStep)) {
+        return {
+          restartPoint: { stack: resolvedStack },
+        };
+      }
+
+      const child = resolveCallableChild(workflowToVisit, initialStep, context);
+      assertCallableChildBoundary(child, ancestorsToVisit);
+      ancestorsToVisit = [...ancestorsToVisit, getWorkflowReference(child)];
+      workflowToVisit = child;
+    }
+  };
+
   for (let index = 0; index < stack.length; index += 1) {
     const entry = stack[index]!;
     const entryMatchesWorkflow = options.requireRestartIdentity
@@ -211,10 +1077,16 @@ function resolveTaskRetryStackPathWithOptions(
       return undefined;
     }
     const step = steps.find((candidate) => candidate.name === entry.step);
-    if (step === undefined || getWorkflowStepKind(step) !== entry.kind) {
+    if (step === undefined) {
       return undefined;
     }
-    segments.push(step.name);
+    const expectedKind = options.requireRestartIdentity
+      ? getWorkflowStepKind(step)
+      : getWorkflowResumeFrameKind(step);
+    if (expectedKind !== entry.kind) {
+      return undefined;
+    }
+    const nextRestartStack = [...restartStack, createRestartEntry(workflow, step)];
     const isTerminalEntry = index === stack.length - 1;
     if (isTerminalEntry && options.requireRestartTarget && !isWorkflowRestartTarget(step)) {
       return undefined;
@@ -223,16 +1095,23 @@ function resolveTaskRetryStackPathWithOptions(
       const child = resolveCallableChild(workflow, step, context);
       assertCallableChildBoundary(child, ancestors);
       if (isTerminalEntry) {
-        return { segments };
+        if (options.requireRestartIdentity) {
+          return { restartPoint: { stack: nextRestartStack } };
+        }
+        return resolveInitialRestartLeaf(
+          child,
+          [...ancestors, getWorkflowReference(child)],
+          nextRestartStack,
+        );
       }
       workflow = child;
       steps = child.steps;
+      restartStack = nextRestartStack;
       ancestors.push(getWorkflowReference(child));
-      segments.push(child.name);
       continue;
     }
     if (isTerminalEntry) {
-      return { segments };
+      return { restartPoint: { stack: nextRestartStack } };
     }
     if (
       !options.allowParallelEntries
@@ -241,6 +1120,7 @@ function resolveTaskRetryStackPathWithOptions(
     ) {
       return undefined;
     }
+    restartStack = nextRestartStack;
     steps = step.parallel;
   }
   return undefined;

--- a/src/shared/prompt/select-menu.ts
+++ b/src/shared/prompt/select-menu.ts
@@ -14,6 +14,8 @@ export interface SelectOptionItem<T extends string> {
   value: T;
   description?: string;
   details?: string[];
+  leadingLines?: string[];
+  indent?: number;
 }
 
 export type KeyInputResult =
@@ -37,25 +39,62 @@ const LABEL_PREFIX = 4;
 const DESC_PREFIX = 5;
 const DETAIL_PREFIX = 9;
 
+function getIndentWithinWidth(indent: string, prefixWidth: number, maxWidth: number): string {
+  return indent.slice(0, Math.max(0, maxWidth - prefixWidth));
+}
+
+export function getLeadingLinesToRender(
+  leadingLines: readonly string[],
+  previousLeadingLines: readonly string[],
+): string[] {
+  let commonLength = 0;
+  while (
+    commonLength < leadingLines.length
+    && commonLength < previousLeadingLines.length
+    && leadingLines[commonLength] === previousLeadingLines[commonLength]
+  ) {
+    commonLength++;
+  }
+  return leadingLines.slice(commonLength);
+}
+
 export function renderSingleOption<T extends string>(
   opt: SelectOptionItem<T>,
   isSelected: boolean,
   maxWidth: number,
+  leadingLines = opt.leadingLines,
 ): string[] {
   const lines: string[] = [];
+  for (const leadingLine of leadingLines ?? []) {
+    lines.push(truncateText(`  ${leadingLine}`, maxWidth));
+  }
+
+  const indent = '  '.repeat(opt.indent ?? 0);
   const cursor = isSelected ? chalk.cyan('❯') : ' ';
-  const truncatedLabel = truncateText(opt.label, maxWidth - LABEL_PREFIX);
+  const labelIndent = getIndentWithinWidth(indent, LABEL_PREFIX, maxWidth);
+  const truncatedLabel = truncateText(
+    opt.label,
+    maxWidth - labelIndent.length - LABEL_PREFIX,
+  );
   const label = isSelected ? chalk.cyan.bold(truncatedLabel) : truncatedLabel;
-  lines.push(`  ${cursor} ${label}`);
+  lines.push(`${labelIndent}  ${cursor} ${label}`);
 
   if (opt.description) {
-    const truncatedDesc = truncateText(opt.description, maxWidth - DESC_PREFIX);
-    lines.push(chalk.gray(`     ${truncatedDesc}`));
+    const descriptionIndent = getIndentWithinWidth(indent, DESC_PREFIX, maxWidth);
+    const truncatedDesc = truncateText(
+      opt.description,
+      maxWidth - descriptionIndent.length - DESC_PREFIX,
+    );
+    lines.push(chalk.gray(`${descriptionIndent}     ${truncatedDesc}`));
   }
   if (opt.details && opt.details.length > 0) {
     for (const detail of opt.details) {
-      const truncatedDetail = truncateText(detail, maxWidth - DETAIL_PREFIX);
-      lines.push(chalk.dim(`       • ${truncatedDetail}`));
+      const detailIndent = getIndentWithinWidth(indent, DETAIL_PREFIX, maxWidth);
+      const truncatedDetail = truncateText(
+        detail,
+        maxWidth - detailIndent.length - DETAIL_PREFIX,
+      );
+      lines.push(chalk.dim(`${detailIndent}       • ${truncatedDetail}`));
     }
   }
 
@@ -70,8 +109,12 @@ export function renderCancelOption(isSelected: boolean, cancelLabel: string): st
 
 // ── Public pure functions ────────────────────────────────────────────
 
-export function countItemLines<T extends string>(opt: SelectOptionItem<T>): number {
-  let lines = 1;
+export function countItemLines<T extends string>(
+  opt: SelectOptionItem<T>,
+  previousLeadingLines: readonly string[] = [],
+): number {
+  const leadingLines = getLeadingLinesToRender(opt.leadingLines ?? [], previousLeadingLines);
+  let lines = leadingLines.length + 1;
   if (opt.description) lines++;
   if (opt.details) lines += opt.details.length;
   return lines;
@@ -85,12 +128,20 @@ export function renderMenu<T extends string>(
 ): string[] {
   const maxWidth = process.stdout.columns || 80;
   const lines: string[] = [];
+  let previousLeadingLines: string[] = [];
 
   for (let i = 0; i < options.length; i++) {
     const opt = options[i];
     if (!opt) continue;
     const isSelected = i === selectedIndex;
-    lines.push(...renderSingleOption(opt, isSelected, maxWidth));
+    const leadingLines = opt.leadingLines ?? [];
+    lines.push(...renderSingleOption(
+      opt,
+      isSelected,
+      maxWidth,
+      getLeadingLinesToRender(leadingLines, previousLeadingLines),
+    ));
+    previousLeadingLines = leadingLines;
   }
 
   if (hasCancelOption) {
@@ -106,8 +157,10 @@ export function countRenderedLines<T extends string>(
   hasCancelOption: boolean,
 ): number {
   let count = 0;
+  let previousLeadingLines: readonly string[] = [];
   for (const opt of options) {
-    count += countItemLines(opt);
+    count += countItemLines(opt, previousLeadingLines);
+    previousLeadingLines = opt.leadingLines ?? [];
   }
   if (hasCancelOption) count++;
   return count;

--- a/src/shared/prompt/select-viewport.ts
+++ b/src/shared/prompt/select-viewport.ts
@@ -6,7 +6,13 @@
 
 import chalk from 'chalk';
 import type { SelectOptionItem, ViewportState } from './select-menu.js';
-import { countItemLines, countRenderedLines, renderSingleOption, renderCancelOption } from './select-menu.js';
+import {
+  countItemLines,
+  countRenderedLines,
+  getLeadingLinesToRender,
+  renderSingleOption,
+  renderCancelOption,
+} from './select-menu.js';
 
 const HEADER_LINES = 4;
 
@@ -53,9 +59,12 @@ function calculateVisibleRange<T extends string>(
   const hasHiddenAbove = scrollOffset > 0;
   let usedLines = 0;
   let count = 0;
+  let previousLeadingLines: readonly string[] = [];
 
   for (let i = scrollOffset; i < totalItems; i++) {
-    const itemLines = i < options.length ? countItemLines(options[i]!) : 1;
+    const itemLines = i < options.length
+      ? countItemLines(options[i]!, previousLeadingLines)
+      : 1;
     const remainingItems = totalItems - (i + 1);
     const hasHiddenBelow = remainingItems > 0;
     const nextUsedLines = usedLines + itemLines;
@@ -67,6 +76,9 @@ function calculateVisibleRange<T extends string>(
 
     usedLines = nextUsedLines;
     count++;
+    if (i < options.length) {
+      previousLeadingLines = options[i]!.leadingLines ?? [];
+    }
   }
 
   if (count === 0 && scrollOffset < totalItems) {
@@ -150,11 +162,19 @@ export function renderMenuWithViewport<T extends string>(
     lines.push(chalk.gray(`  ↑ ${scrollOffset} more`));
   }
 
+  let previousLeadingLines: string[] = [];
   for (let i = scrollOffset; i < endIndex; i++) {
     if (i < options.length) {
       const opt = options[i]!;
       const isSelected = i === selectedIndex;
-      lines.push(...renderSingleOption(opt, isSelected, maxWidth));
+      const leadingLines = opt.leadingLines ?? [];
+      lines.push(...renderSingleOption(
+        opt,
+        isSelected,
+        maxWidth,
+        getLeadingLinesToRender(leadingLines, previousLeadingLines),
+      ));
+      previousLeadingLines = leadingLines;
     } else {
       const isCancelSelected = selectedIndex === options.length;
       lines.push(renderCancelOption(isCancelSelected, cancelLabel));

--- a/src/shared/prompt/select.ts
+++ b/src/shared/prompt/select.ts
@@ -173,6 +173,14 @@ function interactiveSelect<T extends string>(
 
     const terminalRows = process.stdout.rows ?? 24;
     let viewport = createViewportState(terminalRows, currentOptions, hasCancelOption);
+    if (viewport.active) {
+      viewport = {
+        ...viewport,
+        scrollOffset: adjustScrollOffset(
+          initialIndex, viewport.scrollOffset, currentOptions, hasCancelOption, viewport.maxOptionLines,
+        ),
+      };
+    }
     let totalLines = 0;
 
     const cleanup = (): unknown => {
@@ -394,26 +402,47 @@ export async function selectOption<T extends string>(
  */
 export async function selectOptionWithDefault<T extends string>(
   message: string,
-  options: { label: string; value: T }[],
+  options: SelectOptionItem<T>[],
   defaultValue: T,
+  callbacks?: InteractiveSelectCallbacks<T>,
 ): Promise<T | null> {
   if (options.length === 0) return defaultValue;
 
   const defaultIndex = options.findIndex((opt) => opt.value === defaultValue);
   const initialIndex = defaultIndex >= 0 ? defaultIndex : 0;
 
-  const decoratedOptions: SelectOptionItem<T>[] = options.map((opt) => ({
+  const decorateDefaultOptions = (items: SelectOptionItem<T>[]): SelectOptionItem<T>[] => items.map((opt) => ({
     ...opt,
     label: opt.value === defaultValue ? `${opt.label} ${chalk.green('(default)')}` : opt.label,
   }));
+  const decoratedOptions = decorateDefaultOptions(options);
+  const decoratedCallbacks: InteractiveSelectCallbacks<T> | undefined = callbacks === undefined
+    ? undefined
+    : {
+      ...callbacks,
+      ...(callbacks.onKeyPress === undefined
+        ? {}
+        : {
+          onKeyPress: (key: string, value: T, index: number): SelectOptionItem<T>[] | null => {
+            const updatedOptions = callbacks.onKeyPress!(key, value, index);
+            return updatedOptions === null ? null : decorateDefaultOptions(updatedOptions);
+          },
+        }),
+    };
 
-  const { selectedIndex } = await interactiveSelect(message, decoratedOptions, initialIndex, true);
+  const { selectedIndex, finalOptions } = await interactiveSelect(
+    message,
+    decoratedOptions,
+    initialIndex,
+    true,
+    decoratedCallbacks,
+  );
 
-  if (selectedIndex === options.length || selectedIndex === -1) {
+  if (selectedIndex === finalOptions.length || selectedIndex === -1) {
     return null;
   }
 
-  const selected = options[selectedIndex];
+  const selected = finalOptions[selectedIndex];
   if (selected) {
     console.log(chalk.green(`  ✓ ${selected.label}`));
     return selected.value;


### PR DESCRIPTION
Closes #1223

## 概要

`takt list` の retry / requeue 再開位置ピッカーを、workflow_call 単位の確定を許すページング UI から、葉 step のみ選択可能なツリー選択 UI へ作り直します。あわせて、TAKT ラン中の独立検証で確認された2件の残存欠陥（Resume 候補消失・stale child frame）を設計レベルで修正します。

## 変更内容

### ツリー選択への作り直し（059caf76）

- workflow_call は展開/折りたたみのナビゲーション行になり、確定できるのは葉 step のみになります。選択結果の stack は常に step で終わります
- 失敗位置（Resume 候補）の葉に default を付け、カーソル初期位置を合わせます
- 深い階層はページングではなくスクロールと展開/折りたたみで辿ります
- 全候補の事前展開をやめ、window 幅 50 の遅延投影に変更します（大規模ワークフローでの eager 展開によるリソース消費を回避）

### 残存欠陥の修正（f578a598）

1. **Resume 候補消失**: ターゲットと無関係なブランチを展開しただけで、親 window の置換により Resume/preferred 葉が候補と default から消えていました。window 変更を `structural` / `scroll` に分類し、構造変更（展開・初期化・可視化）では変更前に可視だったターゲットを新 window へ再包含します。明示スクロールのみターゲットの一時退避を許可し、逆スクロールで復帰します
2. **stale child frame**: parallel 親の window 退避時に `activeParallelWindows` だけが削除され、対応する child frame が残存して再展開時に再利用されていました。`childFrames` / `expandedCallKeys` / `nodeIds` の3つの Map をノード単位の単一 state（`nodeStates`）へ統合し、prune は全キーへ同一の active 判定を適用してエントリごと原子的に破棄します。破棄後の再展開は fresh frame を生成し、cycle/depth 検証も再実行されます

## テスト

新規 `src/__tests__/taskRetryStartTreeInvariants.test.ts` に不変条件テスト5件を追加しました。

- 非対象ブランチ展開後も Resume/preferred が候補・default に残る（修正前は失敗する反例）
- 予約超過で structural fallback により window が実際に移動しても Resume が再包含される
- parallel 親退避で child 状態が原子的に消え、再展開は resolver 再実行（呼び出し回数 2→3）で fresh frame になる
- 明示スクロールでの退避と逆スクロールでの復帰

## 検証

- `npm test`（fast unit 4-shard、1493件）成功
- `npm run test:it`（light IT、2324件）成功
- `npm run lint` / `npx tsc --noEmit` / `npm run build` 成功
- Codex Sol High 二体（実装担当・敵対レビュー担当）による反復レビューで blocking finding なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - タスクの再試行・再開地点を、階層ツリー形式で選択できるようになりました。
  - ワークフロー呼び出し、並列処理、深い階層や同名ステップを扱えるようになりました。
  - 展開・折りたたみやスクロールで、目的の地点へ移動できます。
- **改善**
  - 大量の選択肢でも表示範囲を適切に管理します。
  - 見出しの重複を省略し、インデントや端末幅に応じて読みやすく表示します。
  - 解決できない再開地点や不正な選択を明確にエラーとして扱います。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->