### PR TITLE
[#1352] add-workflow-rules

### DIFF
--- a/builtins/skill-codex/references/yaml-schema.md
+++ b/builtins/skill-codex/references/yaml-schema.md
@@ -10,6 +10,12 @@ description: 説明テキスト      # 任意
 max_steps: 10                 # 最大イテレーション数（省略時デフォルトあり）
 initial_step: plan            # 最初に実行する step 名（省略時は steps の先頭）
 
+all_steps:                    # workflow 全体に適用する宣言（任意）
+  rules:
+    - findings-handling       # workflows/rules/findings-handling.md
+    - ref: careful-findings
+      position: before_instruction
+
 # ワークフロー全体の provider / runtime 等
 workflow_config:
   provider_options:
@@ -35,6 +41,8 @@ knowledge:                    # ナレッジ定義（任意）
 steps: [...]                  # step 定義の配列（推奨キー名）
 loop_monitors: [...]          # ループ監視設定（任意）。cycle には step 名を並べる
 ```
+
+`all_steps.rules` はすべての agent step の Phase 1 指示へ適用するルール参照です。参照は project `.takt/workflows/rules/`、global `~/.takt/workflows/rules/`、builtin の順に `<ref>.md` を解決します。文字列は自動実行ルールの後、object の `position: before_instruction` は `Instructions` の直前に挿入されます。ルールは `workflow_call` の子へ親から子の順で加算継承されます。レポート出力・ステータス判定・companion には適用されず、必須出力見出しと `{report:...}` を含むルールファイルはロード時に拒否されます。`all_steps` を省略した場合は従来の prompt を維持します。
 
 ### セクションマップの解決
 

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -39,6 +39,12 @@ description: 任意の説明
 max_steps: 10
 initial_step: first-step          # 省略可、デフォルトは最初の step
 
+all_steps:
+  rules:
+    - findings-handling
+    - ref: careful-findings
+      position: before_instruction
+
 # セクションマップ（キー → workflow YAML からの相対パス）
 personas:
   planner: ../facets/personas/planner.md
@@ -98,6 +104,14 @@ steps:
 step はキー名で section map を参照します (例: `persona: coder`)。ファイルパスではありません。section map の中のパスは workflow YAML ファイルのディレクトリからの相対で解決されます。
 
 section map は任意です。facet は bare name で直接参照できます（`personas` マップの項目がなくても `persona: coder` と書けます）。bare name は project `.takt/facets/<type>/` → global `~/.takt/facets/<type>/` → 同梱の `builtins/{lang}/facets/<type>/` の優先順で解決されます。section map が必要になるのは、カスタムエイリアスや明示的なファイルパスを使いたい場合だけです。
+
+### ワークフロー横断ルール（`all_steps.rules`）
+
+すべての agent step に適用するルールは `all_steps.rules` に宣言します。各要素はルール参照文字列、または `ref` と任意の `position: before_instruction` を持つ object です。`position` を省略すると自動実行ルールの後に配置され、`before_instruction` は step の `Instructions` セクション直前に配置されます。
+
+ルールファイルは `workflows/rules/<ref>.md` です。project `.takt/workflows/rules/` → global `~/.takt/workflows/rules/` → 同梱 builtin ディレクトリの順で解決します。適用通知とルール見出しは prompt ごとに1回だけ出力されます。対象は Phase 1 の agent 指示だけで、レポート出力、ステータスルーティング、companion reviewer には適用されません。`workflow_call` 先は親のルールを先に継承し、自身の `all_steps.rules` を後ろに加算します。
+
+ルールファイルに必須出力見出しまたは `{report:...}` 参照を含めることはできません。違反時は参照されたファイルを示して workflow の読み込みに失敗します。`all_steps` を省略した場合、既存の prompt は維持されます。将来の workflow 横断宣言は `all_steps` 配下に追加し、未知のトップレベルキーは引き続き拒否されます。
 
 ### 再利用可能な step fragment
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -39,6 +39,12 @@ description: Optional description
 max_steps: 10
 initial_step: first-step          # Optional, defaults to the first step
 
+all_steps:
+  rules:
+    - findings-handling
+    - ref: careful-findings
+      position: before_instruction
+
 # Section maps (key → file path relative to workflow YAML directory)
 personas:
   planner: ../facets/personas/planner.md
@@ -98,6 +104,14 @@ steps:
 Steps reference section maps by key name (e.g., `persona: coder`), not by file path. Paths in section maps are resolved relative to the workflow YAML file's directory.
 
 Section maps are optional. Facets can be referenced directly by bare name (e.g., `persona: coder` without a `personas` map entry); bare names are resolved through the facet layers in priority order — project `.takt/facets/<type>/`, then global `~/.takt/facets/<type>/`, then bundled `builtins/{lang}/facets/<type>/`. Use a section map only when you need a custom alias or an explicit file path.
+
+### Workflow-wide rules (`all_steps.rules`)
+
+Declare rules that apply to every agent step in the workflow under `all_steps.rules`. Each entry is either a rule reference or an object with `ref` and the optional `position: before_instruction`. An omitted position places the rule after the automatic execution rules; `before_instruction` places it immediately before the step's `Instructions` section.
+
+Rule files are Markdown files named `<ref>.md` under `workflows/rules/`. They resolve in project `.takt/workflows/rules/`, then global `~/.takt/workflows/rules/`, then the bundled builtin directory. The applicability notice and rule heading are rendered once per prompt. These rules apply only to Phase 1 agent instructions, not output reports, status routing, or companion reviewers. A called workflow inherits its parent's rules additively before its own `all_steps.rules`.
+
+Rule files must not contain the required-output heading or `{report:...}` references; invalid content fails workflow loading and identifies the referenced file. Omitting `all_steps` preserves the existing prompt. Future workflow-wide declarations belong under `all_steps`; unknown root-level keys remain invalid.
 
 ### Reusable step fragments
 

--- a/src/__tests__/engine-arpeggio.test.ts
+++ b/src/__tests__/engine-arpeggio.test.ts
@@ -499,6 +499,60 @@ describe('ArpeggioRunner integration', () => {
     expect(phaseStarts.every((instruction) => instruction.includes('git check-ignore -v'))).toBe(true);
   });
 
+  it('injects workflow-wide rules into every arpeggio Phase 1 batch prompt', async () => {
+    const { tmpDir, csvPath, templatePath } = createArpeggioTestDir();
+    const config = {
+      ...buildArpeggioWorkflowConfig(
+        createArpeggioConfig(csvPath, templatePath),
+        tmpDir,
+      ),
+      allStepsRules: [
+        {
+          ref: 'arpeggio-execution-rule',
+          position: 'after_execution_rules' as const,
+          content: 'ARPEGGIO_EXECUTION_RULE',
+        },
+        {
+          ref: 'arpeggio-instruction-rule',
+          position: 'before_instruction' as const,
+          content: 'ARPEGGIO_INSTRUCTION_RULE',
+        },
+      ],
+    };
+    const phaseStarts: string[] = [];
+
+    mockRunAgentWithPrompt(
+      makeResponse({ content: 'A' }),
+      makeResponse({ content: 'B' }),
+      makeResponse({ content: 'C' }),
+    );
+    vi.mocked(mockRuleEvaluation).mockReturnValueOnce({ index: 0, method: 'phase3_tag' });
+
+    engine = new WorkflowEngine(config, tmpDir, 'test task', createEngineOptions(tmpDir));
+    engine.on('phase:start', (step, phase, phaseName, instruction) => {
+      if (step.name !== 'process' || phase !== 1 || phaseName !== 'execute') return;
+      phaseStarts.push(instruction);
+    });
+
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+    expect(phaseStarts).toHaveLength(3);
+    expect(phaseStarts.every((instruction) => instruction.includes('ARPEGGIO_EXECUTION_RULE'))).toBe(true);
+    expect(phaseStarts.every((instruction) => instruction.includes('ARPEGGIO_INSTRUCTION_RULE'))).toBe(true);
+    expect(phaseStarts.every((instruction) => (
+      instruction.match(/all steps in this workflow/gi) ?? []
+    ).length === 1)).toBe(true);
+    for (const instruction of phaseStarts) {
+      expect(instruction.indexOf('ARPEGGIO_EXECUTION_RULE')).toBeGreaterThan(
+        instruction.indexOf('Do NOT use `cd` in Bash commands.'),
+      );
+      expect(instruction.indexOf('ARPEGGIO_INSTRUCTION_RULE')).toBeLessThan(
+        instruction.indexOf('Process '),
+      );
+    }
+  });
+
   it('wraps arpeggio batch executions in phase spans', async () => {
     const { tmpDir, csvPath, templatePath } = createArpeggioTestDir();
     const arpeggioConfig = createArpeggioConfig(csvPath, templatePath, { concurrency: 2 });

--- a/src/__tests__/engine-loop-monitors.test.ts
+++ b/src/__tests__/engine-loop-monitors.test.ts
@@ -150,6 +150,18 @@ describe('WorkflowEngine Integration: Loop Monitors', () => {
           rules: loopJudgeRules(),
         },
       });
+      config.allStepsRules = [
+        {
+          ref: 'phase1-after-execution-rule',
+          position: 'after_execution_rules',
+          content: 'PHASE1_AFTER_EXECUTION_RULE',
+        },
+        {
+          ref: 'phase1-before-instruction-rule',
+          position: 'before_instruction',
+          content: 'PHASE1_BEFORE_INSTRUCTION_RULE',
+        },
+      ];
       engine = new WorkflowEngine(config, tmpDir, 'test task', {
         projectCwd: tmpDir,
         provider: 'mock',
@@ -193,9 +205,22 @@ describe('WorkflowEngine Integration: Loop Monitors', () => {
       expect(state.status).toBe('completed');
       expect(cycleDetectedFn).toHaveBeenCalledOnce();
       expect(cycleDetectedFn.mock.calls[0][1]).toBe(2); // cycleCount
+      const implementCall = vi.mocked(runAgent).mock.calls[0];
+      if (!implementCall) {
+        throw new Error('implement call is required');
+      }
       const judgeCall = vi.mocked(runAgent).mock.calls.find((call) => call[0] === 'supervisor');
-      expect(judgeCall?.[1]).toContain('The loop repeated 2 times.');
-      expect(judgeCall?.[1]).not.toContain('{cycle_count}');
+      if (!judgeCall) {
+        throw new Error('loop monitor judge call is required');
+      }
+      expect(implementCall[1]).toContain('PHASE1_AFTER_EXECUTION_RULE');
+      expect(implementCall[1]).toContain('PHASE1_BEFORE_INSTRUCTION_RULE');
+      expect(implementCall[1]).toContain('The following rules apply to all steps in this workflow.');
+      expect(judgeCall[1]).toContain('The loop repeated 2 times.');
+      expect(judgeCall[1]).not.toContain('{cycle_count}');
+      expect(judgeCall[1]).not.toContain('PHASE1_AFTER_EXECUTION_RULE');
+      expect(judgeCall[1]).not.toContain('PHASE1_BEFORE_INSTRUCTION_RULE');
+      expect(judgeCall[1]).not.toContain('The following rules apply to all steps in this workflow.');
       // 7 iterations: implement + ai_review + ai_fix + ai_review + ai_fix + judge + reviewers
       expect(state.iteration).toBe(7);
     });

--- a/src/__tests__/engine-workflow-call.test.ts
+++ b/src/__tests__/engine-workflow-call.test.ts
@@ -161,6 +161,68 @@ describe('WorkflowEngine workflow_call integration', () => {
     expect(onEffectiveAutoRoutingReached).not.toHaveBeenCalled();
   });
 
+  it('workflow-wide rules are inherited additively by a workflow_call child', async () => {
+    writeWorkflow(tmpDir, 'rules/parent-rule.md', 'PARENT_WORKFLOW_RULE');
+    writeWorkflow(tmpDir, 'rules/child-rule.md', 'CHILD_WORKFLOW_RULE');
+    writeWorkflow(tmpDir, 'child.yaml', `name: child
+subworkflow:
+  callable: true
+  returns: [ok]
+initial_step: review
+max_steps: 3
+all_steps:
+  rules:
+    - ref: child-rule
+      position: before_instruction
+steps:
+  - name: review
+    persona: reviewer
+    instruction: Review child work
+    rules:
+      - condition: done
+        return: ok
+`);
+
+    const config = createParentWorkflow(tmpDir, {
+      name: 'parent',
+      initial_step: 'delegate',
+      max_steps: 3,
+      all_steps: { rules: ['parent-rule'] },
+      steps: [{
+        name: 'delegate',
+        kind: 'workflow_call',
+        call: 'child',
+        rules: [{ condition: 'ok', next: 'COMPLETE' }],
+      }],
+    });
+    mockPersonaResponses({ reviewer: 'done' });
+    mockRuleEvaluationSequence([
+      { index: 0, method: 'phase3_tag' },
+      { index: 0, method: 'phase3_tag' },
+    ]);
+
+    engine = new WorkflowEngine(
+      config,
+      tmpDir,
+      'test task',
+      createWorkflowCallOptions(tmpDir),
+    );
+    const state = await engine.run();
+
+    expect(state.status).toBe('completed');
+    const childPrompt = vi.mocked(runAgent).mock.calls[0]?.[1];
+    expect(childPrompt).toEqual(expect.any(String));
+    expect(childPrompt).toContain('PARENT_WORKFLOW_RULE');
+    expect(childPrompt).toContain('CHILD_WORKFLOW_RULE');
+    expect(childPrompt!.indexOf('PARENT_WORKFLOW_RULE')).toBeLessThan(
+      childPrompt!.indexOf('CHILD_WORKFLOW_RULE'),
+    );
+    expect(childPrompt!.indexOf('CHILD_WORKFLOW_RULE')).toBeLessThan(
+      childPrompt!.indexOf('Review child work'),
+    );
+    expect(childPrompt!.match(/all steps in this workflow/gi)).toHaveLength(1);
+  });
+
   it('strategy override がない場合は到達した child 内の未到達 workflow_call を解決しない', async () => {
     const config = createParentWorkflow(tmpDir, {
       name: 'parent-with-child-that-finishes-directly',

--- a/src/__tests__/it-workflow-all-steps-rules.test.ts
+++ b/src/__tests__/it-workflow-all-steps-rules.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { invalidateGlobalConfigCache } from '../infra/config/global/globalConfig.js';
+import { loadWorkflowFromFile } from '../infra/config/loaders/workflowFileLoader.js';
+
+vi.mock('../infra/config/paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../infra/config/paths.js')>();
+  return {
+    ...actual,
+    getBuiltinWorkflowsDir: () => (
+      process.env.TAKT_TEST_BUILTIN_WORKFLOWS_DIR ?? actual.getBuiltinWorkflowsDir('en')
+    ),
+  };
+});
+
+type ResolvedAllStepsRule = {
+  readonly ref: string;
+  readonly position: 'after_execution_rules' | 'before_instruction';
+  readonly content: string;
+};
+
+type WorkflowWithAllStepsRules = {
+  readonly allStepsRules?: readonly ResolvedAllStepsRule[];
+};
+
+function resolvedRules(workflow: unknown): readonly ResolvedAllStepsRule[] | undefined {
+  return (workflow as WorkflowWithAllStepsRules).allStepsRules;
+}
+
+function workflowYaml(name: string, refs: readonly string[]): string {
+  return `name: ${name}
+initial_step: work
+max_steps: 1
+all_steps:
+  rules:
+${refs.map((ref) => `    - ${ref}`).join('\n')}
+steps:
+  - name: work
+    persona: coder
+    instruction: Work
+`;
+}
+
+describe('workflow-wide rule loading', () => {
+  let projectDir: string;
+  let globalConfigDir: string;
+  let builtinWorkflowsDir: string;
+  let previousConfigDir: string | undefined;
+  let previousBuiltinWorkflowsDir: string | undefined;
+
+  beforeEach(() => {
+    previousConfigDir = process.env.TAKT_CONFIG_DIR;
+    previousBuiltinWorkflowsDir = process.env.TAKT_TEST_BUILTIN_WORKFLOWS_DIR;
+    projectDir = mkdtempSync(join(tmpdir(), 'takt-all-steps-rules-project-'));
+    globalConfigDir = mkdtempSync(join(tmpdir(), 'takt-all-steps-rules-global-'));
+    builtinWorkflowsDir = mkdtempSync(join(tmpdir(), 'takt-all-steps-rules-builtin-'));
+    process.env.TAKT_CONFIG_DIR = globalConfigDir;
+    process.env.TAKT_TEST_BUILTIN_WORKFLOWS_DIR = builtinWorkflowsDir;
+    invalidateGlobalConfigCache();
+  });
+
+  afterEach(() => {
+    if (previousConfigDir === undefined) {
+      delete process.env.TAKT_CONFIG_DIR;
+    } else {
+      process.env.TAKT_CONFIG_DIR = previousConfigDir;
+    }
+    if (previousBuiltinWorkflowsDir === undefined) {
+      delete process.env.TAKT_TEST_BUILTIN_WORKFLOWS_DIR;
+    } else {
+      process.env.TAKT_TEST_BUILTIN_WORKFLOWS_DIR = previousBuiltinWorkflowsDir;
+    }
+    invalidateGlobalConfigCache();
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(globalConfigDir, { recursive: true, force: true });
+    rmSync(builtinWorkflowsDir, { recursive: true, force: true });
+  });
+
+  it('resolves project rules before global rules and retains normalized positions', () => {
+    const projectRulesDir = join(projectDir, '.takt', 'workflows', 'rules');
+    const globalRulesDir = join(globalConfigDir, 'workflows', 'rules');
+    mkdirSync(projectRulesDir, { recursive: true });
+    mkdirSync(globalRulesDir, { recursive: true });
+    writeFileSync(join(projectRulesDir, 'shared.md'), 'PROJECT_SHARED', 'utf-8');
+    writeFileSync(join(globalRulesDir, 'shared.md'), 'GLOBAL_SHARED', 'utf-8');
+    writeFileSync(join(globalRulesDir, 'global-only.md'), 'GLOBAL_ONLY', 'utf-8');
+
+    const workflowPath = join(projectDir, 'rules.yaml');
+    writeFileSync(workflowPath, `name: rules-loader
+initial_step: work
+max_steps: 1
+all_steps:
+  rules:
+    - shared
+    - ref: global-only
+      position: before_instruction
+steps:
+  - name: work
+    persona: coder
+    instruction: Work
+`, 'utf-8');
+
+    const workflow = loadWorkflowFromFile(workflowPath, projectDir);
+
+    expect(resolvedRules(workflow)).toEqual([
+      { ref: 'shared', position: 'after_execution_rules', content: 'PROJECT_SHARED' },
+      { ref: 'global-only', position: 'before_instruction', content: 'GLOBAL_ONLY' },
+    ]);
+  });
+
+  it('fails at workflow load when a declared rule cannot be resolved', () => {
+    const workflowPath = join(projectDir, 'missing-rule.yaml');
+    writeFileSync(workflowPath, workflowYaml('missing-rule', ['does-not-exist']), 'utf-8');
+
+    expect(() => loadWorkflowFromFile(workflowPath, projectDir)).toThrow(
+      /all_steps\.rules\[0\].*does-not-exist|does-not-exist.*all_steps\.rules\[0\]/,
+    );
+  });
+
+  it('uses the builtin rule layer when project and global layers have no matching ref', () => {
+    const builtinRulesDir = join(builtinWorkflowsDir, 'rules');
+    mkdirSync(builtinRulesDir, { recursive: true });
+    writeFileSync(join(builtinRulesDir, 'builtin-only.md'), 'BUILTIN_ONLY', 'utf-8');
+    const workflowPath = join(projectDir, 'builtin-rule.yaml');
+    writeFileSync(workflowPath, workflowYaml('builtin-rule', ['builtin-only']), 'utf-8');
+
+    const workflow = loadWorkflowFromFile(workflowPath, projectDir);
+
+    expect(resolvedRules(workflow)).toEqual([
+      { ref: 'builtin-only', position: 'after_execution_rules', content: 'BUILTIN_ONLY' },
+    ]);
+  });
+
+  it.each([
+    ['required-output-heading', '**必須出力（見出しを含める）**'],
+    ['required-output-heading-with-article', '**Required output (include the headings)**'],
+    ['required-output-section', '## 必須出力'],
+    ['required-output-decorated-section-en', '## **Required Output**'],
+    ['required-output-decorated-section-ja', '## **必須出力**'],
+    ['required-output-link-section-en', '## [Required Output](https://example.com/output)'],
+    ['required-output-link-section-ja', '## [必須出力](https://example.com/output)'],
+    ['required-output-html-section-en', '## Required <strong>Output</strong>'],
+    ['required-output-html-section-ja', '## 必須<strong>出力</strong>'],
+    ['report-reference', 'Previous result: {report:previous.md}'],
+  ])('rejects %s in a rule file and identifies the source file', (ref, content) => {
+    const rulesDir = join(projectDir, '.takt', 'workflows', 'rules');
+    mkdirSync(rulesDir, { recursive: true });
+    const rulePath = join(rulesDir, `${ref}.md`);
+    writeFileSync(rulePath, content, 'utf-8');
+    const workflowPath = join(projectDir, `${ref}.yaml`);
+    writeFileSync(workflowPath, workflowYaml(ref, [ref]), 'utf-8');
+
+    expect(() => loadWorkflowFromFile(workflowPath, projectDir)).toThrow(
+      new RegExp(`all_steps\\.rules\\[0\\].*${ref}\\.md|${ref}\\.md.*all_steps\\.rules\\[0\\]`),
+    );
+  });
+});

--- a/src/__tests__/previewPrompts.test.ts
+++ b/src/__tests__/previewPrompts.test.ts
@@ -20,6 +20,7 @@ const {
   mockInfo,
   mockError,
   mockBlankLine,
+  mockInstructionBuilder,
   mockInstructionBuild,
   mockReportBuild,
   mockJudgmentBuild,
@@ -36,6 +37,7 @@ const {
   mockInfo: vi.fn(),
   mockError: vi.fn(),
   mockBlankLine: vi.fn(),
+  mockInstructionBuilder: vi.fn(),
   mockInstructionBuild: vi.fn(() => 'phase1'),
   mockReportBuild: vi.fn(() => 'phase2'),
   mockJudgmentBuild: vi.fn(() => 'phase3'),
@@ -86,7 +88,7 @@ function compiledEnvironment(
 }
 
 vi.mock('../core/workflow/instruction/InstructionBuilder.js', () => ({
-  InstructionBuilder: vi.fn().mockImplementation(() => ({
+  InstructionBuilder: mockInstructionBuilder.mockImplementation(() => ({
     build: mockInstructionBuild,
   })),
 }));
@@ -217,6 +219,74 @@ describe('previewPrompts', () => {
     await previewPrompts('/project', undefined, undefined);
 
     expect(console.log).toHaveBeenCalledWith('Step 1: implement (persona: coder)');
+  });
+
+  it('workflow-wide ruleのref・正規化位置・本文を表示する', async () => {
+    mockLoadWorkflowByIdentifier.mockReturnValueOnce({
+      name: 'rules-preview',
+      maxSteps: 1,
+      allStepsRules: [{
+        ref: 'review-boundary',
+        position: 'after_execution_rules',
+        content: 'PREVIEW_RULE_BODY',
+      }],
+      steps: [
+        {
+          name: 'implement',
+          personaDisplayName: 'coder',
+          outputContracts: [],
+        },
+      ],
+    });
+
+    await previewPrompts('/project');
+    const output = JSON.stringify([
+      ...consoleLogSpy.mock.calls,
+      ...mockInfo.mock.calls,
+    ]);
+
+    expect(output).toContain('review-boundary');
+    expect(output).toContain('after_execution_rules');
+    expect(output).toContain('PREVIEW_RULE_BODY');
+  });
+
+  it('合成ステップのPhase 1プレビューにはworkflow-wide ruleを渡さない', async () => {
+    const workflowRules = [{
+      ref: 'review-boundary',
+      position: 'after_execution_rules',
+      content: 'PREVIEW_RULE_BODY',
+    }];
+    mockLoadWorkflowByIdentifier.mockReturnValueOnce({
+      name: 'rules-preview',
+      maxSteps: 2,
+      allStepsRules: workflowRules,
+      steps: [
+        {
+          name: 'implement',
+          personaDisplayName: 'coder',
+          outputContracts: [],
+        },
+        {
+          name: 'synthesized-judge',
+          personaDisplayName: 'judge',
+          outputContracts: [],
+          engineSynthesized: true,
+        },
+      ],
+    });
+
+    await previewPrompts('/project');
+
+    expect(mockInstructionBuilder).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ name: 'implement' }),
+      expect.objectContaining({ workflowRules }),
+    );
+    expect(mockInstructionBuilder).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ name: 'synthesized-judge', engineSynthesized: true }),
+      expect.objectContaining({ workflowRules: undefined }),
+    );
   });
 
   it('dynamic parallel の mode と fixed/pool role を表示する', async () => {

--- a/src/__tests__/report-phase-soft-error.test.ts
+++ b/src/__tests__/report-phase-soft-error.test.ts
@@ -102,6 +102,7 @@ function makeStepExecutor(): StepExecutor {
     getWorkflowSteps: () => [{ name: 'review' }],
     getWorkflowName: () => 'test-workflow',
     getWorkflowDescription: () => undefined,
+    getWorkflowRules: () => undefined,
     getRetryNote: () => undefined,
     getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
     structuredCaller: {

--- a/src/__tests__/session-compaction-wiring.test.ts
+++ b/src/__tests__/session-compaction-wiring.test.ts
@@ -190,6 +190,7 @@ function makeNormalDeps(
     getWorkflowName: () => 'test-workflow',
     getTask: () => 'task',
     getWorkflowDescription: () => undefined,
+    getWorkflowRules: () => undefined,
     getRetryNote: () => undefined,
     getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
     structuredCaller: {
@@ -255,6 +256,7 @@ describe('session compaction Phase 1 wiring', () => {
       getWorkflowSteps: () => [{ name: 'review' }],
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
+      getWorkflowRules: () => undefined,
       getRetryNote: () => undefined,
       getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
@@ -303,6 +305,7 @@ describe('session compaction Phase 1 wiring', () => {
       getWorkflowSteps: () => [{ name: 'review' }],
       getWorkflowName: () => 'test-workflow',
       getWorkflowDescription: () => undefined,
+      getWorkflowRules: () => undefined,
       getRetryNote: () => undefined,
       getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {
@@ -378,6 +381,7 @@ describe('session compaction Phase 1 wiring', () => {
         makeWorkflowResumePointEntry({ step: 'review' }),
       ],
       getWorkflowDescription: () => undefined,
+      getWorkflowRules: () => undefined,
       getRetryNote: () => undefined,
       getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
       structuredCaller: {

--- a/src/__tests__/step-executor.test.ts
+++ b/src/__tests__/step-executor.test.ts
@@ -662,6 +662,7 @@ describe('StepExecutor dynamic facet integration', () => {
         getWorkflowName: () => 'test-workflow',
         getTask: () => 'task',
         getWorkflowDescription: () => undefined,
+        getWorkflowRules: () => undefined,
         getRetryNote: () => undefined,
         getReviewScope: () => ({ kind: 'not_a_git_repository' } as const),
         structuredCaller: {

--- a/src/__tests__/workflow-all-steps-rules.test.ts
+++ b/src/__tests__/workflow-all-steps-rules.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import { WorkflowConfigRawSchema } from '../core/models/workflow-schemas.js';
+import { InstructionBuilder } from '../core/workflow/instruction/InstructionBuilder.js';
+import type { InstructionContext } from '../core/workflow/instruction/instruction-context.js';
+import { ReportInstructionBuilder } from '../core/workflow/instruction/ReportInstructionBuilder.js';
+import type { ReportInstructionContext } from '../core/workflow/instruction/ReportInstructionBuilder.js';
+import { StatusJudgmentBuilder } from '../core/workflow/instruction/StatusJudgmentBuilder.js';
+import type { StatusJudgmentContext } from '../core/workflow/instruction/StatusJudgmentBuilder.js';
+import { makeInstructionContext, makeRule, makeStep } from './test-helpers.js';
+
+type ResolvedWorkflowRule = {
+  readonly ref: string;
+  readonly position: 'after_execution_rules' | 'before_instruction';
+  readonly content: string;
+};
+
+type WorkflowRuleInstructionContext = InstructionContext & {
+  readonly workflowRules?: readonly ResolvedWorkflowRule[];
+};
+
+function workflowRuleContext(
+  rules: readonly ResolvedWorkflowRule[],
+  language: 'en' | 'ja' = 'en',
+): WorkflowRuleInstructionContext {
+  return {
+    ...makeInstructionContext({
+      language,
+      workflowName: 'rules-test',
+    }),
+    workflowRules: rules,
+  };
+}
+
+describe('all_steps.rules schema', () => {
+  it('accepts string refs and before_instruction entries in declaration order', () => {
+    const result = WorkflowConfigRawSchema.safeParse({
+      name: 'rules-schema',
+      all_steps: {
+        rules: [
+          'first-rule',
+          { ref: 'second-rule', position: 'before_instruction' },
+        ],
+      },
+      steps: [{ name: 'step', instruction: 'Work' }],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const parsed = result.data as {
+      readonly all_steps?: {
+        readonly rules?: unknown;
+      };
+    };
+    expect(parsed.all_steps?.rules).toEqual([
+      'first-rule',
+      { ref: 'second-rule', position: 'before_instruction' },
+    ]);
+  });
+
+  it('rejects unsupported positions, unknown all_steps keys, and a top-level rules key', () => {
+    expect(WorkflowConfigRawSchema.safeParse({
+      name: 'invalid-position',
+      all_steps: { rules: [{ ref: 'rule', position: 'after_task' }] },
+      steps: [{ name: 'step', instruction: 'Work' }],
+    }).success).toBe(false);
+
+    expect(WorkflowConfigRawSchema.safeParse({
+      name: 'unknown-all-steps-key',
+      all_steps: { rules: [], other: true },
+      steps: [{ name: 'step', instruction: 'Work' }],
+    }).success).toBe(false);
+
+    expect(WorkflowConfigRawSchema.safeParse({
+      name: 'top-level-rules',
+      rules: ['rule'],
+      steps: [{ name: 'step', instruction: 'Work' }],
+    }).success).toBe(false);
+  });
+});
+
+describe('workflow-wide Phase 1 rule rendering', () => {
+  const rules: readonly ResolvedWorkflowRule[] = [
+    {
+      ref: 'execution-first',
+      position: 'after_execution_rules',
+      content: 'RULE_EXECUTION_FIRST',
+    },
+    {
+      ref: 'instruction-first',
+      position: 'before_instruction',
+      content: 'RULE_INSTRUCTION_FIRST',
+    },
+    {
+      ref: 'execution-second',
+      position: 'after_execution_rules',
+      content: 'RULE_EXECUTION_SECOND',
+    },
+  ];
+
+  it('injects each rule once, keeps declaration order within each position, and emits one applicability notice', () => {
+    const prompt = new InstructionBuilder(
+      makeStep({
+        name: 'work',
+        instruction: 'Do the requested work.',
+        allowGitCommit: false,
+      }),
+      workflowRuleContext(rules),
+    ).build();
+
+    expect(prompt).toContain('RULE_EXECUTION_FIRST');
+    expect(prompt).toContain('RULE_EXECUTION_SECOND');
+    expect(prompt).toContain('RULE_INSTRUCTION_FIRST');
+    expect(prompt.indexOf('RULE_EXECUTION_FIRST')).toBeLessThan(prompt.indexOf('RULE_EXECUTION_SECOND'));
+    expect(prompt.indexOf('RULE_EXECUTION_SECOND')).toBeLessThan(prompt.indexOf('RULE_INSTRUCTION_FIRST'));
+    expect(prompt.indexOf('RULE_INSTRUCTION_FIRST')).toBeLessThan(prompt.indexOf('Do the requested work.'));
+    expect(prompt.indexOf('Do NOT run git commit')).toBeLessThan(prompt.indexOf('RULE_EXECUTION_FIRST'));
+    expect(prompt.indexOf('RULE_EXECUTION_FIRST')).toBeLessThan(prompt.indexOf('Do the requested work.'));
+    expect(prompt.match(/all steps in this workflow/gi)).toHaveLength(1);
+    for (const rule of rules) {
+      expect(prompt.split(rule.content).length - 1).toBe(1);
+    }
+  });
+
+  it.each([
+    ['en', 'Note: This section is metadata. Follow the language used in the rest of the prompt.', 2],
+    ['ja', '## 判断ルール', 3],
+  ] as const)('keeps the pre-rules prompt spacing for %s', (language, followingSection, expectedNewlines) => {
+    for (const edit of [undefined, true, false] as const) {
+      const withoutRules = new InstructionBuilder(
+        makeStep({
+          name: 'work',
+          instruction: 'Do the requested work.',
+          ...(edit === undefined ? {} : { edit }),
+        }),
+        makeInstructionContext({ language, workflowName: 'rules-test' }),
+      ).build();
+      const withEmptyRules = new InstructionBuilder(
+        makeStep({
+          name: 'work',
+          instruction: 'Do the requested work.',
+          ...(edit === undefined ? {} : { edit }),
+        }),
+        workflowRuleContext([], language),
+      ).build();
+
+      const followingSectionIndex = withoutRules.indexOf(followingSection);
+      expect(followingSectionIndex).toBeGreaterThan(0);
+      const precedingNewlines = withoutRules
+        .slice(0, followingSectionIndex)
+        .match(/\n+$/)?.[0].length;
+      expect(precedingNewlines).toBe(expectedNewlines);
+      expect(withoutRules).toContain('## Instructions\nDo the requested work.');
+      expect(withoutRules).not.toContain('## Instructions\n\nDo the requested work.');
+      expect(withEmptyRules).toBe(withoutRules);
+    }
+  });
+});
+
+describe('workflow-wide rule phase boundaries', () => {
+  it('keeps workflow-wide rules out of Phase 2 and Phase 3 builders', () => {
+    const step = makeStep({
+      name: 'review',
+      rules: [makeRule('approved', 'COMPLETE')],
+      outputContracts: [{ name: 'report.md', format: 'Report' }],
+    });
+    const marker = 'RULE_MUST_STAY_IN_PHASE_1';
+    const workflowRule = {
+      ref: 'phase-1-only',
+      position: 'after_execution_rules' as const,
+      content: marker,
+    };
+
+    const phase2 = new ReportInstructionBuilder(step, {
+      ...workflowRuleContext([workflowRule]),
+      reportDir: '/tmp/test/reports',
+      stepIteration: 1,
+      task: 'Write the report.',
+    } as unknown as ReportInstructionContext).build();
+    const phase3 = new StatusJudgmentBuilder(step, {
+      ...workflowRuleContext([workflowRule]),
+      reportContent: 'The report is complete.',
+      inputSource: 'report',
+    } as unknown as StatusJudgmentContext).build();
+
+    expect(phase2).not.toContain(marker);
+    expect(phase3).not.toContain(marker);
+  });
+});

--- a/src/__tests__/workflow-execution-bundle.test.ts
+++ b/src/__tests__/workflow-execution-bundle.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../features/tasks/execute/workflowExecutionBundle.js';
 import { attachLegacyWorkflowExecutionBundle } from '../features/workflowAuthoring/attachExecutionBundle.js';
 import { normalizeWorkflowConfig } from '../infra/config/loaders/workflowParser.js';
+import { loadWorkflowFromFile } from '../infra/config/loaders/workflowFileLoader.js';
 import { buildWorkflowStepParticipationIdentity } from '../core/workflow/workflow-step-participation-index.js';
 import { canonicalJson } from '../shared/utils/canonical-json.js';
 
@@ -34,6 +35,51 @@ function workflow(name: string, steps: WorkflowConfig['steps']): WorkflowConfig 
 }
 
 describe('workflow execution bundle', () => {
+  it('restores normalized workflow-wide rules after the source rule file is removed', () => {
+    const root = mkdtempSync(join(tmpdir(), 'takt-workflow-bundle-rules-'));
+    roots.push(root);
+    const workflowDir = join(root, '.takt', 'workflows');
+    const rulePath = join(workflowDir, 'rules', 'bundle-rule.md');
+    const workflowPath = join(workflowDir, 'root.yaml');
+    mkdirSync(join(workflowDir, 'rules'), { recursive: true });
+    writeFileSync(rulePath, 'BUNDLE_RULE_BODY', 'utf-8');
+    writeFileSync(workflowPath, `name: root
+initial_step: work
+max_steps: 1
+all_steps:
+  rules:
+    - bundle-rule
+steps:
+  - name: work
+    persona: coder
+    instruction: Work
+`, 'utf-8');
+
+    const config = loadWorkflowFromFile(workflowPath, root);
+    const originalRules = (config as unknown as {
+      readonly allStepsRules: readonly unknown[];
+    }).allStepsRules;
+    expect(originalRules).toEqual([{
+      ref: 'bundle-rule',
+      position: 'after_execution_rules',
+      content: 'BUNDLE_RULE_BODY',
+    }]);
+
+    const paths = buildRunPaths(root, 'bundle-rules-run');
+    publishWorkflowExecutionBundle(paths, prepareWorkflowExecutionBundle({
+      rootWorkflow: config,
+      workflowCallResolver: () => null,
+      projectCwd: root,
+      lookupCwd: root,
+    }));
+    rmSync(rulePath);
+
+    const loaded = loadWorkflowExecutionBundle(paths);
+    expect((loaded.rootWorkflow as unknown as {
+      readonly allStepsRules: readonly unknown[];
+    }).allStepsRules).toEqual(originalRules);
+  });
+
   it('round-trips an args-specific graph without replacing workflow_ref with node hashes', () => {
     const root = mkdtempSync(join(tmpdir(), 'takt-workflow-bundle-'));
     roots.push(root);

--- a/src/core/models/index.ts
+++ b/src/core/models/index.ts
@@ -58,6 +58,7 @@ export type {
   ProviderRoutingConfig,
   ProviderRoutingEntry,
   WorkflowRule,
+  WorkflowWideRule,
   StepProviderOptions,
   OpenCodeGuardOptions,
   OpenCodeGuardProfile,

--- a/src/core/models/types.ts
+++ b/src/core/models/types.ts
@@ -36,6 +36,7 @@ export type {
 // Workflow configuration and runtime state
 export type {
   WorkflowRule,
+  WorkflowWideRule,
   WorkflowMaxSteps,
   WorkflowStructuredOutput,
   WorkflowPrListWhere,

--- a/src/core/models/workflow-schemas.ts
+++ b/src/core/models/workflow-schemas.ts
@@ -211,6 +211,18 @@ const WorkflowRuleConditionRawSchema = z.string().trim().min(1).superRefine((con
   }
 });
 
+const WorkflowWideRuleReferenceSchema = z.string().trim().min(1);
+const WorkflowWideRuleEntrySchema = z.union([
+  WorkflowWideRuleReferenceSchema,
+  z.object({
+    ref: WorkflowWideRuleReferenceSchema,
+    position: z.literal('before_instruction').optional(),
+  }).strict(),
+]);
+const WorkflowAllStepsRawSchema = z.object({
+  rules: z.array(WorkflowWideRuleEntrySchema).optional(),
+}).strict().optional();
+
 const WorkflowResultLabelSchema = z.string().trim().min(1);
 
 /** Rule-based transition schema (new unified format) */
@@ -1163,6 +1175,7 @@ export const WorkflowConfigRawSchema = z.object({
   knowledge: z.record(z.string(), z.string()).optional(),
   instructions: z.record(z.string(), z.string()).optional(),
   report_formats: z.record(z.string(), z.string()).optional(),
+  all_steps: WorkflowAllStepsRawSchema,
   facet_pools: z.record(z.string().min(1), FacetPoolRawSchema).optional(),
   steps: z.array(WorkflowConfigStepRawSchema).min(1),
   initial_step: z.string().optional(),

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -83,6 +83,12 @@ export interface WorkflowRule {
   interactiveOnly?: boolean;
 }
 
+export interface WorkflowWideRule {
+  readonly ref: string;
+  readonly position: 'after_execution_rules' | 'before_instruction';
+  readonly content: string;
+}
+
 export type WorkflowMaxSteps = number | 'infinite';
 
 export interface WorkflowStructuredOutput {
@@ -559,6 +565,7 @@ export interface WorkflowConfig {
   knowledge?: Record<string, string>;
   instructions?: Record<string, string>;
   reportFormats?: Record<string, string>;
+  allStepsRules?: readonly WorkflowWideRule[];
   steps: WorkflowStep[];
   initialStep: string;
   maxSteps: WorkflowMaxSteps;

--- a/src/core/workflow/engine/ArpeggioRunner.ts
+++ b/src/core/workflow/engine/ArpeggioRunner.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowState,
   AgentResponse,
   WorkflowResumePointEntry,
+  WorkflowWideRule,
 } from '../../models/types.js';
 import type { ArpeggioStepConfig, BatchResult, DataBatch } from '../arpeggio/types.js';
 import { createDataSource } from '../arpeggio/data-source-factory.js';
@@ -26,6 +27,7 @@ import type { StepExecutor } from './StepExecutor.js';
 import type { PhaseName, PhasePromptParts, RuntimeStepResolution, StepProviderInfo, StepRunResult } from '../types.js';
 import { buildGitRules } from '../instruction/instruction-context.js';
 import { renderFallbackNotice } from '../instruction/fallback-notice.js';
+import { renderWorkflowWideRules } from '../instruction/workflow-wide-rules.js';
 import { runWithPhaseSpan } from '../observability/workflowSpans.js';
 import { USAGE_MISSING_REASONS } from '../../logging/contracts.js';
 import {
@@ -41,6 +43,7 @@ export interface ArpeggioRunnerDeps {
   readonly stepExecutor: StepExecutor;
   readonly getCwd: () => string;
   readonly getWorkflowName: () => string;
+  readonly getWorkflowRules: () => readonly WorkflowWideRule[] | undefined;
   readonly getInteractive: () => boolean;
   readonly childProcessEnv?: RunAgentOptions['childProcessEnv'];
   readonly observabilityEnabled: boolean;
@@ -122,6 +125,7 @@ async function executeBatchWithRetry(
   retryDelayMs: number,
   observability: ArpeggioBatchObservability,
   runtime?: RuntimeStepResolution,
+  workflowRules?: readonly WorkflowWideRule[],
 ): Promise<BatchResult> {
   const prompt = buildArpeggioPrompt(
     template,
@@ -129,6 +133,7 @@ async function executeBatchWithRetry(
     allowGitCommit,
     agentOptions.language ?? 'en',
     runtime,
+    workflowRules,
   );
   let lastError: string | undefined;
 
@@ -238,13 +243,23 @@ function buildArpeggioPrompt(
   allowGitCommit: boolean | undefined,
   language: NonNullable<RunAgentOptions['language']>,
   runtime?: RuntimeStepResolution,
+  workflowRules?: readonly WorkflowWideRule[],
 ): string {
   const prompt = expandTemplate(template, batch);
   const gitRules = buildGitRules(allowGitCommit, language, 'phase1');
   const fallbackNotice = runtime?.fallback
     ? renderFallbackNotice(runtime.fallback, language)
     : '';
-  return [gitRules, fallbackNotice, prompt]
+  const renderedRules = renderWorkflowWideRules(workflowRules, language);
+  return [
+    gitRules,
+    renderedRules.noticeAfterExecutionRules,
+    renderedRules.afterExecutionRules,
+    fallbackNotice,
+    renderedRules.noticeBeforeInstructionRules,
+    renderedRules.beforeInstructionRules,
+    prompt,
+  ]
     .filter((part): part is string => typeof part === 'string' && part.length > 0)
     .join('\n\n');
 }
@@ -430,6 +445,7 @@ export class ArpeggioRunner {
             getPromptParts: () => resolvedPromptParts,
           },
           runtime,
+          this.deps.getWorkflowRules(),
         );
         if (!didEmitPhaseStart) {
           throw new Error(`Missing prompt parts for phase start: ${step.name}:1`);

--- a/src/core/workflow/engine/StepExecutor.ts
+++ b/src/core/workflow/engine/StepExecutor.ts
@@ -16,6 +16,7 @@ import type {
   Language,
   FallbackContext,
   WorkflowConfig,
+  WorkflowWideRule,
   WorkflowResumePointEntry,
   NormalAgentWorkflowStep,
   ResolvedFacetPool,
@@ -174,6 +175,7 @@ export interface StepExecutorDeps {
   readonly getWorkflowName: () => string;
   readonly getTask: () => string;
   readonly getWorkflowDescription: () => string | undefined;
+  readonly getWorkflowRules: () => readonly WorkflowWideRule[] | undefined;
   readonly getWorkflowCallVars?: () => Readonly<Record<string, string | number | boolean>> | undefined;
   readonly getRetryNote: () => string | undefined;
   readonly getPrContext?: () => PullRequestContext | undefined;
@@ -1116,6 +1118,7 @@ export class StepExecutor {
       previousResponseSourcePath: state.previousResponseSourcePath,
       fallbackContext,
       workflowState: state,
+      ...(step.engineSynthesized === true ? {} : { workflowRules: this.deps.getWorkflowRules() }),
       ...(!this.deps.companionEnabled
         || !isNormalAgentWorkflowStep(step)
         || step.companion === undefined

--- a/src/core/workflow/engine/WorkflowCallExecutor.ts
+++ b/src/core/workflow/engine/WorkflowCallExecutor.ts
@@ -635,6 +635,10 @@ export class WorkflowCallExecutor {
         ...options.workflowCallVars,
         ...request.step.vars,
       },
+      inheritedWorkflowRules: [
+        ...(options.inheritedWorkflowRules ?? []),
+        ...(parentConfig.allStepsRules ?? []),
+      ],
       sharedRuntime: this.deps.sharedRuntime,
       resumeStackPrefix: [
         ...resumeStackPrefix,

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowResumePointEntry,
   WorkflowState,
   WorkflowStep,
+  WorkflowWideRule,
 } from '../../models/types.js';
 import { prepareRuntimeEnvironment } from '../../runtime/runtime-environment.js';
 import type { RunPaths } from '../run/run-paths.js';
@@ -249,6 +250,10 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
       : { inputReader: new SelectorInputReader(params.options.selectorGitCommandRunner) }),
   });
   const companionEnabled = params.options.companionEnabled ?? DEFAULT_COMPANION_ENABLED;
+  const workflowRules: readonly WorkflowWideRule[] = [
+    ...(params.options.inheritedWorkflowRules ?? []),
+    ...(params.config.allStepsRules ?? []),
+  ];
 
   const stepExecutor = new StepExecutor({
     optionsBuilder,
@@ -263,6 +268,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     getWorkflowName: () => params.config.name,
     getTask: () => params.task,
     getWorkflowDescription: () => params.config.description,
+    getWorkflowRules: () => workflowRules,
     getWorkflowCallVars: () => params.options.workflowCallVars,
     getRetryNote: () => params.options.retryNote,
     getPrContext: () => params.options.prContext,
@@ -382,6 +388,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
     stepExecutor,
     getCwd: params.getCwd,
     getWorkflowName: () => params.config.name,
+    getWorkflowRules: () => workflowRules,
     getInteractive: () => params.options.interactive === true,
     childProcessEnv: params.options.childProcessEnv,
     observabilityEnabled: params.options.observability?.enabled === true,

--- a/src/core/workflow/instruction/InstructionBuilder.ts
+++ b/src/core/workflow/instruction/InstructionBuilder.ts
@@ -23,6 +23,7 @@ import {
 import { renderPullRequestContext } from '../pr-context.js';
 import { isNormalAgentWorkflowStep } from '../../models/workflow-types.js';
 import { getCompanionInstructionCopy } from '../companion/evidence.js';
+import { renderWorkflowWideRules } from './workflow-wide-rules.js';
 
 const CONTEXT_MAX_CHARS = 2000;
 
@@ -85,6 +86,7 @@ export class InstructionBuilder {
     const editRule = buildEditRule(this.step.edit, language);
     const gitRules = buildGitRules(this.step.allowGitCommit, language, 'phase1');
     const hasGitRules = gitRules.length > 0;
+    const workflowRules = renderWorkflowWideRules(this.context.workflowRules, language);
     const fallbackNotice = this.context.fallbackContext
       ? renderFallbackNotice(this.context.fallbackContext, language)
       : '';
@@ -218,6 +220,12 @@ export class InstructionBuilder {
       knowledgeContent,
       hasQualityGates,
       qualityGatesContent,
+      hasWorkflowRulesAfterExecution: workflowRules.hasAfterExecutionRules,
+      workflowRulesNoticeAfterExecution: workflowRules.noticeAfterExecutionRules,
+      workflowRulesAfterExecution: workflowRules.afterExecutionRules,
+      hasWorkflowRulesBeforeInstruction: workflowRules.hasBeforeInstructionRules,
+      workflowRulesNoticeBeforeInstruction: workflowRules.noticeBeforeInstructionRules,
+      workflowRulesBeforeInstruction: workflowRules.beforeInstructionRules,
       instructions,
     });
   }

--- a/src/core/workflow/instruction/instruction-context.ts
+++ b/src/core/workflow/instruction/instruction-context.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowMaxSteps,
   WorkflowState,
   ResolvedFacetContent,
+  WorkflowWideRule,
 } from '../../models/types.js';
 import { loadTemplate } from '../../../shared/prompts/index.js';
 import type { PullRequestContext } from '../pr-context.js';
@@ -85,6 +86,8 @@ export interface InstructionContext {
   knowledgeSourcePath?: string;
   /** Workflow state for context/structured/effect interpolation */
   workflowState?: WorkflowState;
+  /** Resolved workflow-wide rules for Phase 1 only. */
+  workflowRules?: readonly WorkflowWideRule[];
   /** Scalar context inherited through workflow_call boundaries. */
   workflowCallVars?: Readonly<Record<string, string | number | boolean>>;
   companion?: {

--- a/src/core/workflow/instruction/workflow-wide-rules.ts
+++ b/src/core/workflow/instruction/workflow-wide-rules.ts
@@ -1,0 +1,42 @@
+import type { Language, WorkflowWideRule } from '../../models/types.js';
+import { loadTemplate } from '../../../shared/prompts/index.js';
+
+export interface RenderedWorkflowWideRules {
+  readonly hasAfterExecutionRules: boolean;
+  readonly afterExecutionRules: string;
+  readonly noticeAfterExecutionRules: string;
+  readonly hasBeforeInstructionRules: boolean;
+  readonly beforeInstructionRules: string;
+  readonly noticeBeforeInstructionRules: string;
+}
+
+function renderRule(rule: WorkflowWideRule, language: Language): string {
+  return loadTemplate('parts/workflow_wide_rule', language, {
+    ref: rule.ref,
+    content: rule.content.trimEnd(),
+  }).trimEnd();
+}
+
+function applicabilityNotice(language: Language): string {
+  return loadTemplate('parts/workflow_wide_rules_notice', language).trim();
+}
+
+export function renderWorkflowWideRules(
+  rules: readonly WorkflowWideRule[] | undefined,
+  language: Language,
+): RenderedWorkflowWideRules {
+  const afterExecutionRules = rules?.filter((rule) => rule.position === 'after_execution_rules') ?? [];
+  const beforeInstructionRules = rules?.filter((rule) => rule.position === 'before_instruction') ?? [];
+  const notice = applicabilityNotice(language);
+
+  return {
+    hasAfterExecutionRules: afterExecutionRules.length > 0,
+    afterExecutionRules: afterExecutionRules.map((rule) => renderRule(rule, language)).join('\n\n'),
+    noticeAfterExecutionRules: afterExecutionRules.length > 0 ? notice : '',
+    hasBeforeInstructionRules: beforeInstructionRules.length > 0,
+    beforeInstructionRules: beforeInstructionRules.map((rule) => renderRule(rule, language)).join('\n\n'),
+    noticeBeforeInstructionRules: afterExecutionRules.length === 0 && beforeInstructionRules.length > 0
+      ? notice
+      : '',
+  };
+}

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -6,6 +6,7 @@ import type {
   Language,
   LoopMonitorConfig,
   WorkflowConfig,
+  WorkflowWideRule,
   WorkflowCallStep,
   WorkflowMaxSteps,
   WorkflowRestartPoint,
@@ -697,6 +698,8 @@ export interface WorkflowEngineOptions {
   sharedRuntime?: WorkflowSharedRuntimeState;
   resumeStackPrefix?: WorkflowResumePointEntry[];
   workflowCallResolver?: WorkflowCallResolver;
+  /** Workflow-wide rules inherited from the caller workflow. */
+  inheritedWorkflowRules?: readonly WorkflowWideRule[];
   /** Scalar execution context inherited through nested workflow_call boundaries. */
   workflowCallVars?: Readonly<Record<string, string | number | boolean>>;
   /** Exact verified resource root for the run's workflow execution bundle. */

--- a/src/features/prompt/preview.ts
+++ b/src/features/prompt/preview.ts
@@ -153,6 +153,7 @@ function buildInstructionContext(
     validateReportReferences: false,
     language,
     reviewScope,
+    workflowRules: step.engineSynthesized === true ? undefined : config.allStepsRules,
   };
 }
 
@@ -236,6 +237,14 @@ export async function previewPrompts(
   header(`Workflow Prompt Preview: ${safeWorkflowName}`);
   info(`Steps: ${config.steps.length}`);
   info(`Language: ${language}`);
+  if (config.allStepsRules && config.allStepsRules.length > 0) {
+    info('Workflow-wide rules:');
+    for (const rule of config.allStepsRules) {
+      info(`- ref: ${sanitizeTerminalText(rule.ref)}`);
+      info(`  position: ${sanitizeTerminalText(rule.position)}`);
+      info(`  content: ${sanitizeTerminalText(rule.content)}`);
+    }
+  }
   blankLine();
 
   const reviewScope = resolvePreviewReviewScope(cwd);

--- a/src/infra/config/loaders/workflowAllStepsRuleResolver.ts
+++ b/src/infra/config/loaders/workflowAllStepsRuleResolver.ts
@@ -1,0 +1,159 @@
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { getBuiltinWorkflowsDir, getGlobalWorkflowsDir, getProjectWorkflowsDir } from '../paths.js';
+import type { Language, WorkflowWideRule } from '../../../core/models/index.js';
+import { extractReportReferences } from '../../../core/workflow/instruction/report-reference.js';
+import { withWorkflowConfigErrorPath } from '../../../core/workflow/workflow-config-error.js';
+import { readRegularFileNoFollow } from '../../../shared/utils/private-file.js';
+import { assertPathSegmentsAreSafe, lstatIfExists } from '../../../shared/utils/pathBoundary.js';
+
+type RawWorkflowWideRule = string | {
+  readonly ref: string;
+  readonly position?: 'before_instruction';
+};
+
+const REQUIRED_OUTPUT_HEADING = /(?:必須出力（見出しを含める）|Required Output \(include (?:the )?headings\))/i;
+const MARKDOWN_HEADING_LINE = /^\s*#{1,6}\s*(.+)$/;
+const REQUIRED_OUTPUT_SECTION_TITLE = /^(?:必須出力|Required Outputs?)(?:\s|$|[（(：:])/i;
+
+function containsRequiredOutputSection(content: string): boolean {
+  return content.split(/\r?\n/).some((line) => {
+    const heading = MARKDOWN_HEADING_LINE.exec(line);
+    if (heading === null) {
+      return false;
+    }
+    const title = heading[1];
+    if (title === undefined) {
+      return false;
+    }
+    const undecoratedTitle = title
+      .replace(/\[([^\]]+)](?:\([^)]*\)|\[[^\]]*])?/g, '$1')
+      .replace(/<[^>]*>/g, '')
+      .replace(/[*_~`]/g, '')
+      .trim();
+    return REQUIRED_OUTPUT_SECTION_TITLE.test(undecoratedTitle);
+  });
+}
+
+function assertSafeRuleReference(ref: string, index: number): void {
+  if (
+    ref.length === 0
+    || isAbsolute(ref)
+    || ref.includes('/')
+    || ref.includes('\\')
+    || ref === '.'
+    || ref === '..'
+  ) {
+    throw new Error(`Invalid workflow-wide rule reference at all_steps.rules[${index}]: "${ref}"`);
+  }
+}
+
+function ruleFilePath(root: string, ref: string): string {
+  const rulesDir = join(root, 'rules');
+  const filePath = join(rulesDir, `${ref}.md`);
+  const rootPath = resolve(rulesDir);
+  const relativePath = relative(rootPath, resolve(filePath));
+  if (relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new Error(`Workflow-wide rule reference escapes the rules directory: "${ref}"`);
+  }
+  return filePath;
+}
+
+function readRuleFile(root: string, filePath: string): string | undefined {
+  const rootStats = lstatIfExists(root);
+  if (rootStats !== null && (rootStats.isSymbolicLink() || !rootStats.isDirectory())) {
+    throw new Error(`Workflow-wide rule root must be a directory and must not be a symlink: ${root}`);
+  }
+
+  const stats = assertPathSegmentsAreSafe(
+    root,
+    filePath,
+    (_violation, segmentPath) => new Error(
+      `Workflow-wide rule must stay inside its candidate root and must not use symlinks: ${segmentPath}`,
+    ),
+  );
+  if (stats === null) return undefined;
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error(`Workflow-wide rule must be a regular file and must not be a symlink: ${filePath}`);
+  }
+
+  return readRegularFileNoFollow(filePath, stats).toString('utf-8');
+}
+
+function assertAllowedRuleContent(content: string, filePath: string, index: number): void {
+  if (REQUIRED_OUTPUT_HEADING.test(content) || containsRequiredOutputSection(content)) {
+    throw withWorkflowConfigErrorPath(
+      new Error(
+        `Invalid workflow-wide rule file "${filePath}" referenced by all_steps.rules[${index}]: `
+        + 'rule files must not contain required output headings',
+      ),
+      ['all_steps', 'rules', index],
+    );
+  }
+
+  if (extractReportReferences(content).length > 0) {
+    throw withWorkflowConfigErrorPath(
+      new Error(
+        `Invalid workflow-wide rule file "${filePath}" referenced by all_steps.rules[${index}]: `
+        + 'rule files must not contain {report:...} references',
+      ),
+      ['all_steps', 'rules', index],
+    );
+  }
+}
+
+function resolveRuleFile(
+  ref: string,
+  roots: readonly string[],
+  index: number,
+): { filePath: string; content: string } {
+  assertSafeRuleReference(ref, index);
+  for (const root of roots) {
+    const filePath = ruleFilePath(root, ref);
+    const content = readRuleFile(root, filePath);
+    if (content !== undefined) {
+      return { filePath, content };
+    }
+  }
+
+  throw new Error(
+    `Workflow-wide rule "${ref}" referenced by all_steps.rules[${index}] was not found `
+    + 'in project, global, or builtin workflow rules',
+  );
+}
+
+function normalizeRuleEntry(entry: RawWorkflowWideRule): { ref: string; position: WorkflowWideRule['position'] } {
+  if (typeof entry === 'string') {
+    return { ref: entry, position: 'after_execution_rules' };
+  }
+  return {
+    ref: entry.ref,
+    position: entry.position ?? 'after_execution_rules',
+  };
+}
+
+export function resolveWorkflowWideRules(
+  entries: readonly RawWorkflowWideRule[] | undefined,
+  projectCwd: string,
+  language: Language,
+): readonly WorkflowWideRule[] | undefined {
+  if (entries === undefined) {
+    return undefined;
+  }
+
+  const roots = [
+    getProjectWorkflowsDir(projectCwd),
+    getGlobalWorkflowsDir(),
+    getBuiltinWorkflowsDir(language),
+  ];
+
+  return entries.map((entry, index) => {
+    const normalized = normalizeRuleEntry(entry);
+    const resolved = resolveRuleFile(normalized.ref, roots, index);
+    assertAllowedRuleContent(resolved.content, resolved.filePath, index);
+    return {
+      ref: normalized.ref,
+      position: normalized.position,
+      content: resolved.content,
+    };
+  });
+}

--- a/src/infra/config/loaders/workflowParser.ts
+++ b/src/infra/config/loaders/workflowParser.ts
@@ -46,6 +46,7 @@ import {
 import type { WorkflowTrustInfo } from './workflowTrustSource.js';
 import { withWorkflowConfigErrorPath as withWorkflowStepErrorPath } from '../../../core/workflow/workflow-config-error.js';
 import { validateDynamicParallelContracts } from '../../../core/workflow/dynamic-parallel/validator.js';
+import { resolveWorkflowWideRules } from './workflowAllStepsRuleResolver.js';
 
 type RawSubworkflowParams = NonNullable<ReturnType<typeof WorkflowConfigRawSchema.parse>['subworkflow']>['params'];
 
@@ -141,6 +142,11 @@ export function normalizeWorkflowConfig(
       context,
     },
   );
+  const workflowWideRules = resolveWorkflowWideRules(
+    parsed.all_steps?.rules,
+    context?.projectDir ?? workflowDir,
+    context?.lang ?? 'en',
+  );
   const selectorInstructionRefs = collectSelectorInstructionRefs(parsed.steps);
   const resolvedPoliciesWithSource = resolveSectionMapWithSource(parsed.policies, workflowDir, 'policies', context);
   const resolvedKnowledgeWithSource = resolveSectionMapWithSource(parsed.knowledge, workflowDir, 'knowledge', context);
@@ -225,6 +231,7 @@ export function normalizeWorkflowConfig(
     knowledge: sections.resolvedKnowledge,
     instructions: sections.resolvedInstructions,
     reportFormats: sections.resolvedReportFormats,
+    ...(workflowWideRules === undefined ? {} : { allStepsRules: workflowWideRules }),
     steps,
     initialStep: parsed.initial_step ?? steps[0]!.name,
     maxSteps: parsed.max_steps,

--- a/src/shared/prompts/en/parts/workflow_wide_rule.md
+++ b/src/shared/prompts/en/parts/workflow_wide_rule.md
@@ -1,0 +1,7 @@
+<!--
+  template: parts/workflow_wide_rule
+  vars: ref, content
+-->
+### Workflow-wide rule: {{ref}}
+
+{{content}}

--- a/src/shared/prompts/en/parts/workflow_wide_rules_notice.md
+++ b/src/shared/prompts/en/parts/workflow_wide_rules_notice.md
@@ -1,0 +1,4 @@
+<!--
+  template: parts/workflow_wide_rules_notice
+-->
+The following rules apply to all steps in this workflow.

--- a/src/shared/prompts/en/perform_phase1_message.md
+++ b/src/shared/prompts/en/perform_phase1_message.md
@@ -7,6 +7,8 @@
         hasReport, reportInfo, phaseNote, hasTaskSection, userRequest, hasPreviousResponse,
         previousResponse, hasUserInputs, userInputs, hasRetryNote, retryNote, hasPrContext, prContext, hasPolicy,
         policyContent, hasKnowledge, knowledgeContent, hasQualityGates, qualityGatesContent,
+        hasWorkflowRulesAfterExecution, workflowRulesNoticeAfterExecution, workflowRulesAfterExecution,
+        hasWorkflowRulesBeforeInstruction, workflowRulesNoticeBeforeInstruction, workflowRulesBeforeInstruction,
         instructions
   builder: InstructionBuilder
 -->
@@ -22,6 +24,9 @@
 {{/if}}
 - **Do NOT use `cd` in Bash commands.** Your working directory is already set correctly. Run commands directly without changing directories.
 {{#if editRule}}- {{editRule}}
+{{/if}}{{#if hasWorkflowRulesAfterExecution}}
+{{workflowRulesNoticeAfterExecution}}
+{{workflowRulesAfterExecution}}
 {{/if}}
 Note: This section is metadata. Follow the language used in the rest of the prompt.
 
@@ -85,7 +90,10 @@ Knowledge may be truncated. Always follow Source paths and read original files b
 {{/if}}
 
 ## Instructions
-{{instructions}}
+{{#if hasWorkflowRulesBeforeInstruction}}{{workflowRulesNoticeBeforeInstruction}}
+{{workflowRulesBeforeInstruction}}
+
+{{/if}}{{instructions}}
 {{#if hasQualityGates}}
 
 ## Quality Gates

--- a/src/shared/prompts/ja/parts/workflow_wide_rule.md
+++ b/src/shared/prompts/ja/parts/workflow_wide_rule.md
@@ -1,0 +1,7 @@
+<!--
+  template: parts/workflow_wide_rule
+  vars: ref, content
+-->
+### ワークフロールール: {{ref}}
+
+{{content}}

--- a/src/shared/prompts/ja/parts/workflow_wide_rules_notice.md
+++ b/src/shared/prompts/ja/parts/workflow_wide_rules_notice.md
@@ -1,0 +1,4 @@
+<!--
+  template: parts/workflow_wide_rules_notice
+-->
+次の約束はこのワークフローの全ステップに適用されます。

--- a/src/shared/prompts/ja/perform_phase1_message.md
+++ b/src/shared/prompts/ja/perform_phase1_message.md
@@ -7,6 +7,8 @@
         hasReport, reportInfo, phaseNote, hasTaskSection, userRequest, hasPreviousResponse,
         previousResponse, hasUserInputs, userInputs, hasRetryNote, retryNote, hasPrContext, prContext, hasPolicy,
         policyContent, hasKnowledge, knowledgeContent, hasQualityGates, qualityGatesContent,
+        hasWorkflowRulesAfterExecution, workflowRulesNoticeAfterExecution, workflowRulesAfterExecution,
+        hasWorkflowRulesBeforeInstruction, workflowRulesNoticeBeforeInstruction, workflowRulesBeforeInstruction,
         instructions
   builder: InstructionBuilder
 -->
@@ -22,6 +24,9 @@
 {{/if}}
 - **Bashコマンドで `cd` を使用しないでください。** 作業ディレクトリは既に正しく設定されています。ディレクトリを変更せずにコマンドを実行してください。
 {{#if editRule}}- {{editRule}}
+{{/if}}{{#if hasWorkflowRulesAfterExecution}}
+{{workflowRulesNoticeAfterExecution}}
+{{workflowRulesAfterExecution}}
 {{/if}}
 
 ## 判断ルール
@@ -84,7 +89,10 @@ Knowledge はトリミングされる場合があります。Source Path に従�
 {{/if}}
 
 ## Instructions
-{{instructions}}
+{{#if hasWorkflowRulesBeforeInstruction}}{{workflowRulesNoticeBeforeInstruction}}
+{{workflowRulesBeforeInstruction}}
+
+{{/if}}{{instructions}}
 {{#if hasQualityGates}}
 
 ## Quality Gates


### PR DESCRIPTION
## Summary

## 観測

「findings の扱い方」のような、特定ステップの手順ではなくワークフロー内の複数ステップを横断する作業の約束事を配る手段がない。現状の選択肢はどれも合わない。

- policy は判定基準（REJECT/承認）の置き場であり、作業の進め方の約束事とは役割が違う
- instruction はステップ単位で、横断の約束を配るには `{{include:...}}` 1行のラッパーファセットが増殖する。組み合わせはワークフロー YAML から見えない
- エンジンが全ステップへ自動注入する「実行ルール」（git commit するな等）はまさに横断の約束だが、ハードコードでありユーザーが定義できない

現行 builtins/ja の棚卸しでは、次の3つに約15箇所の同義文が散在している。

| 約束 | 散在箇所（例） |
|---|---|
| レポートと現在のコードを一次情報とし、前の応答・要約・自己申告に依存しない | implement 系3、fix-supervisor、ai-antipattern-fix、team-leader-fix、e2e-coverage-plan ほか |
| 観測した事実だけを finding・報告にする（推測を書かない） | adjudicate-review-findings、gather-review、review-implementation-semantics、base-plan ほか |
| テスト成功だけを完了根拠にしない | contract-family-fix-verifier、test-contract-discrimination、change-contract-traceability |

## 期待

ワークフロー定義に、全ステップへ配る作業の約束（rules）を0個以上宣言できること。rules は短い平易な文章であり、手順・必須出力・判定基準を持たない。宣言がなければ従来と完全に同一の動作であること。

## 提案

### YAML

```yaml
name: my-workflow
all_steps:
  rules:
    - findings-handling              # 位置指定なし → デフォルト
    - ref: careful-findings
      position: before_instruction   # 指示の直前に置く
steps: ...
```

- `all_steps` は「全ステップに付くもの」という適用範囲だけを表す。v1 の中身は `rules` のみ
- 配列の要素は参照文字列、または `ref` と `position` を持つオブジェクト
- `position` の値は v1 では `before_instruction` のみ（省略時はプロンプト上側＝自動注入の実行ルールの直後）。他の位置は必要になるまで追加しない。どの約束をどちらに置くかは eval で測って決められる（宣言の差し替えだけで A/B できる）

### 置き場と解決

- ファイルは `workflows/rules/*.md`。facets には置かない（facets はステップのプロンプトを組み立てる部品の置き場であり、rules はステップ選択を経ずワークフロー単位で注入されるため）
- 解決はワークフローと同じ3層（`.takt/workflows/rules/` → `~/.takt/workflows/rules/` → builtins）

### 注入の規則

- phase 1 のみ。レポート出力 phase と状態判定 phase には入れない
- companion には配らない。`all_steps` の適用範囲はステップの phase 1 のみ（companion はステップではなく、自前のプロンプト構成を持つ別エージェント。必要になれば companion プロンプトの再設計 #1345 側で明示的に取り込む）
- workflow_call のサブワークフローへ伝播し、子は追加のみできる（除去の意味論は作らない）
- 適用を示す一文（「次の約束はこのワークフローの全ステップに適用される」）は注入ヘッダが一度だけ持つ。instruction 側に「rules に従うこと」とは書かない（ファセットは他の部品を参照できないため、宙に浮く参照を作らない）
- rule ファセットが必須出力見出しや `{report:...}` 参照を含む場合は読み込み時にエラーとする

### トップレベルキーの増殖防止

トップレベルキーの新設は「ワークフロー全体の性質」であって既存の器（`all_steps` / `provider_routing` / `subworkflow`）に収まらないものに限る。全ステップ横断の宣言は今後も `all_steps` 配下へ足し、トップレベルを増やさない。

### 役割の線引き

- policy = 何を不合格にするか / rule = どう作業するかの約束 / instruction = いまこのステップで何をするか
- knowledge / policies は従来どおりステップ単位で付ける（workflow スコープ化はしない）
- 「編集しないでください」系はステップの性質であり、`capabilities` に edit がないステップへエンジンが機械的に注入するのが正しい（本 Issue の範囲外の別改善）
- 手順に編み込まれた約束文（例: verify-fix の「修正報告を正解表にせず」）は instruction に残す。移行で削る場合は eval で退行がないことを確認してから行う

## 受入条件（Gherkin）

```gherkin
Feature: ワークフロー横断の作業ルールの宣言と注入

  Scenario: デフォルト位置への注入
    Given ワークフローが all_steps.rules に位置指定なしのルールを宣言している
    When 任意のステップの phase 1 指示を組み立てる
    Then ルール本文が自動注入の実行ルールの直後に、宣言順で含まれる

  Scenario: 指示直前への注入
    Given all_steps.rules のルールが position: before_instruction を指定している
    When phase 1 指示を組み立てる
    Then そのルール本文がステップの指示の直前に含まれる

  Scenario: ルールなしの互換
    Given all_steps を宣言していない既存ワークフロー
    When ワークフローを読み込んで実行する
    Then 従来と同一の指示が組み立てられる

  Scenario: サブワークフローへの伝播
    Given 親ワークフローが all_steps.rules を宣言し、workflow_call で子を呼ぶ
    When 子ワークフローのステップを実行する
    Then 親のルールが子のステップにも注入される

  Scenario: 不正なルールの検出
    Given rules に必須出力見出しまたは {report:...} 参照を含むファイルが指定されている
    When ワークフローを読み込む
    Then どのファイルが不正かを示すエラーで失敗する

  Scenario: プレビューでの可視化
    Given all_steps.rules を宣言したワークフロー
    When takt prompt でプレビューする
    Then 注入されるルールの参照一覧・位置・本文が表示される
```

## 導入時の移行（参考）

instruction の手直しは実質「削除」になる。例:

- Before（`base-fix-plan-from-review-resolution.md`）: 「**重要:** このステップではソースを編集しないでください。Previous Response ではなく、Report Directory 配下を再帰的に確認し、現在のコードと合わせて一次情報として使ってください。」
- After: 「**重要:** このステップではソースを編集しないでください。」＋ rule `report-first.md`（レポートと現在のコードを一次情報として使う。前の応答や会話の要約、他の担当者の自己申告だけを根拠にしない）

移行は棚卸し表の3つの約束から始め、前後で eval フルランを比較して挙動が変わらないことを確認しながら行う。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #1352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ワークフロー全体に適用する `all_steps.rules` を設定できるようになりました。
  * ルールの適用位置を指定でき、通常のステップやバッチ処理に反映されます。
  * 子ワークフローには親のルールが継承されます。
  * プロンプトプレビューで、適用されるルールの内容を確認できます。
  * ルール参照の探索順や不正な設定が検証されます。

* **ドキュメント**
  * 設定方法、探索順、継承、制限事項、互換動作を日本語・英語で説明しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->