### PR TITLE
fix(prompt-evals): Windows taskkill の PID 再利用によるフレークを解消する

### DIFF
--- a/prompt-evals/process-tree.d.mts
+++ b/prompt-evals/process-tree.d.mts
@@ -2,5 +2,5 @@ export function terminateProcessTree(pid: number | undefined): Promise<void>;
 
 export function terminateWindowsProcessTree(
   pid: number,
-  executeFile: (file: string, args: readonly string[]) => Promise<unknown>,
+  executeFile: (file: string, args: readonly string[], options: { timeout: number }) => Promise<unknown>,
 ): Promise<void>;

--- a/prompt-evals/process-tree.mjs
+++ b/prompt-evals/process-tree.mjs
@@ -5,6 +5,7 @@ const execFileAsync = promisify(execFile);
 const PROCESS_TERMINATION_GRACE_MS = 500;
 const PROCESS_TERMINATION_FORCE_MS = 5_000;
 const PROCESS_EXIT_POLL_MS = 10;
+const WINDOWS_COMMAND_TIMEOUT_MS = 5_000;
 
 export async function terminateProcessTree(pid) {
   if (pid === undefined) {
@@ -25,59 +26,116 @@ export async function terminateProcessTree(pid) {
 }
 
 export async function terminateWindowsProcessTree(pid, executeFile) {
-  const descendants = await listWindowsDescendantPids(pid, executeFile);
-  try {
-    await executeFile('taskkill', ['/PID', String(pid), '/T', '/F']);
-  } catch (error) {
-    if (isProcessAlive(pid)) {
-      throw error;
+  const snapshot = await listWindowsProcesses(executeFile);
+  if (snapshot === undefined) {
+    await taskkillBestEffort(pid, executeFile);
+    return;
+  }
+  const processTree = collectWindowsProcessTree(pid, snapshot);
+
+  await taskkillBestEffort(pid, executeFile);
+  const descendants = processTree.filter((processInfo) => processInfo.pid !== pid).reverse();
+  for (const descendant of descendants) {
+    if (await hasMatchingCreationDate(descendant, executeFile)) {
+      await taskkillBestEffort(descendant.pid, executeFile);
     }
   }
-  for (const descendantPid of descendants.reverse()) {
-    try {
-      await executeFile('taskkill', ['/PID', String(descendantPid), '/T', '/F']);
-    } catch (error) {
-      if (isProcessAlive(descendantPid)) {
-        throw error;
-      }
-    }
+
+  const currentProcesses = await listWindowsProcesses(executeFile);
+  if (currentProcesses === undefined) {
+    return;
   }
-  const remaining = await listWindowsDescendantPids(pid, executeFile);
+  const currentCreationDates = new Map(
+    currentProcesses.map((processInfo) => [processInfo.pid, processInfo.creationDate]),
+  );
+  const remaining = processTree.filter(
+    (processInfo) => currentCreationDates.get(processInfo.pid) === processInfo.creationDate,
+  );
   if (remaining.length > 0) {
-    throw new Error(`Windows process tree ${pid} retained descendants: ${remaining.join(', ')}`);
+    throw new Error(
+      `Windows process tree ${pid} retained processes: ${remaining.map(({ pid: processId }) => processId).join(', ')}`,
+    );
   }
 }
 
-async function listWindowsDescendantPids(rootPid, executeFile) {
-  const result = await executeFile('powershell.exe', [
-    '-NoProfile',
-    '-NonInteractive',
-    '-Command',
-    'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId | ConvertTo-Json -Compress',
-  ]);
+async function taskkillBestEffort(pid, executeFile) {
+  try {
+    await executeFile(
+      'taskkill',
+      ['/PID', String(pid), '/T', '/F'],
+      { timeout: WINDOWS_COMMAND_TIMEOUT_MS },
+    );
+  } catch {
+    return;
+  }
+}
+
+async function hasMatchingCreationDate(processInfo, executeFile) {
+  const currentProcesses = await queryWindowsProcesses(
+    executeFile,
+    `Get-CimInstance Win32_Process -Filter "ProcessId = ${processInfo.pid}" | Select-Object ProcessId,ParentProcessId,CreationDate | ConvertTo-Json -Compress`,
+  );
+  return currentProcesses === undefined || currentProcesses.some(
+    (current) => current.pid === processInfo.pid
+      && current.creationDate === processInfo.creationDate,
+  );
+}
+
+async function listWindowsProcesses(executeFile) {
+  return queryWindowsProcesses(
+    executeFile,
+    'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CreationDate | ConvertTo-Json -Compress',
+  );
+}
+
+async function queryWindowsProcesses(executeFile, command) {
+  try {
+    const result = await executeFile('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      command,
+    ], { timeout: WINDOWS_COMMAND_TIMEOUT_MS });
+    return parseWindowsProcesses(result);
+  } catch {
+    // Cleanup must still attempt taskkill when CIM is unavailable or malformed.
+    return undefined;
+  }
+}
+
+function parseWindowsProcesses(result) {
   const stdout = typeof result?.stdout === 'string' ? result.stdout.trim() : '';
   if (stdout.length === 0) {
     return [];
   }
   const parsed = JSON.parse(stdout);
   const processes = Array.isArray(parsed) ? parsed : [parsed];
+  return processes.flatMap((processInfo) => {
+    const pid = Number(processInfo?.ProcessId);
+    const parentProcessId = Number(processInfo?.ParentProcessId);
+    const creationDate = processInfo?.CreationDate;
+    if (!Number.isInteger(pid) || !Number.isInteger(parentProcessId) || typeof creationDate !== 'string') {
+      return [];
+    }
+    return [{ pid, parentProcessId, creationDate }];
+  });
+}
+
+function collectWindowsProcessTree(rootPid, processes) {
   const childrenByParent = new Map();
   for (const processInfo of processes) {
-    const processId = Number(processInfo?.ProcessId);
-    const parentProcessId = Number(processInfo?.ParentProcessId);
-    if (!Number.isInteger(processId) || !Number.isInteger(parentProcessId)) continue;
-    const children = childrenByParent.get(parentProcessId) ?? [];
-    children.push(processId);
-    childrenByParent.set(parentProcessId, children);
+    const children = childrenByParent.get(processInfo.parentProcessId) ?? [];
+    children.push(processInfo);
+    childrenByParent.set(processInfo.parentProcessId, children);
   }
-  const descendants = [];
+  const processTree = processes.filter((processInfo) => processInfo.pid === rootPid);
   const pending = [...(childrenByParent.get(rootPid) ?? [])];
   while (pending.length > 0) {
-    const processId = pending.pop();
-    descendants.push(processId);
-    pending.push(...(childrenByParent.get(processId) ?? []));
+    const processInfo = pending.pop();
+    processTree.push(processInfo);
+    pending.push(...(childrenByParent.get(processInfo.pid) ?? []));
   }
-  return descendants;
+  return processTree;
 }
 
 function signalProcessGroup(pid, signal) {
@@ -104,17 +162,6 @@ async function waitForProcessGroupExit(pid, timeoutMs) {
 function isProcessGroupAlive(pid) {
   try {
     process.kill(-pid, 0);
-    return true;
-  } catch (error) {
-    if (error.code === 'ESRCH') return false;
-    if (error.code === 'EPERM') return true;
-    throw error;
-  }
-}
-
-function isProcessAlive(pid) {
-  try {
-    process.kill(pid, 0);
     return true;
   } catch (error) {
     if (error.code === 'ESRCH') return false;

--- a/src/__tests__/promptEvalProbeLifecycle.test.ts
+++ b/src/__tests__/promptEvalProbeLifecycle.test.ts
@@ -450,18 +450,82 @@ describe('prompt eval probe lifecycle', () => {
     expect(executeFile).toHaveBeenCalledWith(
       'taskkill',
       ['/PID', '4321', '/T', '/F'],
+      { timeout: 5_000 },
     );
   });
 
+  it.each([
+    ['PowerShell fails', () => { throw new Error('PowerShell failed'); }],
+    ['PowerShell returns malformed JSON', () => ({ stdout: '{invalid' })],
+  ])('should still taskkill the root when %s during the initial snapshot', async (_scenario, query) => {
+    const executeFile = vi.fn(async (file: string) => (
+      file === 'powershell.exe' ? query() : undefined
+    ));
+
+    await expect(terminateWindowsProcessTree(4321, executeFile)).resolves.toBeUndefined();
+
+    expect(executeFile).toHaveBeenCalledWith(
+      'taskkill',
+      ['/PID', '4321', '/T', '/F'],
+      { timeout: 5_000 },
+    );
+  });
+
+  it.each(['descendant identity', 'final remaining-process'])(
+    'should keep taskkill best-effort when the %s query returns malformed JSON',
+    async (failureStage) => {
+      let fullSnapshot = 0;
+      const executeFile = vi.fn(async (file: string, args: readonly string[]) => {
+        if (file !== 'powershell.exe') return undefined;
+        if (args[3]?.includes('-Filter')) {
+          return failureStage === 'descendant identity'
+            ? { stdout: '{invalid' }
+            : { stdout: JSON.stringify({
+              ProcessId: 5001,
+              ParentProcessId: 4321,
+              CreationDate: 'created-5001',
+            }) };
+        }
+        fullSnapshot += 1;
+        if (fullSnapshot === 1) {
+          return { stdout: JSON.stringify({
+            ProcessId: 5001,
+            ParentProcessId: 4321,
+            CreationDate: 'created-5001',
+          }) };
+        }
+        return failureStage === 'final remaining-process'
+          ? { stdout: '{invalid' }
+          : { stdout: '[]' };
+      });
+
+      await expect(terminateWindowsProcessTree(4321, executeFile)).resolves.toBeUndefined();
+
+      expect(executeFile).toHaveBeenCalledWith(
+        'taskkill',
+        ['/PID', '5001', '/T', '/F'],
+        { timeout: 5_000 },
+      );
+    },
+  );
+
   it('should terminate recorded Windows descendants after the parent has already exited', async () => {
-    let snapshot = 0;
+    let fullSnapshot = 0;
     const executeFile = vi.fn(async (file: string, args: readonly string[]) => {
       if (file === 'powershell.exe') {
-        snapshot += 1;
-        return snapshot === 1
+        if (args[3]?.includes('-Filter')) {
+          const processId = args[3].includes('5002') ? 5002 : 5001;
+          return { stdout: JSON.stringify({
+            ProcessId: processId,
+            ParentProcessId: processId === 5002 ? 5001 : 4321,
+            CreationDate: `created-${processId}`,
+          }) };
+        }
+        fullSnapshot += 1;
+        return fullSnapshot === 1
           ? { stdout: JSON.stringify([
-            { ProcessId: 5001, ParentProcessId: 4321 },
-            { ProcessId: 5002, ParentProcessId: 5001 },
+            { ProcessId: 5001, ParentProcessId: 4321, CreationDate: 'created-5001' },
+            { ProcessId: 5002, ParentProcessId: 5001, CreationDate: 'created-5002' },
           ]) }
           : { stdout: '[]' };
       }
@@ -470,21 +534,73 @@ describe('prompt eval probe lifecycle', () => {
       }
       return undefined;
     });
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid) => {
-      if (pid === 4321) {
-        throw Object.assign(new Error('not found'), { code: 'ESRCH' });
+
+    await terminateWindowsProcessTree(4321, executeFile);
+
+    expect(executeFile).toHaveBeenCalledWith(
+      'taskkill',
+      ['/PID', '5002', '/T', '/F'],
+      { timeout: 5_000 },
+    );
+    expect(executeFile).toHaveBeenCalledWith(
+      'taskkill',
+      ['/PID', '5001', '/T', '/F'],
+      { timeout: 5_000 },
+    );
+  });
+
+  it('should ignore taskkill failure when a descendant PID is later reused', async () => {
+    let fullSnapshot = 0;
+    const executeFile = vi.fn(async (file: string, args: readonly string[]) => {
+      if (file === 'taskkill' && args[1] === '5001') {
+        throw new Error('taskkill failed');
       }
-      return true;
+      if (args[3]?.includes('-Filter')) {
+        return { stdout: JSON.stringify({
+          ProcessId: 5001,
+          ParentProcessId: 4321,
+          CreationDate: 'created-original',
+        }) };
+      }
+      fullSnapshot += 1;
+      return fullSnapshot === 1
+        ? { stdout: JSON.stringify({
+          ProcessId: 5001,
+          ParentProcessId: 4321,
+          CreationDate: 'created-original',
+        }) }
+        : { stdout: JSON.stringify({
+          ProcessId: 5001,
+          ParentProcessId: 9999,
+          CreationDate: 'created-reused',
+        }) };
     });
 
-    try {
-      await terminateWindowsProcessTree(4321, executeFile);
-    } finally {
-      killSpy.mockRestore();
-    }
+    await expect(terminateWindowsProcessTree(4321, executeFile)).resolves.toBeUndefined();
 
-    expect(executeFile).toHaveBeenCalledWith('taskkill', ['/PID', '5002', '/T', '/F']);
-    expect(executeFile).toHaveBeenCalledWith('taskkill', ['/PID', '5001', '/T', '/F']);
+    expect(executeFile).toHaveBeenCalledWith(
+      'taskkill',
+      ['/PID', '5001', '/T', '/F'],
+      { timeout: 5_000 },
+    );
+  });
+
+  it('should throw when a snapshotted Windows process remains alive', async () => {
+    const processSnapshot = JSON.stringify({
+      ProcessId: 4321,
+      ParentProcessId: 1000,
+      CreationDate: 'created-root',
+    });
+    const executeFile = vi.fn(async (file: string) => {
+      if (file === 'taskkill') {
+        throw new Error('taskkill failed');
+      }
+      return { stdout: processSnapshot };
+    });
+
+    await expect(terminateWindowsProcessTree(4321, executeFile)).rejects.toThrow(
+      'Windows process tree 4321 retained processes: 4321',
+    );
   });
 
   it('should stop the timed-out child and grandchild before removing the parent-owned workspace', async () => {


### PR DESCRIPTION
## 背景

PR #1350 の CI で `windows-private-artifacts` の `promptEvalProbeLifecycle.test.ts` が稀に失敗する。

```
Error: Command failed: taskkill /PID 744 /T /F
Reason: This is critical system process. Taskkill cannot end this process.
```

原因は `terminateWindowsProcessTree` の設計にある。子孫 PID をスナップショット→root を taskkill→各子孫を個別 taskkill の間に、死んだ子孫の PID が別プロセスへ再利用されると taskkill が失敗し、catch の `isProcessAlive` が「再利用した別人」を生存と誤認して throw する。

## 修正

- プロセスの同一性を (PID, CreationDate) の組で判定し、再利用 PID を別プロセスとして除外する
- root identity は spawn 直後に `--import` プリローダーと IPC handshake で取得し、identity 確定前は対象スクリプトを実行しない。「取得前に終了した child は何も spawn していない」を構造的に保証する
- 残存判定を初期スナップショットとの identity 照合へ一本化し、死んだ中間親の下に残る孫も検出する
- WMI 照会に 5 秒 timeout。identity 拒否は外側 Promise へ即時伝播し、全失敗分岐で IPC を切断して gate 待機中の child リークを防ぐ

## 検証

- 敵対レビュー6ラウンド（PID 再利用・孫残存・root 再利用・即終了 child・gate リーク等の反例を都度実行検証、最終 APPROVE）
- `promptEvalProbeLifecycle.test.ts` 64件成功（反例を回帰テスト化）
- npm test / lint / build 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * プローブおよびスモーク実行時の子プロセスと子孫プロセスを、より確実に終了できるようになりました。
  * タイムアウト、出力超過、異常終了などのエラー報告を統一し、複数の問題をまとめて確認できるようになりました。
  * Windows環境でプロセスの識別情報を確認し、安全に終了処理を行えるようになりました。

* **バグ修正**
  * プロセス終了処理や実行結果の通知が重複して発生する問題を防止しました。
  * 子プロセスの残存や終了失敗を検知し、適切にエラーとして扱えるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->