### PR TITLE
fix: add Codex permission control option

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -940,7 +940,7 @@ workflow の `provider_options.extends` は、共有 YAML プリセットを名�
 
 `provider_options.extends` は、preset または path を解決できない場合、scoped ref が利用可能な repertoire package を指していない場合、参照先 YAML が不正または provider-options object でない場合、extends チェーンが循環している場合、削除済みの `$ref` キーが使われた場合に、設定エラーとして fail fast します。相対 path は workflow file 基準で解決され、symlink 解決後も workflow directory 内に留まる必要があります。絶対 path と、実体が workflow directory 外へ出る path は拒否されます。
 
-provider option の leaf は環境変数でも上書きできます。OpenCode の model variant は `TAKT_PROVIDER_OPTIONS_OPENCODE_VARIANT=high` で `provider_options.opencode.variant` を設定できます。provider base URL は `TAKT_PROVIDER_OPTIONS_CODEX_BASE_URL=http://127.0.0.1:8787/v1` または `TAKT_PROVIDER_OPTIONS_CLAUDE_BASE_URL=http://127.0.0.1:8787` を使用できます。これらは config layer を設定するもので、step や workflow routing の `base_url` leaf は上書きしません。Codex Skill の継承は `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_REPO=true` または `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_USER=true` で設定できます。Claude Skill の継承は `TAKT_PROVIDER_OPTIONS_CLAUDE_SKILLS_ENABLED=true` で設定できます。Claude terminal は `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_BACKEND=tmux`、`TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_TIMEOUT_MS=900000`、`TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_KEEP_SESSION=false`、`TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_TRANSCRIPT_POLL_INTERVAL_MS=500` を使用できます。Kiro の custom agent は `TAKT_PROVIDER_OPTIONS_KIRO_AGENT=planner-agent` で `provider_options.kiro.agent` を設定できます。Pi の resource loading は `TAKT_PROVIDER_OPTIONS_PI_EXTENSIONS='["npm:pi-fff"]'`、`TAKT_PROVIDER_OPTIONS_PI_NO_EXTENSIONS=true`、`TAKT_PROVIDER_OPTIONS_PI_NO_SKILLS=true`、`TAKT_PROVIDER_OPTIONS_PI_NO_PROMPT_TEMPLATES=true`、`TAKT_PROVIDER_OPTIONS_PI_NO_THEMES=true`、`TAKT_PROVIDER_OPTIONS_PI_NO_CONTEXT_FILES=true` を使用できます。
+provider option の leaf は環境変数でも上書きできます。OpenCode の model variant は `TAKT_PROVIDER_OPTIONS_OPENCODE_VARIANT=high` で `provider_options.opencode.variant` を設定できます。provider base URL は `TAKT_PROVIDER_OPTIONS_CODEX_BASE_URL=http://127.0.0.1:8787/v1` または `TAKT_PROVIDER_OPTIONS_CLAUDE_BASE_URL=http://127.0.0.1:8787` を使用できます。これらは config layer を設定するもので、step や workflow routing の `base_url` leaf は上書きしません。Codex の permission control は `TAKT_PROVIDER_OPTIONS_CODEX_PERMISSION_CONTROL=takt` または `TAKT_PROVIDER_OPTIONS_CODEX_PERMISSION_CONTROL=codex` で設定できます。Codex Skill の継承は `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_REPO=true` または `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_USER=true` で設定できます。Claude Skill の継承は `TAKT_PROVIDER_OPTIONS_CLAUDE_SKILLS_ENABLED=true` で設定できます。Claude terminal は `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_BACKEND=tmux`、`TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_TIMEOUT_MS=900000`、`TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_KEEP_SESSION=false`、`TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_TRANSCRIPT_POLL_INTERVAL_MS=500` を使用できます。Kiro の custom agent は `TAKT_PROVIDER_OPTIONS_KIRO_AGENT=planner-agent` で `provider_options.kiro.agent` を設定できます。Pi の resource loading は `TAKT_PROVIDER_OPTIONS_PI_EXTENSIONS='["npm:pi-fff"]'`、`TAKT_PROVIDER_OPTIONS_PI_NO_EXTENSIONS=true`、`TAKT_PROVIDER_OPTIONS_PI_NO_SKILLS=true`、`TAKT_PROVIDER_OPTIONS_PI_NO_PROMPT_TEMPLATES=true`、`TAKT_PROVIDER_OPTIONS_PI_NO_THEMES=true`、`TAKT_PROVIDER_OPTIONS_PI_NO_CONTEXT_FILES=true` を使用できます。
 
 これにより、表示名と provider 選択を分離したまま、単一の workflow 内で provider や model を混在させることができます。
 
@@ -995,6 +995,20 @@ provider_options:
 ```
 
 step / `provider_routing` / deprecated の `persona_providers` / `workflow_config` / project / global の各レイヤーで設定でき、step が最優先です。環境変数 `TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS=true` でも上書きできます。
+
+#### Codex の permission control (`permission_control`)
+
+Codex はデフォルトで TAKT の permission mode マッピングを使います。これは `permission_control: takt` と同じで、解決済みの TAKT `permission_mode` を Codex SDK の `sandboxMode` へ渡します。`network_access` を指定した場合は `networkAccessEnabled` にも渡します。省略時は Codex の既定値（`false`）を維持します。
+
+Codex 側へ権限制御を委譲する場合だけ、明示的に opt-in します。
+
+```yaml
+provider_options:
+  codex:
+    permission_control: codex
+```
+
+`permission_control: codex` では、通常の Codex 呼び出しと strict isolated structured 呼び出しの両方で TAKT は `sandboxMode` と `networkAccessEnabled` を渡しません。実効権限は Codex の `config.toml`、`default_permissions`、permission profile に委譲されます。非対話実行を成立させるため `approvalPolicy: never` は引き続き設定されます。`permission_control: codex` と `network_access` は併用できず、解決後に両方が残る設定は fail fast で拒否されます。明示的な opt-in のため、権限の結果は利用者の自己責任です。
 
 #### Codex Skill の継承 (`skills`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -946,7 +946,7 @@ Workflow `provider_options.extends` can load shared YAML presets by name. Names 
 
 `provider_options.extends` fails fast as a configuration error when a preset or path cannot be resolved, a scoped ref points to an unavailable repertoire package, the target YAML is invalid or is not a provider-options object, the extends chain is circular, or the removed `$ref` key is used. Relative paths are resolved from the workflow file and must stay inside the workflow directory after symlink resolution; absolute paths and paths whose real target escapes that directory are rejected.
 
-Provider option leaves can also be overridden from env. For OpenCode model variants, use `TAKT_PROVIDER_OPTIONS_OPENCODE_VARIANT=high` to set `provider_options.opencode.variant`. For provider base URLs, use `TAKT_PROVIDER_OPTIONS_CODEX_BASE_URL=http://127.0.0.1:8787/v1` or `TAKT_PROVIDER_OPTIONS_CLAUDE_BASE_URL=http://127.0.0.1:8787`; these populate the config layer and do not override step or workflow routing `base_url` leaves. For Codex Skill inheritance, use `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_REPO=true` or `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_USER=true`. For Claude Skill inheritance, use `TAKT_PROVIDER_OPTIONS_CLAUDE_SKILLS_ENABLED=true`. For Claude terminal, use `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_BACKEND=tmux`, `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_TIMEOUT_MS=900000`, `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_KEEP_SESSION=false`, or `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_TRANSCRIPT_POLL_INTERVAL_MS=500`. For Kiro custom agents, use `TAKT_PROVIDER_OPTIONS_KIRO_AGENT=planner-agent` to set `provider_options.kiro.agent`. For Pi resource loading, use `TAKT_PROVIDER_OPTIONS_PI_EXTENSIONS='["npm:pi-fff"]'`, `TAKT_PROVIDER_OPTIONS_PI_NO_EXTENSIONS=true`, `TAKT_PROVIDER_OPTIONS_PI_NO_SKILLS=true`, `TAKT_PROVIDER_OPTIONS_PI_NO_PROMPT_TEMPLATES=true`, `TAKT_PROVIDER_OPTIONS_PI_NO_THEMES=true`, or `TAKT_PROVIDER_OPTIONS_PI_NO_CONTEXT_FILES=true`.
+Provider option leaves can also be overridden from env. For OpenCode model variants, use `TAKT_PROVIDER_OPTIONS_OPENCODE_VARIANT=high` to set `provider_options.opencode.variant`. For provider base URLs, use `TAKT_PROVIDER_OPTIONS_CODEX_BASE_URL=http://127.0.0.1:8787/v1` or `TAKT_PROVIDER_OPTIONS_CLAUDE_BASE_URL=http://127.0.0.1:8787`; these populate the config layer and do not override step or workflow routing `base_url` leaves. For Codex permission control, use `TAKT_PROVIDER_OPTIONS_CODEX_PERMISSION_CONTROL=takt` or `TAKT_PROVIDER_OPTIONS_CODEX_PERMISSION_CONTROL=codex`. For Codex Skill inheritance, use `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_REPO=true` or `TAKT_PROVIDER_OPTIONS_CODEX_SKILLS_USER=true`. For Claude Skill inheritance, use `TAKT_PROVIDER_OPTIONS_CLAUDE_SKILLS_ENABLED=true`. For Claude terminal, use `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_BACKEND=tmux`, `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_TIMEOUT_MS=900000`, `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_KEEP_SESSION=false`, or `TAKT_PROVIDER_OPTIONS_CLAUDE_TERMINAL_TRANSCRIPT_POLL_INTERVAL_MS=500`. For Kiro custom agents, use `TAKT_PROVIDER_OPTIONS_KIRO_AGENT=planner-agent` to set `provider_options.kiro.agent`. For Pi resource loading, use `TAKT_PROVIDER_OPTIONS_PI_EXTENSIONS='["npm:pi-fff"]'`, `TAKT_PROVIDER_OPTIONS_PI_NO_EXTENSIONS=true`, `TAKT_PROVIDER_OPTIONS_PI_NO_SKILLS=true`, `TAKT_PROVIDER_OPTIONS_PI_NO_PROMPT_TEMPLATES=true`, `TAKT_PROVIDER_OPTIONS_PI_NO_THEMES=true`, or `TAKT_PROVIDER_OPTIONS_PI_NO_CONTEXT_FILES=true`.
 
 This allows mixing providers and models within a single workflow while keeping display names independent from provider selection.
 
@@ -1001,6 +1001,20 @@ provider_options:
 ```
 
 `network_access` can be set at step / `provider_routing` / deprecated `persona_providers` / `workflow_config` / project / global levels, with step having the highest priority. The environment variable `TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS=true` also works as an override.
+
+#### Codex permission control (`permission_control`)
+
+Codex uses TAKT's permission mode mapping by default. This is equivalent to `permission_control: takt` and passes the resolved TAKT `permission_mode` to the Codex SDK as `sandboxMode`. `network_access`, when set, is also passed as `networkAccessEnabled`; when omitted, Codex keeps its default (`false`).
+
+To delegate permission control to Codex, explicitly opt in:
+
+```yaml
+provider_options:
+  codex:
+    permission_control: codex
+```
+
+With `permission_control: codex`, TAKT omits both `sandboxMode` and `networkAccessEnabled` from every Codex call, including strict isolated structured calls. Codex's `config.toml`, `default_permissions`, and permission profile determine the effective permissions. TAKT still sets `approvalPolicy: never` for non-interactive execution. `permission_control: codex` cannot be combined with `network_access`; the resolved configuration fails fast when both remain set. This is an explicit opt-in and its permission behavior is the user's responsibility.
 
 #### Codex Skill inheritance (`skills`)
 

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -889,6 +889,7 @@ promotion は並列サブ step ではサポートされません。
 | `provider_options.*.guards.call_timeout_ms` | 60分 | 全 provider profile（`codex`、`opencode`、`claude`、`claude_terminal`、`cursor`、`copilot`、`kiro`、`pi`）の call-wide wall-clock deadline（[configuration ガイド](./configuration.ja.md#プロバイダ-call-deadline-と-opencode-実行ガード)参照） |
 | `provider_options.codex.base_url` | - | Codex SDK constructor option 用の OpenAI 互換 base URL（[configuration ガイド](./configuration.ja.md#provider-base-url-base_url) 参照） |
 | `provider_options.codex.network_access` | - | Codex サンドボックスからのネットワークアクセスを許可（[configuration ガイド](./configuration.ja.md#ネットワークアクセス-network_access) 参照） |
+| `provider_options.codex.permission_control` | 省略時は `takt` 相当 | `takt` は TAKT の permission mode を Codex sandbox option へ変換し、`codex` は sandbox と network の権限制御を Codex config へ委譲（[configuration ガイド](./configuration.ja.md#codex-の-permission-control-permission_control) 参照） |
 | `provider_options.codex.reasoning_effort` | - | Codex の provider 固有 reasoning effort 文字列。TAKT は値を provider へそのまま渡す |
 | `provider_options.codex.skills.repo` | `false` | 実行 CWD から repository root までの `.agents/skills` にある Codex Skill を継承（[configuration ガイド](./configuration.ja.md#codex-skill-の継承-skills) 参照） |
 | `provider_options.codex.skills.user` | `false` | user scope の Codex Skill を継承（[configuration ガイド](./configuration.ja.md#codex-skill-の継承-skills) 参照） |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -890,6 +890,7 @@ Promotion is not supported on parallel sub-steps.
 | `provider_options.*.guards.call_timeout_ms` | 60 minutes | Call-wide wall-clock deadline for every provider profile (`codex`, `opencode`, `claude`, `claude_terminal`, `cursor`, `copilot`, `kiro`, and `pi`; see [configuration guide](./configuration.md#provider-call-deadline-and-opencode-execution-guards)) |
 | `provider_options.codex.base_url` | - | OpenAI-compatible base URL for Codex SDK constructor options (see [configuration guide](./configuration.md#provider-base-url-base_url)) |
 | `provider_options.codex.network_access` | - | Allow Codex sandbox to access the network (see [configuration guide](./configuration.md#network-access-network_access)) |
+| `provider_options.codex.permission_control` | `takt` behavior when omitted | `takt` maps TAKT permission modes to Codex sandbox options; `codex` delegates sandbox and network permission control to Codex config (see [configuration guide](./configuration.md#codex-permission-control-permission_control)) |
 | `provider_options.codex.reasoning_effort` | - | Provider-specific Codex reasoning effort string, passed through to the provider |
 | `provider_options.codex.skills.repo` | `false` | Inherit Codex Skills from `.agents/skills` between the execution CWD and repository root (see [configuration guide](./configuration.md#codex-skill-inheritance-skills)) |
 | `provider_options.codex.skills.user` | `false` | Inherit Codex Skills from user scope (see [configuration guide](./configuration.md#codex-skill-inheritance-skills)) |

--- a/src/__tests__/codex-structured-output.test.ts
+++ b/src/__tests__/codex-structured-output.test.ts
@@ -312,6 +312,34 @@ describe('CodexClient — structuredOutput 抽出', () => {
     expect(lastTurnOptions).toMatchObject({ outputSchema: schema });
   });
 
+  it('permission_control=codex は sandbox と network の指定を省略し approval policy は維持する', async () => {
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    await client.call('selector', 'prompt', {
+      cwd: '/tmp',
+      permissionMode: 'readonly',
+      permissionControl: 'codex',
+    });
+
+    expect(lastThreadOptions).toMatchObject({ approvalPolicy: 'never' });
+    expect(lastThreadOptions).not.toHaveProperty('sandboxMode');
+    expect(lastThreadOptions).not.toHaveProperty('networkAccessEnabled');
+  });
+
+  it('permission_control=codex と network_access の直接指定も fail fast する', async () => {
+    const client = new CodexClient();
+
+    await expect(client.call('coder', 'prompt', {
+      cwd: '/tmp',
+      permissionControl: 'codex',
+      networkAccess: false,
+    })).rejects.toThrow(/permission_control=codex.*network_access/);
+  });
+
   it('provider_options.codex.network_access が ThreadOptions に反映される', async () => {
     mockEvents = [
       { type: 'thread.started', thread_id: 'thread-1' },
@@ -327,6 +355,22 @@ describe('CodexClient — structuredOutput 抽出', () => {
     expect(lastThreadOptions).toMatchObject({
       networkAccessEnabled: true,
     });
+  });
+
+  it('permission_control 省略時は従来どおり TAKT sandbox mapping を使う', async () => {
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    await client.call('coder', 'prompt', { cwd: '/tmp', permissionMode: 'edit' });
+
+    expect(lastThreadOptions).toMatchObject({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'never',
+    });
+    expect(lastThreadOptions).not.toHaveProperty('networkAccessEnabled');
   });
 
   it('provider_options.codex.reasoningEffort が安全な config override に反映される', async () => {

--- a/src/__tests__/codex-structured-output.test.ts
+++ b/src/__tests__/codex-structured-output.test.ts
@@ -337,7 +337,7 @@ describe('CodexClient — structuredOutput 抽出', () => {
       cwd: '/tmp',
       permissionControl: 'codex',
       networkAccess: false,
-    })).rejects.toThrow(/permission_control=codex.*network_access/);
+    })).rejects.toThrow();
   });
 
   it('provider_options.codex.network_access が ThreadOptions に反映される', async () => {
@@ -371,6 +371,27 @@ describe('CodexClient — structuredOutput 抽出', () => {
       approvalPolicy: 'never',
     });
     expect(lastThreadOptions).not.toHaveProperty('networkAccessEnabled');
+  });
+
+  it('permission_control=takt は従来の sandbox と network mapping を明示的に維持する', async () => {
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    await client.call('coder', 'prompt', {
+      cwd: '/tmp',
+      permissionMode: 'readonly',
+      permissionControl: 'takt',
+      networkAccess: true,
+    });
+
+    expect(lastThreadOptions).toMatchObject({
+      sandboxMode: 'read-only',
+      networkAccessEnabled: true,
+      approvalPolicy: 'never',
+    });
   });
 
   it('provider_options.codex.reasoningEffort が安全な config override に反映される', async () => {

--- a/src/__tests__/config-env-overrides.test.ts
+++ b/src/__tests__/config-env-overrides.test.ts
@@ -105,6 +105,34 @@ describe('config traced env overrides', () => {
     });
   });
 
+  it('project config は Codex permission control の env override を反映する', () => {
+    const projectDir = join(testRoot, 'project-codex-permission-control-env');
+    const configDir = getProjectConfigDir(projectDir);
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.yaml'), 'provider: codex\n', 'utf-8');
+    process.env.TAKT_PROVIDER_OPTIONS_CODEX_PERMISSION_CONTROL = 'codex';
+
+    const config = loadProjectConfig(projectDir);
+
+    expect(config.providerOptions).toEqual({
+      codex: { permissionControl: 'codex' },
+    });
+  });
+
+  it('project config と env の解決後に競合する Codex options を拒否する', () => {
+    const projectDir = join(testRoot, 'project-codex-permission-control-conflict-env');
+    const configDir = getProjectConfigDir(projectDir);
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'config.yaml'),
+      ['provider_options:', '  codex:', '    network_access: true'].join('\n'),
+      'utf-8',
+    );
+    process.env.TAKT_PROVIDER_OPTIONS_CODEX_PERMISSION_CONTROL = 'codex';
+
+    expect(() => loadProjectConfig(projectDir)).toThrow(/permission_control=codex.*network_access/);
+  });
+
   it('project config は Codex Skill scope ごとの env override を反映する', () => {
     const projectDir = join(testRoot, 'project-codex-skills-env');
     const configDir = getProjectConfigDir(projectDir);

--- a/src/__tests__/config-env-overrides.test.ts
+++ b/src/__tests__/config-env-overrides.test.ts
@@ -130,7 +130,7 @@ describe('config traced env overrides', () => {
     );
     process.env.TAKT_PROVIDER_OPTIONS_CODEX_PERMISSION_CONTROL = 'codex';
 
-    expect(() => loadProjectConfig(projectDir)).toThrow(/permission_control=codex.*network_access/);
+    expect(() => loadProjectConfig(projectDir)).toThrow();
   });
 
   it('project config は Codex Skill scope ごとの env override を反映する', () => {

--- a/src/__tests__/config-normalizers-provider-options.test.ts
+++ b/src/__tests__/config-normalizers-provider-options.test.ts
@@ -155,13 +155,13 @@ describe('denormalizeProviderOptions', () => {
         permission_control: 'codex',
         network_access: false,
       },
-    })).toThrow(/permission_control=codex.*network_access/);
+    })).toThrow();
     expect(() => denormalizeProviderOptions({
       codex: {
         permissionControl: 'codex',
         networkAccess: false,
       },
-    })).toThrow(/permission_control=codex.*network_access/);
+    })).toThrow();
   });
 
   it('should round-trip OpenCode guard leaves and model_profiles', () => {

--- a/src/__tests__/config-normalizers-provider-options.test.ts
+++ b/src/__tests__/config-normalizers-provider-options.test.ts
@@ -132,6 +132,38 @@ describe('denormalizeProviderOptions', () => {
     expect(denormalizedProviderOptions).toEqual(rawProviderOptions);
   });
 
+  it('should round-trip Codex permission control', () => {
+    const rawProviderOptions = {
+      codex: {
+        permission_control: 'codex',
+      },
+    };
+
+    const normalizedProviderOptions = normalizeProviderOptions(rawProviderOptions);
+
+    expect(normalizedProviderOptions).toEqual({
+      codex: {
+        permissionControl: 'codex',
+      },
+    });
+    expect(denormalizeProviderOptions(normalizedProviderOptions)).toEqual(rawProviderOptions);
+  });
+
+  it('should reject Codex permission control with network access', () => {
+    expect(() => normalizeProviderOptions({
+      codex: {
+        permission_control: 'codex',
+        network_access: false,
+      },
+    })).toThrow(/permission_control=codex.*network_access/);
+    expect(() => denormalizeProviderOptions({
+      codex: {
+        permissionControl: 'codex',
+        networkAccess: false,
+      },
+    })).toThrow(/permission_control=codex.*network_access/);
+  });
+
   it('should round-trip OpenCode guard leaves and model_profiles', () => {
     const rawProviderOptions = {
       opencode: {

--- a/src/__tests__/provider-options-resolution.test.ts
+++ b/src/__tests__/provider-options-resolution.test.ts
@@ -79,6 +79,37 @@ describe('resolveEffectiveProviderOptions', () => {
     });
   });
 
+  it('permissionControl is resolved with normal provider-option precedence', () => {
+    const result = resolveEffectiveProviderOptions(
+      'project',
+      (path: string) => (path === 'codex.permissionControl' ? 'env' : 'local'),
+      {
+        codex: { permissionControl: 'takt' },
+      },
+      {
+        codex: { permissionControl: 'codex' },
+      },
+    );
+
+    expect(result).toEqual({
+      codex: { permissionControl: 'takt' },
+    });
+  });
+
+  it('rejects permissionControl codex when network access survives merge', () => {
+    expect(() => mergeProviderOptions(
+      { codex: { networkAccess: true } },
+      { codex: { permissionControl: 'codex' } },
+    )).toThrow(/permission_control=codex.*network_access/);
+
+    expect(() => resolveEffectiveProviderOptions(
+      'project',
+      undefined,
+      { codex: { networkAccess: true } },
+      { codex: { permissionControl: 'codex' } },
+    )).toThrow(/permission_control=codex.*network_access/);
+  });
+
   it('Claude Skill enabled resolves false from config even when other Claude leaves come from the step', () => {
     const result = resolveEffectiveProviderOptions(
       'project',
@@ -598,13 +629,16 @@ describe('resolveProviderOptionsSources (all paths)', () => {
   it('returns only paths with a defined source', () => {
     const result = resolveProviderOptionsSources(
       { claude: { effort: 'xhigh' } },
-      [{ source: 'persona_providers', options: { codex: { reasoningEffort: 'high' } } }],
+      [{ source: 'persona_providers', options: {
+        codex: { permissionControl: 'codex', reasoningEffort: 'high' },
+      } }],
       { copilot: { effort: 'medium' } },
       undefined,
       'global',
     );
     expect(result).toEqual({
       'claude.effort': 'step',
+      'codex.permissionControl': 'persona_providers',
       'codex.reasoningEffort': 'persona_providers',
       'copilot.effort': 'global',
     });
@@ -731,6 +765,7 @@ describe('providerOptionsContract', () => {
       'provider_options',
       'provider_options.codex.base_url',
       'provider_options.codex.network_access',
+      'provider_options.codex.permission_control',
       'provider_options.codex.reasoning_effort',
       'provider_options.codex.guards.call_timeout_ms',
       'provider_options.codex.skills.repo',
@@ -773,6 +808,7 @@ describe('providerOptionsContract', () => {
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.claude.allowed_tools');
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.claude.skills.enabled');
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.codex.reasoning_effort');
+    expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.codex.permission_control');
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.codex.guards.call_timeout_ms');
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.codex.skills.repo');
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.codex.skills.user');
@@ -821,6 +857,8 @@ describe('providerOptionsContract', () => {
       .toBe('provider_options.claude.skills.enabled');
     expect(toProviderOptionsTracePath('codex.reasoningEffort'))
       .toBe('provider_options.codex.reasoning_effort');
+    expect(toProviderOptionsTracePath('codex.permissionControl'))
+      .toBe('provider_options.codex.permission_control');
     expect(toProviderOptionsTracePath('codex.guards.callTimeoutMs'))
       .toBe('provider_options.codex.guards.call_timeout_ms');
     expect(toProviderOptionsTracePath('codex.skills.repo'))
@@ -858,6 +896,7 @@ describe('providerOptionsContract', () => {
       codex: {
         baseUrl: 'http://127.0.0.1:8787/v1',
         networkAccess: true,
+        permissionControl: 'takt',
         reasoningEffort: 'high',
         guards: { callTimeoutMs: 120_000 },
         skills: { repo: false, user: true },
@@ -880,6 +919,7 @@ describe('providerOptionsContract', () => {
     } as Parameters<typeof getPresentProviderOptionPaths>[0])).toEqual([
       'codex.baseUrl',
       'codex.networkAccess',
+      'codex.permissionControl',
       'codex.reasoningEffort',
       'codex.guards.callTimeoutMs',
       'codex.skills.repo',

--- a/src/__tests__/provider-options-resolution.test.ts
+++ b/src/__tests__/provider-options-resolution.test.ts
@@ -100,14 +100,14 @@ describe('resolveEffectiveProviderOptions', () => {
     expect(() => mergeProviderOptions(
       { codex: { networkAccess: true } },
       { codex: { permissionControl: 'codex' } },
-    )).toThrow(/permission_control=codex.*network_access/);
+    )).toThrow();
 
     expect(() => resolveEffectiveProviderOptions(
       'project',
       undefined,
       { codex: { networkAccess: true } },
       { codex: { permissionControl: 'codex' } },
-    )).toThrow(/permission_control=codex.*network_access/);
+    )).toThrow();
   });
 
   it('Claude Skill enabled resolves false from config even when other Claude leaves come from the step', () => {

--- a/src/__tests__/provider-schema.test.ts
+++ b/src/__tests__/provider-schema.test.ts
@@ -213,6 +213,23 @@ describe('provider effort values', () => {
   });
 });
 
+describe('Codex permission control provider option', () => {
+  it('accepts takt and codex values', () => {
+    expect(StepProviderOptionsSchema.parse({
+      codex: { permission_control: 'takt' },
+    })).toEqual({ codex: { permission_control: 'takt' } });
+    expect(StepProviderOptionsSchema.parse({
+      codex: { permission_control: 'codex' },
+    })).toEqual({ codex: { permission_control: 'codex' } });
+  });
+
+  it('rejects unknown permission control values', () => {
+    expect(() => StepProviderOptionsSchema.parse({
+      codex: { permission_control: 'workspace' },
+    })).toThrow(/permission_control|Invalid option/i);
+  });
+});
+
 describe('Claude terminal provider contract', () => {
   beforeEach(() => {
     ProviderRegistry.resetInstance();

--- a/src/__tests__/provider-structured-output.test.ts
+++ b/src/__tests__/provider-structured-output.test.ts
@@ -407,6 +407,33 @@ describe('CodexProvider — structured output', () => {
     });
   });
 
+  it('permission_control=codex を通常経路と strict isolated structured 経路へ渡す', async () => {
+    mockCallCodex.mockResolvedValue(doneResponse('coder'));
+
+    const provider = new CodexProvider();
+    await provider.setup({ name: 'coder' }).call('prompt', {
+      cwd: '/tmp',
+      permissionMode: 'edit',
+      providerOptions: { codex: { permissionControl: 'codex' } },
+    });
+    expect(mockCallCodex.mock.calls[0]?.[2]).toMatchObject({
+      permissionMode: 'edit',
+      permissionControl: 'codex',
+    });
+
+    await provider.setupIsolatedStructured({ name: 'selector' }).call('prompt', {
+      cwd: '/tmp',
+      permissionMode: 'full',
+      providerOptions: { codex: { permissionControl: 'codex' } },
+      outputSchema: SCHEMA,
+    });
+    expect(mockCallCodex.mock.calls[1]?.[2]).toMatchObject({
+      permissionMode: 'readonly',
+      permissionControl: 'codex',
+    });
+    expect(mockCallCodex.mock.calls[1]?.[2].networkAccess).toBeUndefined();
+  });
+
   it('childProcessEnv を callCodex に渡す', async () => {
     mockCallCodex.mockResolvedValue(doneResponse('coder'));
     const childProcessEnv = { TAKT_OBSERVABILITY: '{"enabled":true}' };

--- a/src/__tests__/resolveProviderOptionsWithTrace.test.ts
+++ b/src/__tests__/resolveProviderOptionsWithTrace.test.ts
@@ -356,8 +356,7 @@ describe('resolveProviderOptionsWithTrace', () => {
       'utf-8',
     );
 
-    expect(() => resolveProviderOptionsWithTrace(projectDir))
-      .toThrow(/permission_control=codex.*network_access/);
+    expect(() => resolveProviderOptionsWithTrace(projectDir)).toThrow();
   });
 
   it('片方だけ指定した Codex Skill scope の未指定値を default のまま保つ', () => {

--- a/src/__tests__/resolveProviderOptionsWithTrace.test.ts
+++ b/src/__tests__/resolveProviderOptionsWithTrace.test.ts
@@ -335,6 +335,31 @@ describe('resolveProviderOptionsWithTrace', () => {
     expect(result.originResolver('codex.networkAccess')).toBe('env');
   });
 
+  it('global/project provider_options の解決後に Codex permission control の競合を拒否する', () => {
+    writeFileSync(
+      globalConfigPath,
+      [
+        'language: en',
+        'provider_options:',
+        '  codex:',
+        '    permission_control: codex',
+      ].join('\n'),
+      'utf-8',
+    );
+    invalidateGlobalConfigCache();
+
+    const configDir = getProjectConfigDir(projectDir);
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'config.yaml'),
+      ['provider_options:', '  codex:', '    network_access: true'].join('\n'),
+      'utf-8',
+    );
+
+    expect(() => resolveProviderOptionsWithTrace(projectDir))
+      .toThrow(/permission_control=codex.*network_access/);
+  });
+
   it('片方だけ指定した Codex Skill scope の未指定値を default のまま保つ', () => {
     process.env.TAKT_PROVIDER_OPTIONS = JSON.stringify({
       codex: { skills: { repo: true } },

--- a/src/core/models/index.ts
+++ b/src/core/models/index.ts
@@ -18,6 +18,8 @@ export type {
   CommandQualityGate,
   QualityGate,
   McpServerConfig,
+  CodexProviderOptions,
+  CodexPermissionControl,
   RuntimePreparePreset,
   RuntimePrepareEntry,
   WorkflowRuntimeConfig,

--- a/src/core/models/schema-base.ts
+++ b/src/core/models/schema-base.ts
@@ -82,6 +82,7 @@ const ProviderGuardOptionsSchema = z.object(ProviderGuardOptionShape).strict();
 const CodexProviderOptionShape = {
   base_url: z.string().min(1).optional(),
   network_access: z.boolean().optional(),
+  permission_control: z.enum(['takt', 'codex']).optional(),
   reasoning_effort: ProviderEffortSchema.optional(),
   skills: z.object(CodexSkillsShape).optional(),
   guards: ProviderGuardOptionsSchema.optional(),
@@ -601,6 +602,7 @@ const NormalizedStepProviderOptionsSchema = z.object({
   codex: z.object({
     baseUrl: z.string().min(1).optional(),
     networkAccess: z.boolean().optional(),
+    permissionControl: z.enum(['takt', 'codex']).optional(),
     reasoningEffort: ProviderEffortSchema.optional(),
     guards: z.object({
       callTimeoutMs: z.number().int().min(60_000).max(86_400_000).optional(),

--- a/src/core/models/types.ts
+++ b/src/core/models/types.ts
@@ -52,6 +52,8 @@ export type {
   CommandQualityGate,
   QualityGate,
   McpServerConfig,
+  CodexProviderOptions,
+  CodexPermissionControl,
   RuntimePreparePreset,
   RuntimePrepareEntry,
   WorkflowRuntimeConfig,

--- a/src/core/models/workflow-provider-options.ts
+++ b/src/core/models/workflow-provider-options.ts
@@ -29,6 +29,7 @@ export interface ProviderGuardOptions {
 export interface CodexProviderOptions {
   baseUrl?: string;
   networkAccess?: boolean;
+  permissionControl?: CodexPermissionControl;
   reasoningEffort?: CodexReasoningEffort;
   guards?: ProviderGuardOptions;
   skills?: {
@@ -36,6 +37,8 @@ export interface CodexProviderOptions {
     user?: boolean;
   };
 }
+
+export type CodexPermissionControl = 'takt' | 'codex';
 
 export const OPENCODE_GUARD_PROFILES = ['standard', 'minimal'] as const;
 export type OpenCodeGuardProfile = (typeof OPENCODE_GUARD_PROFILES)[number];

--- a/src/core/models/workflow-types.ts
+++ b/src/core/models/workflow-types.ts
@@ -55,6 +55,7 @@ export type {
   ClaudeSandboxSettings,
   ProviderGuardOptions,
   CodexProviderOptions,
+  CodexPermissionControl,
   OpenCodeGuardOptions,
   OpenCodeGuardProfile,
   OpenCodeProviderOptions,

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -334,19 +334,27 @@ export class CodexClient {
     prompt: string,
     options: CodexCallOptions,
   ): Promise<AgentResponse> {
-    const sandboxMode = options.permissionMode
-      ? mapToCodexSandboxMode(options.permissionMode)
-      : 'workspace-write';
+    if (options.permissionControl === 'codex' && options.networkAccess !== undefined) {
+      throw new Error(
+        'Configuration error: provider_options.codex.permission_control=codex cannot be combined with provider_options.codex.network_access.',
+      );
+    }
     const threadOptions = {
       ...(options.model ? { model: options.model } : {}),
       workingDirectory: options.cwd,
-      sandboxMode,
+      ...(options.permissionControl === 'codex'
+        ? {}
+        : {
+            sandboxMode: options.permissionMode
+              ? mapToCodexSandboxMode(options.permissionMode)
+              : 'workspace-write' as const,
+            ...(options.networkAccess === undefined
+              ? {}
+              : { networkAccessEnabled: options.networkAccess }),
+          }),
       // TAKT runs Codex non-interactively — there is no human to approve escalations.
-      // Force `never` so the sandbox mode is the sole authority: without it, Codex falls
-      // back to its configured approval policy (e.g. on-request + approvals_reviewer=auto_review),
-      // which auto-approves escalation past a read-only sandbox and lets writes through.
+      // Force `never` so Codex cannot wait for an approval that no caller can provide.
       approvalPolicy: 'never' as const,
-      ...(options.networkAccess === undefined ? {} : { networkAccessEnabled: options.networkAccess }),
     };
     let threadId = options.sessionId;
 

--- a/src/infra/codex/types.ts
+++ b/src/infra/codex/types.ts
@@ -3,7 +3,10 @@
  */
 
 import type { PermissionMode } from '../../core/models/index.js';
-import type { CodexReasoningEffort } from '../../core/models/workflow-types.js';
+import type {
+  CodexPermissionControl,
+  CodexReasoningEffort,
+} from '../../core/models/workflow-types.js';
 import type { ProviderImageAttachment } from '../providers/types.js';
 import type { ProviderActivityCallback, StreamCallback } from '../../shared/types/provider.js';
 
@@ -28,9 +31,11 @@ export interface CodexCallOptions {
   model?: string;
   reasoningEffort?: CodexReasoningEffort;
   systemPrompt?: string;
-  /** Permission mode for sandbox configuration */
+  /** Permission mode for the TAKT-controlled sandbox */
   permissionMode?: PermissionMode;
-  /** Enable network access for workspace-write sandbox */
+  /** Select whether TAKT or Codex controls permissions. */
+  permissionControl?: CodexPermissionControl;
+  /** Enable network access for the TAKT-controlled sandbox */
   networkAccess?: boolean;
   /** Enable streaming mode with callback (best-effort) */
   onStream?: StreamCallback;

--- a/src/infra/config/configNormalizers.ts
+++ b/src/infra/config/configNormalizers.ts
@@ -32,6 +32,7 @@ import {
   type ConfigProviderReference,
 } from './providerReference.js';
 import {
+  assertValidCodexProviderOptions,
   assertAllowedNormalizedProviderBaseUrls,
   normalizeProviderOptions,
   type NormalizeProviderOptionsOptions,
@@ -658,11 +659,13 @@ export function denormalizeProviderOptions(
   if (!providerOptions) {
     return undefined;
   }
+  assertValidCodexProviderOptions(providerOptions);
 
   const raw: Record<string, unknown> = {};
   if (
     providerOptions.codex?.baseUrl !== undefined
     || providerOptions.codex?.networkAccess !== undefined
+    || providerOptions.codex?.permissionControl !== undefined
     || providerOptions.codex?.reasoningEffort !== undefined
     || providerOptions.codex?.guards?.callTimeoutMs !== undefined
     || providerOptions.codex?.skills?.repo !== undefined
@@ -674,6 +677,9 @@ export function denormalizeProviderOptions(
         : {}),
       ...(providerOptions.codex.networkAccess !== undefined
         ? { network_access: providerOptions.codex.networkAccess }
+        : {}),
+      ...(providerOptions.codex.permissionControl !== undefined
+        ? { permission_control: providerOptions.codex.permissionControl }
         : {}),
       ...(providerOptions.codex.reasoningEffort !== undefined
         ? { reasoning_effort: providerOptions.codex.reasoningEffort }

--- a/src/infra/config/providerOptions.ts
+++ b/src/infra/config/providerOptions.ts
@@ -1,6 +1,7 @@
 import type {
   ClaudeEffort,
   ClaudeTerminalProviderOptions,
+  CodexPermissionControl,
   CodexReasoningEffort,
   CopilotEffort,
   OpenCodeGuardProfile,
@@ -28,6 +29,7 @@ type RawProviderOptions = {
   codex?: {
     base_url?: string;
     network_access?: boolean;
+    permission_control?: CodexPermissionControl;
     reasoning_effort?: CodexReasoningEffort;
     guards?: RawProviderGuardOptions;
     skills?: {
@@ -101,6 +103,19 @@ export interface NormalizeProviderOptionsOptions {
 export interface ProviderOptionsLayer {
   source: ProviderResolutionSource;
   options: StepProviderOptions | undefined;
+}
+
+export function assertValidCodexProviderOptions(
+  providerOptions: StepProviderOptions | undefined,
+): void {
+  if (
+    providerOptions?.codex?.permissionControl === 'codex'
+    && providerOptions.codex.networkAccess !== undefined
+  ) {
+    throw new Error(
+      'Configuration error: provider_options.codex.permission_control=codex cannot be combined with provider_options.codex.network_access.',
+    );
+  }
 }
 
 interface StepProviderOptionsLayerContext {
@@ -207,6 +222,7 @@ export function normalizeProviderOptions(
   if (
     options.codex?.base_url !== undefined
     || options.codex?.network_access !== undefined
+    || options.codex?.permission_control !== undefined
     || options.codex?.reasoning_effort !== undefined
     || options.codex?.guards !== undefined
     || options.codex?.skills?.repo !== undefined
@@ -220,6 +236,9 @@ export function normalizeProviderOptions(
         : {}),
       ...(options.codex.network_access !== undefined
         ? { networkAccess: options.codex.network_access }
+        : {}),
+      ...(options.codex.permission_control !== undefined
+        ? { permissionControl: options.codex.permission_control }
         : {}),
       ...(options.codex.reasoning_effort !== undefined
         ? { reasoningEffort: options.codex.reasoning_effort }
@@ -388,7 +407,9 @@ export function normalizeProviderOptions(
         : {}),
     };
   }
-  return Object.keys(result).length > 0 ? result : undefined;
+  const normalized = Object.keys(result).length > 0 ? result : undefined;
+  assertValidCodexProviderOptions(normalized);
+  return normalized;
 }
 
 /** Deep merge provider options. Later sources override earlier ones. */
@@ -407,6 +428,9 @@ export function mergeProviderOptions(
           : {}),
         ...(layer.codex.networkAccess !== undefined
           ? { networkAccess: layer.codex.networkAccess }
+          : {}),
+        ...(layer.codex.permissionControl !== undefined
+          ? { permissionControl: layer.codex.permissionControl }
           : {}),
         ...(layer.codex.reasoningEffort !== undefined
           ? { reasoningEffort: layer.codex.reasoningEffort }
@@ -543,7 +567,9 @@ export function mergeProviderOptions(
     }
   }
 
-  return Object.keys(result).length > 0 ? result : undefined;
+  const merged = Object.keys(result).length > 0 ? result : undefined;
+  assertValidCodexProviderOptions(merged);
+  return merged;
 }
 
 function resolveFallbackOrigin(
@@ -740,6 +766,7 @@ export function resolveEffectiveProviderOptions(
     return mergeProviderOptions(personaOptions, stepOptions);
   }
   if (!personaOptions && !stepOptions) {
+    assertValidCodexProviderOptions(resolvedConfigOptions);
     return resolvedConfigOptions;
   }
 
@@ -798,6 +825,12 @@ export function resolveEffectiveProviderOptions(
     personaOptions?.codex?.networkAccess,
     stepOptions?.codex?.networkAccess,
     resolveProviderOptionOrigin(originResolver, 'codex.networkAccess', source),
+  );
+  const codexPermissionControl = selectProviderValue(
+    resolvedConfigOptions.codex?.permissionControl,
+    personaOptions?.codex?.permissionControl,
+    stepOptions?.codex?.permissionControl,
+    resolveProviderOptionOrigin(originResolver, 'codex.permissionControl', source),
   );
   const codexReasoningEffort = selectProviderValue(
     resolvedConfigOptions.codex?.reasoningEffort,
@@ -988,6 +1021,7 @@ export function resolveEffectiveProviderOptions(
   const result: StepProviderOptions = {
     ...(codexBaseUrl !== undefined
       || codexNetworkAccess !== undefined
+      || codexPermissionControl !== undefined
       || codexReasoningEffort !== undefined
       || codexCallTimeoutMs !== undefined
       || codexRepoSkills !== undefined
@@ -996,6 +1030,7 @@ export function resolveEffectiveProviderOptions(
           codex: {
             ...(codexBaseUrl !== undefined ? { baseUrl: codexBaseUrl } : {}),
             ...(codexNetworkAccess !== undefined ? { networkAccess: codexNetworkAccess } : {}),
+            ...(codexPermissionControl !== undefined ? { permissionControl: codexPermissionControl } : {}),
             ...(codexReasoningEffort !== undefined ? { reasoningEffort: codexReasoningEffort } : {}),
             ...(codexCallTimeoutMs !== undefined
               ? { guards: { callTimeoutMs: codexCallTimeoutMs } }
@@ -1139,7 +1174,9 @@ export function resolveEffectiveProviderOptions(
       : {}),
   };
 
-  return Object.keys(result).length > 0 ? result : undefined;
+  const effective = Object.keys(result).length > 0 ? result : undefined;
+  assertValidCodexProviderOptions(effective);
+  return effective;
 }
 
 function stripClaudeAllowedTools(
@@ -1260,6 +1297,7 @@ export const PROVIDER_OPTION_PATHS = [
   'claude.guards.callTimeoutMs',
   'codex.baseUrl',
   'codex.networkAccess',
+  'codex.permissionControl',
   'codex.reasoningEffort',
   'codex.guards.callTimeoutMs',
   'codex.skills.repo',

--- a/src/infra/config/providerOptionsContract.ts
+++ b/src/infra/config/providerOptionsContract.ts
@@ -5,6 +5,7 @@ const PROVIDER_OPTIONS_ENV_SPEC_ENTRIES = [
   { path: 'provider_options', type: 'json' },
   { path: 'provider_options.codex.base_url', type: 'string' },
   { path: 'provider_options.codex.network_access', type: 'boolean' },
+  { path: 'provider_options.codex.permission_control', type: 'string' },
   { path: 'provider_options.codex.reasoning_effort', type: 'string' },
   { path: 'provider_options.codex.guards.call_timeout_ms', type: 'number' },
   { path: 'provider_options.codex.skills.repo', type: 'boolean' },
@@ -48,6 +49,7 @@ const PROVIDER_OPTIONS_TRACE_PATH_ENTRIES = [
   'provider_options.codex',
   'provider_options.codex.base_url',
   'provider_options.codex.network_access',
+  'provider_options.codex.permission_control',
   'provider_options.codex.reasoning_effort',
   'provider_options.codex.guards',
   'provider_options.codex.guards.call_timeout_ms',
@@ -113,6 +115,7 @@ const PROVIDER_OPTIONS_FILE_PREFERRED_ENV_PATH_ENTRIES = [
 const PROVIDER_OPTIONS_INTERNAL_PATH_ENTRIES = [
   'codex.baseUrl',
   'codex.networkAccess',
+  'codex.permissionControl',
   'codex.reasoningEffort',
   'codex.guards.callTimeoutMs',
   'codex.skills.repo',

--- a/src/infra/providers/codex.ts
+++ b/src/infra/providers/codex.ts
@@ -25,6 +25,7 @@ function toCodexOptions(options: ProviderCallOptions): CodexCallOptions {
     model: options.model,
     reasoningEffort: options.providerOptions?.codex?.reasoningEffort,
     permissionMode: options.permissionMode,
+    permissionControl: options.providerOptions?.codex?.permissionControl,
     networkAccess: options.providerOptions?.codex?.networkAccess,
     onStream: options.onStream,
     onActivity: options.onActivity,


### PR DESCRIPTION
## Summary

- add `provider_options.codex.permission_control` with `takt` and `codex` values
- preserve the existing TAKT sandbox mapping when the option is omitted or set to `takt`
- omit Codex SDK `sandboxMode` and `networkAccessEnabled` when set to `codex`, allowing Codex permission profiles and `config.toml` to control permissions
- reject `permission_control: codex` combined with `network_access` after configuration resolution
- apply the behavior to normal and strict isolated structured Codex calls
- document the option in English and Japanese

## Why

TAKT always supplied a Codex SDK sandbox mode. The SDK translated that into `codex exec --sandbox`, which causes Codex permission profiles to be ignored. Users therefore could not rely on filesystem and network rules from their Codex configuration when running Codex through TAKT.

The new option makes delegation explicit while retaining the current TAKT-controlled behavior by default.

## User impact

Existing configurations are unchanged. Users who want Codex to own permission decisions can opt in with:

```yaml
provider_options:
  codex:
    permission_control: codex
```

TAKT continues to set `approvalPolicy: never` for non-interactive execution. When Codex controls permissions, effective access is the user's responsibility.

## Execution Report

- `npm run build`
- `npm run lint`
- `npm test`
- `npm run test:it`
- `npm run test:e2e:mock`
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts`
- targeted Codex runtime and provider-option resolution tests
- `git diff --check`

All checks passed.

Closes #1373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Codex の権限制御方式を `takt` または `codex` から選択できるようになりました。
  - 環境変数による設定上書きに対応しました。
  - `codex` 指定時は権限管理を Codex 側へ委譲します。
- **設定**
  - `codex` とネットワークアクセスを同時指定した場合、設定エラーとして通知します。
  - 既定では従来どおり TAKT がサンドボックスとネットワーク設定を管理します。
- **ドキュメント**
  - 設定方法、ワークフローでの利用方法、制約事項を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->