### PR TITLE
fix: codexのreasoning summaryを有効化しcompanion固定タイマーを削除する

### DIFF
--- a/scripts/probe-codex-reasoning-stream.mjs
+++ b/scripts/probe-codex-reasoning-stream.mjs
@@ -3,6 +3,7 @@ import { createWriteStream } from 'node:fs';
 import { performance } from 'node:perf_hooks';
 import { dirname, resolve } from 'node:path';
 import { finished } from 'node:stream/promises';
+import { fileURLToPath } from 'node:url';
 import { Codex } from '@openai/codex-sdk';
 
 function isRecord(value) {
@@ -94,6 +95,7 @@ function createEventRecorder() {
     maxEventGap: undefined,
     usage: undefined,
     status: 'running',
+    error: undefined,
   };
 }
 
@@ -134,6 +136,11 @@ function recordEvent(file, recorder, event) {
   }
   if (event.type === 'turn.failed') {
     recorder.status = 'failed';
+    recorder.error = String(event.error?.message ?? 'Codex turn failed');
+  }
+  if (event.type === 'error') {
+    recorder.status = 'error';
+    recorder.error = typeof event.message === 'string' ? event.message : 'Codex stream error';
   }
   recorder.previousMonotonicMs = monotonicMs;
   recorder.previousEventType = event.type;
@@ -141,6 +148,7 @@ function recordEvent(file, recorder, event) {
 }
 
 function buildSummary(options, recorder, error) {
+  const summaryError = error ?? recorder.error;
   const durationMs = recorder.turnStartedMonotonicMs === undefined
     || recorder.turnCompletedMonotonicMs === undefined
     ? null
@@ -164,7 +172,7 @@ function buildSummary(options, recorder, error) {
       toEventType: recorder.maxEventGap.toEventType,
     },
     usage: recorder.usage ?? null,
-    ...(error === undefined ? {} : { error }),
+    ...(summaryError === undefined ? {} : { error: summaryError }),
   };
 }
 
@@ -186,6 +194,9 @@ async function runProbe(options) {
   const file = createWriteStream(options.output, { encoding: 'utf8' });
   const recorder = createEventRecorder();
   let streamError;
+  const fileFinished = finished(file).catch((error) => {
+    streamError ??= error instanceof Error ? error.message : String(error);
+  });
   try {
     for await (const event of events) {
       recordEvent(file, recorder, event);
@@ -194,16 +205,12 @@ async function runProbe(options) {
     streamError = error instanceof Error ? error.message : String(error);
   } finally {
     file.end();
-    try {
-      await finished(file);
-    } catch (error) {
-      streamError ??= error instanceof Error ? error.message : String(error);
-    }
+    await fileFinished;
   }
 
   const summary = buildSummary(probeOptions, recorder, streamError);
   process.stdout.write(`${JSON.stringify(summary)}\n`);
-  if (streamError !== undefined) {
+  if (streamError !== undefined || recorder.status !== 'completed') {
     process.exitCode = 1;
   }
 }
@@ -217,7 +224,14 @@ async function main() {
   await runProbe(options);
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n${usageText()}\n`);
-  process.exitCode = 1;
-});
+export { parseArguments, runProbe };
+
+if (
+  process.argv[1] !== undefined
+  && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n${usageText()}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/probe-codex-reasoning-stream.mjs
+++ b/scripts/probe-codex-reasoning-stream.mjs
@@ -189,7 +189,6 @@ async function runProbe(options) {
     sandboxMode: 'read-only',
     approvalPolicy: 'never',
   });
-  const { events } = await thread.runStreamed(options.prompt);
   await mkdir(dirname(options.output), { recursive: true });
   const file = createWriteStream(options.output, { encoding: 'utf8' });
   const recorder = createEventRecorder();
@@ -198,6 +197,7 @@ async function runProbe(options) {
     streamError ??= error instanceof Error ? error.message : String(error);
   });
   try {
+    const { events } = await thread.runStreamed(options.prompt);
     for await (const event of events) {
       recordEvent(file, recorder, event);
     }

--- a/scripts/probe-codex-reasoning-stream.mjs
+++ b/scripts/probe-codex-reasoning-stream.mjs
@@ -1,0 +1,223 @@
+import { mkdir } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { performance } from 'node:perf_hooks';
+import { dirname, resolve } from 'node:path';
+import { finished } from 'node:stream/promises';
+import { Codex } from '@openai/codex-sdk';
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function usageText() {
+  return [
+    'Usage:',
+    '  node scripts/probe-codex-reasoning-stream.mjs',
+    '    --model <model>',
+    '    --prompt <prompt>',
+    '    --output <events.jsonl>',
+    '    [--effort <effort>]',
+    '    [--config <json-object>]',
+    '    [--cwd <directory>]',
+    '',
+    'Example:',
+    '  node scripts/probe-codex-reasoning-stream.mjs \\',
+    '    --model gpt-5.6-luna --effort xhigh \\',
+    '    --config \'{"model_reasoning_summary":"auto"}\' \\',
+    '    --prompt \'長い推論を必要とする検証を実行する\' \\',
+    '    --output .takt/probes/luna-xhigh-auto.jsonl',
+  ].join('\n');
+}
+
+function parseArguments(argv) {
+  const values = new Map();
+  const allowedArguments = new Set(['model', 'prompt', 'output', 'effort', 'config', 'cwd']);
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help') {
+      return { help: true };
+    }
+    if (!argument.startsWith('--')) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for ${argument}`);
+    }
+    const name = argument.slice(2);
+    if (!allowedArguments.has(name)) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    values.set(name, value);
+    index += 1;
+  }
+
+  const model = values.get('model');
+  const prompt = values.get('prompt');
+  const output = values.get('output');
+  if (model === undefined || prompt === undefined || output === undefined) {
+    throw new Error('--model, --prompt, and --output are required');
+  }
+
+  const rawConfig = values.get('config') ?? '{}';
+  let config;
+  try {
+    config = JSON.parse(rawConfig);
+  } catch (error) {
+    throw new Error(`--config must be valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!isRecord(config)) {
+    throw new Error('--config must be a JSON object');
+  }
+
+  return {
+    help: false,
+    model,
+    prompt,
+    output: resolve(output),
+    cwd: resolve(values.get('cwd') ?? process.cwd()),
+    effort: values.get('effort'),
+    config,
+  };
+}
+
+function roundMilliseconds(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+function createEventRecorder() {
+  return {
+    sequence: 0,
+    previousMonotonicMs: undefined,
+    turnStartedMonotonicMs: undefined,
+    turnCompletedMonotonicMs: undefined,
+    maxEventGap: undefined,
+    usage: undefined,
+    status: 'running',
+  };
+}
+
+function recordEvent(file, recorder, event) {
+  const monotonicMs = performance.now();
+  const gapMs = recorder.previousMonotonicMs === undefined
+    ? undefined
+    : monotonicMs - recorder.previousMonotonicMs;
+  const previousEventType = recorder.previousEventType;
+  if (
+    gapMs !== undefined
+    && recorder.turnStartedMonotonicMs !== undefined
+    && (recorder.maxEventGap === undefined || gapMs > recorder.maxEventGap.gapMs)
+  ) {
+    recorder.maxEventGap = {
+      gapMs,
+      fromEventType: previousEventType,
+      toEventType: event.type,
+    };
+  }
+
+  const line = {
+    sequence: recorder.sequence,
+    wallClock: new Date().toISOString(),
+    monotonicMs: roundMilliseconds(monotonicMs),
+    ...(gapMs === undefined ? {} : { eventGapMs: roundMilliseconds(gapMs) }),
+    event,
+  };
+  file.write(`${JSON.stringify(line)}\n`);
+
+  if (event.type === 'turn.started') {
+    recorder.turnStartedMonotonicMs = monotonicMs;
+  }
+  if (event.type === 'turn.completed') {
+    recorder.turnCompletedMonotonicMs = monotonicMs;
+    recorder.usage = isRecord(event.usage) ? event.usage : null;
+    recorder.status = 'completed';
+  }
+  if (event.type === 'turn.failed') {
+    recorder.status = 'failed';
+  }
+  recorder.previousMonotonicMs = monotonicMs;
+  recorder.previousEventType = event.type;
+  recorder.sequence += 1;
+}
+
+function buildSummary(options, recorder, error) {
+  const durationMs = recorder.turnStartedMonotonicMs === undefined
+    || recorder.turnCompletedMonotonicMs === undefined
+    ? null
+    : recorder.turnCompletedMonotonicMs - recorder.turnStartedMonotonicMs;
+  return {
+    model: options.model,
+    effort: options.effort ?? null,
+    config: options.config,
+    cwd: options.cwd,
+    output: options.output,
+    status: error === undefined ? recorder.status : 'error',
+    eventCount: recorder.sequence,
+    turnStarted: recorder.turnStartedMonotonicMs !== undefined,
+    turnCompleted: recorder.turnCompletedMonotonicMs !== undefined,
+    turnDurationMs: durationMs === null ? null : roundMilliseconds(durationMs),
+    maxEventGapMs: recorder.maxEventGap === undefined
+      ? null
+      : roundMilliseconds(recorder.maxEventGap.gapMs),
+    maxEventGap: recorder.maxEventGap === undefined ? null : {
+      fromEventType: recorder.maxEventGap.fromEventType,
+      toEventType: recorder.maxEventGap.toEventType,
+    },
+    usage: recorder.usage ?? null,
+    ...(error === undefined ? {} : { error }),
+  };
+}
+
+async function runProbe(options) {
+  const config = {
+    ...options.config,
+    ...(options.effort === undefined ? {} : { model_reasoning_effort: options.effort }),
+  };
+  const probeOptions = { ...options, config };
+  const codex = new Codex({ config });
+  const thread = codex.startThread({
+    model: options.model,
+    workingDirectory: options.cwd,
+    sandboxMode: 'read-only',
+    approvalPolicy: 'never',
+  });
+  const { events } = await thread.runStreamed(options.prompt);
+  await mkdir(dirname(options.output), { recursive: true });
+  const file = createWriteStream(options.output, { encoding: 'utf8' });
+  const recorder = createEventRecorder();
+  let streamError;
+  try {
+    for await (const event of events) {
+      recordEvent(file, recorder, event);
+    }
+  } catch (error) {
+    streamError = error instanceof Error ? error.message : String(error);
+  } finally {
+    file.end();
+    try {
+      await finished(file);
+    } catch (error) {
+      streamError ??= error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const summary = buildSummary(probeOptions, recorder, streamError);
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+  if (streamError !== undefined) {
+    process.exitCode = 1;
+  }
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(`${usageText()}\n`);
+    return;
+  }
+  await runProbe(options);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n${usageText()}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/test-classification.mjs
+++ b/scripts/test-classification.mjs
@@ -221,6 +221,7 @@ export const fileSystemIntegrationTestFiles = Object.freeze([
   'src/__tests__/pathBoundary.test.ts',
   'src/__tests__/pi-client.test.ts',
   'src/__tests__/policy-persona.test.ts',
+  'src/__tests__/probe-codex-reasoning-stream.test.ts',
   'src/__tests__/projectBoundaryError.test.ts',
   'src/__tests__/projectLocalTaktSync.test.ts',
   'src/__tests__/promotion-schema-normalizer.test.ts',

--- a/src/__tests__/codex-client-retry.test.ts
+++ b/src/__tests__/codex-client-retry.test.ts
@@ -315,6 +315,7 @@ describe('CodexClient retry', () => {
       skills: {
         config: [{ path: fs.realpathSync(skillPath), enabled: false }],
       },
+      model_reasoning_summary: 'auto',
     };
 
     expect(result.status).toBe('done');

--- a/src/__tests__/codex-stream-handler.test.ts
+++ b/src/__tests__/codex-stream-handler.test.ts
@@ -3,6 +3,7 @@ import {
   createStreamTrackingState,
   emitCodexItemCompleted,
   emitCodexItemStart,
+  emitCodexItemUpdate,
   emitResult,
 } from '../infra/codex/CodexStreamHandler.js';
 import type { StreamCallback } from '../core/workflow/types.js';
@@ -110,5 +111,32 @@ describe('CodexStreamHandler active tool tracking', () => {
       input: { command: 'npm run lint' },
     });
     expect(state.activeTool?.id).not.toBe(firstId);
+  });
+});
+
+describe('CodexStreamHandler reasoning summaries', () => {
+  it('reasoning item を thinking イベントへ変換し、更新内容を重複させない', () => {
+    const onStream: StreamCallback = vi.fn();
+    const state = createStreamTrackingState();
+
+    emitCodexItemUpdate(
+      { id: 'reasoning-1', type: 'reasoning', text: 'summary draft' },
+      onStream,
+      state,
+    );
+    emitCodexItemCompleted(
+      { id: 'reasoning-1', type: 'reasoning', text: 'summary draft completed' },
+      onStream,
+      state,
+    );
+
+    expect(onStream).toHaveBeenNthCalledWith(1, {
+      type: 'thinking',
+      data: { thinking: 'summary draft' },
+    });
+    expect(onStream).toHaveBeenNthCalledWith(2, {
+      type: 'thinking',
+      data: { thinking: ' completed\n' },
+    });
   });
 });

--- a/src/__tests__/codex-stream-handler.test.ts
+++ b/src/__tests__/codex-stream-handler.test.ts
@@ -138,5 +138,6 @@ describe('CodexStreamHandler reasoning summaries', () => {
       type: 'thinking',
       data: { thinking: ' completed\n' },
     });
+    expect(onStream).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/__tests__/codex-structured-output.test.ts
+++ b/src/__tests__/codex-structured-output.test.ts
@@ -64,8 +64,13 @@ describe('CodexClient — structuredOutput 抽出', () => {
 
   it('outputSchema 指定時に agent_message の JSON テキストを structuredOutput として返す', async () => {
     const schema = { type: 'object', properties: { step: { type: 'integer' } } };
+    const onStream = vi.fn();
     mockEvents = [
       { type: 'thread.started', thread_id: 'thread-1' },
+      {
+        type: 'item.completed',
+        item: { id: 'reasoning-1', type: 'reasoning', text: 'internal reasoning summary' },
+      },
       {
         type: 'item.completed',
         item: { id: 'msg-1', type: 'agent_message', text: '{"step": 2, "reason": "approved"}' },
@@ -74,10 +79,15 @@ describe('CodexClient — structuredOutput 抽出', () => {
     ];
 
     const client = new CodexClient();
-    const result = await client.call('coder', 'prompt', { cwd: '/tmp', outputSchema: schema });
+    const result = await client.call('coder', 'prompt', { cwd: '/tmp', outputSchema: schema, onStream });
 
     expect(result.status).toBe('done');
     expect(result.structuredOutput).toEqual({ step: 2, reason: 'approved' });
+    expect(result.content).not.toContain('internal reasoning summary');
+    expect(onStream).toHaveBeenCalledWith({
+      type: 'thinking',
+      data: { thinking: 'internal reasoning summary\n' },
+    });
   });
 
   it('複数の agent_message JSON がある場合は最後の JSON を structuredOutput として返す', async () => {
@@ -334,9 +344,26 @@ describe('CodexClient — structuredOutput 抽出', () => {
     expect(lastCodexConstructorOptions).toMatchObject({
       config: {
         model_reasoning_effort: 'vendor"level',
+        model_reasoning_summary: 'auto',
       },
     });
     expect(lastThreadOptions).not.toHaveProperty('modelReasoningEffort');
+  });
+
+  it('reasoningEffort がなくても Codex config に reasoning summary を設定する', async () => {
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    await client.call('coder', 'prompt', { cwd: '/tmp' });
+
+    expect(lastCodexConstructorOptions).toMatchObject({
+      config: {
+        model_reasoning_summary: 'auto',
+      },
+    });
   });
 
   it('codexPathOverride が Codex constructor options に反映される', async () => {

--- a/src/__tests__/companion-completion-coordinator.test.ts
+++ b/src/__tests__/companion-completion-coordinator.test.ts
@@ -54,6 +54,7 @@ describe('companion completion coordinator', () => {
           }, { once: true });
         });
       },
+      refreshRetryRequest: async (request) => request,
     });
     const running = queue.enqueue({
       companionName: 'security-reviewer',
@@ -180,6 +181,7 @@ describe('companion completion coordinator', () => {
     });
     const queue = new CompanionReviewQueue({
       runReview: vi.fn().mockRejectedValue(new Error('review failed')),
+      refreshRetryRequest: async (request) => request,
     });
     const synchronizeSnapshot = vi.fn();
     const coordinator = createCoordinator({ current, queue, synchronizeSnapshot });
@@ -304,7 +306,10 @@ function createCoordinator(input: {
   decision?: CompanionTerminalDecisionTracker;
   abortSignal?: AbortSignal;
 }): CompanionCompletionCoordinator {
-  const queue = input.queue ?? new CompanionReviewQueue({ runReview: vi.fn() });
+  const queue = input.queue ?? new CompanionReviewQueue({
+    runReview: vi.fn(),
+    refreshRetryRequest: async (request) => request,
+  });
   return new CompanionCompletionCoordinator({
     activeNames: () => ['security-reviewer'],
     detectors: new Map([['security-reviewer', input.current]]),

--- a/src/__tests__/companion-review-queue.test.ts
+++ b/src/__tests__/companion-review-queue.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { CompanionReviewQueue } from '../core/workflow/companion/review-queue.js';
+import {
+  CompanionReviewQueue,
+  type CompanionReviewRequest,
+} from '../core/workflow/companion/review-queue.js';
 
 function snapshot(digest: string) {
   return {
@@ -23,6 +26,10 @@ function request(digest: string, reason: 'quiet' | 'forced' | 'completion' = 'qu
   };
 }
 
+const keepRetryRequest = async (
+  current: CompanionReviewRequest,
+): Promise<CompanionReviewRequest> => current;
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((done) => { resolve = done; });
@@ -40,6 +47,7 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
     });
     const queue = new CompanionReviewQueue({
       runReview,
+      refreshRetryRequest: keepRetryRequest,
       onCoalesced: (event) => coalesced.push(event),
     });
 
@@ -80,6 +88,7 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
         await release.promise;
         active.delete(companionName);
       }),
+      refreshRetryRequest: keepRetryRequest,
     });
 
     const security = queue.enqueue(request('diff-a'));
@@ -99,14 +108,15 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
         await new Promise<void>((_resolve, reject) => {
           signal.addEventListener('abort', () => {
             order.push('abort:wip');
-            reject(new DOMException('Aborted', 'AbortError'));
+            reject(new Error('abort cleanup failed'));
           }, { once: true });
         });
       }),
+      refreshRetryRequest: keepRetryRequest,
     });
 
     const wip = queue.enqueue(request('wip'));
-    const wipRejected = expect(wip).rejects.toMatchObject({ name: 'AbortError' });
+    const wipRejected = expect(wip).rejects.toThrow('abort cleanup failed');
     await Promise.resolve();
     await queue.complete({ ...request('final', 'completion') });
     await wipRejected;
@@ -114,54 +124,144 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
     expect(order).toEqual(['start:quiet', 'abort:wip', 'start:completion']);
   });
 
-  it('should reject pending waiters and allow a later round after a non-abort failure', async () => {
-    const runReview = vi.fn(async ({ snapshot: current }: { snapshot: { digest: string } }) => {
-      if (current.digest === 'fail') throw new Error('review failed');
-    });
-    const queue = new CompanionReviewQueue({ runReview });
-
-    const failed = queue.enqueue(request('fail'));
-    const pending = queue.enqueue(request('pending'));
-    await expect(failed).rejects.toThrow('review failed');
-    await expect(pending).rejects.toThrow('review failed');
-    await expect(queue.enqueue(request('recovered'))).resolves.toBeUndefined();
-  });
-
-  it('should keep completion and a settlement-time enqueue serialized after a failure', async () => {
-    const failing = deferred<void>();
-    const completion = deferred<void>();
+  it('should keep failed waiters pending until a single retry succeeds', async () => {
+    const refreshStarted = deferred<void>();
+    const releaseRefresh = deferred<void>();
     const starts: string[] = [];
-    let concurrency = 0;
-    let maximumConcurrency = 0;
+    let attempts = 0;
     const queue = new CompanionReviewQueue({
       runReview: vi.fn(async ({ snapshot: current }: { snapshot: { digest: string } }) => {
         starts.push(current.digest);
-        concurrency += 1;
-        maximumConcurrency = Math.max(maximumConcurrency, concurrency);
-        try {
-          if (current.digest === 'failing') {
-            await failing.promise;
-            throw new Error('review failed');
-          }
-          if (current.digest === 'completion') await completion.promise;
-        } finally {
-          concurrency -= 1;
-        }
+        if (attempts++ === 0) throw new Error('review failed');
       }),
+      refreshRetryRequest: async (current) => {
+        refreshStarted.resolve();
+        await releaseRefresh.promise;
+        return current;
+      },
     });
 
-    const failed = queue.enqueue(request('failing'));
-    const pending = queue.enqueue(request('pending', 'forced'));
-    failing.resolve();
-    const final = failed.catch(async () => queue.complete(request('completion', 'completion')));
-    const afterFailure = failed.catch(async () => queue.enqueue(request('after-failure')));
-    await expect(failed).rejects.toThrow('review failed');
-    await expect(pending).rejects.toThrow('review failed');
-    completion.resolve();
-    await Promise.all([final, afterFailure]);
+    const failed = queue.enqueue(request('fail'));
+    let settled = false;
+    failed.then(
+      () => { settled = true; },
+      () => { settled = true; },
+    );
+    await refreshStarted.promise;
+    expect(settled).toBe(false);
 
-    expect(starts).toEqual(['failing', 'completion', 'after-failure']);
-    expect(maximumConcurrency).toBe(1);
+    releaseRefresh.resolve();
+    await expect(failed).resolves.toBeUndefined();
+    expect(starts).toEqual(['fail', 'fail']);
+  });
+
+  it('should run a pending newer batch before retrying the failed batch', async () => {
+    const newerStarted = deferred<void>();
+    const releaseNewer = deferred<void>();
+    const starts: string[] = [];
+    const queue = new CompanionReviewQueue({
+      runReview: vi.fn(async ({ snapshot: current }: { snapshot: { digest: string } }) => {
+        starts.push(current.digest);
+        if (current.digest === 'failed') {
+          if (starts.length === 1) throw new Error('review failed');
+          return;
+        }
+        newerStarted.resolve();
+        await releaseNewer.promise;
+      }),
+      refreshRetryRequest: keepRetryRequest,
+    });
+
+    const failed = queue.enqueue(request('failed'));
+    const newer = queue.enqueue(request('newer', 'forced'));
+    let failedSettled = false;
+    failed.then(
+      () => { failedSettled = true; },
+      () => { failedSettled = true; },
+    );
+    await newerStarted.promise;
+    expect(starts).toEqual(['failed', 'newer']);
+    expect(failedSettled).toBe(false);
+
+    releaseNewer.resolve();
+    await Promise.all([
+      expect(newer).resolves.toBeUndefined(),
+      expect(failed).resolves.toBeUndefined(),
+    ]);
+    expect(starts).toEqual(['failed', 'newer', 'failed']);
+  });
+
+  it('should refresh the snapshot and generation immediately before retrying', async () => {
+    const starts: Array<{
+      companionName: string;
+      reason: CompanionReviewRequest['reason'];
+      digest: string;
+      observedGeneration: number;
+    }> = [];
+    const refreshRetryRequest = vi.fn(async (current: CompanionReviewRequest) => ({
+      ...current,
+      snapshot: snapshot('latest'),
+      observedGeneration: 7,
+    }));
+    const queue = new CompanionReviewQueue({
+      runReview: vi.fn(async ({
+        companionName,
+        reason,
+        snapshot: current,
+        observedGeneration,
+      }: CompanionReviewRequest) => {
+        starts.push({
+          companionName,
+          reason,
+          digest: current.digest,
+          observedGeneration,
+        });
+        if (current.digest === 'stale') throw new Error('review failed');
+      }),
+      refreshRetryRequest,
+    });
+
+    await expect(queue.enqueue(request('stale'))).resolves.toBeUndefined();
+
+    expect(refreshRetryRequest).toHaveBeenCalledTimes(1);
+    expect(refreshRetryRequest).toHaveBeenCalledWith(request('stale'));
+    expect(starts).toEqual([
+      {
+        companionName: 'security-reviewer',
+        reason: 'quiet',
+        digest: 'stale',
+        observedGeneration: 1,
+      },
+      {
+        companionName: 'security-reviewer',
+        reason: 'quiet',
+        digest: 'latest',
+        observedGeneration: 7,
+      },
+    ]);
+  });
+
+  it('should reject after one retry and keep later batches alive', async () => {
+    const starts: string[] = [];
+    let failures = 0;
+    const queue = new CompanionReviewQueue({
+      runReview: vi.fn(async ({ snapshot: current }: { snapshot: { digest: string } }) => {
+        starts.push(current.digest);
+        if (current.digest === 'failed') {
+          failures += 1;
+          throw new Error(`review failed ${failures}`);
+        }
+      }),
+      refreshRetryRequest: keepRetryRequest,
+    });
+
+    const failed = queue.enqueue(request('failed'));
+    const later = queue.enqueue(request('later', 'forced'));
+
+    await expect(failed).rejects.toThrow('review failed 2');
+    await expect(later).resolves.toBeUndefined();
+    expect(failures).toBe(2);
+    expect(starts).toEqual(['failed', 'later', 'failed']);
   });
 
   it('should abort the active review and reject pending work when stopped', async () => {
@@ -177,6 +277,7 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
           { once: true },
         ));
       }),
+      refreshRetryRequest: keepRetryRequest,
     });
     const active = queue.enqueue(request('active'));
     const activeRejected = expect(active).rejects.toMatchObject({ name: 'AbortError' });
@@ -201,14 +302,15 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
           'abort',
           async () => {
             await releaseCleanup.promise;
-            reject(new DOMException('Aborted', 'AbortError'));
+            reject(new Error('abort cleanup failed'));
           },
           { once: true },
         ));
       }),
+      refreshRetryRequest: keepRetryRequest,
     });
     const active = queue.enqueue(request('active'));
-    const activeRejected = expect(active).rejects.toMatchObject({ name: 'AbortError' });
+    const activeRejected = expect(active).rejects.toThrow('abort cleanup failed');
     await started.promise;
     const pending = queue.enqueue(request('pending', 'forced'));
     const pendingRejected = expect(pending).rejects.toMatchObject({ name: 'AbortError' });

--- a/src/__tests__/companion-review-queue.test.ts
+++ b/src/__tests__/companion-review-queue.test.ts
@@ -224,7 +224,7 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
     await expect(queue.enqueue(request('stale'))).resolves.toBeUndefined();
 
     expect(refreshRetryRequest).toHaveBeenCalledTimes(1);
-    expect(refreshRetryRequest).toHaveBeenCalledWith(request('stale'));
+    expect(refreshRetryRequest).toHaveBeenCalledWith(request('stale'), expect.any(AbortSignal));
     expect(starts).toEqual([
       {
         companionName: 'security-reviewer',
@@ -239,6 +239,43 @@ describe('CT-COMP-05 companion review queue lifecycle', () => {
         observedGeneration: 7,
       },
     ]);
+  });
+
+  it('should abort retry refresh before starting the completion batch', async () => {
+    const refreshStarted = deferred<void>();
+    const starts: string[] = [];
+    const queue = new CompanionReviewQueue({
+      runReview: vi.fn(async ({ reason }: CompanionReviewRequest) => {
+        starts.push(reason);
+        if (reason === 'quiet') throw new Error('review failed');
+      }),
+      refreshRetryRequest: vi.fn(async (
+        current: CompanionReviewRequest,
+        signal: AbortSignal,
+      ) => {
+        refreshStarted.resolve();
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            { once: true },
+          );
+        });
+        return current;
+      }),
+    });
+
+    const failed = queue.enqueue(request('failed'));
+    const failedRejected = expect(failed).rejects.toMatchObject({ name: 'AbortError' });
+    await refreshStarted.promise;
+
+    const completion = queue.complete({ ...request('completion', 'completion') });
+    await Promise.all([
+      failedRejected,
+      expect(completion).resolves.toBeUndefined(),
+    ]);
+
+    expect(starts).toEqual(['quiet', 'completion']);
   });
 
   it('should reject after one retry and keep later batches alive', async () => {

--- a/src/__tests__/companion-review-runner.test.ts
+++ b/src/__tests__/companion-review-runner.test.ts
@@ -476,16 +476,14 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
     expect(recordUsage).not.toHaveBeenCalled();
   });
 
-  it('should retry and record failed usage when companion calls reach their timeout', async () => {
+  it('should continue past 300 seconds and complete when the provider resolves', async () => {
     vi.useFakeTimers();
     const recordUsage = vi.fn();
-    const call = vi.fn((_system, _prompt, _schema, options: { abortSignal: AbortSignal }) => (
-      new Promise<AgentResponse>((_resolve, reject) => {
-        options.abortSignal.addEventListener('abort', () => {
-          reject(new DOMException('Aborted', 'AbortError'));
-        }, { once: true });
-      })
-    ));
+    const recordCall = vi.fn();
+    let resolveCall!: (value: AgentResponse) => void;
+    const call = vi.fn(() => new Promise<AgentResponse>((resolve) => {
+      resolveCall = resolve;
+    }));
 
     try {
       const execution = executeCompanionStructuredAgent({
@@ -499,21 +497,24 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
         failureDir: '/project/.takt/runs/run/failures',
         language: 'en',
         resolution: { provider: 'mock', model: 'mock-model', providerOptions: {} },
-        timeoutMs: 100,
         call,
         recordUsage,
+        recordCall,
       });
-      const rejection = expect(execution).rejects.toThrow(/timeout|timed out/i);
-      await vi.advanceTimersByTimeAsync(100);
-      await vi.advanceTimersByTimeAsync(100);
 
-      await rejection;
-      expect(call).toHaveBeenCalledTimes(2);
-      expect(recordUsage).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(300_001);
+      expect(call).toHaveBeenCalledOnce();
+      expect(call.mock.calls[0]?.[3]).toMatchObject({
+        abortSignal: { aborted: false },
+      });
+
+      resolveCall(response('done'));
+      await expect(execution).resolves.toMatchObject({ status: 'done' });
       expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({
         purpose: 'reviewer',
-        success: false,
+        success: true,
       }));
+      expect(recordCall.mock.calls[0]?.[0]).not.toHaveProperty('error');
     } finally {
       vi.useRealTimers();
     }

--- a/src/__tests__/companion-review-runner.test.ts
+++ b/src/__tests__/companion-review-runner.test.ts
@@ -514,6 +514,7 @@ describe('CT-COMP-06 and CT-COMP-11 structured internal agent execution', () => 
         purpose: 'reviewer',
         success: true,
       }));
+      expect(recordCall).toHaveBeenCalledOnce();
       expect(recordCall.mock.calls[0]?.[0]).not.toHaveProperty('error');
     } finally {
       vi.useRealTimers();

--- a/src/__tests__/companion-runtime-lifecycle.integration.test.ts
+++ b/src/__tests__/companion-runtime-lifecycle.integration.test.ts
@@ -160,7 +160,8 @@ describe('companion runtime lifecycle', () => {
       type: 'tool_use',
       data: { tool: 'Bash', input: { command: 'git commit -m change' }, id: 'commit' },
     });
-    await vi.waitFor(() => expect(readDiff).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(readDiff).toHaveBeenCalledTimes(3));
+    expect(readDiff.mock.calls.at(-1)?.[2]).toBeInstanceOf(AbortSignal);
     runtime.stop();
   });
 

--- a/src/__tests__/probe-codex-reasoning-stream.test.ts
+++ b/src/__tests__/probe-codex-reasoning-stream.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => {
+  const startThread = vi.fn();
+  const Codex = vi.fn(() => ({ startThread }));
+  return { Codex, startThread };
+});
+
+vi.mock('@openai/codex-sdk', () => ({ Codex: sdk.Codex }));
+
+import { parseArguments, runProbe } from '../../scripts/probe-codex-reasoning-stream.mjs';
+
+async function* eventsOf(events: readonly Record<string, unknown>[]): AsyncGenerator<Record<string, unknown>> {
+  yield* events;
+}
+
+describe('probe-codex-reasoning-stream', () => {
+  let root: string;
+  let output: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'takt-probe-test-'));
+    process.exitCode = undefined;
+    output = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    output.mockRestore();
+    process.exitCode = undefined;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('should validate required arguments and JSON object config', () => {
+    expect(() => parseArguments([])).toThrow('--model, --prompt, and --output are required');
+    expect(() => parseArguments([
+      '--model', 'model',
+      '--prompt', 'prompt',
+      '--output', join(root, 'events.jsonl'),
+      '--config', '[]',
+    ])).toThrow('--config must be a JSON object');
+  });
+
+  it('should write JSONL events and a successful summary with the SDK contract', async () => {
+    const outputPath = join(root, 'nested', 'events.jsonl');
+    const runStreamed = vi.fn().mockResolvedValue({
+      events: eventsOf([
+        { type: 'turn.started' },
+        { type: 'turn.completed', usage: { input_tokens: 10 } },
+      ]),
+    });
+    sdk.startThread.mockReturnValue({ runStreamed });
+
+    await runProbe(parseArguments([
+      '--model', 'model',
+      '--prompt', 'prompt',
+      '--output', outputPath,
+      '--effort', 'xhigh',
+      '--config', '{"custom":"value"}',
+    ]));
+
+    expect(sdk.Codex).toHaveBeenCalledWith({
+      config: {
+        custom: 'value',
+        model_reasoning_effort: 'xhigh',
+      },
+    });
+    expect(sdk.startThread).toHaveBeenCalledWith({
+      model: 'model',
+      workingDirectory: process.cwd(),
+      sandboxMode: 'read-only',
+      approvalPolicy: 'never',
+    });
+    expect(runStreamed).toHaveBeenCalledWith('prompt');
+
+    const lines = readFileSync(outputPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines.map((line) => JSON.parse(line).event.type)).toEqual([
+      'turn.started',
+      'turn.completed',
+    ]);
+    expect(JSON.parse(String(output.mock.calls.at(-1)?.[0]))).toMatchObject({
+      status: 'completed',
+      eventCount: 2,
+      turnCompleted: true,
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it.each([
+    ['turn.failed', { type: 'turn.failed', error: { message: 'turn failed' } }, 'failed', 'turn failed'],
+    ['error', { type: 'error', message: 'stream failed' }, 'error', 'stream failed'],
+  ])('should report a %s event as a failed probe', async (_name, event, status, message) => {
+    const outputPath = join(root, 'events.jsonl');
+    sdk.startThread.mockReturnValue({
+      runStreamed: vi.fn().mockResolvedValue({ events: eventsOf([event]) }),
+    });
+
+    await runProbe(parseArguments([
+      '--model', 'model',
+      '--prompt', 'prompt',
+      '--output', outputPath,
+    ]));
+
+    expect(JSON.parse(String(output.mock.calls.at(-1)?.[0]))).toMatchObject({
+      status,
+      error: message,
+      eventCount: 1,
+      turnCompleted: false,
+    });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should report an async stream failure in the summary and exit non-zero', async () => {
+    const outputPath = join(root, 'events.jsonl');
+    async function* failingEvents() {
+      yield { type: 'turn.started' };
+      throw new Error('stream exploded');
+    }
+    sdk.startThread.mockReturnValue({
+      runStreamed: vi.fn().mockResolvedValue({ events: failingEvents() }),
+    });
+
+    await runProbe(parseArguments([
+      '--model', 'model',
+      '--prompt', 'prompt',
+      '--output', outputPath,
+    ]));
+
+    expect(JSON.parse(String(output.mock.calls.at(-1)?.[0]))).toMatchObject({
+      status: 'error',
+      error: 'stream exploded',
+      eventCount: 1,
+    });
+    expect(process.exitCode).toBe(1);
+  });
+  it('should record a failed summary and non-zero exit when runStreamed rejects at start', async () => {
+    const outputPath = join(root, 'start-failure.jsonl');
+    const runStreamed = vi.fn().mockRejectedValue(new Error('startup refused'));
+    sdk.startThread.mockReturnValue({ runStreamed });
+
+    await runProbe(parseArguments([
+      '--model', 'model',
+      '--prompt', 'prompt',
+      '--output', outputPath,
+    ]));
+
+    const summary = JSON.parse(String(output.mock.calls.at(-1)?.[0]));
+    expect(summary).toMatchObject({
+      error: 'startup refused',
+    });
+    expect(summary.status).not.toBe('completed');
+    expect(process.exitCode).toBe(1);
+  });
+
+});

--- a/src/core/workflow/companion/review-queue.ts
+++ b/src/core/workflow/companion/review-queue.ts
@@ -48,7 +48,10 @@ export class CompanionReviewQueue {
 
   constructor(private readonly input: {
     runReview: (request: CompanionReviewRequest & { signal: AbortSignal }) => Promise<void>;
-    refreshRetryRequest: (request: CompanionReviewRequest) => Promise<CompanionReviewRequest>;
+    refreshRetryRequest: (
+      request: CompanionReviewRequest,
+      signal: AbortSignal,
+    ) => Promise<CompanionReviewRequest>;
     onCoalesced?: (event: CompanionReviewQueueCoalesced) => void;
   }) {}
 
@@ -125,7 +128,7 @@ export class CompanionReviewQueue {
         let request = batch.request;
         if (batch.retried) {
           if (this.stopped || controller.signal.aborted) throw createAbortError();
-          request = await this.input.refreshRetryRequest(request);
+          request = await this.input.refreshRetryRequest(request, controller.signal);
           if (this.stopped || controller.signal.aborted) throw createAbortError();
         }
         await this.input.runReview({ ...request, signal: controller.signal });

--- a/src/core/workflow/companion/review-queue.ts
+++ b/src/core/workflow/companion/review-queue.ts
@@ -32,6 +32,7 @@ interface QueueWaiter {
 interface PendingBatch {
   request: CompanionReviewRequest;
   readonly waiters: QueueWaiter[];
+  readonly retried: boolean;
 }
 
 interface QueueState {
@@ -47,6 +48,7 @@ export class CompanionReviewQueue {
 
   constructor(private readonly input: {
     runReview: (request: CompanionReviewRequest & { signal: AbortSignal }) => Promise<void>;
+    refreshRetryRequest: (request: CompanionReviewRequest) => Promise<CompanionReviewRequest>;
     onCoalesced?: (event: CompanionReviewQueueCoalesced) => void;
   }) {}
 
@@ -65,7 +67,7 @@ export class CompanionReviewQueue {
         replacement: toQueueAuditRequest(request),
       });
     } else {
-      state.pending.push({ request, waiters: [waiter.waiter] });
+      state.pending.push({ request, waiters: [waiter.waiter], retried: false });
     }
     this.startDrain(state);
     return waiter.promise;
@@ -81,6 +83,7 @@ export class CompanionReviewQueue {
     state.pending.push({
       request: { ...request, reason: 'completion' },
       waiters: [waiter.waiter],
+      retried: false,
     });
     this.startDrain(state);
     return waiter.promise;
@@ -119,11 +122,25 @@ export class CompanionReviewQueue {
       const controller = new AbortController();
       state.running = controller;
       try {
-        await this.input.runReview({ ...batch.request, signal: controller.signal });
+        let request = batch.request;
+        if (batch.retried) {
+          if (this.stopped || controller.signal.aborted) throw createAbortError();
+          request = await this.input.refreshRetryRequest(request);
+          if (this.stopped || controller.signal.aborted) throw createAbortError();
+        }
+        await this.input.runReview({ ...request, signal: controller.signal });
         for (const waiter of batch.waiters) waiter.resolve();
       } catch (error) {
-        for (const waiter of batch.waiters) waiter.reject(error);
-        if (!isAbortError(error)) this.rejectPending(state, error);
+        if (
+          !batch.retried
+          && !isAbortError(error)
+          && !controller.signal.aborted
+          && !this.stopped
+        ) {
+          state.pending.push({ ...batch, retried: true });
+        } else {
+          for (const waiter of batch.waiters) waiter.reject(error);
+        }
       } finally {
         state.running = undefined;
       }

--- a/src/core/workflow/companion/review-runner.ts
+++ b/src/core/workflow/companion/review-runner.ts
@@ -44,7 +44,6 @@ export interface CompanionCallAudit {
 
 export type CompanionStructuredResponseValidator = (response: AgentResponse) => void;
 
-const COMPANION_CALL_TIMEOUT_MS = 300_000;
 const MAX_COMPANION_CALL_ATTEMPTS = 2;
 
 export async function executeCompanionStructuredAgent(input: {
@@ -58,7 +57,6 @@ export async function executeCompanionStructuredAgent(input: {
   failureDir: string;
   language: string;
   resolution: CompanionAgentResolution;
-  timeoutMs?: number;
   abortSignal?: AbortSignal;
   call: (
     systemPrompt: string,
@@ -127,7 +125,6 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
   };
   if (input.abortSignal?.aborted) throw createAbortError(input.abortSignal.reason);
   input.abortSignal?.addEventListener('abort', abortFromParent, { once: true });
-  let timer: ReturnType<typeof setTimeout> | undefined;
   let response: AgentResponse | undefined;
   let callAuditRecorded = false;
   const guardedSystemPrompt = appendCompanionEvidenceSystemGuard(input.systemPrompt);
@@ -175,14 +172,6 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
     }
   };
   try {
-    const timeoutMs = input.timeoutMs ?? COMPANION_CALL_TIMEOUT_MS;
-    const timeout = new Promise<never>((_resolve, reject) => {
-      timer = setTimeout(() => {
-        reject(new Error(`Companion ${input.purpose} call timed out after ${timeoutMs}ms`));
-        controller.abort();
-      }, timeoutMs);
-    });
-    void timeout.catch(() => undefined);
     const call = input.call(
       guardedSystemPrompt,
       input.prompt,
@@ -204,7 +193,6 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
     void call.catch(() => undefined);
     response = await Promise.race([
       call,
-      timeout,
       parentAbort,
     ]);
     if (response.status === 'done') {
@@ -252,7 +240,6 @@ async function executeCompanionStructuredAgentInternal(input: Parameters<
     }
     throw error;
   } finally {
-    if (timer !== undefined) clearTimeout(timer);
     input.abortSignal?.removeEventListener('abort', abortFromParent);
   }
 }

--- a/src/core/workflow/companion/step-runtime.ts
+++ b/src/core/workflow/companion/step-runtime.ts
@@ -134,13 +134,13 @@ export class CompanionStepRuntime {
       runReview: async (request) => {
         await this.runReview(request);
       },
-      refreshRetryRequest: async (request) => {
+      refreshRetryRequest: async (request, signal) => {
         const detector = this.detectors.get(request.companionName);
         if (detector === undefined) {
           throw new Error(`Missing detector for companion "${request.companionName}"`);
         }
         const observedGeneration = detector.getObservedGeneration();
-        const snapshot = await this.readSnapshot();
+        const snapshot = await this.readSnapshot(signal);
         return { ...request, snapshot, observedGeneration };
       },
       onCoalesced: (event) => this.events.queueCoalesced({
@@ -263,7 +263,7 @@ export class CompanionStepRuntime {
       this.requireProvider(item.name);
       return { name: item.name, definition };
     });
-    const initialSnapshot = await this.readSnapshot();
+    const initialSnapshot = await this.readSnapshot(this.deps.abortSignal);
     for (const { name, definition } of resolved) {
       this.active.set(name, definition);
       try {
@@ -276,7 +276,7 @@ export class CompanionStepRuntime {
         intervalMs: definition.intervalMs,
         minimumChangedLines: MINIMUM_CHANGED_LINES,
         now: Date.now,
-        readDiff: async () => this.readSnapshot(),
+        readDiff: async () => this.readSnapshot(this.deps.abortSignal),
       }));
       this.events.start(name);
     }
@@ -286,7 +286,7 @@ export class CompanionStepRuntime {
       allowGitCommit: this.deps.step.allowGitCommit === true,
       queue: this.queue,
       initialSnapshot,
-      readSnapshot: () => this.readSnapshot(),
+      readSnapshot: () => this.readSnapshot(this.deps.abortSignal),
       isAborted: () => this.deps.abortSignal?.aborted === true,
       onError: () => log.warn('Companion live review failed; the change remains unreviewed', {
         step: this.deps.step.name,
@@ -305,7 +305,7 @@ export class CompanionStepRuntime {
       activeNames: () => [...this.active.keys()],
       detectors: this.detectors,
       queue: this.queue,
-      readSnapshot: () => this.readSnapshot(),
+      readSnapshot: () => this.readSnapshot(this.deps.abortSignal),
       synchronizeSnapshot: (snapshot) => this.requireScheduler().synchronizeSnapshot(snapshot),
       openMustFix: () => this.openMustFix(),
       recordCompletionRound: async (snapshot) => this.recordStandaloneRound(
@@ -591,11 +591,11 @@ export class CompanionStepRuntime {
     return [this.deps.runSlug, ...this.deps.runPathNamespace, this.deps.step.name].join('\0');
   }
 
-  private async readSnapshot(): Promise<CompanionDiff> {
+  private async readSnapshot(signal: AbortSignal | undefined): Promise<CompanionDiff> {
     const result = await this.deps.diffReader.readDiff(
       this.deps.cwd,
       this.baselineSha,
-      this.deps.abortSignal,
+      signal,
     );
     if (result.status === 'ok') return result.snapshot;
     if (result.failure.code === 'aborted') throw createAbortError();

--- a/src/core/workflow/companion/step-runtime.ts
+++ b/src/core/workflow/companion/step-runtime.ts
@@ -134,6 +134,15 @@ export class CompanionStepRuntime {
       runReview: async (request) => {
         await this.runReview(request);
       },
+      refreshRetryRequest: async (request) => {
+        const detector = this.detectors.get(request.companionName);
+        if (detector === undefined) {
+          throw new Error(`Missing detector for companion "${request.companionName}"`);
+        }
+        const observedGeneration = detector.getObservedGeneration();
+        const snapshot = await this.readSnapshot();
+        return { ...request, snapshot, observedGeneration };
+      },
       onCoalesced: (event) => this.events.queueCoalesced({
         companion: event.companionName,
         replaced: event.replaced,

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -389,12 +389,13 @@ export class CodexClient {
       return errorResponse;
     }
 
-    const codexConfig: CodexOptions['config'] = options.reasoningEffort === undefined
-      ? skillConfig
-      : {
-          ...(skillConfig ?? {}),
-          model_reasoning_effort: options.reasoningEffort,
-        };
+    const codexConfig: CodexOptions['config'] = {
+      ...(skillConfig ?? {}),
+      ...(options.reasoningEffort === undefined
+        ? {}
+        : { model_reasoning_effort: options.reasoningEffort }),
+      model_reasoning_summary: 'auto',
+    };
 
     while (true) {
       const attempt = standardRetryCount + timeoutRetryCount + refusalRetryCount + 1;
@@ -407,7 +408,7 @@ export class CodexClient {
         ...(options.openaiApiKey ? { apiKey: options.openaiApiKey } : {}),
         ...(options.baseUrl !== undefined ? { baseUrl: options.baseUrl } : {}),
         ...(options.codexPathOverride ? { codexPathOverride: options.codexPathOverride } : {}),
-        ...(codexConfig !== undefined ? { config: codexConfig } : {}),
+        config: codexConfig,
       };
       const codex = new Codex(codexClientOptions);
       const thread = threadId


### PR DESCRIPTION
深い推論中はストリームイベントが出ず、10分idle watchdogが推論をハングと
誤認して切断する(実測: luna xhighのfixステップがitem.completed後10分無音で
failed)。model_reasoning_summary: 'auto' を常時configに合成し、推論中も
イベントが流れるようにする(skill設定に上書きされない後置)。

companionのライブレビューは5分固定タイマー(COMPANION_CALL_TIMEOUT_MS)が
luna xhighの応答時間より短く全滅していた(11/11失敗を実測)。固定タイマーを
削除し、親ステップのabortとプロバイダwatchdogを下限とする。

reasoning summaryが長考中に本当に周期的に流れるかは保証がないため、
実機計測用のprobeスクリプトを追加。計測不合格の場合はtransport変更を別PRで行う。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 推論ストリームを実行し、イベントをJSONLで保存できるCLIを追加しました。
  * 推論内容を回答本文と分離し、「thinking」イベントとしてストリーミング通知します。
  * 推論要約を自動的に有効化しました。

* **改善**
  * 長時間実行されるレビュー処理が、固定タイムアウトで中断されず完了まで継続するようになりました。
  * 一時的に失敗したレビューを、最新の変更内容で1回再試行できるようになりました。
  * 推論イベントの重複通知を防止しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->