### PR TITLE
chore(deps): @openai/codex-sdk を 0.147.0 へ更新する

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-uAF4AV9mLPgdOogWN6lfzN1N4PQt2xU7uUQA6nJ6GI4=";
+            npmDepsHash = "sha256-csZ/PC5Jv3GYWqJal5N2B2lMQ/0EIYoQb4jdtq9Ya+o=";
             npmDepsFetcherVersion = 2;
             nodejs = nodejs;
             ONNXRUNTIME_NODE_INSTALL = "skip";

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@earendil-works/pi-ai": "^0.84.1",
         "@earendil-works/pi-coding-agent": "^0.84.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/codex-sdk": "^0.144.1",
+        "@openai/codex-sdk": "^0.147.0",
         "@opencode-ai/sdk": "1.18.2",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
@@ -5510,9 +5510,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.1",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
-      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0.tgz",
+      "integrity": "sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -5521,19 +5521,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.147.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.147.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.147.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.147.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.147.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.147.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
-      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
+      "version": "0.147.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz",
+      "integrity": "sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==",
       "cpu": [
         "arm64"
       ],
@@ -5548,9 +5548,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
-      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
+      "version": "0.147.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-x64.tgz",
+      "integrity": "sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==",
       "cpu": [
         "x64"
       ],
@@ -5565,9 +5565,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
-      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
+      "version": "0.147.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-arm64.tgz",
+      "integrity": "sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==",
       "cpu": [
         "arm64"
       ],
@@ -5582,9 +5582,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
-      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
+      "version": "0.147.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-x64.tgz",
+      "integrity": "sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==",
       "cpu": [
         "x64"
       ],
@@ -5598,12 +5598,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.144.1",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.144.1.tgz",
-      "integrity": "sha512-NVb1R5+QJBecLrLrtljHkS7djXu/fGWVaA0FUhop6KgPTdeDzvgMo9uhgAuLi+4mwgf29IhMyNGU/kHG3aV4NA==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.147.0.tgz",
+      "integrity": "sha512-nJL0maDBZy31uEArs+u46tW22veNdHjfs96AGaFTnI3jF+g8U+a422uaPiDZwEKmyxcNwStTRz6sIh6C7XxGFQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.144.1"
+        "@openai/codex": "0.147.0"
       },
       "engines": {
         "node": ">=18"
@@ -5611,9 +5611,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
-      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
+      "version": "0.147.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-arm64.tgz",
+      "integrity": "sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==",
       "cpu": [
         "arm64"
       ],
@@ -5628,9 +5628,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
-      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
+      "version": "0.147.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-x64.tgz",
+      "integrity": "sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@earendil-works/pi-ai": "^0.84.1",
     "@earendil-works/pi-coding-agent": "^0.84.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex-sdk": "^0.144.1",
+    "@openai/codex-sdk": "^0.147.0",
     "@opencode-ai/sdk": "1.18.2",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",


### PR DESCRIPTION
eval の codex-sdk を最新へ更新する（ユーザー指示）。npm がキャッシュ解決時に落とす integrity フィールドをレジストリ値で補完し、Nix ビルド（全レジストリ依存に integrity 必須）との整合を維持。npm ci / npm test / lint 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **更新**
  * Codex SDK のバージョンを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->