### PR TITLE
fix(companion): disable reviewers by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,17 +412,19 @@ naming the file and the key to migrate to. Without a `runtime.yaml`,
 [docs/configuration.md](docs/configuration.md) for the schema and the
 migration table.
 
-Companion reviewers are enabled by default. To disable them, set the
+Companion reviewers are disabled by default. To enable them, set the
 top-level policy in `runtime.yaml`:
 
 ```yaml
 version: 1
 companion:
-  enabled: false
+  enabled: true
 ```
 
-The global and project policies are combined with logical AND, so a global
-`false` cannot be re-enabled by a project setting.
+When both global and project policies are set, they are combined with logical
+AND, so a global `false` cannot be re-enabled by a project setting. An omitted
+policy is neutral during layer merging; Companion stays disabled when neither
+layer specifies one.
 
 ## Customization
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -374,15 +374,15 @@ export TAKT_KIRO_API_KEY=...               # Kiro CLI
 
 プロバイダー・モデル・プロバイダーオプション・自動ルーティング・内部エージェント割り当ては、`config.yaml` ではなく専用レイヤーに置けます。`~/.takt/runtime.yaml` と `<project>/.takt/runtime.yaml` があり、プロジェクト側が優先されます。`runtime.yaml` が置き換えるのは `config.yaml` の旧プロバイダーキーが担っていた設定レイヤーの既定値で、それより上位の解決はこれまでどおり適用されます。CLI・環境変数の上書きが最優先で、次に `promotion`、step 直接指定、`workflow_call`、`provider_routing`、auto routing の順です。provider と model はフィールド単位で独立に解決されます。旧プロバイダーキーとの混在は、問題のファイルと移行先キーを示す診断つきで拒否されます。`runtime.yaml` がなければ `config.yaml` は従来どおり動作します。
 
-companion reviewer は既定で有効です。無効化する場合は、`runtime.yaml` のトップレベルに次を設定します。
+companion reviewer は既定で無効です。有効化する場合は、`runtime.yaml` のトップレベルに次を設定します。
 
 ```yaml
 version: 1
 companion:
-  enabled: false
+  enabled: true
 ```
 
-global と project の設定は論理積で合成するため、global 側の `false` を project 側で再有効化することはできません。
+global と project の両方に設定がある場合は論理積で合成するため、global 側の `false` を project 側で再有効化することはできません。レイヤー合成時に未指定の設定は中立として扱い、両方とも未指定なら companion は無効のままです。
 
 全設定項目・プロバイダープロファイル・モデル解決の詳細は [Configuration Guide](./configuration.ja.md) を参照してください。
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -568,17 +568,19 @@ steps:
 1. `~/.takt/runtime.yaml`
 2. `<project>/.takt/runtime.yaml`
 
-companion reviewer は既定で有効です。無効化する場合は、トップレベルの
+companion reviewer は既定で無効です。有効化する場合は、トップレベルの
 `companion.enabled` を設定します。
 
 ```yaml
 version: 1
 companion:
-  enabled: false
+  enabled: true
 ```
 
-global と project の値は論理積で合成されるため、global 側で無効化した companion を
-project 側の `true` で再有効化することはできません。
+global と project の両方にポリシーがある場合、その値は論理積で合成されるため、global
+側で無効化した companion を project 側の `true` で再有効化することはできません。
+レイヤー合成時に未指定のポリシーは中立として扱い、両方とも未指定なら companion は
+無効のままです。
 
 companion の provider target（`targets.companions`）とプロバイダ能力要件が適用されるのは
 companion が有効な間だけです。無効時も companion 宣言と `targets.companions` の構造検証は

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -573,17 +573,19 @@ steps:
 1. `~/.takt/runtime.yaml`
 2. `<project>/.takt/runtime.yaml`
 
-Companion reviewers are enabled by default. Disable them with the top-level
+Companion reviewers are disabled by default. Enable them with the top-level
 `companion.enabled` policy:
 
 ```yaml
 version: 1
 companion:
-  enabled: false
+  enabled: true
 ```
 
-The global and project values are combined with logical AND; a project value
-of `true` cannot re-enable a globally disabled companion.
+When both global and project policies are specified, their values are combined
+with logical AND; a project value of `true` cannot re-enable a globally disabled
+companion. An omitted policy is neutral during layer merging, and Companion
+remains disabled when neither layer specifies one.
 
 Companion provider targets (`targets.companions`) and provider capability
 requirements apply only while companions are enabled. When disabled, companion

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -1198,6 +1198,9 @@ steps:
 
 通常の agent step に `companion` を指定すると、実装エージェントの編集と並行して、ステートレスかつ read-only のレビュアーが動きます。名前配列は固定レビュアーの短縮形です。object 形式では固定レビュアー、step 開始時に1回だけ選抜する pool、任意の moderator を組み合わせられます。同時実行は最大3名です。
 
+companion reviewer は既定で無効です。workflow に宣言した reviewer を実行するには、
+`runtime.yaml` で `companion.enabled: true` を設定します。
+
 ```yaml
 - name: implement
   persona: coder

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1199,6 +1199,9 @@ steps:
 
 Add `companion` to a normal agent step to run stateless, read-only reviewers while the agent edits. A shorthand list selects fixed reviewers. Use the object form to combine fixed reviewers with a pool selected once at step startup and an optional moderator. At most three reviewers run together.
 
+Companion reviewers are disabled by default. Set `companion.enabled: true` in
+`runtime.yaml` to run reviewers declared by a workflow.
+
 ```yaml
 - name: implement
   persona: coder

--- a/e2e/specs/companion-review.e2e.ts
+++ b/e2e/specs/companion-review.e2e.ts
@@ -63,6 +63,8 @@ describe('E2E: companion review', () => {
     ].join('\n'), 'utf8');
     writeFileSync(join(repo.path, '.takt', 'runtime.yaml'), [
       'version: 1',
+      'companion:',
+      '  enabled: true',
       'provider:',
       '  profiles:',
       '    mock:',

--- a/src/__tests__/it-companion-entrypoints.test.ts
+++ b/src/__tests__/it-companion-entrypoints.test.ts
@@ -136,6 +136,13 @@ function createFixture(options: FixtureOptions): CompanionEntrypointFixture {
       ...targets,
       '',
     ].join('\n'));
+  } else if (options.companionEnabled !== undefined) {
+    writeFileSync(join(projectDir, '.takt', 'runtime.yaml'), [
+      'version: 1',
+      'companion:',
+      `  enabled: ${options.companionEnabled}`,
+      '',
+    ].join('\n'));
   }
   writeFileSync(join(configDir, 'config.yaml'), [
     'language: en',
@@ -220,17 +227,17 @@ describe('companion runtime, preview, and doctor entrypoint parity', () => {
   }[] = [
     {
       name: 'accepts an explicit companion target',
-      options: { assignment: 'target' },
+      options: { assignment: 'target', companionEnabled: true },
       succeeds: true,
     },
     {
       name: 'accepts provider defaults when the target is omitted',
-      options: { assignment: 'defaults' },
+      options: { assignment: 'defaults', companionEnabled: true },
       succeeds: true,
     },
     {
       name: 'rejects legacy provider configuration',
-      options: { assignment: 'legacy' },
+      options: { assignment: 'legacy', companionEnabled: true },
       succeeds: false,
       errorPattern: /require runtime\.yaml|migrate provider configuration/,
     },
@@ -242,6 +249,11 @@ describe('companion runtime, preview, and doctor entrypoint parity', () => {
     {
       name: 'skips companion provider resolution when disabled',
       options: { assignment: 'target', companionEnabled: false, invalidCompanionTarget: true },
+      succeeds: true,
+    },
+    {
+      name: 'skips companion provider resolution when the policy is omitted',
+      options: { assignment: 'target', invalidCompanionTarget: true },
       succeeds: true,
     },
     {

--- a/src/__tests__/it-companion-worktree.test.ts
+++ b/src/__tests__/it-companion-worktree.test.ts
@@ -63,6 +63,8 @@ describe('CT-COMP-12 worktree companion runtime continuity', () => {
     ].join('\n'));
     writeFileSync(join(projectDir, '.takt', 'runtime.yaml'), [
       'version: 1',
+      'companion:',
+      '  enabled: true',
       'provider:',
       '  profiles:',
       '    mock:',

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -647,6 +647,7 @@ describe('experimental builtin workflow', () => {
       const engine = new WorkflowEngine(workflow, projectDir, 'Implement and review a TAKT local execution security change', {
         projectCwd: projectDir,
         provider: 'mock',
+        companionEnabled: true,
         selectorProvider: SELECTOR_PROVIDER,
         selectorGitCommandRunner: SELECTOR_GIT_COMMAND_RUNNER,
         companionProviders: {
@@ -873,6 +874,7 @@ describe('experimental builtin workflow', () => {
       const engine = new WorkflowEngine(wrapper, projectDir, 'Implement a change that cannot be remediated', {
         projectCwd: projectDir,
         provider: 'mock',
+        companionEnabled: true,
         selectorProvider: SELECTOR_PROVIDER,
         selectorGitCommandRunner: SELECTOR_GIT_COMMAND_RUNNER,
         companionProviders: {

--- a/src/__tests__/runtime-provider-loader.test.ts
+++ b/src/__tests__/runtime-provider-loader.test.ts
@@ -344,7 +344,8 @@ describe('runtime-provider loader', () => {
 
     const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
 
-    expect(resolved?.companion).toBeUndefined();
+    expect(resolved).toBeDefined();
+    expect(resolved!.companion).toBeUndefined();
   });
 
   it('Given neither file present, When resolving, Then it returns undefined (C1)', () => {

--- a/src/__tests__/runtime-provider-loader.test.ts
+++ b/src/__tests__/runtime-provider-loader.test.ts
@@ -338,6 +338,15 @@ describe('runtime-provider loader', () => {
     expect(resolved?.companion?.enabled).toBe(true);
   });
 
+  it('Given both files omit companion, When resolving, Then companion remains undefined', () => {
+    writeRuntimeYaml(globalDir, ['version: 1']);
+    writeRuntimeYaml(projectDir, ['version: 1']);
+
+    const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
+
+    expect(resolved?.companion).toBeUndefined();
+  });
+
   it('Given neither file present, When resolving, Then it returns undefined (C1)', () => {
     expect(resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir })).toBeUndefined();
   });

--- a/src/__tests__/runtime-provider-loader.test.ts
+++ b/src/__tests__/runtime-provider-loader.test.ts
@@ -325,6 +325,19 @@ describe('runtime-provider loader', () => {
     expect(resolved?.companion?.enabled).toBe(false);
   });
 
+  it('Given global companion.enabled=true and an unrelated project file, When resolving, Then companion remains enabled', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'companion:',
+      '  enabled: true',
+    ]);
+    writeRuntimeYaml(projectDir, ['version: 1']);
+
+    const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
+
+    expect(resolved?.companion?.enabled).toBe(true);
+  });
+
   it('Given neither file present, When resolving, Then it returns undefined (C1)', () => {
     expect(resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir })).toBeUndefined();
   });

--- a/src/__tests__/runtime-provider-mode.test.ts
+++ b/src/__tests__/runtime-provider-mode.test.ts
@@ -52,6 +52,13 @@ describe('hasActiveProviderSection (C11/C25)', () => {
     }))).toBe(false);
   });
 
+  it('Given a companion-only target without a companion policy, Then it is inactive by default', () => {
+    expect(hasActiveProviderSection(runtimeFile({
+      version: 1,
+      provider: { targets: { companions: { security: { profile: 'security' } } } },
+    }))).toBe(false);
+  });
+
   it('Given an enabled companion-only target, Then it is active', () => {
     expect(hasActiveProviderSection(runtimeFile({
       version: 1,

--- a/src/__tests__/runtime-provider-schema.test.ts
+++ b/src/__tests__/runtime-provider-schema.test.ts
@@ -152,7 +152,7 @@ describe('RuntimeProviderFileSchema', () => {
     }
   });
 
-  it('Given companion-only targets without a companion policy or defaults, When parsed, Then it is rejected for missing defaults', () => {
+  it('Given companion-only targets without a companion policy or defaults, When parsed, Then it remains inactive by default', () => {
     const result = RuntimeProviderFileSchema.safeParse({
       version: 1,
       provider: {
@@ -160,10 +160,7 @@ describe('RuntimeProviderFileSchema', () => {
       },
     });
 
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((issue) => issue.message.includes('provider.defaults'))).toBe(true);
-    }
+    expect(result.success).toBe(true);
   });
 
   it('Given defaults.pool with a defined pool and fallback profile, When parsed, Then it is rejected with a pool-specific error', () => {

--- a/src/__tests__/runtime-provider-seam.integration.test.ts
+++ b/src/__tests__/runtime-provider-seam.integration.test.ts
@@ -302,12 +302,14 @@ describe('resolveCompiledProviderEnvironment seam', () => {
   });
 
   it('passes legacy engine-options through unchanged when no runtime.yaml exists', () => {
-    const env = resolveCompiledProviderEnvironment({
+    const resolved = resolveRuntimeEnvironment({
       projectCwd,
       legacy: legacyInput,
       legacySignals: [],
     });
 
+    const env = resolved.providerEnvironment;
+    expect(resolved.companionEnabled).toBe(false);
     expect(env.provider).toBe('codex');
     expect(env.providerSource).toBe('global');
     expect(env.model).toBe('gpt-x');

--- a/src/__tests__/selector-provider-resolution.test.ts
+++ b/src/__tests__/selector-provider-resolution.test.ts
@@ -354,7 +354,9 @@ describe('workflow selector resolution', () => {
       }],
     };
 
-    expect(resolveWorkflowSelectorForProject(workflow, projectDir)).toMatchObject({
+    expect(resolveWorkflowSelectorForProject(workflow, projectDir, {
+      companionEnabled: true,
+    })).toMatchObject({
       applies: true,
       selectorProvider: { provider: 'codex', model: 'gpt-selector' },
     });

--- a/src/core/workflow/engine/WorkflowEngineSetup.ts
+++ b/src/core/workflow/engine/WorkflowEngineSetup.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type { StructuredCaller } from '../../../agents/structured-caller.js';
 import { createLogger } from '../../../shared/utils/index.js';
+import { DEFAULT_COMPANION_ENABLED } from '../../../shared/constants.js';
 import type {
   AgentResponse,
   WorkflowConfig,
@@ -247,7 +248,7 @@ export function createWorkflowEngineServices(params: WorkflowEngineSetupParams):
       ? {}
       : { inputReader: new SelectorInputReader(params.options.selectorGitCommandRunner) }),
   });
-  const companionEnabled = params.options.companionEnabled ?? true;
+  const companionEnabled = params.options.companionEnabled ?? DEFAULT_COMPANION_ENABLED;
 
   const stepExecutor = new StepExecutor({
     optionsBuilder,

--- a/src/infra/config/runtime-provider/loader.ts
+++ b/src/infra/config/runtime-provider/loader.ts
@@ -80,11 +80,12 @@ function mergeRuntimeProviderFiles(
   project: RuntimeProviderFile,
 ): RuntimeProviderFile {
   const provider = mergeProviderSections(global.provider, project.provider);
-  const companionEnabled = (global.companion?.enabled ?? true)
-    && (project.companion?.enabled ?? true);
   const companion = global.companion === undefined && project.companion === undefined
     ? undefined
-    : { enabled: companionEnabled };
+    : {
+        enabled: global.companion?.enabled !== false
+          && project.companion?.enabled !== false,
+      };
   return provider
     ? {
         version: RUNTIME_PROVIDER_VERSION,

--- a/src/infra/config/runtime-provider/mode.ts
+++ b/src/infra/config/runtime-provider/mode.ts
@@ -9,6 +9,7 @@
  */
 
 import { hasActiveProviderContent, type RuntimeProviderFile } from './schema.js';
+import { DEFAULT_COMPANION_ENABLED } from '../../../shared/constants.js';
 
 export type ProviderConfigMode = 'legacy' | 'runtime-v1';
 
@@ -28,7 +29,10 @@ export interface DetermineProviderConfigModeInput {
 
 /** True only when the runtime.yaml carries a provider section with meaningful content. */
 export function hasActiveProviderSection(file: RuntimeProviderFile | undefined): boolean {
-  return hasActiveProviderContent(file?.provider, file?.companion?.enabled ?? true);
+  return hasActiveProviderContent(
+    file?.provider,
+    file?.companion?.enabled ?? DEFAULT_COMPANION_ENABLED,
+  );
 }
 
 export function determineProviderConfigMode(

--- a/src/infra/config/runtime-provider/provider-environment.ts
+++ b/src/infra/config/runtime-provider/provider-environment.ts
@@ -39,6 +39,7 @@ import { resolveEffectiveAutoRouting } from '../../../core/workflow/auto-routing
 import type { WorkflowConfig } from '../../../core/models/index.js';
 import { getEffectiveRuntimeProviderFile } from './schema.js';
 import { createRuntimeProviderResolutionContext } from './resolution-context.js';
+import { DEFAULT_COMPANION_ENABLED } from '../../../shared/constants.js';
 
 export interface ResolvedRuntimeEnvironment {
   providerEnvironment: CompiledProviderEnvironment;
@@ -69,7 +70,7 @@ export function resolveRuntimeEnvironment(
     projectConfigDir: getProjectConfigDir(input.projectCwd),
   });
   const runtimeFile = resolvedRuntimeFile.runtimeFile;
-  const companionEnabled = runtimeFile?.companion?.enabled ?? true;
+  const companionEnabled = runtimeFile?.companion?.enabled ?? DEFAULT_COMPANION_ENABLED;
   const runtimeFileForProviderResolution = getEffectiveRuntimeProviderFile(runtimeFile);
   const { mode } = determineProviderConfigMode({
     runtimeFile: runtimeFileForProviderResolution,

--- a/src/infra/config/runtime-provider/schema.ts
+++ b/src/infra/config/runtime-provider/schema.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import { PROVIDER_TYPES } from '../../../shared/types/provider.js';
 import { PermissionModeSchema } from '../../../core/models/schema-base.js';
 import { RUNTIME_PROVIDER_VERSION } from './constants.js';
+import { DEFAULT_COMPANION_ENABLED } from '../../../shared/constants.js';
 
 const ProviderNameSchema = z.enum(PROVIDER_TYPES);
 
@@ -222,7 +223,7 @@ function getEffectiveProviderSection(
 /** Determine whether a provider section has active runtime configuration. */
 export function hasActiveProviderContent(
   section: RuntimeProviderSectionShape | undefined,
-  companionEnabled = true,
+  companionEnabled = DEFAULT_COMPANION_ENABLED,
 ): boolean {
   const effectiveSection = getEffectiveProviderSection(section, companionEnabled);
   if (effectiveSection === undefined) {
@@ -248,7 +249,7 @@ export const RuntimeProviderFileSchema = z
   })
   .strict()
   .superRefine((value, ctx) => {
-    const companionEnabled = value.companion?.enabled ?? true;
+    const companionEnabled = value.companion?.enabled ?? DEFAULT_COMPANION_ENABLED;
     if (hasActiveProviderContent(value.provider, companionEnabled) && value.provider?.defaults === undefined) {
       ctx.addIssue({
         code: 'custom',
@@ -274,7 +275,7 @@ export function getEffectiveRuntimeProviderFile(
   }
   const provider = getEffectiveProviderSection(
     file.provider,
-    file.companion?.enabled ?? true,
+    file.companion?.enabled ?? DEFAULT_COMPANION_ENABLED,
   );
   return {
     ...file,

--- a/src/infra/config/workflowSelectorResolution.ts
+++ b/src/infra/config/workflowSelectorResolution.ts
@@ -10,6 +10,7 @@ import { getWorkflowReference } from '../../core/workflow/workflow-reference.js'
 import type { ProviderType } from '../../shared/types/provider.js';
 import type { StepProviderOptions } from '../../core/models/workflow-types.js';
 import type { WorkflowCallResolver } from '../../core/workflow/types.js';
+import { DEFAULT_COMPANION_ENABLED } from '../../shared/constants.js';
 import { resolveWorkflowCallTarget } from './loaders/workflowCallResolver.js';
 import { collectReachableWorkflowCallSteps } from './loaders/workflowParallelTraversal.js';
 import {
@@ -75,7 +76,8 @@ function workflowGraphHasDynamicFacets(
   activeReferences: ReadonlySet<string>,
   depth: number,
 ): boolean {
-  if (hasDynamicFacets(workflow) || (options.companionEnabled !== false && hasCompanionPool(workflow))) {
+  const companionEnabled = options.companionEnabled ?? DEFAULT_COMPANION_ENABLED;
+  if (hasDynamicFacets(workflow) || (companionEnabled && hasCompanionPool(workflow))) {
     return true;
   }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -11,6 +11,9 @@ export const DEFAULT_WORKFLOW_NAME = 'default';
 /** Default language for new installations */
 export const DEFAULT_LANGUAGE: Language = 'en';
 
+/** Companion reviewers are opt-in unless runtime.yaml explicitly enables them. */
+export const DEFAULT_COMPANION_ENABLED = false;
+
 /** Slash commands recognized in interactive mode */
 export const SlashCommand = {
   Accept: '/accept',


### PR DESCRIPTION
## Summary

- make Companion reviewers opt-in by changing the default of `companion.enabled` from `true` to `false`
- keep explicit `true` support and the existing global/project safety rule where any explicit `false` wins
- treat an omitted policy as neutral while merging layers, so an unrelated runtime file does not override an explicit enablement
- apply the same default to runtime loading, provider-mode detection, selector resolution, and direct workflow engine setup
- update English/Japanese documentation and Companion fixtures for the opt-in behavior

## Root cause and impact

The previous default was repeated across several runtime and engine seams. Omitting `companion.enabled` therefore started Companion reviewers and activated Companion-only provider targets implicitly.

After this change, workflows that declare Companion reviewers run without them unless either the global or project `runtime.yaml` explicitly contains:

```yaml
version: 1
companion:
  enabled: true
```

If both layers specify the policy, their values are still combined with logical AND, so a project cannot re-enable a globally disabled Companion policy.

## Validation

- `npm run build`
- `npm run lint`
- `npm test` (all four unit shards)
- `npm run test:it`
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts`
- targeted changed heavy integration tests, including `src/__tests__/it-companion-entrypoints.test.ts`
- `npm run test:e2e:mock`

## Review notes

- No generated `dist/` files or dependency lockfile changes are included.
- No issue is closed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * Companion reviewer の既定状態を無効に変更しました。
  * `companion.enabled: true` を明示した場合のみ有効になります。
  * グローバル設定とプロジェクト設定を組み合わせて判定し、両方が未指定の場合は無効になります。

* **ドキュメント**
  * 設定方法とワークフローでの有効化手順を更新しました。

* **テスト**
  * Companion reviewer の有効・無効状態や設定の組み合わせに関する検証を更新・追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->