### PR TITLE
Release v0.59.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.59.1] - 2026-08-16
+
+### Fixed
+
+- The builtin review-fix loop no longer re-adjudicates stale findings from `review-resolution.md` (#1393). A `review-resolution.md` that exists when adjudication starts is treated as adjudication history and the step's output destination, never as a finding submission source: only findings submitted by the reviewer reports of the immediately preceding completed review round can enter the actionable set. The selector continues a reviewer only from the current `Actionable Families` section — history, dispositions, and carry-forward rows cannot keep a reviewer selected — and when the latest round approves with no findings while a verified fix merely repeats in the resolution file, the loop monitor chooses its declared non-retry outcome instead of rerunning reviewers or the same fix.
+
 ## [0.59.0] - 2026-08-16
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.59.1] - 2026-08-16
+
+### Fixed
+
+- ビルトインの review-fix ループが `review-resolution.md` の過去 finding を再裁定しなくなりました (#1393)。裁定開始時に存在する `review-resolution.md` は裁定履歴および当該ステップの出力先として扱い、finding の提出元にはしません。actionable 集合に入れるのは、直前に完了したレビューラウンドのレビュアーレポートが提出した finding だけです。セレクターによるレビュアー継続は現在の `Actionable Families` セクションのみを根拠とし、履歴・disposition・carry-forward の行では継続されません。また、最新ラウンドが finding なしで承認しているのに検証済みの修正が resolution ファイル上で繰り返されるだけの場合、ループモニターはレビュアーや同じ修正の再実行ではなく、宣言済みの非再試行の結果を選びます。
+
 ## [0.59.0] - 2026-08-16
 
 ### Added

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-eZs0dIPGEMCoiTVsj9502ULNGNjufUq6xREMS+MjgEk=";
+            npmDepsHash = "sha256-PSle6RleJAVcFhdmvd2TD11uE3xR/TMTA/elbMx9tk4=";
             npmDepsFetcherVersion = 2;
             nodejs = nodejs;
             ONNXRUNTIME_NODE_INSTALL = "skip";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.59.0",
+      "version": "0.59.1",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Workflow control for AI coding agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Fixed

- The builtin review-fix loop no longer re-adjudicates stale findings from `review-resolution.md` (#1393). A `review-resolution.md` that exists when adjudication starts is treated as adjudication history and the step's output destination, never as a finding submission source: only findings submitted by the reviewer reports of the immediately preceding completed review round can enter the actionable set. The selector continues a reviewer only from the current `Actionable Families` section — history, dispositions, and carry-forward rows cannot keep a reviewer selected — and when the latest round approves with no findings while a verified fix merely repeats in the resolution file, the loop monitor chooses its declared non-retry outcome instead of rerunning reviewers or the same fix.

## Commits

- 8771a2f7 fix: prevent stale review adjudication loops (#1393)
- 6a4ce4e5 Release v0.59.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 直前のレビューラウンドで報告された指摘のみを、修正対象として扱うよう改善しました。
  * 現在の対応対象に基づいてレビュアーを選択するようになりました。
  * 指摘のない承認後に既知の修正が再検出された場合、不要な再試行を避けます。

* **ドキュメント**
  * バージョン0.59.1（2026年8月16日）の変更履歴を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->