### PR TITLE
docs: document Pi global settings boundary

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -298,7 +298,30 @@ ignore_exceed: false          # takt run / takt watch で --ignore-exceed 相当
 
 ```
 
-Pi SDK session は現在の TAKT process 内だけ memory に保持します。TAKT は Pi の session JSONL を書き込みません。`provider_options.pi` のリソース読み込み（`extensions`、`no_*`）、temporary resolution、信頼境界は [Pi のリソース読み込み](#pi-resource-loading) を参照してください。
+### Pi provider の session 境界
+
+TAKT の Pi provider は、現在の TAKT process 内だけで使う embedded な in-memory Pi SDK session を使用します。Pi の session JSONL ファイルを書き込まず、Pi CLI のグローバル `settings.json` も読み書きしません。そのため、デフォルト model、thinking level、shell、retry option などの Pi グローバル設定は TAKT に自動継承されません。
+
+Pi のデフォルトとして使う model は TAKT の設定で明示してください。Pi の model には `:<thinking-level>` suffix を付けられます。例えば次のように設定します。
+
+```yaml
+# ~/.takt/config.yaml または .takt/config.yaml
+provider: pi
+model: provider/model:high
+```
+
+workflow の step に model と thinking level を設定することもできます。
+
+```yaml
+steps:
+  - name: implement
+    provider: pi
+    model: provider/model:high
+```
+
+`provider` と `model` の宣言は TAKT 実行で使う provider、model、thinking level を選択するもので、Pi CLI の設定を取り込むものではありません。Pi の認証は Pi SDK credential store または provider-native 環境変数で別途処理されます。この境界により、グローバル設定への意図しない書き込みを防ぎ、プロジェクトローカル設定の信頼性と予測可能性を保ちます。
+
+`provider_options.pi` は、`extensions` や `no_*` の探索制御など、Pi リソースを読み込むための別経路です。これらの option は認証、model、thinking level を宣言するものではありません。明示したリソース source は TAKT 実行時だけ temporary resolution され、Pi settings には永続化されません。リソースの信頼境界については [Pi のリソース読み込み](#pi-resource-loading) を参照してください。
 
 ### OpenCode 実行ガード
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,7 +298,30 @@ ignore_exceed: false          # Applies to takt run and takt watch like --ignore
 
 ```
 
-Pi SDK sessions are kept in memory for the current TAKT process. TAKT does not write Pi session JSONL files. For `provider_options.pi` resource loading (`extensions`, `no_*`), temporary resolution, and trust boundaries, see [Pi resource loading](#pi-resource-loading).
+### Pi provider session boundary
+
+The TAKT Pi provider uses an embedded, in-memory Pi SDK session for the current TAKT process. It does not write Pi session JSONL files, and it does not read or write the Pi CLI global `settings.json`. Consequently, Pi global settings such as the default model, thinking level, shell, and retry options are not automatically inherited by TAKT.
+
+Set the model explicitly in TAKT configuration when it should be the default for Pi. A Pi model can include a `:<thinking-level>` suffix, for example:
+
+```yaml
+# ~/.takt/config.yaml or .takt/config.yaml
+provider: pi
+model: provider/model:high
+```
+
+You can also set the model and thinking level on a workflow step:
+
+```yaml
+steps:
+  - name: implement
+    provider: pi
+    model: provider/model:high
+```
+
+The `provider` and `model` declarations select the provider, model, and thinking level for a TAKT run; they do not import Pi CLI settings. Pi authentication is handled separately through the Pi SDK credential store or provider-native environment variables. The boundary avoids unintended writes to global settings and keeps project-local configuration trustworthy and predictable.
+
+`provider_options.pi` is a separate path for loading Pi resources such as `extensions` and `no_*` discovery controls. These options do not declare authentication, model, or thinking level. Explicit resource sources are resolved temporarily for the TAKT run and are not persisted to Pi settings; see [Pi resource loading](#pi-resource-loading) for the resource trust boundary.
 
 ### OpenCode execution guards
 


### PR DESCRIPTION
## Summary

- `docs/configuration.md` / `docs/configuration.ja.md` に Pi provider の embedded / in-memory session 境界を追加
- Pi CLI global `settings.json` を読み書きせず、default model、thinking level、shell、retry options を自動継承しないことを明記
- TAKT config / workflow での model と thinking level の明示方法を追加
- auth / model declarations と `provider_options.pi` resource loading の経路を分離して説明
- runtime/code は変更しない docs-only change

## Test plan

- [x] 英日ドキュメントの内容・例・リンクの対応を確認
- [x] `git diff --check`
- [x] TAKT workflow review: approved
- [ ] `npm run build`（docs-only のため未実行）

Closes #1348


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Pi プロバイダーのセッション境界とリソース読み込み動作を詳しく説明しました。
  * セッションファイルやグローバル設定を使用しないことを明記しました。
  * モデル、思考レベル、認証方法の設定箇所を整理しました。
  * `provider_options.pi` の用途と、一時的なリソース解決について追記しました。
  * 英語・日本語の設定ガイドを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->