### PR TITLE
feat(workflows): team系ワークフローのリーダーとpartへ識別タグを追加する

### DIFF
--- a/builtins/en/workflows/development-implement-team.yaml
+++ b/builtins/en/workflows/development-implement-team.yaml
@@ -32,6 +32,7 @@ initial_step: implement
 steps:
   - name: implement
     capabilities: [edit, enable-skills]
+    tags: [coding, coding-leader]
     uses: development-core-implement
     with:
       development_policy:
@@ -43,7 +44,7 @@ steps:
       max_concurrency: 2
       initial_max_parts: 2
       fail_on_part_error: false
-      part_tags: [coding]
+      part_tags: [coding, coding-part]
       part_persona: coder
       part_edit: true
       part_permission_mode: edit

--- a/builtins/en/workflows/development-remediation-team.yaml
+++ b/builtins/en/workflows/development-remediation-team.yaml
@@ -94,6 +94,7 @@ steps:
         return: need_replan
   - name: fix
     capabilities: [edit, enable-skills]
+    tags: [coding, coding-leader]
     uses: peer-review-fix
     with:
       fix_policy:
@@ -105,7 +106,7 @@ steps:
       max_concurrency: 2
       initial_max_parts: 2
       fail_on_part_error: false
-      part_tags: [coding]
+      part_tags: [coding, coding-part]
       part_persona: coder
       part_edit: true
       part_permission_mode: edit
@@ -132,6 +133,7 @@ steps:
         next: fix-plan
   - name: fix-retry
     capabilities: [edit, enable-skills]
+    tags: [coding, coding-leader]
     uses: peer-review-fix
     with:
       fix_policy:
@@ -143,7 +145,7 @@ steps:
       max_concurrency: 2
       initial_max_parts: 2
       fail_on_part_error: false
-      part_tags: [coding]
+      part_tags: [coding, coding-part]
       part_persona: coder
       part_edit: true
       part_permission_mode: edit

--- a/builtins/ja/workflows/development-implement-team.yaml
+++ b/builtins/ja/workflows/development-implement-team.yaml
@@ -32,6 +32,7 @@ initial_step: implement
 steps:
   - name: implement
     capabilities: [edit, enable-skills]
+    tags: [coding, coding-leader]
     uses: development-core-implement
     with:
       development_policy:
@@ -43,7 +44,7 @@ steps:
       max_concurrency: 2
       initial_max_parts: 2
       fail_on_part_error: false
-      part_tags: [coding]
+      part_tags: [coding, coding-part]
       part_persona: coder
       part_edit: true
       part_permission_mode: edit

--- a/builtins/ja/workflows/development-remediation-team.yaml
+++ b/builtins/ja/workflows/development-remediation-team.yaml
@@ -94,6 +94,7 @@ steps:
         return: need_replan
   - name: fix
     capabilities: [edit, enable-skills]
+    tags: [coding, coding-leader]
     uses: peer-review-fix
     with:
       fix_policy:
@@ -105,7 +106,7 @@ steps:
       max_concurrency: 2
       initial_max_parts: 2
       fail_on_part_error: false
-      part_tags: [coding]
+      part_tags: [coding, coding-part]
       part_persona: coder
       part_edit: true
       part_permission_mode: edit
@@ -132,6 +133,7 @@ steps:
         next: fix-plan
   - name: fix-retry
     capabilities: [edit, enable-skills]
+    tags: [coding, coding-leader]
     uses: peer-review-fix
     with:
       fix_policy:
@@ -143,7 +145,7 @@ steps:
       max_concurrency: 2
       initial_max_parts: 2
       fail_on_part_error: false
-      part_tags: [coding]
+      part_tags: [coding, coding-part]
       part_persona: coder
       part_edit: true
       part_permission_mode: edit


### PR DESCRIPTION
## 背景

`team_leader` ステップはリーダー(ステップ本体)が分解と統合を行い、part が実働する。両者は provider を分けて割り当てたい場面がある(リーダーは判断が要るので強いモデル、part は実装の物量なので安いモデル)。

しかし現状は、リーダー側のタグが fragment 由来の `[coding]`、part 側も `part_tags: [coding]` で同一のため、`provider_routing.tags` で coding に profile を割り当てるとリーダーと part の両方が同じ provider になる。ステップ名指定でしか分離できず、タグベースの振り分けと一貫しない。

## 変更内容

team_leader を持つステップに識別用のタグを追加する。

- リーダー側(ステップの `tags`): `[coding, coding-leader]`
- part 側(`part_tags`): `[coding, coding-part]`

対象は `development-implement-team`(implement)と `development-remediation-team`(fix / fix-retry)の ja / en。

`coding` は両方に残しているので、既存の coding タグへ profile を割り当てている設定の挙動は変わらない。分離したい場合だけ `coding-leader` / `coding-part` に割り当てる。

```yaml
provider:
  targets:
    tags:
      coding-leader: { profile: strong }
      coding-part: { profile: local }
```

## テスト

- team-leader-schema-loader 24件、provider-routing 52件、lint、build すべて成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 実装および修正ワークフローで、リーダー担当と分割作業を識別しやすくなりました。
  * 英語版・日本語版のワークフローに同じ識別情報を反映しました。
  * 既存の作業分類は維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->