### PR TITLE
fix(eval): レビュアー評価の合成へ動的facet選択の結果を含める

### DIFF
--- a/eval/scripts/prepare.mjs
+++ b/eval/scripts/prepare.mjs
@@ -206,6 +206,11 @@ const TARGETS = [
     step: 'security-review',
     fixture: 'eval/fixtures/review-adjudication-binding',
     includeOutputContract: true,
+    dynamicFacetSelection: {
+      sourceWorkflow: 'experimental-review',
+      pool: 'security-review-facets',
+      candidateIds: ['cli'],
+    },
   },
   {
     id: 'security-review-method',
@@ -214,6 +219,11 @@ const TARGETS = [
     step: 'security-review',
     fixture: 'eval/fixtures/security-review-method',
     includeOutputContract: true,
+    dynamicFacetSelection: {
+      sourceWorkflow: 'experimental-review',
+      pool: 'security-review-facets',
+      candidateIds: ['cli'],
+    },
   },
   {
     id: 'review-mode-authority',
@@ -279,6 +289,9 @@ const { ReportInstructionBuilder } = await import(
 );
 const { StatusJudgmentBuilder } = await import(
   pathToFileURL(join(repoRoot, 'dist/core/workflow/instruction/StatusJudgmentBuilder.js')).href
+);
+const { composeDynamicFacets } = await import(
+  pathToFileURL(join(repoRoot, 'dist/core/workflow/dynamic-facets/dynamicFacetComposer.js')).href
 );
 const { getAllParallelSubSteps } = await import(
   pathToFileURL(join(repoRoot, 'dist/core/models/types.js')).href
@@ -361,6 +374,47 @@ function findStepThroughCall(workflow, callStepName, stepName) {
   return findStepTarget(child, stepName, 1);
 }
 
+function composeConfiguredDynamicFacets(target, selection, targetId, stepName) {
+  if (selection === undefined) return target;
+
+  const sourceWorkflow = loadWorkflowByIdentifier(selection.sourceWorkflow, repoRoot);
+  if (!sourceWorkflow) {
+    throw new Error(`Dynamic facet source workflow not found: ${selection.sourceWorkflow}`);
+  }
+  const source = findStepTarget(sourceWorkflow, stepName);
+  if (!source || source.target.dynamicFacets === undefined) {
+    throw new Error(`Dynamic facet source step not found: ${selection.sourceWorkflow}/${stepName}`);
+  }
+  if (source.target.dynamicFacets.pool !== selection.pool) {
+    throw new Error(
+      `Dynamic facet pool mismatch for eval target "${targetId}": `
+      + `expected "${selection.pool}", source uses "${source.target.dynamicFacets.pool}"`,
+    );
+  }
+
+  const pool = source.workflow.facetPools?.[selection.pool];
+  if (pool === undefined) {
+    throw new Error(`Dynamic facet pool not found: ${selection.sourceWorkflow}/${selection.pool}`);
+  }
+  const knownCandidateIds = new Set(pool.candidates.map(({ id }) => id));
+  const unknownCandidateId = selection.candidateIds.find((id) => !knownCandidateIds.has(id));
+  if (unknownCandidateId !== undefined) {
+    throw new Error(
+      `Unknown dynamic facet candidate "${unknownCandidateId}" for eval target "${targetId}"`,
+    );
+  }
+
+  const composed = composeDynamicFacets(pool, selection.candidateIds, {
+    policyContents: target.policyContents ?? [],
+    knowledgeContents: source.target.knowledgeContents ?? [],
+  });
+  return {
+    ...target,
+    policyContents: composed.policyContents.map((content) => ({ content })),
+    knowledgeContents: composed.knowledgeContents.map((content) => ({ content })),
+  };
+}
+
 for (const {
   id,
   workflow: workflowName,
@@ -376,6 +430,7 @@ for (const {
   phase: requestedPhase,
   targetFile,
   includeOutputContract,
+  dynamicFacetSelection,
 } of targets) {
   if (requestedPhase !== undefined && monitorCycle !== undefined) {
     throw new Error(`Target "${id}" cannot define both phase and monitorCycle`);
@@ -486,6 +541,8 @@ for (const {
     };
   }
 
+  target = composeConfiguredDynamicFacets(target, dynamicFacetSelection, id, stepName);
+
   if (facetMode === 'none') {
     target = { ...target, policyContents: [], knowledgeContents: [] };
   } else if (facetMode === 'unrelated') {
@@ -591,4 +648,9 @@ for (const {
   console.log(`  Run dir:            ${runDir}`);
   console.log(`  Policy snapshot:    ${policySourcePath ?? '(none)'}`);
   console.log(`  Knowledge snapshot: ${knowledgeSourcePath ?? '(none)'}`);
+  if (dynamicFacetSelection !== undefined) {
+    console.log(
+      `  Dynamic selection:  ${dynamicFacetSelection.pool} -> ${dynamicFacetSelection.candidateIds.join(', ') || '(none)'}`,
+    );
+  }
 }

--- a/eval/scripts/prepare.mjs
+++ b/eval/scripts/prepare.mjs
@@ -379,11 +379,22 @@ function composeConfiguredDynamicFacets(target, selection, targetId, stepName) {
 
   const sourceWorkflow = loadWorkflowByIdentifier(selection.sourceWorkflow, repoRoot);
   if (!sourceWorkflow) {
-    throw new Error(`Dynamic facet source workflow not found: ${selection.sourceWorkflow}`);
+    throw new Error(
+      `Dynamic facet source workflow not found for eval target "${targetId}": ${selection.sourceWorkflow}`,
+    );
   }
   const source = findStepTarget(sourceWorkflow, stepName);
-  if (!source || source.target.dynamicFacets === undefined) {
-    throw new Error(`Dynamic facet source step not found: ${selection.sourceWorkflow}/${stepName}`);
+  if (!source) {
+    throw new Error(
+      `Dynamic facet source step not found for eval target "${targetId}": `
+      + `${selection.sourceWorkflow}/${stepName}`,
+    );
+  }
+  if (source.target.dynamicFacets === undefined) {
+    throw new Error(
+      `Dynamic facet source step has no dynamicFacets configuration for eval target "${targetId}": `
+      + `${selection.sourceWorkflow}/${stepName}`,
+    );
   }
   if (source.target.dynamicFacets.pool !== selection.pool) {
     throw new Error(
@@ -394,13 +405,17 @@ function composeConfiguredDynamicFacets(target, selection, targetId, stepName) {
 
   const pool = source.workflow.facetPools?.[selection.pool];
   if (pool === undefined) {
-    throw new Error(`Dynamic facet pool not found: ${selection.sourceWorkflow}/${selection.pool}`);
+    throw new Error(
+      `Dynamic facet pool not found for eval target "${targetId}": `
+      + `${selection.sourceWorkflow}/${selection.pool}`,
+    );
   }
   const knownCandidateIds = new Set(pool.candidates.map(({ id }) => id));
   const unknownCandidateId = selection.candidateIds.find((id) => !knownCandidateIds.has(id));
   if (unknownCandidateId !== undefined) {
     throw new Error(
-      `Unknown dynamic facet candidate "${unknownCandidateId}" for eval target "${targetId}"`,
+      `Dynamic facet candidate mismatch for eval target "${targetId}": `
+      + `candidate "${unknownCandidateId}" is not in pool "${selection.pool}"`,
     );
   }
 


### PR DESCRIPTION
## 目的

eval の prepare がレビュアーのプロンプトを固定 facet だけで合成しており、実運用で dynamic facet selector が追加する境界別 knowledge を含めていなかった。実際より knowledge の少ないプロンプトを評価する状態を解消する。

## 変更

- 各 eval ケースに pool・候補の選択設定を明示し、実運用と同じ composeDynamicFacets で合成する（現行2 suite はいずれもローカル/CLI 境界の事例のため cli 候補 = security-local）
- pool・候補・source step の不整合は prepare 時に対象 ID 付きのエラーで検出する
- 将来の web 境界の事例は設定追加のみで対応できる（ケース別分岐のハードコードなし）

変更は eval/scripts/prepare.mjs のみ。builtins・src は不変。

## テスト

- 両 suite の合成プロンプトに security-local が含まれることを確認
- 3モデル評価（claude-opus-5 / gpt-5.6-luna max / gpt-5.6-sol high）: review-adjudication-binding 15/15、security-review-method 21/21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - セキュリティ評価で、指定した候補から評価対象のファセットを動的に選択できるようになりました。
  - 選択内容が評価用のポリシーや知識コンテンツ、プロンプトに反映されます。
  - 評価実行時のログに、適用された選択内容が表示されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->