### PR TITLE
fix(workflow): built-in completion retryを一時無効化する

### DIFF
--- a/builtins/en/steps/experimental-review.yaml
+++ b/builtins/en/steps/experimental-review.yaml
@@ -13,7 +13,6 @@ params:
   coding_review_instruction: { type: facet_ref, facet_kind: instruction }
   ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction }
   frontend_review_instruction: { type: facet_ref, facet_kind: instruction }
-  completion_retry_instruction: { type: facet_ref, facet_kind: instruction }
 
 name: review
 tags: [review]
@@ -22,8 +21,6 @@ parallel:
     - name: coding-review
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: coding-reviewer
       policy:
@@ -47,8 +44,6 @@ parallel:
     - name: ai-antipattern-review
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: ai-antipattern-reviewer
       policy:
@@ -71,8 +66,6 @@ parallel:
       description: Review module structure, responsibility boundaries, dependency direction, and call paths.
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: architecture-reviewer
       policy: [contract-change, review]
@@ -88,8 +81,6 @@ parallel:
       description: Review UI, components, state management, accessibility, and presentation.
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: frontend-reviewer
       policy: [contract-change, review]
@@ -105,8 +96,6 @@ parallel:
       description: Review APIs, domain logic, server-side processing, and persistence.
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: coding-reviewer
       policy: [contract-change, review, coding]
@@ -122,8 +111,6 @@ parallel:
       description: Review authentication, authorization, input validation, secrets, dependencies, and security boundaries.
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: security-reviewer
       policy: [contract-change, security-review]
@@ -143,8 +130,6 @@ parallel:
       description: Review test coverage, test design, integration boundaries, and E2E boundaries.
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: testing-reviewer
       policy: [contract-change, review, testing]

--- a/builtins/en/steps/peer-review-cqrs-reviewer.yaml
+++ b/builtins/en/steps/peer-review-cqrs-reviewer.yaml
@@ -8,16 +8,10 @@ params:
   cqrs_es_review_instruction:
     type: facet_ref
     facet_kind: instruction
-  completion_retry_instruction:
-    type: facet_ref
-    facet_kind: instruction
 name: cqrs-es-review
 capabilities: readonly
 tags:
   - review
-completion_retry:
-  retry_instruction:
-    $param: completion_retry_instruction
 edit: false
 persona: cqrs-es-reviewer
 policy:

--- a/builtins/en/steps/peer-review-frontend-reviewer.yaml
+++ b/builtins/en/steps/peer-review-frontend-reviewer.yaml
@@ -8,16 +8,10 @@ params:
   frontend_review_instruction:
     type: facet_ref
     facet_kind: instruction
-  completion_retry_instruction:
-    type: facet_ref
-    facet_kind: instruction
 name: frontend-review
 capabilities: readonly
 tags:
   - review
-completion_retry:
-  retry_instruction:
-    $param: completion_retry_instruction
 edit: false
 persona: frontend-reviewer
 policy:

--- a/builtins/en/steps/peer-review-reviewers.yaml
+++ b/builtins/en/steps/peer-review-reviewers.yaml
@@ -20,9 +20,6 @@ params:
   ai_antipattern_review_instruction:
     type: facet_ref
     facet_kind: instruction
-  completion_retry_instruction:
-    type: facet_ref
-    facet_kind: instruction
 name: reviewers
 tags:
   - review
@@ -31,9 +28,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: architecture-reviewer
     policy:
@@ -53,9 +47,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: security-reviewer
     policy:
@@ -81,9 +72,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: testing-reviewer
     policy:
@@ -106,9 +94,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: coding-reviewer
     policy:
@@ -130,9 +115,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: ai-antipattern-reviewer
     policy:

--- a/builtins/en/steps/peer-review-suite-call.yaml
+++ b/builtins/en/steps/peer-review-suite-call.yaml
@@ -20,8 +20,6 @@ args:
     $param: frontend_review_instruction
   cqrs_es_review_instruction:
     $param: cqrs_es_review_instruction
-  completion_retry_instruction:
-    $param: completion_retry_instruction
 params:
   reviewer_suite:
     type: workflow_ref
@@ -50,8 +48,5 @@ params:
     type: facet_ref
     facet_kind: instruction
   cqrs_es_review_instruction:
-    type: facet_ref
-    facet_kind: instruction
-  completion_retry_instruction:
     type: facet_ref
     facet_kind: instruction

--- a/builtins/en/workflows/experimental-review-adapter.yaml
+++ b/builtins/en/workflows/experimental-review-adapter.yaml
@@ -20,7 +20,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: review
 steps:
   - name: review
@@ -38,7 +37,6 @@ steps:
       coding_review_instruction: { $param: coding_review_instruction }
       ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
       frontend_review_instruction: { $param: frontend_review_instruction }
-      completion_retry_instruction: { $param: completion_retry_instruction }
     rules:
       - condition: COMPLETE
         next: COMPLETE

--- a/builtins/en/workflows/experimental-review.yaml
+++ b/builtins/en/workflows/experimental-review.yaml
@@ -22,7 +22,6 @@ subworkflow:
     coding_review_instruction: { type: facet_ref, facet_kind: instruction, default: coding-review }
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 facet_pools:
   security-review-facets:
     uses: security-review-facets
@@ -43,7 +42,6 @@ steps:
       coding_review_instruction: { $param: coding_review_instruction }
       ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
       frontend_review_instruction: { $param: frontend_review_instruction }
-      completion_retry_instruction: { $param: completion_retry_instruction }
     rules:
       self:
         - condition: all("approved")

--- a/builtins/en/workflows/peer-review-suite-base.yaml
+++ b/builtins/en/workflows/peer-review-suite-base.yaml
@@ -42,10 +42,6 @@ subworkflow:
       type: facet_ref
       facet_kind: instruction
       default: cqrs-es-review
-    completion_retry_instruction:
-      type: facet_ref
-      facet_kind: instruction
-      default: review-completion-retry
 initial_step: reviewers
 steps:
   - name: reviewers
@@ -65,8 +61,6 @@ steps:
         $param: coding_review_instruction
       ai_antipattern_review_instruction:
         $param: ai_antipattern_review_instruction
-      completion_retry_instruction:
-        $param: completion_retry_instruction
     rules:
       self:
         - condition: all("approved")

--- a/builtins/en/workflows/peer-review-suite-cqrs.yaml
+++ b/builtins/en/workflows/peer-review-suite-cqrs.yaml
@@ -21,7 +21,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: reviewers
 steps:
   - name: reviewers
@@ -44,8 +43,6 @@ steps:
             $param: coding_review_instruction
           ai_antipattern_review_instruction:
             $param: ai_antipattern_review_instruction
-          completion_retry_instruction:
-            $param: completion_retry_instruction
         rules:
           - condition: COMPLETE
           - condition: needs_fix
@@ -58,8 +55,6 @@ steps:
             $param: review_knowledge_additions
           cqrs_es_review_instruction:
             $param: cqrs_es_review_instruction
-          completion_retry_instruction:
-            $param: completion_retry_instruction
         rules:
           - condition: approved
           - condition: needs_fix

--- a/builtins/en/workflows/peer-review-suite-frontend-cqrs.yaml
+++ b/builtins/en/workflows/peer-review-suite-frontend-cqrs.yaml
@@ -21,7 +21,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: reviewers
 steps:
   - name: reviewers
@@ -39,7 +38,6 @@ steps:
           testing_review_instruction: { $param: testing_review_instruction }
           coding_review_instruction: { $param: coding_review_instruction }
           ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
-          completion_retry_instruction: { $param: completion_retry_instruction }
         rules:
           - condition: COMPLETE
           - condition: needs_fix
@@ -51,7 +49,6 @@ steps:
           review_knowledge_additions:
             $param: review_knowledge_additions
           frontend_review_instruction: { $param: frontend_review_instruction }
-          completion_retry_instruction: { $param: completion_retry_instruction }
         rules:
           - condition: approved
           - condition: needs_fix
@@ -63,7 +60,6 @@ steps:
           review_knowledge_additions:
             $param: review_knowledge_additions
           cqrs_es_review_instruction: { $param: cqrs_es_review_instruction }
-          completion_retry_instruction: { $param: completion_retry_instruction }
         rules:
           - condition: approved
           - condition: needs_fix

--- a/builtins/en/workflows/peer-review-suite-frontend.yaml
+++ b/builtins/en/workflows/peer-review-suite-frontend.yaml
@@ -21,7 +21,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: reviewers
 steps:
   - name: reviewers
@@ -44,8 +43,6 @@ steps:
             $param: coding_review_instruction
           ai_antipattern_review_instruction:
             $param: ai_antipattern_review_instruction
-          completion_retry_instruction:
-            $param: completion_retry_instruction
         rules:
           - condition: COMPLETE
           - condition: needs_fix
@@ -58,8 +55,6 @@ steps:
             $param: review_knowledge_additions
           frontend_review_instruction:
             $param: frontend_review_instruction
-          completion_retry_instruction:
-            $param: completion_retry_instruction
         rules:
           - condition: approved
           - condition: needs_fix

--- a/builtins/en/workflows/peer-review.yaml
+++ b/builtins/en/workflows/peer-review.yaml
@@ -131,7 +131,6 @@ steps:
       ai_antipattern_review_instruction: initial-ai-antipattern-review
       frontend_review_instruction: frontend-review
       cqrs_es_review_instruction: cqrs-es-review
-      completion_retry_instruction: initial-review-completion-retry
     rules:
       - condition: COMPLETE
         next: review-adjudication
@@ -153,7 +152,6 @@ steps:
       ai_antipattern_review_instruction: follow-up-ai-antipattern-review
       frontend_review_instruction: follow-up-frontend-review
       cqrs_es_review_instruction: follow-up-cqrs-es-review
-      completion_retry_instruction: follow-up-review-completion-retry
     rules:
       - condition: COMPLETE
         next: review-adjudication

--- a/builtins/en/workflows/takt-experimental-review-adapter.yaml
+++ b/builtins/en/workflows/takt-experimental-review-adapter.yaml
@@ -20,7 +20,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: review
 steps:
   - name: review
@@ -38,7 +37,6 @@ steps:
       coding_review_instruction: { $param: coding_review_instruction }
       ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
       frontend_review_instruction: { $param: frontend_review_instruction }
-      completion_retry_instruction: { $param: completion_retry_instruction }
     rules:
       - condition: COMPLETE
         next: COMPLETE

--- a/builtins/en/workflows/takt-experimental-review.yaml
+++ b/builtins/en/workflows/takt-experimental-review.yaml
@@ -22,7 +22,6 @@ subworkflow:
     coding_review_instruction: { type: facet_ref, facet_kind: instruction, default: coding-review }
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 facet_pools:
   takt-security-review-facets:
     uses: takt-security-review-facets
@@ -43,15 +42,12 @@ steps:
       coding_review_instruction: { $param: coding_review_instruction }
       ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
       frontend_review_instruction: { $param: frontend_review_instruction }
-      completion_retry_instruction: { $param: completion_retry_instruction }
     parallel:
       pool:
         - name: architecture-review
           description: Review module structure, responsibility boundaries, dependency direction, and call paths.
           capabilities: readonly
           tags: [review]
-          completion_retry:
-            retry_instruction: { $param: completion_retry_instruction }
           edit: false
           persona: architecture-reviewer
           policy: [contract-change, review]
@@ -67,8 +63,6 @@ steps:
           description: Review concrete security boundaries introduced by TAKT changes.
           capabilities: readonly
           tags: [review]
-          completion_retry:
-            retry_instruction: { $param: completion_retry_instruction }
           edit: false
           persona: security-reviewer
           policy: [contract-change, security-review]
@@ -88,8 +82,6 @@ steps:
           description: Review test coverage, test design, integration boundaries, and E2E boundaries.
           capabilities: readonly
           tags: [review]
-          completion_retry:
-            retry_instruction: { $param: completion_retry_instruction }
           edit: false
           persona: testing-reviewer
           policy: [contract-change, review, testing, takt-testing]

--- a/builtins/ja/steps/experimental-review.yaml
+++ b/builtins/ja/steps/experimental-review.yaml
@@ -13,7 +13,6 @@ params:
   coding_review_instruction: { type: facet_ref, facet_kind: instruction }
   ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction }
   frontend_review_instruction: { type: facet_ref, facet_kind: instruction }
-  completion_retry_instruction: { type: facet_ref, facet_kind: instruction }
 
 name: review
 tags: [review]
@@ -22,8 +21,6 @@ parallel:
     - name: coding-review
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: coding-reviewer
       policy:
@@ -47,8 +44,6 @@ parallel:
     - name: ai-antipattern-review
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: ai-antipattern-reviewer
       policy:
@@ -71,8 +66,6 @@ parallel:
       description: モジュール構造、責務分割、依存方向、呼び出し経路をレビューする
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: architecture-reviewer
       policy: [contract-change, review]
@@ -88,8 +81,6 @@ parallel:
       description: UI、コンポーネント、状態管理、アクセシビリティをレビューする
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: frontend-reviewer
       policy: [contract-change, review]
@@ -105,8 +96,6 @@ parallel:
       description: API、ドメインロジック、サーバー側処理、永続化をレビューする
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: coding-reviewer
       policy: [contract-change, review, coding]
@@ -122,8 +111,6 @@ parallel:
       description: 認証認可、入力検証、機密情報、依存関係、セキュリティ境界をレビューする
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: security-reviewer
       policy: [contract-change, security-review]
@@ -143,8 +130,6 @@ parallel:
       description: テストカバレッジ、テスト設計、統合境界、E2E境界をレビューする
       capabilities: readonly
       tags: [review]
-      completion_retry:
-        retry_instruction: { $param: completion_retry_instruction }
       edit: false
       persona: testing-reviewer
       policy: [contract-change, review, testing]

--- a/builtins/ja/steps/peer-review-cqrs-reviewer.yaml
+++ b/builtins/ja/steps/peer-review-cqrs-reviewer.yaml
@@ -8,16 +8,10 @@ params:
   cqrs_es_review_instruction:
     type: facet_ref
     facet_kind: instruction
-  completion_retry_instruction:
-    type: facet_ref
-    facet_kind: instruction
 name: cqrs-es-review
 capabilities: readonly
 tags:
   - review
-completion_retry:
-  retry_instruction:
-    $param: completion_retry_instruction
 edit: false
 persona: cqrs-es-reviewer
 policy:

--- a/builtins/ja/steps/peer-review-frontend-reviewer.yaml
+++ b/builtins/ja/steps/peer-review-frontend-reviewer.yaml
@@ -8,16 +8,10 @@ params:
   frontend_review_instruction:
     type: facet_ref
     facet_kind: instruction
-  completion_retry_instruction:
-    type: facet_ref
-    facet_kind: instruction
 name: frontend-review
 capabilities: readonly
 tags:
   - review
-completion_retry:
-  retry_instruction:
-    $param: completion_retry_instruction
 edit: false
 persona: frontend-reviewer
 policy:

--- a/builtins/ja/steps/peer-review-reviewers.yaml
+++ b/builtins/ja/steps/peer-review-reviewers.yaml
@@ -20,9 +20,6 @@ params:
   ai_antipattern_review_instruction:
     type: facet_ref
     facet_kind: instruction
-  completion_retry_instruction:
-    type: facet_ref
-    facet_kind: instruction
 name: reviewers
 tags:
   - review
@@ -31,9 +28,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: architecture-reviewer
     policy:
@@ -53,9 +47,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: security-reviewer
     policy:
@@ -81,9 +72,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: testing-reviewer
     policy:
@@ -106,9 +94,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: coding-reviewer
     policy:
@@ -130,9 +115,6 @@ parallel:
     capabilities: readonly
     tags:
       - review
-    completion_retry:
-      retry_instruction:
-        $param: completion_retry_instruction
     edit: false
     persona: ai-antipattern-reviewer
     policy:

--- a/builtins/ja/steps/peer-review-suite-call.yaml
+++ b/builtins/ja/steps/peer-review-suite-call.yaml
@@ -20,8 +20,6 @@ args:
     $param: frontend_review_instruction
   cqrs_es_review_instruction:
     $param: cqrs_es_review_instruction
-  completion_retry_instruction:
-    $param: completion_retry_instruction
 params:
   reviewer_suite:
     type: workflow_ref
@@ -50,8 +48,5 @@ params:
     type: facet_ref
     facet_kind: instruction
   cqrs_es_review_instruction:
-    type: facet_ref
-    facet_kind: instruction
-  completion_retry_instruction:
     type: facet_ref
     facet_kind: instruction

--- a/builtins/ja/workflows/experimental-review-adapter.yaml
+++ b/builtins/ja/workflows/experimental-review-adapter.yaml
@@ -20,7 +20,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: review
 steps:
   - name: review
@@ -38,7 +37,6 @@ steps:
       coding_review_instruction: { $param: coding_review_instruction }
       ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
       frontend_review_instruction: { $param: frontend_review_instruction }
-      completion_retry_instruction: { $param: completion_retry_instruction }
     rules:
       - condition: COMPLETE
         next: COMPLETE

--- a/builtins/ja/workflows/experimental-review.yaml
+++ b/builtins/ja/workflows/experimental-review.yaml
@@ -22,7 +22,6 @@ subworkflow:
     coding_review_instruction: { type: facet_ref, facet_kind: instruction, default: coding-review }
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 facet_pools:
   security-review-facets:
     uses: security-review-facets
@@ -43,7 +42,6 @@ steps:
       coding_review_instruction: { $param: coding_review_instruction }
       ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
       frontend_review_instruction: { $param: frontend_review_instruction }
-      completion_retry_instruction: { $param: completion_retry_instruction }
     rules:
       self:
         - condition: all("approved")

--- a/builtins/ja/workflows/peer-review-suite-base.yaml
+++ b/builtins/ja/workflows/peer-review-suite-base.yaml
@@ -42,10 +42,6 @@ subworkflow:
       type: facet_ref
       facet_kind: instruction
       default: cqrs-es-review
-    completion_retry_instruction:
-      type: facet_ref
-      facet_kind: instruction
-      default: review-completion-retry
 initial_step: reviewers
 steps:
   - name: reviewers
@@ -65,8 +61,6 @@ steps:
         $param: coding_review_instruction
       ai_antipattern_review_instruction:
         $param: ai_antipattern_review_instruction
-      completion_retry_instruction:
-        $param: completion_retry_instruction
     rules:
       self:
         - condition: all("approved")

--- a/builtins/ja/workflows/peer-review-suite-cqrs.yaml
+++ b/builtins/ja/workflows/peer-review-suite-cqrs.yaml
@@ -21,7 +21,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: reviewers
 steps:
   - name: reviewers
@@ -44,8 +43,6 @@ steps:
             $param: coding_review_instruction
           ai_antipattern_review_instruction:
             $param: ai_antipattern_review_instruction
-          completion_retry_instruction:
-            $param: completion_retry_instruction
         rules:
           - condition: COMPLETE
           - condition: needs_fix
@@ -58,8 +55,6 @@ steps:
             $param: review_knowledge_additions
           cqrs_es_review_instruction:
             $param: cqrs_es_review_instruction
-          completion_retry_instruction:
-            $param: completion_retry_instruction
         rules:
           - condition: approved
           - condition: needs_fix

--- a/builtins/ja/workflows/peer-review-suite-frontend-cqrs.yaml
+++ b/builtins/ja/workflows/peer-review-suite-frontend-cqrs.yaml
@@ -21,7 +21,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: reviewers
 steps:
   - name: reviewers
@@ -39,7 +38,6 @@ steps:
           testing_review_instruction: { $param: testing_review_instruction }
           coding_review_instruction: { $param: coding_review_instruction }
           ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
-          completion_retry_instruction: { $param: completion_retry_instruction }
         rules:
           - condition: COMPLETE
           - condition: needs_fix
@@ -51,7 +49,6 @@ steps:
           review_knowledge_additions:
             $param: review_knowledge_additions
           frontend_review_instruction: { $param: frontend_review_instruction }
-          completion_retry_instruction: { $param: completion_retry_instruction }
         rules:
           - condition: approved
           - condition: needs_fix
@@ -63,7 +60,6 @@ steps:
           review_knowledge_additions:
             $param: review_knowledge_additions
           cqrs_es_review_instruction: { $param: cqrs_es_review_instruction }
-          completion_retry_instruction: { $param: completion_retry_instruction }
         rules:
           - condition: approved
           - condition: needs_fix

--- a/builtins/ja/workflows/peer-review-suite-frontend.yaml
+++ b/builtins/ja/workflows/peer-review-suite-frontend.yaml
@@ -21,7 +21,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: reviewers
 steps:
   - name: reviewers
@@ -44,8 +43,6 @@ steps:
             $param: coding_review_instruction
           ai_antipattern_review_instruction:
             $param: ai_antipattern_review_instruction
-          completion_retry_instruction:
-            $param: completion_retry_instruction
         rules:
           - condition: COMPLETE
           - condition: needs_fix
@@ -58,8 +55,6 @@ steps:
             $param: review_knowledge_additions
           frontend_review_instruction:
             $param: frontend_review_instruction
-          completion_retry_instruction:
-            $param: completion_retry_instruction
         rules:
           - condition: approved
           - condition: needs_fix

--- a/builtins/ja/workflows/peer-review.yaml
+++ b/builtins/ja/workflows/peer-review.yaml
@@ -131,7 +131,6 @@ steps:
       ai_antipattern_review_instruction: initial-ai-antipattern-review
       frontend_review_instruction: frontend-review
       cqrs_es_review_instruction: cqrs-es-review
-      completion_retry_instruction: initial-review-completion-retry
     rules:
       - condition: COMPLETE
         next: review-adjudication
@@ -153,7 +152,6 @@ steps:
       ai_antipattern_review_instruction: follow-up-ai-antipattern-review
       frontend_review_instruction: follow-up-frontend-review
       cqrs_es_review_instruction: follow-up-cqrs-es-review
-      completion_retry_instruction: follow-up-review-completion-retry
     rules:
       - condition: COMPLETE
         next: review-adjudication

--- a/builtins/ja/workflows/takt-experimental-review-adapter.yaml
+++ b/builtins/ja/workflows/takt-experimental-review-adapter.yaml
@@ -20,7 +20,6 @@ subworkflow:
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
     cqrs_es_review_instruction: { type: facet_ref, facet_kind: instruction, default: cqrs-es-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 initial_step: review
 steps:
   - name: review
@@ -38,7 +37,6 @@ steps:
       coding_review_instruction: { $param: coding_review_instruction }
       ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
       frontend_review_instruction: { $param: frontend_review_instruction }
-      completion_retry_instruction: { $param: completion_retry_instruction }
     rules:
       - condition: COMPLETE
         next: COMPLETE

--- a/builtins/ja/workflows/takt-experimental-review.yaml
+++ b/builtins/ja/workflows/takt-experimental-review.yaml
@@ -22,7 +22,6 @@ subworkflow:
     coding_review_instruction: { type: facet_ref, facet_kind: instruction, default: coding-review }
     ai_antipattern_review_instruction: { type: facet_ref, facet_kind: instruction, default: ai-antipattern-review }
     frontend_review_instruction: { type: facet_ref, facet_kind: instruction, default: frontend-review }
-    completion_retry_instruction: { type: facet_ref, facet_kind: instruction, default: review-completion-retry }
 facet_pools:
   takt-security-review-facets:
     uses: takt-security-review-facets
@@ -43,15 +42,12 @@ steps:
       coding_review_instruction: { $param: coding_review_instruction }
       ai_antipattern_review_instruction: { $param: ai_antipattern_review_instruction }
       frontend_review_instruction: { $param: frontend_review_instruction }
-      completion_retry_instruction: { $param: completion_retry_instruction }
     parallel:
       pool:
         - name: architecture-review
           description: モジュール構造、責務分割、依存方向、呼び出し経路をレビューする
           capabilities: readonly
           tags: [review]
-          completion_retry:
-            retry_instruction: { $param: completion_retry_instruction }
           edit: false
           persona: architecture-reviewer
           policy: [contract-change, review]
@@ -67,8 +63,6 @@ steps:
           description: TAKTの変更で生じる具体的なセキュリティ境界をレビューする
           capabilities: readonly
           tags: [review]
-          completion_retry:
-            retry_instruction: { $param: completion_retry_instruction }
           edit: false
           persona: security-reviewer
           policy: [contract-change, security-review]
@@ -88,8 +82,6 @@ steps:
           description: テストカバレッジ、テスト設計、統合境界、E2E境界をレビューする
           capabilities: readonly
           tags: [review]
-          completion_retry:
-            retry_instruction: { $param: completion_retry_instruction }
           edit: false
           persona: testing-reviewer
           policy: [contract-change, review, testing, takt-testing]

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -254,33 +254,6 @@ function expectResolvedReviewerInstructions(
   }
 }
 
-function expectResolvedCompletionRetryInstruction(
-  language: 'en' | 'ja',
-  reviewerCall: WorkflowStep,
-  reviewerSteps: readonly ReviewerStepReference[],
-  projectDir: string,
-): string {
-  const instructionRef = reviewerCall.args?.completion_retry_instruction;
-  if (typeof instructionRef !== 'string') {
-    throw new Error(`Completion retry instruction argument not found for "${reviewerCall.name}"`);
-  }
-  const resolvedInstruction = resolveRefToContent(
-    instructionRef,
-    undefined,
-    projectDir,
-    'instructions',
-    { projectDir, lang: language },
-  );
-  if (typeof resolvedInstruction !== 'string') {
-    throw new Error(`Completion retry instruction "${instructionRef}" could not be resolved`);
-  }
-  expect(resolvedInstruction).not.toBe('');
-  for (const { step } of reviewerSteps) {
-    expect(step.completionRetry?.retryInstruction).toBe(resolvedInstruction);
-  }
-  return resolvedInstruction;
-}
-
 function collectReviewerSteps(
   language: 'en' | 'ja',
   workflow: WorkflowConfig,
@@ -594,22 +567,6 @@ describe('experimental builtin workflow', () => {
           expect(initialInstruction).not.toBe('');
           expect(followUpReviewers.get(reviewer)).not.toBe(initialInstruction);
         }
-        const initialRetryInstruction = expectResolvedCompletionRetryInstruction(
-          language,
-          reviewerCalls[0]!,
-          initialReviewerSteps,
-          projectDir,
-        );
-        const followUpRetryInstruction = expectResolvedCompletionRetryInstruction(
-          language,
-          reviewerCalls[1]!,
-          followUpReviewerSteps,
-          projectDir,
-        );
-        expect(reviewerCalls[0]!.args?.completion_retry_instruction)
-          .not.toBe(reviewerCalls[1]!.args?.completion_retry_instruction);
-        expect(initialRetryInstruction).not.toBe(followUpRetryInstruction);
-
         const reviewerSuite = initialSuite!;
         const securityReview = findWorkflowStep(reviewerSuite, 'security-review');
         const poolName = securityReview.dynamicFacets?.pool;


### PR DESCRIPTION
## Summary

組み込みの reviewer workflow から `completion_retry` を一時的に無効化します。

- 英語・日本語の標準／experimental reviewer 設定から `completion_retry` を削除
- workflow 間の `completion_retry_instruction` パラメータ受け渡しを削除
- 組み込み YAML の当該設定を固定していた既存テストを削除
- エンジン、スキーマ、カスタム workflow 向け機能は維持

`implement` と `fix` には元から `completion_retry` が設定されていないため、変更はありません。

## Why

reviewer の completion retry が繰り返し実行され、provider の wall-clock deadline を使い切って後続の判定エラーにつながるケースが確認されました。収束条件と証拠の渡し方を次期リリースで再検討するまで、組み込み workflow では利用しません。

Related to #1352

## Verification

- `npm run build`
- `npm run lint`
- `npm test`
- `npm run test:it`
- `npm test -- src/__tests__/it-experimental-workflow.test.ts`
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts`

`npm run test:e2e:mock` は途中まで実行し、依頼により完了を待たず停止しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * レビュー完了時の自動リトライ指示を削除しました。
  * 英語・日本語の各種レビューで、関連するリトライ設定と引数を廃止しました。
  * 初回レビュー、フォローアップ、判定、修復などの主要なレビュー処理は従来どおりです。

* **テスト**
  * 完了時リトライ設定に関する検証を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->