### PR TITLE
test(eval): prepareのCLI実行境界を検証する

### DIFF
--- a/eval/asserts/prepare-dynamic-facet-composition.test.mjs
+++ b/eval/asserts/prepare-dynamic-facet-composition.test.mjs
@@ -1,10 +1,20 @@
+import { spawnSync } from 'node:child_process';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 const { composeConfiguredDynamicFacets } = await import('../scripts/prepare.mjs');
 
 const TARGET_ID = 'prepare-dynamic-facet-composition-contract';
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+const SMOKE_TARGET_ID = 'coding-review';
+const SMOKE_PROMPT_PATH = fileURLToPath(
+  new URL(`../../eval/prompts/${SMOKE_TARGET_ID}.phase1.md`, import.meta.url),
+);
+const SMOKE_RUNTIME_DIR = fileURLToPath(
+  new URL('../../eval/fixtures/sample-project/.takt', import.meta.url),
+);
 const SOURCE_WORKFLOW = 'experimental-review';
 const SECURITY_REVIEW_POOL = 'security-review-facets';
 const CANDIDATE_KNOWLEDGE = readFileSync(
@@ -25,6 +35,16 @@ function target() {
   return {
     policyContents: [{ content: 'fixed policy' }],
     knowledgeContents: [{ content: 'fixed knowledge' }],
+  };
+}
+
+function snapshotFile(path) {
+  if (!existsSync(path)) return null;
+  const stat = statSync(path, { bigint: true });
+  return {
+    content: readFileSync(path),
+    mtimeNs: stat.mtimeNs,
+    size: stat.size,
   };
 }
 
@@ -93,4 +113,47 @@ test('reports an unknown candidate ID with the target ID', () => {
     ),
     /Dynamic facet candidate mismatch.*candidate "unknown-candidate".*pool "security-review-facets"/,
   );
+});
+
+test('executes main when prepare.mjs is launched directly', () => {
+  const promptBefore = snapshotFile(SMOKE_PROMPT_PATH);
+  const runtimeDirBefore = existsSync(SMOKE_RUNTIME_DIR);
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      ['eval/scripts/prepare.mjs', SMOKE_TARGET_ID],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, new RegExp(`\\[${SMOKE_TARGET_ID}\\]`));
+  } finally {
+    if (promptBefore === null) {
+      rmSync(SMOKE_PROMPT_PATH, { force: true });
+    }
+    if (!runtimeDirBefore) {
+      rmSync(SMOKE_RUNTIME_DIR, { recursive: true, force: true });
+    }
+  }
+});
+
+test('does not execute main when prepare.mjs is imported', () => {
+  const promptBefore = snapshotFile(SMOKE_PROMPT_PATH);
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `await import(${JSON.stringify(new URL('../scripts/prepare.mjs', import.meta.url).href)});`,
+    ],
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, '');
+  assert.equal(result.stderr, '');
+  assert.deepEqual(snapshotFile(SMOKE_PROMPT_PATH), promptBefore);
 });


### PR DESCRIPTION
## 目的

#1381 マージ後に届いた CodeRabbit 指摘への追い対応。CLI 実行境界のテストがなかった。

## 変更

- 直接起動で main() が実行され正常終了することの検証
- module import では main() が実行されない（出力・prompt 生成の副作用なし）ことの検証
- prepare.mjs 本体は不変

## テスト

node --test eval/asserts/prepare-dynamic-facet-composition.test.mjs: 8件成功、lint 成功