### PR TITLE
docs: add Pi provider resource-loading examples

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1013,6 +1013,30 @@ provider_options:
 
 ファイル編集の権限は引き続き `permission_mode` で制御されます。
 
+#### Pi のリソース読み込み (`extensions`, `no_*`)
+
+TAKT 実行時に Pi package / extension を読み込む、または探索する Pi リソース種別を制限するには `provider_options.pi` を使います。
+
+```yaml
+provider_options:
+  pi:
+    extensions:
+      - npm:pi-fff
+      # - git:https://github.com/example/pi-extension
+      # - /absolute/path/to/local-extension
+    no_extensions: true        # 探索を無効化。上記の明示した extension は読み込む
+    no_skills: true            # Pi Skill の探索を無効化
+    no_prompt_templates: true  # Pi prompt template の探索を無効化
+    no_themes: true            # Pi theme の探索を無効化
+    no_context_files: true     # Pi context file の探索を無効化
+```
+
+- `extensions` には npm package、Git source、local path を指定できます。
+- 明示した source は TAKT 実行時に temporary resolution され、Pi settings には永続化されません。
+- `no_extensions` は extension 探索を無効にしますが、`extensions` に列挙した source は読み込みます。
+- その他の `no_*` オプションは、それぞれ対応するリソース種別の探索を無効にします。
+- 明示した extension は TAKT process 内で実行されるため、信頼できる source だけを設定してください。
+
 <a id="workflow-categories"></a>
 
 ## Workflow カテゴリ

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -298,8 +298,7 @@ ignore_exceed: false          # takt run / takt watch で --ignore-exceed 相当
 
 ```
 
-Pi SDK session は現在の TAKT process 内だけ memory に保持します。TAKT は Pi の session JSONL を書き込まず、`provider_options.pi.extensions` を Pi settings に永続化しません。明示した package は Pi の temporary resolution path で解決します。
-暗黙の project-local Pi extension は信頼せず、読み込みません。明示した Pi extension は TAKT process 内で実行されるため、信頼できる local path と package source だけを設定してください。認証情報を埋め込んだ URL や secret 系 query parameter を含む extension URL は拒否します。
+Pi SDK session は現在の TAKT process 内だけ memory に保持します。TAKT は Pi の session JSONL を書き込みません。`provider_options.pi` のリソース読み込み（`extensions`、`no_*`）、temporary resolution、信頼境界は [Pi のリソース読み込み](#pi-resource-loading) を参照してください。
 
 ### OpenCode 実行ガード
 
@@ -1013,6 +1012,8 @@ provider_options:
 
 ファイル編集の権限は引き続き `permission_mode` で制御されます。
 
+<a id="pi-resource-loading"></a>
+
 #### Pi のリソース読み込み (`extensions`, `no_*`)
 
 TAKT 実行時に Pi package / extension を読み込む、または探索する Pi リソース種別を制限するには `provider_options.pi` を使います。
@@ -1035,7 +1036,9 @@ provider_options:
 - 明示した source は TAKT 実行時に temporary resolution され、Pi settings には永続化されません。
 - `no_extensions` は extension 探索を無効にしますが、`extensions` に列挙した source は読み込みます。
 - その他の `no_*` オプションは、それぞれ対応するリソース種別の探索を無効にします。
-- 明示した extension は TAKT process 内で実行されるため、信頼できる source だけを設定してください。
+- 暗黙の project-local Pi extension は信頼せず、読み込みません。
+- 明示した extension は TAKT process 内で実行されるため、信頼できる local path と package source だけを設定してください。
+- 認証情報を埋め込んだ URL や secret 系 query parameter を含む extension URL は拒否します。
 
 <a id="workflow-categories"></a>
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1040,6 +1040,8 @@ provider_options:
 - 明示した extension は TAKT process 内で実行されるため、信頼できる local path と package source だけを設定してください。
 - 認証情報を埋め込んだ URL や secret 系 query parameter を含む extension URL は拒否します。
 
+これらの設定は通常の provider option leaf 優先順位に従い、`TAKT_PROVIDER_OPTIONS_PI_*` でも上書きできます。
+
 <a id="workflow-categories"></a>
 
 ## Workflow カテゴリ

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1046,6 +1046,8 @@ provider_options:
 - Explicit extensions execute inside the TAKT process, so configure only trusted local paths and package sources.
 - Extension URLs containing embedded credentials or secret-bearing query parameters are rejected.
 
+These settings follow normal provider-option leaf priority, including `TAKT_PROVIDER_OPTIONS_PI_*`.
+
 <a id="workflow-categories"></a>
 
 ## Workflow categories

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1019,6 +1019,30 @@ provider_options:
 
 File-edit permissions continue to be governed by `permission_mode`.
 
+#### Pi resource loading (`extensions`, `no_*`)
+
+Use `provider_options.pi` when a TAKT run should load Pi packages / extensions or restrict which Pi resource types are discovered:
+
+```yaml
+provider_options:
+  pi:
+    extensions:
+      - npm:pi-fff
+      # - git:https://github.com/example/pi-extension
+      # - /absolute/path/to/local-extension
+    no_extensions: true       # Disable discovery; still load the explicit extensions above
+    no_skills: true           # Disable Pi Skill discovery
+    no_prompt_templates: true # Disable Pi prompt-template discovery
+    no_themes: true           # Disable Pi theme discovery
+    no_context_files: true    # Disable Pi context-file discovery
+```
+
+- `extensions` accepts npm packages, Git sources, and local paths.
+- Explicit sources are resolved temporarily for the TAKT run and are not persisted into Pi settings.
+- `no_extensions` disables extension discovery but still loads the sources listed in `extensions`.
+- The other `no_*` options disable discovery of their respective resource types.
+- Explicit extensions execute inside the TAKT process, so configure only trusted sources.
+
 <a id="workflow-categories"></a>
 
 ## Workflow categories

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,8 +298,7 @@ ignore_exceed: false          # Applies to takt run and takt watch like --ignore
 
 ```
 
-Pi SDK sessions are kept in memory for the current TAKT process. TAKT does not write Pi session JSONL files or persist `provider_options.pi.extensions` into Pi settings; explicitly requested packages use Pi's temporary resolution path.
-Implicit project-local Pi extensions are not trusted or loaded. Explicit Pi extensions execute inside the TAKT process, so only configure trusted local paths and package sources. Extension URLs containing embedded credentials or secret-bearing query parameters are rejected.
+Pi SDK sessions are kept in memory for the current TAKT process. TAKT does not write Pi session JSONL files. For `provider_options.pi` resource loading (`extensions`, `no_*`), temporary resolution, and trust boundaries, see [Pi resource loading](#pi-resource-loading).
 
 ### OpenCode execution guards
 
@@ -1019,6 +1018,8 @@ provider_options:
 
 File-edit permissions continue to be governed by `permission_mode`.
 
+<a id="pi-resource-loading"></a>
+
 #### Pi resource loading (`extensions`, `no_*`)
 
 Use `provider_options.pi` when a TAKT run should load Pi packages / extensions or restrict which Pi resource types are discovered:
@@ -1041,7 +1042,9 @@ provider_options:
 - Explicit sources are resolved temporarily for the TAKT run and are not persisted into Pi settings.
 - `no_extensions` disables extension discovery but still loads the sources listed in `extensions`.
 - The other `no_*` options disable discovery of their respective resource types.
-- Explicit extensions execute inside the TAKT process, so configure only trusted sources.
+- Implicit project-local Pi extensions are not trusted or loaded.
+- Explicit extensions execute inside the TAKT process, so configure only trusted local paths and package sources.
+- Extension URLs containing embedded credentials or secret-bearing query parameters are rejected.
 
 <a id="workflow-categories"></a>
 


### PR DESCRIPTION
## Summary
- `docs/configuration.md` / `docs/configuration.ja.md` の `Provider-specific options in practice` 配下へ、Pi resource loading の実用例を追加
- `extensions`（npm / Git / local）、temporary resolution、各 `no_*` option、信頼境界を EN/JA で同じ粒度で記載
- #1331 の docs-only スコープを維持（認証・model 解決・実装/schema 変更なし）

## Test plan
- [x] `docs/configuration.md` と `docs/configuration.ja.md` を比較し、小節構成と例が一致することを確認
- [x] `git diff --check`
- [x] `npm run build`

Closes #1331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Pi のリソース読み込み設定と信頼境界に関する説明を追加しました。
  * npm、Git、ローカルパスから拡張機能を明示的に指定できます。
  * 拡張機能、Skills、プロンプトテンプレート、テーマ、コンテキストファイルの自動検出を個別に無効化できます。
  * 明示指定した拡張機能は一時的に適用され、設定に保存されません。
  * 暗黙的なローカル拡張機能は読み込まず、認証情報を含むURLは拒否します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->