### PR TITLE
fix(codex): preserve PATH for tool shell

### DIFF
--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -180,7 +180,7 @@ GitHub Actions の CI（`ci.yml`）が実行する E2E は `test:e2e:mock` の�
   - 手順（ユーザー行動/コマンド）:
     - E2E用 `config.yaml` に `runtime.prepare: [gradle, node]` を設定する。
     - mock providerの呼び出しログで、`TMPDIR`、`TAKT_RUNTIME_TMP`、`GRADLE_USER_HOME`、`npm_config_cache` がprovider呼び出し前に注入されたことを確認する。未設定時は注入されないことを確認する。
-    - `takt --task '<gradle/npm を実行する指示>' --workflow e2e/fixtures/workflows/simple.yaml` を実行する。
+    - 正例では `takt --task '<./gradlew test && npm test を1回のコマンドとして実行する指示>' --workflow e2e/fixtures/workflows/simple.yaml` を実行し、Gradle 成功後に npm が同じ provider 実行環境で続けて起動することを確認する。
     - 正例では、作業リポジトリに `.takt/.runtime/env.sh` と `.takt/.runtime/{cache,config,state,gradle,npm}` が作成されていることを確認する。`TMPDIR` はworktree固有の短い外部パスであり、NodeとGradleに同じ値が伝播することを確認する。
     - 負例（`runtime.prepare` 未設定）では、隔離環境から `GRADLE_USER_HOME` と `npm_config_cache` を除外し、Gradle の欠落環境変数および npm のruntimeキャッシュ未注入を示す専用証跡ファイルと両コマンドの実行markerを確認する。`.takt/.runtime/env.sh` は生成されないことを確認する。
 - Runtime.yaml provider section（runtime-v1）（`e2e/specs/runtime-provider.e2e.ts`）

--- a/e2e/specs/runtime-config-provider.e2e.ts
+++ b/e2e/specs/runtime-config-provider.e2e.ts
@@ -6,7 +6,7 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { createIsolatedEnv, type IsolatedEnv, updateIsolatedConfig } from '../helpers/isolated-env';
-import { runTakt } from '../helpers/takt-runner';
+import { formatTaktRunResult, runTakt } from '../helpers/takt-runner';
 import { createLocalRepo, type LocalRepo } from '../helpers/test-repo';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -466,8 +466,8 @@ describe('E2E: runtime.prepare with provider', () => {
       args: [
         '--task',
         [
-          'Run `./gradlew test` and `npm test` in the repository root.',
-          'If both commands succeed, respond exactly with: Task completed',
+          'In the repository root, run exactly this command once: `./gradlew test && npm test`.',
+          'Only if the entire command succeeds, respond exactly with: Task completed',
         ].join(' '),
         '--workflow', workflowPath,
       ],
@@ -477,8 +477,9 @@ describe('E2E: runtime.prepare with provider', () => {
     });
 
     registerRuntimeTmpDirectory(repo.path, envFile, runtimeTempRoot);
+    const runDiagnostics = formatTaktRunResult(result);
 
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode, runDiagnostics).toBe(0);
 
     expect(existsSync(runtimeRoot)).toBe(true);
     expect(existsSync(join(runtimeRoot, 'cache'))).toBe(true);
@@ -486,8 +487,14 @@ describe('E2E: runtime.prepare with provider', () => {
     expect(existsSync(join(runtimeRoot, 'state'))).toBe(true);
     expect(existsSync(join(runtimeRoot, 'gradle'))).toBe(true);
     expect(existsSync(join(runtimeRoot, 'npm'))).toBe(true);
-    expect(existsSync(join(runtimeRoot, 'gradle', 'gradle-ok.txt'))).toBe(true);
-    expect(existsSync(join(runtimeRoot, 'npm', 'npm-ok.txt'))).toBe(true);
+    expect(
+      existsSync(join(runtimeRoot, 'gradle', 'gradle-ok.txt')),
+      runDiagnostics,
+    ).toBe(true);
+    expect(
+      existsSync(join(runtimeRoot, 'npm', 'npm-ok.txt')),
+      runDiagnostics,
+    ).toBe(true);
     expect(existsSync(envFile)).toBe(true);
 
     const envContent = readFileSync(envFile, 'utf-8');

--- a/src/__tests__/codex-client-retry.test.ts
+++ b/src/__tests__/codex-client-retry.test.ts
@@ -155,6 +155,7 @@ describe('CodexClient retry', () => {
   afterEach(() => {
     vi.clearAllTimers();
     vi.useRealTimers();
+    vi.unstubAllEnvs();
     for (const root of tempRoots) {
       fs.rmSync(root, { recursive: true, force: true });
     }
@@ -325,6 +326,9 @@ describe('CodexClient retry', () => {
         config: [{ path: fs.realpathSync(skillPath), enabled: false }],
       },
       model_reasoning_summary: 'auto',
+      shell_environment_policy: {
+        set: { PATH: process.env.PATH },
+      },
     };
 
     expect(result.status).toBe('done');
@@ -334,6 +338,33 @@ describe('CodexClient retry', () => {
       expectedConfig,
       expectedConfig,
     ]);
+  });
+
+  it('Codex の tool shell に CLI process と同じ PATH を渡す', async () => {
+    const shellPath = '/opt/takt/bin:/usr/bin:/bin';
+    vi.stubEnv('PATH', shellPath);
+    runPlans = [
+      {
+        type: 'events',
+        events: [
+          { type: 'thread.started', thread_id: 'thread-1' },
+          { type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1 } },
+        ],
+      },
+    ];
+
+    const result = await new CodexClient().call('coder', 'prompt', { cwd: '/tmp' });
+
+    expect(result.status).toBe('done');
+    expect(codexConstructorCalls).toHaveLength(1);
+    expect(codexConstructorCalls[0]).toMatchObject({
+      env: { PATH: shellPath },
+      config: {
+        shell_environment_policy: {
+          set: { PATH: shellPath },
+        },
+      },
+    });
   });
 
   it('例外経路の at capacity を 1 秒、2 秒の指数バックオフで retry する', async () => {

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -389,12 +389,24 @@ export class CodexClient {
       return errorResponse;
     }
 
+    const codexEnvironment = buildEnvWithNestedObservabilitySnapshot(
+      process.env,
+      options.childProcessEnv,
+    ) as Record<string, string>;
+    const shellPath = codexEnvironment.PATH;
     const codexConfig: CodexOptions['config'] = {
       ...(skillConfig ?? {}),
       ...(options.reasoningEffort === undefined
         ? {}
         : { model_reasoning_effort: options.reasoningEffort }),
       model_reasoning_summary: 'auto',
+      ...(shellPath === undefined
+        ? {}
+        : {
+            shell_environment_policy: {
+              set: { PATH: shellPath },
+            },
+          }),
     };
 
     while (true) {
@@ -402,10 +414,7 @@ export class CodexClient {
       options.onActivity?.({ kind: 'attempt_started' });
       let currentThreadId = threadId;
       const codexClientOptions: CodexOptions = {
-        env: buildEnvWithNestedObservabilitySnapshot(
-          process.env,
-          options.childProcessEnv,
-        ) as Record<string, string>,
+        env: codexEnvironment,
         ...(options.openaiApiKey ? { apiKey: options.openaiApiKey } : {}),
         ...(options.baseUrl !== undefined ? { baseUrl: options.baseUrl } : {}),
         ...(options.codexPathOverride ? { codexPathOverride: options.codexPathOverride } : {}),


### PR DESCRIPTION
## Summary

- Codex CLI のツールシェルへ、CLI プロセスと同じ `PATH` を `shell_environment_policy.set` で渡す
- `runtime.prepare` の実 provider E2E を単一の連結コマンドにし、失敗時の診断情報を追加する
- Codex の `PATH` 引き継ぎに対する回帰テストと E2E ドキュメントを更新する

## Root cause

Codex SDK に渡したプロセス環境の `PATH` が Codex のツールシェルには引き継がれず、mise 配下の `npm` を解決できませんでした。その結果、`runtime.prepare` の Gradle コマンドは成功しても `npm test` が終了コード 127 で失敗していました。

## Impact

Codex provider が実行するシェルコマンドで、TAKT を起動した環境と同じ `PATH` を利用できます。環境全体を継承せず `PATH` のみを明示設定するため、不要な環境変数はツールシェルへ追加公開しません。

## Execution Report

- `npm test -- src/__tests__/codex-client-retry.test.ts` — 36 passed
- `npm run build` — passed
- `npm run lint` — passed
- Codex の対象 real-provider E2E — 1 passed
- `npm run test:e2e:provider:opencode` — 9 files / 23 tests passed
- `git diff --check` — passed

## Issue

関連 Issue の指定はありません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - 実プロバイダー環境で、Gradleとnpmを連続実行するE2E検証を追加・改善しました。
  - 実行結果や生成成果物を診断情報付きで確認できるようになりました。
  - Codex実行時の環境変数や`PATH`が、CLIと一貫して引き継がれることを検証するテストを追加しました。
- **ドキュメント**
  - ランタイム設定注入に関するE2E手順を、実際の検証フローに合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->