### PR TITLE
fix(engine): ラン全損を防ぐ3つの耐性修正（無応答deadline・requeue採番継続・error受けルール）

### DIFF
--- a/builtins/en/workflows/compound-eye.yaml
+++ b/builtins/en/workflows/compound-eye.yaml
@@ -75,6 +75,8 @@ steps:
                 - {action}
                 ```
     rules:
+      - condition: any("error")
+        next: evaluate
       - condition: any("done")
         next: synthesize
   - name: synthesize
@@ -94,8 +96,8 @@ steps:
       1. Read reports in the Report Directory
          - `eye1-review.md` (eye 1's response)
          - `eye2-review.md` (eye 2's response)
-         Note: If one report is missing (that eye failed), synthesize from the available report only
-      2. If both reports exist, compare and clarify:
+         Both reports are required; the evaluate step retries when either eye ends in error.
+      2. Compare and clarify:
          - Points of agreement
          - Points of disagreement
          - Points mentioned by only one eye

--- a/builtins/en/workflows/experimental-review.yaml
+++ b/builtins/en/workflows/experimental-review.yaml
@@ -46,6 +46,8 @@ steps:
       review_completion_retry_instruction: { $param: review_completion_retry_instruction }
     rules:
       self:
+        - condition: any("error")
+          next: review
         - condition: all("approved")
           next: COMPLETE
         - condition: any("needs_fix")

--- a/builtins/en/workflows/mini-core.yaml
+++ b/builtins/en/workflows/mini-core.yaml
@@ -133,6 +133,8 @@ steps:
               format: supervisor-summary
               use_judge: false
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: any("BLOCKED")
         next: ABORT
       - condition: all("No AI-specific issues", "All checks passed")

--- a/builtins/en/workflows/peer-review-suite-base.yaml
+++ b/builtins/en/workflows/peer-review-suite-base.yaml
@@ -69,6 +69,8 @@ steps:
         $param: review_completion_retry_instruction
     rules:
       self:
+        - condition: any("error")
+          next: reviewers
         - condition: all("approved")
           next: COMPLETE
         - condition: any("needs_fix")

--- a/builtins/en/workflows/peer-review-suite-cqrs.yaml
+++ b/builtins/en/workflows/peer-review-suite-cqrs.yaml
@@ -64,6 +64,8 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("COMPLETE", "approved")
         next: COMPLETE
       - condition: any("needs_fix")

--- a/builtins/en/workflows/peer-review-suite-frontend-cqrs.yaml
+++ b/builtins/en/workflows/peer-review-suite-frontend-cqrs.yaml
@@ -68,6 +68,8 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("COMPLETE", "approved", "approved")
         next: COMPLETE
       - condition: any("needs_fix")

--- a/builtins/en/workflows/peer-review-suite-frontend.yaml
+++ b/builtins/en/workflows/peer-review-suite-frontend.yaml
@@ -64,6 +64,8 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("COMPLETE", "approved")
         next: COMPLETE
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-backend-cqrs.yaml
+++ b/builtins/en/workflows/review-backend-cqrs.yaml
@@ -97,6 +97,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-backend.yaml
+++ b/builtins/en/workflows/review-backend.yaml
@@ -76,6 +76,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-default.yaml
+++ b/builtins/en/workflows/review-default.yaml
@@ -100,6 +100,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-dual-cqrs.yaml
+++ b/builtins/en/workflows/review-dual-cqrs.yaml
@@ -118,6 +118,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-dual.yaml
+++ b/builtins/en/workflows/review-dual.yaml
@@ -97,6 +97,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-fix-backend-cqrs.yaml
+++ b/builtins/en/workflows/review-fix-backend-cqrs.yaml
@@ -113,6 +113,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-fix-backend.yaml
+++ b/builtins/en/workflows/review-fix-backend.yaml
@@ -92,6 +92,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-fix-default.yaml
+++ b/builtins/en/workflows/review-fix-default.yaml
@@ -116,6 +116,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-fix-dual-cqrs.yaml
+++ b/builtins/en/workflows/review-fix-dual-cqrs.yaml
@@ -134,6 +134,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-fix-dual.yaml
+++ b/builtins/en/workflows/review-fix-dual.yaml
@@ -113,6 +113,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-fix-frontend.yaml
+++ b/builtins/en/workflows/review-fix-frontend.yaml
@@ -112,6 +112,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-frontend.yaml
+++ b/builtins/en/workflows/review-frontend.yaml
@@ -96,6 +96,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/en/workflows/review-takt-default.yaml
+++ b/builtins/en/workflows/review-takt-default.yaml
@@ -121,6 +121,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/en/workflows/takt-experimental-review.yaml
+++ b/builtins/en/workflows/takt-experimental-review.yaml
@@ -103,6 +103,8 @@ steps:
                 format: testing-review
     rules:
       self:
+        - condition: any("error")
+          next: review
         - condition: all("approved")
           next: COMPLETE
         - condition: any("needs_fix")

--- a/builtins/en/workflows/terraform.yaml
+++ b/builtins/en/workflows/terraform.yaml
@@ -115,6 +115,8 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("Complies with Terraform conventions", "No AI-specific issues", "approved")
         next: merge-readiness-review
       - condition: any("Convention violations found", "AI-specific issues found", "needs_fix")

--- a/builtins/ja/workflows/compound-eye.yaml
+++ b/builtins/ja/workflows/compound-eye.yaml
@@ -75,6 +75,8 @@ steps:
                 - {アクション}
                 ```
     rules:
+      - condition: any("error")
+        next: evaluate
       - condition: any("done")
         next: synthesize
   - name: synthesize
@@ -93,8 +95,8 @@ steps:
       1. Report Directory のレポートを読む
          - `eye1-review.md`（eye 1 の回答）
          - `eye2-review.md`（eye 2 の回答）
-         注意: 片方のレポートが無い場合（その eye が失敗した場合）は、あるレポートだけで統合する
-      2. 両方のレポートがある場合、比較して明確にする:
+         両方のレポートが必須であり、いずれかの eye が error なら evaluate ステップを再試行する。
+      2. 両方のレポートを比較して明確にする:
          - 一致している点
          - 食い違っている点
          - 片方だけが言及している点

--- a/builtins/ja/workflows/experimental-review.yaml
+++ b/builtins/ja/workflows/experimental-review.yaml
@@ -46,6 +46,8 @@ steps:
       review_completion_retry_instruction: { $param: review_completion_retry_instruction }
     rules:
       self:
+        - condition: any("error")
+          next: review
         - condition: all("approved")
           next: COMPLETE
         - condition: any("needs_fix")

--- a/builtins/ja/workflows/mini-core.yaml
+++ b/builtins/ja/workflows/mini-core.yaml
@@ -133,6 +133,8 @@ steps:
               format: supervisor-summary
               use_judge: false
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: any("BLOCKED")
         next: ABORT
       - condition: all("AI特有の問題なし", "すべて問題なし")

--- a/builtins/ja/workflows/peer-review-suite-base.yaml
+++ b/builtins/ja/workflows/peer-review-suite-base.yaml
@@ -69,6 +69,8 @@ steps:
         $param: review_completion_retry_instruction
     rules:
       self:
+        - condition: any("error")
+          next: reviewers
         - condition: all("approved")
           next: COMPLETE
         - condition: any("needs_fix")

--- a/builtins/ja/workflows/peer-review-suite-cqrs.yaml
+++ b/builtins/ja/workflows/peer-review-suite-cqrs.yaml
@@ -64,6 +64,8 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("COMPLETE", "approved")
         next: COMPLETE
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/peer-review-suite-frontend-cqrs.yaml
+++ b/builtins/ja/workflows/peer-review-suite-frontend-cqrs.yaml
@@ -68,6 +68,8 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("COMPLETE", "approved", "approved")
         next: COMPLETE
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/peer-review-suite-frontend.yaml
+++ b/builtins/ja/workflows/peer-review-suite-frontend.yaml
@@ -64,6 +64,8 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("COMPLETE", "approved")
         next: COMPLETE
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-backend-cqrs.yaml
+++ b/builtins/ja/workflows/review-backend-cqrs.yaml
@@ -97,6 +97,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-backend.yaml
+++ b/builtins/ja/workflows/review-backend.yaml
@@ -76,6 +76,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-default.yaml
+++ b/builtins/ja/workflows/review-default.yaml
@@ -100,6 +100,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-dual-cqrs.yaml
+++ b/builtins/ja/workflows/review-dual-cqrs.yaml
@@ -118,6 +118,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-dual.yaml
+++ b/builtins/ja/workflows/review-dual.yaml
@@ -97,6 +97,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-fix-backend-cqrs.yaml
+++ b/builtins/ja/workflows/review-fix-backend-cqrs.yaml
@@ -113,6 +113,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-fix-backend.yaml
+++ b/builtins/ja/workflows/review-fix-backend.yaml
@@ -92,6 +92,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-fix-default.yaml
+++ b/builtins/ja/workflows/review-fix-default.yaml
@@ -116,6 +116,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-fix-dual-cqrs.yaml
+++ b/builtins/ja/workflows/review-fix-dual-cqrs.yaml
@@ -134,6 +134,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-fix-dual.yaml
+++ b/builtins/ja/workflows/review-fix-dual.yaml
@@ -113,6 +113,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-fix-frontend.yaml
+++ b/builtins/ja/workflows/review-fix-frontend.yaml
@@ -112,6 +112,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: final-gate
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-frontend.yaml
+++ b/builtins/ja/workflows/review-frontend.yaml
@@ -96,6 +96,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/review-takt-default.yaml
+++ b/builtins/ja/workflows/review-takt-default.yaml
@@ -121,6 +121,8 @@ steps:
           - condition: needs_fix
 
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("approved")
         next: merge-readiness-review
       - condition: any("needs_fix")

--- a/builtins/ja/workflows/takt-experimental-review.yaml
+++ b/builtins/ja/workflows/takt-experimental-review.yaml
@@ -103,6 +103,8 @@ steps:
                 format: testing-review
     rules:
       self:
+        - condition: any("error")
+          next: review
         - condition: all("approved")
           next: COMPLETE
         - condition: any("needs_fix")

--- a/builtins/ja/workflows/terraform.yaml
+++ b/builtins/ja/workflows/terraform.yaml
@@ -115,6 +115,8 @@ steps:
           - condition: approved
           - condition: needs_fix
     rules:
+      - condition: any("error")
+        next: reviewers
       - condition: all("Terraform規約に準拠", "AI特有の問題なし", "approved")
         next: merge-readiness-review
       - condition: any("規約違反あり", "AI特有の問題あり", "needs_fix")

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -325,9 +325,11 @@ steps:
 
 `provider_options.pi` は、`extensions` や `no_*` の探索制御など、Pi リソースを読み込むための別経路です。これらの option は認証、model、thinking level を宣言するものではありません。明示したリソース source は TAKT 実行時だけ temporary resolution され、Pi settings には永続化されません。リソースの信頼境界については [Pi のリソース読み込み](#pi-resource-loading) を参照してください。
 
-### プロバイダ call deadline と OpenCode 実行ガード
+### プロバイダ無応答 deadline と OpenCode 実行ガード
 
-全 provider の call-wide wall-clock deadline は `guards.call_timeout_ms` で設定します。
+全 provider で観測可能な provider event が届かない時間の上限は
+`guards.call_timeout_ms` で設定します。stream/tool event、phase 完了、新しい provider
+試行の開始ごとにタイマーをリセットし、累積実行時間には上限を設けません。
 対象は `codex`、`opencode`、`claude`（`claude-sdk` を含む）、`claude_terminal`、
 `cursor`、`copilot`、`kiro`、`pi` です。値は 60,000〜86,400,000 ms の整数で、
 未指定時は 3,600,000 ms（60 分）です。通常の `provider_options` profile 解決を経て
@@ -342,18 +344,16 @@ steps:
 各 leaf は provider option の各レイヤー間で個別にマージされますが、上位優先度の
 `model_profiles` は下位の map 全体を置換します。
 
-OpenCode の単一 call には既定で 3,600,000 ms（60分）の wall-clock 上限があります。
-60分を超える可能性がある call は、60,000〜86,400,000 の
-`call_timeout_ms` を明示してください。テストスイートの実行のような長時間の作業を
-含む step は、この上限に達して切断されます。`event_limit` の既定値は 500,000 で、
+OpenCode の単一 call には既定で 3,600,000 ms（60分）の provider event 無応答上限が
+あります。event が継続して届く健全な call は60分を超えて実行できます。
+`event_limit` の既定値は 500,000 で、
 `TAKT_OPENCODE_STREAM_EVENT_LIMIT` でも上書きできます。`text_byte_limit` の既定値は 1 MiB、
 `reasoning_byte_limit` は 4 MiB です。
 
-OpenCode の output-idle watchdog は既定で無効です。OpenCode は tool_use から
-tool_result までイベントを流さないことがあり、推論や長時間のツール実行中の無音を
-idle と誤認し得るためです。出力がない call も `call_timeout_ms` の wall-clock 上限で
-終了します。発行間隔を認証できる transport だけが、provider/model 単位の明示的な
-追加 watchdog を有効化できます。
+この上限は provider から実際に届く event を観測し、TAKT は keepalive を合成しません。
+OpenCode では tool の実行開始 event から終端 event までを in-flight として追跡し、その間は
+通常の無応答判定を停止します。終端 event が欠落した完全ハングを無界に待たないよう、
+in-flight 状態自体は `call_timeout_ms` の6倍で stale と判定し、`PART_TIMEOUT` で終了します。
 
 数値上限の不正値は入力経路で扱いが異なります。`guards.*` に書いた値（および
 `TAKT_PROVIDER_OPTIONS_*` 由来の値）は宣言された設定なので、正の整数でなければ

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -325,9 +325,11 @@ The `provider` and `model` declarations select the provider, model, and thinking
 
 `provider_options.pi` is a separate path for loading Pi resources such as `extensions` and `no_*` discovery controls. These options do not declare authentication, model, or thinking level. Explicit resource sources are resolved temporarily for the TAKT run and are not persisted to Pi settings; see [Pi resource loading](#pi-resource-loading) for the resource trust boundary.
 
-### Provider call deadline and OpenCode execution guards
+### Provider inactivity deadline and OpenCode execution guards
 
-Every provider uses `guards.call_timeout_ms` for its call-wide wall-clock deadline.
+Every provider uses `guards.call_timeout_ms` as its maximum period without an
+observable provider event. Each stream/tool event, phase completion, and new
+provider attempt resets the timer; cumulative execution time is not capped.
 It applies to `codex`, `opencode`, `claude` (including `claude-sdk`),
 `claude_terminal`, `cursor`, `copilot`, `kiro`, and `pi`. Values are integer
 milliseconds from 60,000 through 86,400,000; the default is 3,600,000 ms
@@ -344,19 +346,18 @@ wildcard. Guard leaves merge independently across provider-option layers, while
 each higher-priority `model_profiles` value replaces the complete lower-priority
 map.
 
-Each OpenCode call has a 3,600,000 ms (60 minute) wall-clock limit. A call that
-may run longer than 60 minutes — a step that runs a full test suite, for
-example — must explicitly set `call_timeout_ms` from 60,000 through 86,400,000.
+Each OpenCode call has a 3,600,000 ms (60 minute) provider-event inactivity
+limit. A healthy call may run longer while events continue to arrive.
 `event_limit` defaults to 500,000 and can be overridden by
 `TAKT_OPENCODE_STREAM_EVENT_LIMIT`. `text_byte_limit` defaults to 1 MiB and
 `reasoning_byte_limit` to 4 MiB.
 
-The OpenCode output-idle watchdog is disabled by default. OpenCode may emit no
-events between tool_use and tool_result, so treating silence during reasoning
-or a long-running tool as inactivity can terminate a healthy call. Calls with
-no output are instead bounded by the `call_timeout_ms` wall-clock limit. An
-additional provider/model-specific watchdog may be enabled only for a transport
-whose emission interval has been authenticated.
+The timeout observes provider events as delivered; TAKT does not synthesize
+keepalives. OpenCode tracks the interval from a tool-start event through its
+terminal event as in-flight and suspends the ordinary inactivity check during
+that interval. To keep a missing terminal event or complete hang bounded, the
+in-flight state becomes stale after six times `call_timeout_ms` and ends as
+`PART_TIMEOUT`.
 
 Invalid numeric limits are treated differently per input path. Values written
 under `guards.*` (including those from `TAKT_PROVIDER_OPTIONS_*`) are declared

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -871,8 +871,8 @@ promotion は並列サブ step ではサポートされません。
 | `provider_options.claude.skills.enabled` | `false` | `claude-sdk`、`claude`、`claude-terminal` の Claude filesystem Skill 探索を有効化する（[configuration ガイド](./configuration.ja.md#claude-skill-の継承-skills) 参照） |
 | `provider_options.opencode.allowed_tools` | - | OpenCode のツール許可リスト。ツール名は `read`, `glob`, `grep`, `bash`, `websearch`, `webfetch` のように lowercase |
 | `provider_options.opencode.variant` | - | OpenCode の model variant。プロバイダー / model 固有の文字列としてパススルー |
-| `provider_options.opencode.guards` | `standard` / 60分 | OpenCode の guard profile、先勝ちの `model_profiles`、call wall-clock、text/reasoning byte 上限（[configuration ガイド](./configuration.ja.md#プロバイダ-call-deadline-と-opencode-実行ガード)参照） |
-| `provider_options.*.guards.call_timeout_ms` | 60分 | `codex`、`opencode`、`claude`、`claude_terminal`、`cursor`、`copilot`、`kiro`、`pi` の call-wide wall-clock deadline |
+| `provider_options.opencode.guards` | `standard` / 60分 | OpenCode の guard profile、先勝ちの `model_profiles`、provider event の無応答上限、text/reasoning byte 上限（[configuration ガイド](./configuration.ja.md#プロバイダ無応答-deadline-と-opencode-実行ガード)参照） |
+| `provider_options.*.guards.call_timeout_ms` | 60分 | `codex`、`opencode`、`claude`、`claude_terminal`、`cursor`、`copilot`、`kiro`、`pi` で観測可能な provider event が届かない時間の上限。event 到達と provider 試行開始ごとにタイマーをリセットする |
 | `provider_options.codex.base_url` | - | Codex SDK constructor option 用の OpenAI 互換 base URL（[configuration ガイド](./configuration.ja.md#provider-base-url-base_url) 参照） |
 | `provider_options.codex.network_access` | - | Codex サンドボックスからのネットワークアクセスを許可（[configuration ガイド](./configuration.ja.md#ネットワークアクセス-network_access) 参照） |
 | `provider_options.codex.reasoning_effort` | - | Codex の provider 固有 reasoning effort 文字列。TAKT は値を provider へそのまま渡す |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -872,8 +872,8 @@ Promotion is not supported on parallel sub-steps.
 | `provider_options.claude.skills.enabled` | `false` | Enable Claude filesystem Skill discovery for `claude-sdk`, `claude`, and `claude-terminal` (see [configuration guide](./configuration.md#claude-skill-inheritance-skills)) |
 | `provider_options.opencode.allowed_tools` | - | OpenCode tool allowlist. Tool names are lowercase, for example `read`, `glob`, `grep`, `bash`, `websearch`, `webfetch` |
 | `provider_options.opencode.variant` | - | OpenCode model variant, passed through as a provider/model-specific string |
-| `provider_options.opencode.guards` | `standard` / 60 minutes | OpenCode guard profile, first-match `model_profiles`, call wall-clock, and text/reasoning byte limits (see [configuration guide](./configuration.md#provider-call-deadline-and-opencode-execution-guards)) |
-| `provider_options.*.guards.call_timeout_ms` | 60 minutes | Call-wide wall-clock deadline for every provider profile (`codex`, `opencode`, `claude`, `claude_terminal`, `cursor`, `copilot`, `kiro`, and `pi`) |
+| `provider_options.opencode.guards` | `standard` / 60 minutes | OpenCode guard profile, first-match `model_profiles`, provider-event inactivity timeout, and text/reasoning byte limits (see [configuration guide](./configuration.md#provider-inactivity-deadline-and-opencode-execution-guards)) |
+| `provider_options.*.guards.call_timeout_ms` | 60 minutes | Maximum silence between observable provider events for every provider profile (`codex`, `opencode`, `claude`, `claude_terminal`, `cursor`, `copilot`, `kiro`, and `pi`); each event and provider attempt start resets the timer |
 | `provider_options.codex.base_url` | - | OpenAI-compatible base URL for Codex SDK constructor options (see [configuration guide](./configuration.md#provider-base-url-base_url)) |
 | `provider_options.codex.network_access` | - | Allow Codex sandbox to access the network (see [configuration guide](./configuration.md#network-access-network_access)) |
 | `provider_options.codex.reasoning_effort` | - | Provider-specific Codex reasoning effort string, passed through to the provider |

--- a/src/__tests__/abort-signal.test.ts
+++ b/src/__tests__/abort-signal.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildAbortSignal } from '../core/workflow/engine/abort-signal.js';
+import { buildAbortSignal, buildInactivityAbortSignal } from '../core/workflow/engine/abort-signal.js';
+import { recordWorkflowStepProviderEventActivity } from '../core/workflow/engine/step-deadline.js';
+import { STALE_IN_FLIGHT_TOOL_FACTOR } from '../shared/types/provider-deadline.js';
 
 describe('buildAbortSignal', () => {
   beforeEach(() => {
@@ -64,5 +66,99 @@ describe('buildAbortSignal', () => {
     expect(addSpy).not.toHaveBeenCalled();
 
     dispose();
+  });
+});
+
+describe('buildInactivityAbortSignal', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('活動のたびに無応答期限を更新する', () => {
+    const deadline = buildInactivityAbortSignal(100, undefined);
+
+    vi.advanceTimersByTime(90);
+    deadline.recordActivity();
+    vi.advanceTimersByTime(90);
+    expect(deadline.signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(10);
+    expect(deadline.signal.aborted).toBe(true);
+    expect((deadline.signal.reason as Error).message).toBe('Part timeout after 100ms');
+    deadline.dispose();
+  });
+
+  it('in-flight tool 中は通常期限を停止し、stale 上限で abort する', () => {
+    const timeoutMs = 100;
+    const deadline = buildInactivityAbortSignal(timeoutMs, undefined);
+
+    deadline.recordActivity({
+      kind: 'tool_started',
+      executionUnitKey: 'step',
+      toolCallKey: 'step\0tool-1',
+    });
+    vi.advanceTimersByTime(timeoutMs);
+    expect(deadline.signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(timeoutMs * (STALE_IN_FLIGHT_TOOL_FACTOR - 1) - 1);
+    expect(deadline.signal.aborted).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(deadline.signal.aborted).toBe(true);
+    expect((deadline.signal.reason as Error).message).toBe('Part timeout after 100ms');
+    deadline.dispose();
+  });
+
+  it('tool 終端後は通常の無応答期限を再開する', () => {
+    const deadline = buildInactivityAbortSignal(100, undefined);
+
+    recordWorkflowStepProviderEventActivity(deadline.recordActivity, 'step', {
+      type: 'tool_use',
+      data: { tool: 'Bash', input: {}, id: 'tool-1' },
+    });
+    vi.advanceTimersByTime(150);
+    recordWorkflowStepProviderEventActivity(deadline.recordActivity, 'step', {
+      type: 'tool_result',
+      data: { id: 'tool-1', content: 'done', isError: false },
+    });
+    vi.advanceTimersByTime(99);
+    expect(deadline.signal.aborted).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(deadline.signal.aborted).toBe(true);
+    deadline.dispose();
+  });
+
+  it('新しい attempt 開始時に欠落した tool 状態を破棄して通常期限を満額取り直す', () => {
+    const deadline = buildInactivityAbortSignal(100, undefined);
+
+    deadline.recordActivity({
+      kind: 'tool_started',
+      executionUnitKey: 'step',
+      toolCallKey: 'step\0tool-1',
+    });
+    vi.advanceTimersByTime(90);
+    deadline.recordActivity({ kind: 'attempt_started' });
+    vi.advanceTimersByTime(99);
+    expect(deadline.signal.aborted).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(deadline.signal.aborted).toBe(true);
+    deadline.dispose();
+  });
+
+  it('別 execution unit の attempt 開始で in-flight tool を解除しない', () => {
+    const timeoutMs = 100;
+    const deadline = buildInactivityAbortSignal(timeoutMs, undefined);
+
+    deadline.recordActivity({
+      kind: 'tool_started',
+      executionUnitKey: 'part-a',
+      toolCallKey: 'part-a\0tool-1',
+    });
+    vi.advanceTimersByTime(90);
+    deadline.recordActivity({ kind: 'attempt_started', executionUnitKey: 'part-b' });
+    vi.advanceTimersByTime(timeoutMs);
+    expect(deadline.signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(timeoutMs * (STALE_IN_FLIGHT_TOOL_FACTOR - 1) - 90);
+    expect(deadline.signal.aborted).toBe(true);
+    deadline.dispose();
   });
 });

--- a/src/__tests__/agent-usecases.test.ts
+++ b/src/__tests__/agent-usecases.test.ts
@@ -17,6 +17,11 @@ import { runTagJudgeStage as runTagJudgeStageImpl } from '../agents/judge-status
 import { requestDecompositionRawResponse as requestDecompositionRawResponseImpl } from '../agents/decompose-task-usecase.js';
 import { loadEvaluationSchema, loadJudgmentSchema } from '../infra/resources/schema-loader.js';
 import { OpenCodeProvider } from '../infra/providers/opencode.js';
+import {
+  createWorkflowStepDeadline,
+  recordWorkflowStepProviderActivity,
+  recordWorkflowStepProviderEventActivity,
+} from '../core/workflow/engine/step-deadline.js';
 
 vi.mock('../agents/runner.js', () => ({
   runAgent: vi.fn(),
@@ -250,17 +255,21 @@ describe('agent-usecases', () => {
   );
   it('evaluateCondition は構造化出力の matched_index を優先する', async () => {
     vi.mocked(runAgent).mockResolvedValue(doneResponse('ignored', { matched_index: 2, reason: 'second condition' }));
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
 
     const result = await evaluateCondition('agent output', [
       { index: 0, text: 'first' },
       { index: 1, text: 'second' },
-    ], { cwd: '/repo' });
+    ], { cwd: '/repo', onStream, onActivity });
 
     expect(result).toBe(1);
     expect(runAgent).toHaveBeenCalledWith(undefined, expect.stringContaining('judge prompt'), expect.objectContaining({
       cwd: '/repo',
       resolvedExecution: expect.objectContaining({ provider: 'mock' }),
       outputSchema: expect.any(Object),
+      onStream,
+      onActivity,
     }));
   });
 
@@ -429,6 +438,96 @@ describe('agent-usecases', () => {
 
     expect(result).toEqual({ candidateIndex: 1, method: 'ai_judge' });
     expect(runAgent).toHaveBeenCalledTimes(3);
+  });
+
+  it('judgeStatus は ai_judge fallback の活動中に親 deadline を生存させる', async () => {
+    vi.useFakeTimers();
+    const inactivityTimeoutMs = 60_000;
+    const deadline = createWorkflowStepDeadline('opencode', {
+      opencode: { guards: { callTimeoutMs: inactivityTimeoutMs } },
+    }, undefined);
+    let resolveAiJudgeStarted: (() => void) | undefined;
+    const aiJudgeStarted = new Promise<void>((resolve) => {
+      resolveAiJudgeStarted = resolve;
+    });
+    let releaseStreamActivity: (() => void) | undefined;
+    const streamActivity = new Promise<void>((resolve) => {
+      releaseStreamActivity = resolve;
+    });
+    let releaseRetryActivity: (() => void) | undefined;
+    const retryActivity = new Promise<void>((resolve) => {
+      releaseRetryActivity = resolve;
+    });
+    let releaseAiJudge: (() => void) | undefined;
+    const aiJudgeCompletion = new Promise<void>((resolve) => {
+      releaseAiJudge = resolve;
+    });
+    let providerStage = 0;
+    vi.mocked(runAgent).mockImplementation(async (_persona, _instruction, options) => {
+      providerStage++;
+      if (providerStage === 1) {
+        return {
+          persona: 'conductor',
+          status: 'error',
+          content: 'structured stage failed',
+          timestamp: new Date('2026-08-15T00:00:00.000Z'),
+        };
+      }
+      if (providerStage === 2) {
+        return doneResponse('tag did not match');
+      }
+      options.onActivity?.({ kind: 'attempt_started' });
+      resolveAiJudgeStarted?.();
+      await streamActivity;
+      options.onStream?.({ type: 'text', data: { text: 'ai judge is still working' } });
+      await retryActivity;
+      options.onActivity?.({ kind: 'attempt_started' });
+      await aiJudgeCompletion;
+      return doneResponse('ignored', { matched_index: 2, reason: 'second condition' });
+    });
+
+    try {
+      const judgment = judgeStatus('structured', 'tag', [
+        { label: 'a' },
+        { label: 'b' },
+      ], {
+        ...judgeOptions,
+        abortSignal: deadline.signal,
+        onStream: (event) => recordWorkflowStepProviderEventActivity(
+          deadline.recordActivity,
+          'review',
+          event,
+        ),
+        onActivity: (activity) => recordWorkflowStepProviderActivity(
+          deadline.recordActivity,
+          'review',
+          activity,
+        ),
+      });
+      await aiJudgeStarted;
+      await vi.advanceTimersByTimeAsync(40_000);
+      releaseStreamActivity?.();
+      await vi.advanceTimersByTimeAsync(40_000);
+      releaseRetryActivity?.();
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      expect(deadline.signal.aborted).toBe(false);
+      expect(runAgent).toHaveBeenNthCalledWith(
+        3,
+        undefined,
+        expect.any(String),
+        expect.objectContaining({
+          onStream: expect.any(Function),
+          onActivity: expect.any(Function),
+        }),
+      );
+
+      releaseAiJudge?.();
+      await expect(judgment).resolves.toEqual({ candidateIndex: 1, method: 'ai_judge' });
+    } finally {
+      deadline.dispose();
+      vi.useRealTimers();
+    }
   });
 
   it('judgeStatus passes childProcessEnv to all Phase 3 internal agent calls', async () => {
@@ -862,17 +961,25 @@ describe('agent-usecases', () => {
     vi.mocked(runAgent).mockResolvedValue(response);
     const abortController = new AbortController();
     const onAgentResponse = vi.fn();
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
 
     const result = await decomposeTask('instruction', 2, {
       cwd: '/repo',
       abortSignal: abortController.signal,
+      onStream,
+      onActivity,
       onAgentResponse,
     });
 
     expect(runAgent).toHaveBeenCalledWith(
       undefined,
       expect.any(String),
-      expect.objectContaining({ abortSignal: abortController.signal }),
+      expect.objectContaining({
+        abortSignal: abortController.signal,
+        onStream: expect.any(Function),
+        onActivity,
+      }),
     );
     expect(onAgentResponse).toHaveBeenCalledWith(response);
     expect(result.providerUsage).toEqual(providerUsage);
@@ -1152,6 +1259,8 @@ describe('agent-usecases', () => {
     vi.mocked(runAgent).mockResolvedValue(response);
     const abortController = new AbortController();
     const onAgentResponse = vi.fn();
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
 
     const result = await requestMoreParts(
       'instruction',
@@ -1161,6 +1270,8 @@ describe('agent-usecases', () => {
         cwd: '/repo',
         cancellablePartIds: [],
         abortSignal: abortController.signal,
+        onStream,
+        onActivity,
         onAgentResponse,
       },
     );
@@ -1168,7 +1279,11 @@ describe('agent-usecases', () => {
     expect(runAgent).toHaveBeenCalledWith(
       undefined,
       expect.any(String),
-      expect.objectContaining({ abortSignal: abortController.signal }),
+      expect.objectContaining({
+        abortSignal: abortController.signal,
+        onStream: expect.any(Function),
+        onActivity,
+      }),
     );
     expect(onAgentResponse).toHaveBeenCalledWith(response);
     expect(result.providerUsage).toEqual(providerUsage);

--- a/src/__tests__/aggregate-evaluator.test.ts
+++ b/src/__tests__/aggregate-evaluator.test.ts
@@ -55,6 +55,18 @@ function state(indexes: Record<string, number>): WorkflowState {
   };
 }
 
+function stateWithError(stepName: string): WorkflowState {
+  const evaluatedState = state({ architecture: 0, coding: 0 });
+  evaluatedState.stepOutputs.set(stepName, {
+    persona: stepName,
+    status: 'error',
+    content: '',
+    error: 'Part timeout after 100ms',
+    timestamp: new Date(),
+  });
+  return evaluatedState;
+}
+
 describe('AggregateEvaluator', () => {
   it('all() は全sub-stepの確定ラベルが一致するときだけ真になる', () => {
     expect(new AggregateEvaluator(parent(), state({ architecture: 0, coding: 0 }))
@@ -66,6 +78,14 @@ describe('AggregateEvaluator', () => {
   it('any() はいずれかのsub-stepの確定ラベルが一致するとき真になる', () => {
     expect(new AggregateEvaluator(parent(), state({ architecture: 0, coding: 1 }))
       .evaluateCondition(aggregate('any("needs_fix")'))).toBe(true);
+  });
+
+  it('terminal error を明示的な error 集約ラベルとして評価する', () => {
+    const evaluatedState = stateWithError('coding');
+    const evaluator = new AggregateEvaluator(parent(), evaluatedState);
+
+    expect(evaluator.evaluateCondition(aggregate('any("error")'))).toBe(true);
+    expect(evaluator.evaluateCondition(aggregate('all("approved")'))).toBe(false);
   });
 
   it('uses the active canonical dynamic selection instead of another snapshot with the same step name', () => {

--- a/src/__tests__/auto-routing-resolver.test.ts
+++ b/src/__tests__/auto-routing-resolver.test.ts
@@ -227,6 +227,27 @@ describe('resolveAutoRoutingRuntime', () => {
     });
   });
 
+  it('passes deadline-scoped callbacks through the resolver to the estimator', async () => {
+    const estimate = vi.fn().mockResolvedValue({ requiredTier: 'low', reasonCodes: ['focused-change'] });
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
+
+    await resolveAutoRoutingRuntime({
+      autoRouting: createAutoRoutingConfig({ rules: {}, poolRules: { steps: { unknown: 'general' } } }),
+      step: createStepMetadata({ name: 'unknown', tags: [] }),
+      snapshot: createSnapshot(),
+      estimator: { estimate },
+      currentProviderInfo: { provider: undefined, model: undefined },
+      onStream,
+      onActivity,
+    });
+
+    expect(estimate).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      onStream,
+      onActivity,
+    }));
+  });
+
   it('Given an estimator failure, When resolving auto routing, Then it warns and uses the configured pool fallback', async () => {
     const warn = vi.fn();
     const estimator: WorkRequirementEstimator = { estimate: vi.fn().mockRejectedValue(new Error('router timeout')) };

--- a/src/__tests__/claude-executor.test.ts
+++ b/src/__tests__/claude-executor.test.ts
@@ -782,16 +782,23 @@ describe('QueryExecutor rate limit cause preservation', () => {
     // Given
     queryMock.mockImplementation(() => createMockQuery([], new Error(EXIT_CODE_MESSAGE)));
     const executor = new QueryExecutor();
+    const onActivity = vi.fn();
 
     // When
     const result = await executor.execute('test prompt', {
       cwd: '/tmp/project',
       sessionId: 'resume-session-1',
+      onActivity,
     });
 
     // Then
     expect(result.error).toBe(EXIT_CODE_MESSAGE);
     expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+    expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
+      queryMock.mock.invocationCallOrder[1]!,
+    );
     expect(
       (queryMock.mock.calls[0]?.[0] as { options?: { resume?: string } }).options?.resume,
     ).toBe('resume-session-1');

--- a/src/__tests__/claude-headless-client.test.ts
+++ b/src/__tests__/claude-headless-client.test.ts
@@ -201,6 +201,7 @@ describe('callClaudeHeadless', () => {
   });
 
   it('returns done when stream-json yields text and process exits 0', async () => {
+    const onActivity = vi.fn();
     stubSpawn({
       stdoutChunks: [
         `${JSON.stringify({ type: 'text', text: 'ok' })}\n`,
@@ -208,9 +209,10 @@ describe('callClaudeHeadless', () => {
       ],
       closeCode: 0,
     });
-    const res = await callClaudeHeadless('agent', 'hi', { cwd: '/tmp' });
+    const res = await callClaudeHeadless('agent', 'hi', { cwd: '/tmp', onActivity });
     expect(res.status).toBe('done');
     expect(res.content).toBe('ok');
+    expect(onActivity).toHaveBeenCalledOnce();
   });
 
   it('passes only run-local observability snapshot to headless child env', async () => {

--- a/src/__tests__/claude-headless-provider.test.ts
+++ b/src/__tests__/claude-headless-provider.test.ts
@@ -97,12 +97,14 @@ describe('ClaudeHeadlessProvider', () => {
       name: 'test',
       systemPrompt: 'sys',
     });
+    const onActivity = vi.fn();
 
     await agent.call('prompt', {
       cwd: '/tmp',
       sessionId: 'opaque-session-id-from-report-phase',
       permissionMode: 'edit',
       bypassPermissions: true,
+      onActivity,
       providerOptions: {
         claude: {
           sandbox: {
@@ -118,6 +120,7 @@ describe('ClaudeHeadlessProvider', () => {
       sessionId: 'opaque-session-id-from-report-phase',
       permissionMode: 'edit',
       bypassPermissions: true,
+      onActivity,
       anthropicApiKey: 'sk-ant-from-config',
       sandbox: {
         allowUnsandboxedCommands: true,

--- a/src/__tests__/claude-terminal-client.test.ts
+++ b/src/__tests__/claude-terminal-client.test.ts
@@ -767,6 +767,7 @@ describe('Claude terminal client', () => {
     const backend = createBackend();
     const onPermissionRequest = vi.fn();
     const onAskUserQuestion = vi.fn().mockResolvedValue({ answer: 'Use option A.' });
+    const onActivity = vi.fn();
     const transcriptReader = {
       readBaseline: vi.fn().mockResolvedValue({ byteOffset: 0, lineNumberOffset: 0 }),
       findSession: vi.fn().mockResolvedValue({ sessionId: 'claude-session-1' }),
@@ -793,6 +794,7 @@ describe('Claude terminal client', () => {
       backend: 'tmux',
       onPermissionRequest,
       onAskUserQuestion,
+      onActivity,
       terminalBackend: backend,
       transcriptReader,
     });
@@ -813,6 +815,13 @@ describe('Claude terminal client', () => {
       'Use option A.',
     );
     expect(transcriptReader.waitForAssistantResponse).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenCalledTimes(3);
+    expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
+      transcriptReader.waitForAssistantResponse.mock.invocationCallOrder[0]!,
+    );
+    expect(onActivity.mock.invocationCallOrder[2]).toBeLessThan(
+      transcriptReader.waitForAssistantResponse.mock.invocationCallOrder[1]!,
+    );
     expect(result).toMatchObject({
       persona: 'coder',
       status: 'done',

--- a/src/__tests__/claude-terminal-provider-wiring.test.ts
+++ b/src/__tests__/claude-terminal-provider-wiring.test.ts
@@ -56,6 +56,7 @@ describe('ClaudeTerminalProvider wiring', () => {
     const onStream = vi.fn();
     const onPermissionRequest = vi.fn();
     const onAskUserQuestion = vi.fn();
+    const onActivity = vi.fn();
     const childProcessEnv = { TAKT_OBSERVABILITY: '{"enabled":true}' };
     const mcpServers = {
       docs: { type: 'stdio' as const, command: 'docs-mcp', args: ['serve'] },
@@ -86,6 +87,7 @@ describe('ClaudeTerminalProvider wiring', () => {
       onStream,
       onPermissionRequest,
       onAskUserQuestion,
+      onActivity,
       outputSchema: SCHEMA,
       childProcessEnv,
     });
@@ -109,6 +111,7 @@ describe('ClaudeTerminalProvider wiring', () => {
       onStream,
       onPermissionRequest,
       onAskUserQuestion,
+      onActivity,
       outputSchema: SCHEMA,
       pathToClaudeCodeExecutable: '/opt/claude/bin/claude',
       childProcessEnv,

--- a/src/__tests__/claude-terminal-transcript-reader.test.ts
+++ b/src/__tests__/claude-terminal-transcript-reader.test.ts
@@ -493,7 +493,7 @@ describe('Claude terminal transcript reader', () => {
         baseline: { byteOffset: 0, lineNumberOffset: 0 },
         timeoutMs: 30,
         pollIntervalMs: 5,
-      })).rejects.toThrow(/timed out waiting for claude terminal assistant response/i);
+      })).rejects.toThrow('Part timeout after 30ms');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/src/__tests__/codex-client-retry.test.ts
+++ b/src/__tests__/codex-client-retry.test.ts
@@ -15,6 +15,7 @@ let startThreadCalls: Array<Record<string, unknown> | undefined> = [];
 let resumeThreadCalls: Array<{ threadId: string; options?: Record<string, unknown> }> = [];
 let runStreamedInputs: unknown[] = [];
 let codexConstructorCalls: Array<Record<string, unknown> | undefined> = [];
+let attemptOrder: string[] = [];
 const tempRoots = new Set<string>();
 const CODEX_STREAM_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 const CODEX_RECONNECT_FAILURE_MESSAGE = 'Reconnecting... 2/5 (timeout waiting for child process to exit)';
@@ -122,11 +123,13 @@ vi.mock('@openai/codex-sdk', () => {
       }
 
       async startThread(options?: Record<string, unknown>) {
+        attemptOrder.push('provider');
         startThreadCalls.push(options);
         return createThread('thread-1');
       }
 
       async resumeThread(threadId: string, options?: Record<string, unknown>) {
+        attemptOrder.push('provider');
         resumeThreadCalls.push({ threadId, options });
         return createThread(threadId);
       }
@@ -146,6 +149,7 @@ describe('CodexClient retry', () => {
     resumeThreadCalls = [];
     runStreamedInputs = [];
     codexConstructorCalls = [];
+    attemptOrder = [];
   });
 
   afterEach(() => {
@@ -255,8 +259,9 @@ describe('CodexClient retry', () => {
     ];
 
     const client = new CodexClient();
+    const onActivity = vi.fn(() => attemptOrder.push('activity'));
 
-    const resultPromise = client.call('coder', 'prompt', { cwd: '/tmp' });
+    const resultPromise = client.call('coder', 'prompt', { cwd: '/tmp', onActivity });
 
     await vi.advanceTimersByTimeAsync(999);
     expect(resumeThreadCalls).toHaveLength(0);
@@ -273,6 +278,9 @@ describe('CodexClient retry', () => {
     ]);
     expect(result.status).toBe('done');
     expect(result.content).toBe('retry succeeded');
+    expect(onActivity).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+    expect(attemptOrder).toEqual(['activity', 'provider', 'activity', 'provider']);
   });
 
   it('retry と session resume に同じ Codex Skill override を適用する', async () => {

--- a/src/__tests__/companion-step-executor.integration.test.ts
+++ b/src/__tests__/companion-step-executor.integration.test.ts
@@ -10,6 +10,7 @@ import { CompanionReviewAuthority } from '../core/workflow/companion/review-stat
 import { StepExecutor, type StepExecutorDeps } from '../core/workflow/engine/StepExecutor.js';
 import { createStructuredOutputNormalizerRegistry } from '../core/workflow/engine/structured-output-normalizer.js';
 import { REVIEW_COMPLETION_JUDGE_NAME } from '../core/workflow/review-completion.js';
+import { CompanionStepRuntime } from '../core/workflow/companion/step-runtime.js';
 import type { RunPaths } from '../core/workflow/run/run-paths.js';
 import { executeAgent } from '../agents/agent-usecases.js';
 import { initDebugLogger, resetDebugLogger } from '../shared/utils/debug.js';
@@ -271,6 +272,14 @@ describe('companion StepExecutor lifecycle', () => {
       abortSignal: abortController.signal,
       emitEvent,
     });
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
+    vi.mocked(deps.optionsBuilder.buildAgentOptions).mockReturnValue({
+      cwd,
+      onStream,
+      onActivity,
+    });
+    const createRuntime = vi.spyOn(CompanionStepRuntime, 'create');
     const step = {
       ...createCompanionStep([makeRule('Implementation is complete', 'COMPLETE')]),
       reviewCompletion: {
@@ -290,6 +299,10 @@ describe('companion StepExecutor lifecycle', () => {
     );
 
     expect(result.response).toMatchObject({ content: 'review-2', sessionId: 'session-2' });
+    expect(createRuntime).toHaveBeenCalledWith(expect.objectContaining({
+      onStream,
+      onActivity,
+    }));
     expect(timeline).toEqual([
       'reviewer:1',
       'companion:complete',
@@ -298,6 +311,7 @@ describe('companion StepExecutor lifecycle', () => {
       'companion:complete',
       'judge:2',
     ]);
+    createRuntime.mockRestore();
   });
 
   it('should release the companion parent abort listener after a successful normal step', async () => {

--- a/src/__tests__/companion-structured-call.test.ts
+++ b/src/__tests__/companion-structured-call.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeStructuredAgent } from '../agents/structured-caller/transport.js';
+import { CompanionStructuredCaller } from '../core/workflow/companion/structured-call.js';
+
+vi.mock('../agents/structured-caller/transport.js', () => ({
+  executeStructuredAgent: vi.fn(),
+}));
+
+describe('CompanionStructuredCaller', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('deadline-scoped stream and activity callbacks reach the structured provider call', async () => {
+    vi.mocked(executeStructuredAgent).mockResolvedValue({
+      persona: 'security-reviewer',
+      status: 'done',
+      content: 'reviewed',
+      timestamp: new Date('2026-08-14T00:00:00.000Z'),
+      structuredOutput: { findings: [], updates: [] },
+    });
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
+    const caller = new CompanionStructuredCaller({
+      cwd: '/worktree',
+      projectCwd: '/project',
+      failureDir: '/project/.takt/runs/run/failures',
+      language: 'en',
+      onStream,
+      onActivity,
+      recordUsage: vi.fn(),
+      recordCall: vi.fn(),
+    });
+
+    await caller.call({
+      purpose: 'reviewer',
+      agentName: 'security-reviewer',
+      provider: { provider: 'mock' },
+      systemPrompt: 'review system',
+      prompt: 'review prompt',
+      outputSchema: { type: 'object' },
+    });
+
+    expect(executeStructuredAgent).toHaveBeenCalledWith(
+      'review prompt',
+      { type: 'object' },
+      expect.objectContaining({ onStream, onActivity }),
+    );
+  });
+});

--- a/src/__tests__/copilot-client.test.ts
+++ b/src/__tests__/copilot-client.test.ts
@@ -98,6 +98,7 @@ describe('callCopilot', () => {
   });
 
   it('should invoke copilot with required args including --silent, --no-color', async () => {
+    const onActivity = vi.fn();
     mockSpawnWithScenario({
       stdout: 'Implementation complete. All tests pass.',
       code: 0,
@@ -109,11 +110,13 @@ describe('callCopilot', () => {
       sessionId: 'sess-prev',
       permissionMode: 'full',
       copilotGithubToken: 'gh-token',
+      onActivity,
     });
 
     expect(result.status).toBe('done');
     expect(result.content).toBe('Implementation complete. All tests pass.');
     expect(result.sessionId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    expect(onActivity).toHaveBeenCalledOnce();
 
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const [command, args, options] = mockSpawn.mock.calls[0] as [string, string[], { env?: NodeJS.ProcessEnv; stdio?: unknown }];

--- a/src/__tests__/copilot-provider.test.ts
+++ b/src/__tests__/copilot-provider.test.ts
@@ -166,12 +166,14 @@ for (const c of cases) {
 
       const provider = c.createProvider();
       const agent = provider.setup({ name: 'coder' });
+      const onActivity = vi.fn();
 
       await agent.call('implement', {
         cwd: '/tmp/work',
         model: c.model,
         sessionId: 'sess-1',
         permissionMode: 'full',
+        onActivity,
       });
 
       expect(c.mockCall).toHaveBeenCalledWith(
@@ -182,6 +184,7 @@ for (const c of cases) {
           model: c.model,
           sessionId: 'sess-1',
           permissionMode: 'full',
+          onActivity,
           [c.keyOption]: c.resolvedKey,
         }),
       );

--- a/src/__tests__/cursor-client.test.ts
+++ b/src/__tests__/cursor-client.test.ts
@@ -301,6 +301,7 @@ describe('callCursor', () => {
 
   it('should retry cli-config rename ENOENT and return successful retry result', async () => {
     vi.useFakeTimers();
+    const onActivity = vi.fn();
     mockSpawnWithScenarios([
       {
         code: 1,
@@ -315,6 +316,7 @@ describe('callCursor', () => {
     const resultPromise = callCursor('coding-review', 'review changes', {
       cwd: '/repo',
       sessionId: 'sess-before-retry',
+      onActivity,
     });
 
     await vi.advanceTimersByTimeAsync(999);
@@ -327,6 +329,11 @@ describe('callCursor', () => {
     expect(result.status).toBe('done');
     expect(result.content).toBe('retry succeeded');
     expect(result.sessionId).toBe('sess-after-retry');
+    expect(onActivity).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+    expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
+      mockSpawn.mock.invocationCallOrder[1]!,
+    );
   });
 
   it('should stop cli-config rename ENOENT retry when aborted during retry delay', async () => {

--- a/src/__tests__/dynamic-facet-selector-coordinator.test.ts
+++ b/src/__tests__/dynamic-facet-selector-coordinator.test.ts
@@ -262,6 +262,7 @@ describe('DynamicFacetSelectorCoordinator', () => {
   });
 
   it('passes selector guidance to the isolated agent without replacing the engine contract', async () => {
+    const onActivity = vi.fn();
     const pool = makePool([
       { id: 'frontend', description: 'Frontend changes' },
       { id: 'backend', description: 'Backend changes' },
@@ -274,7 +275,7 @@ describe('DynamicFacetSelectorCoordinator', () => {
       structuredOutput: { selected_ids: ['frontend'], rationale: 'changed paths are frontend-only' },
     });
 
-    const coordinator = new DynamicFacetSelectorCoordinator(buildDeps());
+    const coordinator = new DynamicFacetSelectorCoordinator(buildDeps({ onActivity }));
     await coordinator.resolveDynamicFacets(makeGuidedStep(), makeState(), 'task', pool);
 
     const [systemPrompt, instruction, outputSchema, options] = mockedExecuteAgent.mock.calls[0] ?? [];
@@ -299,6 +300,7 @@ describe('DynamicFacetSelectorCoordinator', () => {
       persona: 'facet-selector',
       personaPath: '/project/.takt/facets/personas/facet-selector.md',
       workflowBundleResourceRoot: '/tmp/project/.takt/runs/bundle/resources',
+      onActivity,
     }));
   });
 

--- a/src/__tests__/dynamic-parallel-selector-coordinator.test.ts
+++ b/src/__tests__/dynamic-parallel-selector-coordinator.test.ts
@@ -120,7 +120,8 @@ describe('DynamicParallelSelectorCoordinator', () => {
       timestamp: new Date(),
       structuredOutput: { selected_ids: ['frontend'], rationale: 'frontend changes are present' },
     });
-    const deps = dependencies();
+    const onActivity = vi.fn();
+    const deps = { ...dependencies(), onActivity };
     const coordinator = new DynamicParallelSelectorCoordinator(deps);
     const step = dynamicParallelStep({
       mode: 'replace',
@@ -158,6 +159,7 @@ describe('DynamicParallelSelectorCoordinator', () => {
       persona: 'reviewer-selector',
       personaPath: '/project/.takt/facets/personas/reviewer-selector.md',
       workflowBundleResourceRoot: '/project/.takt/runs/bundle/resources',
+      onActivity,
     }));
     expect(participants.map(({ name }) => name)).toEqual(['architecture', 'frontend']);
   });

--- a/src/__tests__/engine-loop-monitors.test.ts
+++ b/src/__tests__/engine-loop-monitors.test.ts
@@ -1255,9 +1255,104 @@ describe('WorkflowEngine Integration: Loop Monitors', () => {
       const judgeCalls = vi.mocked(runAgent).mock.calls.filter((call) => call[0] === 'supervisor');
       expect(state.status).toBe('completed');
       expect(judgeCalls.map((call) => call[2]?.sessionId)).toEqual([undefined, undefined]);
+      expect(judgeCalls.every((call) => typeof call[2]?.onStream === 'function')).toBe(true);
+      expect(judgeCalls.every((call) => typeof call[2]?.onActivity === 'function')).toBe(true);
       expect(state.personaSessions.has(
         '["supervisor","opencode","opencode/zai-coding-plan/glm-5.1"]',
       )).toBe(false);
+    });
+
+    it('keeps the loop monitor judge alive past one inactivity window while internal activity continues', async () => {
+      vi.useFakeTimers();
+      const inactivityTimeoutMs = 60_000;
+      const config = buildConfigWithLoopMonitor(1, {
+        judge: {
+          persona: 'supervisor',
+          provider: 'opencode',
+          model: 'opencode/judge-model',
+          providerOptions: {
+            opencode: { guards: { callTimeoutMs: inactivityTimeoutMs } },
+          },
+          rules: loopJudgeRules(),
+        },
+      } as Partial<LoopMonitorConfig>);
+      engine = new WorkflowEngine(config, tmpDir, 'test task', {
+        projectCwd: tmpDir,
+        provider: 'mock',
+      });
+      const regularResponses = [
+        makeResponse({ persona: 'implement', content: 'Implementation done' }),
+        makeResponse({ persona: 'ai_review', content: 'Issues found: X' }),
+        makeResponse({ persona: 'ai_fix', content: 'Fixed X' }),
+        makeResponse({ persona: 'reviewers', content: 'All approved' }),
+      ];
+      let resolveJudgeStarted: (() => void) | undefined;
+      const judgeStarted = new Promise<void>((resolve) => {
+        resolveJudgeStarted = resolve;
+      });
+      let releaseStreamActivity: (() => void) | undefined;
+      const streamActivity = new Promise<void>((resolve) => {
+        releaseStreamActivity = resolve;
+      });
+      let releaseRetryActivity: (() => void) | undefined;
+      const retryActivity = new Promise<void>((resolve) => {
+        releaseRetryActivity = resolve;
+      });
+      let releaseJudgeCompletion: (() => void) | undefined;
+      const judgeCompletion = new Promise<void>((resolve) => {
+        releaseJudgeCompletion = resolve;
+      });
+      let judgeSignal: AbortSignal | undefined;
+      vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
+        options.onPromptResolved?.({
+          systemPrompt: typeof persona === 'string' ? persona : '',
+          userInstruction: instruction,
+        });
+        if (options.outputSchema === undefined) {
+          const response = regularResponses.shift();
+          if (response === undefined) throw new Error('Unexpected regular agent call');
+          return response;
+        }
+        judgeSignal = options.abortSignal;
+        options.onActivity?.({ kind: 'attempt_started' });
+        resolveJudgeStarted?.();
+        await streamActivity;
+        options.onStream?.({ type: 'text', data: { text: 'judge is still working' } });
+        await retryActivity;
+        options.onActivity?.({ kind: 'attempt_started' });
+        await judgeCompletion;
+        return makeResponse({
+          persona: 'supervisor',
+          content: 'Unproductive loop detected',
+          structuredOutput: { content: 'Unproductive loop detected' },
+        });
+      });
+      mockRuleEvaluationSequence([
+        { index: 0, method: 'phase3_tag' },
+        { index: 1, method: 'phase3_tag' },
+        { index: 0, method: 'phase3_tag' },
+        { index: 1, method: 'ai_judge' },
+        { index: 0, method: 'phase3_tag' },
+      ]);
+
+      try {
+        const execution = engine.run();
+        await judgeStarted;
+        await vi.advanceTimersByTimeAsync(40_000);
+        releaseStreamActivity?.();
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(judgeSignal?.aborted).toBe(false);
+        await vi.advanceTimersByTimeAsync(20_000);
+        releaseRetryActivity?.();
+        await vi.advanceTimersByTimeAsync(20_000);
+        releaseJudgeCompletion?.();
+        const state = await execution;
+
+        expect(state.status).toBe('completed');
+        expect(judgeSignal?.aborted).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('keeps loop-judge seat capabilities and permission across a model-only CLI override', async () => {

--- a/src/__tests__/engine-parallel.test.ts
+++ b/src/__tests__/engine-parallel.test.ts
@@ -82,6 +82,7 @@ import {
 import { buildWorkflowCallInvocationIdentity } from '../core/workflow/workflow-call-invocation-index.js';
 import { getWorkflowReference } from '../core/workflow/workflow-reference.js';
 import { buildWorkflowStepParticipationIdentity } from '../core/workflow/workflow-step-participation-index.js';
+import { MAX_EXPLICIT_PARALLEL_ERROR_RETRIES } from '../core/workflow/engine/ParallelRunner.js';
 import {
   makeResponse,
   makeStep,
@@ -578,6 +579,7 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
       resolvedExecution: unknown;
       outputSchema: Record<string, unknown> | undefined;
       internalSystemPrompt: string | undefined;
+      onActivity: unknown;
       instruction: string;
     }> = [];
     vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
@@ -590,6 +592,7 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
         resolvedExecution: options?.resolvedExecution,
         outputSchema: options?.outputSchema,
         internalSystemPrompt: options?.internalSystemPrompt,
+        onActivity: options?.onActivity,
         instruction,
       });
       if (options?.outputSchema) {
@@ -662,6 +665,7 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
       },
       bypassPermissions: false,
       internalSystemPrompt: expect.stringContaining('internal dynamic parallel selector'),
+      onActivity: expect.any(Function),
       outputSchema: expect.objectContaining({
         additionalProperties: false,
         required: ['selected_ids', 'rationale'],
@@ -2483,6 +2487,47 @@ describe('WorkflowEngine Integration: Parallel Step Partial Failure', () => {
     if (existsSync(tmpDir)) {
       rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it('ignoreIterationLimit 下でも persistent parallel error retry を明示上限で abort する', async () => {
+    const config = buildParallelOnlyConfig();
+    config.maxSteps = 1;
+    config.steps[0]!.rules = [
+      makeRule('any("error")', 'reviewers'),
+      ...(config.steps[0]!.rules ?? []),
+    ];
+    const engine = new WorkflowEngine(config, tmpDir, 'test task', {
+      projectCwd: tmpDir,
+      ignoreIterationLimit: true,
+    });
+    vi.mocked(runAgent).mockImplementation(async (persona, task, options) => {
+      options?.onPromptResolved?.({
+        systemPrompt: typeof persona === 'string' ? persona : '',
+        userInstruction: task,
+      });
+      return makeResponse({
+        persona,
+        status: 'error',
+        content: '',
+        error: 'Part timeout after 100ms',
+        failureCategory: 'part_timeout',
+      });
+    });
+    vi.mocked(mockRuleEvaluation).mockImplementation((step) => (
+      step.name === 'reviewers' ? { index: 0, method: 'aggregate' } : undefined
+    ));
+    const abortFn = vi.fn();
+    engine.on('workflow:abort', abortFn);
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('aborted');
+    expect(state.stepIterations.get('reviewers')).toBe(MAX_EXPLICIT_PARALLEL_ERROR_RETRIES + 1);
+    expect(runAgent).toHaveBeenCalledTimes((MAX_EXPLICIT_PARALLEL_ERROR_RETRIES + 1) * 4);
+    expect(abortFn).toHaveBeenCalledOnce();
+    const reason = abortFn.mock.calls[0]![1] as string;
+    expect(reason).toContain(`explicit error retry limit (${MAX_EXPLICIT_PARALLEL_ERROR_RETRIES})`);
+    expect(reason).not.toBe('rule_no_match');
   });
 
   it('should retry a sub-step once with a fresh session when the provider errors', async () => {

--- a/src/__tests__/engine-review-completion.test.ts
+++ b/src/__tests__/engine-review-completion.test.ts
@@ -121,6 +121,8 @@ describe('WorkflowEngine review completion wiring', () => {
     vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
       if (options.internalAgentName === 'review-completion-judge') {
         expect(options.sessionId).toBeUndefined();
+        expect(options.onStream).toEqual(expect.any(Function));
+        expect(options.onActivity).toEqual(expect.any(Function));
         return judgeResponse(true);
       }
       options.onPromptResolved?.({ systemPrompt: String(persona), userInstruction: instruction });

--- a/src/__tests__/it-workflow-loader.test.ts
+++ b/src/__tests__/it-workflow-loader.test.ts
@@ -58,6 +58,11 @@ import { listBuiltinWorkflowNames } from '../infra/config/loaders/workflowResolv
 import { loadGlobalConfig } from '../infra/config/global/globalConfig.js';
 import { validateWorkflowConfig } from '../core/workflow/engine/WorkflowValidator.js';
 import { getLanguageResourcesDir } from '../infra/resources/index.js';
+import {
+  aggregateConditionsOf,
+  PARALLEL_TERMINAL_ERROR_LABEL,
+  semanticLabelsOf,
+} from '../core/models/workflow-rule-condition.js';
 
 const loadWorkflowConfig = loadWorkflow;
 const listBuiltinWorkflowLabels = listBuiltinWorkflowNames;
@@ -108,6 +113,33 @@ describe('Workflow Loader IT: builtin workflow loading', () => {
     expect(Array.from(workflows.values()).every(({ source }) => source === 'builtin')).toBe(true);
     expect(onWarning).not.toHaveBeenCalled();
   });
+
+  it.each(['en', 'ja'] as const)(
+    'parallel 親に review tag を持つ全 %s builtin workflow は error を先頭で明示処理する',
+    (language) => {
+      languageState.value = language;
+      const workflows = loadAllStandaloneWorkflowsWithSources(testDir);
+      const missing: string[] = [];
+
+      for (const name of workflows.keys()) {
+        const config = loadWorkflow(name, testDir);
+        expect(config, name).not.toBeNull();
+        for (const step of config.steps) {
+          if (step.parallel === undefined || !step.tags?.includes('review')) continue;
+          const firstRule = step.rules?.[0];
+          const handlesError = firstRule !== undefined
+            && aggregateConditionsOf(firstRule.condition).some((condition) => (
+              condition.targetConditions.some((target) => (
+                semanticLabelsOf(target).includes(PARALLEL_TERMINAL_ERROR_LABEL)
+              ))
+            ));
+          if (!handlesError) missing.push(`${name}/${step.name}`);
+        }
+      }
+
+      expect(missing).toEqual([]);
+    },
+  );
 
   it.each(['en', 'ja'] as const)(
     'should select scenario facets only from the %s experimental wrappers and forward their params',

--- a/src/__tests__/kiro-client.test.ts
+++ b/src/__tests__/kiro-client.test.ts
@@ -196,6 +196,7 @@ describe('callKiro', () => {
   });
 
   it('Given full permission and a session, When called, Then invokes kiro-cli headless with trust-all and resume-id', async () => {
+    const onActivity = vi.fn();
     mockSpawnWithScenario({
       stdout: 'Implementation complete.',
       code: 0,
@@ -206,11 +207,13 @@ describe('callKiro', () => {
       sessionId: 'sess-prev',
       permissionMode: 'full',
       kiroApiKey: 'kiro-secret',
+      onActivity,
     });
 
     expect(result.status).toBe('done');
     expect(result.content).toBe('Implementation complete.');
     expect(result.sessionId).toBe('sess-prev');
+    expect(onActivity).toHaveBeenCalledOnce();
 
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const [command, args, options] = mockSpawn.mock.calls[0] as [

--- a/src/__tests__/kiro-provider.test.ts
+++ b/src/__tests__/kiro-provider.test.ts
@@ -69,12 +69,14 @@ describe('KiroProvider', () => {
 
     const provider = new KiroProvider();
     const agent = provider.setup({ name: 'coder' });
+    const onActivity = vi.fn();
 
     await agent.call('implement', {
       cwd: '/tmp/work',
       model: 'claude-3-opus',
       sessionId: 'sess-1',
       permissionMode: 'full',
+      onActivity,
     });
 
     expect(mockCallKiro).toHaveBeenCalledWith(
@@ -85,6 +87,7 @@ describe('KiroProvider', () => {
         model: 'claude-3-opus',
         sessionId: 'sess-1',
         permissionMode: 'full',
+        onActivity,
         kiroApiKey: 'resolved-key',
         kiroCliPath: '/custom/bin/kiro-cli',
       }),

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -266,7 +266,7 @@ describe('OpenCodeClient retry', () => {
     expect(result.content).toBe('');
   });
 
-  it('出力がなくても idle では retry せず、call wall-clock で終了する', async () => {
+  it('出力がないと call inactivity timeout で終了する', async () => {
     vi.useFakeTimers();
     runPlans = [{
       type: 'stream',
@@ -290,13 +290,14 @@ describe('OpenCodeClient retry', () => {
     const result = await resultPromise;
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('wall-clock timeout exceeded');
+    expect(result.error).toContain('Part timeout after 60000ms');
+    expect(result.failureCategory).toBe('part_timeout');
     expect(sessionCreate).toHaveBeenCalledOnce();
     expect(promptAsync).toHaveBeenCalledOnce();
     expect(subscribe).toHaveBeenCalledOnce();
   });
 
-  it('call wall-clock timeout は全体を abort し retry しない', async () => {
+  it('call inactivity timeout は全体を abort し retry しない', async () => {
     vi.useFakeTimers();
     runPlans = [{
       type: 'stream',
@@ -320,14 +321,14 @@ describe('OpenCodeClient retry', () => {
     const result = await resultPromise;
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('wall-clock timeout exceeded');
+    expect(result.error).toContain('Part timeout after 60000ms');
     expect(sessionCreate).toHaveBeenCalledOnce();
     expect(promptAsync).toHaveBeenCalledOnce();
     expect(subscribe).toHaveBeenCalledOnce();
     expect(abort).toHaveBeenCalledOnce();
   });
 
-  it('wall-clock signal は未完了の prompt 待ちと iterator close を打ち切る', async () => {
+  it('inactivity timeout signal は未完了の prompt 待ちと iterator close を打ち切る', async () => {
     vi.useFakeTimers();
     const iteratorReturn = vi.fn(() => new Promise<IteratorResult<MockStreamEvent>>(() => {}));
     runPlans = [{
@@ -350,7 +351,7 @@ describe('OpenCodeClient retry', () => {
     const result = await resultPromise;
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('wall-clock timeout exceeded');
+    expect(result.error).toContain('Part timeout after 60000ms');
     expect(iteratorReturn).toHaveBeenCalledOnce();
   });
 
@@ -400,7 +401,7 @@ describe('OpenCodeClient retry', () => {
     const result = await resultPromise;
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('wall-clock timeout exceeded');
+    expect(result.error).toContain('Part timeout after 60000ms');
     expect(onStream).toHaveBeenCalledTimes(streamCallsBeforeDeadline);
     expect(promptAsync).toHaveBeenCalledOnce();
     expect(onAskUserQuestion).not.toHaveBeenCalled();
@@ -476,6 +477,7 @@ describe('OpenCodeClient retry', () => {
     ];
     const { sessionCreate, promptAsync, subscribe } = installOpenCodeMock();
     const onStream = vi.fn();
+    const onActivity = vi.fn();
     const logsDir = mkdtempSync(join(tmpdir(), 'takt-opencode-retry-thinking-'));
     const providerLogger = createProviderEventLogger({
       logsDir,
@@ -496,6 +498,7 @@ describe('OpenCodeClient retry', () => {
       const result = await client.call('coder', 'prompt', {
         cwd: '/tmp',
         model: 'opencode/big-pickle',
+        onActivity,
         onStream: (event) => {
           providerLogger.logEvent(logContext, event);
           onStream(event);
@@ -506,6 +509,11 @@ describe('OpenCodeClient retry', () => {
       expect(sessionCreate).toHaveBeenCalledTimes(2);
       expect(promptAsync).toHaveBeenCalledTimes(2);
       expect(subscribe).toHaveBeenCalledTimes(2);
+      expect(onActivity).toHaveBeenCalledTimes(2);
+      expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+      expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
+        promptAsync.mock.invocationCallOrder[1]!,
+      );
       expect(onStream.mock.calls.filter(([event]) => (
         event.type === 'text' && event.data.text === 'transient retry tail'
       ))).toHaveLength(1);

--- a/src/__tests__/opencode-tool-guard.test.ts
+++ b/src/__tests__/opencode-tool-guard.test.ts
@@ -23,6 +23,7 @@ import {
 import { readOpenCodeToolPart } from '../infra/opencode/guards/tool-events.js';
 import { ExactLoopGuard } from '../infra/opencode/guards/integrity-guards.js';
 import { SensitiveBudgetGuard } from '../infra/opencode/guards/resource-guards.js';
+import { STALE_IN_FLIGHT_TOOL_FACTOR } from '../infra/opencode/guards/time-guards.js';
 import { createBoundedSensitiveValues } from '../shared/utils/sensitiveText.js';
 
 const DEPRECATED_ENV_KEYS = [
@@ -139,7 +140,7 @@ describe('OpenCode guard registry / Strategy', () => {
       { id: 'event-count', layer: 'resource', mandatory: true },
       { id: 'tracked-ids', layer: 'resource', mandatory: true },
       { id: 'sensitive-budget', layer: 'integrity', mandatory: true },
-      { id: 'wall-clock', layer: 'time', mandatory: true },
+      { id: 'inactivity-timeout', layer: 'time', mandatory: true },
       { id: 'exact-loop', layer: 'integrity', mandatory: true },
       { id: 'consecutive-errors', layer: 'heuristic', mandatory: false },
       { id: 'cycle-budget', layer: 'heuristic', mandatory: false },
@@ -155,7 +156,7 @@ describe('OpenCode guard registry / Strategy', () => {
     expect(minimal.enabledGuardIds).toEqual(
       OPENCODE_GUARD_REGISTRY.filter((guard) => guard.mandatory).map((guard) => guard.id),
     );
-    expect(minimal.enabledGuardIds).toContain('wall-clock');
+    expect(minimal.enabledGuardIds).toContain('inactivity-timeout');
     expect(minimal.enabledGuardIds).toContain('exact-loop');
   });
 
@@ -450,15 +451,20 @@ describe('OpenCode guard suite', () => {
     expect(minimal.onEvent(errorTool('m-3', 'tool-3', 'failure-3')).failure).toBeUndefined();
   });
 
-  it('wall-clock は call scope 全体で発火する', () => {
+  it('provider event と attempt 開始で無応答期限を更新する', () => {
     vi.useFakeTimers();
     const suite = resolveOpenCodeGuardSuite({ callTimeoutMs: 60_000 }, 'opencode/big-pickle');
     const failures: string[] = [];
     suite.startCall((failure) => failures.push(failure.guardId));
+    vi.advanceTimersByTime(40_000);
+    suite.onEvent(runningTool('call-1', { command: 'npm test' }));
+    vi.advanceTimersByTime(40_000);
+    suite.startAttempt((failure) => failures.push(failure.guardId));
     vi.advanceTimersByTime(59_999);
     expect(failures).toEqual([]);
     vi.advanceTimersByTime(1);
-    expect(failures).toEqual(['wall-clock']);
+    expect(failures).toEqual(['inactivity-timeout']);
+    suite.stopAttempt();
     suite.stopCall();
   });
 
@@ -475,7 +481,7 @@ describe('OpenCode guard suite', () => {
     suite.stopAttempt();
   });
 
-  it('終端イベントが来ないツールは wall-clock が拾う', () => {
+  it('終端イベント後に無応答が続くと inactivity timeout が発火する', () => {
     vi.useFakeTimers();
     const suite = resolveOpenCodeGuardSuite({ callTimeoutMs: 60_000 }, 'opencode/big-pickle');
     const failures: string[] = [];
@@ -483,11 +489,37 @@ describe('OpenCode guard suite', () => {
     suite.startAttempt((failure) => failures.push(failure.guardId));
 
     suite.onEvent(runningTool('call-1', { command: 'npm run test:it' }));
+    vi.advanceTimersByTime(2 * 60_000);
+    expect(failures).toEqual([]);
+    suite.onEvent(completedTool(
+      'call-1',
+      { command: 'npm run test:it' },
+      'tests passed',
+      { tool: 'bash', exit: 0 },
+    ));
     vi.advanceTimersByTime(59_999);
     expect(failures).toEqual([]);
     vi.advanceTimersByTime(1);
-    expect(failures).toEqual(['wall-clock']);
-    expect(suite.getCallFailure()).toMatchObject({ guardId: 'wall-clock' });
+    expect(failures).toEqual(['inactivity-timeout']);
+    expect(suite.getCallFailure()).toMatchObject({ guardId: 'inactivity-timeout' });
+    suite.stopAttempt();
+    suite.stopCall();
+  });
+
+  it('終端イベントが欠落した in-flight tool は stale 上限で PART_TIMEOUT にする', () => {
+    vi.useFakeTimers();
+    const callTimeoutMs = 60_000;
+    const suite = resolveOpenCodeGuardSuite({ callTimeoutMs }, 'opencode/big-pickle');
+    const failures: string[] = [];
+    suite.startCall((failure) => failures.push(failure.guardId));
+    suite.startAttempt((failure) => failures.push(failure.guardId));
+
+    suite.onEvent(runningTool('call-1', { command: 'npm run test:it' }));
+    vi.advanceTimersByTime(callTimeoutMs * STALE_IN_FLIGHT_TOOL_FACTOR - 1);
+    expect(failures).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(failures).toEqual(['inactivity-timeout']);
+    expect(suite.getCallFailure()?.verdict.reason).toContain('Part timeout');
     suite.stopAttempt();
     suite.stopCall();
   });

--- a/src/__tests__/option-resolution-order.test.ts
+++ b/src/__tests__/option-resolution-order.test.ts
@@ -80,6 +80,17 @@ describe('option resolution order', () => {
     getRuntimeInstructionsMock.mockReturnValue(null);
   });
 
+  it('records an attempt-boundary activity before provider dispatch', async () => {
+    const onActivity = vi.fn();
+
+    await runAgent(undefined, 'task', { cwd: '/repo', provider: 'mock', onActivity });
+
+    expect(onActivity).toHaveBeenCalledOnce();
+    expect(onActivity.mock.invocationCallOrder[0]).toBeLessThan(
+      providerCallMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it('should resolve provider in order: CLI > local config > global config', async () => {
     loadProjectConfigMock.mockReturnValue({ provider: 'opencode' });
     loadGlobalConfigMock.mockReturnValue({

--- a/src/__tests__/parallel-runner-terminal-status.test.ts
+++ b/src/__tests__/parallel-runner-terminal-status.test.ts
@@ -81,6 +81,15 @@ function makeParallelStep(): WorkflowStep {
   });
 }
 
+function makeErrorAwareParallelStep(): WorkflowStep {
+  const step = makeParallelStep();
+  step.rules = [
+    makeRule('any("error")', 'reviewers'),
+    ...(step.rules ?? []),
+  ];
+  return step;
+}
+
 function makeParallelStepInOrder(reversed: boolean): WorkflowStep {
   const aiReview = makeReviewStep('ai-antipattern-review-2nd');
   const securityReview = makeReviewStep('security-review');
@@ -278,6 +287,42 @@ describe('ParallelRunner terminal sub-step statuses', () => {
     expect(result.response.content).toContain('aggregate');
     expect(state.stepOutputs.get('reviewers')).toBe(result.response);
     expect(state.lastOutput).toBe(result.response);
+  });
+
+  it('明示した any("error") で part timeout を集約し、親を done として再試行ルールへ渡す', async () => {
+    const { runner } = makeRunner();
+    const step = makeErrorAwareParallelStep();
+    const state = makeState();
+    vi.mocked(mockRuleEvaluation).mockImplementation((evaluatedStep) => {
+      if (evaluatedStep.name === 'reviewers') return { index: 0, method: 'phase3_tag' };
+      if (evaluatedStep.name === 'security-review') return { index: 0, method: 'phase3_tag' };
+      return undefined;
+    });
+    const timeout = makeAgentResponse({
+      persona: 'ai-antipattern-review-2nd',
+      status: 'error',
+      content: '',
+      error: 'Part timeout after 100ms',
+      failureCategory: 'part_timeout',
+    });
+    queueAgentResponse(timeout);
+    queueAgentResponse(makeAgentResponse({
+      persona: 'security-review',
+      content: '[SECURITY-REVIEW:1] approved',
+    }));
+    queueAgentResponse(timeout);
+
+    const result = await runner.runParallelStep(step, state, 'test task', 5, vi.fn());
+
+    expect(result.response.status).toBe('done');
+    expect(result.response.matchedRuleIndex).toBe(0);
+    expect(result.response.content).toContain('[ERROR]');
+    expect(result.response.content).toContain('failureCategory: part_timeout');
+    expect(result.response.content).toContain('Part timeout after 100ms');
+    expect(result.workflowCallFailure).toMatchObject({
+      kind: 'step_error',
+      failureCategory: 'part_timeout',
+    });
   });
 
   it('passes engine childProcessEnv to parallel sub-step quality gates', async () => {

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -177,16 +177,19 @@ describe('Pi SDK client', () => {
   it('streams text and returns the SDK session response', async () => {
     mocks.resetTransient();
     const events: string[] = [];
+    const onActivity = vi.fn();
 
     const response = await callPi('worker', 'do the work', {
       ...sessionOptions('pi-sdk-success'),
       onStream: (event) => events.push(event.type),
+      onActivity,
     });
 
     expect(response.status).toBe('done');
     expect(response.content).toBe('hello from pi');
     expect(response.sessionId).toMatch(/^sdk-session-\d+$/u);
     expect(events).toEqual(['init', 'text', 'result']);
+    expect(onActivity).toHaveBeenCalledOnce();
     expect(mocks.modelRuntimeCreate).toHaveBeenCalledWith({
       credentials: expect.anything(),
       modelsPath: path.join(tmpdir(), 'pi-agent-test', 'models.json'),

--- a/src/__tests__/pi-provider.test.ts
+++ b/src/__tests__/pi-provider.test.ts
@@ -37,6 +37,7 @@ describe('PiProvider', () => {
     const provider = new PiProvider();
     const agent = provider.setup({ name: 'worker', systemPrompt: 'Be concise.' });
     const onStream = vi.fn();
+    const onActivity = vi.fn();
     const abortController = new AbortController();
 
     await agent.call('implement', {
@@ -51,6 +52,7 @@ describe('PiProvider', () => {
       },
       abortSignal: abortController.signal,
       onStream,
+      onActivity,
     });
 
     expect(mockCallPi).toHaveBeenCalledWith('worker', 'implement', {
@@ -64,6 +66,7 @@ describe('PiProvider', () => {
       abortSignal: abortController.signal,
       systemPrompt: 'Be concise.',
       onStream,
+      onActivity,
       childProcessEnv: undefined,
     });
   });

--- a/src/__tests__/promotion-evaluator.test.ts
+++ b/src/__tests__/promotion-evaluator.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { evaluatePromotion } from '../core/workflow/promotion/PromotionEvaluator.js';
+import {
+  evaluatePromotion,
+  type PromotionEvaluationContext,
+} from '../core/workflow/promotion/PromotionEvaluator.js';
 import type { AgentWorkflowStep, StepProviderOptions } from '../core/models/index.js';
 import type { StructuredCaller } from '../agents/structured-caller.js';
 import type { ProviderType } from '../shared/types/provider.js';
@@ -39,6 +42,8 @@ function makeContext(overrides: {
   resolvedProvider?: ProviderType;
   resolvedModel?: string;
   childProcessEnv?: Readonly<Record<string, string>>;
+  onStream?: PromotionEvaluationContext['onStream'];
+  onActivity?: PromotionEvaluationContext['onActivity'];
 }) {
   return {
     cwd: '/tmp/project',
@@ -48,6 +53,8 @@ function makeContext(overrides: {
     resolvedProvider: overrides.resolvedProvider,
     resolvedModel: overrides.resolvedModel,
     childProcessEnv: overrides.childProcessEnv,
+    onStream: overrides.onStream,
+    onActivity: overrides.onActivity,
   };
 }
 
@@ -100,6 +107,8 @@ describe('evaluatePromotion', () => {
         model: 'gpt-5.5',
       },
     ]);
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
 
     const result = await evaluatePromotion(step, makeContext({
       stepIteration: 1,
@@ -107,6 +116,8 @@ describe('evaluatePromotion', () => {
       structuredCaller: makeStructuredCaller(evaluateCondition),
       resolvedProvider: 'codex',
       resolvedModel: 'gpt-5.4',
+      onStream,
+      onActivity,
     }));
 
     expect(result).toMatchObject({ model: 'gpt-5.5' });
@@ -118,6 +129,8 @@ describe('evaluatePromotion', () => {
         provider: 'codex',
         resolvedProvider: 'codex',
         resolvedModel: 'gpt-5.4',
+        onStream,
+        onActivity,
       }),
     );
   });

--- a/src/__tests__/provider-structured-output.test.ts
+++ b/src/__tests__/provider-structured-output.test.ts
@@ -645,3 +645,28 @@ describe('ClaudeProvider abortSignal wiring', () => {
     expect(callOptions).toHaveProperty('abortSignal', controller.signal);
   });
 });
+
+describe('Provider activity wiring', () => {
+  it.each([
+    ['claude', () => new ClaudeProvider(), mockCallClaude, undefined],
+    ['codex', () => new CodexProvider(), mockCallCodex, undefined],
+    ['opencode', () => new OpenCodeProvider(), mockCallOpenCode, 'opencode/big-pickle'],
+  ] as const)('%s provider は onActivity を client へ渡す', async (
+    _name,
+    createProvider,
+    callMock,
+    model,
+  ) => {
+    vi.clearAllMocks();
+    callMock.mockResolvedValue(doneResponse('coder'));
+    const onActivity = vi.fn();
+
+    await createProvider().setup({ name: 'coder' }).call('prompt', {
+      cwd: '/tmp/project',
+      onActivity,
+      ...(model === undefined ? {} : { model }),
+    });
+
+    expect(callMock.mock.calls[0]?.[2]).toHaveProperty('onActivity', onActivity);
+  });
+});

--- a/src/__tests__/team-leader-runner-structured-caller.test.ts
+++ b/src/__tests__/team-leader-runner-structured-caller.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RuntimeStepResolution } from '../core/workflow/types.js';
-import type { WorkflowStepDeadline, WorkflowStepExecutionDeadlineContext } from '../core/workflow/engine/step-deadline.js';
+import type { WorkflowStepInactivityDeadline, WorkflowStepExecutionDeadlineContext } from '../core/workflow/engine/step-deadline.js';
 import {
   requestValidTeamLeaderDecomposition,
   TeamLeaderDecompositionValidationError,
@@ -101,20 +101,22 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       }),
     };
     const leaderAbortController = new AbortController();
-    const leaderDeadline: WorkflowStepDeadline = {
+    const leaderOnStream = vi.fn();
+    const leaderOnActivity = vi.fn();
+    const leaderDeadline: WorkflowStepInactivityDeadline = {
       signal: leaderAbortController.signal,
+      recordActivity: vi.fn(),
       dispose: vi.fn(),
-      startedAt: Date.now(),
-      timeoutMs: 60_000,
+      inactivityTimeoutMs: 60_000,
     };
     const executionDeadlineContext: WorkflowStepExecutionDeadlineContext = {
       begin: vi.fn((executionUnitKey) => executionUnitKey === 'team-leader:leader'
         ? leaderDeadline
         : {
             signal: new AbortController().signal,
+            recordActivity: vi.fn(),
             dispose: vi.fn(),
-            startedAt: Date.now(),
-            timeoutMs: 60_000,
+            inactivityTimeoutMs: 60_000,
           }),
       runWith: vi.fn(async (_deadline, operation) => operation()),
     };
@@ -128,6 +130,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         }),
         buildBaseOptions: vi.fn().mockReturnValue({
           failureDir: '/tmp/project/.takt/runs/sample/failures',
+          onStream: leaderOnStream,
+          onActivity: leaderOnActivity,
         }),
         buildPhase1WorkflowMeta: vi.fn().mockReturnValue(undefined),
         resolveMcpServersForStep: vi.fn().mockReturnValue(undefined),
@@ -227,6 +231,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         resolvedProvider: 'opencode',
         failureDir: '/tmp/project/.takt/runs/sample/failures',
         abortSignal: leaderAbortController.signal,
+        onStream: leaderOnStream,
+        onActivity: leaderOnActivity,
       }),
     );
     expect(structuredCaller.requestMoreParts).toHaveBeenCalledWith(
@@ -248,6 +254,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         resolvedModel: 'opencode/zai-coding-plan/glm-5.1',
         resolvedProvider: 'opencode',
         failureDir: '/tmp/project/.takt/runs/sample/failures',
+        onStream: leaderOnStream,
+        onActivity: leaderOnActivity,
       }),
     );
     expect(feedbackAbortSignal).toBeDefined();

--- a/src/__tests__/work-requirement-estimator.test.ts
+++ b/src/__tests__/work-requirement-estimator.test.ts
@@ -305,6 +305,35 @@ describe('createWorkRequirementEstimator', () => {
     expect(vi.mocked(runAgent).mock.calls[0]?.[2]?.abortSignal).toBeInstanceOf(AbortSignal);
   });
 
+  it('passes deadline-scoped stream and activity callbacks to the structured provider call', async () => {
+    vi.mocked(runAgent).mockResolvedValue({
+      persona: 'auto-router',
+      status: 'done',
+      content: '{}',
+      timestamp: new Date('2026-08-14T00:00:00.000Z'),
+      structuredOutput: {
+        required_tier: 'low',
+        reason_codes: ['focused-change'],
+        confidence: null,
+      },
+    });
+    const estimator = createWorkRequirementEstimator({
+      cwd: '/repo',
+      provider: 'claude-sdk',
+      model: 'claude-haiku-4-5-20251001',
+    });
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
+
+    await estimator.estimate(createModelInput(), { onStream, onActivity });
+
+    expect(runAgent).toHaveBeenCalledWith(
+      'auto-router',
+      expect.any(String),
+      expect.objectContaining({ onStream, onActivity }),
+    );
+  });
+
   it('Given the router never responds, When the estimator timeout elapses, Then it fails instead of hanging the workflow', async () => {
     vi.useFakeTimers();
     vi.mocked(runAgent).mockReturnValue(new Promise(() => {}));

--- a/src/__tests__/workflow-engine-phase-relay.test.ts
+++ b/src/__tests__/workflow-engine-phase-relay.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkflowStep } from '../core/models/types.js';
+import { createWorkflowPhaseRelay } from '../core/workflow/engine/WorkflowEnginePhaseRelay.js';
+
+describe('WorkflowEnginePhaseRelay activity', () => {
+  it('試行開始・phase完了・judge stage をそれぞれ活動として記録する', () => {
+    const recordActivity = vi.fn();
+    const relay = createWorkflowPhaseRelay(vi.fn(), () => [{
+      workflow: 'test-workflow',
+      workflow_ref: 'test-workflow',
+      step: 'coding-review',
+      kind: 'agent',
+      occurrence: 1,
+    }], recordActivity);
+    const step = { name: 'coding-review', rules: [] } as WorkflowStep;
+    const promptParts = { systemPrompt: 'system', userInstruction: 'review' };
+
+    relay.onPhaseStart(step, 1, 'execute', 'review', promptParts, 'attempt-2', 1);
+    relay.onPhaseComplete(step, 1, 'execute', 'approved', 'done', undefined, 'attempt-2', 1);
+    relay.onPhaseStart(step, 3, 'judge', 'judge', promptParts, 'judge-1', 1);
+    relay.onJudgeStage(step, 3, 'judge', {
+      stage: 1,
+      method: 'structured_output',
+      status: 'done',
+      instruction: 'judge',
+      response: 'approved',
+    }, 'judge-1', 1);
+
+    expect(recordActivity).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/__tests__/workflow-resume-continuation.test.ts
+++ b/src/__tests__/workflow-resume-continuation.test.ts
@@ -7,8 +7,266 @@ import type {
 import { WorkflowResumeContinuation } from '../core/workflow/engine/workflow-resume-continuation.js';
 import { buildScopedStepIterationIdentity } from '../core/workflow/step-iteration-identity.js';
 import { buildWorkflowResumePointEntry } from '../core/workflow/workflow-reference.js';
+import { ResumeArtifactOccurrenceIndex } from '../core/workflow/run/resume-artifact-occurrence-index.js';
+import { buildWorkflowCallInvocationIdentity } from '../core/workflow/workflow-call-invocation-index.js';
+import { buildWorkflowCallSiteIdentity } from '../core/workflow/workflow-call-site-identity.js';
+
+const ARTIFACT_HASH = '0'.repeat(64);
+
+function invocationRecord(
+  workflow: WorkflowConfig,
+  stepName: string,
+  childWorkflow: WorkflowConfig,
+  workflowCallPath: WorkflowResumePoint['stack'],
+  occurrence: number,
+) {
+  const frame = buildWorkflowResumePointEntry(
+    workflow,
+    stepName,
+    'workflow_call',
+    occurrence,
+    undefined,
+    occurrence,
+  );
+  return {
+    identity: buildWorkflowCallInvocationIdentity(workflow.name, stepName, workflowCallPath),
+    namespace: buildWorkflowCallSiteIdentity({
+      stack: [...workflowCallPath, frame],
+      childWorkflow,
+    }).runPathSegment,
+  };
+}
+
+function artifactManifest(namespaces: readonly string[]) {
+  return {
+    version: 1 as const,
+    sourceRunSlug: 'source-run',
+    targetRunSlug: 'target-run',
+    createdAt: new Date(0).toISOString(),
+    files: namespaces.map((namespace) => ({
+      path: `subworkflows/${namespace}/result.md`,
+      size: 1,
+      sha256: ARTIFACT_HASH,
+    })),
+  };
+}
+
+function withLegacyOccurrenceDigest(namespace: string, digestCharacter: string): string {
+  return namespace.replace(/--site-[a-f0-9]{64}$/, `--site-${digestCharacter.repeat(64)}`);
+}
+
+function sourceResumePoint(records: readonly ReturnType<typeof invocationRecord>[]): WorkflowResumePoint {
+  return {
+    version: 2,
+    stack: [],
+    iteration: 1,
+    elapsed_ms: 0,
+    workflow_call_invocations: Object.fromEntries(records.map((record) => [record.identity, {
+      call_instance: Number(/^iteration-(\d+)/.exec(record.namespace)?.[1]),
+      report_namespace_segment: record.namespace,
+    }])),
+    workflow_step_participations: {},
+  };
+}
 
 describe('WorkflowResumeContinuation', () => {
+  it('requeue で継承した workflow_call 成果物の最大 occurrence の続きから採番する', () => {
+    const workflow = {
+      name: 'parent',
+      initialStep: 'remediation',
+      maxSteps: 10,
+      steps: [{
+        name: 'remediation',
+        kind: 'workflow_call',
+        call: 'experimental-remediation',
+        rules: [],
+      }],
+    } as WorkflowConfig;
+    const state: WorkflowState = {
+      workflowName: workflow.name,
+      currentStep: 'remediation',
+      iteration: 1,
+      stepOutputs: new Map(),
+      structuredOutputs: new Map(),
+      systemContexts: new Map(),
+      effectResults: new Map(),
+      userInputs: [],
+      personaSessions: new Map(),
+      stepIterations: new Map(),
+      status: 'running',
+    };
+    const childWorkflow = {
+      name: 'experimental-remediation',
+      subworkflow: { callable: true },
+      initialStep: 'fix',
+      maxSteps: 10,
+      steps: [],
+    } as WorkflowConfig;
+    const records = [1, 2, 6].map((occurrence) => invocationRecord(
+      workflow,
+      'remediation',
+      childWorkflow,
+      [],
+      occurrence,
+    ));
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest(records.map((record) => record.namespace)),
+      sourceResumePoint([records.at(-1)!]),
+    );
+    const continuation = new WorkflowResumeContinuation(workflow, undefined, index);
+
+    expect(continuation.claimStepOccurrence({
+      step: workflow.steps[0]!,
+      resumeStackPrefix: [],
+      state,
+    })).toBe(7);
+    expect(continuation.claimStepOccurrence({
+      step: workflow.steps[0]!,
+      resumeStackPrefix: [],
+      state,
+    })).toBe(8);
+    expect(state.stepIterations.get('remediation')).toBe(8);
+  });
+
+  it('top-level と parallel 内の同名 workflow_call artifact を混同しない', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = {
+      name: 'parent',
+      initialStep: 'delegate',
+      maxSteps: 10,
+      steps: [{ name: 'delegate', kind: 'workflow_call', call: 'child', rules: [] }],
+    } as WorkflowConfig;
+    const parallelFrame = buildWorkflowResumePointEntry(workflow, 'reviewers', 'parallel', 4);
+    const top = invocationRecord(workflow, 'delegate', child, [], 5);
+    const nested = invocationRecord(workflow, 'delegate', child, [parallelFrame], 1);
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([top.namespace, nested.namespace]),
+      sourceResumePoint([top, nested]),
+    );
+
+    expect(index.getMaxOccurrence(workflow, 'delegate', [])).toBe(5);
+    expect(index.getMaxOccurrence(workflow, 'delegate', [parallelFrame])).toBe(1);
+  });
+
+  it('異なる parallel 親の同名 workflow_call artifact を混同しない', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const siteAFrame = buildWorkflowResumePointEntry(workflow, 'review-a', 'parallel', 3);
+    const siteBFrame = buildWorkflowResumePointEntry(workflow, 'review-b', 'parallel', 9);
+    const siteA = invocationRecord(workflow, 'delegate', child, [siteAFrame], 6);
+    const siteB = invocationRecord(workflow, 'delegate', child, [siteBFrame], 2);
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([siteA.namespace, siteB.namespace]),
+      sourceResumePoint([siteA, siteB]),
+    );
+
+    expect(index.getMaxOccurrence(workflow, 'delegate', [siteAFrame])).toBe(6);
+    expect(index.getMaxOccurrence(workflow, 'delegate', [siteBFrame])).toBe(2);
+  });
+
+  it('nested workflow_call artifact を祖先 call-site ごとに分離する', () => {
+    const parent = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const grandchild = { name: 'grandchild', steps: [] } as unknown as WorkflowConfig;
+    const outerA = buildWorkflowResumePointEntry(parent, 'outer-a', 'workflow_call', 2, undefined, 2);
+    const outerB = buildWorkflowResumePointEntry(parent, 'outer-b', 'workflow_call', 7, undefined, 7);
+    const nestedA = invocationRecord(child, 'delegate', grandchild, [outerA], 4);
+    const nestedB = invocationRecord(child, 'delegate', grandchild, [outerB], 1);
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([nestedA.namespace, nestedB.namespace]),
+      sourceResumePoint([nestedA, nestedB]),
+    );
+
+    expect(index.getMaxOccurrence(child, 'delegate', [outerA])).toBe(4);
+    expect(index.getMaxOccurrence(child, 'delegate', [outerB])).toBe(1);
+  });
+
+  it('partial manifest に artifact がない call-site の occurrence を進めない', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const siteAFrame = buildWorkflowResumePointEntry(workflow, 'review-a', 'parallel', 1);
+    const siteBFrame = buildWorkflowResumePointEntry(workflow, 'review-b', 'parallel', 1);
+    const siteA = invocationRecord(workflow, 'delegate', child, [siteAFrame], 6);
+    const siteB = invocationRecord(workflow, 'delegate', child, [siteBFrame], 2);
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([siteA.namespace]),
+      sourceResumePoint([siteA, siteB]),
+    );
+
+    expect(index.getMaxOccurrence(workflow, 'delegate', [siteAFrame])).toBe(6);
+    expect(index.getMaxOccurrence(workflow, 'delegate', [siteBFrame])).toBeUndefined();
+  });
+
+  it('旧 digest の最新 invocation に成果物がなくても一意な call-site の artifact を移行する', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const occurrence1 = invocationRecord(workflow, 'delegate', child, [], 1);
+    const occurrence2 = invocationRecord(workflow, 'delegate', child, [], 2);
+    const legacyOccurrence1 = {
+      ...occurrence1,
+      namespace: withLegacyOccurrenceDigest(occurrence1.namespace, '1'),
+    };
+    const legacyOccurrence2 = {
+      ...occurrence2,
+      namespace: withLegacyOccurrenceDigest(occurrence2.namespace, '2'),
+    };
+
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([legacyOccurrence1.namespace]),
+      sourceResumePoint([legacyOccurrence2]),
+    );
+
+    expect(index.getMaxOccurrence(workflow, 'delegate', [])).toBe(1);
+  });
+
+  it('旧 digest artifact の論理 call-site が複数候補なら明示的に停止する', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const siteAFrame = buildWorkflowResumePointEntry(workflow, 'review-a', 'parallel', 1);
+    const siteBFrame = buildWorkflowResumePointEntry(workflow, 'review-b', 'parallel', 1);
+    const siteAArtifact = invocationRecord(workflow, 'delegate', child, [siteAFrame], 1);
+    const siteALatest = invocationRecord(workflow, 'delegate', child, [siteAFrame], 2);
+    const siteBLatest = invocationRecord(workflow, 'delegate', child, [siteBFrame], 2);
+
+    expect(() => new ResumeArtifactOccurrenceIndex(
+      artifactManifest([
+        withLegacyOccurrenceDigest(siteAArtifact.namespace, '1'),
+      ]),
+      sourceResumePoint([
+        { ...siteALatest, namespace: withLegacyOccurrenceDigest(siteALatest.namespace, '2') },
+        { ...siteBLatest, namespace: withLegacyOccurrenceDigest(siteBLatest.namespace, '3') },
+      ]),
+    )).toThrow('logical call-site is ambiguous');
+  });
+
+  it('通常 resume は artifact occurrence index を適用しない', () => {
+    const workflow = {
+      name: 'parent',
+      initialStep: 'delegate',
+      maxSteps: 10,
+      steps: [{ name: 'delegate', kind: 'workflow_call', call: 'child', rules: [] }],
+    } as WorkflowConfig;
+    const state = {
+      workflowName: workflow.name,
+      currentStep: 'delegate',
+      iteration: 1,
+      stepOutputs: new Map(),
+      structuredOutputs: new Map(),
+      systemContexts: new Map(),
+      effectResults: new Map(),
+      userInputs: [],
+      personaSessions: new Map(),
+      stepIterations: new Map(),
+      status: 'running',
+    } as WorkflowState;
+    const continuation = new WorkflowResumeContinuation(workflow, undefined);
+
+    expect(continuation.claimStepOccurrence({
+      step: workflow.steps[0]!,
+      resumeStackPrefix: [],
+      state,
+    })).toBe(1);
+  });
   it('nested workflow_callのsource continuationを一度だけ消費する', () => {
     const parentWorkflow = {
       name: 'parent',

--- a/src/__tests__/workflow-run-loop-command-gates.test.ts
+++ b/src/__tests__/workflow-run-loop-command-gates.test.ts
@@ -570,7 +570,7 @@ describe('WorkflowRunLoop step deadline', () => {
     })).toBe(MINUTE * 2);
   });
 
-  it('fallback を跨ぐ同一 occurrence は絶対期限をリセットしない', async () => {
+  it('fallback の試行境界で同一 occurrence の無応答期限をリセットする', async () => {
     vi.useFakeTimers();
     const step = makeStep('work', {
       provider: 'opencode',
@@ -608,6 +608,7 @@ describe('WorkflowRunLoop step deadline', () => {
           instruction,
         };
       }
+      context.recordActivity();
       return await new Promise((resolve) => {
         const finish = (): void => {
           signal.removeEventListener('abort', finish);
@@ -633,14 +634,15 @@ describe('WorkflowRunLoop step deadline', () => {
     expect(deps.runStep).toHaveBeenCalledTimes(2);
     expect(callStartedAt).toEqual([startedAt, startedAt + (40 * MINUTE / 60)]);
     expect(providerSignals[0]).toBe(providerSignals[1]);
+    expect(providerSignals[0]?.aborted).toBe(false);
 
-    await vi.advanceTimersByTimeAsync(MINUTE - (40 * MINUTE / 60));
+    await vi.advanceTimersByTimeAsync(MINUTE);
     const result = await execution;
 
     expect(result.state.status).toBe('aborted');
     expect(providerSignals[0]?.aborted).toBe(true);
     expect(providerSignals[1]?.aborted).toBe(true);
-    expect(Date.now()).toBe(startedAt + MINUTE);
+    expect(Date.now()).toBe(startedAt + (40 * MINUTE / 60) + MINUTE);
     expect(vi.getTimerCount()).toBe(0);
   });
 
@@ -813,6 +815,7 @@ describe('WorkflowRunLoop step deadline', () => {
     vi.useFakeTimers();
     const tmpDir = mkdtempSync(join(tmpdir(), 'takt-dynamic-facet-deadline-'));
     let selectorSignal: AbortSignal | undefined;
+    let selectorOnActivity: unknown;
     const step = makeStep('dynamic-review', {
       provider: 'opencode',
       model: 'opencode/step-model',
@@ -869,6 +872,7 @@ describe('WorkflowRunLoop step deadline', () => {
         });
         if (options?.internalSystemPrompt?.includes('dynamic facet selector') === true) {
           selectorSignal = options.abortSignal;
+          selectorOnActivity = options.onActivity;
         }
         if (options?.abortSignal === undefined) {
           throw new Error('dynamic facet selector did not receive a deadline signal');
@@ -879,11 +883,72 @@ describe('WorkflowRunLoop step deadline', () => {
 
       const execution = engine.run();
       await waitForCondition(() => selectorSignal !== undefined, 'dynamic facet selector invocation');
+      expect(selectorOnActivity).toEqual(expect.any(Function));
       await vi.advanceTimersByTimeAsync(MINUTE);
       const result = await execution;
 
       expect(result.status).toBe('aborted');
       expect(selectorSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      engine.removeAllListeners();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('OpenCode tool 実行中は1倍の親期限で生存し、6倍の stale 上限で PART_TIMEOUT にする', async () => {
+    vi.useFakeTimers();
+    const tmpDir = mkdtempSync(join(tmpdir(), 'takt-opencode-tool-deadline-'));
+    let providerSignal: AbortSignal | undefined;
+    const step = makeStep('long-tool', {
+      provider: 'opencode',
+      model: 'opencode/tool-model',
+      providerOptions: { opencode: { guards: { callTimeoutMs: MINUTE } } },
+      rules: [makeRule('approved', 'COMPLETE')],
+    });
+    const config: WorkflowConfig = {
+      name: 'opencode-tool-deadline-workflow',
+      maxSteps: 1,
+      initialStep: step.name,
+      steps: [step],
+    };
+    const engine = new WorkflowEngine(config, tmpDir, 'long tool task', {
+      projectCwd: tmpDir,
+      provider: 'opencode',
+      reportDirName: 'opencode-tool-deadline',
+    });
+    try {
+      mockRuleEvaluation.mockReturnValue(undefined);
+      vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
+        options.onPromptResolved?.({
+          systemPrompt: typeof persona === 'string' ? persona : '',
+          userInstruction: instruction,
+        });
+        options.onActivity?.({ kind: 'attempt_started' });
+        options.onStream?.({
+          type: 'tool_use',
+          data: { tool: 'Bash', input: { command: 'npm test' }, id: 'tool-1' },
+        });
+        providerSignal = options.abortSignal;
+        if (providerSignal === undefined) {
+          throw new Error('OpenCode provider did not receive a deadline signal');
+        }
+        return { ...await waitForAbort(providerSignal), persona: persona ?? 'long-tool' };
+      });
+
+      const execution = engine.run();
+      await waitForCondition(() => providerSignal !== undefined, 'OpenCode tool invocation');
+      await vi.advanceTimersByTimeAsync(MINUTE);
+      expect(providerSignal?.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(MINUTE * 5 - 1);
+      expect(providerSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await execution;
+
+      expect(result.status).toBe('aborted');
+      expect(providerSignal?.aborted).toBe(true);
+      expect((providerSignal?.reason as Error).message).toBe(`Part timeout after ${MINUTE}ms`);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       engine.removeAllListeners();

--- a/src/__tests__/workflow-validator.test.ts
+++ b/src/__tests__/workflow-validator.test.ts
@@ -505,6 +505,22 @@ describe('validateWorkflowConfig', () => {
     );
   });
 
+  it('allows the engine-produced terminal error aggregate label without reviewer-authored error rules', () => {
+    const workflow = createProgrammaticDynamicParallelWorkflow([], [{
+      name: 'frontend',
+      description: 'Review frontend',
+      personaDisplayName: 'frontend',
+      instruction: 'review frontend',
+      rules: [normalizeRule({ condition: 'approved' })],
+    }]);
+    workflow.steps[0]!.rules = [
+      normalizeRule({ condition: 'any("error")', next: 'reviewers' }),
+      normalizeRule({ condition: 'all("approved")', next: 'COMPLETE' }),
+    ];
+
+    expect(() => validateWorkflowConfig(workflow, { projectCwd: process.cwd() })).not.toThrow();
+  });
+
   it('fails fast when a parallel step contains duplicate sibling sub-step names', () => {
     const workflow = createWorkflow({
       initialStep: 'reviewers',

--- a/src/agents/agent-usecases.ts
+++ b/src/agents/agent-usecases.ts
@@ -5,7 +5,8 @@ import {
 } from '../infra/providers/provider-capabilities.js';
 import type { StepProviderOptions } from '../core/models/workflow-types.js';
 import type { Language } from '../core/models/types.js';
-import type { ProviderType } from '../shared/types/provider.js';
+import type { ProviderActivityCallback, ProviderType } from '../shared/types/provider.js';
+import type { StreamCallback } from '../shared/types/provider.js';
 
 export {
   evaluateCondition,
@@ -42,6 +43,8 @@ export interface ResolvedInternalAgentOptions {
   readonly childProcessEnv?: Readonly<Record<string, string>>;
   readonly failureDir?: string;
   readonly sessionId?: string;
+  readonly onStream?: StreamCallback;
+  readonly onActivity?: ProviderActivityCallback;
   readonly resolution: {
     readonly provider: ProviderType;
     readonly model: string | undefined;

--- a/src/agents/auto-routing-usecase.ts
+++ b/src/agents/auto-routing-usecase.ts
@@ -134,7 +134,7 @@ export function createWorkRequirementEstimator(options: WorkRequirementEstimator
   return {
     async estimate(
       input: RoutingModelInput,
-      estimateOptions?: { abortSignal?: AbortSignal },
+      estimateOptions?: Parameters<WorkRequirementEstimator['estimate']>[1],
     ): Promise<WorkRequirementEstimate> {
       options.abortSignal?.throwIfAborted();
       estimateOptions?.abortSignal?.throwIfAborted();
@@ -155,6 +155,8 @@ export function createWorkRequirementEstimator(options: WorkRequirementEstimator
               permissionMode: options.permissionMode,
             },
             abortSignal: abortScope.signal,
+            onStream: estimateOptions?.onStream,
+            onActivity: estimateOptions?.onActivity,
             language: options.language,
             childProcessEnv: options.childProcessEnv,
             failureDir: options.failureDir,

--- a/src/agents/decompose-task-usecase.ts
+++ b/src/agents/decompose-task-usecase.ts
@@ -52,6 +52,7 @@ export interface DecomposeTaskOptions {
   permissionMode?: PermissionMode;
   projectCwd?: string;
   onStream?: StreamCallback;
+  onActivity?: RunAgentOptions['onActivity'];
   workflowMeta?: RunAgentOptions['workflowMeta'];
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
   abortSignal?: RunAgentOptions['abortSignal'];
@@ -119,6 +120,7 @@ export async function requestDecompositionRawResponse(
       ...(options.inspectTools === undefined ? {} : { allowedTools: options.inspectTools }),
       mcpServers: options.mcpServers,
       onStream: createPublicationGuardedStreamCallback(options.onStream, options.abortSignal),
+      onActivity: options.onActivity,
       workflowMeta: options.workflowMeta,
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,
@@ -217,6 +219,7 @@ export async function requestMorePartsRawResponse(
       },
       mcpServers: options.mcpServers,
       onStream: createPublicationGuardedStreamCallback(options.onStream, options.abortSignal),
+      onActivity: options.onActivity,
       workflowMeta: options.workflowMeta,
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,

--- a/src/agents/judge-status-usecase.ts
+++ b/src/agents/judge-status-usecase.ts
@@ -35,6 +35,7 @@ export interface JudgeStatusOptions {
   abortSignal?: AbortSignal;
   failureDir?: RunAgentOptions['failureDir'];
   onStream?: StreamCallback;
+  onActivity?: () => void;
   onJudgeStage?: (entry: JudgeStageLogEntry) => void;
   onStructuredPromptResolved?: (promptParts: {
     systemPrompt: string;
@@ -63,6 +64,7 @@ export interface TagJudgeRunOptions {
   projectCwd?: string;
   language?: Language;
   onStream?: StreamCallback;
+  onActivity?: () => void;
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
   abortSignal?: AbortSignal;
   failureDir?: RunAgentOptions['failureDir'];
@@ -92,6 +94,7 @@ export async function runTagJudgeStage(
       },
       language: runOptions.language,
       onStream: runOptions.onStream,
+      onActivity: runOptions.onActivity,
       childProcessEnv: runOptions.childProcessEnv,
       abortSignal: runOptions.abortSignal,
       failureDir: runOptions.failureDir,
@@ -151,6 +154,8 @@ export interface EvaluateConditionOptions {
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
   abortSignal?: AbortSignal;
   failureDir?: RunAgentOptions['failureDir'];
+  onStream?: RunAgentOptions['onStream'];
+  onActivity?: RunAgentOptions['onActivity'];
   onJudgeResponse?: (entry: {
     instruction: string;
     status: 'done' | 'error';
@@ -205,6 +210,8 @@ export async function evaluateCondition(
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,
       failureDir: options.failureDir,
+      onStream: options.onStream,
+      onActivity: options.onActivity,
     });
   } catch (error) {
     if (!(error instanceof StructuredAgentResponseError)) {
@@ -290,6 +297,8 @@ async function runAiJudgeStage(
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,
       failureDir: options.failureDir,
+      onStream: options.onStream,
+      onActivity: options.onActivity,
       onJudgeResponse: stage3.capture,
     });
   } catch (error) {
@@ -333,6 +342,7 @@ export async function runJudgeFallbackStages(
       projectCwd: options.projectCwd,
       language: options.language,
       onStream: options.onStream,
+      onActivity: options.onActivity,
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,
       failureDir: options.failureDir,
@@ -393,6 +403,7 @@ export async function judgeStatus(
         },
         language: options.language,
         onStream: options.onStream,
+        onActivity: options.onActivity,
         childProcessEnv: options.childProcessEnv,
         abortSignal: options.abortSignal,
         failureDir: options.failureDir,

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -178,6 +178,7 @@ export class AgentRunner {
       permissionMode: resolution.permissionMode,
       providerOptions: resolution.providerOptions,
       onStream: options.onStream,
+      onActivity: options.onActivity,
       onPermissionRequest: options.onPermissionRequest,
       onAskUserQuestion: options.onAskUserQuestion,
       bypassPermissions: options.bypassPermissions,
@@ -364,5 +365,7 @@ export async function runAgent(
   task: string,
   options: RunAgentOptions,
 ): Promise<AgentResponse> {
+  // Provider dispatch is an attempt boundary even when the provider emits no stream events.
+  options.onActivity?.();
   return defaultRunner.run(personaSpec, task, options);
 }

--- a/src/agents/structured-caller/transport.ts
+++ b/src/agents/structured-caller/transport.ts
@@ -32,6 +32,7 @@ export interface StructuredAgentCallOptions {
   readonly childProcessEnv?: Readonly<Record<string, string>>;
   readonly failureDir?: RunAgentOptions['failureDir'];
   readonly onStream?: RunAgentOptions['onStream'];
+  readonly onActivity?: RunAgentOptions['onActivity'];
   readonly onPromptResolved?: RunAgentOptions['onPromptResolved'];
   readonly onDispatch?: RunAgentOptions['onDispatch'];
   readonly workflowMeta?: RunAgentOptions['workflowMeta'];
@@ -111,6 +112,7 @@ async function executeFreshAgent(
     ...(options.childProcessEnv === undefined ? {} : { childProcessEnv: options.childProcessEnv }),
     ...(options.failureDir === undefined ? {} : { failureDir: options.failureDir }),
     ...(options.onStream === undefined ? {} : { onStream: options.onStream }),
+    ...(options.onActivity === undefined ? {} : { onActivity: options.onActivity }),
     ...(options.onPromptResolved === undefined ? {} : { onPromptResolved: options.onPromptResolved }),
     ...(options.onDispatch === undefined ? {} : { onDispatch: options.onDispatch }),
     ...(options.workflowMeta === undefined ? {} : { workflowMeta: options.workflowMeta }),

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -10,7 +10,11 @@ import type {
   StepProviderOptions,
   ProviderPermissionProfiles,
 } from '../core/models/index.js';
-import type { InternalAgentIsolation, ProviderType } from '../shared/types/provider.js';
+import type {
+  InternalAgentIsolation,
+  ProviderActivityCallback,
+  ProviderType,
+} from '../shared/types/provider.js';
 
 export type { StreamCallback };
 
@@ -64,6 +68,7 @@ export interface RunAgentOptions {
   resolvedProviderOptions?: StepProviderOptions | null;
   resolvedExecution?: ResolvedAgentExecution;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   onPermissionRequest?: PermissionHandler;
   onAskUserQuestion?: AskUserQuestionHandler;
   onDispatch?: (permissionMode: PermissionMode | undefined) => void;

--- a/src/core/models/workflow-provider-options.ts
+++ b/src/core/models/workflow-provider-options.ts
@@ -22,7 +22,7 @@ export interface McpHttpServerConfig {
 export type McpServerConfig = McpStdioServerConfig | McpSseServerConfig | McpHttpServerConfig;
 
 export interface ProviderGuardOptions {
-  /** 呼び出し全体の wall-clock 上限 (ms)。既定 60 分。 */
+  /** プロバイダイベントが届かない時間の上限 (ms)。既定 60 分。 */
   callTimeoutMs?: number;
 }
 
@@ -43,7 +43,7 @@ export type OpenCodeGuardProfile = (typeof OPENCODE_GUARD_PROFILES)[number];
 /**
  * OpenCode 実行ガード設定。
  * profile が切るのはヒューリスティック検出（連続エラー・burst・cycle budget・
- * 連続完全一致反復）のみ。wall-clock・有界資源（容量・イベント数・追跡ID数）・
+ * 連続完全一致反復）のみ。無応答期限・有界資源（容量・イベント数・追跡ID数）・
  * 機密リダクションの fail-closed・厳密検出（edit conflict / unavailable / invalid
  * + correction）は minimal でも常時有効。idle watchdog は認証済み transport
  * の拡張として明示的に追加する場合だけ利用する。
@@ -53,7 +53,7 @@ export interface OpenCodeGuardOptions {
   profile?: OpenCodeGuardProfile;
   /** 解決済みモデル文字列に対する先勝ちの `*` ワイルドカードプロファイル。 */
   modelProfiles?: Record<string, OpenCodeGuardProfile>;
-  /** 呼び出し全体の wall-clock 上限 (ms)。60,000〜86,400,000 の整数。0 不可。既定 3,600,000。 */
+  /** プロバイダイベントが届かない時間の上限 (ms)。60,000〜86,400,000 の整数。0 不可。既定 3,600,000。 */
   callTimeoutMs?: number;
   /** 構造イベント数上限。既定 500,000。 */
   eventLimit?: number;
@@ -108,7 +108,7 @@ export interface ClaudeProviderOptions {
 export interface ClaudeTerminalProviderOptions {
   backend?: 'tmux';
   guards?: ProviderGuardOptions;
-  /** 旧設定。guards.callTimeoutMs が未指定の場合だけ呼び出し上限として使う。 */
+  /** 旧設定。guards.callTimeoutMs が未指定の場合だけ無応答上限として使う。 */
   timeoutMs?: number;
   keepSession?: boolean;
   transcriptPollIntervalMs?: number;

--- a/src/core/models/workflow-rule-condition.ts
+++ b/src/core/models/workflow-rule-condition.ts
@@ -15,6 +15,9 @@ export type WorkflowRuleCondition =
   | { kind: 'aggregate'; aggregate: 'all' | 'any'; targetConditions: WorkflowRuleCondition[] }
   | { kind: 'and'; left: WorkflowRuleCondition; right: WorkflowRuleCondition };
 
+/** Engine-produced aggregate label for a parallel participant that ended in terminal error. */
+export const PARALLEL_TERMINAL_ERROR_LABEL = 'error';
+
 /** A semantic label selectable during Phase 3 status judgment. */
 export interface SemanticRuleCandidate {
   label: string;

--- a/src/core/workflow/auto-routing/contracts.ts
+++ b/src/core/workflow/auto-routing/contracts.ts
@@ -1,4 +1,5 @@
 import type { RoutingTier } from '../../models/config-types.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../../shared/types/provider.js';
 
 export type { RoutingTier };
 
@@ -72,5 +73,9 @@ export function validateRoutingReasonCodes(reasonCodes: unknown): asserts reason
 }
 
 export interface WorkRequirementEstimator {
-  estimate(input: RoutingModelInput, options?: { abortSignal?: AbortSignal }): Promise<WorkRequirementEstimate>;
+  estimate(input: RoutingModelInput, options?: {
+    abortSignal?: AbortSignal;
+    onStream?: StreamCallback;
+    onActivity?: ProviderActivityCallback;
+  }): Promise<WorkRequirementEstimate>;
 }

--- a/src/core/workflow/auto-routing/resolver.ts
+++ b/src/core/workflow/auto-routing/resolver.ts
@@ -9,6 +9,7 @@ import { normalizeRoutingWorkSnapshot } from './normalizer.js';
 import { hasAutoRoutingPoolAssignment, resolveAutoRoutingRuleCandidate, selectRoutingCandidate } from './selector.js';
 import type { RoutingRuntime } from './runtime.js';
 import { isProviderStreamParseError } from '../../../shared/types/agent-failure.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../../shared/types/provider.js';
 
 export interface AutoRoutingStepMetadata {
   name: string;
@@ -39,6 +40,8 @@ export interface ResolveAutoRoutingRuntimeInput {
   runtime?: RoutingRuntime;
   logger?: AutoRoutingLogger;
   abortSignal?: AbortSignal;
+  onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
 }
 
 export interface ResolveAutoRoutingBatchItem {
@@ -57,6 +60,8 @@ export interface ResolveAutoRoutingBatchInput {
   runtime?: RoutingRuntime;
   logger?: AutoRoutingLogger;
   abortSignal?: AbortSignal;
+  onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
 }
 
 const CLAUDE_MODEL_ALIASES = new Set(['opus', 'sonnet', 'haiku']);
@@ -174,6 +179,8 @@ export async function resolveAutoRoutingRuntime(input: ResolveAutoRoutingRuntime
       scope: resolveRoutingScope(input),
       snapshot: input.snapshot,
       abortSignal: input.abortSignal,
+      onStream: input.onStream,
+      onActivity: input.onActivity,
     });
     if (decision.fallbackReason !== undefined) {
       input.logger?.warn('Auto routing estimator failed; using configured pool fallback');
@@ -200,6 +207,8 @@ export async function resolveAutoRoutingRuntime(input: ResolveAutoRoutingRuntime
   try {
     estimate = await input.estimator.estimate(normalizeRoutingWorkSnapshot(input.snapshot), {
       abortSignal: input.abortSignal,
+      onStream: input.onStream,
+      onActivity: input.onActivity,
     });
   } catch (error) {
     if (input.abortSignal?.aborted) {

--- a/src/core/workflow/auto-routing/runtime.ts
+++ b/src/core/workflow/auto-routing/runtime.ts
@@ -1,5 +1,6 @@
 import type { AutoRoutingConfig, RoutingTier } from '../../models/config-types.js';
 import type { RoutingWorkSnapshot, WorkRequirementEstimate, WorkRequirementEstimator } from './contracts.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../../shared/types/provider.js';
 import {
   createRoutingModelInputDigest,
   createRoutingWorkFingerprint,
@@ -23,7 +24,13 @@ export class RoutingRuntime {
 
   constructor(private readonly options: { autoRouting: AutoRoutingConfig; estimator: WorkRequirementEstimator }) {}
 
-  async resolve(input: { scope: string; snapshot: RoutingWorkSnapshot; abortSignal?: AbortSignal }) {
+  async resolve(input: {
+    scope: string;
+    snapshot: RoutingWorkSnapshot;
+    abortSignal?: AbortSignal;
+    onStream?: StreamCallback;
+    onActivity?: ProviderActivityCallback;
+  }) {
     input.abortSignal?.throwIfAborted();
     const fingerprint = createRoutingWorkFingerprint(input.snapshot);
     const previous = this.resolutions.get(input.scope);
@@ -40,6 +47,8 @@ export class RoutingRuntime {
       } else {
         estimate = await this.options.estimator.estimate(modelInput, {
           abortSignal: input.abortSignal,
+          onStream: input.onStream,
+          onActivity: input.onActivity,
         });
         this.estimates.set(estimateCacheKey, this.copyEstimate(estimate));
       }

--- a/src/core/workflow/companion/step-runtime.ts
+++ b/src/core/workflow/companion/step-runtime.ts
@@ -66,6 +66,8 @@ interface CompanionStepRuntimeDeps {
   readonly selectorProvider?: SelectorProviderInfo;
   readonly diffReader: CompanionDiffReader;
   readonly abortSignal?: AbortSignal;
+  readonly onStream?: RunAgentOptions['onStream'];
+  readonly onActivity?: RunAgentOptions['onActivity'];
   readonly stateStore: CompanionReviewStateStore;
   readonly emitEvent: CompanionEventEmitter;
   readonly recordUsage: (
@@ -104,6 +106,8 @@ export class CompanionStepRuntime {
       failureDir: deps.failureDir,
       language: deps.language,
       abortSignal: deps.abortSignal,
+      onStream: deps.onStream,
+      onActivity: deps.onActivity,
       recordUsage: deps.recordUsage,
       recordCall: (call: CompanionCallAudit) => {
         this.events.call({

--- a/src/core/workflow/companion/structured-call.ts
+++ b/src/core/workflow/companion/structured-call.ts
@@ -1,6 +1,7 @@
 import { executeStructuredAgent } from '../../../agents/structured-caller/transport.js';
 import type { AgentResponse } from '../../models/types.js';
 import type { ProviderRoutingEntry } from '../../models/config-types.js';
+import type { RunAgentOptions } from '../../../agents/runner.js';
 import {
   executeCompanionStructuredAgent,
   type CompanionAgentPurpose,
@@ -15,6 +16,8 @@ export class CompanionStructuredCaller {
     readonly failureDir: string;
     readonly language: 'en' | 'ja';
     readonly abortSignal?: AbortSignal;
+    readonly onStream?: RunAgentOptions['onStream'];
+    readonly onActivity?: RunAgentOptions['onActivity'];
     readonly recordUsage: (
       name: string,
       provider: ProviderRoutingEntry,
@@ -73,6 +76,8 @@ export class CompanionStructuredCaller {
           systemPrompt,
           language: this.input.language,
           abortSignal: options.abortSignal,
+          onStream: this.input.onStream,
+          onActivity: this.input.onActivity,
           onPromptResolved: options.onPromptResolved,
           resolution: {
             provider: options.resolution.provider,

--- a/src/core/workflow/dynamic-facets/dynamicFacetSelectorCoordinator.ts
+++ b/src/core/workflow/dynamic-facets/dynamicFacetSelectorCoordinator.ts
@@ -24,6 +24,10 @@ import {
   sanitizeSensitiveTextWithKnownValues,
 } from '../../../shared/utils/sensitiveText.js';
 import { SelectorInputReader } from '../dynamic-parallel/selector-input-reader.js';
+import type {
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../../shared/types/provider.js';
 
 const log = createLogger('dynamic-facet-selector');
 const SELECTOR_RATIONALE_LOG_MAX_BYTES = 1024;
@@ -31,6 +35,8 @@ const SELECTOR_RATIONALE_LOG_MAX_BYTES = 1024;
 export interface DynamicFacetSelectorCoordinatorDeps {
   readonly engineOptions: WorkflowEngineOptions;
   readonly getAbortSignal?: () => AbortSignal | undefined;
+  readonly onStream?: StreamCallback;
+  readonly onActivity?: ProviderActivityCallback;
   readonly failureDir: string;
   readonly selectionStore: DynamicFacetSelectionStore;
   readonly getWorkflowReference: () => string;
@@ -140,6 +146,8 @@ export class DynamicFacetSelectorCoordinator {
           persona: step.dynamicFacets.selector?.persona,
           workflowBundleResourceRoot: this.deps.engineOptions.workflowBundleResourceRoot,
           abortSignal: signal,
+          onStream: this.deps.onStream,
+          onActivity: this.deps.onActivity,
           language: this.deps.engineOptions.language,
           failureDir: this.deps.failureDir,
           personaPath: step.dynamicFacets.selector?.personaPath,

--- a/src/core/workflow/dynamic-parallel/selector-coordinator.ts
+++ b/src/core/workflow/dynamic-parallel/selector-coordinator.ts
@@ -21,6 +21,10 @@ import {
   createBoundedSensitiveValues,
   sanitizeSensitiveTextWithKnownValues,
 } from '../../../shared/utils/sensitiveText.js';
+import type {
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../../shared/types/provider.js';
 
 const log = createLogger('dynamic-parallel-selector');
 const SELECTOR_RATIONALE_LOG_MAX_BYTES = 1024;
@@ -28,6 +32,8 @@ const SELECTOR_RATIONALE_LOG_MAX_BYTES = 1024;
 export interface DynamicParallelSelectorCoordinatorDeps {
   readonly engineOptions: WorkflowEngineOptions;
   readonly getAbortSignal?: () => AbortSignal | undefined;
+  readonly onStream?: StreamCallback;
+  readonly onActivity?: ProviderActivityCallback;
   readonly failureDir: string;
   readonly selectionStore: DynamicParallelSelectionStore;
   readonly getCwd: () => string;
@@ -114,6 +120,8 @@ export class DynamicParallelSelectorCoordinator {
           persona: step.parallel.selection.selector?.persona,
           workflowBundleResourceRoot: this.deps.engineOptions.workflowBundleResourceRoot,
           abortSignal: signal,
+          onStream: this.deps.onStream,
+          onActivity: this.deps.onActivity,
           language: this.deps.engineOptions.language,
           failureDir: this.deps.failureDir,
           personaPath: step.parallel.selection.selector?.personaPath,

--- a/src/core/workflow/dynamic-parallel/validator.ts
+++ b/src/core/workflow/dynamic-parallel/validator.ts
@@ -2,6 +2,7 @@ import type { WorkflowRuleCondition } from '../../models/workflow-rule-condition
 import {
   aggregateConditionsOf,
   dynamicParallelAggregateTargetLabel,
+  PARALLEL_TERMINAL_ERROR_LABEL,
   semanticLabelsOf,
 } from '../../models/workflow-rule-condition.js';
 import type {
@@ -82,7 +83,8 @@ function validateAggregateContracts(
   stepPath: readonly PropertyKey[],
 ): void {
   const requiredLabels = new Set((step.rules ?? []).flatMap((rule, index) =>
-    aggregateTargetLabels(rule.condition, [...stepPath, 'rules', index, 'condition'])));
+    aggregateTargetLabels(rule.condition, [...stepPath, 'rules', index, 'condition']))
+    .filter((label) => label !== PARALLEL_TERMINAL_ERROR_LABEL));
   for (const role of ['fixed', 'pool'] as const) {
     for (const [index, subStep] of parallel[role].entries()) {
       const labels = new Set((subStep.rules ?? []).flatMap((rule) => semanticLabelsOf(rule.condition)));

--- a/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
+++ b/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
@@ -95,7 +95,7 @@ export class LoopMonitorJudgeRunner {
       this.deps.stepAbortSignalContext.getAbortSignal(),
     );
     try {
-      return await this.deps.stepAbortSignalContext.runWith(deadline.signal, async () => {
+      return await this.deps.stepAbortSignalContext.runWith(deadline, async () => {
         const stepEventWorkflowStack = this.deps.onStepStart(
           judgeStep,
           this.deps.state.iteration,

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -26,7 +26,11 @@ import {
   providerSupportsMaxTurns,
   providerSupportsStructuredOutput,
 } from '../../../infra/providers/provider-capabilities.js';
-import type { ProviderType, StreamCallback } from '../../../shared/types/provider.js';
+import type {
+  ProviderActivityCallback,
+  ProviderType,
+  StreamCallback,
+} from '../../../shared/types/provider.js';
 import type {
   WorkflowEngineOptions,
   PhaseName,
@@ -41,6 +45,10 @@ import { getWorkflowStepKind } from '../step-kind.js';
 import { resolveStepProviderModel } from '../provider-resolution.js';
 import { resolveDeterministicAutoRoutingProviderInfo, toAutoRoutingStepMetadata } from '../auto-routing/resolver.js';
 import { buildPhase1WorkflowMeta } from './workflow-meta.js';
+import {
+  recordWorkflowStepProviderActivity,
+  recordWorkflowStepProviderEventActivity,
+} from './step-deadline.js';
 
 type ResolvedRunAgentOptions = RunAgentOptions & {
   resolvedProviderOptions?: StepProviderOptions;
@@ -81,6 +89,7 @@ export class OptionsBuilder {
     private readonly getReviewScope?: () => TaskReviewScope,
     private readonly getFailureDir?: () => string,
     private readonly getAbortSignal: () => AbortSignal | undefined = () => this.engineOptions.abortSignal,
+    private readonly recordActivity: ProviderActivityCallback = () => {},
   ) {}
 
   private resolveAbortSignal(): AbortSignal | undefined {
@@ -174,19 +183,36 @@ export class OptionsBuilder {
     output: StreamCallback | undefined,
   ): StreamCallback | undefined {
     const onProviderStream = this.engineOptions.onProviderStream;
-    if (!onProviderStream) {
-      return output;
-    }
-    if (!provider) {
+    if (onProviderStream && !provider) {
       throw new Error(`Step "${step.name}" has no resolved provider for provider event logging`);
     }
     return (event): void => {
-      onProviderStream({
-        step: step.name,
-        provider,
-        providerModel: providerModel ?? '(default)',
-      }, event);
+      recordWorkflowStepProviderEventActivity(this.recordActivity, step.name, event);
+      if (onProviderStream && provider) {
+        onProviderStream({
+          step: step.name,
+          provider,
+          providerModel: providerModel ?? '(default)',
+        }, event);
+      }
       output?.(event);
+    };
+  }
+
+  buildDeadlineActivityCallbacks(
+    executionUnitKey: string,
+  ): Pick<RunAgentOptions, 'onStream' | 'onActivity'> {
+    return {
+      onStream: (event) => recordWorkflowStepProviderEventActivity(
+        this.recordActivity,
+        executionUnitKey,
+        event,
+      ),
+      onActivity: (activity) => recordWorkflowStepProviderActivity(
+        this.recordActivity,
+        executionUnitKey,
+        activity,
+      ),
     };
   }
 
@@ -405,6 +431,11 @@ export class OptionsBuilder {
       resolvedProviderOptions: providerOptions,
       language: this.getLanguage(),
       onStream: this.buildProviderStream(step, resolvedProvider, resolvedModel, this.engineOptions.onStream),
+      onActivity: (activity) => recordWorkflowStepProviderActivity(
+        this.recordActivity,
+        step.name,
+        activity,
+      ),
       onPermissionRequest: this.engineOptions.onPermissionRequest,
       onAskUserQuestion: this.engineOptions.onAskUserQuestion,
       bypassPermissions: this.engineOptions.bypassPermissions,
@@ -677,6 +708,11 @@ export class OptionsBuilder {
         stepProvider.provider,
         stepProvider.model,
         this.engineOptions.onStream,
+      ),
+      onActivity: (activity) => recordWorkflowStepProviderActivity(
+        this.recordActivity,
+        step.name,
+        activity,
       ),
       structuredCaller: this.requireStructuredCaller(),
       resolveStepProviderModel: (step) => this.resolveStepProviderModel(step, runtime),

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -27,7 +27,7 @@ import type { StepExecutor } from './StepExecutor.js';
 import type { WorkflowEngineOptions, PhaseName, PhasePromptParts, JudgeStageEntry, StepRunResult } from '../types.js';
 import type { RuntimeStepResolution } from '../types.js';
 import type {
-  WorkflowStepDeadline,
+  WorkflowStepInactivityDeadline,
   WorkflowStepExecutionDeadlineContext,
 } from './step-deadline.js';
 import type { ParallelLoggerOptions } from './parallel-logger.js';
@@ -46,7 +46,12 @@ import {
 import { compactSessionBeforePhase1 } from './session-compaction.js';
 import { invalidateExpectedPersonaSession, invalidatePersonaSessionIfExpected } from './session-invalidation.js';
 import { recordAgentUsageEvent } from './agent-usage-event.js';
-import { formatWorkflowRuleCondition } from '../../models/workflow-rule-condition.js';
+import {
+  aggregateConditionsOf,
+  formatWorkflowRuleCondition,
+  PARALLEL_TERMINAL_ERROR_LABEL,
+  semanticLabelsOf,
+} from '../../models/workflow-rule-condition.js';
 import { evaluatePostExecutionRules } from './post-execution-rule-evaluator.js';
 import { buildScopedStepIterationIdentity } from '../step-iteration-identity.js';
 import { createRunFailure } from '../run/run-failure.js';
@@ -72,6 +77,7 @@ import {
 } from '../../../shared/types/agent-failure.js';
 
 const log = createLogger('parallel-runner');
+export const MAX_EXPLICIT_PARALLEL_ERROR_RETRIES = 3;
 
 type ParallelSubStepResult = {
   subStep: WorkflowStep;
@@ -96,7 +102,7 @@ function isAgentParallelSubStep(step: WorkflowStep): step is AgentWorkflowStep {
 
 async function runWithExecutionDeadline<T>(
   context: WorkflowStepExecutionDeadlineContext | undefined,
-  deadline: WorkflowStepDeadline | undefined,
+  deadline: WorkflowStepInactivityDeadline | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
   if (context === undefined || deadline === undefined) {
@@ -199,6 +205,8 @@ export interface ParallelRunnerDeps {
 }
 
 export class ParallelRunner {
+  private readonly explicitErrorAttemptsByStep = new Map<string, number>();
+
   constructor(
     private readonly deps: ParallelRunnerDeps,
   ) {}
@@ -310,6 +318,9 @@ export class ParallelRunner {
           runtime: this.deps.engineOptions.routingRuntime,
           logger: log,
           abortSignal: this.resolveAbortSignal(),
+          ...this.deps.optionsBuilder.buildDeadlineActivityCallbacks(
+            `parallel:auto-routing:${step.name}`,
+          ),
         })
       : new Map();
     const workflowCallResumeStack = subSteps.some(isWorkflowCallStep)
@@ -331,8 +342,8 @@ export class ParallelRunner {
       return [subStep.name, providerInfo];
     }));
 
-    const subStepDeadlineByName = new Map<string, WorkflowStepDeadline>();
-    const getSubStepDeadline = (subStep: WorkflowStep): WorkflowStepDeadline | undefined => {
+    const subStepDeadlineByName = new Map<string, WorkflowStepInactivityDeadline>();
+    const getSubStepDeadline = (subStep: WorkflowStep): WorkflowStepInactivityDeadline | undefined => {
       if (executionDeadlineContext === undefined) {
         return undefined;
       }
@@ -489,12 +500,17 @@ export class ParallelRunner {
             updatePersonaSession,
           );
         }
-        // Override onStream with parallel logger's prefixed handler (immutable)
+        // Preserve provider activity/logging while replacing only the display callback.
         const agentOptions: RunAgentOptions = parallelLogger
           ? {
               ...baseOptions,
               ...(compactionOutcome === 'fresh' ? { sessionId: undefined } : {}),
-              onStream: parallelLogger.createStreamHandler(subStep.name, index),
+              onStream: this.deps.optionsBuilder.buildProviderStream(
+                executableSubStep,
+                subPm.provider,
+                subPm.model,
+                parallelLogger.createStreamHandler(subStep.name, index),
+              ),
             }
           : {
               ...baseOptions,
@@ -1007,7 +1023,11 @@ export class ParallelRunner {
     }
 
     const errorResults = terminalResults.filter((r) => r.response.status === 'error');
-    if (errorResults.length > 0) {
+    const hasExplicitErrorRule = this.hasExplicitErrorAggregateRule(step);
+    if (errorResults.length === 0) {
+      this.explicitErrorAttemptsByStep.delete(step.name);
+    } else if (!hasExplicitErrorRule) {
+      this.explicitErrorAttemptsByStep.delete(step.name);
       const primaryFailure = this.firstFailureResult(errorResults);
       if (primaryFailure === undefined) {
         throw new Error(`Parallel step "${step.name}" has no primary error result`);
@@ -1022,6 +1042,35 @@ export class ParallelRunner {
         providerInfo: primaryFailure.providerInfo ?? parentPm,
         primaryFailure,
       });
+    } else {
+      const attempts = (this.explicitErrorAttemptsByStep.get(step.name) ?? 0) + 1;
+      this.explicitErrorAttemptsByStep.set(step.name, attempts);
+      if (attempts > MAX_EXPLICIT_PARALLEL_ERROR_RETRIES) {
+        const primaryFailure = this.firstFailureResult(errorResults);
+        if (primaryFailure === undefined) {
+          throw new Error(`Parallel step "${step.name}" has no primary error result`);
+        }
+        const reason = `Parallel step "${step.name}" exceeded its explicit error retry limit (${MAX_EXPLICIT_PARALLEL_ERROR_RETRIES})`;
+        return this.createTerminalParentResult({
+          step,
+          state,
+          stepIteration,
+          subResults,
+          terminalResults: errorResults,
+          status: 'error',
+          providerInfo: primaryFailure.providerInfo ?? parentPm,
+          primaryFailure,
+          failure: createRunFailure({
+            kind: 'step_error',
+            step: step.name,
+            reason,
+            error: reason,
+            ...(primaryFailure.response.failureCategory === undefined
+              ? {}
+              : { failureCategory: primaryFailure.response.failureCategory }),
+          }),
+        });
+      }
     }
 
     const blockedResults = terminalResults.filter((r) => r.response.status === 'blocked');
@@ -1084,7 +1133,9 @@ export class ParallelRunner {
 
     // Aggregate sub-step outputs into the parent step response
     const aggregatedContent = subResults
-      .map((r) => `## ${r.subStep.name}\n${r.response.content}`)
+      .map((r) => `## ${r.subStep.name}\n${r.response.status === 'error'
+        ? this.buildSubStepErrorDiagnostic(r)
+        : r.response.content}`)
       .join('\n\n---\n\n');
 
     const aggregatedInstruction = subResults
@@ -1398,6 +1449,7 @@ export class ParallelRunner {
     status: ParallelTerminalStatus;
     providerInfo: StepRunResult['providerInfo'];
     primaryFailure: ParallelSubStepResult;
+    failure?: StepRunResult['workflowCallFailure'];
   }): StepRunResult {
     const content = this.buildTerminalDiagnostic(
       options.step,
@@ -1408,7 +1460,11 @@ export class ParallelRunner {
     const failureCategory = primaryFailure.response.failureCategory;
     const boundedContent = truncateUtf8PreservingMarker(content, MAX_AGENT_FAILURE_MESSAGE_BYTES);
     const failureError = truncateUtf8PreservingMarker(
-      sanitizeSensitiveText(primaryFailure.response.error ?? primaryFailure.response.content),
+      sanitizeSensitiveText(
+        options.failure?.error
+          ?? primaryFailure.response.error
+          ?? primaryFailure.response.content,
+      ),
       MAX_AGENT_FAILURE_MESSAGE_BYTES,
     );
     const response: AgentResponse = {
@@ -1443,7 +1499,7 @@ export class ParallelRunner {
       );
     }
 
-    const selectedFailure = this.toRunFailure(primaryFailure);
+    const selectedFailure = options.failure ?? this.toRunFailure(primaryFailure);
     return {
       response,
       instruction: options.subResults.map((result) => result.instruction).join('\n\n'),
@@ -1506,6 +1562,25 @@ export class ParallelRunner {
       || result.response.status === 'blocked'
       || result.response.status === 'rate_limited'
     ));
+  }
+
+  private hasExplicitErrorAggregateRule(step: WorkflowStep): boolean {
+    return step.rules?.some((rule) => aggregateConditionsOf(rule.condition).some(
+      (condition) => condition.targetConditions.some(
+        (target) => semanticLabelsOf(target).includes(PARALLEL_TERMINAL_ERROR_LABEL),
+      ),
+    )) === true;
+  }
+
+  private buildSubStepErrorDiagnostic(result: ParallelSubStepResult): string {
+    const failureCategory = result.response.failureCategory ?? 'none';
+    const detail = sanitizeSensitiveText(result.response.error ?? result.response.content);
+    return [
+      '[ERROR]',
+      `status: ${result.response.status}`,
+      `failureCategory: ${failureCategory}`,
+      `detail: ${detail}`,
+    ].join('\n');
   }
 
   private buildTerminalDiagnostic(

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -387,6 +387,8 @@ export class StepExecutor {
                 abortSignal: this.resolveAbortSignal(),
                 childProcessEnv: judgeOptions.childProcessEnv,
                 failureDir: judgeOptions.failureDir,
+                onStream: judgeOptions.onStream,
+                onActivity: judgeOptions.onActivity,
                 resolution: {
                   provider,
                   model: judgeProviderInfo.model,
@@ -1331,6 +1333,11 @@ export class StepExecutor {
       sessionId: state.personaSessions.get(sessionKey) ?? 'new',
     });
 
+    const builtAgentOptions = this.deps.optionsBuilder.buildAgentOptions(
+      executableStep,
+      executionRuntime,
+    );
+
     // Phase 1: main execution (Write excluded if step has report)
     let companionRuntime: CompanionStepRuntime | undefined;
     if (isNormalAgentWorkflowStep(executableStep)) {
@@ -1388,6 +1395,8 @@ export class StepExecutor {
           selectorProvider: this.deps.companionSelectorProvider,
           diffReader: companionDiffReader,
           abortSignal: this.resolveAbortSignal(),
+          onStream: builtAgentOptions.onStream,
+          onActivity: builtAgentOptions.onActivity,
           stateStore: companionReviewState,
           emitEvent: this.deps.emitEvent,
           recordUsage: (name, companionProvider, success, usage) => {
@@ -1423,10 +1432,6 @@ export class StepExecutor {
       }
     }
     using activeCompanionRuntime = companionRuntime;
-    const builtAgentOptions = this.deps.optionsBuilder.buildAgentOptions(
-      executableStep,
-      executionRuntime,
-    );
     const baseAgentOptions = activeCompanionRuntime?.composeOptions(builtAgentOptions)
       ?? builtAgentOptions;
     const compactionOutcome = await compactSessionBeforePhase1(executableStep, baseAgentOptions);
@@ -1484,6 +1489,7 @@ export class StepExecutor {
                   childProcessEnv: agentOptions.childProcessEnv,
                   failureDir: agentOptions.failureDir,
                   onStream: agentOptions.onStream,
+                  onActivity: agentOptions.onActivity,
                   onPromptResolved,
                   workflowMeta: agentOptions.workflowMeta,
                 }).then((response) => {

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -62,7 +62,7 @@ import type {
 import { createAbortScope } from './abort-signal.js';
 import { isTeamLeaderPartCancellation } from './team-leader-part-cancellation.js';
 import type {
-  WorkflowStepDeadline,
+  WorkflowStepInactivityDeadline,
   WorkflowStepExecutionDeadlineContext,
 } from './step-deadline.js';
 
@@ -70,7 +70,7 @@ const log = createLogger('team-leader-runner');
 
 async function runWithExecutionDeadline<T>(
   context: WorkflowStepExecutionDeadlineContext | undefined,
-  deadline: WorkflowStepDeadline | undefined,
+  deadline: WorkflowStepInactivityDeadline | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
   if (context === undefined || deadline === undefined) {
@@ -263,6 +263,7 @@ export class TeamLeaderRunner {
       failureDir: leaderBaseOptions.failureDir,
       abortSignal: leaderAbortSignal,
       onStream: leaderBaseOptions.onStream,
+      onActivity: leaderBaseOptions.onActivity,
       onAgentResponse: (response: AgentResponse) => {
         this.recordUsage(
           leaderStep.name,
@@ -475,6 +476,7 @@ export class TeamLeaderRunner {
             cancellablePartIds: cancellablePartIdsCopy,
             abortSignal,
             onStream: leaderBaseOptions.onStream,
+            onActivity: leaderBaseOptions.onActivity,
             onAgentResponse: (response: AgentResponse) => {
               this.recordUsage(
                 leaderStep.name,
@@ -732,6 +734,9 @@ export class TeamLeaderRunner {
       runtime: this.deps.engineOptions.routingRuntime,
       logger: log,
       abortSignal: this.resolveAbortSignal(),
+      ...this.deps.optionsBuilder.buildDeadlineActivityCallbacks(
+        `team-leader:auto-routing:${leaderStep.name}`,
+      ),
     });
     if (!autoRuntime) {
       return runtime;
@@ -997,6 +1002,9 @@ export class TeamLeaderRunner {
       runtime: this.deps.engineOptions.routingRuntime,
       logger: log,
       abortSignal: this.resolveAbortSignal(),
+      ...this.deps.optionsBuilder.buildDeadlineActivityCallbacks(
+        `team-parts:auto-routing:${step.name}`,
+      ),
     });
 
     for (const [partId, providerInfo] of routed.entries()) {

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -71,6 +71,9 @@ import { WorkflowResumeContinuation } from './workflow-resume-continuation.js';
 import { inheritWorkflowConfigMetadata, translateWorkflowConfigError } from '../../../shared/workflowConfigMetadata.js';
 import { WorkflowRestartNavigator } from './WorkflowRestartNavigator.js';
 import { withWorkflowTargetContext } from '../provider-target-resolution.js';
+import { readResumeReportSnapshotManifest } from '../run/resume-report-snapshot.js';
+import { ResumeArtifactOccurrenceIndex } from '../run/resume-artifact-occurrence-index.js';
+import { readRunMetaBySlug } from '../run/run-meta.js';
 const log = createLogger('workflow-engine');
 
 type WorkflowEngineRuntimeOptions = WorkflowEngineOptions & {
@@ -254,6 +257,18 @@ export class WorkflowEngine extends EventEmitter {
     this.sharedRuntime.workflowStepParticipationIndex ??=
       restoreWorkflowStepParticipationIndex(this.options.resumePoint);
     this.sharedRuntime.companionReviewAuthority ??= new CompanionReviewAuthority();
+    if (
+      this.sharedRuntime.resumeArtifactOccurrenceIndex === undefined
+      && this.options.resumeSource?.resumeMode === 'requeue'
+    ) {
+      const manifest = readResumeReportSnapshotManifest(this.cwd, runPaths.slug);
+      this.sharedRuntime.resumeArtifactOccurrenceIndex = new ResumeArtifactOccurrenceIndex(
+        manifest,
+        manifest === undefined
+          ? undefined
+          : readRunMetaBySlug(this.cwd, manifest.sourceRunSlug)?.resumePoint,
+      );
+    }
     restoreActiveResumePoint(
       this.sharedRuntime,
       this.options.resumePoint,
@@ -276,6 +291,7 @@ export class WorkflowEngine extends EventEmitter {
     this.resumeContinuation = new WorkflowResumeContinuation(
       this.config,
       this.options.resumePoint,
+      this.sharedRuntime.resumeArtifactOccurrenceIndex,
     );
     this.syncStateDynamicParallelSelections();
     this.syncStateDynamicFacetSelections();

--- a/src/core/workflow/engine/WorkflowEnginePhaseRelay.ts
+++ b/src/core/workflow/engine/WorkflowEnginePhaseRelay.ts
@@ -38,6 +38,7 @@ export interface WorkflowPhaseRelay {
 export function createWorkflowPhaseRelay(
   emit: (event: string, ...args: unknown[]) => void,
   getCurrentWorkflowStack: () => readonly WorkflowResumePointEntry[] | undefined,
+  recordActivity: () => void = () => {},
 ): WorkflowPhaseRelay {
   const workflowStackByPhase = new Map<string, WorkflowResumePointEntry[]>();
   const phaseKey = (
@@ -53,6 +54,7 @@ export function createWorkflowPhaseRelay(
   ]);
   return {
     onPhaseStart: (step, phase, phaseName, instruction, promptParts, phaseExecutionId, iteration) => {
+      recordActivity();
       const workflowStack = requireWorkflowResumeStackSnapshot(
         getCurrentWorkflowStack(),
       );
@@ -73,6 +75,7 @@ export function createWorkflowPhaseRelay(
       );
     },
     onPhaseComplete: (step, phase, phaseName, content, phaseStatus, error, phaseExecutionId, iteration) => {
+      recordActivity();
       const key = phaseKey(step, phase, phaseExecutionId, iteration);
       const workflowStack = workflowStackByPhase.get(key);
       if (workflowStack === undefined) {
@@ -93,6 +96,7 @@ export function createWorkflowPhaseRelay(
       );
     },
     onJudgeStage: (step, phase, phaseName, entry, phaseExecutionId, iteration) => {
+      recordActivity();
       const workflowStack = workflowStackByPhase.get(
         phaseKey(step, phase, phaseExecutionId, iteration),
       );

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -51,6 +51,8 @@ import { restoreWorkflowStepParticipationIndex } from '../workflow-step-particip
 import { CompanionReviewAuthority } from '../companion/review-state-store.js';
 import {
   createWorkflowStepAbortSignalContext,
+  recordWorkflowStepProviderActivity,
+  recordWorkflowStepProviderEventActivity,
   type WorkflowStepAbortSignalContext,
 } from './step-deadline.js';
 
@@ -185,6 +187,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
   const phaseRelay = createWorkflowPhaseRelay(
     (event, ...args) => params.emitEvent(event, ...args),
     params.getCurrentWorkflowStack,
+    stepAbortSignalContext.recordActivity,
   );
   // base の解決は ref 走査を伴うため、ラン境界で一度だけ解決して保持する。
   const getReviewScope = createTaskReviewScopeResolver({
@@ -208,11 +211,22 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     getReviewScope,
     () => failureDir,
     stepAbortSignalContext.getAbortSignal,
+    stepAbortSignalContext.recordActivity,
   );
 
   const dynamicFacetSelector = new DynamicFacetSelectorCoordinator({
     engineOptions: params.options,
     getAbortSignal: stepAbortSignalContext.getAbortSignal,
+    onStream: (event) => recordWorkflowStepProviderEventActivity(
+      stepAbortSignalContext.recordActivity,
+      'dynamic-facet-selector',
+      event,
+    ),
+    onActivity: (activity) => recordWorkflowStepProviderActivity(
+      stepAbortSignalContext.recordActivity,
+      'dynamic-facet-selector',
+      activity,
+    ),
     failureDir,
     selectionStore: params.sharedRuntime.dynamicFacetSelectionStore!,
     getCwd: params.getCwd,
@@ -307,6 +321,16 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
   const dynamicParallelSelector = new DynamicParallelSelectorCoordinator({
     engineOptions: params.options,
     getAbortSignal: stepAbortSignalContext.getAbortSignal,
+    onStream: (event) => recordWorkflowStepProviderEventActivity(
+      stepAbortSignalContext.recordActivity,
+      'dynamic-parallel-selector',
+      event,
+    ),
+    onActivity: (activity) => recordWorkflowStepProviderActivity(
+      stepAbortSignalContext.recordActivity,
+      'dynamic-parallel-selector',
+      activity,
+    ),
     failureDir,
     selectionStore: params.sharedRuntime.dynamicParallelSelectionStore!,
     getCwd: params.getCwd,

--- a/src/core/workflow/engine/WorkflowEngineStepCoordinator.ts
+++ b/src/core/workflow/engine/WorkflowEngineStepCoordinator.ts
@@ -22,7 +22,7 @@ import { RuleDetectionExhaustedError } from '../evaluation/RuleDetectionExhauste
 import {
   createWorkflowStepCompositeDeadline,
   createWorkflowStepDeadline,
-  type WorkflowStepDeadline,
+  type WorkflowStepInactivityDeadline,
   type WorkflowStepDeadlineProviderInfo,
   type WorkflowStepExecutionDeadlineContext,
 } from './step-deadline.js';
@@ -144,7 +144,7 @@ interface WorkflowEngineStepCoordinatorDeps {
 }
 
 export class WorkflowEngineStepCoordinator {
-  private readonly stepDeadlines = new Map<string, WorkflowStepDeadline>();
+  private readonly stepDeadlines = new Map<string, WorkflowStepInactivityDeadline>();
 
   constructor(private readonly deps: WorkflowEngineStepCoordinatorDeps) {}
 
@@ -152,7 +152,7 @@ export class WorkflowEngineStepCoordinator {
     step: WorkflowStep,
     runtime: RuntimeStepResolution | undefined,
     stepIteration: number,
-  ): WorkflowStepDeadline {
+  ): WorkflowStepInactivityDeadline {
     const providerInfos = this.resolveStepDeadlineProviderInfos(step, runtime);
     return this.getOrCreateStepDeadline(
       step,
@@ -166,7 +166,7 @@ export class WorkflowEngineStepCoordinator {
     step: WorkflowStep,
     runtime: RuntimeStepResolution | undefined,
     stepIteration: number,
-  ): WorkflowStepDeadline {
+  ): WorkflowStepInactivityDeadline {
     const key = this.stepDeadlineKey(step, stepIteration, 'step');
     const existing = this.stepDeadlines.get(key);
     if (existing === undefined) {
@@ -177,7 +177,6 @@ export class WorkflowEngineStepCoordinator {
     const deadline = createWorkflowStepCompositeDeadline(
       providerInfos,
       this.deps.getOptions().abortSignal,
-      existing.startedAt,
     );
     this.stepDeadlines.set(key, deadline);
     return deadline;
@@ -188,7 +187,7 @@ export class WorkflowEngineStepCoordinator {
     stepIteration: number,
     executionUnitKey: string,
     providerInfo: WorkflowStepDeadlineProviderInfo,
-  ): WorkflowStepDeadline {
+  ): WorkflowStepInactivityDeadline {
     return this.getOrCreateStepDeadline(
       step,
       stepIteration,
@@ -252,8 +251,8 @@ export class WorkflowEngineStepCoordinator {
     step: WorkflowStep,
     stepIteration: number,
     executionUnitKey: string,
-    create: () => WorkflowStepDeadline,
-  ): WorkflowStepDeadline {
+    create: () => WorkflowStepInactivityDeadline,
+  ): WorkflowStepInactivityDeadline {
     const key = this.stepDeadlineKey(step, stepIteration, executionUnitKey);
     const existing = this.stepDeadlines.get(key);
     if (existing !== undefined) {
@@ -287,11 +286,11 @@ export class WorkflowEngineStepCoordinator {
         executionUnitKey,
         providerInfo,
       ),
-      runWith: <T>(deadline: WorkflowStepDeadline, operation: () => Promise<T>): Promise<T> => {
+      runWith: <T>(deadline: WorkflowStepInactivityDeadline, operation: () => Promise<T>): Promise<T> => {
         if (this.deps.stepAbortSignalContext === undefined) {
           return operation();
         }
-        return this.deps.stepAbortSignalContext.runWith(deadline.signal, operation);
+        return this.deps.stepAbortSignalContext.runWith(deadline, operation);
       },
     };
   }

--- a/src/core/workflow/engine/WorkflowRunLoop.ts
+++ b/src/core/workflow/engine/WorkflowRunLoop.ts
@@ -43,10 +43,16 @@ import {
   isAgentFailureError,
   isProviderStreamParseError,
 } from '../../../shared/types/agent-failure.js';
-import type {
-  WorkflowStepAbortSignalContext,
-  WorkflowStepDeadline,
+import {
+  recordWorkflowStepProviderActivity,
+  recordWorkflowStepProviderEventActivity,
+  type WorkflowStepAbortSignalContext,
+  type WorkflowStepInactivityDeadline,
 } from './step-deadline.js';
+import type {
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../../shared/types/provider.js';
 
 const log = createLogger('workflow-run-loop');
 
@@ -74,12 +80,12 @@ interface WorkflowRunLoopDeps {
     step: WorkflowStep,
     runtime: RuntimeStepResolution | undefined,
     stepIteration: number,
-  ) => WorkflowStepDeadline;
+  ) => WorkflowStepInactivityDeadline;
   refreshStepDeadline?: (
     step: WorkflowStep,
     runtime: RuntimeStepResolution | undefined,
     stepIteration: number,
-  ) => WorkflowStepDeadline;
+  ) => WorkflowStepInactivityDeadline;
   disposeStepDeadline?: (step: WorkflowStep, stepIteration: number) => void;
   disposeAllStepDeadlines?: () => void;
   stepAbortSignalContext?: WorkflowStepAbortSignalContext;
@@ -144,17 +150,39 @@ interface WorkflowRunLoopDeps {
 
 async function runWithStepDeadline<T>(
   deps: WorkflowRunLoopDeps,
-  deadline: WorkflowStepDeadline | undefined,
+  deadline: WorkflowStepInactivityDeadline | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
   if (deadline === undefined || deps.stepAbortSignalContext === undefined) {
     return operation();
   }
-  return deps.stepAbortSignalContext.runWith(deadline.signal, operation);
+  return deps.stepAbortSignalContext.runWith(deadline, operation);
 }
 
 function resolveStepAbortSignal(deps: WorkflowRunLoopDeps): AbortSignal | undefined {
   return deps.stepAbortSignalContext?.getAbortSignal() ?? deps.options.abortSignal;
+}
+
+function buildDeadlineActivityCallbacks(
+  deps: WorkflowRunLoopDeps,
+  executionUnitKey: string,
+): { onStream?: StreamCallback; onActivity?: ProviderActivityCallback } {
+  const recordActivity = deps.stepAbortSignalContext?.recordActivity;
+  if (recordActivity === undefined) {
+    return {};
+  }
+  return {
+    onStream: (event) => recordWorkflowStepProviderEventActivity(
+      recordActivity,
+      executionUnitKey,
+      event,
+    ),
+    onActivity: (activity) => recordWorkflowStepProviderActivity(
+      recordActivity,
+      executionUnitKey,
+      activity,
+    ),
+  };
 }
 
 async function resolveStepPromotionRuntime(
@@ -171,6 +199,8 @@ async function resolveStepPromotionRuntime(
     resolveStepProviderModel: deps.resolveStepProviderModelBeforeAutoRouting,
     providerLadders: deps.options.providerLadders,
     providerRoutingTagConflictPolicy: deps.options.providerRoutingTagConflictPolicy,
+    abortSignal: resolveStepAbortSignal(deps),
+    ...buildDeadlineActivityCallbacks(deps, `promotion:${step.name}`),
   }, step, stepIteration, runtime);
 }
 
@@ -225,6 +255,7 @@ async function resolveStepAutoRoutingRuntime(
     runtime: deps.options.routingRuntime,
     logger: log,
     abortSignal: resolveStepAbortSignal(deps),
+    ...buildDeadlineActivityCallbacks(deps, `auto-routing:${step.name}`),
   });
   if (!autoRuntime) {
     return runtime;
@@ -825,7 +856,7 @@ async function runWorkflowToCompletionCore(deps: WorkflowRunLoopDeps): Promise<W
       abort = abortWorkflowRuntimeError(deps, error);
       break;
     }
-    let stepDeadline: WorkflowStepDeadline | undefined;
+    let stepDeadline: WorkflowStepInactivityDeadline | undefined;
     let stepRuntime: RuntimeStepResolution | undefined;
     let preparedExecution: PreparedNormalStepExecution | undefined;
     let executionStep: WorkflowStep;
@@ -1217,7 +1248,7 @@ async function runSingleWorkflowIterationCore(deps: WorkflowRunLoopDeps): Promis
   const isDelegated = isDelegatedWorkflowStep(step);
   const stepIteration = deps.claimStepOccurrence(step);
   const workflowCallExecution = deps.setActiveStep(step, activeIteration, stepIteration);
-  let stepDeadline: WorkflowStepDeadline | undefined;
+  let stepDeadline: WorkflowStepInactivityDeadline | undefined;
   try {
     stepDeadline = isNormalAgentWorkflowStep(step)
       ? deps.beginStepDeadline?.(

--- a/src/core/workflow/engine/abort-signal.ts
+++ b/src/core/workflow/engine/abort-signal.ts
@@ -1,4 +1,9 @@
 import { createPartTimeoutReason } from '../../../shared/types/agent-failure.js';
+import { STALE_IN_FLIGHT_TOOL_FACTOR } from '../../../shared/types/provider-deadline.js';
+import type {
+  ProviderActivityCallback,
+  ProviderActivityEvent,
+} from '../../../shared/types/provider.js';
 
 export interface AbortScope {
   readonly signal: AbortSignal;
@@ -46,6 +51,91 @@ export function buildAbortSignal(
     signal: timeoutController.signal,
     dispose: () => {
       clearTimeout(timeoutId);
+      if (parentSignal && abortListener) {
+        parentSignal.removeEventListener('abort', abortListener);
+      }
+    },
+  };
+}
+
+export interface InactivityAbortSignal {
+  readonly signal: AbortSignal;
+  readonly recordActivity: ProviderActivityCallback;
+  readonly dispose: () => void;
+}
+
+export function buildInactivityAbortSignal(
+  inactivityTimeoutMs: number,
+  parentSignal: AbortSignal | undefined,
+): InactivityAbortSignal {
+  const timeoutController = new AbortController();
+  const toolStaleTimeoutMs = inactivityTimeoutMs * STALE_IN_FLIGHT_TOOL_FACTOR;
+  const inFlightTools = new Map<string, {
+    readonly executionUnitKey: string;
+    readonly startedAt: number;
+  }>();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const abortForInactivity = (): void => {
+    timeoutController.abort(new Error(createPartTimeoutReason(inactivityTimeoutMs)));
+  };
+  const armTimeoutAt = (deadlineAt: number): void => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    timeoutId = setTimeout(abortForInactivity, Math.max(0, deadlineAt - Date.now()));
+  };
+  const armTimeout = (): void => {
+    const earliestToolStart = inFlightTools.size === 0
+      ? undefined
+      : Math.min(...[...inFlightTools.values()].map(({ startedAt }) => startedAt));
+    armTimeoutAt(
+      earliestToolStart === undefined
+        ? Date.now() + inactivityTimeoutMs
+        : earliestToolStart + toolStaleTimeoutMs,
+    );
+  };
+  const applyActivity = (activity: ProviderActivityEvent | undefined): void => {
+    if (activity?.kind === 'attempt_started') {
+      if (activity.executionUnitKey === undefined) {
+        inFlightTools.clear();
+      } else {
+        for (const [toolCallKey, tool] of inFlightTools) {
+          if (tool.executionUnitKey === activity.executionUnitKey) {
+            inFlightTools.delete(toolCallKey);
+          }
+        }
+      }
+    } else if (activity?.kind === 'tool_started') {
+      if (!inFlightTools.has(activity.toolCallKey)) {
+        inFlightTools.set(activity.toolCallKey, {
+          executionUnitKey: activity.executionUnitKey,
+          startedAt: Date.now(),
+        });
+      }
+    } else if (activity?.kind === 'tool_finished') {
+      inFlightTools.delete(activity.toolCallKey);
+    }
+  };
+
+  let abortListener: (() => void) | undefined;
+  if (parentSignal) {
+    abortListener = () => timeoutController.abort(parentSignal.reason);
+    if (parentSignal.aborted) {
+      abortListener();
+    } else {
+      parentSignal.addEventListener('abort', abortListener, { once: true });
+    }
+  }
+  if (!timeoutController.signal.aborted) armTimeout();
+
+  return {
+    signal: timeoutController.signal,
+    recordActivity: (activity) => {
+      if (timeoutController.signal.aborted) return;
+      applyActivity(activity);
+      armTimeout();
+    },
+    dispose: () => {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      inFlightTools.clear();
       if (parentSignal && abortListener) {
         parentSignal.removeEventListener('abort', abortListener);
       }

--- a/src/core/workflow/engine/step-deadline.ts
+++ b/src/core/workflow/engine/step-deadline.ts
@@ -1,29 +1,71 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { StepProviderOptions } from '../../models/workflow-types.js';
-import type { ProviderType } from '../../../shared/types/provider.js';
+import type {
+  ProviderActivityCallback,
+  ProviderType,
+  StreamEvent,
+} from '../../../shared/types/provider.js';
 import { resolveProviderCallTimeoutMs } from '../../../shared/types/provider-deadline.js';
-import { buildAbortSignal } from './abort-signal.js';
+import { buildInactivityAbortSignal } from './abort-signal.js';
 
 export interface WorkflowStepAbortSignalContext {
   getAbortSignal(): AbortSignal | undefined;
-  runWith<T>(signal: AbortSignal, operation: () => Promise<T>): Promise<T>;
+  recordActivity: ProviderActivityCallback;
+  runWith<T>(deadline: WorkflowStepInactivityDeadline, operation: () => Promise<T>): Promise<T>;
 }
 
-export interface WorkflowStepDeadline {
+export interface WorkflowStepInactivityDeadline {
   readonly signal: AbortSignal;
+  readonly recordActivity: ProviderActivityCallback;
   readonly dispose: () => void;
-  readonly startedAt: number;
-  readonly timeoutMs: number;
+  readonly inactivityTimeoutMs: number;
+}
+
+export function recordWorkflowStepProviderEventActivity(
+  recordActivity: ProviderActivityCallback,
+  executionUnitKey: string,
+  event: StreamEvent,
+): void {
+  if (event.type === 'tool_use') {
+    recordActivity({
+      kind: 'tool_started',
+      executionUnitKey,
+      toolCallKey: JSON.stringify([executionUnitKey, event.data.id]),
+    });
+    return;
+  }
+  if (event.type === 'tool_result' && event.data.id !== undefined) {
+    recordActivity({
+      kind: 'tool_finished',
+      executionUnitKey,
+      toolCallKey: JSON.stringify([executionUnitKey, event.data.id]),
+    });
+    return;
+  }
+  recordActivity();
+}
+
+export function recordWorkflowStepProviderActivity(
+  recordActivity: ProviderActivityCallback,
+  executionUnitKey: string,
+  activity?: Parameters<ProviderActivityCallback>[0],
+): void {
+  if (activity?.kind === 'attempt_started') {
+    recordActivity({ ...activity, executionUnitKey });
+    return;
+  }
+  recordActivity(activity);
 }
 
 export function createWorkflowStepAbortSignalContext(
   parentSignal: AbortSignal | undefined,
 ): WorkflowStepAbortSignalContext {
-  const signalStorage = new AsyncLocalStorage<AbortSignal>();
+  const deadlineStorage = new AsyncLocalStorage<WorkflowStepInactivityDeadline>();
   return {
-    getAbortSignal: () => signalStorage.getStore() ?? parentSignal,
-    runWith: async <T>(signal: AbortSignal, operation: () => Promise<T>): Promise<T> => {
-      return signalStorage.run(signal, operation);
+    getAbortSignal: () => deadlineStorage.getStore()?.signal ?? parentSignal,
+    recordActivity: (activity) => deadlineStorage.getStore()?.recordActivity(activity),
+    runWith: async <T>(deadline: WorkflowStepInactivityDeadline, operation: () => Promise<T>): Promise<T> => {
+      return deadlineStorage.run(deadline, operation);
     },
   };
 }
@@ -83,8 +125,8 @@ export interface WorkflowStepExecutionDeadlineContext {
   begin(
     executionUnitKey: string,
     providerInfo: WorkflowStepDeadlineProviderInfo,
-  ): WorkflowStepDeadline;
-  runWith<T>(deadline: WorkflowStepDeadline, operation: () => Promise<T>): Promise<T>;
+  ): WorkflowStepInactivityDeadline;
+  runWith<T>(deadline: WorkflowStepInactivityDeadline, operation: () => Promise<T>): Promise<T>;
 }
 
 export function resolveWorkflowStepCompositeCallTimeoutMs(
@@ -103,19 +145,17 @@ export function createWorkflowStepDeadline(
   provider: ProviderType | undefined,
   providerOptions: StepProviderOptions | undefined,
   parentSignal: AbortSignal | undefined,
-): WorkflowStepDeadline {
-  const timeoutMs = resolveWorkflowStepCallTimeoutMs(provider, providerOptions);
-  const startedAt = Date.now();
-  const deadline = buildAbortSignal(timeoutMs, parentSignal, startedAt + timeoutMs);
-  return { ...deadline, startedAt, timeoutMs };
+): WorkflowStepInactivityDeadline {
+  const inactivityTimeoutMs = resolveWorkflowStepCallTimeoutMs(provider, providerOptions);
+  const deadline = buildInactivityAbortSignal(inactivityTimeoutMs, parentSignal);
+  return { ...deadline, inactivityTimeoutMs };
 }
 
 export function createWorkflowStepCompositeDeadline(
   providerInfos: readonly WorkflowStepDeadlineProviderInfo[],
   parentSignal: AbortSignal | undefined,
-  startedAt = Date.now(),
-): WorkflowStepDeadline {
-  const timeoutMs = resolveWorkflowStepCompositeCallTimeoutMs(providerInfos);
-  const deadline = buildAbortSignal(timeoutMs, parentSignal, startedAt + timeoutMs);
-  return { ...deadline, startedAt, timeoutMs };
+): WorkflowStepInactivityDeadline {
+  const inactivityTimeoutMs = resolveWorkflowStepCompositeCallTimeoutMs(providerInfos);
+  const deadline = buildInactivityAbortSignal(inactivityTimeoutMs, parentSignal);
+  return { ...deadline, inactivityTimeoutMs };
 }

--- a/src/core/workflow/engine/workflow-resume-continuation.ts
+++ b/src/core/workflow/engine/workflow-resume-continuation.ts
@@ -5,7 +5,8 @@ import type {
   WorkflowState,
   WorkflowStep,
 } from '../../models/types.js';
-import { getWorkflowResumeFrameKind } from '../step-kind.js';
+import { getWorkflowResumeFrameKind, isWorkflowCallStep } from '../step-kind.js';
+import type { ResumeArtifactOccurrenceIndex } from '../run/resume-artifact-occurrence-index.js';
 import { matchesResumeStackPrefix } from '../run/resume-point.js';
 import {
   workflowEntriesMatch,
@@ -17,6 +18,7 @@ import { incrementStepIteration } from './state-manager.js';
 export class WorkflowResumeContinuation {
   readonly #workflow: WorkflowConfig;
   readonly #source: WorkflowResumePoint | undefined;
+  readonly #resumeArtifactOccurrences: ResumeArtifactOccurrenceIndex | undefined;
   readonly #consumedFrameIndices = new Set<number>();
   readonly #claimedWorkflowCallFrames = new Map<
     number,
@@ -26,9 +28,11 @@ export class WorkflowResumeContinuation {
   constructor(
     workflow: WorkflowConfig,
     source: WorkflowResumePoint | undefined,
+    resumeArtifactOccurrences?: ResumeArtifactOccurrenceIndex,
   ) {
     this.#workflow = workflow;
     this.#source = source;
+    this.#resumeArtifactOccurrences = resumeArtifactOccurrences;
   }
 
   claimStepOccurrence(input: {
@@ -56,6 +60,17 @@ export class WorkflowResumeContinuation {
       || sourceFrame.step !== input.step.name
       || sourceFrame.kind !== getWorkflowResumeFrameKind(input.step)
     ) {
+      if (isWorkflowCallStep(input.step)) {
+        const inheritedMax = this.#resumeArtifactOccurrences?.getMaxOccurrence(
+          this.#workflow,
+          input.step.name,
+          input.resumeStackPrefix,
+        );
+        const current = input.state.stepIterations.get(stepIterationIdentity) ?? 0;
+        if (inheritedMax !== undefined && inheritedMax > current) {
+          input.state.stepIterations.set(stepIterationIdentity, inheritedMax);
+        }
+      }
       return incrementStepIteration(input.state, stepIterationIdentity);
     }
 

--- a/src/core/workflow/evaluation/AggregateEvaluator.ts
+++ b/src/core/workflow/evaluation/AggregateEvaluator.ts
@@ -7,6 +7,7 @@ import {
 import {
   dynamicParallelAggregateTargetLabel,
   formatWorkflowRuleCondition,
+  PARALLEL_TERMINAL_ERROR_LABEL,
   semanticLabelsOf,
   type WorkflowRuleCondition,
 } from '../../models/workflow-rule-condition.js';
@@ -64,6 +65,9 @@ export class AggregateEvaluator {
 
   private matchedCondition(subStep: WorkflowStep): WorkflowRuleCondition | undefined {
     const output = this.state.stepOutputs.get(subStep.name);
+    if (output?.status === 'error') {
+      return { kind: 'semantic', label: PARALLEL_TERMINAL_ERROR_LABEL };
+    }
     return output?.matchedRuleIndex === undefined
       ? undefined
       : subStep.rules?.[output.matchedRuleIndex]?.condition;

--- a/src/core/workflow/phase-runner.ts
+++ b/src/core/workflow/phase-runner.ts
@@ -62,6 +62,8 @@ export interface BasePhaseRunnerContext {
   failureDir?: string;
   /** Stream callback for provider event logging */
   onStream?: import('../../agents/types.js').StreamCallback;
+  /** Records provider activity that does not produce a public stream event. */
+  onActivity?: RunAgentOptions['onActivity'];
   /** Parent workflow iteration for sub-step phase events */
   iteration?: number;
   /** Callback for phase lifecycle logging */

--- a/src/core/workflow/promotion/PromotionEvaluator.ts
+++ b/src/core/workflow/promotion/PromotionEvaluator.ts
@@ -18,6 +18,9 @@ export interface PromotionEvaluationContext {
   resolvedProviderOptions?: StepProviderOptions;
   permissionMode?: PermissionMode;
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
+  abortSignal?: RunAgentOptions['abortSignal'];
+  onStream?: RunAgentOptions['onStream'];
+  onActivity?: RunAgentOptions['onActivity'];
 }
 
 function matchesAt(entry: WorkflowPromotionEntry, stepIteration: number): boolean {
@@ -90,6 +93,9 @@ async function matchesAiCondition(
       resolvedProviderOptions: context.resolvedProviderOptions,
       permissionMode: context.permissionMode,
       childProcessEnv: context.childProcessEnv,
+      abortSignal: context.abortSignal,
+      onStream: context.onStream,
+      onActivity: context.onActivity,
     },
   );
   return matchedIndex === entryIndex;

--- a/src/core/workflow/promotion/promotion-runtime.ts
+++ b/src/core/workflow/promotion/promotion-runtime.ts
@@ -22,6 +22,9 @@ export interface PromotionRuntimeContext {
   previousResponseContent: string;
   structuredCaller?: StructuredCaller;
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
+  abortSignal?: RunAgentOptions['abortSignal'];
+  onStream?: RunAgentOptions['onStream'];
+  onActivity?: RunAgentOptions['onActivity'];
   resolveStepProviderModel: (step: WorkflowStep, runtime?: RuntimeStepResolution) => StepProviderInfo;
   /**
    * Fully-resolved runtime.yaml `ladder` stages (issue #1208). A matched target-less `{at:N}`
@@ -142,6 +145,9 @@ export async function resolvePromotionRuntime(
     resolvedProviderOptions: baseProviderInfo.providerOptions,
     permissionMode: baseProviderInfo.permissionMode,
     childProcessEnv: context.childProcessEnv,
+    abortSignal: context.abortSignal,
+    onStream: context.onStream,
+    onActivity: context.onActivity,
   });
 
   if (promotion !== undefined && isTargetedPromotionEntry(promotion)) {

--- a/src/core/workflow/run/resume-artifact-occurrence-index.ts
+++ b/src/core/workflow/run/resume-artifact-occurrence-index.ts
@@ -1,0 +1,130 @@
+import type {
+  WorkflowConfig,
+  WorkflowResumePoint,
+  WorkflowResumePointEntry,
+} from '../../models/types.js';
+import { getWorkflowReference } from '../workflow-reference.js';
+import { parseWorkflowCallInvocationIdentity } from '../workflow-execution-identity-codec.js';
+import type { ResumeReportSnapshotManifest } from './resume-report-snapshot.js';
+import { parseWorkflowCallNamespaceSegment } from '../workflow-call-namespace.js';
+
+function logicalCallSiteKey(
+  workflowReference: string,
+  stepName: string,
+  workflowCallPath: readonly Pick<WorkflowResumePointEntry, 'workflow_ref' | 'step' | 'kind'>[],
+): string {
+  return JSON.stringify({
+    workflow: workflowReference,
+    step: stepName,
+    calls: workflowCallPath.map((entry) => ({
+      workflow: entry.workflow_ref,
+      step: entry.step,
+      kind: entry.kind,
+    })),
+  });
+}
+
+function invocationLogicalCallSiteKey(identity: string): string | undefined {
+  const parsed = parseWorkflowCallInvocationIdentity(identity);
+  if (parsed === undefined) return undefined;
+  return JSON.stringify({
+    workflow: parsed.workflow,
+    step: parsed.step,
+    calls: parsed.calls.map((call) => ({
+      workflow: call.workflow,
+      step: call.step,
+      kind: call.kind,
+    })),
+  });
+}
+
+function namespaceSignature(stepName: string, workflowName: string, siteDigest?: string): string {
+  return JSON.stringify([stepName, workflowName, siteDigest]);
+}
+
+function legacyNamespaceSignature(stepName: string, workflowName: string): string {
+  return JSON.stringify([stepName, workflowName]);
+}
+
+export class ResumeArtifactOccurrenceIndex {
+  readonly #maxByCallSite = new Map<string, number>();
+
+  constructor(
+    manifest: ResumeReportSnapshotManifest | undefined,
+    sourceResumePoint?: WorkflowResumePoint,
+  ) {
+    const callSitesByNamespace = new Map<string, string>();
+    const callSitesBySignature = new Map<string, Set<string>>();
+    const callSitesByLegacySignature = new Map<string, Set<string>>();
+    for (const [identity, record] of Object.entries(
+      sourceResumePoint?.workflow_call_invocations ?? {},
+    )) {
+      const callSite = invocationLogicalCallSiteKey(identity);
+      const namespace = parseWorkflowCallNamespaceSegment(record.report_namespace_segment);
+      if (callSite === undefined || namespace === undefined || namespace.iteration === '*') continue;
+      callSitesByNamespace.set(record.report_namespace_segment, callSite);
+      const signature = namespaceSignature(
+        namespace.stepName,
+        namespace.workflowName,
+        namespace.siteDigest,
+      );
+      const callSites = callSitesBySignature.get(signature) ?? new Set<string>();
+      callSites.add(callSite);
+      callSitesBySignature.set(signature, callSites);
+      const legacySignature = legacyNamespaceSignature(
+        namespace.stepName,
+        namespace.workflowName,
+      );
+      const legacyCallSites = callSitesByLegacySignature.get(legacySignature) ?? new Set<string>();
+      legacyCallSites.add(callSite);
+      callSitesByLegacySignature.set(legacySignature, legacyCallSites);
+    }
+
+    for (const file of manifest?.files ?? []) {
+      const segments = file.path.split('/');
+      for (let index = 0; index + 1 < segments.length; index += 1) {
+        if (segments[index] !== 'subworkflows') continue;
+        const namespaceSegment = segments[index + 1]!;
+        const parsed = parseWorkflowCallNamespaceSegment(namespaceSegment);
+        if (parsed === undefined || parsed.iteration === '*') continue;
+        const signature = namespaceSignature(
+          parsed.stepName,
+          parsed.workflowName,
+          parsed.siteDigest,
+        );
+        const candidates = callSitesBySignature.get(signature);
+        let callSite = callSitesByNamespace.get(namespaceSegment)
+          ?? (candidates?.size === 1 ? [...candidates][0] : undefined);
+        if (callSite === undefined) {
+          const legacyCandidates = callSitesByLegacySignature.get(
+            legacyNamespaceSignature(parsed.stepName, parsed.workflowName),
+          );
+          if (legacyCandidates?.size === 1) {
+            callSite = [...legacyCandidates][0];
+          } else if (legacyCandidates !== undefined && legacyCandidates.size > 1) {
+            throw new Error(
+              `Cannot migrate legacy workflow-call artifact namespace "${namespaceSegment}": logical call-site is ambiguous`,
+            );
+          }
+        }
+        if (callSite === undefined) continue;
+        this.#maxByCallSite.set(
+          callSite,
+          Math.max(this.#maxByCallSite.get(callSite) ?? 0, parsed.iteration),
+        );
+      }
+    }
+  }
+
+  getMaxOccurrence(
+    workflow: WorkflowConfig,
+    stepName: string,
+    workflowCallPath: readonly WorkflowResumePointEntry[],
+  ): number | undefined {
+    return this.#maxByCallSite.get(logicalCallSiteKey(
+      getWorkflowReference(workflow),
+      stepName,
+      workflowCallPath,
+    ));
+  }
+}

--- a/src/core/workflow/status-judgment-phase.ts
+++ b/src/core/workflow/status-judgment-phase.ts
@@ -147,6 +147,7 @@ export async function runStatusJudgmentPhase(
         failureDir: ctx.failureDir,
         childProcessEnv: ctx.childProcessEnv,
         onStream: ctx.onStream,
+        onActivity: ctx.onActivity,
         onStructuredPromptResolved: (promptParts) => {
           if (!didEmitPhaseStart) {
             emitPhaseStart(promptParts);

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -206,6 +206,7 @@ export interface WorkflowSharedRuntimeState {
   workflowCallInvocationEvidence?: WorkflowCallInvocationEvidence;
   workflowStepParticipationIndex?: WorkflowStepParticipationIndex;
   companionReviewAuthority?: CompanionReviewAuthority;
+  resumeArtifactOccurrenceIndex?: import('./run/resume-artifact-occurrence-index.js').ResumeArtifactOccurrenceIndex;
 }
 
 export type WorkflowAbortKind =

--- a/src/core/workflow/workflow-call-site-identity.ts
+++ b/src/core/workflow/workflow-call-site-identity.ts
@@ -20,7 +20,6 @@ function frameIdentity(entry: WorkflowResumePointEntry) {
       : { workflowRef: entry.workflow_ref }),
     step: entry.step,
     kind: entry.kind,
-    occurrence: entry.occurrence,
   };
 }
 

--- a/src/infra/claude-headless/client.ts
+++ b/src/infra/claude-headless/client.ts
@@ -166,6 +166,7 @@ export async function callClaudeHeadless(
     const prepared = await buildSpawnArgs(prompt, options);
     cleanup = prepared.cleanup;
     const { args, expectedSessionId } = prepared;
+    options.onActivity?.({ kind: 'attempt_started' });
     const { stdout, stderr } = await runHeadlessCli(args, options);
     const parsed = aggregateResultFromStdout(stdout);
     const sessionId = extractSessionIdFromStdout(stdout) ?? expectedSessionId;

--- a/src/infra/claude-headless/types.ts
+++ b/src/infra/claude-headless/types.ts
@@ -1,6 +1,10 @@
 import type { McpServerConfig, PermissionMode } from '../../core/models/index.js';
 import type { ClaudeEffort, ClaudeSandboxSettings } from '../../core/models/workflow-types.js';
-import type { InternalAgentIsolation, StreamCallback } from '../../shared/types/provider.js';
+import type {
+  InternalAgentIsolation,
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../shared/types/provider.js';
 
 export interface ClaudeHeadlessCallOptions {
   cwd: string;
@@ -19,6 +23,7 @@ export interface ClaudeHeadlessCallOptions {
   bypassPermissions?: boolean;
   sandbox?: ClaudeSandboxSettings;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   claudeCliPath?: string;
   systemPrompt?: string;
   outputSchema?: Record<string, unknown>;

--- a/src/infra/claude-terminal/client.ts
+++ b/src/infra/claude-terminal/client.ts
@@ -159,7 +159,6 @@ export async function callClaudeTerminal(
 ): Promise<AgentResponse> {
   const backendName = options.backend ?? DEFAULT_BACKEND;
   const callTimeoutMs = options.callTimeoutMs ?? options.timeoutMs ?? PROVIDER_CALL_TIMEOUT_DEFAULT_MS;
-  const deadlineAt = Date.now() + callTimeoutMs;
   const pollIntervalMs = options.transcriptPollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const keepSession = options.keepSession === true;
   const terminalBackend = resolveTerminalBackend(backendName, options.terminalBackend);
@@ -277,6 +276,7 @@ export async function callClaudeTerminal(
       outputSchema: options.outputSchema,
     });
 
+    options.onActivity?.({ kind: 'attempt_started' });
     const startedSession = await withAbort(() => {
       const startPromise = terminalBackend.start({
         cwd: options.cwd,
@@ -301,10 +301,10 @@ export async function callClaudeTerminal(
     const session = await withAbort(() => transcriptReader.findSession({
       cwd: options.cwd,
       sessionId: claudeSessionId,
-      deadlineAt,
       timeoutMs: callTimeoutMs,
       pollIntervalMs,
       abortSignal: options.abortSignal,
+      onActivity: options.onActivity,
     }));
     responseSessionId = session.sessionId;
     emitInit(options, session.sessionId);
@@ -312,14 +312,15 @@ export async function callClaudeTerminal(
     const handledEvents: ClaudeTerminalEvent[] = [];
     let response: ClaudeTerminalTranscript;
     while (true) {
+      options.onActivity?.({ kind: 'attempt_started' });
       response = await withAbort(() => transcriptReader.waitForAssistantResponse({
         session,
         baseline,
         cwd: options.cwd,
-        deadlineAt,
         timeoutMs: callTimeoutMs,
         pollIntervalMs,
         abortSignal: options.abortSignal,
+        onActivity: options.onActivity,
       }));
 
       handledEvents.push(...response.events);
@@ -361,7 +362,16 @@ export async function callClaudeTerminal(
     ) {
       return createAbortResponse(agentName, error.reason, responseSessionId);
     }
-    return createErrorResponse(agentName, getErrorMessage(error), AGENT_FAILURE_CATEGORIES.PROVIDER_ERROR, responseSessionId);
+    const errorMessage = getErrorMessage(error);
+    const classified = classifyAbortSignalReason(errorMessage);
+    return createErrorResponse(
+      agentName,
+      errorMessage,
+      classified.category === AGENT_FAILURE_CATEGORIES.PART_TIMEOUT
+        ? classified.category
+        : AGENT_FAILURE_CATEGORIES.PROVIDER_ERROR,
+      responseSessionId,
+    );
   } finally {
     if (abortHandler) {
       options.abortSignal?.removeEventListener('abort', abortHandler);

--- a/src/infra/claude-terminal/transcript-reader.ts
+++ b/src/infra/claude-terminal/transcript-reader.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve, sep } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import type { AskUserQuestionInput } from '../../core/workflow/types.js';
+import { createPartTimeoutReason } from '../../shared/types/agent-failure.js';
 import { getClaudeProjectSessionsDir } from '../config/project/sessionStore.js';
 import type {
   ClaudeSessionRef,
@@ -291,16 +292,25 @@ async function sleepWithAbort(pollIntervalMs: number, signal: AbortSignal | unde
 }
 
 async function pollUntil<T>(
-  deadlineAt: number,
+  initialDeadlineAt: number,
+  inactivityTimeoutMs: number | undefined,
   pollIntervalMs: number,
   abortSignal: AbortSignal | undefined,
-  attempt: () => Promise<T | undefined>,
+  onActivity: (() => void) | undefined,
+  attempt: (recordActivity: () => void) => Promise<T | undefined>,
   timeoutMessage: string,
 ): Promise<T> {
+  let deadlineAt = initialDeadlineAt;
+  const recordActivity = (): void => {
+    if (inactivityTimeoutMs !== undefined) {
+      deadlineAt = Date.now() + inactivityTimeoutMs;
+    }
+    onActivity?.();
+  };
   throwIfAborted(abortSignal);
   while (Date.now() <= deadlineAt) {
     throwIfAborted(abortSignal);
-    const value = await attempt();
+    const value = await attempt(recordActivity);
     throwIfAborted(abortSignal);
     if (value !== undefined) {
       return value;
@@ -377,13 +387,16 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
     }
     return pollUntil(
       deadlineAt,
+      options.timeoutMs,
       options.pollIntervalMs,
       options.abortSignal,
-      async () => {
+      options.onActivity,
+      async (recordActivity) => {
         const transcript = await readTranscript(options.cwd, options.sessionId);
         if (transcript === undefined || transcript.trim().length === 0) {
           return undefined;
         }
+        recordActivity();
         const parsed = parseClaudeTerminalTranscript(transcript, {
           allowIncompleteFinalLine: true,
         });
@@ -392,7 +405,9 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
         }
         return { sessionId: parsed.sessionId || options.sessionId };
       },
-      'Timed out waiting for Claude terminal session id.',
+      options.timeoutMs === undefined
+        ? 'Timed out waiting for Claude terminal session id.'
+        : createPartTimeoutReason(options.timeoutMs),
     );
   }
 
@@ -403,14 +418,22 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
     if (deadlineAt === undefined) {
       throw new Error('Claude terminal response deadline is required.');
     }
+    let observedByteLength = options.baseline.byteOffset;
     return pollUntil(
       deadlineAt,
+      options.timeoutMs,
       options.pollIntervalMs,
       options.abortSignal,
-      async () => {
+      options.onActivity,
+      async (recordActivity) => {
         const transcript = await readTranscript(options.cwd, options.session.sessionId);
         if (transcript === undefined || transcript.trim().length === 0) {
           return undefined;
+        }
+        const byteLength = Buffer.byteLength(transcript, 'utf-8');
+        if (byteLength > observedByteLength) {
+          observedByteLength = byteLength;
+          recordActivity();
         }
         const parsed = parseClaudeTerminalTranscript(transcript, {
           baseline: options.baseline,
@@ -430,7 +453,9 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
         }
         return withSessionIdFallback(parsed, options.session.sessionId);
       },
-      'Timed out waiting for Claude terminal assistant response.',
+      options.timeoutMs === undefined
+        ? 'Timed out waiting for Claude terminal assistant response.'
+        : createPartTimeoutReason(options.timeoutMs),
     );
   }
 }

--- a/src/infra/claude-terminal/types.ts
+++ b/src/infra/claude-terminal/types.ts
@@ -1,7 +1,11 @@
 import type { McpServerConfig, PermissionMode } from '../../core/models/index.js';
 import type { ClaudeEffort } from '../../core/models/workflow-types.js';
 import type { PermissionHandler, AskUserQuestionHandler, AskUserQuestionInput } from '../../core/workflow/types.js';
-import type { InternalAgentIsolation, StreamCallback } from '../../shared/types/provider.js';
+import type {
+  InternalAgentIsolation,
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../shared/types/provider.js';
 
 export type ClaudeTerminalBackendName = 'tmux';
 
@@ -63,24 +67,26 @@ export interface ClaudeSessionRef {
 export interface FindClaudeSessionOptions {
   cwd: string;
   sessionId: string;
-  /** 親呼び出し全体の絶対期限。 */
+  /** 互換用。timeoutMs がない直接利用時だけ使う絶対期限。 */
   deadlineAt?: number;
-  /** 互換用。deadlineAt がない直接利用時だけ相対期限として使う。 */
+  /** transcript に変化がない時間の上限。変化するたびに更新する。 */
   timeoutMs?: number;
   pollIntervalMs: number;
   abortSignal?: AbortSignal;
+  onActivity?: ProviderActivityCallback;
 }
 
 export interface WaitForClaudeResponseOptions {
   session: ClaudeSessionRef;
   baseline: ClaudeTranscriptBaseline;
   cwd: string;
-  /** 親呼び出し全体の絶対期限。 */
+  /** 互換用。timeoutMs がない直接利用時だけ使う絶対期限。 */
   deadlineAt?: number;
-  /** 互換用。deadlineAt がない直接利用時だけ相対期限として使う。 */
+  /** transcript に変化がない時間の上限。変化するたびに更新する。 */
   timeoutMs?: number;
   pollIntervalMs: number;
   abortSignal?: AbortSignal;
+  onActivity?: ProviderActivityCallback;
 }
 
 export interface ClaudeTranscriptReader {
@@ -109,6 +115,7 @@ export interface ClaudeTerminalCallOptions {
   keepSession?: boolean;
   transcriptPollIntervalMs?: number;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   onPermissionRequest?: PermissionHandler;
   onAskUserQuestion?: AskUserQuestionHandler;
   outputSchema?: Record<string, unknown>;

--- a/src/infra/claude/client.ts
+++ b/src/infra/claude/client.ts
@@ -49,6 +49,7 @@ export class ClaudeClient {
       agents: options.agents,
       permissionMode: options.permissionMode,
       onStream: options.onStream,
+      onActivity: options.onActivity,
       onPermissionRequest: options.onPermissionRequest,
       onAskUserQuestion: options.onAskUserQuestion,
       bypassPermissions: options.bypassPermissions,

--- a/src/infra/claude/executor.ts
+++ b/src/infra/claude/executor.ts
@@ -157,6 +157,7 @@ export class QueryExecutor {
     prompt: string,
     options: ClaudeSpawnOptions,
   ): Promise<ClaudeResult> {
+    options.onActivity?.({ kind: 'attempt_started' });
     const queryId = generateQueryId();
 
     log.debug('Executing Claude query via SDK', {

--- a/src/infra/claude/types.ts
+++ b/src/infra/claude/types.ts
@@ -24,6 +24,7 @@ import type {
   StreamAssistantErrorEventData as SharedAssistantErrorEventData,
   StreamRateLimitEventData as SharedRateLimitEventData,
   InternalAgentIsolation,
+  ProviderActivityCallback,
 } from '../../shared/types/provider.js';
 
 export type { SandboxSettings };
@@ -119,6 +120,7 @@ export interface ClaudeCallOptions {
   permissionMode?: PermissionMode;
   /** Enable streaming mode with callback for real-time output */
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   /** Custom permission handler for interactive permission prompts */
   onPermissionRequest?: PermissionHandler;
   /** Custom handler for AskUserQuestion tool */
@@ -155,6 +157,7 @@ export interface ClaudeSpawnOptions {
   systemPrompt?: string;
   /** Enable streaming mode with callback */
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   /** Custom agents to register */
   agents?: Record<string, AgentDefinition>;
   /** Permission mode for tool execution (TAKT abstract value, mapped to SDK value in SdkOptionsBuilder) */

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -399,6 +399,7 @@ export class CodexClient {
 
     while (true) {
       const attempt = standardRetryCount + timeoutRetryCount + refusalRetryCount + 1;
+      options.onActivity?.({ kind: 'attempt_started' });
       let currentThreadId = threadId;
       const codexClientOptions: CodexOptions = {
         env: buildEnvWithNestedObservabilitySnapshot(

--- a/src/infra/codex/types.ts
+++ b/src/infra/codex/types.ts
@@ -5,7 +5,7 @@
 import type { PermissionMode } from '../../core/models/index.js';
 import type { CodexReasoningEffort } from '../../core/models/workflow-types.js';
 import type { ProviderImageAttachment } from '../providers/types.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 /** Codex sandbox mode values */
 export type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
@@ -34,6 +34,8 @@ export interface CodexCallOptions {
   networkAccess?: boolean;
   /** Enable streaming mode with callback (best-effort) */
   onStream?: StreamCallback;
+  /** Notify the workflow inactivity deadline immediately before each provider attempt. */
+  onActivity?: ProviderActivityCallback;
   /** OpenAI API key (bypasses CLI auth) */
   openaiApiKey?: string;
   /** OpenAI-compatible API base URL */

--- a/src/infra/copilot/client.ts
+++ b/src/infra/copilot/client.ts
@@ -498,6 +498,7 @@ export class CopilotClient {
       log.debug('mkdtemp failed, skipping session extraction', { err });
     }
 
+    options.onActivity?.({ kind: 'attempt_started' });
     const executionOutcome = await executeCopilotCall(
       prompt,
       options,

--- a/src/infra/copilot/types.ts
+++ b/src/infra/copilot/types.ts
@@ -4,7 +4,7 @@
 
 import type { CopilotEffort } from '../../core/models/workflow-types.js';
 import type { PermissionMode } from '../../core/models/index.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 /** Options for calling GitHub Copilot CLI */
 export interface CopilotCallOptions {
@@ -16,6 +16,7 @@ export interface CopilotCallOptions {
   systemPrompt?: string;
   permissionMode?: PermissionMode;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   /** GitHub token for Copilot authentication */
   copilotGithubToken?: string;
   /** Custom path to copilot executable */

--- a/src/infra/cursor/client.ts
+++ b/src/infra/cursor/client.ts
@@ -498,6 +498,7 @@ export class CursorClient {
     let cliConfigRenameRetryCount = 0;
 
     while (true) {
+      options.onActivity?.({ kind: 'attempt_started' });
       try {
         const { stdout } = await execCursor(args, options);
         const parsed = parseCursorOutput(stdout);

--- a/src/infra/cursor/types.ts
+++ b/src/infra/cursor/types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { PermissionMode } from '../../core/models/index.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 /** Options for calling Cursor Agent CLI */
 export interface CursorCallOptions {
@@ -14,6 +14,7 @@ export interface CursorCallOptions {
   systemPrompt?: string;
   permissionMode?: PermissionMode;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   cursorApiKey?: string;
   /** Custom path to cursor-agent executable */
   cursorCliPath?: string;

--- a/src/infra/kiro/client.ts
+++ b/src/infra/kiro/client.ts
@@ -253,6 +253,7 @@ export class KiroClient {
 
     try {
       const args = buildArgs(effectiveOptions, promptText);
+      options.onActivity?.({ kind: 'attempt_started' });
       const { stdout } = await execKiro(args, effectiveOptions);
       const content = cleanKiroOutput(stdout);
       const outputError = content.length === 0

--- a/src/infra/kiro/types.ts
+++ b/src/infra/kiro/types.ts
@@ -1,5 +1,5 @@
 import type { PermissionMode } from '../../core/models/index.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 export interface KiroCallOptions {
   cwd: string;
@@ -9,6 +9,7 @@ export interface KiroCallOptions {
   systemPrompt?: string;
   permissionMode?: PermissionMode;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   kiroApiKey?: string;
   kiroCliPath?: string;
   agent?: string;

--- a/src/infra/opencode/attempt-runner.ts
+++ b/src/infra/opencode/attempt-runner.ts
@@ -69,6 +69,7 @@ import {
 } from './unavailable-tool-recovery.js';
 import { createOpenCodeSessionLifecycle } from './session-lifecycle.js';
 import type { OpenCodeSessionLifecycle } from './session-lifecycle.js';
+import { AGENT_FAILURE_CATEGORIES } from '../../shared/types/agent-failure.js';
 import { buildRateLimitedResponseFields, containsRateLimitError } from '../rate-limit/detection.js';
 import {
   createSensitiveTextStreamRedactor,
@@ -796,6 +797,7 @@ export class OpenCodeAttemptRunner {
     const provisionalKey = `provisional-${nextProvisionalId++}`;
     try {
       for (let attempt = 1; attempt <= callState.maxAttempts; attempt++) {
+        guardedOptions.onActivity?.({ kind: 'attempt_started' });
         const result = await this.runAttempt(
           agentType,
           prompt,
@@ -931,6 +933,9 @@ export class OpenCodeAttemptRunner {
       error: errorMessage,
       timestamp: new Date(),
       sessionId,
+      ...(abortCause === 'deadline'
+        ? { failureCategory: AGENT_FAILURE_CATEGORIES.PART_TIMEOUT }
+        : {}),
     };
   };
 
@@ -2093,6 +2098,9 @@ export class OpenCodeAttemptRunner {
       error: sanitizedErrorMessage,
       timestamp: new Date(),
       sessionId,
+      ...(abortCause === 'deadline'
+        ? { failureCategory: AGENT_FAILURE_CATEGORIES.PART_TIMEOUT }
+        : {}),
     };
   } finally {
     guardSuite.stopAttempt();

--- a/src/infra/opencode/guards/registry.ts
+++ b/src/infra/opencode/guards/registry.ts
@@ -7,7 +7,7 @@ import {
   TextVolumeGuard,
   TrackedIdsGuard,
 } from './resource-guards.js';
-import { WallClockGuard } from './time-guards.js';
+import { InactivityTimeoutGuard } from './time-guards.js';
 import type { OpenCodeGuardDescriptor } from './types.js';
 
 export const OPENCODE_GUARD_REGISTRY: readonly OpenCodeGuardDescriptor[] = Object.freeze([
@@ -21,7 +21,7 @@ export const OPENCODE_GUARD_REGISTRY: readonly OpenCodeGuardDescriptor[] = Objec
     mandatory: true,
     create: (_policy, context) => new SensitiveBudgetGuard(context.sensitiveValues),
   },
-  { id: 'wall-clock', layer: 'time', mandatory: true, create: (policy) => new WallClockGuard(policy.callTimeoutMs) },
+  { id: 'inactivity-timeout', layer: 'time', mandatory: true, create: (policy) => new InactivityTimeoutGuard(policy.callTimeoutMs) },
   { id: 'exact-loop', layer: 'integrity', mandatory: true, create: (policy) => new ExactLoopGuard(policy) },
   { id: 'consecutive-errors', layer: 'heuristic', mandatory: false, create: (policy) => new ConsecutiveErrorsGuard(policy) },
   { id: 'cycle-budget', layer: 'heuristic', mandatory: false, create: (policy) => new CycleBudgetGuard(policy.messageCycleBudget) },

--- a/src/infra/opencode/guards/time-guards.ts
+++ b/src/infra/opencode/guards/time-guards.ts
@@ -5,40 +5,112 @@ import {
   readOpenCodeToolPart,
 } from './tool-events.js';
 import type { OpenCodeGuard, OpenCodeGuardLifecycleScope, OpenCodeGuardVerdict } from './types.js';
+import { createPartTimeoutReason } from '../../../shared/types/agent-failure.js';
+import { STALE_IN_FLIGHT_TOOL_FACTOR } from '../../../shared/types/provider-deadline.js';
+
+export { STALE_IN_FLIGHT_TOOL_FACTOR } from '../../../shared/types/provider-deadline.js';
 
 export function describeOpenCodeIdleTimeout(timeoutMs: number): string {
   return `OpenCode stream timed out after ${Math.round(timeoutMs / 60000)} minutes of inactivity`;
 }
 
-// カスタムの認証済み transport が idle watchdog を明示的に登録する場合に、
-// ツール結果イベントの取りこぼしで in-flight が残り続ける状態を有界にする倍率。
-// 既定 registry には IdleTimeoutGuard を登録せず、通常の OpenCode 呼び出しでは
-// 親ステップの wall-clock deadline のみを安全装置として使う。
-const STALE_IN_FLIGHT_TOOL_FACTOR = 6;
+// 正当な長時間 tool を通常の無応答として切らず、終端イベント欠落だけを
+// 有界にする。既存の call timeout を基準にすることで、別設定の解決経路を増やさない。
+class InFlightToolTracker {
+  readonly #startedAtByKey = new Map<string, number>();
 
-export class WallClockGuard implements OpenCodeGuard {
-  readonly id = 'wall-clock';
+  observe(event: OpenCodeStreamEvent): void {
+    const toolPart = readOpenCodeToolPart(event);
+    if (toolPart === undefined) return;
+    const key = openCodeToolCallKey(toolPart);
+    if (isOpenCodeToolTerminal(toolPart)) {
+      this.#startedAtByKey.delete(key);
+      return;
+    }
+    if (!this.#startedAtByKey.has(key)) {
+      this.#startedAtByKey.set(key, Date.now());
+    }
+  }
+
+  clear(): void {
+    this.#startedAtByKey.clear();
+  }
+
+  earliestStaleDeadline(staleAfterMs: number): number | undefined {
+    if (this.#startedAtByKey.size === 0) return undefined;
+    return Math.min(...this.#startedAtByKey.values()) + staleAfterMs;
+  }
+
+  pruneStale(staleAfterMs: number): void {
+    const staleBefore = Date.now() - staleAfterMs;
+    for (const [key, startedAt] of this.#startedAtByKey) {
+      if (startedAt <= staleBefore) this.#startedAtByKey.delete(key);
+    }
+  }
+}
+
+export class InactivityTimeoutGuard implements OpenCodeGuard {
+  readonly id = 'inactivity-timeout';
   readonly layer = 'time' as const;
   private timeoutId: ReturnType<typeof setTimeout> | undefined;
+  private onVerdict: ((verdict: OpenCodeGuardVerdict) => void) | undefined;
+  private readonly inFlightTools = new InFlightToolTracker();
+  private readonly staleAfterMs: number;
 
-  constructor(private readonly timeoutMs: number) {}
+  constructor(private readonly timeoutMs: number) {
+    this.staleAfterMs = timeoutMs * STALE_IN_FLIGHT_TOOL_FACTOR;
+  }
 
   start(scope: OpenCodeGuardLifecycleScope, onVerdict: (verdict: OpenCodeGuardVerdict) => void): void {
-    if (scope !== 'call') return;
-    this.stop('call');
-    const timeoutId = setTimeout(() => {
-      onVerdict({
-        action: 'fail',
-        reason: `OpenCode call wall-clock timeout exceeded (${this.timeoutMs} ms)`,
-        abortKind: 'deadline',
-      });
-    }, this.timeoutMs);
-    timeoutId.unref();
-    this.timeoutId = timeoutId;
+    if (scope === 'call') {
+      this.onVerdict = onVerdict;
+    } else {
+      this.inFlightTools.clear();
+    }
+    if (this.onVerdict === undefined) return;
+    this.arm();
+  }
+
+  onEvent(event: OpenCodeStreamEvent): OpenCodeGuardVerdict | undefined {
+    this.inFlightTools.observe(event);
+    this.arm();
+    return undefined;
   }
 
   stop(scope: OpenCodeGuardLifecycleScope): void {
-    if (scope !== 'call' || this.timeoutId === undefined) return;
+    if (scope !== 'call') return;
+    this.disarm();
+    this.inFlightTools.clear();
+    this.onVerdict = undefined;
+  }
+
+  private arm(): void {
+    this.disarm();
+    const staleDeadline = this.inFlightTools.earliestStaleDeadline(this.staleAfterMs);
+    this.timeoutId = staleDeadline === undefined
+      ? this.schedule(() => this.fail(), this.timeoutMs)
+      : this.schedule(() => {
+          this.inFlightTools.pruneStale(this.staleAfterMs);
+          this.fail();
+        }, staleDeadline - Date.now());
+  }
+
+  private fail(): void {
+    this.onVerdict?.({
+      action: 'fail',
+      reason: createPartTimeoutReason(this.timeoutMs),
+      abortKind: 'deadline',
+    });
+  }
+
+  private schedule(handler: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+    const timeoutId = setTimeout(handler, Math.max(delayMs, 0));
+    timeoutId.unref();
+    return timeoutId;
+  }
+
+  private disarm(): void {
+    if (this.timeoutId === undefined) return;
     clearTimeout(this.timeoutId);
     this.timeoutId = undefined;
   }
@@ -49,8 +121,7 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
   readonly layer = 'time' as const;
   private timeoutId: ReturnType<typeof setTimeout> | undefined;
   private onVerdict: ((verdict: OpenCodeGuardVerdict) => void) | undefined;
-  /** in-flight のツール呼び出しキー → 登録時刻。時刻は stale 判定にだけ使う。 */
-  private readonly inFlightToolCalls = new Map<string, number>();
+  private readonly inFlightTools = new InFlightToolTracker();
   private readonly staleAfterMs: number;
 
   constructor(private readonly timeoutMs: number) {
@@ -59,13 +130,13 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
 
   start(scope: OpenCodeGuardLifecycleScope, onVerdict: (verdict: OpenCodeGuardVerdict) => void): void {
     if (scope !== 'attempt') return;
-    this.inFlightToolCalls.clear();
+    this.inFlightTools.clear();
     this.onVerdict = onVerdict;
     this.arm();
   }
 
   onEvent(event: OpenCodeStreamEvent): OpenCodeGuardVerdict | undefined {
-    this.trackToolFlight(event);
+    this.inFlightTools.observe(event);
     this.arm();
     return undefined;
   }
@@ -73,20 +144,8 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
   stop(scope: OpenCodeGuardLifecycleScope): void {
     if (scope !== 'attempt') return;
     this.disarm();
-    this.inFlightToolCalls.clear();
+    this.inFlightTools.clear();
     this.onVerdict = undefined;
-  }
-
-  private trackToolFlight(event: OpenCodeStreamEvent): void {
-    const toolPart = readOpenCodeToolPart(event);
-    if (toolPart === undefined) return;
-    const key = openCodeToolCallKey(toolPart);
-    if (isOpenCodeToolTerminal(toolPart)) {
-      this.inFlightToolCalls.delete(key);
-      return;
-    }
-    if (this.inFlightToolCalls.has(key)) return;
-    this.inFlightToolCalls.set(key, Date.now());
   }
 
   private arm(): void {
@@ -102,7 +161,7 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
       // 続くと arm() も呼ばれないので、stale 期限にタイマーを置いて自力で
       // 除去し、劣化を有界にする（永久停止させない）。
       this.timeoutId = this.schedule(() => {
-        this.pruneStaleToolCalls();
+        this.inFlightTools.pruneStale(this.staleAfterMs);
         this.arm();
       }, staleDeadline - Date.now());
       return;
@@ -116,15 +175,7 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
   }
 
   private earliestStaleDeadline(): number | undefined {
-    if (this.inFlightToolCalls.size === 0) return undefined;
-    return Math.min(...this.inFlightToolCalls.values()) + this.staleAfterMs;
-  }
-
-  private pruneStaleToolCalls(): void {
-    const staleBefore = Date.now() - this.staleAfterMs;
-    for (const [key, registeredAt] of this.inFlightToolCalls) {
-      if (registeredAt <= staleBefore) this.inFlightToolCalls.delete(key);
-    }
+    return this.inFlightTools.earliestStaleDeadline(this.staleAfterMs);
   }
 
   private schedule(handler: () => void, delayMs: number): ReturnType<typeof setTimeout> {

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -4,7 +4,7 @@
 
 import type { AskUserQuestionHandler } from '../../core/workflow/types.js';
 import type { Language, OpenCodeGuardOptions, PermissionMode } from '../../core/models/index.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 import { mapsToOpenCodeEditPermission } from './allowedTools.js';
 
 /** OpenCode permission reply values */
@@ -436,6 +436,7 @@ export interface OpenCodeCallOptions {
   /** Guard feature switches from provider_options.opencode.guards. */
   guards?: OpenCodeGuardOptions;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   onAskUserQuestion?: AskUserQuestionHandler;
   opencodeApiKey?: string;
   interactionTimeoutMs?: number;

--- a/src/infra/pi/client.ts
+++ b/src/infra/pi/client.ts
@@ -1041,6 +1041,7 @@ export async function callPi(
         const imagePrompt = options.imageAttachments && options.imageAttachments.length > 0
           ? `${prompt}\n\n${options.imageAttachments.map((attachment) => attachment.placeholder).join('\n')}`
           : prompt;
+        options.onActivity?.({ kind: 'attempt_started' });
         const promptPromise = session.prompt(
           imagePrompt,
           images.length > 0 ? { images } : undefined,

--- a/src/infra/pi/types.ts
+++ b/src/infra/pi/types.ts
@@ -1,7 +1,7 @@
 import type { PermissionMode } from '../../core/models/index.js';
 import type { PiProviderOptions } from '../../core/models/workflow-provider-options.js';
 import type { ProviderImageAttachment } from '../providers/types.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 /** Options for one Pi SDK session. */
 export interface PiCallOptions {
@@ -15,5 +15,6 @@ export interface PiCallOptions {
   imageAttachments?: ProviderImageAttachment[];
   providerOptions?: PiProviderOptions;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   childProcessEnv?: Readonly<Record<string, string>>;
 }

--- a/src/infra/providers/claude-headless.ts
+++ b/src/infra/providers/claude-headless.ts
@@ -32,6 +32,7 @@ function toHeadlessOptions(options: ProviderCallOptions): ClaudeHeadlessCallOpti
     bypassPermissions: options.bypassPermissions,
     sandbox: claudeOptions?.sandbox,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     claudeCliPath: resolveClaudeCliPath() ?? undefined,
     outputSchema: options.outputSchema,
     childProcessEnv: options.childProcessEnv,

--- a/src/infra/providers/claude-terminal.ts
+++ b/src/infra/providers/claude-terminal.ts
@@ -71,6 +71,7 @@ function toTerminalOptions(options: ProviderCallOptions): ClaudeTerminalCallOpti
     keepSession: terminalOptions?.keepSession,
     transcriptPollIntervalMs: terminalOptions?.transcriptPollIntervalMs,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     onPermissionRequest: options.onPermissionRequest,
     onAskUserQuestion: options.onAskUserQuestion,
     outputSchema: options.outputSchema,

--- a/src/infra/providers/claude.ts
+++ b/src/infra/providers/claude.ts
@@ -30,6 +30,7 @@ function toClaudeOptions(options: ProviderCallOptions): ClaudeCallOptions {
     maxTurns: options.maxTurns,
     permissionMode: options.permissionMode,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     onPermissionRequest: options.onPermissionRequest,
     onAskUserQuestion: options.onAskUserQuestion,
     bypassPermissions: options.bypassPermissions,

--- a/src/infra/providers/codex.ts
+++ b/src/infra/providers/codex.ts
@@ -27,6 +27,7 @@ function toCodexOptions(options: ProviderCallOptions): CodexCallOptions {
     permissionMode: options.permissionMode,
     networkAccess: options.providerOptions?.codex?.networkAccess,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     openaiApiKey: options.openaiApiKey ?? resolveOpenaiApiKey(),
     baseUrl: options.providerOptions?.codex?.baseUrl,
     skills: options.internalAgentIsolation === 'strict-readonly'

--- a/src/infra/providers/copilot.ts
+++ b/src/infra/providers/copilot.ts
@@ -32,6 +32,7 @@ function toCopilotOptions(options: ProviderCallOptions): CopilotCallOptions {
     effort: options.providerOptions?.copilot?.effort,
     permissionMode: options.permissionMode,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     copilotGithubToken: options.copilotGithubToken ?? resolveCopilotGithubToken(),
     copilotCliPath: resolveCopilotCliPath(),
     childProcessEnv: options.childProcessEnv,

--- a/src/infra/providers/cursor.ts
+++ b/src/infra/providers/cursor.ts
@@ -31,6 +31,7 @@ function toCursorOptions(options: ProviderCallOptions): CursorCallOptions {
     model: options.model,
     permissionMode: options.permissionMode,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     cursorApiKey: options.cursorApiKey ?? resolveCursorApiKey(),
     cursorCliPath: resolveCursorCliPath(),
     childProcessEnv: options.childProcessEnv,

--- a/src/infra/providers/kiro.ts
+++ b/src/infra/providers/kiro.ts
@@ -31,6 +31,7 @@ function toKiroOptions(options: ProviderCallOptions, systemPrompt?: string): Kir
     systemPrompt,
     permissionMode: options.permissionMode,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     kiroApiKey: options.kiroApiKey ?? resolveKiroApiKey(),
     kiroCliPath: resolveKiroCliPath(),
     agent: options.providerOptions?.kiro?.agent,

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -67,6 +67,7 @@ function toOpenCodeOptions(options: ProviderCallOptions): OpenCodeCallOptions {
     variant: options.providerOptions?.opencode?.variant,
     guards: options.providerOptions?.opencode?.guards,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     onAskUserQuestion: options.onAskUserQuestion,
     opencodeApiKey: options.opencodeApiKey ?? resolveOpencodeApiKey(),
     childProcessEnv: options.childProcessEnv,

--- a/src/infra/providers/pi.ts
+++ b/src/infra/providers/pi.ts
@@ -43,6 +43,7 @@ function toPiOptions(options: ProviderCallOptions, systemPrompt?: string): PiCal
     imageAttachments: options.imageAttachments,
     providerOptions: options.providerOptions?.pi,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     childProcessEnv: options.childProcessEnv,
   };
 }

--- a/src/infra/providers/types.ts
+++ b/src/infra/providers/types.ts
@@ -1,6 +1,10 @@
 import type { AgentResponse, Language, PermissionMode, McpServerConfig, StepProviderOptions } from '../../core/models/index.js';
 import type { ProviderType as SharedProviderType } from '../../shared/types/provider.js';
-import type { InternalAgentIsolation, StreamCallback } from '../../shared/types/provider.js';
+import type {
+  InternalAgentIsolation,
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../shared/types/provider.js';
 import type { PermissionHandler, AskUserQuestionHandler } from '../../core/workflow/types.js';
 
 export interface AgentSetup {
@@ -25,6 +29,7 @@ export interface ProviderCallOptions {
   permissionMode?: PermissionMode;
   providerOptions?: StepProviderOptions;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   onPermissionRequest?: PermissionHandler;
   onAskUserQuestion?: AskUserQuestionHandler;
   bypassPermissions?: boolean;

--- a/src/shared/types/provider-deadline.ts
+++ b/src/shared/types/provider-deadline.ts
@@ -1,6 +1,7 @@
 export const PROVIDER_CALL_TIMEOUT_MIN_MS = 60_000;
 export const PROVIDER_CALL_TIMEOUT_MAX_MS = 86_400_000;
 export const PROVIDER_CALL_TIMEOUT_DEFAULT_MS = 3_600_000;
+export const STALE_IN_FLIGHT_TOOL_FACTOR = 6;
 
 export function resolveProviderCallTimeoutMs(configured: number | undefined): number {
   const timeoutMs = configured ?? PROVIDER_CALL_TIMEOUT_DEFAULT_MS;

--- a/src/shared/types/provider.ts
+++ b/src/shared/types/provider.ts
@@ -128,3 +128,18 @@ export type StreamEvent =
   | { type: 'error'; data: StreamErrorEventData };
 
 export type StreamCallback = (event: StreamEvent) => void;
+
+export type ProviderActivityEvent =
+  | { readonly kind: 'attempt_started'; readonly executionUnitKey?: string }
+  | {
+    readonly kind: 'tool_started';
+    readonly executionUnitKey: string;
+    readonly toolCallKey: string;
+  }
+  | {
+    readonly kind: 'tool_finished';
+    readonly executionUnitKey: string;
+    readonly toolCallKey: string;
+  };
+
+export type ProviderActivityCallback = (event?: ProviderActivityEvent) => void;


### PR DESCRIPTION
## 背景

run 20260814-090848（takt-experimental）のレビュー5周目で、coding-review が判定者駆動の再走査（#1341）を積み上げた結果、応答し続けているにもかかわらず累積1時間の part deadline（#1351）で打ち切られ、その error が rule 外 terminal としてトップまで遡上し rule_no_match で run 全体が abort した。また同 run は requeue の出現番号振り直しにより、旧成果物の上書きと台帳引き継ぎの stale 選択が起きる状態だった。

## 修正

### 1. part deadline を無応答時間で計測
- プロバイダイベント・フェーズ遷移・再試行開始でタイマーをリセット。完全無応答のときだけ発火
- 実行中ツールの間は通常判定を停止し、stale 上限（call_timeout_ms の6倍、共有定数）だけを適用
- onActivity を全プロバイダおよび全内部 agent（dynamic selector、review-completion judge、Team Leader decomposition/more-parts、Companion、LoopMonitor judge、promotion judge、auto-routing estimator、ai_judge fallback）へ伝搬。AST 全列挙で未伝搬ゼロを確認

### 2. requeue 時の出現番号を継続
- 継承 manifest の最大 occurrence の続きから採番（実録では次が iteration-7）
- 論理 call-site 単位で分離し、同名 step の別 call site を混同しない
- 旧形式 digest は一意に証明できる場合のみ移行、曖昧なら明示エラーで停止
- これにより台帳引き継ぎ規則（数値 N 最大の fix-verification 選択）の正しさが requeue 後も維持される

### 3. parallel の terminal error で run 全体を全損させない
- error を明示ラベルとして集約評価の対象にし、review 系組み込みワークフロー（en/ja 全件、機械走査で網羅確認）へ `any("error")` の再試行ルールを追加
- 再試行は3回まで。超過時は ignore_exceed に依存しない理由付き abort
- 暗黙の success 化はせず、error ルールを持たないカスタムワークフローの fail-fast は不変

## 検証

- 敵対レビュー5ラウンド（実行反証: 20ms誤発火、tool中の親先行発火、call site混同、1000回転の無界ループ、内部agent×6箇所の伝搬漏れ等を都度解消、最終 APPROVE）
- npm test / test:it / lint / build 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
