### PR TITLE
fix: truncate oversized dynamic selector diffs

### DIFF
--- a/src/__tests__/selector-input-reader.test.ts
+++ b/src/__tests__/selector-input-reader.test.ts
@@ -320,9 +320,10 @@ describe('SelectorInputReader', () => {
     );
 
     expect(result.workingTreeDiff).toContain('d'.repeat(64 * 1024));
+    expect(result.workingTreeDiff).toContain('Content status: complete');
   });
 
-  it('should reject a tracked path payload one byte above 64 KiB', async () => {
+  it('should truncate a tracked path payload one byte above 64 KiB', async () => {
     const cwd = createGitDirectory();
     const runner = new FakeGitCommandRunner(
       ['src/a.ts'],
@@ -330,12 +331,131 @@ describe('SelectorInputReader', () => {
       () => Buffer.alloc(64 * 1024 + 1, 'd'),
     );
 
+    const result = await new SelectorInputReader(runner).readInputs(
+      join(cwd, 'reports'),
+      [],
+      cwd,
+      undefined,
+    );
+
+    expect(result.workingTreeDiff).toContain('Source bytes: 65537');
+    expect(result.workingTreeDiff).toContain('Content status: truncated');
+    expect(result.workingTreeDiff).toContain('d'.repeat(64 * 1024));
+  });
+
+  it('should preserve valid UTF-8 when a tracked payload ends mid-character', async () => {
+    const cwd = createGitDirectory();
+    const payload = Buffer.concat([
+      Buffer.alloc(64 * 1024 - 1, 'a'),
+      Buffer.from('界', 'utf-8'),
+    ]);
+    const runner = new FakeGitCommandRunner(
+      ['src/a.ts'],
+      Buffer.byteLength('src/a.ts\0'),
+      () => payload,
+    );
+
+    const result = await new SelectorInputReader(runner).readInputs(
+      join(cwd, 'reports'),
+      [],
+      cwd,
+      undefined,
+    );
+
+    expect(result.workingTreeDiff).toContain('Source bytes: 65538');
+    expect(result.workingTreeDiff).toContain('Content status: truncated');
+    expect(result.workingTreeDiff).toContain('a'.repeat(64 * 1024 - 1));
+    expect(result.workingTreeDiff).not.toContain('\uFFFD');
+  });
+
+  it('should reject invalid UTF-8 inside an oversized tracked payload', async () => {
+    const cwd = createGitDirectory();
+    const payload = Buffer.concat([
+      Buffer.from([0xc3, 0x28]),
+      Buffer.alloc(64 * 1024, 'd'),
+    ]);
+    const runner = new FakeGitCommandRunner(
+      ['src/a.ts'],
+      Buffer.byteLength('src/a.ts\0'),
+      () => payload,
+    );
+
     await expect(new SelectorInputReader(runner).readInputs(
       join(cwd, 'reports'),
       [],
       cwd,
       undefined,
-    )).rejects.toThrow('path payload "src/a.ts" exceeds 65536 bytes');
+    )).rejects.toThrow('is not valid UTF-8');
+  });
+
+  it('should truncate an oversized tracked diff from Git while preserving source bytes', async () => {
+    const cwd = createRepository();
+    const path = 'src/large.ts';
+    mkdirSync(join(cwd, 'src'));
+    writeFileSync(join(cwd, path), 'const value = "before";\n');
+    execFileSync('git', ['add', '-A'], { cwd });
+    execFileSync('git', ['commit', '--quiet', '-m', 'baseline'], { cwd });
+    writeFileSync(join(cwd, path), `const value = "${'x'.repeat(80_000)}";\n`);
+    const gitDiff = execFileSync(
+      'git',
+      ['diff', '--no-ext-diff', '--no-textconv', 'HEAD', '--end-of-options', '--', path],
+      { cwd },
+    );
+
+    const result = await new SelectorInputReader(new GitSelectorCommandRunner()).readInputs(
+      join(cwd, 'reports'),
+      [],
+      cwd,
+      undefined,
+    );
+
+    expect(gitDiff.length).toBeGreaterThan(64 * 1024);
+    expect(result.workingTreeDiff).toContain(`Source bytes: ${gitDiff.length}`);
+    expect(result.workingTreeDiff).toContain('Content status: truncated');
+    expect(result.workingTreeDiff).not.toContain('Dynamic selector path payload');
+  });
+
+  it('should truncate an oversized untracked regular file without rejecting the selector', async () => {
+    const cwd = createGitDirectory();
+    const path = 'src/untracked.ts';
+    const header = `diff --git a/${path} b/${path}\nnew file mode 100644\n--- /dev/null\n+++ b/${path}\n`;
+    const content = 'u'.repeat(64 * 1024);
+    mkdirSync(join(cwd, 'src'));
+    writeFileSync(join(cwd, path), content);
+    const runner = new FakeGitCommandRunner([], 0, () => Buffer.alloc(0), [path]);
+
+    const result = await new SelectorInputReader(runner).readInputs(
+      join(cwd, 'reports'),
+      [],
+      cwd,
+      undefined,
+    );
+
+    expect(result.workingTreeDiff).toContain(
+      `Source bytes: ${Buffer.byteLength(header, 'utf-8') + Buffer.byteLength(content, 'utf-8')}`,
+    );
+    expect(result.workingTreeDiff).toContain('Content status: truncated');
+    expect(result.workingTreeDiff).not.toContain(content);
+  });
+
+  it('should distinguish complete and truncated untracked files at the entry boundary', async () => {
+    const cwd = createGitDirectory();
+    const path = 'src/untracked.ts';
+    const header = `diff --git a/${path} b/${path}\nnew file mode 100644\n--- /dev/null\n+++ b/${path}\n`;
+    const available = 64 * 1024 - Buffer.byteLength(header, 'utf-8');
+    mkdirSync(join(cwd, 'src'));
+    writeFileSync(join(cwd, path), 'u'.repeat(available));
+    const runner = new FakeGitCommandRunner([], 0, () => Buffer.alloc(0), [path]);
+    const reader = new SelectorInputReader(runner);
+
+    const complete = await reader.readInputs(join(cwd, 'reports'), [], cwd, undefined);
+    expect(complete.workingTreeDiff).toContain('Source bytes: 65536');
+    expect(complete.workingTreeDiff).toContain('Content status: complete');
+
+    writeFileSync(join(cwd, path), 'u'.repeat(available + 1));
+    const truncated = await reader.readInputs(join(cwd, 'reports'), [], cwd, undefined);
+    expect(truncated.workingTreeDiff).toContain('Source bytes: 65537');
+    expect(truncated.workingTreeDiff).toContain('Content status: truncated');
   });
 
   it('should enforce the 64 KiB report limit using UTF-8 bytes', async () => {

--- a/src/__tests__/selector-input-reader.test.ts
+++ b/src/__tests__/selector-input-reader.test.ts
@@ -412,6 +412,9 @@ describe('SelectorInputReader', () => {
     expect(gitDiff.length).toBeGreaterThan(64 * 1024);
     expect(result.workingTreeDiff).toContain(`Source bytes: ${gitDiff.length}`);
     expect(result.workingTreeDiff).toContain('Content status: truncated');
+    expect(result.workingTreeDiff).toContain(
+      gitDiff.subarray(0, 64 * 1024).toString('utf-8'),
+    );
     expect(result.workingTreeDiff).not.toContain('Dynamic selector path payload');
   });
 
@@ -420,6 +423,7 @@ describe('SelectorInputReader', () => {
     const path = 'src/untracked.ts';
     const header = `diff --git a/${path} b/${path}\nnew file mode 100644\n--- /dev/null\n+++ b/${path}\n`;
     const content = 'u'.repeat(64 * 1024);
+    const available = 64 * 1024 - Buffer.byteLength(header, 'utf-8');
     mkdirSync(join(cwd, 'src'));
     writeFileSync(join(cwd, path), content);
     const runner = new FakeGitCommandRunner([], 0, () => Buffer.alloc(0), [path]);
@@ -435,6 +439,7 @@ describe('SelectorInputReader', () => {
       `Source bytes: ${Buffer.byteLength(header, 'utf-8') + Buffer.byteLength(content, 'utf-8')}`,
     );
     expect(result.workingTreeDiff).toContain('Content status: truncated');
+    expect(result.workingTreeDiff).toContain('u'.repeat(available));
     expect(result.workingTreeDiff).not.toContain(content);
   });
 
@@ -474,6 +479,8 @@ describe('SelectorInputReader', () => {
       undefined,
     );
     expect(result.reports).toContain(exact);
+    expect(result.reports).toContain('Source bytes: 65536');
+    expect(result.reports).toContain('Content status: complete');
 
     writeFileSync(join(reportDirectory, 'review.md'), `${exact}x`);
     await expect(reader.readInputs(

--- a/src/core/workflow/dynamic-parallel/selector-input-reader.ts
+++ b/src/core/workflow/dynamic-parallel/selector-input-reader.ts
@@ -22,6 +22,14 @@ const MAX_SELECTOR_GIT_CONCURRENCY = 8;
 const MAX_SELECTOR_PATH_LIST_BYTES = 1024 * 1024;
 const TAKT_RUN_PATH_PREFIX = '.takt/runs/';
 
+type SelectorFileReadMode = 'complete' | 'truncated';
+
+interface SelectorFileRead {
+  readonly content: string;
+  readonly bytes: number;
+  readonly truncated: boolean;
+}
+
 export interface SelectorInputs {
   readonly reports: string;
   readonly workingTreeDiff: string;
@@ -115,15 +123,17 @@ export class SelectorInputReader {
       if (!stat.isFile() || stat.isSymbolicLink()) {
         throw new Error(`Selector report is not a regular file: ${relativePath}`);
       }
-      const content = this.readTextFileWithinLimit(
+      const file = this.readTextFile(
         reportPath,
         MAX_SELECTOR_ENTRY_BYTES,
         `Selector report "${relativePath}"`,
+        'complete',
       );
       const report = this.renderEntry(
         relativePath,
-        stat.size,
-        content,
+        file.bytes,
+        file.content,
+        'complete',
       );
       budget.consume(index === 0 ? report : `\n\n${report}`);
       return report;
@@ -150,13 +160,16 @@ export class SelectorInputReader {
       MAX_SELECTOR_ENTRY_BYTES,
       signal,
     );
-    if (result.bytes > MAX_SELECTOR_ENTRY_BYTES) {
-      throw new Error(`Dynamic selector path payload "${path}" exceeds ${MAX_SELECTOR_ENTRY_BYTES} bytes`);
-    }
+    const truncated = result.bytes > MAX_SELECTOR_ENTRY_BYTES;
     return this.renderEntry(
       path,
       result.bytes,
-      this.decodeUtf8(result.output, `Dynamic selector path payload "${path}"`),
+      this.decodeUtf8(
+        result.output,
+        `Dynamic selector path payload "${path}"`,
+        truncated,
+      ),
+      truncated ? 'truncated' : 'complete',
     );
   }
 
@@ -175,29 +188,51 @@ export class SelectorInputReader {
     const header = `diff --git a/${path} b/${path}\nnew file mode ${mode}\n--- /dev/null\n+++ b/${path}\n`;
     if (mode === '120000') {
       const content = `${header}Symbolic link target: ${readlinkSync(absolutePath)}`;
-      if (Buffer.byteLength(content, 'utf-8') > MAX_SELECTOR_ENTRY_BYTES) {
-        throw new Error(`Dynamic selector path payload "${path}" exceeds ${MAX_SELECTOR_ENTRY_BYTES} bytes`);
-      }
-      return this.renderEntry(path, Buffer.byteLength(content), content);
+      const sourceBytes = Buffer.byteLength(content, 'utf-8');
+      const bounded = this.boundUtf8Content(
+        content,
+        MAX_SELECTOR_ENTRY_BYTES,
+        `Dynamic selector path payload "${path}"`,
+      );
+      return this.renderEntry(
+        path,
+        sourceBytes,
+        bounded.content,
+        bounded.truncated ? 'truncated' : 'complete',
+      );
     }
-    const available = Math.max(0, MAX_SELECTOR_ENTRY_BYTES - Buffer.byteLength(header));
-    const content = this.readTextFileWithinLimit(
+    const headerBytes = Buffer.byteLength(header, 'utf-8');
+    const available = Math.max(0, MAX_SELECTOR_ENTRY_BYTES - headerBytes);
+    const file = this.readTextFile(
       absolutePath,
       available,
+      `Dynamic selector path payload "${path}"`,
+      'truncated',
+    );
+    const sourceBytes = headerBytes + file.bytes;
+    const bounded = this.boundUtf8Content(
+      `${header}${file.content}`,
+      MAX_SELECTOR_ENTRY_BYTES,
       `Dynamic selector path payload "${path}"`,
     );
     return this.renderEntry(
       path,
-      Buffer.byteLength(header) + stat.size,
-      `${header}${content}`,
+      sourceBytes,
+      bounded.content,
+      file.truncated || bounded.truncated ? 'truncated' : 'complete',
     );
   }
 
-  private renderEntry(path: string, bytes: number, content: string): string {
+  private renderEntry(
+    path: string,
+    bytes: number,
+    content: string,
+    status: 'complete' | 'truncated',
+  ): string {
     return [
       `## ${path}`,
       `Source bytes: ${bytes}`,
-      'Content status: complete',
+      `Content status: ${status}`,
       '',
       content,
     ].join('\n');
@@ -298,34 +333,56 @@ export class SelectorInputReader {
     }))];
   }
 
-  private readTextFileWithinLimit(
+  private readTextFile(
     path: string,
     maxBytes: number,
     sourceName: string,
-  ): string {
+    mode: SelectorFileReadMode,
+  ): SelectorFileRead {
     const descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
     try {
       const stat = fstatSync(descriptor);
       if (!stat.isFile()) {
         throw new Error(`Selector input is not a regular file: ${path}`);
       }
-      if (stat.size > maxBytes) {
+      const truncated = mode === 'truncated' && stat.size > maxBytes;
+      if (mode === 'complete' && stat.size > maxBytes) {
         throw new Error(`${sourceName} exceeds ${MAX_SELECTOR_ENTRY_BYTES} bytes`);
       }
-      const content = Buffer.alloc(stat.size);
+      const bytesToRead = truncated ? maxBytes : stat.size;
+      const content = Buffer.alloc(bytesToRead);
       const readBytes = readSync(descriptor, content, 0, content.length, 0);
-      if (readBytes !== stat.size) {
+      if (readBytes !== bytesToRead) {
         throw new Error(`Unable to read complete selector input: ${path}`);
       }
-      return this.decodeUtf8(content, sourceName);
+      return {
+        content: this.decodeUtf8(content, sourceName, truncated),
+        bytes: stat.size,
+        truncated,
+      };
     } finally {
       closeSync(descriptor);
     }
   }
 
-  private decodeUtf8(content: Buffer, sourceName: string): string {
+  private boundUtf8Content(
+    content: string,
+    maxBytes: number,
+    sourceName: string,
+  ): { readonly content: string; readonly truncated: boolean } {
+    const bytes = Buffer.from(content, 'utf-8');
+    if (bytes.length <= maxBytes) {
+      return { content, truncated: false };
+    }
+    return {
+      content: this.decodeUtf8(bytes.subarray(0, maxBytes), sourceName, true),
+      truncated: true,
+    };
+  }
+
+  private decodeUtf8(content: Buffer, sourceName: string, truncated: boolean): string {
     try {
-      return new TextDecoder('utf-8', { fatal: true }).decode(content);
+      return new TextDecoder('utf-8', { fatal: true }).decode(content, { stream: truncated });
     } catch (error) {
       throw new Error(`${sourceName} is not valid UTF-8`, { cause: error });
     }


### PR DESCRIPTION
## Summary

- keep dynamic selectors running when a tracked diff exceeds the 64 KiB per-entry capture limit
- expose the original byte count and mark bounded working-tree entries as truncated
- preserve UTF-8 boundaries, invalid-input rejection, report completeness, symlink safety, and the aggregate input budget
- cover tracked Git diffs and untracked files at the size boundary

This fixes the selector runtime failure observed while verifying #1223; it does not change the #1223 retry-start behavior itself.

## Verification

- `npm test -- src/__tests__/selector-input-reader.test.ts` (33 passed)
- `npm test -- src/__tests__/engine-parallel.test.ts` (63 passed)
- `npm run build`
- `npm run lint`
- `npm test`
- `npm run test:it` (1,987 passed)
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts` (17 passed)
- `npm run test:e2e:mock`
- `git diff --check`

## Review

- Luna Max implementation review: blocking 0 / non-blocking 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 大きな追跡済み・未追跡ファイルは64 KiBまで自動的に切り詰め、実際のバイト数と切り詰め状態を表示できるようになりました。
  * UTF-8文字の途中で切り詰めても、不正な置換文字が生成されなくなりました。
* **バグ修正**
  * 不正なUTF-8データは引き続き適切に拒否されます。
  * 64 KiB境界の入力を正しく判定できるようになりました。
  * レポートが上限を超えた場合は、従来どおり拒否されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->