### PR TITLE
fix(workflows): 判断系ステップからreviewタグを外しタグを役割どおりに分類する

### DIFF
--- a/builtins/en/steps/peer-review-adjudication.yaml
+++ b/builtins/en/steps/peer-review-adjudication.yaml
@@ -8,7 +8,7 @@ params:
 name: review-adjudication
 capabilities: readonly
 tags:
-  - review
+  - adjudication
 edit: false
 persona: review-adjudicator
 policy:

--- a/builtins/en/steps/peer-review-final-gate.yaml
+++ b/builtins/en/steps/peer-review-final-gate.yaml
@@ -8,7 +8,6 @@ params:
 name: final-gate
 capabilities: readonly
 tags:
-  - review
   - final-gate
   - supervise
 edit: false

--- a/builtins/en/steps/peer-review-fix-plan.yaml
+++ b/builtins/en/steps/peer-review-fix-plan.yaml
@@ -15,7 +15,6 @@ name: fix-plan
 capabilities: readonly
 tags:
   - plan
-  - review
 edit: false
 persona: planner
 policy:

--- a/builtins/en/steps/peer-review-fix-verifier.yaml
+++ b/builtins/en/steps/peer-review-fix-verifier.yaml
@@ -8,7 +8,7 @@ params:
 name: fix-verifier
 capabilities: readonly
 tags:
-  - review
+  - verification
 edit: false
 persona: coding-reviewer
 policy:

--- a/builtins/en/steps/review-supervise-to-complete.yaml
+++ b/builtins/en/steps/review-supervise-to-complete.yaml
@@ -1,7 +1,6 @@
 name: supervise
 capabilities: readonly
 tags:
-  - review
   - supervise
 edit: false
 persona: supervisor

--- a/builtins/en/steps/review-synthesis-to-complete.yaml
+++ b/builtins/en/steps/review-synthesis-to-complete.yaml
@@ -1,7 +1,6 @@
 name: review-synthesis
 capabilities: readonly
 tags:
-  - review
   - final-gate
   - supervise
 edit: false

--- a/builtins/ja/steps/peer-review-adjudication.yaml
+++ b/builtins/ja/steps/peer-review-adjudication.yaml
@@ -8,7 +8,7 @@ params:
 name: review-adjudication
 capabilities: readonly
 tags:
-  - review
+  - adjudication
 edit: false
 persona: review-adjudicator
 policy:

--- a/builtins/ja/steps/peer-review-final-gate.yaml
+++ b/builtins/ja/steps/peer-review-final-gate.yaml
@@ -8,7 +8,6 @@ params:
 name: final-gate
 capabilities: readonly
 tags:
-  - review
   - final-gate
   - supervise
 edit: false

--- a/builtins/ja/steps/peer-review-fix-plan.yaml
+++ b/builtins/ja/steps/peer-review-fix-plan.yaml
@@ -15,7 +15,6 @@ name: fix-plan
 capabilities: readonly
 tags:
   - plan
-  - review
 edit: false
 persona: planner
 policy:

--- a/builtins/ja/steps/peer-review-fix-verifier.yaml
+++ b/builtins/ja/steps/peer-review-fix-verifier.yaml
@@ -8,7 +8,7 @@ params:
 name: fix-verifier
 capabilities: readonly
 tags:
-  - review
+  - verification
 edit: false
 persona: coding-reviewer
 policy:

--- a/builtins/ja/steps/review-supervise-to-complete.yaml
+++ b/builtins/ja/steps/review-supervise-to-complete.yaml
@@ -1,7 +1,6 @@
 name: supervise
 capabilities: readonly
 tags:
-  - review
   - supervise
 edit: false
 persona: supervisor

--- a/builtins/ja/steps/review-synthesis-to-complete.yaml
+++ b/builtins/ja/steps/review-synthesis-to-complete.yaml
@@ -1,7 +1,6 @@
 name: review-synthesis
 capabilities: readonly
 tags:
-  - review
   - final-gate
   - supervise
 edit: false


### PR DESCRIPTION
## 背景

`review` タグが「レビューを書くステップ」と「レビューを裁く・検証するステップ」の両方に付いていた。そのため `provider_routing.tags` で `review` にローカルの軽いモデルを割り当てると、レビュワーだけのつもりが裁定・修正計画・修正検証まで同じモデルに落ちる。

実測での事故: review にレビュー用ローカルモデルを割り当てた編成で、裁定・fix-plan・fix-verifier までそのモデルが担当になり、fix-plan が同一ツール呼び出しを12回繰り返してループ検出で run が停止した。判断系ステップは routing の対象として意図されていなかった。

## 変更内容

判断系ステップのタグを役割どおりに分類する(ja / en)。

| ステップ | 変更前 | 変更後 |
|---|---|---|
| peer-review-fix-plan | plan, review | plan |
| peer-review-adjudication | review | adjudication |
| peer-review-fix-verifier | review | verification |
| peer-review-final-gate | review, final-gate, supervise | final-gate, supervise |
| review-supervise-to-complete | review, supervise | supervise |
| review-synthesis-to-complete | review, final-gate, supervise | final-gate, supervise |

レビューを書くステップ(reviewers、cqrs、frontend、ai-antipattern 系、second-pass)の `review` タグは変更しない。

## 互換性への影響

`review` タグで裁定系も含めて振り分けていた設定は挙動が変わる(裁定系が defaults へ戻る)。裁定系を明示的に振り分けたい場合は新タグ `adjudication` / `verification`、既存の `final-gate` / `supervise` / `plan` を使う。

## テスト

- provider-routing 52件、lint、build すべて成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 英語・日本語のピアレビュー手順で、タグ分類を見直しました。
  * 判定、検証、最終確認、監督などの手順が、より適切なタグで整理されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->