### PR TITLE
fix(engine): requeue 時の step 出現番号を継承成果物の続きから採番する

### DIFF
--- a/scripts/test-classification.mjs
+++ b/scripts/test-classification.mjs
@@ -54,6 +54,7 @@ const legacyParallelIntegrationTestFiles = Object.freeze([
   'src/__tests__/workflow-call-lifecycle.test.ts',
   'src/__tests__/workflow-engine-single-iteration-span.test.ts',
   'src/__tests__/workflow-promotion-engine.test.ts',
+  'src/__tests__/workflow-resume-continuation-engine.test.ts',
   'src/__tests__/workflow-step-fragment-contracts.test.ts',
   'src/__tests__/workflow-step-fragment-provenance.test.ts',
   'src/__tests__/workflow-step-fragment-provider-provenance.test.ts',

--- a/src/__tests__/workflow-resume-continuation-engine.test.ts
+++ b/src/__tests__/workflow-resume-continuation-engine.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const { mockWorkflowEngineWarn } = vi.hoisted(() => ({
+  mockWorkflowEngineWarn: vi.fn(),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../shared/utils/index.js')>();
+  return {
+    ...original,
+    createLogger: (name: string) => {
+      const logger = original.createLogger(name);
+      return name === 'workflow-engine'
+        ? { ...logger, warn: mockWorkflowEngineWarn }
+        : logger;
+    },
+  };
+});
+
+import type { WorkflowConfig } from '../core/models/index.js';
+import type { WorkflowSharedRuntimeState } from '../core/workflow/types.js';
+import { WorkflowEngine } from '../core/workflow/engine/WorkflowEngine.js';
+import { RESUME_ARTIFACTS_FILE_NAME } from '../core/workflow/run/resume-report-snapshot.js';
+import { ResumeArtifactOccurrenceIndex } from '../core/workflow/run/resume-artifact-occurrence-index.js';
+import { makeRule, makeStep } from './test-helpers.js';
+
+const testDirectories: string[] = [];
+
+function engineWorkflow(): WorkflowConfig {
+  return {
+    name: 'resume-index-engine-test',
+    initialStep: 'work',
+    maxSteps: 2,
+    steps: [makeStep({
+      name: 'work',
+      rules: [makeRule('done', 'COMPLETE')],
+    })],
+  };
+}
+
+function createEngineCwd(): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'takt-resume-index-engine-'));
+  testDirectories.push(cwd);
+  return cwd;
+}
+
+function constructEngine(
+  cwd: string,
+  resumeMode: 'retry' | 'requeue',
+  sharedRuntime: WorkflowSharedRuntimeState,
+): void {
+  new WorkflowEngine(engineWorkflow(), cwd, 'test task', {
+    projectCwd: cwd,
+    reportDirName: 'target-run',
+    resumeSource: { sourceRunSlug: 'source-run', resumeMode },
+    sharedRuntime,
+  });
+}
+
+afterEach(() => {
+  mockWorkflowEngineWarn.mockClear();
+  for (const directory of testDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('WorkflowEngine resume occurrence index gate', () => {
+  it('通常 resume では artifact occurrence index を作らない', () => {
+    const sharedRuntime: WorkflowSharedRuntimeState = { startedAtMs: Date.now() };
+
+    constructEngine(createEngineCwd(), 'retry', sharedRuntime);
+
+    expect(sharedRuntime.resumeArtifactOccurrenceIndex).toBeUndefined();
+  });
+
+  it('requeue では artifact occurrence index を作る', () => {
+    const sharedRuntime: WorkflowSharedRuntimeState = { startedAtMs: Date.now() };
+
+    constructEngine(createEngineCwd(), 'requeue', sharedRuntime);
+
+    expect(sharedRuntime.resumeArtifactOccurrenceIndex).toBeInstanceOf(
+      ResumeArtifactOccurrenceIndex,
+    );
+  });
+
+  it('manifest があるのに source resume point を取得できなければ警告する', () => {
+    const cwd = createEngineCwd();
+    const reportsDir = join(cwd, '.takt', 'runs', 'target-run', 'reports');
+    mkdirSync(reportsDir, { recursive: true });
+    writeFileSync(
+      join(reportsDir, RESUME_ARTIFACTS_FILE_NAME),
+      JSON.stringify({
+        version: 1,
+        sourceRunSlug: 'source-run',
+        targetRunSlug: 'target-run',
+        createdAt: new Date(0).toISOString(),
+        files: [],
+      }),
+      'utf-8',
+    );
+
+    constructEngine(cwd, 'requeue', { startedAtMs: Date.now() });
+
+    expect(mockWorkflowEngineWarn).toHaveBeenCalledWith(
+      'Requeue artifact occurrence restoration is unavailable because source run metadata or resume point is missing',
+      { sourceRunSlug: 'source-run' },
+    );
+  });
+});

--- a/src/__tests__/workflow-resume-continuation.test.ts
+++ b/src/__tests__/workflow-resume-continuation.test.ts
@@ -72,6 +72,33 @@ function sourceResumePoint(records: readonly ReturnType<typeof invocationRecord>
 }
 
 describe('WorkflowResumeContinuation', () => {
+  it('通常実行の nested workflow_call namespace を祖先 invocation ごとに分離する', () => {
+    const parent = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const grandchild = { name: 'grandchild', steps: [] } as unknown as WorkflowConfig;
+    const firstParentCall = buildWorkflowResumePointEntry(
+      parent,
+      'delegate',
+      'workflow_call',
+      1,
+      undefined,
+      1,
+    );
+    const secondParentCall = buildWorkflowResumePointEntry(
+      parent,
+      'delegate',
+      'workflow_call',
+      2,
+      undefined,
+      2,
+    );
+
+    const first = invocationRecord(child, 'nested', grandchild, [firstParentCall], 1);
+    const second = invocationRecord(child, 'nested', grandchild, [secondParentCall], 1);
+
+    expect(first.namespace).not.toBe(second.namespace);
+  });
+
   it('requeue で継承した workflow_call 成果物の最大 occurrence の続きから採番する', () => {
     const workflow = {
       name: 'parent',

--- a/src/__tests__/workflow-resume-continuation.test.ts
+++ b/src/__tests__/workflow-resume-continuation.test.ts
@@ -1,43 +1,18 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
-const { mockWorkflowEngineWarn } = vi.hoisted(() => ({
-  mockWorkflowEngineWarn: vi.fn(),
-}));
-
-vi.mock('../shared/utils/index.js', async (importOriginal) => {
-  const original = await importOriginal<typeof import('../shared/utils/index.js')>();
-  return {
-    ...original,
-    createLogger: (name: string) => {
-      const logger = original.createLogger(name);
-      return name === 'workflow-engine'
-        ? { ...logger, warn: mockWorkflowEngineWarn }
-        : logger;
-    },
-  };
-});
+import { describe, expect, it } from 'vitest';
 
 import type {
   WorkflowConfig,
   WorkflowResumePoint,
   WorkflowState,
 } from '../core/models/index.js';
-import type { WorkflowSharedRuntimeState } from '../core/workflow/types.js';
-import { WorkflowEngine } from '../core/workflow/engine/WorkflowEngine.js';
 import { WorkflowResumeContinuation } from '../core/workflow/engine/workflow-resume-continuation.js';
 import { buildScopedStepIterationIdentity } from '../core/workflow/step-iteration-identity.js';
 import { buildWorkflowResumePointEntry } from '../core/workflow/workflow-reference.js';
-import { RESUME_ARTIFACTS_FILE_NAME } from '../core/workflow/run/resume-report-snapshot.js';
 import { ResumeArtifactOccurrenceIndex } from '../core/workflow/run/resume-artifact-occurrence-index.js';
 import { buildWorkflowCallInvocationIdentity } from '../core/workflow/workflow-call-invocation-index.js';
 import { buildWorkflowCallSiteIdentity } from '../core/workflow/workflow-call-site-identity.js';
-import { makeRule, makeStep } from './test-helpers.js';
 
 const ARTIFACT_HASH = '0'.repeat(64);
-const testDirectories: string[] = [];
 
 function invocationRecord(
   workflow: WorkflowConfig,
@@ -95,83 +70,6 @@ function sourceResumePoint(records: readonly ReturnType<typeof invocationRecord>
     workflow_step_participations: {},
   };
 }
-
-function engineWorkflow(): WorkflowConfig {
-  return {
-    name: 'resume-index-engine-test',
-    initialStep: 'work',
-    maxSteps: 2,
-    steps: [makeStep({
-      name: 'work',
-      rules: [makeRule('done', 'COMPLETE')],
-    })],
-  };
-}
-
-function createEngineCwd(): string {
-  const cwd = mkdtempSync(join(tmpdir(), 'takt-resume-index-engine-'));
-  testDirectories.push(cwd);
-  return cwd;
-}
-
-function constructEngine(
-  cwd: string,
-  resumeMode: 'retry' | 'requeue',
-  sharedRuntime: WorkflowSharedRuntimeState,
-): void {
-  new WorkflowEngine(engineWorkflow(), cwd, 'test task', {
-    projectCwd: cwd,
-    reportDirName: 'target-run',
-    resumeSource: { sourceRunSlug: 'source-run', resumeMode },
-    sharedRuntime,
-  });
-}
-
-afterEach(() => {
-  mockWorkflowEngineWarn.mockClear();
-  for (const directory of testDirectories.splice(0)) {
-    rmSync(directory, { recursive: true, force: true });
-  }
-});
-
-describe('WorkflowEngine resume occurrence index gate', () => {
-  it('通常 resume では artifact occurrence index を作らない', () => {
-    const sharedRuntime: WorkflowSharedRuntimeState = { startedAtMs: Date.now() };
-
-    constructEngine(createEngineCwd(), 'retry', sharedRuntime);
-
-    expect(sharedRuntime.resumeArtifactOccurrenceIndex).toBeUndefined();
-  });
-
-  it('requeue では artifact occurrence index を作る', () => {
-    const sharedRuntime: WorkflowSharedRuntimeState = { startedAtMs: Date.now() };
-
-    constructEngine(createEngineCwd(), 'requeue', sharedRuntime);
-
-    expect(sharedRuntime.resumeArtifactOccurrenceIndex).toBeInstanceOf(
-      ResumeArtifactOccurrenceIndex,
-    );
-  });
-
-  it('manifest があるのに source resume point を取得できなければ警告する', () => {
-    const cwd = createEngineCwd();
-    const reportsDir = join(cwd, '.takt', 'runs', 'target-run', 'reports');
-    const manifest = artifactManifest([]);
-    mkdirSync(reportsDir, { recursive: true });
-    writeFileSync(
-      join(reportsDir, RESUME_ARTIFACTS_FILE_NAME),
-      JSON.stringify(manifest),
-      'utf-8',
-    );
-
-    constructEngine(cwd, 'requeue', { startedAtMs: Date.now() });
-
-    expect(mockWorkflowEngineWarn).toHaveBeenCalledWith(
-      'Requeue artifact occurrence restoration is unavailable because source run metadata or resume point is missing',
-      { sourceRunSlug: 'source-run' },
-    );
-  });
-});
 
 describe('WorkflowResumeContinuation', () => {
   it('requeue で継承した workflow_call 成果物の最大 occurrence の続きから採番する', () => {

--- a/src/__tests__/workflow-resume-continuation.test.ts
+++ b/src/__tests__/workflow-resume-continuation.test.ts
@@ -1,17 +1,43 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const { mockWorkflowEngineWarn } = vi.hoisted(() => ({
+  mockWorkflowEngineWarn: vi.fn(),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../shared/utils/index.js')>();
+  return {
+    ...original,
+    createLogger: (name: string) => {
+      const logger = original.createLogger(name);
+      return name === 'workflow-engine'
+        ? { ...logger, warn: mockWorkflowEngineWarn }
+        : logger;
+    },
+  };
+});
+
 import type {
   WorkflowConfig,
   WorkflowResumePoint,
   WorkflowState,
 } from '../core/models/index.js';
+import type { WorkflowSharedRuntimeState } from '../core/workflow/types.js';
+import { WorkflowEngine } from '../core/workflow/engine/WorkflowEngine.js';
 import { WorkflowResumeContinuation } from '../core/workflow/engine/workflow-resume-continuation.js';
 import { buildScopedStepIterationIdentity } from '../core/workflow/step-iteration-identity.js';
 import { buildWorkflowResumePointEntry } from '../core/workflow/workflow-reference.js';
+import { RESUME_ARTIFACTS_FILE_NAME } from '../core/workflow/run/resume-report-snapshot.js';
 import { ResumeArtifactOccurrenceIndex } from '../core/workflow/run/resume-artifact-occurrence-index.js';
 import { buildWorkflowCallInvocationIdentity } from '../core/workflow/workflow-call-invocation-index.js';
 import { buildWorkflowCallSiteIdentity } from '../core/workflow/workflow-call-site-identity.js';
+import { makeRule, makeStep } from './test-helpers.js';
 
 const ARTIFACT_HASH = '0'.repeat(64);
+const testDirectories: string[] = [];
 
 function invocationRecord(
   workflow: WorkflowConfig,
@@ -34,6 +60,7 @@ function invocationRecord(
       stack: [...workflowCallPath, frame],
       childWorkflow,
     }).runPathSegment,
+    occurrence,
   };
 }
 
@@ -62,12 +89,89 @@ function sourceResumePoint(records: readonly ReturnType<typeof invocationRecord>
     iteration: 1,
     elapsed_ms: 0,
     workflow_call_invocations: Object.fromEntries(records.map((record) => [record.identity, {
-      call_instance: Number(/^iteration-(\d+)/.exec(record.namespace)?.[1]),
+      call_instance: record.occurrence,
       report_namespace_segment: record.namespace,
     }])),
     workflow_step_participations: {},
   };
 }
+
+function engineWorkflow(): WorkflowConfig {
+  return {
+    name: 'resume-index-engine-test',
+    initialStep: 'work',
+    maxSteps: 2,
+    steps: [makeStep({
+      name: 'work',
+      rules: [makeRule('done', 'COMPLETE')],
+    })],
+  };
+}
+
+function createEngineCwd(): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'takt-resume-index-engine-'));
+  testDirectories.push(cwd);
+  return cwd;
+}
+
+function constructEngine(
+  cwd: string,
+  resumeMode: 'retry' | 'requeue',
+  sharedRuntime: WorkflowSharedRuntimeState,
+): void {
+  new WorkflowEngine(engineWorkflow(), cwd, 'test task', {
+    projectCwd: cwd,
+    reportDirName: 'target-run',
+    resumeSource: { sourceRunSlug: 'source-run', resumeMode },
+    sharedRuntime,
+  });
+}
+
+afterEach(() => {
+  mockWorkflowEngineWarn.mockClear();
+  for (const directory of testDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('WorkflowEngine resume occurrence index gate', () => {
+  it('通常 resume では artifact occurrence index を作らない', () => {
+    const sharedRuntime: WorkflowSharedRuntimeState = { startedAtMs: Date.now() };
+
+    constructEngine(createEngineCwd(), 'retry', sharedRuntime);
+
+    expect(sharedRuntime.resumeArtifactOccurrenceIndex).toBeUndefined();
+  });
+
+  it('requeue では artifact occurrence index を作る', () => {
+    const sharedRuntime: WorkflowSharedRuntimeState = { startedAtMs: Date.now() };
+
+    constructEngine(createEngineCwd(), 'requeue', sharedRuntime);
+
+    expect(sharedRuntime.resumeArtifactOccurrenceIndex).toBeInstanceOf(
+      ResumeArtifactOccurrenceIndex,
+    );
+  });
+
+  it('manifest があるのに source resume point を取得できなければ警告する', () => {
+    const cwd = createEngineCwd();
+    const reportsDir = join(cwd, '.takt', 'runs', 'target-run', 'reports');
+    const manifest = artifactManifest([]);
+    mkdirSync(reportsDir, { recursive: true });
+    writeFileSync(
+      join(reportsDir, RESUME_ARTIFACTS_FILE_NAME),
+      JSON.stringify(manifest),
+      'utf-8',
+    );
+
+    constructEngine(cwd, 'requeue', { startedAtMs: Date.now() });
+
+    expect(mockWorkflowEngineWarn).toHaveBeenCalledWith(
+      'Requeue artifact occurrence restoration is unavailable because source run metadata or resume point is missing',
+      { sourceRunSlug: 'source-run' },
+    );
+  });
+});
 
 describe('WorkflowResumeContinuation', () => {
   it('requeue で継承した workflow_call 成果物の最大 occurrence の続きから採番する', () => {

--- a/src/__tests__/workflow-resume-continuation.test.ts
+++ b/src/__tests__/workflow-resume-continuation.test.ts
@@ -7,8 +7,266 @@ import type {
 import { WorkflowResumeContinuation } from '../core/workflow/engine/workflow-resume-continuation.js';
 import { buildScopedStepIterationIdentity } from '../core/workflow/step-iteration-identity.js';
 import { buildWorkflowResumePointEntry } from '../core/workflow/workflow-reference.js';
+import { ResumeArtifactOccurrenceIndex } from '../core/workflow/run/resume-artifact-occurrence-index.js';
+import { buildWorkflowCallInvocationIdentity } from '../core/workflow/workflow-call-invocation-index.js';
+import { buildWorkflowCallSiteIdentity } from '../core/workflow/workflow-call-site-identity.js';
+
+const ARTIFACT_HASH = '0'.repeat(64);
+
+function invocationRecord(
+  workflow: WorkflowConfig,
+  stepName: string,
+  childWorkflow: WorkflowConfig,
+  workflowCallPath: WorkflowResumePoint['stack'],
+  occurrence: number,
+) {
+  const frame = buildWorkflowResumePointEntry(
+    workflow,
+    stepName,
+    'workflow_call',
+    occurrence,
+    undefined,
+    occurrence,
+  );
+  return {
+    identity: buildWorkflowCallInvocationIdentity(workflow.name, stepName, workflowCallPath),
+    namespace: buildWorkflowCallSiteIdentity({
+      stack: [...workflowCallPath, frame],
+      childWorkflow,
+    }).runPathSegment,
+  };
+}
+
+function artifactManifest(namespaces: readonly string[]) {
+  return {
+    version: 1 as const,
+    sourceRunSlug: 'source-run',
+    targetRunSlug: 'target-run',
+    createdAt: new Date(0).toISOString(),
+    files: namespaces.map((namespace) => ({
+      path: `subworkflows/${namespace}/result.md`,
+      size: 1,
+      sha256: ARTIFACT_HASH,
+    })),
+  };
+}
+
+function withLegacyOccurrenceDigest(namespace: string, digestCharacter: string): string {
+  return namespace.replace(/--site-[a-f0-9]{64}$/, `--site-${digestCharacter.repeat(64)}`);
+}
+
+function sourceResumePoint(records: readonly ReturnType<typeof invocationRecord>[]): WorkflowResumePoint {
+  return {
+    version: 2,
+    stack: [],
+    iteration: 1,
+    elapsed_ms: 0,
+    workflow_call_invocations: Object.fromEntries(records.map((record) => [record.identity, {
+      call_instance: Number(/^iteration-(\d+)/.exec(record.namespace)?.[1]),
+      report_namespace_segment: record.namespace,
+    }])),
+    workflow_step_participations: {},
+  };
+}
 
 describe('WorkflowResumeContinuation', () => {
+  it('requeue で継承した workflow_call 成果物の最大 occurrence の続きから採番する', () => {
+    const workflow = {
+      name: 'parent',
+      initialStep: 'remediation',
+      maxSteps: 10,
+      steps: [{
+        name: 'remediation',
+        kind: 'workflow_call',
+        call: 'experimental-remediation',
+        rules: [],
+      }],
+    } as WorkflowConfig;
+    const state: WorkflowState = {
+      workflowName: workflow.name,
+      currentStep: 'remediation',
+      iteration: 1,
+      stepOutputs: new Map(),
+      structuredOutputs: new Map(),
+      systemContexts: new Map(),
+      effectResults: new Map(),
+      userInputs: [],
+      personaSessions: new Map(),
+      stepIterations: new Map(),
+      status: 'running',
+    };
+    const childWorkflow = {
+      name: 'experimental-remediation',
+      subworkflow: { callable: true },
+      initialStep: 'fix',
+      maxSteps: 10,
+      steps: [],
+    } as WorkflowConfig;
+    const records = [1, 2, 6].map((occurrence) => invocationRecord(
+      workflow,
+      'remediation',
+      childWorkflow,
+      [],
+      occurrence,
+    ));
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest(records.map((record) => record.namespace)),
+      sourceResumePoint([records.at(-1)!]),
+    );
+    const continuation = new WorkflowResumeContinuation(workflow, undefined, index);
+
+    expect(continuation.claimStepOccurrence({
+      step: workflow.steps[0]!,
+      resumeStackPrefix: [],
+      state,
+    })).toBe(7);
+    expect(continuation.claimStepOccurrence({
+      step: workflow.steps[0]!,
+      resumeStackPrefix: [],
+      state,
+    })).toBe(8);
+    expect(state.stepIterations.get('remediation')).toBe(8);
+  });
+
+  it('top-level と parallel 内の同名 workflow_call artifact を混同しない', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = {
+      name: 'parent',
+      initialStep: 'delegate',
+      maxSteps: 10,
+      steps: [{ name: 'delegate', kind: 'workflow_call', call: 'child', rules: [] }],
+    } as WorkflowConfig;
+    const parallelFrame = buildWorkflowResumePointEntry(workflow, 'reviewers', 'parallel', 4);
+    const top = invocationRecord(workflow, 'delegate', child, [], 5);
+    const nested = invocationRecord(workflow, 'delegate', child, [parallelFrame], 1);
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([top.namespace, nested.namespace]),
+      sourceResumePoint([top, nested]),
+    );
+
+    expect(index.getMaxOccurrence(workflow, 'delegate', [])).toBe(5);
+    expect(index.getMaxOccurrence(workflow, 'delegate', [parallelFrame])).toBe(1);
+  });
+
+  it('異なる parallel 親の同名 workflow_call artifact を混同しない', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const siteAFrame = buildWorkflowResumePointEntry(workflow, 'review-a', 'parallel', 3);
+    const siteBFrame = buildWorkflowResumePointEntry(workflow, 'review-b', 'parallel', 9);
+    const siteA = invocationRecord(workflow, 'delegate', child, [siteAFrame], 6);
+    const siteB = invocationRecord(workflow, 'delegate', child, [siteBFrame], 2);
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([siteA.namespace, siteB.namespace]),
+      sourceResumePoint([siteA, siteB]),
+    );
+
+    expect(index.getMaxOccurrence(workflow, 'delegate', [siteAFrame])).toBe(6);
+    expect(index.getMaxOccurrence(workflow, 'delegate', [siteBFrame])).toBe(2);
+  });
+
+  it('nested workflow_call artifact を祖先 call-site ごとに分離する', () => {
+    const parent = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const grandchild = { name: 'grandchild', steps: [] } as unknown as WorkflowConfig;
+    const outerA = buildWorkflowResumePointEntry(parent, 'outer-a', 'workflow_call', 2, undefined, 2);
+    const outerB = buildWorkflowResumePointEntry(parent, 'outer-b', 'workflow_call', 7, undefined, 7);
+    const nestedA = invocationRecord(child, 'delegate', grandchild, [outerA], 4);
+    const nestedB = invocationRecord(child, 'delegate', grandchild, [outerB], 1);
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([nestedA.namespace, nestedB.namespace]),
+      sourceResumePoint([nestedA, nestedB]),
+    );
+
+    expect(index.getMaxOccurrence(child, 'delegate', [outerA])).toBe(4);
+    expect(index.getMaxOccurrence(child, 'delegate', [outerB])).toBe(1);
+  });
+
+  it('partial manifest に artifact がない call-site の occurrence を進めない', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const siteAFrame = buildWorkflowResumePointEntry(workflow, 'review-a', 'parallel', 1);
+    const siteBFrame = buildWorkflowResumePointEntry(workflow, 'review-b', 'parallel', 1);
+    const siteA = invocationRecord(workflow, 'delegate', child, [siteAFrame], 6);
+    const siteB = invocationRecord(workflow, 'delegate', child, [siteBFrame], 2);
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([siteA.namespace]),
+      sourceResumePoint([siteA, siteB]),
+    );
+
+    expect(index.getMaxOccurrence(workflow, 'delegate', [siteAFrame])).toBe(6);
+    expect(index.getMaxOccurrence(workflow, 'delegate', [siteBFrame])).toBeUndefined();
+  });
+
+  it('旧 digest の最新 invocation に成果物がなくても一意な call-site の artifact を移行する', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const occurrence1 = invocationRecord(workflow, 'delegate', child, [], 1);
+    const occurrence2 = invocationRecord(workflow, 'delegate', child, [], 2);
+    const legacyOccurrence1 = {
+      ...occurrence1,
+      namespace: withLegacyOccurrenceDigest(occurrence1.namespace, '1'),
+    };
+    const legacyOccurrence2 = {
+      ...occurrence2,
+      namespace: withLegacyOccurrenceDigest(occurrence2.namespace, '2'),
+    };
+
+    const index = new ResumeArtifactOccurrenceIndex(
+      artifactManifest([legacyOccurrence1.namespace]),
+      sourceResumePoint([legacyOccurrence2]),
+    );
+
+    expect(index.getMaxOccurrence(workflow, 'delegate', [])).toBe(1);
+  });
+
+  it('旧 digest artifact の論理 call-site が複数候補なら明示的に停止する', () => {
+    const child = { name: 'child', steps: [] } as unknown as WorkflowConfig;
+    const workflow = { name: 'parent', steps: [] } as unknown as WorkflowConfig;
+    const siteAFrame = buildWorkflowResumePointEntry(workflow, 'review-a', 'parallel', 1);
+    const siteBFrame = buildWorkflowResumePointEntry(workflow, 'review-b', 'parallel', 1);
+    const siteAArtifact = invocationRecord(workflow, 'delegate', child, [siteAFrame], 1);
+    const siteALatest = invocationRecord(workflow, 'delegate', child, [siteAFrame], 2);
+    const siteBLatest = invocationRecord(workflow, 'delegate', child, [siteBFrame], 2);
+
+    expect(() => new ResumeArtifactOccurrenceIndex(
+      artifactManifest([
+        withLegacyOccurrenceDigest(siteAArtifact.namespace, '1'),
+      ]),
+      sourceResumePoint([
+        { ...siteALatest, namespace: withLegacyOccurrenceDigest(siteALatest.namespace, '2') },
+        { ...siteBLatest, namespace: withLegacyOccurrenceDigest(siteBLatest.namespace, '3') },
+      ]),
+    )).toThrow('logical call-site is ambiguous');
+  });
+
+  it('通常 resume は artifact occurrence index を適用しない', () => {
+    const workflow = {
+      name: 'parent',
+      initialStep: 'delegate',
+      maxSteps: 10,
+      steps: [{ name: 'delegate', kind: 'workflow_call', call: 'child', rules: [] }],
+    } as WorkflowConfig;
+    const state = {
+      workflowName: workflow.name,
+      currentStep: 'delegate',
+      iteration: 1,
+      stepOutputs: new Map(),
+      structuredOutputs: new Map(),
+      systemContexts: new Map(),
+      effectResults: new Map(),
+      userInputs: [],
+      personaSessions: new Map(),
+      stepIterations: new Map(),
+      status: 'running',
+    } as WorkflowState;
+    const continuation = new WorkflowResumeContinuation(workflow, undefined);
+
+    expect(continuation.claimStepOccurrence({
+      step: workflow.steps[0]!,
+      resumeStackPrefix: [],
+      state,
+    })).toBe(1);
+  });
   it('nested workflow_callのsource continuationを一度だけ消費する', () => {
     const parentWorkflow = {
       name: 'parent',

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -71,6 +71,9 @@ import { WorkflowResumeContinuation } from './workflow-resume-continuation.js';
 import { inheritWorkflowConfigMetadata, translateWorkflowConfigError } from '../../../shared/workflowConfigMetadata.js';
 import { WorkflowRestartNavigator } from './WorkflowRestartNavigator.js';
 import { withWorkflowTargetContext } from '../provider-target-resolution.js';
+import { readResumeReportSnapshotManifest } from '../run/resume-report-snapshot.js';
+import { ResumeArtifactOccurrenceIndex } from '../run/resume-artifact-occurrence-index.js';
+import { readRunMetaBySlug } from '../run/run-meta.js';
 const log = createLogger('workflow-engine');
 
 type WorkflowEngineRuntimeOptions = WorkflowEngineOptions & {
@@ -254,6 +257,18 @@ export class WorkflowEngine extends EventEmitter {
     this.sharedRuntime.workflowStepParticipationIndex ??=
       restoreWorkflowStepParticipationIndex(this.options.resumePoint);
     this.sharedRuntime.companionReviewAuthority ??= new CompanionReviewAuthority();
+    if (
+      this.sharedRuntime.resumeArtifactOccurrenceIndex === undefined
+      && this.options.resumeSource?.resumeMode === 'requeue'
+    ) {
+      const manifest = readResumeReportSnapshotManifest(this.cwd, runPaths.slug);
+      this.sharedRuntime.resumeArtifactOccurrenceIndex = new ResumeArtifactOccurrenceIndex(
+        manifest,
+        manifest === undefined
+          ? undefined
+          : readRunMetaBySlug(this.cwd, manifest.sourceRunSlug)?.resumePoint,
+      );
+    }
     restoreActiveResumePoint(
       this.sharedRuntime,
       this.options.resumePoint,
@@ -276,6 +291,7 @@ export class WorkflowEngine extends EventEmitter {
     this.resumeContinuation = new WorkflowResumeContinuation(
       this.config,
       this.options.resumePoint,
+      this.sharedRuntime.resumeArtifactOccurrenceIndex,
     );
     this.syncStateDynamicParallelSelections();
     this.syncStateDynamicFacetSelections();

--- a/src/core/workflow/engine/WorkflowEngine.ts
+++ b/src/core/workflow/engine/WorkflowEngine.ts
@@ -262,11 +262,18 @@ export class WorkflowEngine extends EventEmitter {
       && this.options.resumeSource?.resumeMode === 'requeue'
     ) {
       const manifest = readResumeReportSnapshotManifest(this.cwd, runPaths.slug);
+      const sourceResumePoint = manifest === undefined
+        ? undefined
+        : readRunMetaBySlug(this.cwd, manifest.sourceRunSlug)?.resumePoint;
+      if (manifest !== undefined && sourceResumePoint === undefined) {
+        log.warn(
+          'Requeue artifact occurrence restoration is unavailable because source run metadata or resume point is missing',
+          { sourceRunSlug: manifest.sourceRunSlug },
+        );
+      }
       this.sharedRuntime.resumeArtifactOccurrenceIndex = new ResumeArtifactOccurrenceIndex(
         manifest,
-        manifest === undefined
-          ? undefined
-          : readRunMetaBySlug(this.cwd, manifest.sourceRunSlug)?.resumePoint,
+        sourceResumePoint,
       );
     }
     restoreActiveResumePoint(

--- a/src/core/workflow/engine/workflow-resume-continuation.ts
+++ b/src/core/workflow/engine/workflow-resume-continuation.ts
@@ -5,7 +5,8 @@ import type {
   WorkflowState,
   WorkflowStep,
 } from '../../models/types.js';
-import { getWorkflowResumeFrameKind } from '../step-kind.js';
+import { getWorkflowResumeFrameKind, isWorkflowCallStep } from '../step-kind.js';
+import type { ResumeArtifactOccurrenceIndex } from '../run/resume-artifact-occurrence-index.js';
 import { matchesResumeStackPrefix } from '../run/resume-point.js';
 import {
   workflowEntriesMatch,
@@ -17,6 +18,7 @@ import { incrementStepIteration } from './state-manager.js';
 export class WorkflowResumeContinuation {
   readonly #workflow: WorkflowConfig;
   readonly #source: WorkflowResumePoint | undefined;
+  readonly #resumeArtifactOccurrences: ResumeArtifactOccurrenceIndex | undefined;
   readonly #consumedFrameIndices = new Set<number>();
   readonly #claimedWorkflowCallFrames = new Map<
     number,
@@ -26,9 +28,11 @@ export class WorkflowResumeContinuation {
   constructor(
     workflow: WorkflowConfig,
     source: WorkflowResumePoint | undefined,
+    resumeArtifactOccurrences?: ResumeArtifactOccurrenceIndex,
   ) {
     this.#workflow = workflow;
     this.#source = source;
+    this.#resumeArtifactOccurrences = resumeArtifactOccurrences;
   }
 
   claimStepOccurrence(input: {
@@ -56,6 +60,17 @@ export class WorkflowResumeContinuation {
       || sourceFrame.step !== input.step.name
       || sourceFrame.kind !== getWorkflowResumeFrameKind(input.step)
     ) {
+      if (isWorkflowCallStep(input.step)) {
+        const inheritedMax = this.#resumeArtifactOccurrences?.getMaxOccurrence(
+          this.#workflow,
+          input.step.name,
+          input.resumeStackPrefix,
+        );
+        const current = input.state.stepIterations.get(stepIterationIdentity) ?? 0;
+        if (inheritedMax !== undefined && inheritedMax > current) {
+          input.state.stepIterations.set(stepIterationIdentity, inheritedMax);
+        }
+      }
       return incrementStepIteration(input.state, stepIterationIdentity);
     }
 

--- a/src/core/workflow/run/resume-artifact-occurrence-index.ts
+++ b/src/core/workflow/run/resume-artifact-occurrence-index.ts
@@ -1,0 +1,130 @@
+import type {
+  WorkflowConfig,
+  WorkflowResumePoint,
+  WorkflowResumePointEntry,
+} from '../../models/types.js';
+import { getWorkflowReference } from '../workflow-reference.js';
+import { parseWorkflowCallInvocationIdentity } from '../workflow-execution-identity-codec.js';
+import type { ResumeReportSnapshotManifest } from './resume-report-snapshot.js';
+import { parseWorkflowCallNamespaceSegment } from '../workflow-call-namespace.js';
+
+function logicalCallSiteKey(
+  workflowReference: string,
+  stepName: string,
+  workflowCallPath: readonly Pick<WorkflowResumePointEntry, 'workflow_ref' | 'step' | 'kind'>[],
+): string {
+  return JSON.stringify({
+    workflow: workflowReference,
+    step: stepName,
+    calls: workflowCallPath.map((entry) => ({
+      workflow: entry.workflow_ref,
+      step: entry.step,
+      kind: entry.kind,
+    })),
+  });
+}
+
+function invocationLogicalCallSiteKey(identity: string): string | undefined {
+  const parsed = parseWorkflowCallInvocationIdentity(identity);
+  if (parsed === undefined) return undefined;
+  return JSON.stringify({
+    workflow: parsed.workflow,
+    step: parsed.step,
+    calls: parsed.calls.map((call) => ({
+      workflow: call.workflow,
+      step: call.step,
+      kind: call.kind,
+    })),
+  });
+}
+
+function namespaceSignature(stepName: string, workflowName: string, siteDigest?: string): string {
+  return JSON.stringify([stepName, workflowName, siteDigest]);
+}
+
+function legacyNamespaceSignature(stepName: string, workflowName: string): string {
+  return JSON.stringify([stepName, workflowName]);
+}
+
+export class ResumeArtifactOccurrenceIndex {
+  readonly #maxByCallSite = new Map<string, number>();
+
+  constructor(
+    manifest: ResumeReportSnapshotManifest | undefined,
+    sourceResumePoint?: WorkflowResumePoint,
+  ) {
+    const callSitesByNamespace = new Map<string, string>();
+    const callSitesBySignature = new Map<string, Set<string>>();
+    const callSitesByLegacySignature = new Map<string, Set<string>>();
+    for (const [identity, record] of Object.entries(
+      sourceResumePoint?.workflow_call_invocations ?? {},
+    )) {
+      const callSite = invocationLogicalCallSiteKey(identity);
+      const namespace = parseWorkflowCallNamespaceSegment(record.report_namespace_segment);
+      if (callSite === undefined || namespace === undefined || namespace.iteration === '*') continue;
+      callSitesByNamespace.set(record.report_namespace_segment, callSite);
+      const signature = namespaceSignature(
+        namespace.stepName,
+        namespace.workflowName,
+        namespace.siteDigest,
+      );
+      const callSites = callSitesBySignature.get(signature) ?? new Set<string>();
+      callSites.add(callSite);
+      callSitesBySignature.set(signature, callSites);
+      const legacySignature = legacyNamespaceSignature(
+        namespace.stepName,
+        namespace.workflowName,
+      );
+      const legacyCallSites = callSitesByLegacySignature.get(legacySignature) ?? new Set<string>();
+      legacyCallSites.add(callSite);
+      callSitesByLegacySignature.set(legacySignature, legacyCallSites);
+    }
+
+    for (const file of manifest?.files ?? []) {
+      const segments = file.path.split('/');
+      for (let index = 0; index + 1 < segments.length; index += 1) {
+        if (segments[index] !== 'subworkflows') continue;
+        const namespaceSegment = segments[index + 1]!;
+        const parsed = parseWorkflowCallNamespaceSegment(namespaceSegment);
+        if (parsed === undefined || parsed.iteration === '*') continue;
+        const signature = namespaceSignature(
+          parsed.stepName,
+          parsed.workflowName,
+          parsed.siteDigest,
+        );
+        const candidates = callSitesBySignature.get(signature);
+        let callSite = callSitesByNamespace.get(namespaceSegment)
+          ?? (candidates?.size === 1 ? [...candidates][0] : undefined);
+        if (callSite === undefined) {
+          const legacyCandidates = callSitesByLegacySignature.get(
+            legacyNamespaceSignature(parsed.stepName, parsed.workflowName),
+          );
+          if (legacyCandidates?.size === 1) {
+            callSite = [...legacyCandidates][0];
+          } else if (legacyCandidates !== undefined && legacyCandidates.size > 1) {
+            throw new Error(
+              `Cannot migrate legacy workflow-call artifact namespace "${namespaceSegment}": logical call-site is ambiguous`,
+            );
+          }
+        }
+        if (callSite === undefined) continue;
+        this.#maxByCallSite.set(
+          callSite,
+          Math.max(this.#maxByCallSite.get(callSite) ?? 0, parsed.iteration),
+        );
+      }
+    }
+  }
+
+  getMaxOccurrence(
+    workflow: WorkflowConfig,
+    stepName: string,
+    workflowCallPath: readonly WorkflowResumePointEntry[],
+  ): number | undefined {
+    return this.#maxByCallSite.get(logicalCallSiteKey(
+      getWorkflowReference(workflow),
+      stepName,
+      workflowCallPath,
+    ));
+  }
+}

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -206,6 +206,7 @@ export interface WorkflowSharedRuntimeState {
   workflowCallInvocationEvidence?: WorkflowCallInvocationEvidence;
   workflowStepParticipationIndex?: WorkflowStepParticipationIndex;
   companionReviewAuthority?: CompanionReviewAuthority;
+  resumeArtifactOccurrenceIndex?: import('./run/resume-artifact-occurrence-index.js').ResumeArtifactOccurrenceIndex;
 }
 
 export type WorkflowAbortKind =

--- a/src/core/workflow/workflow-call-site-identity.ts
+++ b/src/core/workflow/workflow-call-site-identity.ts
@@ -20,7 +20,6 @@ function frameIdentity(entry: WorkflowResumePointEntry) {
       : { workflowRef: entry.workflow_ref }),
     step: entry.step,
     kind: entry.kind,
-    occurrence: entry.occurrence,
   };
 }
 

--- a/src/core/workflow/workflow-call-site-identity.ts
+++ b/src/core/workflow/workflow-call-site-identity.ts
@@ -20,6 +20,7 @@ function frameIdentity(entry: WorkflowResumePointEntry) {
       : { workflowRef: entry.workflow_ref }),
     step: entry.step,
     kind: entry.kind,
+    occurrence: entry.occurrence,
   };
 }
 


### PR DESCRIPTION
## 背景

requeue で開始した run が出現番号を1から振り直すため、(a) コピー済みの旧 iteration-1 成果物を上書きし、(b) ファセットの台帳引き継ぎ規則「iteration-N 最大の fix-verification を選ぶ」が古い成果物へ固定され、最新の台帳を捨てる（run 20260814-090848 で実測）。

## 修正

- 継承 manifest の最大 occurrence の続きから採番（実測ケースでは次が iteration-7）
- 論理 call-site 単位で分離し、同名 step の別 call site（top-level と parallel 内、別 parallel 親、ネスト）を混同しない
- 旧形式 digest は論理 call-site を一意に証明できる場合のみ移行し、曖昧なら明示エラーで停止。通常 resume には不適用

## 検証

敵対レビューで call-site 混同・部分 manifest・旧 digest 互換の実行反証→解消、最終 APPROVE。npm test / test:it / lint / build 成功。

関連: #1357 の3分割の1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * `requeue` によるワークフロー再開時、保存済みの成果物情報をもとに処理位置を正確に復元できるようになりました。
  * トップレベル、並列処理、ネストした呼び出しなど、複雑なワークフロー構成にも対応しました。
  * 旧形式の成果物情報からの移行に対応し、特定できない場合は警告またはエラーで通知します。

* **テスト**
  * 通常の再試行と `requeue` 再開での動作差異、部分的な情報や復元情報不足時の挙動を検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->