### PR TITLE
fix(engine): part deadline を無応答時間で計測し onActivity を全経路へ伝搬する

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -325,9 +325,11 @@ steps:
 
 `provider_options.pi` は、`extensions` や `no_*` の探索制御など、Pi リソースを読み込むための別経路です。これらの option は認証、model、thinking level を宣言するものではありません。明示したリソース source は TAKT 実行時だけ temporary resolution され、Pi settings には永続化されません。リソースの信頼境界については [Pi のリソース読み込み](#pi-resource-loading) を参照してください。
 
-### プロバイダ call deadline と OpenCode 実行ガード
+### プロバイダ無応答 deadline と OpenCode 実行ガード
 
-全 provider の call-wide wall-clock deadline は `guards.call_timeout_ms` で設定します。
+全 provider で観測可能な provider event が届かない時間の上限は
+`guards.call_timeout_ms` で設定します。stream/tool event、phase 完了、新しい provider
+試行の開始ごとにタイマーをリセットし、累積実行時間には上限を設けません。
 対象は `codex`、`opencode`、`claude`（`claude-sdk` を含む）、`claude_terminal`、
 `cursor`、`copilot`、`kiro`、`pi` です。値は 60,000〜86,400,000 ms の整数で、
 未指定時は 3,600,000 ms（60 分）です。通常の `provider_options` profile 解決を経て
@@ -342,18 +344,16 @@ steps:
 各 leaf は provider option の各レイヤー間で個別にマージされますが、上位優先度の
 `model_profiles` は下位の map 全体を置換します。
 
-OpenCode の単一 call には既定で 3,600,000 ms（60分）の wall-clock 上限があります。
-60分を超える可能性がある call は、60,000〜86,400,000 の
-`call_timeout_ms` を明示してください。テストスイートの実行のような長時間の作業を
-含む step は、この上限に達して切断されます。`event_limit` の既定値は 500,000 で、
+OpenCode の単一 call には既定で 3,600,000 ms（60分）の provider event 無応答上限が
+あります。event が継続して届く健全な call は60分を超えて実行できます。
+`event_limit` の既定値は 500,000 で、
 `TAKT_OPENCODE_STREAM_EVENT_LIMIT` でも上書きできます。`text_byte_limit` の既定値は 1 MiB、
 `reasoning_byte_limit` は 4 MiB です。
 
-OpenCode の output-idle watchdog は既定で無効です。OpenCode は tool_use から
-tool_result までイベントを流さないことがあり、推論や長時間のツール実行中の無音を
-idle と誤認し得るためです。出力がない call も `call_timeout_ms` の wall-clock 上限で
-終了します。発行間隔を認証できる transport だけが、provider/model 単位の明示的な
-追加 watchdog を有効化できます。
+この上限は provider から実際に届く event を観測し、TAKT は keepalive を合成しません。
+OpenCode では tool の実行開始 event から終端 event までを in-flight として追跡し、その間は
+通常の無応答判定を停止します。終端 event が欠落した完全ハングを無界に待たないよう、
+in-flight 状態自体は `call_timeout_ms` の6倍で stale と判定し、`PART_TIMEOUT` で終了します。
 
 数値上限の不正値は入力経路で扱いが異なります。`guards.*` に書いた値（および
 `TAKT_PROVIDER_OPTIONS_*` 由来の値）は宣言された設定なので、正の整数でなければ

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -325,9 +325,11 @@ The `provider` and `model` declarations select the provider, model, and thinking
 
 `provider_options.pi` is a separate path for loading Pi resources such as `extensions` and `no_*` discovery controls. These options do not declare authentication, model, or thinking level. Explicit resource sources are resolved temporarily for the TAKT run and are not persisted to Pi settings; see [Pi resource loading](#pi-resource-loading) for the resource trust boundary.
 
-### Provider call deadline and OpenCode execution guards
+### Provider inactivity deadline and OpenCode execution guards
 
-Every provider uses `guards.call_timeout_ms` for its call-wide wall-clock deadline.
+Every provider uses `guards.call_timeout_ms` as its maximum period without an
+observable provider event. Each stream/tool event, phase completion, and new
+provider attempt resets the timer; cumulative execution time is not capped.
 It applies to `codex`, `opencode`, `claude` (including `claude-sdk`),
 `claude_terminal`, `cursor`, `copilot`, `kiro`, and `pi`. Values are integer
 milliseconds from 60,000 through 86,400,000; the default is 3,600,000 ms
@@ -344,19 +346,18 @@ wildcard. Guard leaves merge independently across provider-option layers, while
 each higher-priority `model_profiles` value replaces the complete lower-priority
 map.
 
-Each OpenCode call has a 3,600,000 ms (60 minute) wall-clock limit. A call that
-may run longer than 60 minutes — a step that runs a full test suite, for
-example — must explicitly set `call_timeout_ms` from 60,000 through 86,400,000.
+Each OpenCode call has a 3,600,000 ms (60 minute) provider-event inactivity
+limit. A healthy call may run longer while events continue to arrive.
 `event_limit` defaults to 500,000 and can be overridden by
 `TAKT_OPENCODE_STREAM_EVENT_LIMIT`. `text_byte_limit` defaults to 1 MiB and
 `reasoning_byte_limit` to 4 MiB.
 
-The OpenCode output-idle watchdog is disabled by default. OpenCode may emit no
-events between tool_use and tool_result, so treating silence during reasoning
-or a long-running tool as inactivity can terminate a healthy call. Calls with
-no output are instead bounded by the `call_timeout_ms` wall-clock limit. An
-additional provider/model-specific watchdog may be enabled only for a transport
-whose emission interval has been authenticated.
+The timeout observes provider events as delivered; TAKT does not synthesize
+keepalives. OpenCode tracks the interval from a tool-start event through its
+terminal event as in-flight and suspends the ordinary inactivity check during
+that interval. To keep a missing terminal event or complete hang bounded, the
+in-flight state becomes stale after six times `call_timeout_ms` and ends as
+`PART_TIMEOUT`.
 
 Invalid numeric limits are treated differently per input path. Values written
 under `guards.*` (including those from `TAKT_PROVIDER_OPTIONS_*`) are declared

--- a/src/__tests__/abort-signal.test.ts
+++ b/src/__tests__/abort-signal.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildAbortSignal } from '../core/workflow/engine/abort-signal.js';
+import { buildAbortSignal, buildInactivityAbortSignal } from '../core/workflow/engine/abort-signal.js';
+import { recordWorkflowStepProviderEventActivity } from '../core/workflow/engine/step-deadline.js';
+import { STALE_IN_FLIGHT_TOOL_FACTOR } from '../shared/types/provider-deadline.js';
 
 describe('buildAbortSignal', () => {
   beforeEach(() => {
@@ -64,5 +66,99 @@ describe('buildAbortSignal', () => {
     expect(addSpy).not.toHaveBeenCalled();
 
     dispose();
+  });
+});
+
+describe('buildInactivityAbortSignal', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('活動のたびに無応答期限を更新する', () => {
+    const deadline = buildInactivityAbortSignal(100, undefined);
+
+    vi.advanceTimersByTime(90);
+    deadline.recordActivity();
+    vi.advanceTimersByTime(90);
+    expect(deadline.signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(10);
+    expect(deadline.signal.aborted).toBe(true);
+    expect((deadline.signal.reason as Error).message).toBe('Part timeout after 100ms');
+    deadline.dispose();
+  });
+
+  it('in-flight tool 中は通常期限を停止し、stale 上限で abort する', () => {
+    const timeoutMs = 100;
+    const deadline = buildInactivityAbortSignal(timeoutMs, undefined);
+
+    deadline.recordActivity({
+      kind: 'tool_started',
+      executionUnitKey: 'step',
+      toolCallKey: 'step\0tool-1',
+    });
+    vi.advanceTimersByTime(timeoutMs);
+    expect(deadline.signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(timeoutMs * (STALE_IN_FLIGHT_TOOL_FACTOR - 1) - 1);
+    expect(deadline.signal.aborted).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(deadline.signal.aborted).toBe(true);
+    expect((deadline.signal.reason as Error).message).toBe('Part timeout after 100ms');
+    deadline.dispose();
+  });
+
+  it('tool 終端後は通常の無応答期限を再開する', () => {
+    const deadline = buildInactivityAbortSignal(100, undefined);
+
+    recordWorkflowStepProviderEventActivity(deadline.recordActivity, 'step', {
+      type: 'tool_use',
+      data: { tool: 'Bash', input: {}, id: 'tool-1' },
+    });
+    vi.advanceTimersByTime(150);
+    recordWorkflowStepProviderEventActivity(deadline.recordActivity, 'step', {
+      type: 'tool_result',
+      data: { id: 'tool-1', content: 'done', isError: false },
+    });
+    vi.advanceTimersByTime(99);
+    expect(deadline.signal.aborted).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(deadline.signal.aborted).toBe(true);
+    deadline.dispose();
+  });
+
+  it('新しい attempt 開始時に欠落した tool 状態を破棄して通常期限を満額取り直す', () => {
+    const deadline = buildInactivityAbortSignal(100, undefined);
+
+    deadline.recordActivity({
+      kind: 'tool_started',
+      executionUnitKey: 'step',
+      toolCallKey: 'step\0tool-1',
+    });
+    vi.advanceTimersByTime(90);
+    deadline.recordActivity({ kind: 'attempt_started' });
+    vi.advanceTimersByTime(99);
+    expect(deadline.signal.aborted).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(deadline.signal.aborted).toBe(true);
+    deadline.dispose();
+  });
+
+  it('別 execution unit の attempt 開始で in-flight tool を解除しない', () => {
+    const timeoutMs = 100;
+    const deadline = buildInactivityAbortSignal(timeoutMs, undefined);
+
+    deadline.recordActivity({
+      kind: 'tool_started',
+      executionUnitKey: 'part-a',
+      toolCallKey: 'part-a\0tool-1',
+    });
+    vi.advanceTimersByTime(90);
+    deadline.recordActivity({ kind: 'attempt_started', executionUnitKey: 'part-b' });
+    vi.advanceTimersByTime(timeoutMs);
+    expect(deadline.signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(timeoutMs * (STALE_IN_FLIGHT_TOOL_FACTOR - 1) - 90);
+    expect(deadline.signal.aborted).toBe(true);
+    deadline.dispose();
   });
 });

--- a/src/__tests__/agent-usecases.test.ts
+++ b/src/__tests__/agent-usecases.test.ts
@@ -17,6 +17,11 @@ import { runTagJudgeStage as runTagJudgeStageImpl } from '../agents/judge-status
 import { requestDecompositionRawResponse as requestDecompositionRawResponseImpl } from '../agents/decompose-task-usecase.js';
 import { loadEvaluationSchema, loadJudgmentSchema } from '../infra/resources/schema-loader.js';
 import { OpenCodeProvider } from '../infra/providers/opencode.js';
+import {
+  createWorkflowStepDeadline,
+  recordWorkflowStepProviderActivity,
+  recordWorkflowStepProviderEventActivity,
+} from '../core/workflow/engine/step-deadline.js';
 
 vi.mock('../agents/runner.js', () => ({
   runAgent: vi.fn(),
@@ -250,17 +255,21 @@ describe('agent-usecases', () => {
   );
   it('evaluateCondition は構造化出力の matched_index を優先する', async () => {
     vi.mocked(runAgent).mockResolvedValue(doneResponse('ignored', { matched_index: 2, reason: 'second condition' }));
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
 
     const result = await evaluateCondition('agent output', [
       { index: 0, text: 'first' },
       { index: 1, text: 'second' },
-    ], { cwd: '/repo' });
+    ], { cwd: '/repo', onStream, onActivity });
 
     expect(result).toBe(1);
     expect(runAgent).toHaveBeenCalledWith(undefined, expect.stringContaining('judge prompt'), expect.objectContaining({
       cwd: '/repo',
       resolvedExecution: expect.objectContaining({ provider: 'mock' }),
       outputSchema: expect.any(Object),
+      onStream,
+      onActivity,
     }));
   });
 
@@ -429,6 +438,96 @@ describe('agent-usecases', () => {
 
     expect(result).toEqual({ candidateIndex: 1, method: 'ai_judge' });
     expect(runAgent).toHaveBeenCalledTimes(3);
+  });
+
+  it('judgeStatus は ai_judge fallback の活動中に親 deadline を生存させる', async () => {
+    vi.useFakeTimers();
+    const inactivityTimeoutMs = 60_000;
+    const deadline = createWorkflowStepDeadline('opencode', {
+      opencode: { guards: { callTimeoutMs: inactivityTimeoutMs } },
+    }, undefined);
+    let resolveAiJudgeStarted: (() => void) | undefined;
+    const aiJudgeStarted = new Promise<void>((resolve) => {
+      resolveAiJudgeStarted = resolve;
+    });
+    let releaseStreamActivity: (() => void) | undefined;
+    const streamActivity = new Promise<void>((resolve) => {
+      releaseStreamActivity = resolve;
+    });
+    let releaseRetryActivity: (() => void) | undefined;
+    const retryActivity = new Promise<void>((resolve) => {
+      releaseRetryActivity = resolve;
+    });
+    let releaseAiJudge: (() => void) | undefined;
+    const aiJudgeCompletion = new Promise<void>((resolve) => {
+      releaseAiJudge = resolve;
+    });
+    let providerStage = 0;
+    vi.mocked(runAgent).mockImplementation(async (_persona, _instruction, options) => {
+      providerStage++;
+      if (providerStage === 1) {
+        return {
+          persona: 'conductor',
+          status: 'error',
+          content: 'structured stage failed',
+          timestamp: new Date('2026-08-15T00:00:00.000Z'),
+        };
+      }
+      if (providerStage === 2) {
+        return doneResponse('tag did not match');
+      }
+      options.onActivity?.({ kind: 'attempt_started' });
+      resolveAiJudgeStarted?.();
+      await streamActivity;
+      options.onStream?.({ type: 'text', data: { text: 'ai judge is still working' } });
+      await retryActivity;
+      options.onActivity?.({ kind: 'attempt_started' });
+      await aiJudgeCompletion;
+      return doneResponse('ignored', { matched_index: 2, reason: 'second condition' });
+    });
+
+    try {
+      const judgment = judgeStatus('structured', 'tag', [
+        { label: 'a' },
+        { label: 'b' },
+      ], {
+        ...judgeOptions,
+        abortSignal: deadline.signal,
+        onStream: (event) => recordWorkflowStepProviderEventActivity(
+          deadline.recordActivity,
+          'review',
+          event,
+        ),
+        onActivity: (activity) => recordWorkflowStepProviderActivity(
+          deadline.recordActivity,
+          'review',
+          activity,
+        ),
+      });
+      await aiJudgeStarted;
+      await vi.advanceTimersByTimeAsync(40_000);
+      releaseStreamActivity?.();
+      await vi.advanceTimersByTimeAsync(40_000);
+      releaseRetryActivity?.();
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      expect(deadline.signal.aborted).toBe(false);
+      expect(runAgent).toHaveBeenNthCalledWith(
+        3,
+        undefined,
+        expect.any(String),
+        expect.objectContaining({
+          onStream: expect.any(Function),
+          onActivity: expect.any(Function),
+        }),
+      );
+
+      releaseAiJudge?.();
+      await expect(judgment).resolves.toEqual({ candidateIndex: 1, method: 'ai_judge' });
+    } finally {
+      deadline.dispose();
+      vi.useRealTimers();
+    }
   });
 
   it('judgeStatus passes childProcessEnv to all Phase 3 internal agent calls', async () => {
@@ -862,17 +961,25 @@ describe('agent-usecases', () => {
     vi.mocked(runAgent).mockResolvedValue(response);
     const abortController = new AbortController();
     const onAgentResponse = vi.fn();
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
 
     const result = await decomposeTask('instruction', 2, {
       cwd: '/repo',
       abortSignal: abortController.signal,
+      onStream,
+      onActivity,
       onAgentResponse,
     });
 
     expect(runAgent).toHaveBeenCalledWith(
       undefined,
       expect.any(String),
-      expect.objectContaining({ abortSignal: abortController.signal }),
+      expect.objectContaining({
+        abortSignal: abortController.signal,
+        onStream: expect.any(Function),
+        onActivity,
+      }),
     );
     expect(onAgentResponse).toHaveBeenCalledWith(response);
     expect(result.providerUsage).toEqual(providerUsage);
@@ -1152,6 +1259,8 @@ describe('agent-usecases', () => {
     vi.mocked(runAgent).mockResolvedValue(response);
     const abortController = new AbortController();
     const onAgentResponse = vi.fn();
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
 
     const result = await requestMoreParts(
       'instruction',
@@ -1161,6 +1270,8 @@ describe('agent-usecases', () => {
         cwd: '/repo',
         cancellablePartIds: [],
         abortSignal: abortController.signal,
+        onStream,
+        onActivity,
         onAgentResponse,
       },
     );
@@ -1168,7 +1279,11 @@ describe('agent-usecases', () => {
     expect(runAgent).toHaveBeenCalledWith(
       undefined,
       expect.any(String),
-      expect.objectContaining({ abortSignal: abortController.signal }),
+      expect.objectContaining({
+        abortSignal: abortController.signal,
+        onStream: expect.any(Function),
+        onActivity,
+      }),
     );
     expect(onAgentResponse).toHaveBeenCalledWith(response);
     expect(result.providerUsage).toEqual(providerUsage);

--- a/src/__tests__/auto-routing-resolver.test.ts
+++ b/src/__tests__/auto-routing-resolver.test.ts
@@ -227,6 +227,27 @@ describe('resolveAutoRoutingRuntime', () => {
     });
   });
 
+  it('passes deadline-scoped callbacks through the resolver to the estimator', async () => {
+    const estimate = vi.fn().mockResolvedValue({ requiredTier: 'low', reasonCodes: ['focused-change'] });
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
+
+    await resolveAutoRoutingRuntime({
+      autoRouting: createAutoRoutingConfig({ rules: {}, poolRules: { steps: { unknown: 'general' } } }),
+      step: createStepMetadata({ name: 'unknown', tags: [] }),
+      snapshot: createSnapshot(),
+      estimator: { estimate },
+      currentProviderInfo: { provider: undefined, model: undefined },
+      onStream,
+      onActivity,
+    });
+
+    expect(estimate).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      onStream,
+      onActivity,
+    }));
+  });
+
   it('Given an estimator failure, When resolving auto routing, Then it warns and uses the configured pool fallback', async () => {
     const warn = vi.fn();
     const estimator: WorkRequirementEstimator = { estimate: vi.fn().mockRejectedValue(new Error('router timeout')) };

--- a/src/__tests__/claude-executor.test.ts
+++ b/src/__tests__/claude-executor.test.ts
@@ -782,16 +782,23 @@ describe('QueryExecutor rate limit cause preservation', () => {
     // Given
     queryMock.mockImplementation(() => createMockQuery([], new Error(EXIT_CODE_MESSAGE)));
     const executor = new QueryExecutor();
+    const onActivity = vi.fn();
 
     // When
     const result = await executor.execute('test prompt', {
       cwd: '/tmp/project',
       sessionId: 'resume-session-1',
+      onActivity,
     });
 
     // Then
     expect(result.error).toBe(EXIT_CODE_MESSAGE);
     expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+    expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
+      queryMock.mock.invocationCallOrder[1]!,
+    );
     expect(
       (queryMock.mock.calls[0]?.[0] as { options?: { resume?: string } }).options?.resume,
     ).toBe('resume-session-1');

--- a/src/__tests__/claude-executor.test.ts
+++ b/src/__tests__/claude-executor.test.ts
@@ -795,6 +795,7 @@ describe('QueryExecutor rate limit cause preservation', () => {
     expect(result.error).toBe(EXIT_CODE_MESSAGE);
     expect(queryMock).toHaveBeenCalledTimes(2);
     expect(onActivity).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenNthCalledWith(1, { kind: 'attempt_started' });
     expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
     expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
       queryMock.mock.invocationCallOrder[1]!,

--- a/src/__tests__/claude-headless-client.test.ts
+++ b/src/__tests__/claude-headless-client.test.ts
@@ -201,6 +201,7 @@ describe('callClaudeHeadless', () => {
   });
 
   it('returns done when stream-json yields text and process exits 0', async () => {
+    const onActivity = vi.fn();
     stubSpawn({
       stdoutChunks: [
         `${JSON.stringify({ type: 'text', text: 'ok' })}\n`,
@@ -208,9 +209,10 @@ describe('callClaudeHeadless', () => {
       ],
       closeCode: 0,
     });
-    const res = await callClaudeHeadless('agent', 'hi', { cwd: '/tmp' });
+    const res = await callClaudeHeadless('agent', 'hi', { cwd: '/tmp', onActivity });
     expect(res.status).toBe('done');
     expect(res.content).toBe('ok');
+    expect(onActivity).toHaveBeenCalledOnce();
   });
 
   it('passes only run-local observability snapshot to headless child env', async () => {

--- a/src/__tests__/claude-headless-client.test.ts
+++ b/src/__tests__/claude-headless-client.test.ts
@@ -213,6 +213,7 @@ describe('callClaudeHeadless', () => {
     expect(res.status).toBe('done');
     expect(res.content).toBe('ok');
     expect(onActivity).toHaveBeenCalledOnce();
+    expect(onActivity).toHaveBeenCalledWith({ kind: 'attempt_started' });
   });
 
   it('passes only run-local observability snapshot to headless child env', async () => {

--- a/src/__tests__/claude-headless-provider.test.ts
+++ b/src/__tests__/claude-headless-provider.test.ts
@@ -97,12 +97,14 @@ describe('ClaudeHeadlessProvider', () => {
       name: 'test',
       systemPrompt: 'sys',
     });
+    const onActivity = vi.fn();
 
     await agent.call('prompt', {
       cwd: '/tmp',
       sessionId: 'opaque-session-id-from-report-phase',
       permissionMode: 'edit',
       bypassPermissions: true,
+      onActivity,
       providerOptions: {
         claude: {
           sandbox: {
@@ -118,6 +120,7 @@ describe('ClaudeHeadlessProvider', () => {
       sessionId: 'opaque-session-id-from-report-phase',
       permissionMode: 'edit',
       bypassPermissions: true,
+      onActivity,
       anthropicApiKey: 'sk-ant-from-config',
       sandbox: {
         allowUnsandboxedCommands: true,

--- a/src/__tests__/claude-terminal-client.test.ts
+++ b/src/__tests__/claude-terminal-client.test.ts
@@ -767,6 +767,7 @@ describe('Claude terminal client', () => {
     const backend = createBackend();
     const onPermissionRequest = vi.fn();
     const onAskUserQuestion = vi.fn().mockResolvedValue({ answer: 'Use option A.' });
+    const onActivity = vi.fn();
     const transcriptReader = {
       readBaseline: vi.fn().mockResolvedValue({ byteOffset: 0, lineNumberOffset: 0 }),
       findSession: vi.fn().mockResolvedValue({ sessionId: 'claude-session-1' }),
@@ -793,6 +794,7 @@ describe('Claude terminal client', () => {
       backend: 'tmux',
       onPermissionRequest,
       onAskUserQuestion,
+      onActivity,
       terminalBackend: backend,
       transcriptReader,
     });
@@ -813,6 +815,13 @@ describe('Claude terminal client', () => {
       'Use option A.',
     );
     expect(transcriptReader.waitForAssistantResponse).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenCalledTimes(3);
+    expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
+      transcriptReader.waitForAssistantResponse.mock.invocationCallOrder[0]!,
+    );
+    expect(onActivity.mock.invocationCallOrder[2]).toBeLessThan(
+      transcriptReader.waitForAssistantResponse.mock.invocationCallOrder[1]!,
+    );
     expect(result).toMatchObject({
       persona: 'coder',
       status: 'done',

--- a/src/__tests__/claude-terminal-client.test.ts
+++ b/src/__tests__/claude-terminal-client.test.ts
@@ -816,6 +816,9 @@ describe('Claude terminal client', () => {
     );
     expect(transcriptReader.waitForAssistantResponse).toHaveBeenCalledTimes(2);
     expect(onActivity).toHaveBeenCalledTimes(3);
+    expect(onActivity).toHaveBeenNthCalledWith(1, { kind: 'attempt_started' });
+    expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+    expect(onActivity).toHaveBeenNthCalledWith(3, { kind: 'attempt_started' });
     expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
       transcriptReader.waitForAssistantResponse.mock.invocationCallOrder[0]!,
     );

--- a/src/__tests__/claude-terminal-provider-wiring.test.ts
+++ b/src/__tests__/claude-terminal-provider-wiring.test.ts
@@ -56,6 +56,7 @@ describe('ClaudeTerminalProvider wiring', () => {
     const onStream = vi.fn();
     const onPermissionRequest = vi.fn();
     const onAskUserQuestion = vi.fn();
+    const onActivity = vi.fn();
     const childProcessEnv = { TAKT_OBSERVABILITY: '{"enabled":true}' };
     const mcpServers = {
       docs: { type: 'stdio' as const, command: 'docs-mcp', args: ['serve'] },
@@ -86,6 +87,7 @@ describe('ClaudeTerminalProvider wiring', () => {
       onStream,
       onPermissionRequest,
       onAskUserQuestion,
+      onActivity,
       outputSchema: SCHEMA,
       childProcessEnv,
     });
@@ -109,6 +111,7 @@ describe('ClaudeTerminalProvider wiring', () => {
       onStream,
       onPermissionRequest,
       onAskUserQuestion,
+      onActivity,
       outputSchema: SCHEMA,
       pathToClaudeCodeExecutable: '/opt/claude/bin/claude',
       childProcessEnv,

--- a/src/__tests__/claude-terminal-transcript-reader.test.ts
+++ b/src/__tests__/claude-terminal-transcript-reader.test.ts
@@ -493,7 +493,7 @@ describe('Claude terminal transcript reader', () => {
         baseline: { byteOffset: 0, lineNumberOffset: 0 },
         timeoutMs: 30,
         pollIntervalMs: 5,
-      })).rejects.toThrow(/timed out waiting for claude terminal assistant response/i);
+      })).rejects.toThrow('Part timeout after 30ms');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/src/__tests__/claude-terminal-transcript-reader.test.ts
+++ b/src/__tests__/claude-terminal-transcript-reader.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getClaudeProjectSessionsDir } from '../infra/config/project/sessionStore.js';
 import {
   parseClaudeTerminalTranscript,
@@ -79,6 +79,10 @@ async function expectRejectedBeforePollingInterval(settlementPromise: Promise<Pr
 describe('Claude terminal transcript reader', () => {
   beforeEach(() => {
     fsMockState.readFileCount = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('Given Claude transcript JSONL, When parsing, Then session id, assistant text, and tool events are extracted', () => {
@@ -526,6 +530,47 @@ describe('Claude terminal transcript reader', () => {
         timeoutMs: 30,
         pollIntervalMs: 5,
       })).resolves.toEqual({ sessionId });
+    });
+  });
+
+  it('Given findSession sees a static invalid transcript, When polling, Then activity is recorded once and inactivity times out', async () => {
+    vi.useFakeTimers();
+    await withTemporaryClaudeHome(async (projectDir) => {
+      const sessionId = 'claude-session-static';
+      const sessionsDir = getClaudeProjectSessionsDir(projectDir);
+      await mkdir(sessionsDir, { recursive: true });
+      await writeFile(join(sessionsDir, `${sessionId}.jsonl`), '{"type":"assistant"', 'utf-8');
+      const onActivity = vi.fn();
+      const controller = new AbortController();
+      let rejection: unknown;
+      const sessionPromise = new ProjectClaudeTranscriptReader().findSession({
+        cwd: projectDir,
+        sessionId,
+        timeoutMs: 100,
+        pollIntervalMs: 10,
+        abortSignal: controller.signal,
+        onActivity,
+      }).catch((error: unknown) => {
+        rejection = error;
+      });
+
+      try {
+        await vi.waitFor(() => expect(onActivity).toHaveBeenCalledOnce(), {
+          timeout: 1_000,
+          interval: 1,
+        });
+        await vi.waitFor(() => expect(rejection).toEqual(expect.objectContaining({
+          message: 'Part timeout after 100ms',
+        })), {
+          timeout: 1_000,
+          interval: 10,
+        });
+        expect(fsMockState.readFileCount).toBeGreaterThan(1);
+        expect(onActivity).toHaveBeenCalledOnce();
+      } finally {
+        controller.abort(new Error('test cleanup'));
+        await sessionPromise;
+      }
     });
   });
 

--- a/src/__tests__/codex-client-retry.test.ts
+++ b/src/__tests__/codex-client-retry.test.ts
@@ -15,6 +15,7 @@ let startThreadCalls: Array<Record<string, unknown> | undefined> = [];
 let resumeThreadCalls: Array<{ threadId: string; options?: Record<string, unknown> }> = [];
 let runStreamedInputs: unknown[] = [];
 let codexConstructorCalls: Array<Record<string, unknown> | undefined> = [];
+let attemptOrder: string[] = [];
 const tempRoots = new Set<string>();
 const CODEX_STREAM_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 const CODEX_RECONNECT_FAILURE_MESSAGE = 'Reconnecting... 2/5 (timeout waiting for child process to exit)';
@@ -122,11 +123,13 @@ vi.mock('@openai/codex-sdk', () => {
       }
 
       async startThread(options?: Record<string, unknown>) {
+        attemptOrder.push('provider');
         startThreadCalls.push(options);
         return createThread('thread-1');
       }
 
       async resumeThread(threadId: string, options?: Record<string, unknown>) {
+        attemptOrder.push('provider');
         resumeThreadCalls.push({ threadId, options });
         return createThread(threadId);
       }
@@ -146,6 +149,7 @@ describe('CodexClient retry', () => {
     resumeThreadCalls = [];
     runStreamedInputs = [];
     codexConstructorCalls = [];
+    attemptOrder = [];
   });
 
   afterEach(() => {
@@ -255,8 +259,9 @@ describe('CodexClient retry', () => {
     ];
 
     const client = new CodexClient();
+    const onActivity = vi.fn(() => attemptOrder.push('activity'));
 
-    const resultPromise = client.call('coder', 'prompt', { cwd: '/tmp' });
+    const resultPromise = client.call('coder', 'prompt', { cwd: '/tmp', onActivity });
 
     await vi.advanceTimersByTimeAsync(999);
     expect(resumeThreadCalls).toHaveLength(0);
@@ -273,6 +278,9 @@ describe('CodexClient retry', () => {
     ]);
     expect(result.status).toBe('done');
     expect(result.content).toBe('retry succeeded');
+    expect(onActivity).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+    expect(attemptOrder).toEqual(['activity', 'provider', 'activity', 'provider']);
   });
 
   it('retry と session resume に同じ Codex Skill override を適用する', async () => {

--- a/src/__tests__/codex-client-retry.test.ts
+++ b/src/__tests__/codex-client-retry.test.ts
@@ -279,6 +279,7 @@ describe('CodexClient retry', () => {
     expect(result.status).toBe('done');
     expect(result.content).toBe('retry succeeded');
     expect(onActivity).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenNthCalledWith(1, { kind: 'attempt_started' });
     expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
     expect(attemptOrder).toEqual(['activity', 'provider', 'activity', 'provider']);
   });

--- a/src/__tests__/companion-step-executor.integration.test.ts
+++ b/src/__tests__/companion-step-executor.integration.test.ts
@@ -10,6 +10,7 @@ import { CompanionReviewAuthority } from '../core/workflow/companion/review-stat
 import { StepExecutor, type StepExecutorDeps } from '../core/workflow/engine/StepExecutor.js';
 import { createStructuredOutputNormalizerRegistry } from '../core/workflow/engine/structured-output-normalizer.js';
 import { COMPLETION_RETRY_JUDGE_NAME } from '../core/workflow/completion-retry.js';
+import { CompanionStepRuntime } from '../core/workflow/companion/step-runtime.js';
 import type { RunPaths } from '../core/workflow/run/run-paths.js';
 import { executeAgent } from '../agents/agent-usecases.js';
 import { initDebugLogger, resetDebugLogger } from '../shared/utils/debug.js';
@@ -271,6 +272,14 @@ describe('companion StepExecutor lifecycle', () => {
       abortSignal: abortController.signal,
       emitEvent,
     });
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
+    vi.mocked(deps.optionsBuilder.buildAgentOptions).mockReturnValue({
+      cwd,
+      onStream,
+      onActivity,
+    });
+    const createRuntime = vi.spyOn(CompanionStepRuntime, 'create');
     const step = {
       ...createCompanionStep([makeRule('Implementation is complete', 'COMPLETE')]),
       completionRetry: {
@@ -290,6 +299,10 @@ describe('companion StepExecutor lifecycle', () => {
     );
 
     expect(result.response).toMatchObject({ content: 'review-2', sessionId: 'session-2' });
+    expect(createRuntime).toHaveBeenCalledWith(expect.objectContaining({
+      onStream,
+      onActivity,
+    }));
     expect(timeline).toEqual([
       'reviewer:1',
       'companion:complete',
@@ -298,6 +311,7 @@ describe('companion StepExecutor lifecycle', () => {
       'companion:complete',
       'judge:2',
     ]);
+    createRuntime.mockRestore();
   });
 
   it('should release the companion parent abort listener after a successful normal step', async () => {

--- a/src/__tests__/companion-structured-call.test.ts
+++ b/src/__tests__/companion-structured-call.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeStructuredAgent } from '../agents/structured-caller/transport.js';
+import { CompanionStructuredCaller } from '../core/workflow/companion/structured-call.js';
+
+vi.mock('../agents/structured-caller/transport.js', () => ({
+  executeStructuredAgent: vi.fn(),
+}));
+
+describe('CompanionStructuredCaller', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('deadline-scoped stream and activity callbacks reach the structured provider call', async () => {
+    vi.mocked(executeStructuredAgent).mockResolvedValue({
+      persona: 'security-reviewer',
+      status: 'done',
+      content: 'reviewed',
+      timestamp: new Date('2026-08-14T00:00:00.000Z'),
+      structuredOutput: { findings: [], updates: [] },
+    });
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
+    const caller = new CompanionStructuredCaller({
+      cwd: '/worktree',
+      projectCwd: '/project',
+      failureDir: '/project/.takt/runs/run/failures',
+      language: 'en',
+      onStream,
+      onActivity,
+      recordUsage: vi.fn(),
+      recordCall: vi.fn(),
+    });
+
+    await caller.call({
+      purpose: 'reviewer',
+      agentName: 'security-reviewer',
+      provider: { provider: 'mock' },
+      systemPrompt: 'review system',
+      prompt: 'review prompt',
+      outputSchema: { type: 'object' },
+    });
+
+    expect(executeStructuredAgent).toHaveBeenCalledWith(
+      'review prompt',
+      { type: 'object' },
+      expect.objectContaining({ onStream, onActivity }),
+    );
+  });
+});

--- a/src/__tests__/copilot-client.test.ts
+++ b/src/__tests__/copilot-client.test.ts
@@ -98,6 +98,7 @@ describe('callCopilot', () => {
   });
 
   it('should invoke copilot with required args including --silent, --no-color', async () => {
+    const onActivity = vi.fn();
     mockSpawnWithScenario({
       stdout: 'Implementation complete. All tests pass.',
       code: 0,
@@ -109,11 +110,13 @@ describe('callCopilot', () => {
       sessionId: 'sess-prev',
       permissionMode: 'full',
       copilotGithubToken: 'gh-token',
+      onActivity,
     });
 
     expect(result.status).toBe('done');
     expect(result.content).toBe('Implementation complete. All tests pass.');
     expect(result.sessionId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    expect(onActivity).toHaveBeenCalledOnce();
 
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const [command, args, options] = mockSpawn.mock.calls[0] as [string, string[], { env?: NodeJS.ProcessEnv; stdio?: unknown }];

--- a/src/__tests__/copilot-provider.test.ts
+++ b/src/__tests__/copilot-provider.test.ts
@@ -166,12 +166,14 @@ for (const c of cases) {
 
       const provider = c.createProvider();
       const agent = provider.setup({ name: 'coder' });
+      const onActivity = vi.fn();
 
       await agent.call('implement', {
         cwd: '/tmp/work',
         model: c.model,
         sessionId: 'sess-1',
         permissionMode: 'full',
+        onActivity,
       });
 
       expect(c.mockCall).toHaveBeenCalledWith(
@@ -182,6 +184,7 @@ for (const c of cases) {
           model: c.model,
           sessionId: 'sess-1',
           permissionMode: 'full',
+          onActivity,
           [c.keyOption]: c.resolvedKey,
         }),
       );

--- a/src/__tests__/cursor-client.test.ts
+++ b/src/__tests__/cursor-client.test.ts
@@ -301,6 +301,7 @@ describe('callCursor', () => {
 
   it('should retry cli-config rename ENOENT and return successful retry result', async () => {
     vi.useFakeTimers();
+    const onActivity = vi.fn();
     mockSpawnWithScenarios([
       {
         code: 1,
@@ -315,6 +316,7 @@ describe('callCursor', () => {
     const resultPromise = callCursor('coding-review', 'review changes', {
       cwd: '/repo',
       sessionId: 'sess-before-retry',
+      onActivity,
     });
 
     await vi.advanceTimersByTimeAsync(999);
@@ -327,6 +329,11 @@ describe('callCursor', () => {
     expect(result.status).toBe('done');
     expect(result.content).toBe('retry succeeded');
     expect(result.sessionId).toBe('sess-after-retry');
+    expect(onActivity).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+    expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
+      mockSpawn.mock.invocationCallOrder[1]!,
+    );
   });
 
   it('should stop cli-config rename ENOENT retry when aborted during retry delay', async () => {

--- a/src/__tests__/dynamic-facet-selector-coordinator.test.ts
+++ b/src/__tests__/dynamic-facet-selector-coordinator.test.ts
@@ -262,6 +262,7 @@ describe('DynamicFacetSelectorCoordinator', () => {
   });
 
   it('passes selector guidance to the isolated agent without replacing the engine contract', async () => {
+    const onActivity = vi.fn();
     const pool = makePool([
       { id: 'frontend', description: 'Frontend changes' },
       { id: 'backend', description: 'Backend changes' },
@@ -274,7 +275,7 @@ describe('DynamicFacetSelectorCoordinator', () => {
       structuredOutput: { selected_ids: ['frontend'], rationale: 'changed paths are frontend-only' },
     });
 
-    const coordinator = new DynamicFacetSelectorCoordinator(buildDeps());
+    const coordinator = new DynamicFacetSelectorCoordinator(buildDeps({ onActivity }));
     await coordinator.resolveDynamicFacets(makeGuidedStep(), makeState(), 'task', pool);
 
     const [systemPrompt, instruction, outputSchema, options] = mockedExecuteAgent.mock.calls[0] ?? [];
@@ -299,6 +300,7 @@ describe('DynamicFacetSelectorCoordinator', () => {
       persona: 'facet-selector',
       personaPath: '/project/.takt/facets/personas/facet-selector.md',
       workflowBundleResourceRoot: '/tmp/project/.takt/runs/bundle/resources',
+      onActivity,
     }));
   });
 

--- a/src/__tests__/dynamic-parallel-selector-coordinator.test.ts
+++ b/src/__tests__/dynamic-parallel-selector-coordinator.test.ts
@@ -120,7 +120,8 @@ describe('DynamicParallelSelectorCoordinator', () => {
       timestamp: new Date(),
       structuredOutput: { selected_ids: ['frontend'], rationale: 'frontend changes are present' },
     });
-    const deps = dependencies();
+    const onActivity = vi.fn();
+    const deps = { ...dependencies(), onActivity };
     const coordinator = new DynamicParallelSelectorCoordinator(deps);
     const step = dynamicParallelStep({
       mode: 'replace',
@@ -158,6 +159,7 @@ describe('DynamicParallelSelectorCoordinator', () => {
       persona: 'reviewer-selector',
       personaPath: '/project/.takt/facets/personas/reviewer-selector.md',
       workflowBundleResourceRoot: '/project/.takt/runs/bundle/resources',
+      onActivity,
     }));
     expect(participants.map(({ name }) => name)).toEqual(['architecture', 'frontend']);
   });

--- a/src/__tests__/engine-completion-retry.test.ts
+++ b/src/__tests__/engine-completion-retry.test.ts
@@ -121,6 +121,8 @@ describe('WorkflowEngine completion retry wiring', () => {
     vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
       if (options.internalAgentName === 'review-completion-judge') {
         expect(options.sessionId).toBeUndefined();
+        expect(options.onStream).toEqual(expect.any(Function));
+        expect(options.onActivity).toEqual(expect.any(Function));
         return judgeResponse(true);
       }
       options.onPromptResolved?.({ systemPrompt: String(persona), userInstruction: instruction });

--- a/src/__tests__/engine-loop-monitors.test.ts
+++ b/src/__tests__/engine-loop-monitors.test.ts
@@ -1255,9 +1255,104 @@ describe('WorkflowEngine Integration: Loop Monitors', () => {
       const judgeCalls = vi.mocked(runAgent).mock.calls.filter((call) => call[0] === 'supervisor');
       expect(state.status).toBe('completed');
       expect(judgeCalls.map((call) => call[2]?.sessionId)).toEqual([undefined, undefined]);
+      expect(judgeCalls.every((call) => typeof call[2]?.onStream === 'function')).toBe(true);
+      expect(judgeCalls.every((call) => typeof call[2]?.onActivity === 'function')).toBe(true);
       expect(state.personaSessions.has(
         '["supervisor","opencode","opencode/zai-coding-plan/glm-5.1"]',
       )).toBe(false);
+    });
+
+    it('keeps the loop monitor judge alive past one inactivity window while internal activity continues', async () => {
+      vi.useFakeTimers();
+      const inactivityTimeoutMs = 60_000;
+      const config = buildConfigWithLoopMonitor(1, {
+        judge: {
+          persona: 'supervisor',
+          provider: 'opencode',
+          model: 'opencode/judge-model',
+          providerOptions: {
+            opencode: { guards: { callTimeoutMs: inactivityTimeoutMs } },
+          },
+          rules: loopJudgeRules(),
+        },
+      } as Partial<LoopMonitorConfig>);
+      engine = new WorkflowEngine(config, tmpDir, 'test task', {
+        projectCwd: tmpDir,
+        provider: 'mock',
+      });
+      const regularResponses = [
+        makeResponse({ persona: 'implement', content: 'Implementation done' }),
+        makeResponse({ persona: 'ai_review', content: 'Issues found: X' }),
+        makeResponse({ persona: 'ai_fix', content: 'Fixed X' }),
+        makeResponse({ persona: 'reviewers', content: 'All approved' }),
+      ];
+      let resolveJudgeStarted: (() => void) | undefined;
+      const judgeStarted = new Promise<void>((resolve) => {
+        resolveJudgeStarted = resolve;
+      });
+      let releaseStreamActivity: (() => void) | undefined;
+      const streamActivity = new Promise<void>((resolve) => {
+        releaseStreamActivity = resolve;
+      });
+      let releaseRetryActivity: (() => void) | undefined;
+      const retryActivity = new Promise<void>((resolve) => {
+        releaseRetryActivity = resolve;
+      });
+      let releaseJudgeCompletion: (() => void) | undefined;
+      const judgeCompletion = new Promise<void>((resolve) => {
+        releaseJudgeCompletion = resolve;
+      });
+      let judgeSignal: AbortSignal | undefined;
+      vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
+        options.onPromptResolved?.({
+          systemPrompt: typeof persona === 'string' ? persona : '',
+          userInstruction: instruction,
+        });
+        if (options.outputSchema === undefined) {
+          const response = regularResponses.shift();
+          if (response === undefined) throw new Error('Unexpected regular agent call');
+          return response;
+        }
+        judgeSignal = options.abortSignal;
+        options.onActivity?.({ kind: 'attempt_started' });
+        resolveJudgeStarted?.();
+        await streamActivity;
+        options.onStream?.({ type: 'text', data: { text: 'judge is still working' } });
+        await retryActivity;
+        options.onActivity?.({ kind: 'attempt_started' });
+        await judgeCompletion;
+        return makeResponse({
+          persona: 'supervisor',
+          content: 'Unproductive loop detected',
+          structuredOutput: { content: 'Unproductive loop detected' },
+        });
+      });
+      mockRuleEvaluationSequence([
+        { index: 0, method: 'phase3_tag' },
+        { index: 1, method: 'phase3_tag' },
+        { index: 0, method: 'phase3_tag' },
+        { index: 1, method: 'ai_judge' },
+        { index: 0, method: 'phase3_tag' },
+      ]);
+
+      try {
+        const execution = engine.run();
+        await judgeStarted;
+        await vi.advanceTimersByTimeAsync(40_000);
+        releaseStreamActivity?.();
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(judgeSignal?.aborted).toBe(false);
+        await vi.advanceTimersByTimeAsync(20_000);
+        releaseRetryActivity?.();
+        await vi.advanceTimersByTimeAsync(20_000);
+        releaseJudgeCompletion?.();
+        const state = await execution;
+
+        expect(state.status).toBe('completed');
+        expect(judgeSignal?.aborted).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('keeps loop-judge seat capabilities and permission across a model-only CLI override', async () => {

--- a/src/__tests__/engine-parallel.test.ts
+++ b/src/__tests__/engine-parallel.test.ts
@@ -578,6 +578,7 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
       resolvedExecution: unknown;
       outputSchema: Record<string, unknown> | undefined;
       internalSystemPrompt: string | undefined;
+      onActivity: unknown;
       instruction: string;
     }> = [];
     vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
@@ -590,6 +591,7 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
         resolvedExecution: options?.resolvedExecution,
         outputSchema: options?.outputSchema,
         internalSystemPrompt: options?.internalSystemPrompt,
+        onActivity: options?.onActivity,
         instruction,
       });
       if (options?.outputSchema) {
@@ -662,6 +664,7 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
       },
       bypassPermissions: false,
       internalSystemPrompt: expect.stringContaining('internal dynamic parallel selector'),
+      onActivity: expect.any(Function),
       outputSchema: expect.objectContaining({
         additionalProperties: false,
         required: ['selected_ids', 'rationale'],

--- a/src/__tests__/engine-team-leader.test.ts
+++ b/src/__tests__/engine-team-leader.test.ts
@@ -806,8 +806,9 @@ describe('WorkflowEngine Integration: TeamLeaderRunner', () => {
     const config = buildTeamLeaderConfig();
     const abortController = new AbortController();
     const abortReason = new Error('leader routing aborted');
+    let estimatorAbortSignal: AbortSignal | undefined;
     const estimate = vi.fn().mockImplementation(async (_input, options) => {
-      expect(options?.abortSignal).toBe(abortController.signal);
+      estimatorAbortSignal = options?.abortSignal;
       abortController.abort(abortReason);
       throw abortReason;
     });
@@ -826,6 +827,9 @@ describe('WorkflowEngine Integration: TeamLeaderRunner', () => {
 
     expect(state.status).toBe('aborted');
     expect(estimate).toHaveBeenCalledOnce();
+    expect(estimatorAbortSignal).not.toBe(abortController.signal);
+    expect(estimatorAbortSignal?.aborted).toBe(true);
+    expect(estimatorAbortSignal?.reason).toBe(abortReason);
     expect(vi.mocked(runAgent)).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/kiro-client.test.ts
+++ b/src/__tests__/kiro-client.test.ts
@@ -196,6 +196,7 @@ describe('callKiro', () => {
   });
 
   it('Given full permission and a session, When called, Then invokes kiro-cli headless with trust-all and resume-id', async () => {
+    const onActivity = vi.fn();
     mockSpawnWithScenario({
       stdout: 'Implementation complete.',
       code: 0,
@@ -206,11 +207,13 @@ describe('callKiro', () => {
       sessionId: 'sess-prev',
       permissionMode: 'full',
       kiroApiKey: 'kiro-secret',
+      onActivity,
     });
 
     expect(result.status).toBe('done');
     expect(result.content).toBe('Implementation complete.');
     expect(result.sessionId).toBe('sess-prev');
+    expect(onActivity).toHaveBeenCalledOnce();
 
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const [command, args, options] = mockSpawn.mock.calls[0] as [

--- a/src/__tests__/kiro-provider.test.ts
+++ b/src/__tests__/kiro-provider.test.ts
@@ -69,12 +69,14 @@ describe('KiroProvider', () => {
 
     const provider = new KiroProvider();
     const agent = provider.setup({ name: 'coder' });
+    const onActivity = vi.fn();
 
     await agent.call('implement', {
       cwd: '/tmp/work',
       model: 'claude-3-opus',
       sessionId: 'sess-1',
       permissionMode: 'full',
+      onActivity,
     });
 
     expect(mockCallKiro).toHaveBeenCalledWith(
@@ -85,6 +87,7 @@ describe('KiroProvider', () => {
         model: 'claude-3-opus',
         sessionId: 'sess-1',
         permissionMode: 'full',
+        onActivity,
         kiroApiKey: 'resolved-key',
         kiroCliPath: '/custom/bin/kiro-cli',
       }),

--- a/src/__tests__/mock-client-abort.test.ts
+++ b/src/__tests__/mock-client-abort.test.ts
@@ -13,8 +13,8 @@
  *   Fix: toMockOptions() now forwards options.abortSignal.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
-import { callMock } from '../infra/mock/client.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { callMock, callMockCustom } from '../infra/mock/client.js';
 import { ScenarioQueue, setMockScenario, resetScenario } from '../infra/mock/scenario.js';
 
 afterEach(() => {
@@ -69,6 +69,24 @@ describe('ScenarioQueue: persona name matching for path-style persona specs', ()
 // ---------------------------------------------------------------------------
 
 describe('callMock: abortSignal propagation during mock delay', () => {
+  it.each([
+    ['standard', (onActivity: ReturnType<typeof vi.fn>) => callMock('coder', 'task', {
+      cwd: '/tmp/project',
+      onActivity,
+    })],
+    ['custom', (onActivity: ReturnType<typeof vi.fn>) => callMockCustom('coder', 'task', 'system', {
+      cwd: '/tmp/project',
+      onActivity,
+    })],
+  ])('%s call emits attempt_started before completing', async (_label, invoke) => {
+    const onActivity = vi.fn();
+
+    await invoke(onActivity);
+
+    expect(onActivity).toHaveBeenCalledOnce();
+    expect(onActivity).toHaveBeenCalledWith({ kind: 'attempt_started' });
+  });
+
   it('should remain pending until waitForAbort receives an abort signal', async () => {
     setMockScenario([{ status: 'done', content: 'Done', waitForAbort: true }]);
     const controller = new AbortController();

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -266,7 +266,7 @@ describe('OpenCodeClient retry', () => {
     expect(result.content).toBe('');
   });
 
-  it('出力がなくても idle では retry せず、call wall-clock で終了する', async () => {
+  it('出力がないと call inactivity timeout で終了する', async () => {
     vi.useFakeTimers();
     runPlans = [{
       type: 'stream',
@@ -290,13 +290,14 @@ describe('OpenCodeClient retry', () => {
     const result = await resultPromise;
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('wall-clock timeout exceeded');
+    expect(result.error).toContain('Part timeout after 60000ms');
+    expect(result.failureCategory).toBe('part_timeout');
     expect(sessionCreate).toHaveBeenCalledOnce();
     expect(promptAsync).toHaveBeenCalledOnce();
     expect(subscribe).toHaveBeenCalledOnce();
   });
 
-  it('call wall-clock timeout は全体を abort し retry しない', async () => {
+  it('call inactivity timeout は全体を abort し retry しない', async () => {
     vi.useFakeTimers();
     runPlans = [{
       type: 'stream',
@@ -320,14 +321,14 @@ describe('OpenCodeClient retry', () => {
     const result = await resultPromise;
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('wall-clock timeout exceeded');
+    expect(result.error).toContain('Part timeout after 60000ms');
     expect(sessionCreate).toHaveBeenCalledOnce();
     expect(promptAsync).toHaveBeenCalledOnce();
     expect(subscribe).toHaveBeenCalledOnce();
     expect(abort).toHaveBeenCalledOnce();
   });
 
-  it('wall-clock signal は未完了の prompt 待ちと iterator close を打ち切る', async () => {
+  it('inactivity timeout signal は未完了の prompt 待ちと iterator close を打ち切る', async () => {
     vi.useFakeTimers();
     const iteratorReturn = vi.fn(() => new Promise<IteratorResult<MockStreamEvent>>(() => {}));
     runPlans = [{
@@ -350,7 +351,7 @@ describe('OpenCodeClient retry', () => {
     const result = await resultPromise;
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('wall-clock timeout exceeded');
+    expect(result.error).toContain('Part timeout after 60000ms');
     expect(iteratorReturn).toHaveBeenCalledOnce();
   });
 
@@ -400,7 +401,7 @@ describe('OpenCodeClient retry', () => {
     const result = await resultPromise;
 
     expect(result.status).toBe('error');
-    expect(result.error).toContain('wall-clock timeout exceeded');
+    expect(result.error).toContain('Part timeout after 60000ms');
     expect(onStream).toHaveBeenCalledTimes(streamCallsBeforeDeadline);
     expect(promptAsync).toHaveBeenCalledOnce();
     expect(onAskUserQuestion).not.toHaveBeenCalled();
@@ -476,6 +477,7 @@ describe('OpenCodeClient retry', () => {
     ];
     const { sessionCreate, promptAsync, subscribe } = installOpenCodeMock();
     const onStream = vi.fn();
+    const onActivity = vi.fn();
     const logsDir = mkdtempSync(join(tmpdir(), 'takt-opencode-retry-thinking-'));
     const providerLogger = createProviderEventLogger({
       logsDir,
@@ -496,6 +498,7 @@ describe('OpenCodeClient retry', () => {
       const result = await client.call('coder', 'prompt', {
         cwd: '/tmp',
         model: 'opencode/big-pickle',
+        onActivity,
         onStream: (event) => {
           providerLogger.logEvent(logContext, event);
           onStream(event);
@@ -506,6 +509,11 @@ describe('OpenCodeClient retry', () => {
       expect(sessionCreate).toHaveBeenCalledTimes(2);
       expect(promptAsync).toHaveBeenCalledTimes(2);
       expect(subscribe).toHaveBeenCalledTimes(2);
+      expect(onActivity).toHaveBeenCalledTimes(2);
+      expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+      expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
+        promptAsync.mock.invocationCallOrder[1]!,
+      );
       expect(onStream.mock.calls.filter(([event]) => (
         event.type === 'text' && event.data.text === 'transient retry tail'
       ))).toHaveLength(1);

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -510,6 +510,7 @@ describe('OpenCodeClient retry', () => {
       expect(promptAsync).toHaveBeenCalledTimes(2);
       expect(subscribe).toHaveBeenCalledTimes(2);
       expect(onActivity).toHaveBeenCalledTimes(2);
+      expect(onActivity).toHaveBeenNthCalledWith(1, { kind: 'attempt_started' });
       expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
       expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
         promptAsync.mock.invocationCallOrder[1]!,
@@ -534,6 +535,60 @@ describe('OpenCodeClient retry', () => {
     } finally {
       rmSync(logsDir, { recursive: true, force: true });
     }
+  });
+
+  it('resets the internal inactivity deadline before retry attempt initialization', async () => {
+    vi.useFakeTimers();
+    runPlans = [
+      {
+        type: 'events',
+        events: [{
+          type: 'session.error',
+          properties: {
+            sessionID: 'session-1',
+            error: { name: 'RequestError', data: { message: 'fetch failed' } },
+          },
+        }],
+      },
+      {
+        type: 'events',
+        events: [
+          textPartUpdated('session-1', 'recovered', 'recovered'),
+          { type: 'session.idle', properties: { sessionID: 'session-1' } },
+        ],
+      },
+    ];
+    const { sessionCreate, promptAsync, setActiveSessionId } = installOpenCodeMock();
+    setActiveSessionId('session-1');
+    sessionCreate
+      .mockResolvedValueOnce({ data: { id: 'session-1' } })
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        setTimeout(() => resolve({ data: { id: 'session-1' } }), 59_900);
+      }));
+    const onActivity = vi.fn();
+
+    const resultPromise = new OpenCodeClient().call('coder', 'prompt', {
+      cwd: '/tmp',
+      model: 'opencode/big-pickle',
+      guards: { callTimeoutMs: 60_000 },
+      onActivity,
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(sessionCreate).toHaveBeenCalledTimes(2);
+    expect(onActivity).toHaveBeenNthCalledWith(2, { kind: 'attempt_started' });
+    expect(onActivity.mock.invocationCallOrder[1]).toBeLessThan(
+      sessionCreate.mock.invocationCallOrder[1]!,
+    );
+
+    await vi.advanceTimersByTimeAsync(59_750);
+    expect(promptAsync).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(150);
+    const result = await resultPromise;
+
+    expect(result.status).toBe('done');
+    expect(result.content).toBe('recovered');
+    expect(promptAsync).toHaveBeenCalledTimes(2);
   });
 
   it('replays the OpenCode event order from issue #1130 without mixing reasoning and text', async () => {

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -8,6 +8,10 @@ import {
   OPENCODE_STREAM_REASONING_BYTE_LIMIT,
   OPENCODE_STREAM_TEXT_BYTE_LIMIT,
 } from '../infra/opencode/OpenCodeStreamHandler.js';
+import {
+  OpenCodeGuardSuite,
+  type OpenCodeGuardEvaluation,
+} from '../infra/opencode/guards/index.js';
 
 type MockStreamEvent = Record<string, unknown>;
 type RunPlan =
@@ -326,6 +330,72 @@ describe('OpenCodeClient retry', () => {
     expect(promptAsync).toHaveBeenCalledOnce();
     expect(subscribe).toHaveBeenCalledOnce();
     expect(abort).toHaveBeenCalledOnce();
+  });
+
+  it('call deadline と attempt timeout が同時発生しても PART_TIMEOUT 分類を保持する', async () => {
+    let notifyStreamReady!: () => void;
+    const streamReady = new Promise<void>((resolve) => {
+      notifyStreamReady = resolve;
+    });
+    runPlans = [{
+      type: 'stream',
+      createStream: (signal?: AbortSignal) => (async function* () {
+        notifyStreamReady();
+        await waitForAbort(signal);
+      })(),
+    }];
+    const deadlineFailure: OpenCodeGuardEvaluation = {
+      guardId: 'inactivity-timeout',
+      verdict: {
+        action: 'fail',
+        reason: 'Part timeout after 60000ms',
+        abortKind: 'deadline',
+      },
+    };
+    const attemptTimeoutFailure: OpenCodeGuardEvaluation = {
+      guardId: 'idle-timeout',
+      verdict: {
+        action: 'fail',
+        reason: 'OpenCode attempt timed out',
+      },
+    };
+    let failAttempt: ((failure: OpenCodeGuardEvaluation) => void) | undefined;
+    const originalStartAttempt = OpenCodeGuardSuite.prototype.startAttempt;
+    const startAttemptSpy = vi.spyOn(OpenCodeGuardSuite.prototype, 'startAttempt')
+      .mockImplementation(function captureAttemptFailure(onFailure) {
+        failAttempt = onFailure;
+        originalStartAttempt.call(this, onFailure);
+      });
+    const getCallFailureSpy = vi.spyOn(OpenCodeGuardSuite.prototype, 'getCallFailure')
+      .mockReturnValue(deadlineFailure);
+    const { sessionCreate, promptAsync, subscribe } = installOpenCodeMock();
+    const controller = new AbortController();
+
+    try {
+      const resultPromise = new OpenCodeClient().call('coder', 'prompt', {
+        cwd: '/tmp',
+        model: 'opencode/big-pickle',
+        abortSignal: controller.signal,
+      });
+
+      await streamReady;
+      if (failAttempt === undefined) {
+        throw new Error('OpenCode attempt guard callback was not registered');
+      }
+      controller.abort(new Error(deadlineFailure.verdict.reason));
+      failAttempt(attemptTimeoutFailure);
+      const result = await resultPromise;
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain(deadlineFailure.verdict.reason);
+      expect(result.failureCategory).toBe('part_timeout');
+      expect(sessionCreate).toHaveBeenCalledOnce();
+      expect(promptAsync).toHaveBeenCalledOnce();
+      expect(subscribe).toHaveBeenCalledOnce();
+    } finally {
+      startAttemptSpy.mockRestore();
+      getCallFailureSpy.mockRestore();
+    }
   });
 
   it('inactivity timeout signal は未完了の prompt 待ちと iterator close を打ち切る', async () => {

--- a/src/__tests__/opencode-tool-guard.test.ts
+++ b/src/__tests__/opencode-tool-guard.test.ts
@@ -23,6 +23,7 @@ import {
 import { readOpenCodeToolPart } from '../infra/opencode/guards/tool-events.js';
 import { ExactLoopGuard } from '../infra/opencode/guards/integrity-guards.js';
 import { SensitiveBudgetGuard } from '../infra/opencode/guards/resource-guards.js';
+import { STALE_IN_FLIGHT_TOOL_FACTOR } from '../infra/opencode/guards/time-guards.js';
 import { createBoundedSensitiveValues } from '../shared/utils/sensitiveText.js';
 
 const DEPRECATED_ENV_KEYS = [
@@ -139,7 +140,7 @@ describe('OpenCode guard registry / Strategy', () => {
       { id: 'event-count', layer: 'resource', mandatory: true },
       { id: 'tracked-ids', layer: 'resource', mandatory: true },
       { id: 'sensitive-budget', layer: 'integrity', mandatory: true },
-      { id: 'wall-clock', layer: 'time', mandatory: true },
+      { id: 'inactivity-timeout', layer: 'time', mandatory: true },
       { id: 'exact-loop', layer: 'integrity', mandatory: true },
       { id: 'consecutive-errors', layer: 'heuristic', mandatory: false },
       { id: 'cycle-budget', layer: 'heuristic', mandatory: false },
@@ -155,7 +156,7 @@ describe('OpenCode guard registry / Strategy', () => {
     expect(minimal.enabledGuardIds).toEqual(
       OPENCODE_GUARD_REGISTRY.filter((guard) => guard.mandatory).map((guard) => guard.id),
     );
-    expect(minimal.enabledGuardIds).toContain('wall-clock');
+    expect(minimal.enabledGuardIds).toContain('inactivity-timeout');
     expect(minimal.enabledGuardIds).toContain('exact-loop');
   });
 
@@ -450,15 +451,20 @@ describe('OpenCode guard suite', () => {
     expect(minimal.onEvent(errorTool('m-3', 'tool-3', 'failure-3')).failure).toBeUndefined();
   });
 
-  it('wall-clock は call scope 全体で発火する', () => {
+  it('provider event と attempt 開始で無応答期限を更新する', () => {
     vi.useFakeTimers();
     const suite = resolveOpenCodeGuardSuite({ callTimeoutMs: 60_000 }, 'opencode/big-pickle');
     const failures: string[] = [];
     suite.startCall((failure) => failures.push(failure.guardId));
+    vi.advanceTimersByTime(40_000);
+    suite.onEvent(runningTool('call-1', { command: 'npm test' }));
+    vi.advanceTimersByTime(40_000);
+    suite.startAttempt((failure) => failures.push(failure.guardId));
     vi.advanceTimersByTime(59_999);
     expect(failures).toEqual([]);
     vi.advanceTimersByTime(1);
-    expect(failures).toEqual(['wall-clock']);
+    expect(failures).toEqual(['inactivity-timeout']);
+    suite.stopAttempt();
     suite.stopCall();
   });
 
@@ -475,7 +481,7 @@ describe('OpenCode guard suite', () => {
     suite.stopAttempt();
   });
 
-  it('終端イベントが来ないツールは wall-clock が拾う', () => {
+  it('終端イベント後に無応答が続くと inactivity timeout が発火する', () => {
     vi.useFakeTimers();
     const suite = resolveOpenCodeGuardSuite({ callTimeoutMs: 60_000 }, 'opencode/big-pickle');
     const failures: string[] = [];
@@ -483,11 +489,37 @@ describe('OpenCode guard suite', () => {
     suite.startAttempt((failure) => failures.push(failure.guardId));
 
     suite.onEvent(runningTool('call-1', { command: 'npm run test:it' }));
+    vi.advanceTimersByTime(2 * 60_000);
+    expect(failures).toEqual([]);
+    suite.onEvent(completedTool(
+      'call-1',
+      { command: 'npm run test:it' },
+      'tests passed',
+      { tool: 'bash', exit: 0 },
+    ));
     vi.advanceTimersByTime(59_999);
     expect(failures).toEqual([]);
     vi.advanceTimersByTime(1);
-    expect(failures).toEqual(['wall-clock']);
-    expect(suite.getCallFailure()).toMatchObject({ guardId: 'wall-clock' });
+    expect(failures).toEqual(['inactivity-timeout']);
+    expect(suite.getCallFailure()).toMatchObject({ guardId: 'inactivity-timeout' });
+    suite.stopAttempt();
+    suite.stopCall();
+  });
+
+  it('終端イベントが欠落した in-flight tool は stale 上限で PART_TIMEOUT にする', () => {
+    vi.useFakeTimers();
+    const callTimeoutMs = 60_000;
+    const suite = resolveOpenCodeGuardSuite({ callTimeoutMs }, 'opencode/big-pickle');
+    const failures: string[] = [];
+    suite.startCall((failure) => failures.push(failure.guardId));
+    suite.startAttempt((failure) => failures.push(failure.guardId));
+
+    suite.onEvent(runningTool('call-1', { command: 'npm run test:it' }));
+    vi.advanceTimersByTime(callTimeoutMs * STALE_IN_FLIGHT_TOOL_FACTOR - 1);
+    expect(failures).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(failures).toEqual(['inactivity-timeout']);
+    expect(suite.getCallFailure()?.verdict.reason).toContain('Part timeout');
     suite.stopAttempt();
     suite.stopCall();
   });

--- a/src/__tests__/option-resolution-order.test.ts
+++ b/src/__tests__/option-resolution-order.test.ts
@@ -80,6 +80,17 @@ describe('option resolution order', () => {
     getRuntimeInstructionsMock.mockReturnValue(null);
   });
 
+  it('records an attempt-boundary activity before provider dispatch', async () => {
+    const onActivity = vi.fn();
+
+    await runAgent(undefined, 'task', { cwd: '/repo', provider: 'mock', onActivity });
+
+    expect(onActivity).toHaveBeenCalledOnce();
+    expect(onActivity.mock.invocationCallOrder[0]).toBeLessThan(
+      providerCallMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it('should resolve provider in order: CLI > local config > global config', async () => {
     loadProjectConfigMock.mockReturnValue({ provider: 'opencode' });
     loadGlobalConfigMock.mockReturnValue({

--- a/src/__tests__/options-builder.test.ts
+++ b/src/__tests__/options-builder.test.ts
@@ -24,7 +24,11 @@ function createProcessSafetyByStep(parentRunPid: number): WorkflowEngineOptions[
   };
 }
 
-function createBuilder(step: WorkflowStep, engineOverrides: BuilderEngineOverrides = {}): OptionsBuilder {
+function createBuilder(
+  step: WorkflowStep,
+  engineOverrides: BuilderEngineOverrides = {},
+  recordActivity: NonNullable<ConstructorParameters<typeof OptionsBuilder>[14]> = () => {},
+): OptionsBuilder {
   const engineOptions: WorkflowEngineOptions = {
     projectCwd: '/project',
     provider: 'codex',
@@ -50,6 +54,8 @@ function createBuilder(step: WorkflowStep, engineOverrides: BuilderEngineOverrid
     () => 'Original workflow task',
     undefined,
     engineOverrides.failureDir === undefined ? undefined : () => engineOverrides.failureDir,
+    () => engineOptions.abortSignal,
+    recordActivity,
   );
 }
 
@@ -865,6 +871,44 @@ describe('OptionsBuilder.buildResumeOptions', () => {
     expect(resumeOptions.outputSchema).toBeUndefined();
     expect(newSessionOptions.outputSchema).toBeUndefined();
     expect(fallbackOptions.outputSchema).toBeUndefined();
+  });
+
+  it('read-only phase options retain the workflow deadline activity callback', () => {
+    const step = createStep({ provider: 'opencode', model: 'opencode/report-model' });
+    const recordActivity = vi.fn();
+    const builder = createBuilder(step, {
+      reportFallbackProvider: { provider: 'mock', model: 'mock-report-model' },
+    }, recordActivity);
+    const resumeOptions = builder.buildResumeOptions(step, 'session-123', { maxTurns: 3 });
+    const newSessionOptions = builder.buildNewSessionReportOptions(step, {
+      allowedTools: [],
+      maxTurns: 3,
+    });
+    const fallbackOptions = builder.buildFallbackReportOptions(step, newSessionOptions, {
+      allowedTools: [],
+      maxTurns: 3,
+    });
+
+    if (fallbackOptions === undefined) {
+      throw new Error('Expected fallback report options');
+    }
+    resumeOptions.onActivity?.({ kind: 'attempt_started' });
+    newSessionOptions.onActivity?.({ kind: 'attempt_started' });
+    fallbackOptions.onActivity?.({ kind: 'attempt_started' });
+
+    expect(recordActivity).toHaveBeenCalledTimes(3);
+    expect(recordActivity).toHaveBeenNthCalledWith(1, {
+      kind: 'attempt_started',
+      executionUnitKey: step.name,
+    });
+    expect(recordActivity).toHaveBeenNthCalledWith(2, {
+      kind: 'attempt_started',
+      executionUnitKey: step.name,
+    });
+    expect(recordActivity).toHaveBeenNthCalledWith(3, {
+      kind: 'attempt_started',
+      executionUnitKey: step.name,
+    });
   });
 
   it('removes report/status phase maxTurns when provider does not support it', () => {

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -190,6 +190,7 @@ describe('Pi SDK client', () => {
     expect(response.sessionId).toMatch(/^sdk-session-\d+$/u);
     expect(events).toEqual(['init', 'text', 'result']);
     expect(onActivity).toHaveBeenCalledOnce();
+    expect(onActivity).toHaveBeenCalledWith({ kind: 'attempt_started' });
     expect(mocks.modelRuntimeCreate).toHaveBeenCalledWith({
       credentials: expect.anything(),
       modelsPath: path.join(tmpdir(), 'pi-agent-test', 'models.json'),

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -177,16 +177,19 @@ describe('Pi SDK client', () => {
   it('streams text and returns the SDK session response', async () => {
     mocks.resetTransient();
     const events: string[] = [];
+    const onActivity = vi.fn();
 
     const response = await callPi('worker', 'do the work', {
       ...sessionOptions('pi-sdk-success'),
       onStream: (event) => events.push(event.type),
+      onActivity,
     });
 
     expect(response.status).toBe('done');
     expect(response.content).toBe('hello from pi');
     expect(response.sessionId).toMatch(/^sdk-session-\d+$/u);
     expect(events).toEqual(['init', 'text', 'result']);
+    expect(onActivity).toHaveBeenCalledOnce();
     expect(mocks.modelRuntimeCreate).toHaveBeenCalledWith({
       credentials: expect.anything(),
       modelsPath: path.join(tmpdir(), 'pi-agent-test', 'models.json'),

--- a/src/__tests__/pi-provider.test.ts
+++ b/src/__tests__/pi-provider.test.ts
@@ -37,6 +37,7 @@ describe('PiProvider', () => {
     const provider = new PiProvider();
     const agent = provider.setup({ name: 'worker', systemPrompt: 'Be concise.' });
     const onStream = vi.fn();
+    const onActivity = vi.fn();
     const abortController = new AbortController();
 
     await agent.call('implement', {
@@ -51,6 +52,7 @@ describe('PiProvider', () => {
       },
       abortSignal: abortController.signal,
       onStream,
+      onActivity,
     });
 
     expect(mockCallPi).toHaveBeenCalledWith('worker', 'implement', {
@@ -64,6 +66,7 @@ describe('PiProvider', () => {
       abortSignal: abortController.signal,
       systemPrompt: 'Be concise.',
       onStream,
+      onActivity,
       childProcessEnv: undefined,
     });
   });

--- a/src/__tests__/promotion-evaluator.test.ts
+++ b/src/__tests__/promotion-evaluator.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { evaluatePromotion } from '../core/workflow/promotion/PromotionEvaluator.js';
+import {
+  evaluatePromotion,
+  type PromotionEvaluationContext,
+} from '../core/workflow/promotion/PromotionEvaluator.js';
 import type { AgentWorkflowStep, StepProviderOptions } from '../core/models/index.js';
 import type { StructuredCaller } from '../agents/structured-caller.js';
 import type { ProviderType } from '../shared/types/provider.js';
@@ -39,6 +42,8 @@ function makeContext(overrides: {
   resolvedProvider?: ProviderType;
   resolvedModel?: string;
   childProcessEnv?: Readonly<Record<string, string>>;
+  onStream?: PromotionEvaluationContext['onStream'];
+  onActivity?: PromotionEvaluationContext['onActivity'];
 }) {
   return {
     cwd: '/tmp/project',
@@ -48,6 +53,8 @@ function makeContext(overrides: {
     resolvedProvider: overrides.resolvedProvider,
     resolvedModel: overrides.resolvedModel,
     childProcessEnv: overrides.childProcessEnv,
+    onStream: overrides.onStream,
+    onActivity: overrides.onActivity,
   };
 }
 
@@ -100,6 +107,8 @@ describe('evaluatePromotion', () => {
         model: 'gpt-5.5',
       },
     ]);
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
 
     const result = await evaluatePromotion(step, makeContext({
       stepIteration: 1,
@@ -107,6 +116,8 @@ describe('evaluatePromotion', () => {
       structuredCaller: makeStructuredCaller(evaluateCondition),
       resolvedProvider: 'codex',
       resolvedModel: 'gpt-5.4',
+      onStream,
+      onActivity,
     }));
 
     expect(result).toMatchObject({ model: 'gpt-5.5' });
@@ -118,6 +129,8 @@ describe('evaluatePromotion', () => {
         provider: 'codex',
         resolvedProvider: 'codex',
         resolvedModel: 'gpt-5.4',
+        onStream,
+        onActivity,
       }),
     );
   });

--- a/src/__tests__/provider-structured-output.test.ts
+++ b/src/__tests__/provider-structured-output.test.ts
@@ -651,6 +651,7 @@ describe('Provider activity wiring', () => {
     ['claude', () => new ClaudeProvider(), mockCallClaude, undefined],
     ['codex', () => new CodexProvider(), mockCallCodex, undefined],
     ['opencode', () => new OpenCodeProvider(), mockCallOpenCode, 'opencode/big-pickle'],
+    ['mock', () => new MockProvider(), mockCallMock, undefined],
   ] as const)('%s provider は onActivity を client へ渡す', async (
     _name,
     createProvider,

--- a/src/__tests__/provider-structured-output.test.ts
+++ b/src/__tests__/provider-structured-output.test.ts
@@ -645,3 +645,28 @@ describe('ClaudeProvider abortSignal wiring', () => {
     expect(callOptions).toHaveProperty('abortSignal', controller.signal);
   });
 });
+
+describe('Provider activity wiring', () => {
+  it.each([
+    ['claude', () => new ClaudeProvider(), mockCallClaude, undefined],
+    ['codex', () => new CodexProvider(), mockCallCodex, undefined],
+    ['opencode', () => new OpenCodeProvider(), mockCallOpenCode, 'opencode/big-pickle'],
+  ] as const)('%s provider は onActivity を client へ渡す', async (
+    _name,
+    createProvider,
+    callMock,
+    model,
+  ) => {
+    vi.clearAllMocks();
+    callMock.mockResolvedValue(doneResponse('coder'));
+    const onActivity = vi.fn();
+
+    await createProvider().setup({ name: 'coder' }).call('prompt', {
+      cwd: '/tmp/project',
+      onActivity,
+      ...(model === undefined ? {} : { model }),
+    });
+
+    expect(callMock.mock.calls[0]?.[2]).toHaveProperty('onActivity', onActivity);
+  });
+});

--- a/src/__tests__/team-leader-runner-structured-caller.test.ts
+++ b/src/__tests__/team-leader-runner-structured-caller.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RuntimeStepResolution } from '../core/workflow/types.js';
-import type { WorkflowStepDeadline, WorkflowStepExecutionDeadlineContext } from '../core/workflow/engine/step-deadline.js';
+import type { WorkflowStepInactivityDeadline, WorkflowStepExecutionDeadlineContext } from '../core/workflow/engine/step-deadline.js';
 import {
   requestValidTeamLeaderDecomposition,
   TeamLeaderDecompositionValidationError,
@@ -101,20 +101,22 @@ describe('TeamLeaderRunner with structuredCaller', () => {
       }),
     };
     const leaderAbortController = new AbortController();
-    const leaderDeadline: WorkflowStepDeadline = {
+    const leaderOnStream = vi.fn();
+    const leaderOnActivity = vi.fn();
+    const leaderDeadline: WorkflowStepInactivityDeadline = {
       signal: leaderAbortController.signal,
+      recordActivity: vi.fn(),
       dispose: vi.fn(),
-      startedAt: Date.now(),
-      timeoutMs: 60_000,
+      inactivityTimeoutMs: 60_000,
     };
     const executionDeadlineContext: WorkflowStepExecutionDeadlineContext = {
       begin: vi.fn((executionUnitKey) => executionUnitKey === 'team-leader:leader'
         ? leaderDeadline
         : {
             signal: new AbortController().signal,
+            recordActivity: vi.fn(),
             dispose: vi.fn(),
-            startedAt: Date.now(),
-            timeoutMs: 60_000,
+            inactivityTimeoutMs: 60_000,
           }),
       runWith: vi.fn(async (_deadline, operation) => operation()),
     };
@@ -128,6 +130,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         }),
         buildBaseOptions: vi.fn().mockReturnValue({
           failureDir: '/tmp/project/.takt/runs/sample/failures',
+          onStream: leaderOnStream,
+          onActivity: leaderOnActivity,
         }),
         buildPhase1WorkflowMeta: vi.fn().mockReturnValue(undefined),
         resolveMcpServersForStep: vi.fn().mockReturnValue(undefined),
@@ -227,6 +231,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         resolvedProvider: 'opencode',
         failureDir: '/tmp/project/.takt/runs/sample/failures',
         abortSignal: leaderAbortController.signal,
+        onStream: leaderOnStream,
+        onActivity: leaderOnActivity,
       }),
     );
     expect(structuredCaller.requestMoreParts).toHaveBeenCalledWith(
@@ -248,6 +254,8 @@ describe('TeamLeaderRunner with structuredCaller', () => {
         resolvedModel: 'opencode/zai-coding-plan/glm-5.1',
         resolvedProvider: 'opencode',
         failureDir: '/tmp/project/.takt/runs/sample/failures',
+        onStream: leaderOnStream,
+        onActivity: leaderOnActivity,
       }),
     );
     expect(feedbackAbortSignal).toBeDefined();

--- a/src/__tests__/work-requirement-estimator.test.ts
+++ b/src/__tests__/work-requirement-estimator.test.ts
@@ -305,6 +305,35 @@ describe('createWorkRequirementEstimator', () => {
     expect(vi.mocked(runAgent).mock.calls[0]?.[2]?.abortSignal).toBeInstanceOf(AbortSignal);
   });
 
+  it('passes deadline-scoped stream and activity callbacks to the structured provider call', async () => {
+    vi.mocked(runAgent).mockResolvedValue({
+      persona: 'auto-router',
+      status: 'done',
+      content: '{}',
+      timestamp: new Date('2026-08-14T00:00:00.000Z'),
+      structuredOutput: {
+        required_tier: 'low',
+        reason_codes: ['focused-change'],
+        confidence: null,
+      },
+    });
+    const estimator = createWorkRequirementEstimator({
+      cwd: '/repo',
+      provider: 'claude-sdk',
+      model: 'claude-haiku-4-5-20251001',
+    });
+    const onStream = vi.fn();
+    const onActivity = vi.fn();
+
+    await estimator.estimate(createModelInput(), { onStream, onActivity });
+
+    expect(runAgent).toHaveBeenCalledWith(
+      'auto-router',
+      expect.any(String),
+      expect.objectContaining({ onStream, onActivity }),
+    );
+  });
+
   it('Given the router never responds, When the estimator timeout elapses, Then it fails instead of hanging the workflow', async () => {
     vi.useFakeTimers();
     vi.mocked(runAgent).mockReturnValue(new Promise(() => {}));

--- a/src/__tests__/workflow-engine-phase-relay.test.ts
+++ b/src/__tests__/workflow-engine-phase-relay.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkflowStep } from '../core/models/types.js';
+import { createWorkflowPhaseRelay } from '../core/workflow/engine/WorkflowEnginePhaseRelay.js';
+
+describe('WorkflowEnginePhaseRelay activity', () => {
+  it('試行開始・phase完了・judge stage をそれぞれ活動として記録する', () => {
+    const recordActivity = vi.fn();
+    const relay = createWorkflowPhaseRelay(vi.fn(), () => [{
+      workflow: 'test-workflow',
+      workflow_ref: 'test-workflow',
+      step: 'coding-review',
+      kind: 'agent',
+      occurrence: 1,
+    }], recordActivity);
+    const step = { name: 'coding-review', rules: [] } as WorkflowStep;
+    const promptParts = { systemPrompt: 'system', userInstruction: 'review' };
+
+    relay.onPhaseStart(step, 1, 'execute', 'review', promptParts, 'attempt-2', 1);
+    relay.onPhaseComplete(step, 1, 'execute', 'approved', 'done', undefined, 'attempt-2', 1);
+    relay.onPhaseStart(step, 3, 'judge', 'judge', promptParts, 'judge-1', 1);
+    relay.onJudgeStage(step, 3, 'judge', {
+      stage: 1,
+      method: 'structured_output',
+      status: 'done',
+      instruction: 'judge',
+      response: 'approved',
+    }, 'judge-1', 1);
+
+    expect(recordActivity).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/__tests__/workflow-run-loop-command-gates.test.ts
+++ b/src/__tests__/workflow-run-loop-command-gates.test.ts
@@ -32,6 +32,7 @@ import {
   resolveWorkflowStepCallTimeoutMs,
 } from '../core/workflow/engine/step-deadline.js';
 import type { WorkflowEngineOptions } from '../core/workflow/types.js';
+import type { ProviderActivityCallback } from '../shared/types/provider.js';
 import { WorkflowEngine } from '../core/workflow/index.js';
 import { runAgent } from '../agents/runner.js';
 import { mockRuleEvaluation } from './rule-evaluator-test-double.js';
@@ -449,7 +450,7 @@ function makeDeadlineCoordinator(
   options: WorkflowEngineOptions,
   step: WorkflowStep,
   context: ReturnType<typeof createWorkflowStepAbortSignalContext>,
-): WorkflowEngineStepCoordinator {
+): { coordinator: WorkflowEngineStepCoordinator; optionsBuilder: OptionsBuilder } {
   const optionsBuilder = new OptionsBuilder(
     options,
     () => '/worktree',
@@ -465,12 +466,14 @@ function makeDeadlineCoordinator(
     undefined,
     () => '/worktree/.takt/runs/test/failures',
     context.getAbortSignal,
+    context.recordActivity,
   );
-  return new WorkflowEngineStepCoordinator({
+  const coordinator = new WorkflowEngineStepCoordinator({
     getOptions: () => options,
     optionsBuilder,
     stepAbortSignalContext: context,
   } as never);
+  return { coordinator, optionsBuilder };
 }
 
 function makeDeadlineDeps(
@@ -583,17 +586,23 @@ describe('WorkflowRunLoop step deadline', () => {
     };
     const state = createInitialState(makeDeadlineConfig(step), options);
     const context = createWorkflowStepAbortSignalContext(undefined);
-    const coordinator = makeDeadlineCoordinator(options, step, context);
+    const { coordinator, optionsBuilder } = makeDeadlineCoordinator(options, step, context);
     const deps = makeDeadlineDeps(state, step, options, context, coordinator);
     const providerSignals: AbortSignal[] = [];
     const callStartedAt: number[] = [];
     const startedAt = Date.now();
     let attempt = 0;
-    deps.runStep = vi.fn(async (_step: WorkflowStep, instruction: string) => {
+    deps.runStep = vi.fn(async (
+      currentStep: WorkflowStep,
+      instruction: string,
+      runtime: Parameters<OptionsBuilder['buildAgentOptions']>[1],
+    ) => {
       const signal = context.getAbortSignal();
       if (signal === undefined) {
         throw new Error('step deadline signal was not propagated');
       }
+      const providerOptions = optionsBuilder.buildAgentOptions(currentStep, runtime);
+      providerOptions.onActivity?.({ kind: 'attempt_started' });
       providerSignals.push(signal);
       callStartedAt.push(Date.now());
       if (attempt++ === 0) {
@@ -608,7 +617,6 @@ describe('WorkflowRunLoop step deadline', () => {
           instruction,
         };
       }
-      context.recordActivity();
       return await new Promise((resolve) => {
         const finish = (): void => {
           signal.removeEventListener('abort', finish);
@@ -729,6 +737,144 @@ describe('WorkflowRunLoop step deadline', () => {
       expect(result.status).toBe('aborted');
       expect(providerSignal?.aborted).toBe(true);
       expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      engine.removeAllListeners();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parallel auto-routing 自体を router provider の無応答期限スコープで実行する', async () => {
+    vi.useFakeTimers();
+    const tmpDir = mkdtempSync(join(tmpdir(), 'takt-parallel-routing-deadline-'));
+    let routingSignal: AbortSignal | undefined;
+    let routingActivity: ProviderActivityCallback | undefined;
+    const subStep = makeStep('routed-substep', {
+      rules: [makeRule('approved', 'COMPLETE')],
+    });
+    const step = makeStep('parallel-routing', {
+      parallel: [subStep],
+      rules: [makeRule('all("approved")', 'COMPLETE')],
+    });
+    const config: WorkflowConfig = {
+      name: 'parallel-routing-deadline-workflow',
+      maxSteps: 1,
+      initialStep: step.name,
+      steps: [step],
+    };
+    const estimate = vi.fn((_input, estimatorOptions) => {
+      routingSignal = estimatorOptions?.abortSignal;
+      routingActivity = estimatorOptions?.onActivity;
+      setTimeout(() => estimatorOptions?.onActivity?.({ kind: 'attempt_started' }), 40_000);
+      return new Promise<never>((_resolve, reject) => {
+        const abort = (): void => reject(routingSignal?.reason ?? new Error('routing aborted'));
+        if (routingSignal?.aborted) abort();
+        else routingSignal?.addEventListener('abort', abort, { once: true });
+      });
+    });
+    const engine = new WorkflowEngine(config, tmpDir, 'parallel routing deadline task', {
+      projectCwd: tmpDir,
+      autoRouting: {
+        strategy: 'balanced',
+        router: {
+          provider: 'opencode',
+          model: 'opencode/router-model',
+          providerOptions: { opencode: { guards: { callTimeoutMs: MINUTE } } },
+        },
+        candidates: [{
+          name: 'worker',
+          provider: 'mock',
+          model: 'worker-model',
+          routingTier: 'medium',
+        }],
+        defaultPool: 'default',
+        candidatePools: { default: { candidates: ['worker'], fallback: 'worker' } },
+        poolRules: { steps: { 'routed-substep': 'default' } },
+      },
+      autoRoutingEstimator: { estimate },
+    });
+
+    try {
+      const execution = engine.run();
+      await waitForCondition(() => routingSignal !== undefined, 'parallel auto-routing invocation');
+      expect(routingActivity).toEqual(expect.any(Function));
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(routingSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(40_000);
+      const result = await execution;
+
+      expect(result.status).toBe('aborted');
+      expect(routingSignal?.aborted).toBe(true);
+    } finally {
+      engine.removeAllListeners();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('team leader auto-routing 自体を router provider の無応答期限スコープで実行する', async () => {
+    vi.useFakeTimers();
+    const tmpDir = mkdtempSync(join(tmpdir(), 'takt-leader-routing-deadline-'));
+    let routingSignal: AbortSignal | undefined;
+    let routingActivity: ProviderActivityCallback | undefined;
+    const step = makeStep('leader-routing', {
+      teamLeader: {
+        persona: '../personas/team-leader.md',
+        maxConcurrency: 1,
+        timeoutMs: MINUTE,
+        partPersona: '../personas/coder.md',
+      },
+      rules: [makeRule('done', 'COMPLETE')],
+    });
+    const config: WorkflowConfig = {
+      name: 'leader-routing-deadline-workflow',
+      maxSteps: 1,
+      initialStep: step.name,
+      steps: [step],
+    };
+    const estimate = vi.fn((_input, estimatorOptions) => {
+      routingSignal = estimatorOptions?.abortSignal;
+      routingActivity = estimatorOptions?.onActivity;
+      setTimeout(() => estimatorOptions?.onActivity?.({ kind: 'attempt_started' }), 40_000);
+      return new Promise<never>((_resolve, reject) => {
+        const abort = (): void => reject(routingSignal?.reason ?? new Error('routing aborted'));
+        if (routingSignal?.aborted) abort();
+        else routingSignal?.addEventListener('abort', abort, { once: true });
+      });
+    });
+    const engine = new WorkflowEngine(config, tmpDir, 'leader routing deadline task', {
+      projectCwd: tmpDir,
+      autoRouting: {
+        strategy: 'balanced',
+        router: {
+          provider: 'opencode',
+          model: 'opencode/router-model',
+          providerOptions: { opencode: { guards: { callTimeoutMs: MINUTE } } },
+        },
+        candidates: [{
+          name: 'leader',
+          provider: 'mock',
+          model: 'leader-model',
+          routingTier: 'medium',
+        }],
+        defaultPool: 'default',
+        candidatePools: { default: { candidates: ['leader'], fallback: 'leader' } },
+        poolRules: { steps: { 'leader-routing': 'default' } },
+      },
+      autoRoutingEstimator: { estimate },
+    });
+
+    try {
+      const execution = engine.run();
+      await waitForCondition(() => routingSignal !== undefined, 'team leader auto-routing invocation');
+      expect(routingActivity).toEqual(expect.any(Function));
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(routingSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(40_000);
+      const result = await execution;
+
+      expect(result.status).toBe('aborted');
+      expect(routingSignal?.aborted).toBe(true);
     } finally {
       engine.removeAllListeners();
       rmSync(tmpDir, { recursive: true, force: true });

--- a/src/__tests__/workflow-run-loop-command-gates.test.ts
+++ b/src/__tests__/workflow-run-loop-command-gates.test.ts
@@ -570,7 +570,7 @@ describe('WorkflowRunLoop step deadline', () => {
     })).toBe(MINUTE * 2);
   });
 
-  it('fallback を跨ぐ同一 occurrence は絶対期限をリセットしない', async () => {
+  it('fallback の試行境界で同一 occurrence の無応答期限をリセットする', async () => {
     vi.useFakeTimers();
     const step = makeStep('work', {
       provider: 'opencode',
@@ -608,6 +608,7 @@ describe('WorkflowRunLoop step deadline', () => {
           instruction,
         };
       }
+      context.recordActivity();
       return await new Promise((resolve) => {
         const finish = (): void => {
           signal.removeEventListener('abort', finish);
@@ -633,14 +634,15 @@ describe('WorkflowRunLoop step deadline', () => {
     expect(deps.runStep).toHaveBeenCalledTimes(2);
     expect(callStartedAt).toEqual([startedAt, startedAt + (40 * MINUTE / 60)]);
     expect(providerSignals[0]).toBe(providerSignals[1]);
+    expect(providerSignals[0]?.aborted).toBe(false);
 
-    await vi.advanceTimersByTimeAsync(MINUTE - (40 * MINUTE / 60));
+    await vi.advanceTimersByTimeAsync(MINUTE);
     const result = await execution;
 
     expect(result.state.status).toBe('aborted');
     expect(providerSignals[0]?.aborted).toBe(true);
     expect(providerSignals[1]?.aborted).toBe(true);
-    expect(Date.now()).toBe(startedAt + MINUTE);
+    expect(Date.now()).toBe(startedAt + (40 * MINUTE / 60) + MINUTE);
     expect(vi.getTimerCount()).toBe(0);
   });
 
@@ -813,6 +815,7 @@ describe('WorkflowRunLoop step deadline', () => {
     vi.useFakeTimers();
     const tmpDir = mkdtempSync(join(tmpdir(), 'takt-dynamic-facet-deadline-'));
     let selectorSignal: AbortSignal | undefined;
+    let selectorOnActivity: unknown;
     const step = makeStep('dynamic-review', {
       provider: 'opencode',
       model: 'opencode/step-model',
@@ -869,6 +872,7 @@ describe('WorkflowRunLoop step deadline', () => {
         });
         if (options?.internalSystemPrompt?.includes('dynamic facet selector') === true) {
           selectorSignal = options.abortSignal;
+          selectorOnActivity = options.onActivity;
         }
         if (options?.abortSignal === undefined) {
           throw new Error('dynamic facet selector did not receive a deadline signal');
@@ -879,11 +883,72 @@ describe('WorkflowRunLoop step deadline', () => {
 
       const execution = engine.run();
       await waitForCondition(() => selectorSignal !== undefined, 'dynamic facet selector invocation');
+      expect(selectorOnActivity).toEqual(expect.any(Function));
       await vi.advanceTimersByTimeAsync(MINUTE);
       const result = await execution;
 
       expect(result.status).toBe('aborted');
       expect(selectorSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      engine.removeAllListeners();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('OpenCode tool 実行中は1倍の親期限で生存し、6倍の stale 上限で PART_TIMEOUT にする', async () => {
+    vi.useFakeTimers();
+    const tmpDir = mkdtempSync(join(tmpdir(), 'takt-opencode-tool-deadline-'));
+    let providerSignal: AbortSignal | undefined;
+    const step = makeStep('long-tool', {
+      provider: 'opencode',
+      model: 'opencode/tool-model',
+      providerOptions: { opencode: { guards: { callTimeoutMs: MINUTE } } },
+      rules: [makeRule('approved', 'COMPLETE')],
+    });
+    const config: WorkflowConfig = {
+      name: 'opencode-tool-deadline-workflow',
+      maxSteps: 1,
+      initialStep: step.name,
+      steps: [step],
+    };
+    const engine = new WorkflowEngine(config, tmpDir, 'long tool task', {
+      projectCwd: tmpDir,
+      provider: 'opencode',
+      reportDirName: 'opencode-tool-deadline',
+    });
+    try {
+      mockRuleEvaluation.mockReturnValue(undefined);
+      vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
+        options.onPromptResolved?.({
+          systemPrompt: typeof persona === 'string' ? persona : '',
+          userInstruction: instruction,
+        });
+        options.onActivity?.({ kind: 'attempt_started' });
+        options.onStream?.({
+          type: 'tool_use',
+          data: { tool: 'Bash', input: { command: 'npm test' }, id: 'tool-1' },
+        });
+        providerSignal = options.abortSignal;
+        if (providerSignal === undefined) {
+          throw new Error('OpenCode provider did not receive a deadline signal');
+        }
+        return { ...await waitForAbort(providerSignal), persona: persona ?? 'long-tool' };
+      });
+
+      const execution = engine.run();
+      await waitForCondition(() => providerSignal !== undefined, 'OpenCode tool invocation');
+      await vi.advanceTimersByTimeAsync(MINUTE);
+      expect(providerSignal?.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(MINUTE * 5 - 1);
+      expect(providerSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await execution;
+
+      expect(result.status).toBe('aborted');
+      expect(providerSignal?.aborted).toBe(true);
+      expect((providerSignal?.reason as Error).message).toBe(`Part timeout after ${MINUTE}ms`);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       engine.removeAllListeners();

--- a/src/agents/agent-usecases.ts
+++ b/src/agents/agent-usecases.ts
@@ -5,7 +5,8 @@ import {
 } from '../infra/providers/provider-capabilities.js';
 import type { StepProviderOptions } from '../core/models/workflow-types.js';
 import type { Language } from '../core/models/types.js';
-import type { ProviderType } from '../shared/types/provider.js';
+import type { ProviderActivityCallback, ProviderType } from '../shared/types/provider.js';
+import type { StreamCallback } from '../shared/types/provider.js';
 
 export {
   evaluateCondition,
@@ -42,6 +43,8 @@ export interface ResolvedInternalAgentOptions {
   readonly childProcessEnv?: Readonly<Record<string, string>>;
   readonly failureDir?: string;
   readonly sessionId?: string;
+  readonly onStream?: StreamCallback;
+  readonly onActivity?: ProviderActivityCallback;
   readonly resolution: {
     readonly provider: ProviderType;
     readonly model: string | undefined;

--- a/src/agents/auto-routing-usecase.ts
+++ b/src/agents/auto-routing-usecase.ts
@@ -134,7 +134,7 @@ export function createWorkRequirementEstimator(options: WorkRequirementEstimator
   return {
     async estimate(
       input: RoutingModelInput,
-      estimateOptions?: { abortSignal?: AbortSignal },
+      estimateOptions?: Parameters<WorkRequirementEstimator['estimate']>[1],
     ): Promise<WorkRequirementEstimate> {
       options.abortSignal?.throwIfAborted();
       estimateOptions?.abortSignal?.throwIfAborted();
@@ -155,6 +155,8 @@ export function createWorkRequirementEstimator(options: WorkRequirementEstimator
               permissionMode: options.permissionMode,
             },
             abortSignal: abortScope.signal,
+            onStream: estimateOptions?.onStream,
+            onActivity: estimateOptions?.onActivity,
             language: options.language,
             childProcessEnv: options.childProcessEnv,
             failureDir: options.failureDir,

--- a/src/agents/decompose-task-usecase.ts
+++ b/src/agents/decompose-task-usecase.ts
@@ -52,6 +52,7 @@ export interface DecomposeTaskOptions {
   permissionMode?: PermissionMode;
   projectCwd?: string;
   onStream?: StreamCallback;
+  onActivity?: RunAgentOptions['onActivity'];
   workflowMeta?: RunAgentOptions['workflowMeta'];
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
   abortSignal?: RunAgentOptions['abortSignal'];
@@ -119,6 +120,7 @@ export async function requestDecompositionRawResponse(
       ...(options.inspectTools === undefined ? {} : { allowedTools: options.inspectTools }),
       mcpServers: options.mcpServers,
       onStream: createPublicationGuardedStreamCallback(options.onStream, options.abortSignal),
+      onActivity: options.onActivity,
       workflowMeta: options.workflowMeta,
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,
@@ -217,6 +219,7 @@ export async function requestMorePartsRawResponse(
       },
       mcpServers: options.mcpServers,
       onStream: createPublicationGuardedStreamCallback(options.onStream, options.abortSignal),
+      onActivity: options.onActivity,
       workflowMeta: options.workflowMeta,
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,

--- a/src/agents/judge-status-usecase.ts
+++ b/src/agents/judge-status-usecase.ts
@@ -35,6 +35,7 @@ export interface JudgeStatusOptions {
   abortSignal?: AbortSignal;
   failureDir?: RunAgentOptions['failureDir'];
   onStream?: StreamCallback;
+  onActivity?: () => void;
   onJudgeStage?: (entry: JudgeStageLogEntry) => void;
   onStructuredPromptResolved?: (promptParts: {
     systemPrompt: string;
@@ -63,6 +64,7 @@ export interface TagJudgeRunOptions {
   projectCwd?: string;
   language?: Language;
   onStream?: StreamCallback;
+  onActivity?: () => void;
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
   abortSignal?: AbortSignal;
   failureDir?: RunAgentOptions['failureDir'];
@@ -92,6 +94,7 @@ export async function runTagJudgeStage(
       },
       language: runOptions.language,
       onStream: runOptions.onStream,
+      onActivity: runOptions.onActivity,
       childProcessEnv: runOptions.childProcessEnv,
       abortSignal: runOptions.abortSignal,
       failureDir: runOptions.failureDir,
@@ -151,6 +154,8 @@ export interface EvaluateConditionOptions {
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
   abortSignal?: AbortSignal;
   failureDir?: RunAgentOptions['failureDir'];
+  onStream?: RunAgentOptions['onStream'];
+  onActivity?: RunAgentOptions['onActivity'];
   onJudgeResponse?: (entry: {
     instruction: string;
     status: 'done' | 'error';
@@ -205,6 +210,8 @@ export async function evaluateCondition(
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,
       failureDir: options.failureDir,
+      onStream: options.onStream,
+      onActivity: options.onActivity,
     });
   } catch (error) {
     if (!(error instanceof StructuredAgentResponseError)) {
@@ -290,6 +297,8 @@ async function runAiJudgeStage(
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,
       failureDir: options.failureDir,
+      onStream: options.onStream,
+      onActivity: options.onActivity,
       onJudgeResponse: stage3.capture,
     });
   } catch (error) {
@@ -333,6 +342,7 @@ export async function runJudgeFallbackStages(
       projectCwd: options.projectCwd,
       language: options.language,
       onStream: options.onStream,
+      onActivity: options.onActivity,
       childProcessEnv: options.childProcessEnv,
       abortSignal: options.abortSignal,
       failureDir: options.failureDir,
@@ -393,6 +403,7 @@ export async function judgeStatus(
         },
         language: options.language,
         onStream: options.onStream,
+        onActivity: options.onActivity,
         childProcessEnv: options.childProcessEnv,
         abortSignal: options.abortSignal,
         failureDir: options.failureDir,

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -178,6 +178,7 @@ export class AgentRunner {
       permissionMode: resolution.permissionMode,
       providerOptions: resolution.providerOptions,
       onStream: options.onStream,
+      onActivity: options.onActivity,
       onPermissionRequest: options.onPermissionRequest,
       onAskUserQuestion: options.onAskUserQuestion,
       bypassPermissions: options.bypassPermissions,
@@ -364,5 +365,7 @@ export async function runAgent(
   task: string,
   options: RunAgentOptions,
 ): Promise<AgentResponse> {
+  // Provider dispatch is an attempt boundary even when the provider emits no stream events.
+  options.onActivity?.();
   return defaultRunner.run(personaSpec, task, options);
 }

--- a/src/agents/structured-caller/transport.ts
+++ b/src/agents/structured-caller/transport.ts
@@ -32,6 +32,7 @@ export interface StructuredAgentCallOptions {
   readonly childProcessEnv?: Readonly<Record<string, string>>;
   readonly failureDir?: RunAgentOptions['failureDir'];
   readonly onStream?: RunAgentOptions['onStream'];
+  readonly onActivity?: RunAgentOptions['onActivity'];
   readonly onPromptResolved?: RunAgentOptions['onPromptResolved'];
   readonly onDispatch?: RunAgentOptions['onDispatch'];
   readonly workflowMeta?: RunAgentOptions['workflowMeta'];
@@ -111,6 +112,7 @@ async function executeFreshAgent(
     ...(options.childProcessEnv === undefined ? {} : { childProcessEnv: options.childProcessEnv }),
     ...(options.failureDir === undefined ? {} : { failureDir: options.failureDir }),
     ...(options.onStream === undefined ? {} : { onStream: options.onStream }),
+    ...(options.onActivity === undefined ? {} : { onActivity: options.onActivity }),
     ...(options.onPromptResolved === undefined ? {} : { onPromptResolved: options.onPromptResolved }),
     ...(options.onDispatch === undefined ? {} : { onDispatch: options.onDispatch }),
     ...(options.workflowMeta === undefined ? {} : { workflowMeta: options.workflowMeta }),

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -10,7 +10,11 @@ import type {
   StepProviderOptions,
   ProviderPermissionProfiles,
 } from '../core/models/index.js';
-import type { InternalAgentIsolation, ProviderType } from '../shared/types/provider.js';
+import type {
+  InternalAgentIsolation,
+  ProviderActivityCallback,
+  ProviderType,
+} from '../shared/types/provider.js';
 
 export type { StreamCallback };
 
@@ -64,6 +68,7 @@ export interface RunAgentOptions {
   resolvedProviderOptions?: StepProviderOptions | null;
   resolvedExecution?: ResolvedAgentExecution;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   onPermissionRequest?: PermissionHandler;
   onAskUserQuestion?: AskUserQuestionHandler;
   onDispatch?: (permissionMode: PermissionMode | undefined) => void;

--- a/src/core/models/workflow-provider-options.ts
+++ b/src/core/models/workflow-provider-options.ts
@@ -22,7 +22,7 @@ export interface McpHttpServerConfig {
 export type McpServerConfig = McpStdioServerConfig | McpSseServerConfig | McpHttpServerConfig;
 
 export interface ProviderGuardOptions {
-  /** 呼び出し全体の wall-clock 上限 (ms)。既定 60 分。 */
+  /** プロバイダイベントが届かない時間の上限 (ms)。既定 60 分。 */
   callTimeoutMs?: number;
 }
 
@@ -43,7 +43,7 @@ export type OpenCodeGuardProfile = (typeof OPENCODE_GUARD_PROFILES)[number];
 /**
  * OpenCode 実行ガード設定。
  * profile が切るのはヒューリスティック検出（連続エラー・burst・cycle budget・
- * 連続完全一致反復）のみ。wall-clock・有界資源（容量・イベント数・追跡ID数）・
+ * 連続完全一致反復）のみ。無応答期限・有界資源（容量・イベント数・追跡ID数）・
  * 機密リダクションの fail-closed・厳密検出（edit conflict / unavailable / invalid
  * + correction）は minimal でも常時有効。idle watchdog は認証済み transport
  * の拡張として明示的に追加する場合だけ利用する。
@@ -53,7 +53,7 @@ export interface OpenCodeGuardOptions {
   profile?: OpenCodeGuardProfile;
   /** 解決済みモデル文字列に対する先勝ちの `*` ワイルドカードプロファイル。 */
   modelProfiles?: Record<string, OpenCodeGuardProfile>;
-  /** 呼び出し全体の wall-clock 上限 (ms)。60,000〜86,400,000 の整数。0 不可。既定 3,600,000。 */
+  /** プロバイダイベントが届かない時間の上限 (ms)。60,000〜86,400,000 の整数。0 不可。既定 3,600,000。 */
   callTimeoutMs?: number;
   /** 構造イベント数上限。既定 500,000。 */
   eventLimit?: number;
@@ -108,7 +108,7 @@ export interface ClaudeProviderOptions {
 export interface ClaudeTerminalProviderOptions {
   backend?: 'tmux';
   guards?: ProviderGuardOptions;
-  /** 旧設定。guards.callTimeoutMs が未指定の場合だけ呼び出し上限として使う。 */
+  /** 旧設定。guards.callTimeoutMs が未指定の場合だけ無応答上限として使う。 */
   timeoutMs?: number;
   keepSession?: boolean;
   transcriptPollIntervalMs?: number;

--- a/src/core/workflow/auto-routing/contracts.ts
+++ b/src/core/workflow/auto-routing/contracts.ts
@@ -1,4 +1,5 @@
 import type { RoutingTier } from '../../models/config-types.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../../shared/types/provider.js';
 
 export type { RoutingTier };
 
@@ -72,5 +73,9 @@ export function validateRoutingReasonCodes(reasonCodes: unknown): asserts reason
 }
 
 export interface WorkRequirementEstimator {
-  estimate(input: RoutingModelInput, options?: { abortSignal?: AbortSignal }): Promise<WorkRequirementEstimate>;
+  estimate(input: RoutingModelInput, options?: {
+    abortSignal?: AbortSignal;
+    onStream?: StreamCallback;
+    onActivity?: ProviderActivityCallback;
+  }): Promise<WorkRequirementEstimate>;
 }

--- a/src/core/workflow/auto-routing/resolver.ts
+++ b/src/core/workflow/auto-routing/resolver.ts
@@ -9,6 +9,7 @@ import { normalizeRoutingWorkSnapshot } from './normalizer.js';
 import { hasAutoRoutingPoolAssignment, resolveAutoRoutingRuleCandidate, selectRoutingCandidate } from './selector.js';
 import type { RoutingRuntime } from './runtime.js';
 import { isProviderStreamParseError } from '../../../shared/types/agent-failure.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../../shared/types/provider.js';
 
 export interface AutoRoutingStepMetadata {
   name: string;
@@ -39,6 +40,8 @@ export interface ResolveAutoRoutingRuntimeInput {
   runtime?: RoutingRuntime;
   logger?: AutoRoutingLogger;
   abortSignal?: AbortSignal;
+  onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
 }
 
 export interface ResolveAutoRoutingBatchItem {
@@ -57,6 +60,8 @@ export interface ResolveAutoRoutingBatchInput {
   runtime?: RoutingRuntime;
   logger?: AutoRoutingLogger;
   abortSignal?: AbortSignal;
+  onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
 }
 
 const CLAUDE_MODEL_ALIASES = new Set(['opus', 'sonnet', 'haiku']);
@@ -174,6 +179,8 @@ export async function resolveAutoRoutingRuntime(input: ResolveAutoRoutingRuntime
       scope: resolveRoutingScope(input),
       snapshot: input.snapshot,
       abortSignal: input.abortSignal,
+      onStream: input.onStream,
+      onActivity: input.onActivity,
     });
     if (decision.fallbackReason !== undefined) {
       input.logger?.warn('Auto routing estimator failed; using configured pool fallback');
@@ -200,6 +207,8 @@ export async function resolveAutoRoutingRuntime(input: ResolveAutoRoutingRuntime
   try {
     estimate = await input.estimator.estimate(normalizeRoutingWorkSnapshot(input.snapshot), {
       abortSignal: input.abortSignal,
+      onStream: input.onStream,
+      onActivity: input.onActivity,
     });
   } catch (error) {
     if (input.abortSignal?.aborted) {

--- a/src/core/workflow/auto-routing/runtime.ts
+++ b/src/core/workflow/auto-routing/runtime.ts
@@ -1,5 +1,6 @@
 import type { AutoRoutingConfig, RoutingTier } from '../../models/config-types.js';
 import type { RoutingWorkSnapshot, WorkRequirementEstimate, WorkRequirementEstimator } from './contracts.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../../shared/types/provider.js';
 import {
   createRoutingModelInputDigest,
   createRoutingWorkFingerprint,
@@ -23,7 +24,13 @@ export class RoutingRuntime {
 
   constructor(private readonly options: { autoRouting: AutoRoutingConfig; estimator: WorkRequirementEstimator }) {}
 
-  async resolve(input: { scope: string; snapshot: RoutingWorkSnapshot; abortSignal?: AbortSignal }) {
+  async resolve(input: {
+    scope: string;
+    snapshot: RoutingWorkSnapshot;
+    abortSignal?: AbortSignal;
+    onStream?: StreamCallback;
+    onActivity?: ProviderActivityCallback;
+  }) {
     input.abortSignal?.throwIfAborted();
     const fingerprint = createRoutingWorkFingerprint(input.snapshot);
     const previous = this.resolutions.get(input.scope);
@@ -40,6 +47,8 @@ export class RoutingRuntime {
       } else {
         estimate = await this.options.estimator.estimate(modelInput, {
           abortSignal: input.abortSignal,
+          onStream: input.onStream,
+          onActivity: input.onActivity,
         });
         this.estimates.set(estimateCacheKey, this.copyEstimate(estimate));
       }

--- a/src/core/workflow/companion/step-runtime.ts
+++ b/src/core/workflow/companion/step-runtime.ts
@@ -66,6 +66,8 @@ interface CompanionStepRuntimeDeps {
   readonly selectorProvider?: SelectorProviderInfo;
   readonly diffReader: CompanionDiffReader;
   readonly abortSignal?: AbortSignal;
+  readonly onStream?: RunAgentOptions['onStream'];
+  readonly onActivity?: RunAgentOptions['onActivity'];
   readonly stateStore: CompanionReviewStateStore;
   readonly emitEvent: CompanionEventEmitter;
   readonly recordUsage: (
@@ -104,6 +106,8 @@ export class CompanionStepRuntime {
       failureDir: deps.failureDir,
       language: deps.language,
       abortSignal: deps.abortSignal,
+      onStream: deps.onStream,
+      onActivity: deps.onActivity,
       recordUsage: deps.recordUsage,
       recordCall: (call: CompanionCallAudit) => {
         this.events.call({

--- a/src/core/workflow/companion/structured-call.ts
+++ b/src/core/workflow/companion/structured-call.ts
@@ -1,6 +1,7 @@
 import { executeStructuredAgent } from '../../../agents/structured-caller/transport.js';
 import type { AgentResponse } from '../../models/types.js';
 import type { ProviderRoutingEntry } from '../../models/config-types.js';
+import type { RunAgentOptions } from '../../../agents/runner.js';
 import {
   executeCompanionStructuredAgent,
   type CompanionAgentPurpose,
@@ -15,6 +16,8 @@ export class CompanionStructuredCaller {
     readonly failureDir: string;
     readonly language: 'en' | 'ja';
     readonly abortSignal?: AbortSignal;
+    readonly onStream?: RunAgentOptions['onStream'];
+    readonly onActivity?: RunAgentOptions['onActivity'];
     readonly recordUsage: (
       name: string,
       provider: ProviderRoutingEntry,
@@ -73,6 +76,8 @@ export class CompanionStructuredCaller {
           systemPrompt,
           language: this.input.language,
           abortSignal: options.abortSignal,
+          onStream: this.input.onStream,
+          onActivity: this.input.onActivity,
           onPromptResolved: options.onPromptResolved,
           resolution: {
             provider: options.resolution.provider,

--- a/src/core/workflow/dynamic-facets/dynamicFacetSelectorCoordinator.ts
+++ b/src/core/workflow/dynamic-facets/dynamicFacetSelectorCoordinator.ts
@@ -24,6 +24,10 @@ import {
   sanitizeSensitiveTextWithKnownValues,
 } from '../../../shared/utils/sensitiveText.js';
 import { SelectorInputReader } from '../dynamic-parallel/selector-input-reader.js';
+import type {
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../../shared/types/provider.js';
 
 const log = createLogger('dynamic-facet-selector');
 const SELECTOR_RATIONALE_LOG_MAX_BYTES = 1024;
@@ -31,6 +35,8 @@ const SELECTOR_RATIONALE_LOG_MAX_BYTES = 1024;
 export interface DynamicFacetSelectorCoordinatorDeps {
   readonly engineOptions: WorkflowEngineOptions;
   readonly getAbortSignal?: () => AbortSignal | undefined;
+  readonly onStream?: StreamCallback;
+  readonly onActivity?: ProviderActivityCallback;
   readonly failureDir: string;
   readonly selectionStore: DynamicFacetSelectionStore;
   readonly getWorkflowReference: () => string;
@@ -140,6 +146,8 @@ export class DynamicFacetSelectorCoordinator {
           persona: step.dynamicFacets.selector?.persona,
           workflowBundleResourceRoot: this.deps.engineOptions.workflowBundleResourceRoot,
           abortSignal: signal,
+          onStream: this.deps.onStream,
+          onActivity: this.deps.onActivity,
           language: this.deps.engineOptions.language,
           failureDir: this.deps.failureDir,
           personaPath: step.dynamicFacets.selector?.personaPath,

--- a/src/core/workflow/dynamic-parallel/selector-coordinator.ts
+++ b/src/core/workflow/dynamic-parallel/selector-coordinator.ts
@@ -21,6 +21,10 @@ import {
   createBoundedSensitiveValues,
   sanitizeSensitiveTextWithKnownValues,
 } from '../../../shared/utils/sensitiveText.js';
+import type {
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../../shared/types/provider.js';
 
 const log = createLogger('dynamic-parallel-selector');
 const SELECTOR_RATIONALE_LOG_MAX_BYTES = 1024;
@@ -28,6 +32,8 @@ const SELECTOR_RATIONALE_LOG_MAX_BYTES = 1024;
 export interface DynamicParallelSelectorCoordinatorDeps {
   readonly engineOptions: WorkflowEngineOptions;
   readonly getAbortSignal?: () => AbortSignal | undefined;
+  readonly onStream?: StreamCallback;
+  readonly onActivity?: ProviderActivityCallback;
   readonly failureDir: string;
   readonly selectionStore: DynamicParallelSelectionStore;
   readonly getCwd: () => string;
@@ -114,6 +120,8 @@ export class DynamicParallelSelectorCoordinator {
           persona: step.parallel.selection.selector?.persona,
           workflowBundleResourceRoot: this.deps.engineOptions.workflowBundleResourceRoot,
           abortSignal: signal,
+          onStream: this.deps.onStream,
+          onActivity: this.deps.onActivity,
           language: this.deps.engineOptions.language,
           failureDir: this.deps.failureDir,
           personaPath: step.parallel.selection.selector?.personaPath,

--- a/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
+++ b/src/core/workflow/engine/LoopMonitorJudgeRunner.ts
@@ -95,7 +95,7 @@ export class LoopMonitorJudgeRunner {
       this.deps.stepAbortSignalContext.getAbortSignal(),
     );
     try {
-      return await this.deps.stepAbortSignalContext.runWith(deadline.signal, async () => {
+      return await this.deps.stepAbortSignalContext.runWith(deadline, async () => {
         const stepEventWorkflowStack = this.deps.onStepStart(
           judgeStep,
           this.deps.state.iteration,

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -26,7 +26,11 @@ import {
   providerSupportsMaxTurns,
   providerSupportsStructuredOutput,
 } from '../../../infra/providers/provider-capabilities.js';
-import type { ProviderType, StreamCallback } from '../../../shared/types/provider.js';
+import type {
+  ProviderActivityCallback,
+  ProviderType,
+  StreamCallback,
+} from '../../../shared/types/provider.js';
 import type {
   WorkflowEngineOptions,
   PhaseName,
@@ -41,6 +45,10 @@ import { getWorkflowStepKind } from '../step-kind.js';
 import { resolveStepProviderModel } from '../provider-resolution.js';
 import { resolveDeterministicAutoRoutingProviderInfo, toAutoRoutingStepMetadata } from '../auto-routing/resolver.js';
 import { buildPhase1WorkflowMeta } from './workflow-meta.js';
+import {
+  recordWorkflowStepProviderActivity,
+  recordWorkflowStepProviderEventActivity,
+} from './step-deadline.js';
 
 type ResolvedRunAgentOptions = RunAgentOptions & {
   resolvedProviderOptions?: StepProviderOptions;
@@ -81,6 +89,7 @@ export class OptionsBuilder {
     private readonly getReviewScope?: () => TaskReviewScope,
     private readonly getFailureDir?: () => string,
     private readonly getAbortSignal: () => AbortSignal | undefined = () => this.engineOptions.abortSignal,
+    private readonly recordActivity: ProviderActivityCallback = () => {},
   ) {}
 
   private resolveAbortSignal(): AbortSignal | undefined {
@@ -174,19 +183,36 @@ export class OptionsBuilder {
     output: StreamCallback | undefined,
   ): StreamCallback | undefined {
     const onProviderStream = this.engineOptions.onProviderStream;
-    if (!onProviderStream) {
-      return output;
-    }
-    if (!provider) {
+    if (onProviderStream && !provider) {
       throw new Error(`Step "${step.name}" has no resolved provider for provider event logging`);
     }
     return (event): void => {
-      onProviderStream({
-        step: step.name,
-        provider,
-        providerModel: providerModel ?? '(default)',
-      }, event);
+      recordWorkflowStepProviderEventActivity(this.recordActivity, step.name, event);
+      if (onProviderStream && provider) {
+        onProviderStream({
+          step: step.name,
+          provider,
+          providerModel: providerModel ?? '(default)',
+        }, event);
+      }
       output?.(event);
+    };
+  }
+
+  buildDeadlineActivityCallbacks(
+    executionUnitKey: string,
+  ): Pick<RunAgentOptions, 'onStream' | 'onActivity'> {
+    return {
+      onStream: (event) => recordWorkflowStepProviderEventActivity(
+        this.recordActivity,
+        executionUnitKey,
+        event,
+      ),
+      onActivity: (activity) => recordWorkflowStepProviderActivity(
+        this.recordActivity,
+        executionUnitKey,
+        activity,
+      ),
     };
   }
 
@@ -405,6 +431,11 @@ export class OptionsBuilder {
       resolvedProviderOptions: providerOptions,
       language: this.getLanguage(),
       onStream: this.buildProviderStream(step, resolvedProvider, resolvedModel, this.engineOptions.onStream),
+      onActivity: (activity) => recordWorkflowStepProviderActivity(
+        this.recordActivity,
+        step.name,
+        activity,
+      ),
       onPermissionRequest: this.engineOptions.onPermissionRequest,
       onAskUserQuestion: this.engineOptions.onAskUserQuestion,
       bypassPermissions: this.engineOptions.bypassPermissions,
@@ -677,6 +708,11 @@ export class OptionsBuilder {
         stepProvider.provider,
         stepProvider.model,
         this.engineOptions.onStream,
+      ),
+      onActivity: (activity) => recordWorkflowStepProviderActivity(
+        this.recordActivity,
+        step.name,
+        activity,
       ),
       structuredCaller: this.requireStructuredCaller(),
       resolveStepProviderModel: (step) => this.resolveStepProviderModel(step, runtime),

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -201,15 +201,16 @@ export class OptionsBuilder {
 
   buildDeadlineActivityCallbacks(
     executionUnitKey: string,
+    recordActivity: ProviderActivityCallback = this.recordActivity,
   ): Pick<RunAgentOptions, 'onStream' | 'onActivity'> {
     return {
       onStream: (event) => recordWorkflowStepProviderEventActivity(
-        this.recordActivity,
+        recordActivity,
         executionUnitKey,
         event,
       ),
       onActivity: (activity) => recordWorkflowStepProviderActivity(
-        this.recordActivity,
+        recordActivity,
         executionUnitKey,
         activity,
       ),
@@ -470,6 +471,7 @@ export class OptionsBuilder {
       resolvedProviderOptions: baseOptions.resolvedProviderOptions,
       language: baseOptions.language,
       onStream: baseOptions.onStream,
+      onActivity: baseOptions.onActivity,
       onPermissionRequest: baseOptions.onPermissionRequest,
       onAskUserQuestion: baseOptions.onAskUserQuestion,
       workflowMeta: baseOptions.workflowMeta,

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -271,9 +271,16 @@ export class ParallelRunner {
       });
       return [subStep.name, providerInfo];
     }));
-    const routedProviderInfoByStep = this.deps.engineOptions.autoRouting
-      ? await resolveAutoRoutingBatch({
-          autoRouting: this.deps.engineOptions.autoRouting,
+    const autoRouting = this.deps.engineOptions.autoRouting;
+    const routingDeadline = autoRouting === undefined
+      ? undefined
+      : executionDeadlineContext?.begin(`parallel:auto-routing:${step.name}`, {
+          provider: autoRouting.router.provider,
+          providerOptions: autoRouting.router.providerOptions,
+        });
+    const routedProviderInfoByStep = autoRouting
+      ? await runWithExecutionDeadline(executionDeadlineContext, routingDeadline, () => resolveAutoRoutingBatch({
+          autoRouting,
           concurrency: step.concurrency,
           items: agentSubSteps.map((subStep) => ({
             id: subStep.name,
@@ -312,8 +319,9 @@ export class ParallelRunner {
           abortSignal: this.resolveAbortSignal(),
           ...this.deps.optionsBuilder.buildDeadlineActivityCallbacks(
             `parallel:auto-routing:${step.name}`,
+            routingDeadline?.recordActivity,
           ),
-        })
+        }))
       : new Map();
     const workflowCallResumeStack = subSteps.some(isWorkflowCallStep)
       ? this.requireWorkflowCallResumeStack(step, stepIteration)

--- a/src/core/workflow/engine/ParallelRunner.ts
+++ b/src/core/workflow/engine/ParallelRunner.ts
@@ -27,7 +27,7 @@ import type { StepExecutor } from './StepExecutor.js';
 import type { WorkflowEngineOptions, PhaseName, PhasePromptParts, JudgeStageEntry, StepRunResult } from '../types.js';
 import type { RuntimeStepResolution } from '../types.js';
 import type {
-  WorkflowStepDeadline,
+  WorkflowStepInactivityDeadline,
   WorkflowStepExecutionDeadlineContext,
 } from './step-deadline.js';
 import type { ParallelLoggerOptions } from './parallel-logger.js';
@@ -96,7 +96,7 @@ function isAgentParallelSubStep(step: WorkflowStep): step is AgentWorkflowStep {
 
 async function runWithExecutionDeadline<T>(
   context: WorkflowStepExecutionDeadlineContext | undefined,
-  deadline: WorkflowStepDeadline | undefined,
+  deadline: WorkflowStepInactivityDeadline | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
   if (context === undefined || deadline === undefined) {
@@ -310,6 +310,9 @@ export class ParallelRunner {
           runtime: this.deps.engineOptions.routingRuntime,
           logger: log,
           abortSignal: this.resolveAbortSignal(),
+          ...this.deps.optionsBuilder.buildDeadlineActivityCallbacks(
+            `parallel:auto-routing:${step.name}`,
+          ),
         })
       : new Map();
     const workflowCallResumeStack = subSteps.some(isWorkflowCallStep)
@@ -331,8 +334,8 @@ export class ParallelRunner {
       return [subStep.name, providerInfo];
     }));
 
-    const subStepDeadlineByName = new Map<string, WorkflowStepDeadline>();
-    const getSubStepDeadline = (subStep: WorkflowStep): WorkflowStepDeadline | undefined => {
+    const subStepDeadlineByName = new Map<string, WorkflowStepInactivityDeadline>();
+    const getSubStepDeadline = (subStep: WorkflowStep): WorkflowStepInactivityDeadline | undefined => {
       if (executionDeadlineContext === undefined) {
         return undefined;
       }
@@ -489,12 +492,17 @@ export class ParallelRunner {
             updatePersonaSession,
           );
         }
-        // Override onStream with parallel logger's prefixed handler (immutable)
+        // Preserve provider activity/logging while replacing only the display callback.
         const agentOptions: RunAgentOptions = parallelLogger
           ? {
               ...baseOptions,
               ...(compactionOutcome === 'fresh' ? { sessionId: undefined } : {}),
-              onStream: parallelLogger.createStreamHandler(subStep.name, index),
+              onStream: this.deps.optionsBuilder.buildProviderStream(
+                executableSubStep,
+                subPm.provider,
+                subPm.model,
+                parallelLogger.createStreamHandler(subStep.name, index),
+              ),
             }
           : {
               ...baseOptions,

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -387,6 +387,8 @@ export class StepExecutor {
                 abortSignal: this.resolveAbortSignal(),
                 childProcessEnv: judgeOptions.childProcessEnv,
                 failureDir: judgeOptions.failureDir,
+                onStream: judgeOptions.onStream,
+                onActivity: judgeOptions.onActivity,
                 resolution: {
                   provider,
                   model: judgeProviderInfo.model,
@@ -1331,6 +1333,11 @@ export class StepExecutor {
       sessionId: state.personaSessions.get(sessionKey) ?? 'new',
     });
 
+    const builtAgentOptions = this.deps.optionsBuilder.buildAgentOptions(
+      executableStep,
+      executionRuntime,
+    );
+
     // Phase 1: main execution (Write excluded if step has report)
     let companionRuntime: CompanionStepRuntime | undefined;
     if (isNormalAgentWorkflowStep(executableStep)) {
@@ -1388,6 +1395,8 @@ export class StepExecutor {
           selectorProvider: this.deps.companionSelectorProvider,
           diffReader: companionDiffReader,
           abortSignal: this.resolveAbortSignal(),
+          onStream: builtAgentOptions.onStream,
+          onActivity: builtAgentOptions.onActivity,
           stateStore: companionReviewState,
           emitEvent: this.deps.emitEvent,
           recordUsage: (name, companionProvider, success, usage) => {
@@ -1423,10 +1432,6 @@ export class StepExecutor {
       }
     }
     using activeCompanionRuntime = companionRuntime;
-    const builtAgentOptions = this.deps.optionsBuilder.buildAgentOptions(
-      executableStep,
-      executionRuntime,
-    );
     const baseAgentOptions = activeCompanionRuntime?.composeOptions(builtAgentOptions)
       ?? builtAgentOptions;
     const compactionOutcome = await compactSessionBeforePhase1(executableStep, baseAgentOptions);
@@ -1484,6 +1489,7 @@ export class StepExecutor {
                   childProcessEnv: agentOptions.childProcessEnv,
                   failureDir: agentOptions.failureDir,
                   onStream: agentOptions.onStream,
+                  onActivity: agentOptions.onActivity,
                   onPromptResolved,
                   workflowMeta: agentOptions.workflowMeta,
                 }).then((response) => {

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -210,7 +210,11 @@ export class TeamLeaderRunner {
       runtime?.fallback,
       instructionTransaction,
     );
-    const leaderRuntime = await this.resolveLeaderAutoRouting(leaderStep, runtime);
+    const leaderRuntime = await this.resolveLeaderAutoRouting(
+      leaderStep,
+      runtime,
+      executionDeadlineContext,
+    );
     const leaderProviderInfo = this.deps.optionsBuilder.resolveStepProviderModel(leaderStep, leaderRuntime);
     const { provider: leaderProvider, model: leaderModel } = leaderProviderInfo;
     const leaderDeadline = executionDeadlineContext?.begin('team-leader:leader', leaderProviderInfo);
@@ -694,50 +698,64 @@ export class TeamLeaderRunner {
   private async resolveLeaderAutoRouting(
     leaderStep: WorkflowStep,
     runtime: RuntimeStepResolution | undefined,
+    executionDeadlineContext: WorkflowStepExecutionDeadlineContext | undefined,
   ): Promise<RuntimeStepResolution | undefined> {
-    if (!this.deps.engineOptions.autoRouting || runtime?.fallback) {
+    const autoRouting = this.deps.engineOptions.autoRouting;
+    if (!autoRouting || runtime?.fallback) {
       return runtime;
     }
 
     const currentProviderInfo = this.deps.optionsBuilder.resolveStepProviderModelBeforeAutoRouting(leaderStep, runtime);
-    const autoRuntime = await resolveAutoRoutingRuntime({
-      autoRouting: this.deps.engineOptions.autoRouting,
-      scope: createRoutingScope({
-        workflow: this.deps.getWorkflowName(),
-        parentStep: leaderStep.name,
-        workItem: 'leader',
-      }),
-      step: {
-        name: leaderStep.name,
-        tags: leaderStep.tags,
-        personaKey: leaderStep.providerRoutingPersonaKey,
-        instruction: leaderStep.instruction,
+    const routingDeadline = executionDeadlineContext?.begin(
+      `team-leader:auto-routing:${leaderStep.name}`,
+      {
+        provider: autoRouting.router.provider,
+        providerOptions: autoRouting.router.providerOptions,
       },
-      snapshot: buildRoutingWorkSnapshot({
-        goal: this.deps.getTask(),
-        userInputs: this.deps.getState().userInputs,
-        retryNote: this.deps.engineOptions.retryNote,
+    );
+    const autoRuntime = await runWithExecutionDeadline(
+      executionDeadlineContext,
+      routingDeadline,
+      () => resolveAutoRoutingRuntime({
+        autoRouting,
+        scope: createRoutingScope({
+          workflow: this.deps.getWorkflowName(),
+          parentStep: leaderStep.name,
+          workItem: 'leader',
+        }),
         step: {
           name: leaderStep.name,
-          tags: leaderStep.tags ?? [],
+          tags: leaderStep.tags,
           personaKey: leaderStep.providerRoutingPersonaKey,
           instruction: leaderStep.instruction,
-          stepType: 'agent',
-          edit: leaderStep.edit,
-          passPreviousResponse: leaderStep.passPreviousResponse === true,
         },
-        lastOutput: this.deps.getState().lastOutput?.content,
-        sensitiveValues: this.deps.engineOptions.routingSensitiveValues,
+        snapshot: buildRoutingWorkSnapshot({
+          goal: this.deps.getTask(),
+          userInputs: this.deps.getState().userInputs,
+          retryNote: this.deps.engineOptions.retryNote,
+          step: {
+            name: leaderStep.name,
+            tags: leaderStep.tags ?? [],
+            personaKey: leaderStep.providerRoutingPersonaKey,
+            instruction: leaderStep.instruction,
+            stepType: 'agent',
+            edit: leaderStep.edit,
+            passPreviousResponse: leaderStep.passPreviousResponse === true,
+          },
+          lastOutput: this.deps.getState().lastOutput?.content,
+          sensitiveValues: this.deps.engineOptions.routingSensitiveValues,
+        }),
+        currentProviderInfo,
+        estimator: this.deps.engineOptions.autoRoutingEstimator,
+        runtime: this.deps.engineOptions.routingRuntime,
+        logger: log,
+        abortSignal: this.resolveAbortSignal(),
+        ...this.deps.optionsBuilder.buildDeadlineActivityCallbacks(
+          `team-leader:auto-routing:${leaderStep.name}`,
+          routingDeadline?.recordActivity,
+        ),
       }),
-      currentProviderInfo,
-      estimator: this.deps.engineOptions.autoRoutingEstimator,
-      runtime: this.deps.engineOptions.routingRuntime,
-      logger: log,
-      abortSignal: this.resolveAbortSignal(),
-      ...this.deps.optionsBuilder.buildDeadlineActivityCallbacks(
-        `team-leader:auto-routing:${leaderStep.name}`,
-      ),
-    });
+    );
     if (!autoRuntime) {
       return runtime;
     }

--- a/src/core/workflow/engine/TeamLeaderRunner.ts
+++ b/src/core/workflow/engine/TeamLeaderRunner.ts
@@ -62,7 +62,7 @@ import type {
 import { createAbortScope } from './abort-signal.js';
 import { isTeamLeaderPartCancellation } from './team-leader-part-cancellation.js';
 import type {
-  WorkflowStepDeadline,
+  WorkflowStepInactivityDeadline,
   WorkflowStepExecutionDeadlineContext,
 } from './step-deadline.js';
 
@@ -70,7 +70,7 @@ const log = createLogger('team-leader-runner');
 
 async function runWithExecutionDeadline<T>(
   context: WorkflowStepExecutionDeadlineContext | undefined,
-  deadline: WorkflowStepDeadline | undefined,
+  deadline: WorkflowStepInactivityDeadline | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
   if (context === undefined || deadline === undefined) {
@@ -263,6 +263,7 @@ export class TeamLeaderRunner {
       failureDir: leaderBaseOptions.failureDir,
       abortSignal: leaderAbortSignal,
       onStream: leaderBaseOptions.onStream,
+      onActivity: leaderBaseOptions.onActivity,
       onAgentResponse: (response: AgentResponse) => {
         this.recordUsage(
           leaderStep.name,
@@ -475,6 +476,7 @@ export class TeamLeaderRunner {
             cancellablePartIds: cancellablePartIdsCopy,
             abortSignal,
             onStream: leaderBaseOptions.onStream,
+            onActivity: leaderBaseOptions.onActivity,
             onAgentResponse: (response: AgentResponse) => {
               this.recordUsage(
                 leaderStep.name,
@@ -732,6 +734,9 @@ export class TeamLeaderRunner {
       runtime: this.deps.engineOptions.routingRuntime,
       logger: log,
       abortSignal: this.resolveAbortSignal(),
+      ...this.deps.optionsBuilder.buildDeadlineActivityCallbacks(
+        `team-leader:auto-routing:${leaderStep.name}`,
+      ),
     });
     if (!autoRuntime) {
       return runtime;
@@ -997,6 +1002,9 @@ export class TeamLeaderRunner {
       runtime: this.deps.engineOptions.routingRuntime,
       logger: log,
       abortSignal: this.resolveAbortSignal(),
+      ...this.deps.optionsBuilder.buildDeadlineActivityCallbacks(
+        `team-parts:auto-routing:${step.name}`,
+      ),
     });
 
     for (const [partId, providerInfo] of routed.entries()) {

--- a/src/core/workflow/engine/WorkflowEnginePhaseRelay.ts
+++ b/src/core/workflow/engine/WorkflowEnginePhaseRelay.ts
@@ -38,6 +38,7 @@ export interface WorkflowPhaseRelay {
 export function createWorkflowPhaseRelay(
   emit: (event: string, ...args: unknown[]) => void,
   getCurrentWorkflowStack: () => readonly WorkflowResumePointEntry[] | undefined,
+  recordActivity: () => void = () => {},
 ): WorkflowPhaseRelay {
   const workflowStackByPhase = new Map<string, WorkflowResumePointEntry[]>();
   const phaseKey = (
@@ -53,6 +54,7 @@ export function createWorkflowPhaseRelay(
   ]);
   return {
     onPhaseStart: (step, phase, phaseName, instruction, promptParts, phaseExecutionId, iteration) => {
+      recordActivity();
       const workflowStack = requireWorkflowResumeStackSnapshot(
         getCurrentWorkflowStack(),
       );
@@ -73,6 +75,7 @@ export function createWorkflowPhaseRelay(
       );
     },
     onPhaseComplete: (step, phase, phaseName, content, phaseStatus, error, phaseExecutionId, iteration) => {
+      recordActivity();
       const key = phaseKey(step, phase, phaseExecutionId, iteration);
       const workflowStack = workflowStackByPhase.get(key);
       if (workflowStack === undefined) {
@@ -93,6 +96,7 @@ export function createWorkflowPhaseRelay(
       );
     },
     onJudgeStage: (step, phase, phaseName, entry, phaseExecutionId, iteration) => {
+      recordActivity();
       const workflowStack = workflowStackByPhase.get(
         phaseKey(step, phase, phaseExecutionId, iteration),
       );

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -51,6 +51,8 @@ import { restoreWorkflowStepParticipationIndex } from '../workflow-step-particip
 import { CompanionReviewAuthority } from '../companion/review-state-store.js';
 import {
   createWorkflowStepAbortSignalContext,
+  recordWorkflowStepProviderActivity,
+  recordWorkflowStepProviderEventActivity,
   type WorkflowStepAbortSignalContext,
 } from './step-deadline.js';
 
@@ -185,6 +187,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
   const phaseRelay = createWorkflowPhaseRelay(
     (event, ...args) => params.emitEvent(event, ...args),
     params.getCurrentWorkflowStack,
+    stepAbortSignalContext.recordActivity,
   );
   // base の解決は ref 走査を伴うため、ラン境界で一度だけ解決して保持する。
   const getReviewScope = createTaskReviewScopeResolver({
@@ -208,11 +211,22 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     getReviewScope,
     () => failureDir,
     stepAbortSignalContext.getAbortSignal,
+    stepAbortSignalContext.recordActivity,
   );
 
   const dynamicFacetSelector = new DynamicFacetSelectorCoordinator({
     engineOptions: params.options,
     getAbortSignal: stepAbortSignalContext.getAbortSignal,
+    onStream: (event) => recordWorkflowStepProviderEventActivity(
+      stepAbortSignalContext.recordActivity,
+      'dynamic-facet-selector',
+      event,
+    ),
+    onActivity: (activity) => recordWorkflowStepProviderActivity(
+      stepAbortSignalContext.recordActivity,
+      'dynamic-facet-selector',
+      activity,
+    ),
     failureDir,
     selectionStore: params.sharedRuntime.dynamicFacetSelectionStore!,
     getCwd: params.getCwd,
@@ -307,6 +321,16 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
   const dynamicParallelSelector = new DynamicParallelSelectorCoordinator({
     engineOptions: params.options,
     getAbortSignal: stepAbortSignalContext.getAbortSignal,
+    onStream: (event) => recordWorkflowStepProviderEventActivity(
+      stepAbortSignalContext.recordActivity,
+      'dynamic-parallel-selector',
+      event,
+    ),
+    onActivity: (activity) => recordWorkflowStepProviderActivity(
+      stepAbortSignalContext.recordActivity,
+      'dynamic-parallel-selector',
+      activity,
+    ),
     failureDir,
     selectionStore: params.sharedRuntime.dynamicParallelSelectionStore!,
     getCwd: params.getCwd,

--- a/src/core/workflow/engine/WorkflowEngineStepCoordinator.ts
+++ b/src/core/workflow/engine/WorkflowEngineStepCoordinator.ts
@@ -22,7 +22,7 @@ import { RuleDetectionExhaustedError } from '../evaluation/RuleDetectionExhauste
 import {
   createWorkflowStepCompositeDeadline,
   createWorkflowStepDeadline,
-  type WorkflowStepDeadline,
+  type WorkflowStepInactivityDeadline,
   type WorkflowStepDeadlineProviderInfo,
   type WorkflowStepExecutionDeadlineContext,
 } from './step-deadline.js';
@@ -144,7 +144,7 @@ interface WorkflowEngineStepCoordinatorDeps {
 }
 
 export class WorkflowEngineStepCoordinator {
-  private readonly stepDeadlines = new Map<string, WorkflowStepDeadline>();
+  private readonly stepDeadlines = new Map<string, WorkflowStepInactivityDeadline>();
 
   constructor(private readonly deps: WorkflowEngineStepCoordinatorDeps) {}
 
@@ -152,7 +152,7 @@ export class WorkflowEngineStepCoordinator {
     step: WorkflowStep,
     runtime: RuntimeStepResolution | undefined,
     stepIteration: number,
-  ): WorkflowStepDeadline {
+  ): WorkflowStepInactivityDeadline {
     const providerInfos = this.resolveStepDeadlineProviderInfos(step, runtime);
     return this.getOrCreateStepDeadline(
       step,
@@ -166,7 +166,7 @@ export class WorkflowEngineStepCoordinator {
     step: WorkflowStep,
     runtime: RuntimeStepResolution | undefined,
     stepIteration: number,
-  ): WorkflowStepDeadline {
+  ): WorkflowStepInactivityDeadline {
     const key = this.stepDeadlineKey(step, stepIteration, 'step');
     const existing = this.stepDeadlines.get(key);
     if (existing === undefined) {
@@ -177,7 +177,6 @@ export class WorkflowEngineStepCoordinator {
     const deadline = createWorkflowStepCompositeDeadline(
       providerInfos,
       this.deps.getOptions().abortSignal,
-      existing.startedAt,
     );
     this.stepDeadlines.set(key, deadline);
     return deadline;
@@ -188,7 +187,7 @@ export class WorkflowEngineStepCoordinator {
     stepIteration: number,
     executionUnitKey: string,
     providerInfo: WorkflowStepDeadlineProviderInfo,
-  ): WorkflowStepDeadline {
+  ): WorkflowStepInactivityDeadline {
     return this.getOrCreateStepDeadline(
       step,
       stepIteration,
@@ -252,8 +251,8 @@ export class WorkflowEngineStepCoordinator {
     step: WorkflowStep,
     stepIteration: number,
     executionUnitKey: string,
-    create: () => WorkflowStepDeadline,
-  ): WorkflowStepDeadline {
+    create: () => WorkflowStepInactivityDeadline,
+  ): WorkflowStepInactivityDeadline {
     const key = this.stepDeadlineKey(step, stepIteration, executionUnitKey);
     const existing = this.stepDeadlines.get(key);
     if (existing !== undefined) {
@@ -287,11 +286,11 @@ export class WorkflowEngineStepCoordinator {
         executionUnitKey,
         providerInfo,
       ),
-      runWith: <T>(deadline: WorkflowStepDeadline, operation: () => Promise<T>): Promise<T> => {
+      runWith: <T>(deadline: WorkflowStepInactivityDeadline, operation: () => Promise<T>): Promise<T> => {
         if (this.deps.stepAbortSignalContext === undefined) {
           return operation();
         }
-        return this.deps.stepAbortSignalContext.runWith(deadline.signal, operation);
+        return this.deps.stepAbortSignalContext.runWith(deadline, operation);
       },
     };
   }

--- a/src/core/workflow/engine/WorkflowRunLoop.ts
+++ b/src/core/workflow/engine/WorkflowRunLoop.ts
@@ -43,10 +43,16 @@ import {
   isAgentFailureError,
   isProviderStreamParseError,
 } from '../../../shared/types/agent-failure.js';
-import type {
-  WorkflowStepAbortSignalContext,
-  WorkflowStepDeadline,
+import {
+  recordWorkflowStepProviderActivity,
+  recordWorkflowStepProviderEventActivity,
+  type WorkflowStepAbortSignalContext,
+  type WorkflowStepInactivityDeadline,
 } from './step-deadline.js';
+import type {
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../../shared/types/provider.js';
 
 const log = createLogger('workflow-run-loop');
 
@@ -74,12 +80,12 @@ interface WorkflowRunLoopDeps {
     step: WorkflowStep,
     runtime: RuntimeStepResolution | undefined,
     stepIteration: number,
-  ) => WorkflowStepDeadline;
+  ) => WorkflowStepInactivityDeadline;
   refreshStepDeadline?: (
     step: WorkflowStep,
     runtime: RuntimeStepResolution | undefined,
     stepIteration: number,
-  ) => WorkflowStepDeadline;
+  ) => WorkflowStepInactivityDeadline;
   disposeStepDeadline?: (step: WorkflowStep, stepIteration: number) => void;
   disposeAllStepDeadlines?: () => void;
   stepAbortSignalContext?: WorkflowStepAbortSignalContext;
@@ -144,17 +150,39 @@ interface WorkflowRunLoopDeps {
 
 async function runWithStepDeadline<T>(
   deps: WorkflowRunLoopDeps,
-  deadline: WorkflowStepDeadline | undefined,
+  deadline: WorkflowStepInactivityDeadline | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
   if (deadline === undefined || deps.stepAbortSignalContext === undefined) {
     return operation();
   }
-  return deps.stepAbortSignalContext.runWith(deadline.signal, operation);
+  return deps.stepAbortSignalContext.runWith(deadline, operation);
 }
 
 function resolveStepAbortSignal(deps: WorkflowRunLoopDeps): AbortSignal | undefined {
   return deps.stepAbortSignalContext?.getAbortSignal() ?? deps.options.abortSignal;
+}
+
+function buildDeadlineActivityCallbacks(
+  deps: WorkflowRunLoopDeps,
+  executionUnitKey: string,
+): { onStream?: StreamCallback; onActivity?: ProviderActivityCallback } {
+  const recordActivity = deps.stepAbortSignalContext?.recordActivity;
+  if (recordActivity === undefined) {
+    return {};
+  }
+  return {
+    onStream: (event) => recordWorkflowStepProviderEventActivity(
+      recordActivity,
+      executionUnitKey,
+      event,
+    ),
+    onActivity: (activity) => recordWorkflowStepProviderActivity(
+      recordActivity,
+      executionUnitKey,
+      activity,
+    ),
+  };
 }
 
 async function resolveStepPromotionRuntime(
@@ -171,6 +199,8 @@ async function resolveStepPromotionRuntime(
     resolveStepProviderModel: deps.resolveStepProviderModelBeforeAutoRouting,
     providerLadders: deps.options.providerLadders,
     providerRoutingTagConflictPolicy: deps.options.providerRoutingTagConflictPolicy,
+    abortSignal: resolveStepAbortSignal(deps),
+    ...buildDeadlineActivityCallbacks(deps, `promotion:${step.name}`),
   }, step, stepIteration, runtime);
 }
 
@@ -225,6 +255,7 @@ async function resolveStepAutoRoutingRuntime(
     runtime: deps.options.routingRuntime,
     logger: log,
     abortSignal: resolveStepAbortSignal(deps),
+    ...buildDeadlineActivityCallbacks(deps, `auto-routing:${step.name}`),
   });
   if (!autoRuntime) {
     return runtime;
@@ -825,7 +856,7 @@ async function runWorkflowToCompletionCore(deps: WorkflowRunLoopDeps): Promise<W
       abort = abortWorkflowRuntimeError(deps, error);
       break;
     }
-    let stepDeadline: WorkflowStepDeadline | undefined;
+    let stepDeadline: WorkflowStepInactivityDeadline | undefined;
     let stepRuntime: RuntimeStepResolution | undefined;
     let preparedExecution: PreparedNormalStepExecution | undefined;
     let executionStep: WorkflowStep;
@@ -1217,7 +1248,7 @@ async function runSingleWorkflowIterationCore(deps: WorkflowRunLoopDeps): Promis
   const isDelegated = isDelegatedWorkflowStep(step);
   const stepIteration = deps.claimStepOccurrence(step);
   const workflowCallExecution = deps.setActiveStep(step, activeIteration, stepIteration);
-  let stepDeadline: WorkflowStepDeadline | undefined;
+  let stepDeadline: WorkflowStepInactivityDeadline | undefined;
   try {
     stepDeadline = isNormalAgentWorkflowStep(step)
       ? deps.beginStepDeadline?.(

--- a/src/core/workflow/engine/abort-signal.ts
+++ b/src/core/workflow/engine/abort-signal.ts
@@ -1,4 +1,9 @@
 import { createPartTimeoutReason } from '../../../shared/types/agent-failure.js';
+import { STALE_IN_FLIGHT_TOOL_FACTOR } from '../../../shared/types/provider-deadline.js';
+import type {
+  ProviderActivityCallback,
+  ProviderActivityEvent,
+} from '../../../shared/types/provider.js';
 
 export interface AbortScope {
   readonly signal: AbortSignal;
@@ -46,6 +51,91 @@ export function buildAbortSignal(
     signal: timeoutController.signal,
     dispose: () => {
       clearTimeout(timeoutId);
+      if (parentSignal && abortListener) {
+        parentSignal.removeEventListener('abort', abortListener);
+      }
+    },
+  };
+}
+
+export interface InactivityAbortSignal {
+  readonly signal: AbortSignal;
+  readonly recordActivity: ProviderActivityCallback;
+  readonly dispose: () => void;
+}
+
+export function buildInactivityAbortSignal(
+  inactivityTimeoutMs: number,
+  parentSignal: AbortSignal | undefined,
+): InactivityAbortSignal {
+  const timeoutController = new AbortController();
+  const toolStaleTimeoutMs = inactivityTimeoutMs * STALE_IN_FLIGHT_TOOL_FACTOR;
+  const inFlightTools = new Map<string, {
+    readonly executionUnitKey: string;
+    readonly startedAt: number;
+  }>();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const abortForInactivity = (): void => {
+    timeoutController.abort(new Error(createPartTimeoutReason(inactivityTimeoutMs)));
+  };
+  const armTimeoutAt = (deadlineAt: number): void => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    timeoutId = setTimeout(abortForInactivity, Math.max(0, deadlineAt - Date.now()));
+  };
+  const armTimeout = (): void => {
+    const earliestToolStart = inFlightTools.size === 0
+      ? undefined
+      : Math.min(...[...inFlightTools.values()].map(({ startedAt }) => startedAt));
+    armTimeoutAt(
+      earliestToolStart === undefined
+        ? Date.now() + inactivityTimeoutMs
+        : earliestToolStart + toolStaleTimeoutMs,
+    );
+  };
+  const applyActivity = (activity: ProviderActivityEvent | undefined): void => {
+    if (activity?.kind === 'attempt_started') {
+      if (activity.executionUnitKey === undefined) {
+        inFlightTools.clear();
+      } else {
+        for (const [toolCallKey, tool] of inFlightTools) {
+          if (tool.executionUnitKey === activity.executionUnitKey) {
+            inFlightTools.delete(toolCallKey);
+          }
+        }
+      }
+    } else if (activity?.kind === 'tool_started') {
+      if (!inFlightTools.has(activity.toolCallKey)) {
+        inFlightTools.set(activity.toolCallKey, {
+          executionUnitKey: activity.executionUnitKey,
+          startedAt: Date.now(),
+        });
+      }
+    } else if (activity?.kind === 'tool_finished') {
+      inFlightTools.delete(activity.toolCallKey);
+    }
+  };
+
+  let abortListener: (() => void) | undefined;
+  if (parentSignal) {
+    abortListener = () => timeoutController.abort(parentSignal.reason);
+    if (parentSignal.aborted) {
+      abortListener();
+    } else {
+      parentSignal.addEventListener('abort', abortListener, { once: true });
+    }
+  }
+  if (!timeoutController.signal.aborted) armTimeout();
+
+  return {
+    signal: timeoutController.signal,
+    recordActivity: (activity) => {
+      if (timeoutController.signal.aborted) return;
+      applyActivity(activity);
+      armTimeout();
+    },
+    dispose: () => {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      inFlightTools.clear();
       if (parentSignal && abortListener) {
         parentSignal.removeEventListener('abort', abortListener);
       }

--- a/src/core/workflow/engine/step-deadline.ts
+++ b/src/core/workflow/engine/step-deadline.ts
@@ -1,29 +1,71 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { StepProviderOptions } from '../../models/workflow-types.js';
-import type { ProviderType } from '../../../shared/types/provider.js';
+import type {
+  ProviderActivityCallback,
+  ProviderType,
+  StreamEvent,
+} from '../../../shared/types/provider.js';
 import { resolveProviderCallTimeoutMs } from '../../../shared/types/provider-deadline.js';
-import { buildAbortSignal } from './abort-signal.js';
+import { buildInactivityAbortSignal } from './abort-signal.js';
 
 export interface WorkflowStepAbortSignalContext {
   getAbortSignal(): AbortSignal | undefined;
-  runWith<T>(signal: AbortSignal, operation: () => Promise<T>): Promise<T>;
+  recordActivity: ProviderActivityCallback;
+  runWith<T>(deadline: WorkflowStepInactivityDeadline, operation: () => Promise<T>): Promise<T>;
 }
 
-export interface WorkflowStepDeadline {
+export interface WorkflowStepInactivityDeadline {
   readonly signal: AbortSignal;
+  readonly recordActivity: ProviderActivityCallback;
   readonly dispose: () => void;
-  readonly startedAt: number;
-  readonly timeoutMs: number;
+  readonly inactivityTimeoutMs: number;
+}
+
+export function recordWorkflowStepProviderEventActivity(
+  recordActivity: ProviderActivityCallback,
+  executionUnitKey: string,
+  event: StreamEvent,
+): void {
+  if (event.type === 'tool_use') {
+    recordActivity({
+      kind: 'tool_started',
+      executionUnitKey,
+      toolCallKey: JSON.stringify([executionUnitKey, event.data.id]),
+    });
+    return;
+  }
+  if (event.type === 'tool_result' && event.data.id !== undefined) {
+    recordActivity({
+      kind: 'tool_finished',
+      executionUnitKey,
+      toolCallKey: JSON.stringify([executionUnitKey, event.data.id]),
+    });
+    return;
+  }
+  recordActivity();
+}
+
+export function recordWorkflowStepProviderActivity(
+  recordActivity: ProviderActivityCallback,
+  executionUnitKey: string,
+  activity?: Parameters<ProviderActivityCallback>[0],
+): void {
+  if (activity?.kind === 'attempt_started') {
+    recordActivity({ ...activity, executionUnitKey });
+    return;
+  }
+  recordActivity(activity);
 }
 
 export function createWorkflowStepAbortSignalContext(
   parentSignal: AbortSignal | undefined,
 ): WorkflowStepAbortSignalContext {
-  const signalStorage = new AsyncLocalStorage<AbortSignal>();
+  const deadlineStorage = new AsyncLocalStorage<WorkflowStepInactivityDeadline>();
   return {
-    getAbortSignal: () => signalStorage.getStore() ?? parentSignal,
-    runWith: async <T>(signal: AbortSignal, operation: () => Promise<T>): Promise<T> => {
-      return signalStorage.run(signal, operation);
+    getAbortSignal: () => deadlineStorage.getStore()?.signal ?? parentSignal,
+    recordActivity: (activity) => deadlineStorage.getStore()?.recordActivity(activity),
+    runWith: async <T>(deadline: WorkflowStepInactivityDeadline, operation: () => Promise<T>): Promise<T> => {
+      return deadlineStorage.run(deadline, operation);
     },
   };
 }
@@ -83,8 +125,8 @@ export interface WorkflowStepExecutionDeadlineContext {
   begin(
     executionUnitKey: string,
     providerInfo: WorkflowStepDeadlineProviderInfo,
-  ): WorkflowStepDeadline;
-  runWith<T>(deadline: WorkflowStepDeadline, operation: () => Promise<T>): Promise<T>;
+  ): WorkflowStepInactivityDeadline;
+  runWith<T>(deadline: WorkflowStepInactivityDeadline, operation: () => Promise<T>): Promise<T>;
 }
 
 export function resolveWorkflowStepCompositeCallTimeoutMs(
@@ -103,19 +145,17 @@ export function createWorkflowStepDeadline(
   provider: ProviderType | undefined,
   providerOptions: StepProviderOptions | undefined,
   parentSignal: AbortSignal | undefined,
-): WorkflowStepDeadline {
-  const timeoutMs = resolveWorkflowStepCallTimeoutMs(provider, providerOptions);
-  const startedAt = Date.now();
-  const deadline = buildAbortSignal(timeoutMs, parentSignal, startedAt + timeoutMs);
-  return { ...deadline, startedAt, timeoutMs };
+): WorkflowStepInactivityDeadline {
+  const inactivityTimeoutMs = resolveWorkflowStepCallTimeoutMs(provider, providerOptions);
+  const deadline = buildInactivityAbortSignal(inactivityTimeoutMs, parentSignal);
+  return { ...deadline, inactivityTimeoutMs };
 }
 
 export function createWorkflowStepCompositeDeadline(
   providerInfos: readonly WorkflowStepDeadlineProviderInfo[],
   parentSignal: AbortSignal | undefined,
-  startedAt = Date.now(),
-): WorkflowStepDeadline {
-  const timeoutMs = resolveWorkflowStepCompositeCallTimeoutMs(providerInfos);
-  const deadline = buildAbortSignal(timeoutMs, parentSignal, startedAt + timeoutMs);
-  return { ...deadline, startedAt, timeoutMs };
+): WorkflowStepInactivityDeadline {
+  const inactivityTimeoutMs = resolveWorkflowStepCompositeCallTimeoutMs(providerInfos);
+  const deadline = buildInactivityAbortSignal(inactivityTimeoutMs, parentSignal);
+  return { ...deadline, inactivityTimeoutMs };
 }

--- a/src/core/workflow/phase-runner.ts
+++ b/src/core/workflow/phase-runner.ts
@@ -62,6 +62,8 @@ export interface BasePhaseRunnerContext {
   failureDir?: string;
   /** Stream callback for provider event logging */
   onStream?: import('../../agents/types.js').StreamCallback;
+  /** Records provider activity that does not produce a public stream event. */
+  onActivity?: RunAgentOptions['onActivity'];
   /** Parent workflow iteration for sub-step phase events */
   iteration?: number;
   /** Callback for phase lifecycle logging */

--- a/src/core/workflow/promotion/PromotionEvaluator.ts
+++ b/src/core/workflow/promotion/PromotionEvaluator.ts
@@ -18,6 +18,9 @@ export interface PromotionEvaluationContext {
   resolvedProviderOptions?: StepProviderOptions;
   permissionMode?: PermissionMode;
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
+  abortSignal?: RunAgentOptions['abortSignal'];
+  onStream?: RunAgentOptions['onStream'];
+  onActivity?: RunAgentOptions['onActivity'];
 }
 
 function matchesAt(entry: WorkflowPromotionEntry, stepIteration: number): boolean {
@@ -90,6 +93,9 @@ async function matchesAiCondition(
       resolvedProviderOptions: context.resolvedProviderOptions,
       permissionMode: context.permissionMode,
       childProcessEnv: context.childProcessEnv,
+      abortSignal: context.abortSignal,
+      onStream: context.onStream,
+      onActivity: context.onActivity,
     },
   );
   return matchedIndex === entryIndex;

--- a/src/core/workflow/promotion/promotion-runtime.ts
+++ b/src/core/workflow/promotion/promotion-runtime.ts
@@ -22,6 +22,9 @@ export interface PromotionRuntimeContext {
   previousResponseContent: string;
   structuredCaller?: StructuredCaller;
   childProcessEnv?: RunAgentOptions['childProcessEnv'];
+  abortSignal?: RunAgentOptions['abortSignal'];
+  onStream?: RunAgentOptions['onStream'];
+  onActivity?: RunAgentOptions['onActivity'];
   resolveStepProviderModel: (step: WorkflowStep, runtime?: RuntimeStepResolution) => StepProviderInfo;
   /**
    * Fully-resolved runtime.yaml `ladder` stages (issue #1208). A matched target-less `{at:N}`
@@ -142,6 +145,9 @@ export async function resolvePromotionRuntime(
     resolvedProviderOptions: baseProviderInfo.providerOptions,
     permissionMode: baseProviderInfo.permissionMode,
     childProcessEnv: context.childProcessEnv,
+    abortSignal: context.abortSignal,
+    onStream: context.onStream,
+    onActivity: context.onActivity,
   });
 
   if (promotion !== undefined && isTargetedPromotionEntry(promotion)) {

--- a/src/core/workflow/status-judgment-phase.ts
+++ b/src/core/workflow/status-judgment-phase.ts
@@ -147,6 +147,7 @@ export async function runStatusJudgmentPhase(
         failureDir: ctx.failureDir,
         childProcessEnv: ctx.childProcessEnv,
         onStream: ctx.onStream,
+        onActivity: ctx.onActivity,
         onStructuredPromptResolved: (promptParts) => {
           if (!didEmitPhaseStart) {
             emitPhaseStart(promptParts);

--- a/src/infra/claude-headless/client.ts
+++ b/src/infra/claude-headless/client.ts
@@ -166,6 +166,7 @@ export async function callClaudeHeadless(
     const prepared = await buildSpawnArgs(prompt, options);
     cleanup = prepared.cleanup;
     const { args, expectedSessionId } = prepared;
+    options.onActivity?.({ kind: 'attempt_started' });
     const { stdout, stderr } = await runHeadlessCli(args, options);
     const parsed = aggregateResultFromStdout(stdout);
     const sessionId = extractSessionIdFromStdout(stdout) ?? expectedSessionId;

--- a/src/infra/claude-headless/types.ts
+++ b/src/infra/claude-headless/types.ts
@@ -1,6 +1,10 @@
 import type { McpServerConfig, PermissionMode } from '../../core/models/index.js';
 import type { ClaudeEffort, ClaudeSandboxSettings } from '../../core/models/workflow-types.js';
-import type { InternalAgentIsolation, StreamCallback } from '../../shared/types/provider.js';
+import type {
+  InternalAgentIsolation,
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../shared/types/provider.js';
 
 export interface ClaudeHeadlessCallOptions {
   cwd: string;
@@ -19,6 +23,7 @@ export interface ClaudeHeadlessCallOptions {
   bypassPermissions?: boolean;
   sandbox?: ClaudeSandboxSettings;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   claudeCliPath?: string;
   systemPrompt?: string;
   outputSchema?: Record<string, unknown>;

--- a/src/infra/claude-terminal/client.ts
+++ b/src/infra/claude-terminal/client.ts
@@ -159,7 +159,6 @@ export async function callClaudeTerminal(
 ): Promise<AgentResponse> {
   const backendName = options.backend ?? DEFAULT_BACKEND;
   const callTimeoutMs = options.callTimeoutMs ?? options.timeoutMs ?? PROVIDER_CALL_TIMEOUT_DEFAULT_MS;
-  const deadlineAt = Date.now() + callTimeoutMs;
   const pollIntervalMs = options.transcriptPollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const keepSession = options.keepSession === true;
   const terminalBackend = resolveTerminalBackend(backendName, options.terminalBackend);
@@ -277,6 +276,7 @@ export async function callClaudeTerminal(
       outputSchema: options.outputSchema,
     });
 
+    options.onActivity?.({ kind: 'attempt_started' });
     const startedSession = await withAbort(() => {
       const startPromise = terminalBackend.start({
         cwd: options.cwd,
@@ -301,10 +301,10 @@ export async function callClaudeTerminal(
     const session = await withAbort(() => transcriptReader.findSession({
       cwd: options.cwd,
       sessionId: claudeSessionId,
-      deadlineAt,
       timeoutMs: callTimeoutMs,
       pollIntervalMs,
       abortSignal: options.abortSignal,
+      onActivity: options.onActivity,
     }));
     responseSessionId = session.sessionId;
     emitInit(options, session.sessionId);
@@ -312,14 +312,15 @@ export async function callClaudeTerminal(
     const handledEvents: ClaudeTerminalEvent[] = [];
     let response: ClaudeTerminalTranscript;
     while (true) {
+      options.onActivity?.({ kind: 'attempt_started' });
       response = await withAbort(() => transcriptReader.waitForAssistantResponse({
         session,
         baseline,
         cwd: options.cwd,
-        deadlineAt,
         timeoutMs: callTimeoutMs,
         pollIntervalMs,
         abortSignal: options.abortSignal,
+        onActivity: options.onActivity,
       }));
 
       handledEvents.push(...response.events);
@@ -361,7 +362,16 @@ export async function callClaudeTerminal(
     ) {
       return createAbortResponse(agentName, error.reason, responseSessionId);
     }
-    return createErrorResponse(agentName, getErrorMessage(error), AGENT_FAILURE_CATEGORIES.PROVIDER_ERROR, responseSessionId);
+    const errorMessage = getErrorMessage(error);
+    const classified = classifyAbortSignalReason(errorMessage);
+    return createErrorResponse(
+      agentName,
+      errorMessage,
+      classified.category === AGENT_FAILURE_CATEGORIES.PART_TIMEOUT
+        ? classified.category
+        : AGENT_FAILURE_CATEGORIES.PROVIDER_ERROR,
+      responseSessionId,
+    );
   } finally {
     if (abortHandler) {
       options.abortSignal?.removeEventListener('abort', abortHandler);

--- a/src/infra/claude-terminal/transcript-reader.ts
+++ b/src/infra/claude-terminal/transcript-reader.ts
@@ -385,6 +385,7 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
     if (deadlineAt === undefined) {
       throw new Error('Claude terminal session deadline is required.');
     }
+    let observedTranscript: string | undefined;
     return pollUntil(
       deadlineAt,
       options.timeoutMs,
@@ -396,7 +397,10 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
         if (transcript === undefined || transcript.trim().length === 0) {
           return undefined;
         }
-        recordActivity();
+        if (transcript !== observedTranscript) {
+          observedTranscript = transcript;
+          recordActivity();
+        }
         const parsed = parseClaudeTerminalTranscript(transcript, {
           allowIncompleteFinalLine: true,
         });

--- a/src/infra/claude-terminal/transcript-reader.ts
+++ b/src/infra/claude-terminal/transcript-reader.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve, sep } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import type { AskUserQuestionInput } from '../../core/workflow/types.js';
+import { createPartTimeoutReason } from '../../shared/types/agent-failure.js';
 import { getClaudeProjectSessionsDir } from '../config/project/sessionStore.js';
 import type {
   ClaudeSessionRef,
@@ -291,16 +292,25 @@ async function sleepWithAbort(pollIntervalMs: number, signal: AbortSignal | unde
 }
 
 async function pollUntil<T>(
-  deadlineAt: number,
+  initialDeadlineAt: number,
+  inactivityTimeoutMs: number | undefined,
   pollIntervalMs: number,
   abortSignal: AbortSignal | undefined,
-  attempt: () => Promise<T | undefined>,
+  onActivity: (() => void) | undefined,
+  attempt: (recordActivity: () => void) => Promise<T | undefined>,
   timeoutMessage: string,
 ): Promise<T> {
+  let deadlineAt = initialDeadlineAt;
+  const recordActivity = (): void => {
+    if (inactivityTimeoutMs !== undefined) {
+      deadlineAt = Date.now() + inactivityTimeoutMs;
+    }
+    onActivity?.();
+  };
   throwIfAborted(abortSignal);
   while (Date.now() <= deadlineAt) {
     throwIfAborted(abortSignal);
-    const value = await attempt();
+    const value = await attempt(recordActivity);
     throwIfAborted(abortSignal);
     if (value !== undefined) {
       return value;
@@ -377,13 +387,16 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
     }
     return pollUntil(
       deadlineAt,
+      options.timeoutMs,
       options.pollIntervalMs,
       options.abortSignal,
-      async () => {
+      options.onActivity,
+      async (recordActivity) => {
         const transcript = await readTranscript(options.cwd, options.sessionId);
         if (transcript === undefined || transcript.trim().length === 0) {
           return undefined;
         }
+        recordActivity();
         const parsed = parseClaudeTerminalTranscript(transcript, {
           allowIncompleteFinalLine: true,
         });
@@ -392,7 +405,9 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
         }
         return { sessionId: parsed.sessionId || options.sessionId };
       },
-      'Timed out waiting for Claude terminal session id.',
+      options.timeoutMs === undefined
+        ? 'Timed out waiting for Claude terminal session id.'
+        : createPartTimeoutReason(options.timeoutMs),
     );
   }
 
@@ -403,14 +418,22 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
     if (deadlineAt === undefined) {
       throw new Error('Claude terminal response deadline is required.');
     }
+    let observedByteLength = options.baseline.byteOffset;
     return pollUntil(
       deadlineAt,
+      options.timeoutMs,
       options.pollIntervalMs,
       options.abortSignal,
-      async () => {
+      options.onActivity,
+      async (recordActivity) => {
         const transcript = await readTranscript(options.cwd, options.session.sessionId);
         if (transcript === undefined || transcript.trim().length === 0) {
           return undefined;
+        }
+        const byteLength = Buffer.byteLength(transcript, 'utf-8');
+        if (byteLength > observedByteLength) {
+          observedByteLength = byteLength;
+          recordActivity();
         }
         const parsed = parseClaudeTerminalTranscript(transcript, {
           baseline: options.baseline,
@@ -430,7 +453,9 @@ export class ProjectClaudeTranscriptReader implements ClaudeTranscriptReader {
         }
         return withSessionIdFallback(parsed, options.session.sessionId);
       },
-      'Timed out waiting for Claude terminal assistant response.',
+      options.timeoutMs === undefined
+        ? 'Timed out waiting for Claude terminal assistant response.'
+        : createPartTimeoutReason(options.timeoutMs),
     );
   }
 }

--- a/src/infra/claude-terminal/types.ts
+++ b/src/infra/claude-terminal/types.ts
@@ -1,7 +1,11 @@
 import type { McpServerConfig, PermissionMode } from '../../core/models/index.js';
 import type { ClaudeEffort } from '../../core/models/workflow-types.js';
 import type { PermissionHandler, AskUserQuestionHandler, AskUserQuestionInput } from '../../core/workflow/types.js';
-import type { InternalAgentIsolation, StreamCallback } from '../../shared/types/provider.js';
+import type {
+  InternalAgentIsolation,
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../shared/types/provider.js';
 
 export type ClaudeTerminalBackendName = 'tmux';
 
@@ -63,24 +67,26 @@ export interface ClaudeSessionRef {
 export interface FindClaudeSessionOptions {
   cwd: string;
   sessionId: string;
-  /** 親呼び出し全体の絶対期限。 */
+  /** 互換用。timeoutMs がない直接利用時だけ使う絶対期限。 */
   deadlineAt?: number;
-  /** 互換用。deadlineAt がない直接利用時だけ相対期限として使う。 */
+  /** transcript に変化がない時間の上限。変化するたびに更新する。 */
   timeoutMs?: number;
   pollIntervalMs: number;
   abortSignal?: AbortSignal;
+  onActivity?: ProviderActivityCallback;
 }
 
 export interface WaitForClaudeResponseOptions {
   session: ClaudeSessionRef;
   baseline: ClaudeTranscriptBaseline;
   cwd: string;
-  /** 親呼び出し全体の絶対期限。 */
+  /** 互換用。timeoutMs がない直接利用時だけ使う絶対期限。 */
   deadlineAt?: number;
-  /** 互換用。deadlineAt がない直接利用時だけ相対期限として使う。 */
+  /** transcript に変化がない時間の上限。変化するたびに更新する。 */
   timeoutMs?: number;
   pollIntervalMs: number;
   abortSignal?: AbortSignal;
+  onActivity?: ProviderActivityCallback;
 }
 
 export interface ClaudeTranscriptReader {
@@ -109,6 +115,7 @@ export interface ClaudeTerminalCallOptions {
   keepSession?: boolean;
   transcriptPollIntervalMs?: number;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   onPermissionRequest?: PermissionHandler;
   onAskUserQuestion?: AskUserQuestionHandler;
   outputSchema?: Record<string, unknown>;

--- a/src/infra/claude/client.ts
+++ b/src/infra/claude/client.ts
@@ -49,6 +49,7 @@ export class ClaudeClient {
       agents: options.agents,
       permissionMode: options.permissionMode,
       onStream: options.onStream,
+      onActivity: options.onActivity,
       onPermissionRequest: options.onPermissionRequest,
       onAskUserQuestion: options.onAskUserQuestion,
       bypassPermissions: options.bypassPermissions,

--- a/src/infra/claude/executor.ts
+++ b/src/infra/claude/executor.ts
@@ -157,6 +157,7 @@ export class QueryExecutor {
     prompt: string,
     options: ClaudeSpawnOptions,
   ): Promise<ClaudeResult> {
+    options.onActivity?.({ kind: 'attempt_started' });
     const queryId = generateQueryId();
 
     log.debug('Executing Claude query via SDK', {

--- a/src/infra/claude/types.ts
+++ b/src/infra/claude/types.ts
@@ -24,6 +24,7 @@ import type {
   StreamAssistantErrorEventData as SharedAssistantErrorEventData,
   StreamRateLimitEventData as SharedRateLimitEventData,
   InternalAgentIsolation,
+  ProviderActivityCallback,
 } from '../../shared/types/provider.js';
 
 export type { SandboxSettings };
@@ -119,6 +120,7 @@ export interface ClaudeCallOptions {
   permissionMode?: PermissionMode;
   /** Enable streaming mode with callback for real-time output */
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   /** Custom permission handler for interactive permission prompts */
   onPermissionRequest?: PermissionHandler;
   /** Custom handler for AskUserQuestion tool */
@@ -155,6 +157,7 @@ export interface ClaudeSpawnOptions {
   systemPrompt?: string;
   /** Enable streaming mode with callback */
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   /** Custom agents to register */
   agents?: Record<string, AgentDefinition>;
   /** Permission mode for tool execution (TAKT abstract value, mapped to SDK value in SdkOptionsBuilder) */

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -399,6 +399,7 @@ export class CodexClient {
 
     while (true) {
       const attempt = standardRetryCount + timeoutRetryCount + refusalRetryCount + 1;
+      options.onActivity?.({ kind: 'attempt_started' });
       let currentThreadId = threadId;
       const codexClientOptions: CodexOptions = {
         env: buildEnvWithNestedObservabilitySnapshot(

--- a/src/infra/codex/types.ts
+++ b/src/infra/codex/types.ts
@@ -5,7 +5,7 @@
 import type { PermissionMode } from '../../core/models/index.js';
 import type { CodexReasoningEffort } from '../../core/models/workflow-types.js';
 import type { ProviderImageAttachment } from '../providers/types.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 /** Codex sandbox mode values */
 export type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
@@ -34,6 +34,8 @@ export interface CodexCallOptions {
   networkAccess?: boolean;
   /** Enable streaming mode with callback (best-effort) */
   onStream?: StreamCallback;
+  /** Notify the workflow inactivity deadline immediately before each provider attempt. */
+  onActivity?: ProviderActivityCallback;
   /** OpenAI API key (bypasses CLI auth) */
   openaiApiKey?: string;
   /** OpenAI-compatible API base URL */

--- a/src/infra/copilot/client.ts
+++ b/src/infra/copilot/client.ts
@@ -498,6 +498,7 @@ export class CopilotClient {
       log.debug('mkdtemp failed, skipping session extraction', { err });
     }
 
+    options.onActivity?.({ kind: 'attempt_started' });
     const executionOutcome = await executeCopilotCall(
       prompt,
       options,

--- a/src/infra/copilot/types.ts
+++ b/src/infra/copilot/types.ts
@@ -4,7 +4,7 @@
 
 import type { CopilotEffort } from '../../core/models/workflow-types.js';
 import type { PermissionMode } from '../../core/models/index.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 /** Options for calling GitHub Copilot CLI */
 export interface CopilotCallOptions {
@@ -16,6 +16,7 @@ export interface CopilotCallOptions {
   systemPrompt?: string;
   permissionMode?: PermissionMode;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   /** GitHub token for Copilot authentication */
   copilotGithubToken?: string;
   /** Custom path to copilot executable */

--- a/src/infra/cursor/client.ts
+++ b/src/infra/cursor/client.ts
@@ -498,6 +498,7 @@ export class CursorClient {
     let cliConfigRenameRetryCount = 0;
 
     while (true) {
+      options.onActivity?.({ kind: 'attempt_started' });
       try {
         const { stdout } = await execCursor(args, options);
         const parsed = parseCursorOutput(stdout);

--- a/src/infra/cursor/types.ts
+++ b/src/infra/cursor/types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { PermissionMode } from '../../core/models/index.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 /** Options for calling Cursor Agent CLI */
 export interface CursorCallOptions {
@@ -14,6 +14,7 @@ export interface CursorCallOptions {
   systemPrompt?: string;
   permissionMode?: PermissionMode;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   cursorApiKey?: string;
   /** Custom path to cursor-agent executable */
   cursorCliPath?: string;

--- a/src/infra/kiro/client.ts
+++ b/src/infra/kiro/client.ts
@@ -253,6 +253,7 @@ export class KiroClient {
 
     try {
       const args = buildArgs(effectiveOptions, promptText);
+      options.onActivity?.({ kind: 'attempt_started' });
       const { stdout } = await execKiro(args, effectiveOptions);
       const content = cleanKiroOutput(stdout);
       const outputError = content.length === 0

--- a/src/infra/kiro/types.ts
+++ b/src/infra/kiro/types.ts
@@ -1,5 +1,5 @@
 import type { PermissionMode } from '../../core/models/index.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 export interface KiroCallOptions {
   cwd: string;
@@ -9,6 +9,7 @@ export interface KiroCallOptions {
   systemPrompt?: string;
   permissionMode?: PermissionMode;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   kiroApiKey?: string;
   kiroCliPath?: string;
   agent?: string;

--- a/src/infra/mock/client.ts
+++ b/src/infra/mock/client.ts
@@ -198,6 +198,7 @@ export async function callMock(
   prompt: string,
   options: MockCallOptions
 ): Promise<AgentResponse> {
+  options.onActivity?.({ kind: 'attempt_started' });
   const sessionId = options.sessionId ?? generateMockSessionId();
 
   // Scenario queue takes priority over explicit options

--- a/src/infra/mock/types.ts
+++ b/src/infra/mock/types.ts
@@ -4,7 +4,7 @@
 
 import type { Status } from '../../core/models/status.js';
 import type { AgentFailureCategory } from '../../shared/types/agent-failure.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 /** Options for mock calls */
 export interface MockCallOptions {
@@ -13,6 +13,7 @@ export interface MockCallOptions {
   sessionId?: string;
   model?: string;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   allowedTools?: string[];
   /** Native structured-output schema requested by the caller. */
   outputSchema?: Record<string, unknown>;

--- a/src/infra/opencode/attempt-runner.ts
+++ b/src/infra/opencode/attempt-runner.ts
@@ -69,6 +69,7 @@ import {
 } from './unavailable-tool-recovery.js';
 import { createOpenCodeSessionLifecycle } from './session-lifecycle.js';
 import type { OpenCodeSessionLifecycle } from './session-lifecycle.js';
+import { AGENT_FAILURE_CATEGORIES } from '../../shared/types/agent-failure.js';
 import { buildRateLimitedResponseFields, containsRateLimitError } from '../rate-limit/detection.js';
 import {
   createSensitiveTextStreamRedactor,
@@ -796,6 +797,7 @@ export class OpenCodeAttemptRunner {
     const provisionalKey = `provisional-${nextProvisionalId++}`;
     try {
       for (let attempt = 1; attempt <= callState.maxAttempts; attempt++) {
+        guardedOptions.onActivity?.({ kind: 'attempt_started' });
         const result = await this.runAttempt(
           agentType,
           prompt,
@@ -931,6 +933,9 @@ export class OpenCodeAttemptRunner {
       error: errorMessage,
       timestamp: new Date(),
       sessionId,
+      ...(abortCause === 'deadline'
+        ? { failureCategory: AGENT_FAILURE_CATEGORIES.PART_TIMEOUT }
+        : {}),
     };
   };
 
@@ -2093,6 +2098,9 @@ export class OpenCodeAttemptRunner {
       error: sanitizedErrorMessage,
       timestamp: new Date(),
       sessionId,
+      ...(abortCause === 'deadline'
+        ? { failureCategory: AGENT_FAILURE_CATEGORIES.PART_TIMEOUT }
+        : {}),
     };
   } finally {
     guardSuite.stopAttempt();

--- a/src/infra/opencode/attempt-runner.ts
+++ b/src/infra/opencode/attempt-runner.ts
@@ -982,6 +982,13 @@ export class OpenCodeAttemptRunner {
     throw new Error(failure?.verdict.reason ?? OPENCODE_STREAM_ABORTED_MESSAGE);
   };
 
+  guardSuite.startAttempt((failure) => {
+    timeoutMessage = failure.verdict.reason;
+    log.warn(failure.verdict.reason, { sessionId, model: options.model });
+    abortCause = 'timeout';
+    streamAbortController.abort(new Error(failure.verdict.reason));
+  });
+
   let attemptResult: AgentResponse | typeof RETRY_ATTEMPT;
   try {
     attemptResult = await (async (): Promise<AgentResponse | typeof RETRY_ATTEMPT> => {
@@ -1095,12 +1102,6 @@ export class OpenCodeAttemptRunner {
       { signal: streamAbortController.signal },
     );
     throwIfCallAborted();
-    guardSuite.startAttempt((failure) => {
-      timeoutMessage = failure.verdict.reason;
-      log.warn(failure.verdict.reason, { sessionId, model: options.model });
-      abortCause = 'timeout';
-      streamAbortController.abort(new Error(failure.verdict.reason));
-    });
     diag.onConnected();
     if (appliedPermissionRuleset) {
       emitPermissionSummary(options.onStream, {

--- a/src/infra/opencode/attempt-runner.ts
+++ b/src/infra/opencode/attempt-runner.ts
@@ -983,6 +983,7 @@ export class OpenCodeAttemptRunner {
   };
 
   guardSuite.startAttempt((failure) => {
+    if (streamAbortController.signal.aborted) return;
     timeoutMessage = failure.verdict.reason;
     log.warn(failure.verdict.reason, { sessionId, model: options.model });
     abortCause = 'timeout';

--- a/src/infra/opencode/guards/registry.ts
+++ b/src/infra/opencode/guards/registry.ts
@@ -7,7 +7,7 @@ import {
   TextVolumeGuard,
   TrackedIdsGuard,
 } from './resource-guards.js';
-import { WallClockGuard } from './time-guards.js';
+import { InactivityTimeoutGuard } from './time-guards.js';
 import type { OpenCodeGuardDescriptor } from './types.js';
 
 export const OPENCODE_GUARD_REGISTRY: readonly OpenCodeGuardDescriptor[] = Object.freeze([
@@ -21,7 +21,7 @@ export const OPENCODE_GUARD_REGISTRY: readonly OpenCodeGuardDescriptor[] = Objec
     mandatory: true,
     create: (_policy, context) => new SensitiveBudgetGuard(context.sensitiveValues),
   },
-  { id: 'wall-clock', layer: 'time', mandatory: true, create: (policy) => new WallClockGuard(policy.callTimeoutMs) },
+  { id: 'inactivity-timeout', layer: 'time', mandatory: true, create: (policy) => new InactivityTimeoutGuard(policy.callTimeoutMs) },
   { id: 'exact-loop', layer: 'integrity', mandatory: true, create: (policy) => new ExactLoopGuard(policy) },
   { id: 'consecutive-errors', layer: 'heuristic', mandatory: false, create: (policy) => new ConsecutiveErrorsGuard(policy) },
   { id: 'cycle-budget', layer: 'heuristic', mandatory: false, create: (policy) => new CycleBudgetGuard(policy.messageCycleBudget) },

--- a/src/infra/opencode/guards/time-guards.ts
+++ b/src/infra/opencode/guards/time-guards.ts
@@ -5,40 +5,112 @@ import {
   readOpenCodeToolPart,
 } from './tool-events.js';
 import type { OpenCodeGuard, OpenCodeGuardLifecycleScope, OpenCodeGuardVerdict } from './types.js';
+import { createPartTimeoutReason } from '../../../shared/types/agent-failure.js';
+import { STALE_IN_FLIGHT_TOOL_FACTOR } from '../../../shared/types/provider-deadline.js';
+
+export { STALE_IN_FLIGHT_TOOL_FACTOR } from '../../../shared/types/provider-deadline.js';
 
 export function describeOpenCodeIdleTimeout(timeoutMs: number): string {
   return `OpenCode stream timed out after ${Math.round(timeoutMs / 60000)} minutes of inactivity`;
 }
 
-// カスタムの認証済み transport が idle watchdog を明示的に登録する場合に、
-// ツール結果イベントの取りこぼしで in-flight が残り続ける状態を有界にする倍率。
-// 既定 registry には IdleTimeoutGuard を登録せず、通常の OpenCode 呼び出しでは
-// 親ステップの wall-clock deadline のみを安全装置として使う。
-const STALE_IN_FLIGHT_TOOL_FACTOR = 6;
+// 正当な長時間 tool を通常の無応答として切らず、終端イベント欠落だけを
+// 有界にする。既存の call timeout を基準にすることで、別設定の解決経路を増やさない。
+class InFlightToolTracker {
+  readonly #startedAtByKey = new Map<string, number>();
 
-export class WallClockGuard implements OpenCodeGuard {
-  readonly id = 'wall-clock';
+  observe(event: OpenCodeStreamEvent): void {
+    const toolPart = readOpenCodeToolPart(event);
+    if (toolPart === undefined) return;
+    const key = openCodeToolCallKey(toolPart);
+    if (isOpenCodeToolTerminal(toolPart)) {
+      this.#startedAtByKey.delete(key);
+      return;
+    }
+    if (!this.#startedAtByKey.has(key)) {
+      this.#startedAtByKey.set(key, Date.now());
+    }
+  }
+
+  clear(): void {
+    this.#startedAtByKey.clear();
+  }
+
+  earliestStaleDeadline(staleAfterMs: number): number | undefined {
+    if (this.#startedAtByKey.size === 0) return undefined;
+    return Math.min(...this.#startedAtByKey.values()) + staleAfterMs;
+  }
+
+  pruneStale(staleAfterMs: number): void {
+    const staleBefore = Date.now() - staleAfterMs;
+    for (const [key, startedAt] of this.#startedAtByKey) {
+      if (startedAt <= staleBefore) this.#startedAtByKey.delete(key);
+    }
+  }
+}
+
+export class InactivityTimeoutGuard implements OpenCodeGuard {
+  readonly id = 'inactivity-timeout';
   readonly layer = 'time' as const;
   private timeoutId: ReturnType<typeof setTimeout> | undefined;
+  private onVerdict: ((verdict: OpenCodeGuardVerdict) => void) | undefined;
+  private readonly inFlightTools = new InFlightToolTracker();
+  private readonly staleAfterMs: number;
 
-  constructor(private readonly timeoutMs: number) {}
+  constructor(private readonly timeoutMs: number) {
+    this.staleAfterMs = timeoutMs * STALE_IN_FLIGHT_TOOL_FACTOR;
+  }
 
   start(scope: OpenCodeGuardLifecycleScope, onVerdict: (verdict: OpenCodeGuardVerdict) => void): void {
-    if (scope !== 'call') return;
-    this.stop('call');
-    const timeoutId = setTimeout(() => {
-      onVerdict({
-        action: 'fail',
-        reason: `OpenCode call wall-clock timeout exceeded (${this.timeoutMs} ms)`,
-        abortKind: 'deadline',
-      });
-    }, this.timeoutMs);
-    timeoutId.unref();
-    this.timeoutId = timeoutId;
+    if (scope === 'call') {
+      this.onVerdict = onVerdict;
+    } else {
+      this.inFlightTools.clear();
+    }
+    if (this.onVerdict === undefined) return;
+    this.arm();
+  }
+
+  onEvent(event: OpenCodeStreamEvent): OpenCodeGuardVerdict | undefined {
+    this.inFlightTools.observe(event);
+    this.arm();
+    return undefined;
   }
 
   stop(scope: OpenCodeGuardLifecycleScope): void {
-    if (scope !== 'call' || this.timeoutId === undefined) return;
+    if (scope !== 'call') return;
+    this.disarm();
+    this.inFlightTools.clear();
+    this.onVerdict = undefined;
+  }
+
+  private arm(): void {
+    this.disarm();
+    const staleDeadline = this.inFlightTools.earliestStaleDeadline(this.staleAfterMs);
+    this.timeoutId = staleDeadline === undefined
+      ? this.schedule(() => this.fail(), this.timeoutMs)
+      : this.schedule(() => {
+          this.inFlightTools.pruneStale(this.staleAfterMs);
+          this.fail();
+        }, staleDeadline - Date.now());
+  }
+
+  private fail(): void {
+    this.onVerdict?.({
+      action: 'fail',
+      reason: createPartTimeoutReason(this.timeoutMs),
+      abortKind: 'deadline',
+    });
+  }
+
+  private schedule(handler: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+    const timeoutId = setTimeout(handler, Math.max(delayMs, 0));
+    timeoutId.unref();
+    return timeoutId;
+  }
+
+  private disarm(): void {
+    if (this.timeoutId === undefined) return;
     clearTimeout(this.timeoutId);
     this.timeoutId = undefined;
   }
@@ -49,8 +121,7 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
   readonly layer = 'time' as const;
   private timeoutId: ReturnType<typeof setTimeout> | undefined;
   private onVerdict: ((verdict: OpenCodeGuardVerdict) => void) | undefined;
-  /** in-flight のツール呼び出しキー → 登録時刻。時刻は stale 判定にだけ使う。 */
-  private readonly inFlightToolCalls = new Map<string, number>();
+  private readonly inFlightTools = new InFlightToolTracker();
   private readonly staleAfterMs: number;
 
   constructor(private readonly timeoutMs: number) {
@@ -59,13 +130,13 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
 
   start(scope: OpenCodeGuardLifecycleScope, onVerdict: (verdict: OpenCodeGuardVerdict) => void): void {
     if (scope !== 'attempt') return;
-    this.inFlightToolCalls.clear();
+    this.inFlightTools.clear();
     this.onVerdict = onVerdict;
     this.arm();
   }
 
   onEvent(event: OpenCodeStreamEvent): OpenCodeGuardVerdict | undefined {
-    this.trackToolFlight(event);
+    this.inFlightTools.observe(event);
     this.arm();
     return undefined;
   }
@@ -73,20 +144,8 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
   stop(scope: OpenCodeGuardLifecycleScope): void {
     if (scope !== 'attempt') return;
     this.disarm();
-    this.inFlightToolCalls.clear();
+    this.inFlightTools.clear();
     this.onVerdict = undefined;
-  }
-
-  private trackToolFlight(event: OpenCodeStreamEvent): void {
-    const toolPart = readOpenCodeToolPart(event);
-    if (toolPart === undefined) return;
-    const key = openCodeToolCallKey(toolPart);
-    if (isOpenCodeToolTerminal(toolPart)) {
-      this.inFlightToolCalls.delete(key);
-      return;
-    }
-    if (this.inFlightToolCalls.has(key)) return;
-    this.inFlightToolCalls.set(key, Date.now());
   }
 
   private arm(): void {
@@ -102,7 +161,7 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
       // 続くと arm() も呼ばれないので、stale 期限にタイマーを置いて自力で
       // 除去し、劣化を有界にする（永久停止させない）。
       this.timeoutId = this.schedule(() => {
-        this.pruneStaleToolCalls();
+        this.inFlightTools.pruneStale(this.staleAfterMs);
         this.arm();
       }, staleDeadline - Date.now());
       return;
@@ -116,15 +175,7 @@ export class IdleTimeoutGuard implements OpenCodeGuard {
   }
 
   private earliestStaleDeadline(): number | undefined {
-    if (this.inFlightToolCalls.size === 0) return undefined;
-    return Math.min(...this.inFlightToolCalls.values()) + this.staleAfterMs;
-  }
-
-  private pruneStaleToolCalls(): void {
-    const staleBefore = Date.now() - this.staleAfterMs;
-    for (const [key, registeredAt] of this.inFlightToolCalls) {
-      if (registeredAt <= staleBefore) this.inFlightToolCalls.delete(key);
-    }
+    return this.inFlightTools.earliestStaleDeadline(this.staleAfterMs);
   }
 
   private schedule(handler: () => void, delayMs: number): ReturnType<typeof setTimeout> {

--- a/src/infra/opencode/types.ts
+++ b/src/infra/opencode/types.ts
@@ -4,7 +4,7 @@
 
 import type { AskUserQuestionHandler } from '../../core/workflow/types.js';
 import type { Language, OpenCodeGuardOptions, PermissionMode } from '../../core/models/index.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 import { mapsToOpenCodeEditPermission } from './allowedTools.js';
 
 /** OpenCode permission reply values */
@@ -436,6 +436,7 @@ export interface OpenCodeCallOptions {
   /** Guard feature switches from provider_options.opencode.guards. */
   guards?: OpenCodeGuardOptions;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   onAskUserQuestion?: AskUserQuestionHandler;
   opencodeApiKey?: string;
   interactionTimeoutMs?: number;

--- a/src/infra/pi/client.ts
+++ b/src/infra/pi/client.ts
@@ -1041,6 +1041,7 @@ export async function callPi(
         const imagePrompt = options.imageAttachments && options.imageAttachments.length > 0
           ? `${prompt}\n\n${options.imageAttachments.map((attachment) => attachment.placeholder).join('\n')}`
           : prompt;
+        options.onActivity?.({ kind: 'attempt_started' });
         const promptPromise = session.prompt(
           imagePrompt,
           images.length > 0 ? { images } : undefined,

--- a/src/infra/pi/types.ts
+++ b/src/infra/pi/types.ts
@@ -1,7 +1,7 @@
 import type { PermissionMode } from '../../core/models/index.js';
 import type { PiProviderOptions } from '../../core/models/workflow-provider-options.js';
 import type { ProviderImageAttachment } from '../providers/types.js';
-import type { StreamCallback } from '../../shared/types/provider.js';
+import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
 /** Options for one Pi SDK session. */
 export interface PiCallOptions {
@@ -15,5 +15,6 @@ export interface PiCallOptions {
   imageAttachments?: ProviderImageAttachment[];
   providerOptions?: PiProviderOptions;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   childProcessEnv?: Readonly<Record<string, string>>;
 }

--- a/src/infra/providers/claude-headless.ts
+++ b/src/infra/providers/claude-headless.ts
@@ -32,6 +32,7 @@ function toHeadlessOptions(options: ProviderCallOptions): ClaudeHeadlessCallOpti
     bypassPermissions: options.bypassPermissions,
     sandbox: claudeOptions?.sandbox,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     claudeCliPath: resolveClaudeCliPath() ?? undefined,
     outputSchema: options.outputSchema,
     childProcessEnv: options.childProcessEnv,

--- a/src/infra/providers/claude-terminal.ts
+++ b/src/infra/providers/claude-terminal.ts
@@ -71,6 +71,7 @@ function toTerminalOptions(options: ProviderCallOptions): ClaudeTerminalCallOpti
     keepSession: terminalOptions?.keepSession,
     transcriptPollIntervalMs: terminalOptions?.transcriptPollIntervalMs,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     onPermissionRequest: options.onPermissionRequest,
     onAskUserQuestion: options.onAskUserQuestion,
     outputSchema: options.outputSchema,

--- a/src/infra/providers/claude.ts
+++ b/src/infra/providers/claude.ts
@@ -30,6 +30,7 @@ function toClaudeOptions(options: ProviderCallOptions): ClaudeCallOptions {
     maxTurns: options.maxTurns,
     permissionMode: options.permissionMode,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     onPermissionRequest: options.onPermissionRequest,
     onAskUserQuestion: options.onAskUserQuestion,
     bypassPermissions: options.bypassPermissions,

--- a/src/infra/providers/codex.ts
+++ b/src/infra/providers/codex.ts
@@ -27,6 +27,7 @@ function toCodexOptions(options: ProviderCallOptions): CodexCallOptions {
     permissionMode: options.permissionMode,
     networkAccess: options.providerOptions?.codex?.networkAccess,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     openaiApiKey: options.openaiApiKey ?? resolveOpenaiApiKey(),
     baseUrl: options.providerOptions?.codex?.baseUrl,
     skills: options.internalAgentIsolation === 'strict-readonly'

--- a/src/infra/providers/copilot.ts
+++ b/src/infra/providers/copilot.ts
@@ -32,6 +32,7 @@ function toCopilotOptions(options: ProviderCallOptions): CopilotCallOptions {
     effort: options.providerOptions?.copilot?.effort,
     permissionMode: options.permissionMode,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     copilotGithubToken: options.copilotGithubToken ?? resolveCopilotGithubToken(),
     copilotCliPath: resolveCopilotCliPath(),
     childProcessEnv: options.childProcessEnv,

--- a/src/infra/providers/cursor.ts
+++ b/src/infra/providers/cursor.ts
@@ -31,6 +31,7 @@ function toCursorOptions(options: ProviderCallOptions): CursorCallOptions {
     model: options.model,
     permissionMode: options.permissionMode,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     cursorApiKey: options.cursorApiKey ?? resolveCursorApiKey(),
     cursorCliPath: resolveCursorCliPath(),
     childProcessEnv: options.childProcessEnv,

--- a/src/infra/providers/kiro.ts
+++ b/src/infra/providers/kiro.ts
@@ -31,6 +31,7 @@ function toKiroOptions(options: ProviderCallOptions, systemPrompt?: string): Kir
     systemPrompt,
     permissionMode: options.permissionMode,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     kiroApiKey: options.kiroApiKey ?? resolveKiroApiKey(),
     kiroCliPath: resolveKiroCliPath(),
     agent: options.providerOptions?.kiro?.agent,

--- a/src/infra/providers/mock.ts
+++ b/src/infra/providers/mock.ts
@@ -27,6 +27,7 @@ function toMockOptions(options: ProviderCallOptions): MockCallOptions {
     sessionId: options.sessionId,
     model: options.model,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     allowedTools: options.allowedTools,
     outputSchema: options.outputSchema,
   };

--- a/src/infra/providers/opencode.ts
+++ b/src/infra/providers/opencode.ts
@@ -67,6 +67,7 @@ function toOpenCodeOptions(options: ProviderCallOptions): OpenCodeCallOptions {
     variant: options.providerOptions?.opencode?.variant,
     guards: options.providerOptions?.opencode?.guards,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     onAskUserQuestion: options.onAskUserQuestion,
     opencodeApiKey: options.opencodeApiKey ?? resolveOpencodeApiKey(),
     childProcessEnv: options.childProcessEnv,

--- a/src/infra/providers/pi.ts
+++ b/src/infra/providers/pi.ts
@@ -43,6 +43,7 @@ function toPiOptions(options: ProviderCallOptions, systemPrompt?: string): PiCal
     imageAttachments: options.imageAttachments,
     providerOptions: options.providerOptions?.pi,
     onStream: options.onStream,
+    onActivity: options.onActivity,
     childProcessEnv: options.childProcessEnv,
   };
 }

--- a/src/infra/providers/types.ts
+++ b/src/infra/providers/types.ts
@@ -1,6 +1,10 @@
 import type { AgentResponse, Language, PermissionMode, McpServerConfig, StepProviderOptions } from '../../core/models/index.js';
 import type { ProviderType as SharedProviderType } from '../../shared/types/provider.js';
-import type { InternalAgentIsolation, StreamCallback } from '../../shared/types/provider.js';
+import type {
+  InternalAgentIsolation,
+  ProviderActivityCallback,
+  StreamCallback,
+} from '../../shared/types/provider.js';
 import type { PermissionHandler, AskUserQuestionHandler } from '../../core/workflow/types.js';
 
 export interface AgentSetup {
@@ -25,6 +29,7 @@ export interface ProviderCallOptions {
   permissionMode?: PermissionMode;
   providerOptions?: StepProviderOptions;
   onStream?: StreamCallback;
+  onActivity?: ProviderActivityCallback;
   onPermissionRequest?: PermissionHandler;
   onAskUserQuestion?: AskUserQuestionHandler;
   bypassPermissions?: boolean;

--- a/src/shared/types/provider-deadline.ts
+++ b/src/shared/types/provider-deadline.ts
@@ -1,6 +1,7 @@
 export const PROVIDER_CALL_TIMEOUT_MIN_MS = 60_000;
 export const PROVIDER_CALL_TIMEOUT_MAX_MS = 86_400_000;
 export const PROVIDER_CALL_TIMEOUT_DEFAULT_MS = 3_600_000;
+export const STALE_IN_FLIGHT_TOOL_FACTOR = 6;
 
 export function resolveProviderCallTimeoutMs(configured: number | undefined): number {
   const timeoutMs = configured ?? PROVIDER_CALL_TIMEOUT_DEFAULT_MS;

--- a/src/shared/types/provider.ts
+++ b/src/shared/types/provider.ts
@@ -128,3 +128,18 @@ export type StreamEvent =
   | { type: 'error'; data: StreamErrorEventData };
 
 export type StreamCallback = (event: StreamEvent) => void;
+
+export type ProviderActivityEvent =
+  | { readonly kind: 'attempt_started'; readonly executionUnitKey?: string }
+  | {
+    readonly kind: 'tool_started';
+    readonly executionUnitKey: string;
+    readonly toolCallKey: string;
+  }
+  | {
+    readonly kind: 'tool_finished';
+    readonly executionUnitKey: string;
+    readonly toolCallKey: string;
+  };
+
+export type ProviderActivityCallback = (event?: ProviderActivityEvent) => void;


### PR DESCRIPTION
## 背景

run 20260814-090848 のレビュー5周目で、coding-review が completion_retry の再走査を積み上げた結果、応答し続けているのに累積1時間の part deadline で打ち切られた（開始からちょうど 3600000ms で発火、以降の試行は即死）。

## 修正

- deadline を「最後の活動からの経過時間」で計測。プロバイダイベント・フェーズ遷移・再試行開始でリセットし、完全無応答のときだけ発火
- 実行中ツールの間は通常判定を停止し、stale 上限（call_timeout_ms の6倍、共有定数）だけを適用
- onActivity を全プロバイダ（claude/claude-sdk/codex/cursor/opencode 等）と全内部 agent（dynamic selector、completion_retry judge、Team Leader decomposition/more-parts、Companion、LoopMonitor judge、promotion judge、auto-routing estimator、ai_judge fallback）へ伝搬。型情報付き AST 列挙で未伝搬ゼロを確認
- PART_TIMEOUT の分類・リトライ経路は現行維持。設定の意味変更をドキュメントへ反映

## 検証

敵対レビュー5ラウンド（20ms 誤発火・tool 中の親先行発火・内部 agent 伝搬漏れ等を実行反証→解消、最終 APPROVE）。npm test / test:it / lint / build 成功。

関連: #1357 の3分割の1（他: requeue 採番継続、parallel error 受けルール）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * プロバイダーのタイムアウトを、呼び出し全体の制限から無応答時間ベースへ変更しました。
  * ストリーム出力、ツール操作、フェーズ完了、再試行開始などの活動でタイマーが更新されます。
  * 活動が継続している処理は、従来より長時間実行できるようになりました。
  * OpenCodeではツール実行中の誤ったタイムアウトを抑制し、終端イベント欠落時は適切にタイムアウト終了します。

* **ドキュメント**
  * 新しいタイムアウト仕様に合わせて設定ガイドを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->