### PR TITLE
fix(workflows): securityレビューを全系統で脅威モデルの消極的選択にする

### DIFF
--- a/builtins/en/steps/peer-review-reviewers.yaml
+++ b/builtins/en/steps/peer-review-reviewers.yaml
@@ -5,6 +5,11 @@ params:
   review_knowledge_additions:
     type: facet_ref[]
     facet_kind: knowledge
+  security_review_knowledge_additions:
+    type: facet_ref[]
+    facet_kind: knowledge
+  security_review_pool:
+    type: facet_pool_ref
   architecture_review_instruction:
     type: facet_ref
     facet_kind: instruction
@@ -24,110 +29,118 @@ name: reviewers
 tags:
   - review
 parallel:
-  - name: arch-review
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: architecture-reviewer
-    policy:
-      - contract-change
-      - review
-      - $param: review_policy_additions
-    knowledge:
-      - architecture
-      - $param: review_knowledge_additions
-    instruction:
-      $param: architecture_review_instruction
-    output_contracts:
-      report:
-        - name: architect-review.md
-          format: architecture-review
-  - name: security-review
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: security-reviewer
-    policy:
-      - contract-change
-      - $param: review_policy_additions
-      - security-review
-    knowledge:
-      - security
-      - security-web
-      - security-api
-      - security-local
-      - security-data
-      - security-dependencies
-      - takt
-      - $param: review_knowledge_additions
-    instruction:
-      $param: security_review_instruction
-    output_contracts:
-      report:
-        - name: security-review.md
-          format: security-review
-  - name: testing-review
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: testing-reviewer
-    policy:
-      - contract-change
-      - review
-      - testing
-      - $param: review_policy_additions
-    knowledge:
-      - unit-testing
-      - e2e-testing
-      - takt
-      - $param: review_knowledge_additions
-    instruction:
-      $param: testing_review_instruction
-    output_contracts:
-      report:
-        - name: testing-review.md
-          format: testing-review
-  - name: coding-review
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: coding-reviewer
-    policy:
-      - contract-change
-      - review
-      - coding
-      - $param: review_policy_additions
-    knowledge:
-      - takt
-      - $param: review_knowledge_additions
-    pass_previous_response: false
-    instruction:
-      $param: coding_review_instruction
-    output_contracts:
-      report:
-        - name: coding-review.md
-          format: coding-review
-  - name: ai-antipattern-review-2nd
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: ai-antipattern-reviewer
-    policy:
-      - contract-change
-      - review
-      - ai-antipattern
-      - $param: review_policy_additions
-    knowledge:
-      - takt
-      - $param: review_knowledge_additions
-    instruction:
-      $param: ai_antipattern_review_instruction
-    output_contracts:
-      report:
-        - name: ai-antipattern-review.md
-          format: ai-antipattern-review
+  fixed:
+    - name: arch-review
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: architecture-reviewer
+      policy:
+        - contract-change
+        - review
+        - $param: review_policy_additions
+      knowledge:
+        - architecture
+        - $param: review_knowledge_additions
+      instruction:
+        $param: architecture_review_instruction
+      output_contracts:
+        report:
+          - name: architect-review.md
+            format: architecture-review
+    - name: testing-review
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: testing-reviewer
+      policy:
+        - contract-change
+        - review
+        - testing
+        - $param: review_policy_additions
+      knowledge:
+        - unit-testing
+        - e2e-testing
+        - takt
+        - $param: review_knowledge_additions
+      instruction:
+        $param: testing_review_instruction
+      output_contracts:
+        report:
+          - name: testing-review.md
+            format: testing-review
+    - name: coding-review
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: coding-reviewer
+      policy:
+        - contract-change
+        - review
+        - coding
+        - $param: review_policy_additions
+      knowledge:
+        - takt
+        - $param: review_knowledge_additions
+      pass_previous_response: false
+      instruction:
+        $param: coding_review_instruction
+      output_contracts:
+        report:
+          - name: coding-review.md
+            format: coding-review
+    - name: ai-antipattern-review-2nd
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: ai-antipattern-reviewer
+      policy:
+        - contract-change
+        - review
+        - ai-antipattern
+        - $param: review_policy_additions
+      knowledge:
+        - takt
+        - $param: review_knowledge_additions
+      instruction:
+        $param: ai_antipattern_review_instruction
+      output_contracts:
+        report:
+          - name: ai-antipattern-review.md
+            format: ai-antipattern-review
+  pool:
+    - name: security-review
+      description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: security-reviewer
+      policy:
+        - contract-change
+        - security-review
+        - $param: review_policy_additions
+      knowledge:
+        - security
+        - security-data
+        - security-dependencies
+        - $param: security_review_knowledge_additions
+      dynamic_facets:
+        pool:
+          $param: security_review_pool
+        selector:
+          instruction: select-applicable-candidates
+      instruction:
+        $param: security_review_instruction
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: security-review.md
+            format: security-review
+  selection:
+    selector:
+      instruction: select-applicable-candidates

--- a/builtins/en/steps/peer-review-suite-call.yaml
+++ b/builtins/en/steps/peer-review-suite-call.yaml
@@ -6,6 +6,10 @@ args:
     $param: review_policy_additions
   review_knowledge_additions:
     $param: review_knowledge_additions
+  security_review_knowledge_additions:
+    $param: security_review_knowledge_additions
+  security_review_pool:
+    $param: security_review_pool
   architecture_review_instruction:
     $param: architecture_review_instruction
   security_review_instruction:
@@ -29,6 +33,11 @@ params:
   review_knowledge_additions:
     type: facet_ref[]
     facet_kind: knowledge
+  security_review_knowledge_additions:
+    type: facet_ref[]
+    facet_kind: knowledge
+  security_review_pool:
+    type: facet_pool_ref
   architecture_review_instruction:
     type: facet_ref
     facet_kind: instruction

--- a/builtins/en/workflows/development-core.yaml
+++ b/builtins/en/workflows/development-core.yaml
@@ -82,6 +82,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: [architecture, unit-testing, e2e-testing]
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     fix_plan_instruction:
       type: facet_ref
       facet_kind: instruction
@@ -101,6 +108,10 @@ facet_pools:
     uses: coding-facets
   takt-coding-facets:
     uses: takt-coding-facets
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 
 steps:
   - name: plan
@@ -206,6 +217,10 @@ steps:
         $param: review_policy_additions
       review_knowledge_additions:
         $param: review_knowledge
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       fix_companions:
         $param: implementation_companions
       remediation_workflow:

--- a/builtins/en/workflows/experimental-review-adapter.yaml
+++ b/builtins/en/workflows/experimental-review-adapter.yaml
@@ -1,5 +1,8 @@
 name: experimental-review-adapter
 description: Bind the generic security review facet pool selected by the experimental wrapper to its reviewer suite.
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -13,6 +16,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -26,7 +36,10 @@ steps:
     kind: workflow_call
     call: experimental-review
     args:
-      security_review_pool: security-review-facets
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       review_policy_additions:
         $param: review_policy_additions
       review_knowledge_additions:

--- a/builtins/en/workflows/peer-review-suite-base.yaml
+++ b/builtins/en/workflows/peer-review-suite-base.yaml
@@ -1,5 +1,10 @@
 name: peer-review-suite-base
 description: Shared specialist reviewer suite with injectable domain review context.
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -14,6 +19,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction:
       type: facet_ref
       facet_kind: instruction
@@ -51,6 +63,10 @@ steps:
         $param: review_policy_additions
       review_knowledge_additions:
         $param: review_knowledge_additions
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       architecture_review_instruction:
         $param: architecture_review_instruction
       security_review_instruction:

--- a/builtins/en/workflows/peer-review-suite-cqrs.yaml
+++ b/builtins/en/workflows/peer-review-suite-cqrs.yaml
@@ -1,5 +1,10 @@
 name: peer-review-suite-cqrs
 description: Shared reviewer suite composed with the CQRS and event-sourcing specialist review.
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -14,6 +19,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -33,6 +45,10 @@ steps:
             $param: review_policy_additions
           review_knowledge_additions:
             $param: review_knowledge_additions
+          security_review_knowledge_additions:
+            $param: security_review_knowledge_additions
+          security_review_pool:
+            $param: security_review_pool
           architecture_review_instruction:
             $param: architecture_review_instruction
           security_review_instruction:

--- a/builtins/en/workflows/peer-review-suite-frontend-cqrs.yaml
+++ b/builtins/en/workflows/peer-review-suite-frontend-cqrs.yaml
@@ -1,5 +1,10 @@
 name: peer-review-suite-frontend-cqrs
 description: Shared reviewer suite composed with both frontend and CQRS specialist reviews.
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -14,6 +19,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -33,6 +45,10 @@ steps:
             $param: review_policy_additions
           review_knowledge_additions:
             $param: review_knowledge_additions
+          security_review_knowledge_additions:
+            $param: security_review_knowledge_additions
+          security_review_pool:
+            $param: security_review_pool
           architecture_review_instruction: { $param: architecture_review_instruction }
           security_review_instruction: { $param: security_review_instruction }
           testing_review_instruction: { $param: testing_review_instruction }

--- a/builtins/en/workflows/peer-review-suite-frontend.yaml
+++ b/builtins/en/workflows/peer-review-suite-frontend.yaml
@@ -1,5 +1,10 @@
 name: peer-review-suite-frontend
 description: Shared reviewer suite composed with the frontend specialist review.
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -14,6 +19,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -33,6 +45,10 @@ steps:
             $param: review_policy_additions
           review_knowledge_additions:
             $param: review_knowledge_additions
+          security_review_knowledge_additions:
+            $param: security_review_knowledge_additions
+          security_review_pool:
+            $param: security_review_pool
           architecture_review_instruction:
             $param: architecture_review_instruction
           security_review_instruction:

--- a/builtins/en/workflows/peer-review.yaml
+++ b/builtins/en/workflows/peer-review.yaml
@@ -28,6 +28,13 @@ subworkflow:
       default:
         - architecture
         - takt
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     fix_knowledge:
       type: facet_ref[]
       facet_kind: knowledge
@@ -77,6 +84,10 @@ facet_pools:
     uses: coding-facets
   takt-coding-facets:
     uses: takt-coding-facets
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 initial_step: initial-reviewers
 loop_monitors:
   - cycle:
@@ -124,6 +135,10 @@ steps:
         $param: review_policy_additions
       review_knowledge_additions:
         $param: review_knowledge_additions
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       architecture_review_instruction: architecture-review
       security_review_instruction: security-review
       testing_review_instruction: testing-review
@@ -145,6 +160,10 @@ steps:
         $param: review_policy_additions
       review_knowledge_additions:
         $param: review_knowledge_additions
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       architecture_review_instruction: follow-up-architecture-review
       security_review_instruction: follow-up-security-review
       testing_review_instruction: follow-up-testing-review

--- a/builtins/en/workflows/review-backend-cqrs.yaml
+++ b/builtins/en/workflows/review-backend-cqrs.yaml
@@ -1,6 +1,9 @@
 name: review-backend-cqrs
 description: CQRS+ES focused review (structure, modularization, domain model, security, coding)
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -58,25 +62,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -95,6 +80,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-backend.yaml
+++ b/builtins/en/workflows/review-backend.yaml
@@ -1,6 +1,9 @@
 name: review-backend
 description: Backend-focused review (structure, modularization, hexagonal architecture, security, coding)
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -33,25 +37,6 @@ steps:
           report:
             - name: architect-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -74,6 +59,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-default.yaml
+++ b/builtins/en/workflows/review-default.yaml
@@ -1,6 +1,9 @@
 name: review-default
 description: Multi-perspective Code Review - reviews changes with specialist parallel reviewers, then has a supervisor synthesize the results.
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -20,6 +23,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -35,25 +39,6 @@ steps:
           report:
             - name: architecture-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-local, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -99,6 +84,37 @@ steps:
           - condition: approved
           - condition: needs_fix
 
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
+
     rules:
       - condition: any("error")
         next: reviewers
@@ -132,13 +148,8 @@ steps:
       Your role is to synthesize the review results and produce a final summary.
 
       **Tasks:**
-      1. Read all review reports in the Report Directory
-         - `review-target.md` (Review target information)
-         - `architecture-review.md` (Architecture review)
-         - `security-review.md` (Security review)
-         - `testing-review.md` (Testing review)
-         - `coding-review.md` (Coding review)
-      2. Synthesize the 4 review results
+      1. Read `review-target.md` and every reviewer report present in the Report Directory. Do not assume an optional reviewer report exists.
+      2. Synthesize all available review results
       3. Produce a consolidated review summary with overall verdict
 
       **Review Summary output contract:**
@@ -153,10 +164,7 @@ steps:
       ## Review Results
       | Review | Result | Key Findings |
       |--------|--------|--------------|
-      | Architecture | APPROVE/REJECT | {Brief finding} |
-      | Security | APPROVE/REJECT | {Brief finding} |
-      | Testing | APPROVE/REJECT | {Brief finding} |
-      | Coding | APPROVE/REJECT | {Brief finding} |
+      | Each available review | APPROVE/REJECT | {Brief finding} |
 
       ## Issues Requiring Attention
       | # | Severity | Source | Location | Issue |
@@ -181,10 +189,7 @@ steps:
             ## Review Results
             | Review | Result | Key Findings |
             |--------|--------|--------------|
-            | Architecture | APPROVE/REJECT | {Overview} |
-            | Security | APPROVE/REJECT | {Overview} |
-            | Testing | APPROVE/REJECT | {Overview} |
-            | Coding | APPROVE/REJECT | {Overview} |
+            | Each available review | APPROVE/REJECT | {Overview} |
 
             ## Current Iteration Findings (new)
             | # | finding_id | Severity | Source | Location | Issue | Fix Suggestion |

--- a/builtins/en/workflows/review-dual-cqrs.yaml
+++ b/builtins/en/workflows/review-dual-cqrs.yaml
@@ -1,6 +1,9 @@
 name: review-dual-cqrs
 description: Frontend + CQRS+ES focused review (structure, modularization, domain model, component design, security, coding)
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -79,25 +83,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -116,6 +101,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-dual.yaml
+++ b/builtins/en/workflows/review-dual.yaml
@@ -1,6 +1,9 @@
 name: review-dual
 description: Frontend + backend focused review (structure, modularization, component design, security, coding)
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -58,25 +62,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -95,6 +80,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-fix-backend-cqrs.yaml
+++ b/builtins/en/workflows/review-fix-backend-cqrs.yaml
@@ -1,6 +1,9 @@
 name: review-fix-backend-cqrs
 description: CQRS+ES focused review + fix loop (structure, modularization, domain model, security, coding)
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -74,25 +78,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -111,6 +96,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-fix-backend.yaml
+++ b/builtins/en/workflows/review-fix-backend.yaml
@@ -1,6 +1,9 @@
 name: review-fix-backend
 description: Backend-focused review + fix loop (structure, modularization, hexagonal architecture, security, coding)
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -49,25 +53,6 @@ steps:
           report:
             - name: architect-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -90,6 +75,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-fix-default.yaml
+++ b/builtins/en/workflows/review-fix-default.yaml
@@ -1,6 +1,9 @@
 name: review-fix-default
 description: Multi-perspective review + fix loop (architecture, security, testing, and coding in parallel, followed by a supervisor checking whether requirements are met)
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -36,6 +39,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -51,25 +55,6 @@ steps:
           report:
             - name: architecture-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-local, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -114,6 +99,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-fix-dual-cqrs.yaml
+++ b/builtins/en/workflows/review-fix-dual-cqrs.yaml
@@ -1,6 +1,9 @@
 name: review-fix-dual-cqrs
 description: Frontend + CQRS+ES focused review + fix loop (structure, modularization, domain model, component design, security, coding)
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -95,25 +99,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -132,6 +117,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-fix-dual.yaml
+++ b/builtins/en/workflows/review-fix-dual.yaml
@@ -1,6 +1,9 @@
 name: review-fix-dual
 description: Frontend + backend focused review + fix loop (structure, modularization, component design, security, coding)
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -74,25 +78,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -111,6 +96,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-fix-frontend.yaml
+++ b/builtins/en/workflows/review-fix-frontend.yaml
@@ -1,6 +1,9 @@
 name: review-fix-frontend
 description: Frontend-focused review + fix loop (structure, modularization, component design, security, coding)
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -73,25 +77,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -110,6 +95,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-fix-takt-default.yaml
+++ b/builtins/en/workflows/review-fix-takt-default.yaml
@@ -27,6 +27,8 @@ steps:
       implementation_instruction: implement
       review_policy: [coding, testing, takt-testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
+      security_review_pool: takt-security-review-facets
+      security_review_knowledge_additions: [takt]
     rules:
       - condition: COMPLETE
         next: COMPLETE

--- a/builtins/en/workflows/review-frontend.yaml
+++ b/builtins/en/workflows/review-frontend.yaml
@@ -1,6 +1,9 @@
 name: review-frontend
 description: Frontend-focused review (structure, modularization, component design, security, coding)
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -57,25 +61,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -94,6 +79,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/en/workflows/review-takt-default.yaml
+++ b/builtins/en/workflows/review-takt-default.yaml
@@ -1,6 +1,9 @@
 name: review-takt-default
-description: "TAKT-focused multi-perspective review (5 reviewers including AI antipattern and coding review)"
+description: "TAKT-focused multi-perspective review with AI antipattern and coding review"
 max_steps: 10
+facet_pools:
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 initial_step: gather
 
 steps:
@@ -20,6 +23,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -37,25 +41,6 @@ steps:
           report:
             - name: architecture-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [takt, security, security-local, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -120,6 +105,38 @@ steps:
           - condition: approved
           - condition: needs_fix
 
+      pool:
+      - name: security-review
+        description: Do not select by default. Select only when (a) the change may affect secret or credential handling, external-input handling, process execution, filesystem operations, network or terminal boundaries, sandboxing, or permissions, or (b) the change is large enough that security impact cannot be confidently ruled out. Do not select for documentation-only, comment-only, or test-only changes, or small localized fixes.
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+          - takt
+        dynamic_facets:
+          pool: takt-security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
+
     rules:
       - condition: any("error")
         next: reviewers
@@ -153,14 +170,8 @@ steps:
       Your role is to synthesize the review results and produce a final summary.
 
       **Tasks:**
-      1. Read all review reports in the Report Directory
-         - `review-target.md` (Review target information)
-         - `architecture-review.md` (Architecture review)
-         - `security-review.md` (Security review)
-         - `testing-review.md` (Testing review)
-         - `ai-antipattern-review.md` (AI antipattern review)
-         - `coding-review.md` (Coding review)
-      2. Synthesize the 5 review results
+      1. Read `review-target.md` and every reviewer report present in the Report Directory. Do not assume an optional reviewer report exists.
+      2. Synthesize all available review results
       3. Produce a consolidated review summary with overall verdict
 
       **Review Summary output contract:**
@@ -175,11 +186,7 @@ steps:
       ## Review Results
       | Review | Result | Key Findings |
       |--------|--------|--------------|
-      | Architecture | APPROVE/REJECT | {Brief finding} |
-      | Security | APPROVE/REJECT | {Brief finding} |
-      | Testing | APPROVE/REJECT | {Brief finding} |
-      | AI Antipattern | APPROVE/REJECT | {Brief finding} |
-      | Coding | APPROVE/REJECT | {Brief finding} |
+      | Each available review | APPROVE/REJECT | {Brief finding} |
 
       ## Issues Requiring Attention
       | # | Severity | Source | Location | Issue |
@@ -204,11 +211,7 @@ steps:
             ## Review Results
             | Review | Result | Key Findings |
             |--------|--------|--------------|
-            | Architecture | APPROVE/REJECT | {Overview} |
-            | Security | APPROVE/REJECT | {Overview} |
-            | Testing | APPROVE/REJECT | {Overview} |
-            | AI Antipattern | APPROVE/REJECT | {Overview} |
-            | Coding | APPROVE/REJECT | {Overview} |
+            | Each available review | APPROVE/REJECT | {Overview} |
 
             ## Current Iteration Findings (new)
             | # | finding_id | Severity | Source | Location | Issue | Fix Suggestion |

--- a/builtins/en/workflows/takt-default.yaml
+++ b/builtins/en/workflows/takt-default.yaml
@@ -16,6 +16,8 @@ steps:
       implementation_instruction: implement
       review_policy: [coding, testing, takt-testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
+      security_review_pool: takt-security-review-facets
+      security_review_knowledge_additions: [takt]
     rules:
       - condition: COMPLETE
         next: COMPLETE

--- a/builtins/en/workflows/takt-experimental-review-adapter.yaml
+++ b/builtins/en/workflows/takt-experimental-review-adapter.yaml
@@ -1,5 +1,8 @@
 name: takt-experimental-review-adapter
 description: Bind the TAKT-specific security review facet pool selected by the takt-experimental wrapper to its reviewer suite.
+facet_pools:
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -13,6 +16,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [takt]
+    security_review_pool:
+      type: facet_pool_ref
+      default: takt-security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -26,7 +36,10 @@ steps:
     kind: workflow_call
     call: takt-experimental-review
     args:
-      security_review_pool: takt-security-review-facets
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       review_policy_additions:
         $param: review_policy_additions
       review_knowledge_additions:

--- a/builtins/en/workflows/takt-experimental.yaml
+++ b/builtins/en/workflows/takt-experimental.yaml
@@ -27,6 +27,8 @@ steps:
       review_policy_additions: [takt-testing]
       review_policy: [coding, testing, takt-testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
+      security_review_pool: takt-security-review-facets
+      security_review_knowledge_additions: [takt]
       plan_knowledge: [takt, architecture, task-decomposition]
       testing_policy: [coding, testing, takt-testing]
       testing_knowledge: [takt, architecture, unit-testing, e2e-testing]

--- a/builtins/ja/steps/peer-review-reviewers.yaml
+++ b/builtins/ja/steps/peer-review-reviewers.yaml
@@ -5,6 +5,11 @@ params:
   review_knowledge_additions:
     type: facet_ref[]
     facet_kind: knowledge
+  security_review_knowledge_additions:
+    type: facet_ref[]
+    facet_kind: knowledge
+  security_review_pool:
+    type: facet_pool_ref
   architecture_review_instruction:
     type: facet_ref
     facet_kind: instruction
@@ -24,110 +29,118 @@ name: reviewers
 tags:
   - review
 parallel:
-  - name: arch-review
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: architecture-reviewer
-    policy:
-      - contract-change
-      - review
-      - $param: review_policy_additions
-    knowledge:
-      - architecture
-      - $param: review_knowledge_additions
-    instruction:
-      $param: architecture_review_instruction
-    output_contracts:
-      report:
-        - name: architect-review.md
-          format: architecture-review
-  - name: security-review
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: security-reviewer
-    policy:
-      - contract-change
-      - $param: review_policy_additions
-      - security-review
-    knowledge:
-      - security
-      - security-web
-      - security-api
-      - security-local
-      - security-data
-      - security-dependencies
-      - takt
-      - $param: review_knowledge_additions
-    instruction:
-      $param: security_review_instruction
-    output_contracts:
-      report:
-        - name: security-review.md
-          format: security-review
-  - name: testing-review
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: testing-reviewer
-    policy:
-      - contract-change
-      - review
-      - testing
-      - $param: review_policy_additions
-    knowledge:
-      - unit-testing
-      - e2e-testing
-      - takt
-      - $param: review_knowledge_additions
-    instruction:
-      $param: testing_review_instruction
-    output_contracts:
-      report:
-        - name: testing-review.md
-          format: testing-review
-  - name: coding-review
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: coding-reviewer
-    policy:
-      - contract-change
-      - review
-      - coding
-      - $param: review_policy_additions
-    knowledge:
-      - takt
-      - $param: review_knowledge_additions
-    pass_previous_response: false
-    instruction:
-      $param: coding_review_instruction
-    output_contracts:
-      report:
-        - name: coding-review.md
-          format: coding-review
-  - name: ai-antipattern-review-2nd
-    capabilities: readonly
-    tags:
-      - review
-    edit: false
-    persona: ai-antipattern-reviewer
-    policy:
-      - contract-change
-      - review
-      - ai-antipattern
-      - $param: review_policy_additions
-    knowledge:
-      - takt
-      - $param: review_knowledge_additions
-    instruction:
-      $param: ai_antipattern_review_instruction
-    output_contracts:
-      report:
-        - name: ai-antipattern-review.md
-          format: ai-antipattern-review
+  fixed:
+    - name: arch-review
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: architecture-reviewer
+      policy:
+        - contract-change
+        - review
+        - $param: review_policy_additions
+      knowledge:
+        - architecture
+        - $param: review_knowledge_additions
+      instruction:
+        $param: architecture_review_instruction
+      output_contracts:
+        report:
+          - name: architect-review.md
+            format: architecture-review
+    - name: testing-review
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: testing-reviewer
+      policy:
+        - contract-change
+        - review
+        - testing
+        - $param: review_policy_additions
+      knowledge:
+        - unit-testing
+        - e2e-testing
+        - takt
+        - $param: review_knowledge_additions
+      instruction:
+        $param: testing_review_instruction
+      output_contracts:
+        report:
+          - name: testing-review.md
+            format: testing-review
+    - name: coding-review
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: coding-reviewer
+      policy:
+        - contract-change
+        - review
+        - coding
+        - $param: review_policy_additions
+      knowledge:
+        - takt
+        - $param: review_knowledge_additions
+      pass_previous_response: false
+      instruction:
+        $param: coding_review_instruction
+      output_contracts:
+        report:
+          - name: coding-review.md
+            format: coding-review
+    - name: ai-antipattern-review-2nd
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: ai-antipattern-reviewer
+      policy:
+        - contract-change
+        - review
+        - ai-antipattern
+        - $param: review_policy_additions
+      knowledge:
+        - takt
+        - $param: review_knowledge_additions
+      instruction:
+        $param: ai_antipattern_review_instruction
+      output_contracts:
+        report:
+          - name: ai-antipattern-review.md
+            format: ai-antipattern-review
+  pool:
+    - name: security-review
+      description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+      capabilities: readonly
+      tags:
+        - review
+      edit: false
+      persona: security-reviewer
+      policy:
+        - contract-change
+        - security-review
+        - $param: review_policy_additions
+      knowledge:
+        - security
+        - security-data
+        - security-dependencies
+        - $param: security_review_knowledge_additions
+      dynamic_facets:
+        pool:
+          $param: security_review_pool
+        selector:
+          instruction: select-applicable-candidates
+      instruction:
+        $param: security_review_instruction
+      pass_previous_response: false
+      output_contracts:
+        report:
+          - name: security-review.md
+            format: security-review
+  selection:
+    selector:
+      instruction: select-applicable-candidates

--- a/builtins/ja/steps/peer-review-suite-call.yaml
+++ b/builtins/ja/steps/peer-review-suite-call.yaml
@@ -6,6 +6,10 @@ args:
     $param: review_policy_additions
   review_knowledge_additions:
     $param: review_knowledge_additions
+  security_review_knowledge_additions:
+    $param: security_review_knowledge_additions
+  security_review_pool:
+    $param: security_review_pool
   architecture_review_instruction:
     $param: architecture_review_instruction
   security_review_instruction:
@@ -29,6 +33,11 @@ params:
   review_knowledge_additions:
     type: facet_ref[]
     facet_kind: knowledge
+  security_review_knowledge_additions:
+    type: facet_ref[]
+    facet_kind: knowledge
+  security_review_pool:
+    type: facet_pool_ref
   architecture_review_instruction:
     type: facet_ref
     facet_kind: instruction

--- a/builtins/ja/workflows/development-core.yaml
+++ b/builtins/ja/workflows/development-core.yaml
@@ -82,6 +82,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: [architecture, unit-testing, e2e-testing]
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     fix_plan_instruction:
       type: facet_ref
       facet_kind: instruction
@@ -101,6 +108,10 @@ facet_pools:
     uses: coding-facets
   takt-coding-facets:
     uses: takt-coding-facets
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 
 steps:
   - name: plan
@@ -206,6 +217,10 @@ steps:
         $param: review_policy_additions
       review_knowledge_additions:
         $param: review_knowledge
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       fix_companions:
         $param: implementation_companions
       remediation_workflow:

--- a/builtins/ja/workflows/experimental-review-adapter.yaml
+++ b/builtins/ja/workflows/experimental-review-adapter.yaml
@@ -1,5 +1,8 @@
 name: experimental-review-adapter
 description: experimental ラッパーが選択した汎用セキュリティレビュー用 facet pool をレビュースイートへ束縛する。
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -13,6 +16,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -26,7 +36,10 @@ steps:
     kind: workflow_call
     call: experimental-review
     args:
-      security_review_pool: security-review-facets
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       review_policy_additions:
         $param: review_policy_additions
       review_knowledge_additions:

--- a/builtins/ja/workflows/peer-review-suite-base.yaml
+++ b/builtins/ja/workflows/peer-review-suite-base.yaml
@@ -1,5 +1,10 @@
 name: peer-review-suite-base
 description: ドメインレビュー文脈を注入できる共通専門レビュースイート。
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -14,6 +19,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction:
       type: facet_ref
       facet_kind: instruction
@@ -51,6 +63,10 @@ steps:
         $param: review_policy_additions
       review_knowledge_additions:
         $param: review_knowledge_additions
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       architecture_review_instruction:
         $param: architecture_review_instruction
       security_review_instruction:

--- a/builtins/ja/workflows/peer-review-suite-cqrs.yaml
+++ b/builtins/ja/workflows/peer-review-suite-cqrs.yaml
@@ -1,5 +1,10 @@
 name: peer-review-suite-cqrs
 description: 共通レビューへCQRS・イベントソーシング専門レビューを合成するスイート。
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -14,6 +19,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -33,6 +45,10 @@ steps:
             $param: review_policy_additions
           review_knowledge_additions:
             $param: review_knowledge_additions
+          security_review_knowledge_additions:
+            $param: security_review_knowledge_additions
+          security_review_pool:
+            $param: security_review_pool
           architecture_review_instruction:
             $param: architecture_review_instruction
           security_review_instruction:

--- a/builtins/ja/workflows/peer-review-suite-frontend-cqrs.yaml
+++ b/builtins/ja/workflows/peer-review-suite-frontend-cqrs.yaml
@@ -1,5 +1,10 @@
 name: peer-review-suite-frontend-cqrs
 description: 共通レビューへフロントエンドとCQRSの両専門レビューを合成するスイート。
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -14,6 +19,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -33,6 +45,10 @@ steps:
             $param: review_policy_additions
           review_knowledge_additions:
             $param: review_knowledge_additions
+          security_review_knowledge_additions:
+            $param: security_review_knowledge_additions
+          security_review_pool:
+            $param: security_review_pool
           architecture_review_instruction: { $param: architecture_review_instruction }
           security_review_instruction: { $param: security_review_instruction }
           testing_review_instruction: { $param: testing_review_instruction }

--- a/builtins/ja/workflows/peer-review-suite-frontend.yaml
+++ b/builtins/ja/workflows/peer-review-suite-frontend.yaml
@@ -1,5 +1,10 @@
 name: peer-review-suite-frontend
 description: 共通レビューへフロントエンド専門レビューを合成するスイート。
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -14,6 +19,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -33,6 +45,10 @@ steps:
             $param: review_policy_additions
           review_knowledge_additions:
             $param: review_knowledge_additions
+          security_review_knowledge_additions:
+            $param: security_review_knowledge_additions
+          security_review_pool:
+            $param: security_review_pool
           architecture_review_instruction:
             $param: architecture_review_instruction
           security_review_instruction:

--- a/builtins/ja/workflows/peer-review.yaml
+++ b/builtins/ja/workflows/peer-review.yaml
@@ -28,6 +28,13 @@ subworkflow:
       default:
         - architecture
         - takt
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    security_review_pool:
+      type: facet_pool_ref
+      default: security-review-facets
     fix_knowledge:
       type: facet_ref[]
       facet_kind: knowledge
@@ -77,6 +84,10 @@ facet_pools:
     uses: coding-facets
   takt-coding-facets:
     uses: takt-coding-facets
+  security-review-facets:
+    uses: security-review-facets
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 initial_step: initial-reviewers
 loop_monitors:
   - cycle:
@@ -124,6 +135,10 @@ steps:
         $param: review_policy_additions
       review_knowledge_additions:
         $param: review_knowledge_additions
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       architecture_review_instruction: architecture-review
       security_review_instruction: security-review
       testing_review_instruction: testing-review
@@ -145,6 +160,10 @@ steps:
         $param: review_policy_additions
       review_knowledge_additions:
         $param: review_knowledge_additions
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       architecture_review_instruction: follow-up-architecture-review
       security_review_instruction: follow-up-security-review
       testing_review_instruction: follow-up-testing-review

--- a/builtins/ja/workflows/review-backend-cqrs.yaml
+++ b/builtins/ja/workflows/review-backend-cqrs.yaml
@@ -1,6 +1,9 @@
 name: review-backend-cqrs
 description: CQRS+ES特化レビュー（構造・モジュール化・ドメインモデル・セキュリティ・コーディング）
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -58,25 +62,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -95,6 +80,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-backend.yaml
+++ b/builtins/ja/workflows/review-backend.yaml
@@ -1,6 +1,9 @@
 name: review-backend
 description: バックエンド特化レビュー（構造・モジュール化・ヘキサゴナルアーキテクチャ・セキュリティ・コーディング）
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -33,25 +37,6 @@ steps:
           report:
             - name: architect-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -74,6 +59,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-default.yaml
+++ b/builtins/ja/workflows/review-default.yaml
@@ -1,6 +1,9 @@
 name: review-default
 description: 多角レビュー - 専門レビュアーで並列レビューした後、supervisor がレビュー結果を統合する
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -20,6 +23,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -35,25 +39,6 @@ steps:
           report:
             - name: architecture-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-local, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -99,6 +84,37 @@ steps:
           - condition: approved
           - condition: needs_fix
 
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
+
     rules:
       - condition: any("error")
         next: reviewers
@@ -132,13 +148,8 @@ steps:
       レビュー結果を統合し、最終サマリーを作成する役割です。
 
       **やること:**
-      1. Report Directory内の全レビューレポートを読む
-         - `review-target.md`（レビュー対象情報）
-         - `architecture-review.md`（アーキテクチャレビュー）
-         - `security-review.md`（セキュリティレビュー）
-         - `testing-review.md`（テストレビュー）
-         - `coding-review.md`（コーディングレビュー）
-      2. 4つのレビュー結果を統合
+      1. `review-target.md` と Report Directory に存在するすべてのレビュワーレポートを読む。任意のレビュワーが未選択の場合、そのレポートが存在すると仮定しない。
+      2. 利用可能なすべてのレビュー結果を統合
       3. 統合レビューサマリーと総合判定を作成
     output_contracts: &review_synthesis_output_contracts
       report:
@@ -155,10 +166,7 @@ steps:
             ## レビュー結果
             | レビュー | 結果 | 主要な発見 |
             |---------|------|-----------|
-            | アーキテクチャ | APPROVE/REJECT | {概要} |
-            | セキュリティ | APPROVE/REJECT | {概要} |
-            | テスト | APPROVE/REJECT | {概要} |
-            | コーディング | APPROVE/REJECT | {概要} |
+            | 存在する各レビュー | APPROVE/REJECT | {概要} |
 
             ## 今回の指摘（new）
             | # | finding_id | 重大度 | ソース | 場所 | 問題 | 修正案 |

--- a/builtins/ja/workflows/review-dual-cqrs.yaml
+++ b/builtins/ja/workflows/review-dual-cqrs.yaml
@@ -1,6 +1,9 @@
 name: review-dual-cqrs
 description: フロントエンド＋CQRS+ES特化レビュー（構造・モジュール化・ドメインモデル・コンポーネント設計・セキュリティ・コーディング）
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -79,25 +83,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -116,6 +101,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-dual.yaml
+++ b/builtins/ja/workflows/review-dual.yaml
@@ -1,6 +1,9 @@
 name: review-dual
 description: フロントエンド＋バックエンド特化レビュー（構造・モジュール化・コンポーネント設計・セキュリティ・コーディング）
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -58,25 +62,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -95,6 +80,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-fix-backend-cqrs.yaml
+++ b/builtins/ja/workflows/review-fix-backend-cqrs.yaml
@@ -1,6 +1,9 @@
 name: review-fix-backend-cqrs
 description: CQRS+ES特化レビュー＋修正ループ（構造・モジュール化・ドメインモデル・セキュリティ・コーディング）
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -74,25 +78,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -111,6 +96,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-fix-backend.yaml
+++ b/builtins/ja/workflows/review-fix-backend.yaml
@@ -1,6 +1,9 @@
 name: review-fix-backend
 description: バックエンド特化レビュー＋修正ループ（構造・モジュール化・ヘキサゴナルアーキテクチャ・セキュリティ・コーディング）
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -49,25 +53,6 @@ steps:
           report:
             - name: architect-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -90,6 +75,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-fix-default.yaml
+++ b/builtins/ja/workflows/review-fix-default.yaml
@@ -1,6 +1,9 @@
 name: review-fix-default
 description: 多角レビュー＋修正ループ（アーキテクチャ・セキュリティ・テスト・コーディングを並列レビューした後、supervisor が要件の充足を確認する）
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -36,6 +39,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -51,25 +55,6 @@ steps:
           report:
             - name: architecture-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-local, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -114,6 +99,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-fix-dual-cqrs.yaml
+++ b/builtins/ja/workflows/review-fix-dual-cqrs.yaml
@@ -1,6 +1,9 @@
 name: review-fix-dual-cqrs
 description: フロントエンド＋CQRS+ES特化レビュー＋修正ループ（構造・モジュール化・ドメインモデル・コンポーネント設計・セキュリティ・コーディング）
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -95,25 +99,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -132,6 +117,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-fix-dual.yaml
+++ b/builtins/ja/workflows/review-fix-dual.yaml
@@ -1,6 +1,9 @@
 name: review-fix-dual
 description: フロントエンド＋バックエンド特化レビュー＋修正ループ（構造・モジュール化・コンポーネント設計・セキュリティ・コーディング）
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -74,25 +78,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-api, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -111,6 +96,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-fix-frontend.yaml
+++ b/builtins/ja/workflows/review-fix-frontend.yaml
@@ -1,6 +1,9 @@
 name: review-fix-frontend
 description: フロントエンド特化レビュー＋修正ループ（構造・モジュール化・コンポーネント設計・セキュリティ・コーディング）
 max_steps: 30
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 loop_monitors:
   - cycle:
@@ -32,6 +35,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -73,25 +77,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -110,6 +95,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-fix-takt-default.yaml
+++ b/builtins/ja/workflows/review-fix-takt-default.yaml
@@ -27,6 +27,8 @@ steps:
       implementation_instruction: implement
       review_policy: [coding, testing, takt-testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
+      security_review_pool: takt-security-review-facets
+      security_review_knowledge_additions: [takt]
     rules:
       - condition: COMPLETE
         next: COMPLETE

--- a/builtins/ja/workflows/review-frontend.yaml
+++ b/builtins/ja/workflows/review-frontend.yaml
@@ -1,6 +1,9 @@
 name: review-frontend
 description: フロントエンド特化レビュー（構造・モジュール化・コンポーネント設計・セキュリティ・コーディング）
 max_steps: 10
+facet_pools:
+  security-review-facets:
+    uses: security-review-facets
 initial_step: gather
 
 steps:
@@ -16,6 +19,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -57,25 +61,6 @@ steps:
           - condition: approved
           - condition: needs_fix
 
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [security, security-web, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
       - name: coding-review
         capabilities: readonly
         tags:
@@ -94,6 +79,37 @@ steps:
         rules:
           - condition: approved
           - condition: needs_fix
+
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+        dynamic_facets:
+          pool: security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
 
     rules:
       - condition: any("error")

--- a/builtins/ja/workflows/review-takt-default.yaml
+++ b/builtins/ja/workflows/review-takt-default.yaml
@@ -1,6 +1,9 @@
 name: review-takt-default
-description: TAKT開発向け多角レビュー（AIアンチパターン・コーディングレビュー含む5観点レビュー）
+description: TAKT開発向け多角レビュー（AIアンチパターン・コーディングレビューを含む）
 max_steps: 10
+facet_pools:
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 initial_step: gather
 
 steps:
@@ -20,6 +23,7 @@ steps:
     tags:
       - review
     parallel:
+      fixed:
       - name: arch-review
         capabilities: readonly
         tags:
@@ -37,25 +41,6 @@ steps:
           report:
             - name: architecture-review.md
               format: architecture-review
-        rules:
-          - condition: approved
-          - condition: needs_fix
-
-      - name: security-review
-        capabilities: readonly
-        tags:
-          - review
-        edit: false
-        persona: security-reviewer
-        policy:
-          - contract-change
-          - security-review
-        knowledge: [takt, security, security-local, security-data, security-dependencies]
-        instruction: review-security
-        output_contracts:
-          report:
-            - name: security-review.md
-              format: security-review
         rules:
           - condition: approved
           - condition: needs_fix
@@ -120,6 +105,38 @@ steps:
           - condition: approved
           - condition: needs_fix
 
+      pool:
+      - name: security-review
+        description: 既定では選ばない。(a) 変更が secret または credential の取扱い、外部入力の処理、process 実行、filesystem 操作、network または terminal の境界、sandbox、権限に影響し得る場合、または (b) 修正の規模が大きく、セキュリティへの影響がないと判断しきれない場合に限って選ぶ。ドキュメントのみ・コメントのみ・テストのみの変更や小さな局所修正では選ばない。
+        capabilities: readonly
+        tags:
+          - review
+        edit: false
+        persona: security-reviewer
+        policy:
+          - contract-change
+          - security-review
+        knowledge:
+          - security
+          - security-data
+          - security-dependencies
+          - takt
+        dynamic_facets:
+          pool: takt-security-review-facets
+          selector:
+            instruction: select-applicable-candidates
+        instruction: review-security
+        output_contracts:
+          report:
+            - name: security-review.md
+              format: security-review
+        rules:
+          - condition: approved
+          - condition: needs_fix
+      selection:
+        selector:
+          instruction: select-applicable-candidates
+
     rules:
       - condition: any("error")
         next: reviewers
@@ -153,14 +170,8 @@ steps:
       レビュー結果を統合し、最終サマリーを作成する役割です。
 
       **やること:**
-      1. Report Directory内の全レビューレポートを読む
-         - `review-target.md`（レビュー対象情報）
-         - `architecture-review.md`（アーキテクチャレビュー）
-         - `security-review.md`（セキュリティレビュー）
-         - `testing-review.md`（テストレビュー）
-         - `ai-antipattern-review.md`（AIアンチパターンレビュー）
-         - `coding-review.md`（コーディングレビュー）
-      2. 5つのレビュー結果を統合
+      1. `review-target.md` と Report Directory に存在するすべてのレビュワーレポートを読む。任意のレビュワーが未選択の場合、そのレポートが存在すると仮定しない。
+      2. 利用可能なすべてのレビュー結果を統合
       3. 統合レビューサマリーと総合判定を作成
     output_contracts: &review_synthesis_output_contracts
       report:
@@ -177,11 +188,7 @@ steps:
             ## レビュー結果
             | レビュー | 結果 | 主要な発見 |
             |---------|------|-----------|
-            | アーキテクチャ | APPROVE/REJECT | {概要} |
-            | セキュリティ | APPROVE/REJECT | {概要} |
-            | テスト | APPROVE/REJECT | {概要} |
-            | AIアンチパターン | APPROVE/REJECT | {概要} |
-            | コーディング | APPROVE/REJECT | {概要} |
+            | 存在する各レビュー | APPROVE/REJECT | {概要} |
 
             ## 今回の指摘（new）
             | # | finding_id | 重大度 | ソース | 場所 | 問題 | 修正案 |

--- a/builtins/ja/workflows/takt-default.yaml
+++ b/builtins/ja/workflows/takt-default.yaml
@@ -16,6 +16,8 @@ steps:
       implementation_instruction: implement
       review_policy: [coding, testing, takt-testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
+      security_review_pool: takt-security-review-facets
+      security_review_knowledge_additions: [takt]
     rules:
       - condition: COMPLETE
         next: COMPLETE

--- a/builtins/ja/workflows/takt-experimental-review-adapter.yaml
+++ b/builtins/ja/workflows/takt-experimental-review-adapter.yaml
@@ -1,5 +1,8 @@
 name: takt-experimental-review-adapter
 description: takt-experimental ラッパーが選択した TAKT 固有セキュリティレビュー用 facet pool をレビュースイートへ束縛する。
+facet_pools:
+  takt-security-review-facets:
+    uses: takt-security-review-facets
 subworkflow:
   callable: true
   visibility: internal
@@ -13,6 +16,13 @@ subworkflow:
       type: facet_ref[]
       facet_kind: knowledge
       default: []
+    security_review_knowledge_additions:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: [takt]
+    security_review_pool:
+      type: facet_pool_ref
+      default: takt-security-review-facets
     architecture_review_instruction: { type: facet_ref, facet_kind: instruction, default: architecture-review }
     security_review_instruction: { type: facet_ref, facet_kind: instruction, default: security-review }
     testing_review_instruction: { type: facet_ref, facet_kind: instruction, default: testing-review }
@@ -26,7 +36,10 @@ steps:
     kind: workflow_call
     call: takt-experimental-review
     args:
-      security_review_pool: takt-security-review-facets
+      security_review_knowledge_additions:
+        $param: security_review_knowledge_additions
+      security_review_pool:
+        $param: security_review_pool
       review_policy_additions:
         $param: review_policy_additions
       review_knowledge_additions:

--- a/builtins/ja/workflows/takt-experimental.yaml
+++ b/builtins/ja/workflows/takt-experimental.yaml
@@ -27,6 +27,8 @@ steps:
       review_policy_additions: [takt-testing]
       review_policy: [coding, testing, takt-testing, review]
       review_knowledge: [takt, architecture, unit-testing, e2e-testing]
+      security_review_pool: takt-security-review-facets
+      security_review_knowledge_additions: [takt]
       plan_knowledge: [takt, architecture, task-decomposition]
       testing_policy: [coding, testing, takt-testing]
       testing_knowledge: [takt, architecture, unit-testing, e2e-testing]

--- a/src/__tests__/it-experimental-workflow.test.ts
+++ b/src/__tests__/it-experimental-workflow.test.ts
@@ -908,18 +908,26 @@ describe('experimental builtin workflow', () => {
       const remediation = loadRemediationForPeerReview(language, peerReview, projectDir);
       const reviewerSuite = loadReviewerSuiteForPeerReview(language, peerReview, projectDir);
       const reviewerSteps = collectReviewerSteps(language, reviewerSuite, projectDir);
+      const reviewRoot = findWorkflowStep(reviewerSuite, reviewerSuite.initialStep);
+      if (reviewRoot.parallel === undefined || Array.isArray(reviewRoot.parallel)) {
+        throw new Error(`Review workflow "${reviewerSuite.name}" has no dynamic parallel reviewers`);
+      }
+      const fixedReviewerNames = new Set(reviewRoot.parallel.fixed.map(({ name }) => name));
+      const fixedReviewerSteps = reviewerSteps.filter(({ step }) => fixedReviewerNames.has(step.name));
       const reviewResponses = (verdict: 'approved' | 'needs_fix'): ScenarioEntry[] =>
-        reviewerSteps.map(({ workflow: reviewerWorkflow, step, persona }) =>
+        fixedReviewerSteps.map(({ workflow: reviewerWorkflow, step, persona }) =>
           response(reviewerWorkflow, step.name, persona, verdict));
       setMockScenario([
         responseForNext(core, 'plan', 'write_tests'),
         responseForNext(core, 'write_tests', 'implement'),
         responseForNext(implementation, 'implement', 'COMPLETE'),
+        parallelSelection([], 'The standard workflow change does not require security review.'),
         ...reviewResponses('needs_fix'),
         responseForNext(peerReview, 'review-adjudication', 'remediation'),
         responseForNext(remediation, 'fix-plan', 'fix'),
         responseForNext(remediation, 'fix', 'fix-verifier'),
         responseForNext(remediation, 'fix-verifier', 'COMPLETE'),
+        parallelSelection([], 'The verified remediation does not require security review.'),
         ...reviewResponses('approved'),
         responseForNext(peerReview, 'review-adjudication', 'final-gate'),
         responseForNext(peerReview, 'final-gate', 'COMPLETE'),


### PR DESCRIPTION
## 目的

security レビュアーが peer-review 系と単体レビュー系で固定メンバーとして毎回実行され、knowledge も全境界を固定注入していた。細かい修正でも security が走り、非本質的な指摘が収束を妨げる実測があった。experimental 系で実証済みの形を全系統へ配線する。

## 変更

- peer-review 系に security_review_pool と security_review_knowledge_additions の param を追加し、初回・follow-up と suite 4変種の nested 経路へ伝搬
- security-review を固定から外側 pool へ移し、既定では選ばない選択基準（セキュリティ境界に触れるおそれがあるか大規模修正のときのみ選ぶ）と select-applicable-candidates guidance を付与。固定 knowledge は security / security-data / security-dependencies の3つに限定し、境界別 knowledge は facet pool（web / cli、TAKT 系は takt-security-review-facets）から差分に応じて動的選択
- 単体レビュー系13 workflow（英日26ファイル）にも同じ形を適用し、レビュー数の固定表現を動的参加数対応へ変更
- audit-security は security の実行自体が目的のため不変（意図的例外）。共有 facet 本文は不変（この PR は配線のみ）

## テスト

- workflow schema / facet include / 合成 / workflow loader 系の対象テスト成功（マージ後に schema 再確認済み）
- モデル評価2 suite（claude-opus-5 / gpt-5.6-luna max / gpt-5.6-sol high）: 15/15、21/21
- npm run build / npm run lint 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 変更内容に応じた動的なセキュリティレビュアー選択に対応しました。
  * セキュリティレビューへ追加知識と対象プールを指定できるようになりました。
  * 通常版およびTAKT向けのセキュリティレビュー設定を追加しました。

* **改善**
  * コーディング、アーキテクチャ、テストなどのレビュー構成を整理しました。
  * 実行されたレビュー結果のみを統合・表示するよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->