### PR TITLE
docs: add Simplified Chinese documentation (#1385)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 
 <p align="center">
   <a href="./README.md">English</a> |
-  <a href="./docs/README.ja.md">日本語</a>
+  <a href="./docs/README.ja.md">日本語</a> |
+  <a href="./docs/README.zh-CN.md">简体中文</a>
 </p>
 
 <p align="center">
@@ -538,6 +539,12 @@ See [External Integrations](./docs/external-integrations.md) for other community
 | [CI/CD Integration](./docs/ci-cd.md) | GitHub Actions and pipeline mode |
 | [External Integrations](./docs/external-integrations.md) | Community examples that extend TAKT without modifying core (audit trails, etc.) |
 | [Changelog](./CHANGELOG.md) ([日本語](./docs/CHANGELOG.ja.md)) | Version history |
+
+### Simplified Chinese documentation
+
+Simplified Chinese documentation uses the `.zh-CN.md` suffix so it can coexist with the English and Japanese pages. Start with the [Chinese documentation index](./docs/README.zh-CN.md).
+
+Translated coverage includes the onboarding path (README, tutorial, configuration, and CLI reference), workflow authoring, provider/external integrations, and task management. The remaining catalog, observability, design, prompting, token-saving, repertoire, CI/CD, testing, contributing, changelog, and internal design/development pages remain available in English or Japanese and are intentionally not duplicated here.
 
 ## Sponsors
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -17,7 +17,8 @@
 
 <p align="center">
   <a href="../README.md">English</a> |
-  <a href="./README.ja.md">日本語</a>
+  <a href="./README.ja.md">日本語</a> |
+  <a href="./README.zh-CN.md">简体中文</a>
 </p>
 
 <p align="center">

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,0 +1,514 @@
+# TAKT
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./assets/takt-logo-dark.svg">
+    <img src="./assets/takt-logo.svg" alt="TAKT 徽标" width="480">
+  </picture>
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/takt"><img src="https://img.shields.io/npm/v/takt?label=npm" alt="npm 版本"></a>
+  <a href="https://github.com/nrslib/takt/stargazers"><img src="https://img.shields.io/github/stars/nrslib/takt?logo=github&label=stars" alt="GitHub stars"></a>
+  <a href="https://github.com/nrslib/takt/actions/workflows/ci.yml"><img src="https://github.com/nrslib/takt/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/github/license/nrslib/takt" alt="许可证"></a>
+  <a href="https://discord.gg/R2Xz3uYWxD"><img src="https://img.shields.io/badge/dynamic/json?label=discord&query=approximate_member_count&url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FR2Xz3uYWxD%3Fwith_counts%3Dtrue&suffix=%20members&logo=discord&logoColor=white&color=5865F2" alt="Discord 成员数"></a>
+</p>
+
+<p align="center">
+  <a href="../README.md">English</a> |
+  <a href="./README.ja.md">日本語</a> |
+  <a href="./README.zh-CN.md">简体中文</a>
+</p>
+
+<p align="center">
+  <a href="https://nrslib.github.io/takt/#tutorial">
+    <img src="./assets/tutorial-preview.gif" alt="展示描述任务、将任务加入队列并由多个 AI 智能体执行的 TAKT 教程预览" width="720">
+  </a>
+</p>
+
+**不再日夜盯着 AI 编码智能体。**
+
+TAKT 是一个开源 CLI，可将 AI 编码智能体变成可重复的开发工作流。你可以在 YAML 中定义规划、实现、审查、修复循环、人工检查点、权限和输出契约，然后在隔离的 worktree 中执行任务并保留可追踪的日志。
+
+你不需要让一个智能体记住整个流程；TAKT 为每个 step 分配独立的角色、上下文和转移规则。AI 负责编写代码，workflow 决定下一步做什么。
+
+![TAKT 控制 AI 编码智能体工作流](./assets/description/01-hero.png)
+
+- 将规划 → 实现 → 审查 → 修复循环定义为明确的 workflow step
+- 通过 step 专属的 persona、policy、knowledge、instruction 和 output contract 保持上下文聚焦
+- 在隔离的 worktree 中执行排队任务，并在之后查看日志和报告
+- 使用 Claude Code、Claude SDK、Codex SDK、OpenCode SDK、Pi SDK、官方 DeepSeek Harness SDK、Cursor、GitHub Copilot CLI 或 Kiro 作为 provider
+
+**T**AKT **A**gent **K**oordination **T**opology 用结构化审查循环、受管理的 prompt 和防护措施来编排多个 AI 智能体。
+
+先和 AI 对话描述需求，再将需求加入任务队列，最后运行 `takt run`。规划、实现、审查和修复循环都定义在 YAML workflow 文件中，不会把整个流程交给智能体自行决定。TAKT 让 Claude Code、Codex、OpenCode、Pi、官方 DeepSeek Harness SDK、Cursor、GitHub Copilot CLI 和 Kiro CLI 以不同的角色、权限和上下文协作。
+
+TAKT 主要用于 AI 编码工作流，但同样适用于任何需要多个 AI 智能体协作，或可以通过审查、判断和反馈循环提高质量的任务。
+
+TAKT 本身也是用 TAKT 开发的（dogfooding）。
+
+## 为什么选择 TAKT
+
+AI 编码智能体很强大，但不会自动形成稳定的开发流程。在长时间工作中，它们可能忘记指令、积累被污染的上下文、混淆实现与审查职责，还会迫使人类反复提出相同的反馈。
+
+把更多规则写入 prompt、`CLAUDE.md` 或 skill 会有所帮助，却不能真正强制流程；规则是否被遵守仍取决于智能体自身的行为。
+
+TAKT 将 AI 智能体视为需要从外部控制的对象，而不是只能被信任的对象。
+
+workflow 定义阶段，每个 step 获得自己的 persona、policy、knowledge、instruction 和 output contract。TAKT 以声明式方式管理实现、审查、修复和再次审查。把职责、知识和限制分开，再只向当前 step 提供所需内容，可以避免上下文膨胀并提高任务质量。
+
+审查不会被静默跳过。发现问题后，工作会回到修复 step；需要时也可以请求人工判断。任务在隔离的 worktree 中运行，每个 step 都留下日志和报告，因此从任务到 PR 的路径可以追溯。
+
+TAKT 的核心是运行可复用的智能体流程：流程拥有角色、阶段、判断和反馈循环。
+
+目标很简单：不依赖人类持续介入，让开发流程可复用、可审查、可复现。
+
+## 5 分钟试用
+
+请在至少有一个 commit 的 Git 仓库中运行：
+
+```bash
+npm install -g takt
+
+# 与 AI 对话描述任务，使用 /go，然后选择“加入任务队列”
+takt
+
+# 在隔离的 worktree 中执行排队任务
+takt run
+
+# 查看 diff、合并、重试、重新排队或删除任务分支
+takt list
+```
+
+首次运行时，请在 `~/.takt/config.yaml` 中配置 provider，或使用[配置](#配置)中列出的 API key 环境变量。`claude-sdk`、`codex`、`opencode` 和 `pi` 等 SDK provider 可在 Node.js 中运行；`deepseek-harness` 还需要 Python 3.10+ 和官方 runtime wheel。CLI provider 还需要对应的外部 CLI。
+
+### 视频教程
+
+请按照[文字教程](./tutorial.zh-CN.md)完成以下实践操作：
+
+| 第 1 章 | 第 2 章 |
+|---------|---------|
+| [![观看 TAKT 视频教程第 1 章](https://i.ytimg.com/vi/HUcFFvOy39I/hqdefault.jpg)](https://youtu.be/HUcFFvOy39I) | [![观看 TAKT 视频教程第 2 章](https://i.ytimg.com/vi/UIlM2iM-rmA/hqdefault.jpg)](https://youtu.be/UIlM2iM-rmA) |
+
+## TAKT 与普通 AI 编码智能体的区别
+
+| 普通 AI 编码智能体 | TAKT |
+|------------------|------|
+| 由 prompt 要求智能体遵守流程 | 由 YAML workflow 管理流程 |
+| 审查步骤可能被忘记或跳过 | 审查和修复循环是明确的转移 |
+| 一个很长的上下文不断增长 | 每个 step 只获得所需上下文 |
+| 实现和审查职责容易混淆 | persona、权限和 output contract 分离职责 |
+| 需要靠记忆重新创建同一流程 | workflow 可复用、可审查、可版本化 |
+
+## 要求
+
+TAKT 需要 Node.js `>=24.15.0`。
+
+所选 provider 决定是否需要外部 CLI，或者是否只用 Node.js 即可通过 TypeScript SDK 运行。
+
+以下 provider 通过 SDK 运行，不需要 CLI：
+
+- `claude-sdk` — `@anthropic-ai/claude-agent-sdk`
+- `codex` — `@openai/codex-sdk`
+- `opencode` — `@opencode-ai/sdk`
+- `pi` — `@earendil-works/pi-coding-agent`
+
+`deepseek-harness` 通过私有 JSON-RPC bridge 使用官方 Python SDK。请在 Python 3.10+ 中安装匹配的 SDK/runtime 包：
+
+```bash
+python3 -m pip install deepseek-harness-sdk deepseek-harness-runtime-bin
+```
+
+官方 runtime 当前支持 Linux x64/arm64 和 macOS arm64。Windows 和 macOS x64 会快速失败；TAKT 不会静默切换到其他 provider。请设置 `DEEPSEEK_API_KEY`，也可以设置 `DEEPSEEK_BASE_URL`。Python SDK 与 `deepseek-harness-runtime-bin` 必须来自匹配的版本。这是 developer-preview 兼容性边界；使用新的 SDK/runtime 组合前，请按照配置指南执行 opt-in live smoke。
+
+以下 provider 需要外部 CLI：
+
+- `claude` — [Claude Code](https://claude.ai/code)
+- `claude-terminal` — 在交互式终端会话中驱动 [Claude Code](https://claude.ai/code)，还需要 [`tmux`](https://github.com/tmux/tmux)
+- `copilot` — [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)
+- `cursor` — [Cursor Agent](https://docs.cursor.com/)
+- `kiro` — [Kiro CLI](https://kiro.dev/docs/cli/headless/)
+
+可选工具：
+
+- [GitHub CLI](https://cli.github.com/)（`gh`）— 用于 `takt #N` GitHub Issue 任务
+- [GitLab CLI](https://gitlab.com/gitlab-org/cli)（`glab`）— GitLab Issue/MR 集成（根据 remote URL 自动检测）
+
+> **关于 OAuth：** 是否可以使用 OAuth 取决于 provider 和使用场景。使用 TAKT 前请查看各 provider 的服务条款。
+
+## 快速开始
+
+### 安装
+
+```bash
+npm install -g takt
+```
+
+使用 Nix flakes：
+
+```bash
+nix run github:nrslib/takt
+nix profile install github:nrslib/takt
+```
+
+Nix 包只安装 TAKT CLI 本身。外部 CLI provider、`git` 以及 `gh`/`glab` 仍需单独安装，并按[要求](#要求)放在 `PATH` 中或另行配置。
+
+### 与 AI 对话并加入任务队列
+
+```text
+$ takt
+
+Select workflow:
+  ❯ 🎼 default (current)
+    📁 🚀 Quick Start/
+    📁 🎨 Frontend/
+    📁 ⚙️ Backend/
+
+> Add user authentication with JWT
+
+[AI clarifies requirements and organizes the task]
+
+> /go
+
+Proposed task:
+  ...
+
+What would you like to do?
+    Execute now
+    Create GitHub Issue
+  ❯ Queue as task          # ← 常规流程
+    Continue conversation
+```
+
+选择 `Queue as task` 会将任务保存到 `.takt/tasks/`。运行 `takt run` 后，TAKT 创建隔离的 worktree，执行 workflow（plan → implement → review → fix 循环），结束后询问是否创建 PR。
+
+```bash
+# 执行排队任务
+takt run
+
+# 也可以从 GitHub Issue 加入任务
+takt add #6
+takt add #12
+
+# 执行所有待处理任务
+takt run
+```
+
+> **选择“Execute now”：** workflow 会直接在当前目录运行，不创建 worktree 隔离。它适合快速实验，但修改会直接进入当前工作树。
+
+### 管理结果
+
+```bash
+# 查看任务分支，并进行合并、重试、重新排队、强制失败或删除
+takt list
+```
+
+## 工作原理
+
+TAKT 的名称来自德语 “Takt”，意为节拍或指挥棒的一击；指挥家用它来让乐团保持同步。TAKT 在面向用户和实现的术语中都统一使用 **workflow** 与 **step**。
+
+workflow 由一系列 step 定义。使用 `steps`、`initial_step` 和 `max_steps`。每个 step 指定 persona（由谁执行）、权限（允许做什么）以及规则（接下来做什么）。最小示例：
+
+```yaml
+name: plan-implement-review
+initial_step: plan
+max_steps: 10
+
+steps:
+  - name: plan
+    persona: planner
+    edit: false
+    rules:
+      - condition: Planning complete
+        next: implement
+
+  - name: implement
+    persona: coder
+    edit: true
+    required_permission_mode: edit
+    rules:
+      - condition: Implementation complete
+        next: review
+
+  - name: review
+    persona: reviewer
+    edit: false
+    rules:
+      - condition: Approved
+        next: COMPLETE
+      - condition: Needs fix
+        next: implement    # ← 修复循环
+```
+
+规则决定下一个 step。`COMPLETE` 表示 workflow 成功结束，`ABORT` 表示失败结束。完整 schema、并行 step 和规则条件类型请参阅 [Workflow Guide](./workflows.zh-CN.md)。
+
+可复用的 step 定义可以放在 `.takt/steps/`，再通过 `uses` 展开。片段查找和覆盖规则请参阅 Workflow Guide。
+
+正式的 workflow 目录名是 `workflows/`。同名 workflow 存在于多个位置时，TAKT 按以下顺序解析：`.takt/workflows/` → `~/.takt/workflows/` → builtins。
+
+## 推荐 workflow
+
+| Workflow | 用途 |
+|----------|------|
+| `default` | 标准开发流程，包含测试优先、多视角并行审查和修复循环 |
+| `frontend` | 前端开发流程 |
+| `backend` | 后端开发流程 |
+| `dual` | 前端与后端组合流程 |
+| `takt-default` | TAKT 自身使用的开发流程，也适用于其他 CLI 工具 |
+| `frontend-maintenance` | 前端生产维护流程 |
+| `backend-maintenance` | 后端生产维护流程 |
+| `*-mini` 系列 | 各 workflow 的轻量版本，省略 `write_tests` |
+
+所有 builtin workflow 和 persona 请参阅 [Builtin Catalog](./builtin-catalog.md)。
+
+## 主要命令
+
+| 命令 | 说明 |
+|------|------|
+| `takt` | 与 AI 对话、完善需求、执行或排队任务 |
+| `takt exec` | 启动即时 Assistant/Worker/Review agent 模式，无需写 workflow YAML |
+| `takt add` | 通过 AI 对话完善任务并加入队列，也可从 GitHub Issue 创建 |
+| `takt run` | 执行所有待处理任务 |
+| `takt watch` | 监视任务队列并自动执行待处理任务 |
+| `takt list` | 管理任务分支：合并、重试、重新排队、强制失败、指导或删除 |
+| `takt #N` | 将 GitHub Issue 作为任务输入 |
+| `takt eject` | 复制 builtin workflow/facet 以便定制 |
+| `takt workflow init` | 创建 workflow scaffold |
+| `takt workflow doctor` | 验证 workflow 定义 |
+| `takt repertoire add` | 从 GitHub 安装 repertoire package |
+
+全部命令和选项请参阅 [CLI Reference](./cli-reference.zh-CN.md)。
+
+TAKT 还提供两个客户端集成入口：`takt-acp` 通过 stdio JSON-RPC 作为 [Agent Client Protocol](./cli-reference.zh-CN.md#acp-agent) agent 运行；`takt-mcp` 作为 stdio [MCP server](./cli-reference.zh-CN.md#mcp-server) 运行，让 MCP 客户端（Codex、Claude Code 等）可以加入任务队列。使用 `takt run` 或 `takt watch` 执行待处理任务。
+
+### 即时 exec 模式
+
+`takt exec` 启动 TAKT 的交互式任务录入模式。Assistant agent 澄清需求，`/go` 将对话转换为生成的 workflow，Worker agent 实现任务，Review agent 审查结果，Replanning agent 在需要时向用户询问方向；循环检测会阻止无效的重复循环。
+
+exec 会从上一次 exec 配置启动；首次使用时使用默认配置。传入 preset 名称可以从指定 preset 开始。在对话中使用 `/setup` 编辑 agent、循环检测阈值、preset 以及引用的 instruction/knowledge/policy facet。builtin/default preset 只定义角色、facet 和循环阈值。exec 启动时从普通 TAKT 配置解析 provider 和 model，并在 Assistant 对话与 `/setup` 显示中使用同一解析结果。生成的 workflow 使用 capability 表达工具/技能需求；provider、model 和 options 留在 runtime 配置中。
+
+exec preset 的解析顺序是：项目 `.takt/exec/presets/` → 全局 `$TAKT_CONFIG_DIR/exec/presets/`（默认 `~/.takt/exec/presets/`）→ builtin `builtins/exec/presets/`。`/setup` 的变更保存到 `$TAKT_CONFIG_DIR/exec.yaml`（默认 `~/.takt/exec.yaml`），供下次 exec 使用。`/go` 会生成 `.takt/exec/workflow.yaml` 并通过普通 workflow engine 执行；没有对话或内联任务文本时，`/go` 不会生成 workflow。使用 `/cancel` 可退出而不运行。
+
+exec 输入支持图片附件。使用 `/paste-image` 或 macOS 上的 `Ctrl+V` 附加剪贴板图片；TAKT 会插入 `[Image #N]` 占位符。只有在 Assistant 消息或 `/go` 备注中引用该占位符时，图片才会随请求发送。支持 PNG、JPEG、GIF 和 WebP，内联及剪贴板图片限制为 10 MiB。
+
+## 配置
+
+最小的 `~/.takt/config.yaml`：
+
+```yaml
+provider: claude              # claude, claude-sdk, claude-terminal, codex, opencode, deepseek-harness, cursor, copilot, kiro, pi, or mock
+model: sonnet                 # 直接传给 provider
+language: en                  # en 或 ja；当前 UI 不提供 zh-CN
+```
+
+下面是保留的旧版配置模式示例。runtime 模式下，应将 provider、model、provider options 和路由放入 `runtime.yaml`；workflow YAML 不能设置这些执行配置：
+
+```yaml
+provider: codex          # 没有 workflow step 上下文时使用；没有 auto_routing 时也是默认值
+model: gpt-5.6-sol
+takt_providers:
+  assistant:             # 可选覆盖；interactive / instruct / retry 不使用 auto routing
+    provider: codex
+    model: gpt-5.6-sol
+auto_routing:
+  strategy: balanced   # cost、balanced 或 performance
+  router:
+    provider: codex
+    model: gpt-5.6-luna
+  candidates:
+    - name: advanced
+      description: Planning, final decisions, requirement-fulfillment judgment, and other advanced reasoning
+      provider: codex
+      model: gpt-5.6-sol
+      routing_tier: high
+    - name: coding
+      description: Implementation, tests, debugging, and refactoring
+      provider: codex
+      model: gpt-5.6-terra
+      routing_tier: medium
+    - name: lightweight
+      description: Formatting and small mechanical edits
+      provider: codex
+      model: gpt-5.6-luna
+      routing_tier: low
+  rules:
+    steps:
+      security-audit: advanced
+  default_pool: general
+  candidate_pools:
+    general:
+      candidates: [lightweight, coding, advanced]
+      fallback: advanced
+    implementation:
+      candidates: [coding, advanced]
+      fallback: advanced
+  pool_rules:
+    tags:
+      implementation: implementation
+```
+
+旧版模式中，没有 workflow-step 上下文的操作使用具体的顶层 provider/model；Assistant 对话不走 auto routing。自动路由决策只在本地以 NDJSON 写入 `.takt/events/`，可通过 `telemetry.routing_decisions` 或 `takt telemetry status|enable|disable` 查看和控制，TAKT 不会上传这些决策。
+
+运行元数据、session、trace、report 等运行产物仍以普通文件保存在 `.takt/runs/<run>/` 下。
+
+更完整的配置、provider profile、model 解析和 `runtime.yaml` 说明请参阅[配置指南](./configuration.zh-CN.md)。
+
+TAKT 也可以直接使用 provider 凭据（当对应 SDK/runtime 已安装时不需要 CLI）：
+
+```bash
+export TAKT_ANTHROPIC_API_KEY=sk-ant-...   # Anthropic（Claude）
+export TAKT_OPENAI_API_KEY=sk-...          # OpenAI（Codex）
+export TAKT_OPENCODE_API_KEY=...           # OpenCode
+export TAKT_CURSOR_API_KEY=...             # Cursor Agent（可选）
+export TAKT_COPILOT_GITHUB_TOKEN=ghp_...   # GitHub Copilot CLI
+export TAKT_KIRO_API_KEY=...               # Kiro CLI
+export DEEPSEEK_API_KEY=...                 # 官方 DeepSeek Harness SDK
+# 可选：export DEEPSEEK_BASE_URL=https://...
+# Pi 使用其 SDK credential store 或 provider 原生环境变量
+```
+
+OpenCode 默认有 60 分钟的 provider-event 不活跃上限；如果调用可能超过此时间，请显式设置 `provider_options.opencode.guards.call_timeout_ms`（最多 86,400,000 ms）：
+
+```yaml
+provider_options:
+  opencode:
+    guards:
+      profile: standard
+      model_profiles:
+        "opencode/big-pickle": minimal
+        "lmstudio/*": standard
+      call_timeout_ms: 7200000
+      text_byte_limit: 1048576
+      reasoning_byte_limit: 4194304
+```
+
+已移除的 `TAKT_OPENCODE_TOOL_ERROR_BUDGET`、`TAKT_OPENCODE_TOOL_SIGNATURE_ABSOLUTE`、`TAKT_OPENCODE_TOOL_SIGNATURE_REPEATS`、`TAKT_OPENCODE_TOOL_SUCCESS_REPEATS` 和 `TAKT_OPENCODE_TOOL_RESULT_STAGNATION_REPEATS` 会被忽略，并发出一次迁移警告。详见配置指南中的 v6 guard 策略。
+
+### 专用 provider 配置（`runtime.yaml`）
+
+provider、model、provider options、自动路由和内部 agent 分配可以放入专用层：`~/.takt/runtime.yaml` 与 `<project>/.takt/runtime.yaml`，项目层优先。`runtime.yaml` 是配置层默认值；CLI 和环境变量覆盖仍然可用。workflow YAML 不能设置 provider/model/options/routing；已移除的字段会在加载时失败并给出迁移提示。
+
+Companion reviewer 默认禁用。要启用它们，请在 `runtime.yaml` 设置顶层策略：
+
+```yaml
+version: 1
+companion:
+  enabled: true
+```
+
+全局和项目策略都设置时按逻辑 AND 合并；全局 `false` 不能由项目设置重新启用。省略的策略在层合并时是 neutral；两层都没有设置时 Companion 仍禁用。Companion target 和 provider capability 只在启用时解析/执行；禁用时仍会进行 companion 声明和 target 结构校验，但不会解析或运行 companion provider。
+
+## 定制
+
+### 自定义 workflow
+
+```bash
+takt workflow init my-flow   # 创建 workflow scaffold
+takt workflow doctor my-flow # 验证 workflow 定义
+takt eject default           # 复制 builtin workflow 到 ~/.takt/workflows/ 并编辑
+```
+
+### 自定义 persona
+
+在 `~/.takt/facets/personas/` 中创建 Markdown 文件：
+
+```markdown
+# ~/.takt/facets/personas/my-reviewer.md
+You are a code reviewer specialized in security.
+```
+
+在 workflow 中引用：`persona: my-reviewer`。
+
+`~/.takt/personas/` 仍作为兼容路径有效，但 `takt catalog` 只扫描 `facets/` 目录。详情请参阅 [Workflow Guide](./workflows.zh-CN.md)。
+
+## CI/CD
+
+TAKT 为 GitHub Actions 提供 [takt-action](https://github.com/nrslib/takt-action)：
+
+```yaml
+- uses: nrslib/takt-action@main
+  with:
+    anthropic_api_key: ${{ secrets.TAKT_ANTHROPIC_API_KEY }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+其他 CI 系统可以使用 pipeline 模式：
+
+```bash
+takt --pipeline --task "Fix the bug" --auto-pr
+```
+
+完整设置请参阅 [CI/CD Guide](./ci-cd.md)。
+
+## 项目结构
+
+```text
+~/.takt/                    # 全局配置
+├── config.yaml             # provider、model、language 等
+├── workflows/              # 用户 workflow 定义
+├── facets/                 # 用户 facet（persona、policy、knowledge 等）
+└── repertoire/             # 已安装的 repertoire package
+
+.takt/                      # 项目级目录
+├── config.yaml             # 项目配置
+├── workflows/              # 项目 workflow 覆盖
+├── facets/                 # 项目 facet
+├── tasks.yaml              # 待处理任务
+├── tasks/                  # 任务规格
+└── runs/                   # 执行报告、日志和上下文
+```
+
+## 采用 Spec-Driven Development
+
+TAKT 以声明式 YAML 状态机强制阶段转移，通过 output contract 固化每个阶段的产物，并通过并行审查和修复循环处理偏差。这种结构适合遵循 Spec-Driven Development（SDD）的用户。社区项目 [j5ik2o/takt-sdd](https://github.com/j5ik2o/takt-sdd) 提供 Requirements → Gap Analysis → Design → Tasks → Implementation → Validation 工作流，以及 OpenSpec 风格的变更提案流程：
+
+```bash
+npx create-takt-sdd
+```
+
+其他社区集成请参阅[外部集成](./external-integrations.zh-CN.md)。
+
+## 文档
+
+### 简体中文文档
+
+本次简体中文翻译采用文件名后缀 `.zh-CN.md`。它与既有英文原文件和 `.ja.md` 日语文件并存；`zh-CN` 明确表示简体中文，而不是运行时 UI 语言。
+
+已翻译并维护以下入口：
+
+| 文档 | 说明 |
+|------|------|
+| [教程](./tutorial.zh-CN.md) | 通过三个阶段改进一个示例，并学习排队、运行和检查任务 |
+| [CLI 参考](./cli-reference.zh-CN.md) | 所有命令和选项 |
+| [配置](./configuration.zh-CN.md) | 全局与项目设置、provider 和 runtime |
+| [Workflow 指南](./workflows.zh-CN.md) | 创建和定制 workflow |
+| [任务管理](./task-management.zh-CN.md) | 任务排队、执行和隔离 |
+| [外部集成](./external-integrations.zh-CN.md) | 不修改核心的社区集成示例 |
+| [中文文档入口](./README.zh-CN.md) | 安装、快速开始和文档导航 |
+
+以下完整文档页面暂不翻译，继续以英文/日文提供：Builtin Catalog、Observability、Design Philosophy、Faceted Prompting、Token Saving、Repertoire Packages、CI/CD、Testing、Contributing、Changelog，以及项目设计和开发内部文档。运行时 UI、prompt 和 `language` 配置也没有新增中文选项；本次变更只增加文档，不修改 runtime 行为。
+
+## 赞助者
+
+TAKT 通过 CodeRabbit 的 Open Source Support Program 获得支持。
+
+<a href="https://coderabbit.link/nrslib">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_79b9189d19.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg">
+    <img alt="CodeRabbit" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg" height="40">
+  </picture>
+</a>
+
+## 社区
+
+如有问题、讨论或更新，欢迎加入 [TAKT Discord](https://discord.gg/R2Xz3uYWxD)。
+
+## 贡献
+
+请参阅英文 [CONTRIBUTING.md](../CONTRIBUTING.md) 了解详情。
+
+## 许可证
+
+MIT — 详情请参阅 [LICENSE](../LICENSE)。

--- a/docs/cli-reference.ja.md
+++ b/docs/cli-reference.ja.md
@@ -1,6 +1,6 @@
 # CLI リファレンス
 
-[English](./cli-reference.md)
+[English](./cli-reference.md) | [日本語](./cli-reference.ja.md) | [简体中文](./cli-reference.zh-CN.md)
 
 このドキュメントは TAKT CLI の全コマンドとオプションの完全なリファレンスです。
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-[日本語](./cli-reference.ja.md)
+[English](./cli-reference.md) | [日本語](./cli-reference.ja.md) | [简体中文](./cli-reference.zh-CN.md)
 
 This document provides a complete reference for all TAKT CLI commands and options.
 

--- a/docs/cli-reference.zh-CN.md
+++ b/docs/cli-reference.zh-CN.md
@@ -1,0 +1,508 @@
+# CLI 参考
+
+[English](./cli-reference.md) | [日本語](./cli-reference.ja.md) | [简体中文](./cli-reference.zh-CN.md)
+
+本文是 TAKT CLI 命令和选项的参考。
+
+## 全局选项
+
+| 选项 | 说明 |
+|------|------|
+| `--pipeline` | 启用 pipeline（非交互）模式；CI/自动化必需 |
+| `-t, --task <text>` | 任务内容（GitHub Issue 的替代方式） |
+| `-i, --issue <N>` | GitHub Issue 编号（等同于交互模式中的 `#N`） |
+| `-w, --workflow <name or path>` | workflow 名称或 workflow YAML 文件路径 |
+| `-b, --branch <name>` | 指定分支名（省略时自动生成） |
+| `--pr <number>` | 获取审查评论并修复指定 PR |
+| `--auto-pr` | 执行后创建 PR（仅 pipeline 模式） |
+| `--draft` | 创建 draft PR（需要 `--auto-pr` 或 `auto_pr` 配置） |
+| `--skip-git` | 跳过创建分支、commit 和 push（pipeline 模式，仅执行 workflow） |
+| `--repo <owner/repo>` | 指定仓库（创建 PR 时使用） |
+| `-q, --quiet` | 最小输出模式：抑制 AI 输出（用于 CI） |
+| `--provider <name>` | 覆盖 agent provider（claude\|claude-sdk\|claude-terminal\|codex\|opencode\|deepseek-harness\|cursor\|copilot\|kiro\|pi\|mock） |
+| `--auto-strategy <strategy>` | 覆盖自动路由策略（`cost`\|`balanced`\|`performance`）。只有执行进入当前 workflow 或具有有效 `auto_routing` 的 workflow-call 子流程时才应用；否则 TAKT 会警告并忽略。 |
+| `--model <name>` | 覆盖 agent model |
+| `-c, --continue` | 从当前项目目录和 provider 的上一次 assistant session 继续 |
+
+`--workflow` 是规范选项。
+
+全局配置目录默认为 `~/.takt/`，可通过 `TAKT_CONFIG_DIR` 环境变量修改。
+
+## 交互模式
+
+交互模式会先与 AI 对话来完善任务内容，然后再执行。当需求不明确，或希望在咨询 AI 的同时明确内容时，这种模式很有用。
+
+```bash
+# 不带参数启动交互模式
+takt
+
+# 指定初始消息（仅短单词）
+takt hello
+```
+
+**注意：** `--task` 会跳过交互模式并直接执行任务。Issue 引用（`#6`、`--issue`）会作为交互模式的初始输入。
+
+### 流程
+
+1. 选择 workflow
+2. 选择交互模式（assistant / grill-me / persona / quiet / passthrough）
+3. 通过与 AI 对话完善任务内容
+4. 使用 `/go` 完成任务指令（也可以使用 `/go additional instructions` 添加额外指令），或使用 `/play <task>` 立即执行任务
+5. 执行 workflow，并按需要创建 PR
+
+### 交互模式变体
+
+| 模式 | 说明 |
+|------|------|
+| `assistant` | 默认模式。AI 会提出澄清问题，然后生成任务指令。 |
+| `grill-me` | 一次处理一个推荐问题，解决重要决策分支；需求准备好后建议使用 `/go`。 |
+| `persona` | 与第一个 step 的 persona 对话（使用其 system prompt 和工具）。 |
+| `quiet` | 不提问，尽力生成任务指令。 |
+| `passthrough` | 将用户输入直接作为任务文本，不经过 AI 处理。 |
+
+workflow 可以通过 YAML 中的 `interactive_mode` 字段设置默认模式。
+
+### 执行示例
+
+```text
+$ takt
+
+Select workflow:
+  > default (current)
+    Development/
+    Research/
+    Cancel
+
+Interactive mode - Enter task content. Commands: /go (execute), /cancel (exit)
+
+> I want to add user authentication feature
+
+[AI confirms and organizes requirements]
+
+> /go
+
+Proposed task instructions:
+---
+Implement user authentication feature.
+
+Requirements:
+- Login with email address and password
+- JWT token-based authentication
+- Password hashing (bcrypt)
+- Login/logout API endpoints
+---
+
+Proceed with these task instructions? (Y/n) y
+
+[Workflow execution starts...]
+```
+
+## 直接执行任务
+
+使用 `--task` 跳过交互模式并直接执行：
+
+```bash
+# 使用 --task 指定任务内容
+takt --task "Fix bug"
+
+# 指定 workflow
+takt --task "Add authentication" --workflow dual
+```
+
+**注意：** 直接传入字符串（例如 `takt "Add login feature"`）仍然会进入交互模式，只是将该字符串作为初始消息。
+
+<a id="acp-agent"></a>
+
+## ACP Agent
+
+`takt-acp` 通过 stdio JSON-RPC 以 Agent Client Protocol agent 的形式启动 TAKT。请在支持 ACP 的客户端中将它作为 agent 命令启动：
+
+```bash
+takt-acp
+```
+
+ACP session 的 `cwd` 必须是绝对路径。TAKT 将该目录同时作为对话基目录和 workflow 项目根目录。默认情况下，`session/prompt` 是“先加入队列”的对话入口：诸如“enqueue this task”或“make it a pending task”的 prompt 会将待处理任务写入 `.takt/tasks.yaml`，之后可以用 `takt run` 执行。只有明确要求“run it now”或“execute now”时才直接执行 workflow；含义不明确的 prompt 会留在对话中。
+
+主 ACP UX 不依赖 `/go` 或 `/play`：`/go` 遵循 session 的 `defaultAction`，默认加入队列；`/play <task>` 只是兼容用的显式直接执行命令。
+
+如果 ACP prompt 创建或直接执行任务，TAKT 使用 `default` workflow，除非对话结果明确给出其他 workflow。
+
+`session/new` 可以省略 `mcpServers`；省略或使用空数组 `mcpServers: []` 都表示没有 MCP server。stdio MCP server 会传给 workflow 执行，但如果某个 step 的有效 provider 不支持 MCP server，TAKT 会在运行前快速失败。非 stdio MCP transport、重复的 MCP server 名称和重复的去空格 MCP 环境变量名会在创建 session 时被拒绝。
+
+TAKT 当前支持 `initialize`、`session/new`、`session/prompt`、`session/cancel` 和 `session/update` 通知。不公布 `additionalDirectories`；非空的 `additionalDirectories` 请求会被拒绝。
+
+<a id="mcp-server"></a>
+
+## MCP Server
+
+`takt-mcp` 通过 stdio 启动 TAKT 的 Model Context Protocol server。若希望 MCP 客户端无需调用 `takt add` 就能加入 TAKT 任务队列，请在客户端中注册它。
+
+```bash
+takt-mcp
+```
+
+对于 Codex，可以将 stdio MCP server 添加到 `~/.codex/config.toml`，或添加到可信项目的 `.codex/config.toml`：
+
+```toml
+[mcp_servers.takt]
+command = "takt-mcp"
+```
+
+也可以使用 Codex MCP CLI 添加：
+
+```bash
+codex mcp add takt -- takt-mcp
+```
+
+server 暴露以下工具：
+
+| 工具 | 说明 |
+|------|------|
+| `takt_enqueue_task` | 将待处理任务保存到 `.takt/tasks.yaml`，可选关联或创建 Issue。 |
+
+每个工具的 `cwd` 都会通过 `realpath` 解析，且必须位于 MCP server 允许的项目根目录内。默认允许的根目录是启动 `takt-mcp` 的目录。
+
+### `takt_enqueue_task`
+
+必需输入：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `cwd` | 绝对路径字符串 | 写入 `.takt/tasks.yaml` 的项目根目录。 |
+| `task` | 字符串 | 任务指令正文。 |
+| `workflow` | 字符串 | workflow 名称或路径。MCP 调用方必须在加入队列前询问使用哪个 workflow。 |
+| `autoPr` | 布尔值 | 是否以启用 auto-PR 的方式保存任务。MCP 调用方必须在加入队列前询问。 |
+
+可选输入：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `worktree` | 布尔值 | `true` 创建自动隔离的 worktree，默认是 `true`。MCP 输入不接受自定义 worktree 路径。 |
+| `issue.number` | 正的安全整数 | 关联已有 Issue，不调用 Issue provider。 |
+| `issue.create` | `true` | 在加入队列前通过配置的 Issue provider 创建 Issue。 |
+| `issue.title` | 字符串 | 新 Issue 的可选非空标题，最多 255 个字符。 |
+| `issue.labels` | 字符串数组 | 新 Issue 的可选非空标签。 |
+| `taskContext.branch` | 字符串 | 保存到任务中的本地分支名。 |
+| `taskContext.baseBranch` | 字符串 | 保存到任务中的基分支名。 |
+| `taskContext.prNumber` | 正的安全整数 | 保存到任务中的 PR 编号；大于 `Number.MAX_SAFE_INTEGER` 的值会被拒绝。 |
+
+输入限制：`task` 最多 128 KiB，`workflow` 最多 128 个字符，Issue 标题最多 255 个字符，每个 Issue 标签最多 100 个字符，标签最多 20 个。
+
+`issue` 对象必须严格是 `{ "number": 123 }` 或 `{ "create": true, "title"?: "...", "labels"?: ["..."] }` 之一；混合 key、空标题、空标签和未知 key 都会被拒绝。Issue 关联的加入队列成功后会返回 `issueNumber`。如果创建 Issue 成功，但保存任务失败或在解析 Issue 编号后被取消，Issue 会保持打开状态；MCP 错误结果包含 `issueCreated`、`issueNumber`、可选的 `issueUrl`、`taskEnqueued`、`stage` 和已清理的 `error`。使用 `{ "issue": { "number": issueNumber } }` 重试可避免重复创建 Issue。如果 `stage` 是 `issue_number_parsing`，则无法得到 `issueNumber`；可以使用可选的 `issueUrl` 找到 Issue 并取得编号后再重试。
+
+MCP 只负责加入任务队列。请使用 `takt run` 执行待处理任务，使用 `takt watch` 持续监视并执行任务。
+
+## 即时 Exec 模式
+
+`takt exec` 启动无需手写 workflow YAML 的交互式任务录入模式。Assistant agent 澄清需求，`/go` 将对话转换成生成的 workflow，Worker agent 实现任务，Review agent 审查结果，Replanning agent 在需要时询问用户方向，循环检测防止无效循环。
+
+```bash
+takt exec          # 使用上一次配置；首次使用时采用默认配置
+takt exec backend  # 从指定名称的 preset 开始
+takt exec --list   # 列出可用 exec preset
+```
+
+preset 查找顺序为项目 `.takt/exec/presets/`、全局 `$TAKT_CONFIG_DIR/exec/presets/`（未设置时为 `~/.takt/exec/presets/`），最后是 builtin `builtins/exec/presets/`。builtin/default preset 只定义 agent 角色、facet 和循环阈值。exec 启动时从普通 TAKT 配置解析 provider 和 model，Assistant 对话与 `/setup` 显示使用同一解析结果。生成的 workflow 使用 capability 表达工具/skill 需求；provider/model/options 留在 `runtime.yaml`（或旧版 config）中。
+
+exec 模式中的命令：
+
+| 命令 | 说明 |
+|------|------|
+| `/setup` | 编辑 agent、replan facet、循环检测阈值以及项目/全局 preset |
+| `/go` | 将对话总结为可执行任务指令，并运行生成的 workflow |
+| `/go <note>` | 运行时将额外备注追加到对话总结 |
+| `/paste-image` | 编辑当前输入行时，将剪贴板图片替换为图片占位符 |
+| `/cancel` | 不执行任务直接退出 |
+
+`/setup` 可以保存或删除项目/全局 preset。instruction、knowledge 和 policy 字段引用普通 facet；新 facet 保存在 `.takt/facets/{instructions,knowledge,policies}/` 或 `$TAKT_CONFIG_DIR/facets/{instructions,knowledge,policies}/`（未设置时为 `~/.takt/facets/{instructions,knowledge,policies}/`）。
+
+执行 `/go` 时，TAKT 写入 `.takt/exec/workflow.yaml`，并通过现有 workflow engine 执行。没有此前对话且没有内联任务文本时，`/go` 会在创建 workflow 前被拒绝。exec workflow 使用 `session_key` 将 Worker、Review 和 Replanning agent 的 session 分开；loop detection judge 始终使用新 session。
+
+exec 输入支持图片附件。使用 `/paste-image` 或 macOS 上的 `Ctrl+V` 附加图片；TAKT 插入 `[Image #N]` 占位符。只有当前消息或 `/go <note>` 引用了占位符时，图片才会发送给 Assistant。支持 PNG、JPEG、GIF 和 WebP，内联及剪贴板图片限制为 10 MiB。没有原生图片输入的 provider 会在 prompt 中收到本地路径引用。
+
+## GitHub Issue 任务
+
+可以直接将 GitHub Issue 作为任务执行。Issue 的标题、正文、标签和评论会自动加入任务内容。
+
+```bash
+# 指定 Issue 编号执行
+takt #6
+takt --issue 6
+
+# 指定 Issue 和 workflow
+takt #6 --workflow dual
+```
+
+**要求：** [GitHub CLI](https://cli.github.com/)（`gh`）必须已安装并完成认证。
+
+## 任务管理命令
+
+任务管理使用 `.takt/tasks.yaml` 批量处理任务，并在 `.takt/tasks/{slug}/` 中保存任务目录。完整说明请参阅[任务管理](./task-management.zh-CN.md)。
+
+### `takt add`
+
+通过 AI 对话完善要求，然后将任务加入 `.takt/tasks.yaml`：
+
+```bash
+# 通过 AI 对话完善要求，然后加入任务
+takt add
+
+# 从 GitHub Issue 添加任务（Issue 编号会反映在分支名中）
+takt add #28
+
+# 指定排队任务使用的 workflow
+takt add -w default
+
+# 根据 PR 审查评论创建任务
+takt add --pr 123
+```
+
+`-w, --workflow <name or path>` 设置任务保存的 workflow；`--pr <number>` 根据 PR 审查评论创建任务。
+
+### `takt run`
+
+执行 `.takt/tasks.yaml` 中所有待处理任务：
+
+```bash
+takt run
+
+# 忽略 workflow max_steps，直到其他停止条件出现
+takt run --ignore-exceed
+```
+
+不使用 `--ignore-exceed` 时，达到 workflow `max_steps` 的任务会以 `exceeded` 状态停止，并在 `.takt/tasks.yaml` 中保存重试元数据。使用该选项只忽略迭代限制，不写入 exceeded 重试元数据。
+
+### `takt watch`
+
+监视 `.takt/tasks.yaml`，作为常驻进程自动执行新任务：
+
+```bash
+takt watch
+
+# 忽略 workflow max_steps，不将任务标记为 exceeded
+takt watch --ignore-exceed
+```
+
+它会持续运行直到 Ctrl+C，监视新的 `pending` 任务并逐个执行；启动时会将中断的 `running` 任务标记为 `failed`，退出时显示任务总数、成功数和失败数。
+
+### `takt list`
+
+列出任务分支并执行操作：
+
+```bash
+# 交互式查看任务分支
+takt list
+
+# CI/脚本使用非交互模式
+takt list --non-interactive
+takt list --non-interactive --action diff --branch takt/my-branch
+takt list --non-interactive --action delete --branch takt/my-branch --yes
+takt list --non-interactive --format json
+```
+
+`--action` 接受 `diff`、`sync`、`try`、`merge` 或 `delete`。非交互操作需要 `--branch`，`delete` 还需要 `--yes`。交互模式中的 **Merge from root** 会将根仓库 HEAD 合并到任务分支，并使用 AI 辅助解决冲突。
+
+### 任务目录工作流（创建 / 运行 / 验证）
+
+1. 运行 `takt add`，确认 `.takt/tasks.yaml` 中出现待处理记录。
+2. 打开生成的 `.takt/tasks/{slug}/order.md`，按需补充详细规格和引用。
+3. 运行 `takt run` 或 `takt watch`，执行 `tasks.yaml` 中的待处理任务。
+4. 在 `.takt/runs/{run}/reports/` 中检查输出；实际 run slug 以 `tasks.yaml` 的 `run_slug` 为准。
+
+## Pipeline 模式
+
+指定 `--pipeline` 会启用非交互 pipeline 模式：自动创建分支、执行 workflow、commit 并 push，适合 CI/CD 自动化。
+
+```bash
+# pipeline 模式执行任务
+takt --pipeline --task "Fix bug"
+
+# 执行并自动创建 PR
+takt --pipeline --task "Fix bug" --auto-pr
+
+# 关联 Issue
+takt --pipeline --issue 99 --auto-pr
+
+# 指定 workflow 和分支
+takt --pipeline --task "Fix bug" -w magi -b feat/fix-bug
+
+# 指定创建 PR 的仓库
+takt --pipeline --task "Fix bug" --auto-pr --repo owner/repo
+
+# 只执行 workflow，跳过创建分支、commit 和 push
+takt --pipeline --task "Fix bug" --skip-git
+
+# CI 最小输出
+takt --pipeline --task "Fix bug" --quiet
+```
+
+pipeline 模式不会自动创建 PR，除非指定 `--auto-pr`。在 GitHub Actions 中使用 TAKT 时，请参阅 [takt-action](https://github.com/nrslib/takt-action)。
+
+## 工具命令
+
+### 交互式选择 workflow
+
+不带任务参数运行 `takt` 可交互选择 workflow：
+
+```bash
+takt
+```
+
+### `takt eject`
+
+将 builtin workflow/persona 复制到本地以便定制：
+
+```bash
+# 复制到项目 .takt/ 以定制
+takt eject
+
+# 复制到 ~/.takt/（全局）
+takt eject --global
+
+# 复制指定 facet
+takt eject persona coder
+takt eject instruction plan --global
+```
+
+`eject` 的 facet 类型使用单数：`persona`、`policy`、`knowledge`、`instruction`、`output-contract`；`takt catalog` 使用复数形式。
+
+### `takt workflow`
+
+初始化和验证自定义 workflow：
+
+```bash
+# 在项目 .takt/workflows/ 创建最小 scaffold
+takt workflow init sample-flow
+
+# 在 ~/.takt/ 创建 faceted scaffold
+takt workflow init review-flow --template faceted --global
+
+# 按名称或路径验证 workflow
+takt workflow doctor sample-flow
+takt workflow doctor .takt/workflows/sample-flow.yaml
+```
+
+### `takt clear`
+
+清除 agent 对话 session（重置状态）：
+
+```bash
+takt clear
+```
+
+### `takt export-cc`
+
+将 builtin workflow/persona 部署为 Claude Code Skill：
+
+```bash
+takt export-cc
+```
+
+### `takt export-codex`
+
+将 TAKT skill 文件部署为 Codex Skill（`~/.agents/skills/takt/`）：
+
+```bash
+takt export-codex
+```
+
+该命令部署 `SKILL.md`、`references/`、`agents/`、`workflows/` 和 `facets/`。
+
+### `takt catalog`
+
+列出各层可用 facet：
+
+```bash
+takt catalog
+takt catalog personas
+```
+
+`catalog` 的 facet 类型参数使用复数：`personas`、`policies`、`knowledge`、`instructions`、`output-contracts`；`takt eject` 使用单数形式。
+
+### `takt prompt`
+
+预览每个 step 和阶段组装后的 prompt：
+
+```bash
+takt prompt
+takt prompt default
+```
+
+### `takt reset`
+
+重置设置：
+
+```bash
+# 重置全局配置为 builtin 模板（会备份原文件）
+takt reset config
+
+# 重置 workflow 分类为 builtin 默认值
+takt reset categories
+```
+
+### `takt metrics`
+
+显示分析指标：
+
+```bash
+# 显示审查质量指标（默认最近 30 天）
+takt metrics review
+
+# 指定时间范围
+takt metrics review --since 7d
+```
+
+### `takt repertoire`
+
+管理来自 GitHub 的外部 TAKT repertoire package：
+
+```bash
+# 从 GitHub 安装 package
+takt repertoire add github:{owner}/{repo}@{ref}
+
+# 从默认分支安装
+takt repertoire add github:{owner}/{repo}
+
+# 列出已安装 package
+takt repertoire list
+
+# 删除 package
+takt repertoire remove @{owner}/{repo}
+```
+
+已安装的 package 保存在 `~/.takt/repertoire/`，其 workflow/facet 会出现在 workflow 选择和 facet 解析中。同名 workflow 的解析顺序为 `.takt/workflows/` → `~/.takt/workflows/` → builtins；repertoire workflow 通过 `@{owner}/{repo}/{workflow-name}` 显式引用。
+
+### `takt telemetry`
+
+管理有效 `auto_routing` 下使用的本地路由事件记录。决策以 NDJSON 写入 `.takt/events/`，TAKT 不会上传这些记录。
+
+```bash
+# 查看本地路由记录状态
+takt telemetry status
+
+# 启用本地路由记录
+takt telemetry enable
+
+# 禁用本地路由记录
+takt telemetry disable
+```
+
+### `takt resume`
+
+为当前项目目录中最近一次中止或失败的直接（one-shot）运行显示交互菜单（Requeue / Retry / Instruct / View reports / Cancel）。worktree/clone 运行不符合条件；恢复执行会将报告写入新的 run 目录。
+
+```bash
+takt resume
+```
+
+### `takt purge`
+
+清理旧的分析事件文件：
+
+```bash
+# 清理超过 30 天的文件（默认）
+takt purge
+
+# 指定保留天数
+takt purge --retention-days 14
+```

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1,6 +1,6 @@
 # 設定
 
-[English](./configuration.md)
+[English](./configuration.md) | [日本語](./configuration.ja.md) | [简体中文](./configuration.zh-CN.md)
 
 このドキュメントは TAKT の全設定オプションのリファレンスです。クイックスタートについては [README](../README.md) を参照してください。
 phase 粒度の usage events と集計方法は [Observability Guide](./observability.ja.md) を参照してください。

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -437,6 +437,8 @@ validation に失敗します。
 
 TAKT は Claude、Codex、OpenCode、Pi、公式 DeepSeek Harness SDK、Cursor、Copilot、Kiro provider をサポートしています。Claude/Codex/OpenCode は各 SDK の認証情報、Pi は Pi SDK の credential store または provider 環境変数、DeepSeek Harness は公式の `DEEPSEEK_API_KEY` 環境変数、Kiro は API キーを使い、Cursor は API キーまたは `cursor-agent login` セッションで認証でき、Copilot は GitHub トークンを使います。
 
+グローバル設定 schema には、現在トップレベル provider として選択できない一部の legacy または provider integration 用 API key フィールドも残っています。これらのフィールドだけでは provider は有効になりません。選択した provider について、以下に記載した認証用の環境変数または設定キーを使用してください。
+
 ### 環境変数（推奨）
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-[日本語](./configuration.ja.md)
+[English](./configuration.md) | [日本語](./configuration.ja.md) | [简体中文](./configuration.zh-CN.md)
 
 This document is a reference for all TAKT configuration options. For a quick start, see the main [README](../README.md).
 For phase-level usage events and analysis, see the [Observability Guide](./observability.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,6 +442,8 @@ Separately from config-key overrides, `TAKT_NOTIFY_WEBHOOK` sets a Slack Incomin
 
 TAKT supports Claude, Codex, OpenCode, Pi, the official DeepSeek Harness SDK, Cursor, Copilot, and Kiro providers. Claude/Codex/OpenCode use their SDK credentials, Pi uses the Pi SDK credential store or provider environment variables, DeepSeek Harness uses the official `DEEPSEEK_API_KEY` environment variable, Kiro uses an API key, Cursor can use either API key or existing `cursor-agent login` session, and Copilot uses a GitHub token.
 
+The global configuration schema also retains API-key fields for some legacy or provider integrations that are not currently selectable as top-level providers. These fields do not activate a provider by themselves; use the authentication variables and keys documented for the selected provider below.
+
 ### Environment Variables (Recommended)
 
 ```bash

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -1,0 +1,1091 @@
+# 配置
+
+[English](./configuration.md) | [日本語](./configuration.ja.md) | [简体中文](./configuration.zh-CN.md)
+
+本文参考 TAKT 的配置选项。快速开始请参阅主 [README](../README.md)。阶段级 usage event 与分析请参阅 [Observability Guide](./observability.md)。
+
+## 全局配置
+
+在 `~/.takt/config.yaml` 中配置 TAKT 默认值。首次运行时会自动创建该文件，所有字段均可省略。
+
+```yaml
+# ~/.takt/config.yaml
+language: en                  # UI 语言：'en' 或 'ja'
+logging:
+  level: info                 # 日志级别：debug、info、warn、error
+provider: claude              # 默认 provider：claude、claude-sdk、claude-terminal、codex、opencode、deepseek-harness、cursor、copilot、kiro、pi 或 mock
+model: sonnet                 # 默认 model（可省略，原样传给 provider）
+branch_name_strategy: romaji  # 分支名生成策略：'romaji'（快）或 'ai'（慢）
+prevent_sleep: false          # 执行期间阻止 macOS 空闲睡眠（caffeinate）
+notification_sound: true      # 启用/禁用通知音
+notification_sound_events:    # 可选的事件级开关（默认所有事件启用）
+  iteration_limit: false      # 示例：将此事件设为 false 即可只禁用它
+  workflow_complete: true
+  workflow_abort: true
+  run_complete: true
+  run_abort: true
+concurrency: 1                # takt run 的并行任务数（1-10，默认 1 = 顺序执行）
+task_poll_interval_ms: 500    # takt run 检查新任务的间隔（100-5000，默认 500）
+interactive_preview_steps: 3  # 交互模式中的 step 预览数（0-10，默认 3）
+auto_requeue_max_attempts: 0  # takt run 期间失败 workflow task 的自动 requeue 次数（非负整数，默认 0 = 禁用）
+ignore_exceed: false          # 对 takt run 和 takt watch 应用 --ignore-exceed（默认 false）
+assistant:
+  gherkin: false              # 将最终任务指令生成为 Markdown + 聚焦的 Gherkin
+# auto_fetch: false           # 创建 clone 前 fetch remote（默认 false）
+# base_branch: main           # 创建 clone 的基分支（默认使用 remote 默认分支）
+
+# 运行环境默认值（除非 workflow_config.runtime 覆盖，否则应用于所有 workflow）
+# runtime:
+#   prepare:
+#     - gradle    # 在 .runtime/ 中准备 Gradle 缓存/配置
+#     - node      # 在 .runtime/ 中准备 npm 缓存/配置
+
+# workflow step 的 provider routing（推荐）
+# 按原始 persona key、step tag 或 step 名称路由，无需复制 workflow
+# provider_routing:
+#   personas:
+#     coder:
+#       provider: codex
+#       model: gpt-5
+#       provider_options:
+#         codex:
+#           reasoning_effort: high
+#   tags:
+#     implementation:
+#       provider: codex
+#       model: gpt-5
+#     review:
+#       provider: opencode
+#       model: opencode/qwen3-coder-next
+#     final-gate:
+#       provider: codex
+#       model: gpt-5
+#       provider_options:
+#         codex:
+#           reasoning_effort: high
+#     edit:
+#       provider_options:
+#         codex:
+#           network_access: true
+#   steps:
+#     ai-antipattern-review-2nd:
+#       provider: opencode
+#       model: opencode/qwen3-coder-next
+
+# 旧版按显示名称覆盖（已弃用；新配置请使用 provider_routing）
+# persona_providers:
+#   coder:
+#     provider: codex
+#     model: gpt-5
+
+# provider 专属权限 profile（可选）
+# 优先级：项目覆盖 > 全局覆盖 > 项目默认 > 全局默认 > required_permission_mode（下限）
+# provider_profiles:
+#   codex:
+#     default_permission_mode: full
+#     step_permission_overrides:
+#       ai_review: readonly
+#   claude:
+#     default_permission_mode: edit
+
+# API key 配置（可选）
+# 可由 TAKT_ANTHROPIC_API_KEY / TAKT_OPENAI_API_KEY / TAKT_OPENCODE_API_KEY / TAKT_CURSOR_API_KEY / TAKT_COPILOT_GITHUB_TOKEN / TAKT_KIRO_API_KEY 覆盖。DeepSeek Harness 使用官方 DEEPSEEK_API_KEY / DEEPSEEK_BASE_URL 环境变量，而不是 YAML API key 字段。
+# anthropic_api_key: sk-ant-...  # Claude（Anthropic）
+# openai_api_key: sk-...         # Codex（OpenAI）
+# opencode_api_key: ...          # OpenCode
+# cursor_api_key: ...            # Cursor Agent（可选；也支持登录 session）
+# copilot_github_token: ...      # Copilot（GitHub token）
+# kiro_api_key: ...              # Kiro CLI
+
+# CLI 路径覆盖（可选）
+# 覆盖 provider CLI 二进制文件（必须是可执行文件的绝对路径）
+# 可由 TAKT_CLAUDE_CLI_PATH / TAKT_CODEX_CLI_PATH / TAKT_CURSOR_CLI_PATH / TAKT_COPILOT_CLI_PATH / TAKT_KIRO_CLI_PATH 覆盖
+# claude_cli_path: /usr/local/bin/claude
+# codex_cli_path: /usr/local/bin/codex
+# cursor_cli_path: /usr/local/bin/cursor-agent
+# copilot_cli_path: /usr/local/bin/github-copilot-cli
+# kiro_cli_path: /usr/local/bin/kiro-cli
+
+# VCS provider（可选）
+# 根据 git remote URL 自动检测（github.com → github，gitlab.com → gitlab）
+# 自托管实例可显式指定
+# vcs_provider: github                   # 'github' 或 'gitlab'
+
+# Assistant provider（可选）
+# 路由 assistant 对话（交互规划、已有任务的 instruct、retry 对话）和 Report 阶段 fallback provider。
+# Report fallback 只在 OpenCode report retry 失败后使用。
+# 项目 assistant 覆盖全局 assistant；未设置 assistant 时，Report fallback 不会回退到顶层 provider/model。
+# takt_providers:
+#   assistant:
+#     provider: claude
+#     model: opus
+#   selector:              # dynamic parallel、dynamic_facets 和 companion pool 的可选 selector 覆盖
+#     provider: codex
+#     model: gpt-5
+#     provider_options:
+#       codex:
+#         reasoning_effort: medium
+```
+
+`takt_providers.selector` 是可选项。provider/model 的优先级为显式 CLI 或环境变量覆盖、项目 selector、全局 selector、项目顶层、全局顶层。model 只有在其 candidate 属于解析出的 provider 时才有效。只有 selector 条目提供 `provider_options`，并按 option leaf 从全局到项目合并；顶层、persona 和 pool sub-step 的 options 不会传给 selector。空 selector 条目或空 `provider_options` 条目会在加载配置时被拒绝。dynamic parallel 和 `dynamic_facets` selector 使用 provider-neutral 的新 session，并传入固定的只读工具 allowlist `Read`、`Glob`、`Grep` 以及 `permission_mode: readonly`。Companion selector 不接收固定的 `allowedTools` 列表，因此可以使用 selector profile 中的 `allowed_tools`。工具 allowlist 只对遵守它的 provider 生效。没有 dynamic parallel、dynamic facets 或启用的 companion pool 时，selector 设置不会使用，也不会影响 workflow。
+
+```yaml
+# ~/.takt/config.yaml（续）
+
+# Workflow 安全策略（默认全部拒绝）
+# 控制不受信任的 workflow YAML 可以执行什么。
+# workflow_mcp_servers:                  # MCP server transport 策略
+#   stdio: true                          # 允许 stdio transport（默认 false）
+#   sse: false                           # 允许 SSE transport（默认 false）
+#   http: false                          # 允许 HTTP transport（默认 false）
+# workflow_arpeggio:                     # Arpeggio 自定义代码策略
+#   custom_data_source_modules: false    # 允许自定义 data source module（默认 false）
+#   custom_merge_inline_js: false        # 允许内联 JS merge 函数（默认 false）
+#   custom_merge_files: false            # 允许外部 merge 文件（默认 false）
+# workflow_runtime_prepare:              # Runtime prepare 策略
+#   custom_scripts: false                # 允许自定义脚本（默认 false；builtin preset 始终允许）
+# workflow_command_gates:                # Workflow YAML command quality gate 策略
+#   custom_scripts: false                # 允许来自 workflow YAML 的 command gate（默认 false）
+# sync_conflict_resolver:                # Sync conflict resolver 策略
+#   auto_approve_tools: false            # 允许工具自动批准（默认 false）
+
+# Builtin workflow 过滤（可选；配置 key 保持 workflow_* 名称）
+# enable_builtin_workflows: true         # 设为 false 禁用所有 builtin workflow
+# disabled_builtins: [magi]              # 按名称禁用指定 builtin workflow
+
+# Pipeline 执行配置（可选）
+# 自定义分支名、commit message 和 PR body。
+# pipeline:
+#   default_branch_prefix: "takt/"
+#   commit_message_template: "feat: {title} (#{issue})"
+#   pr_body_template: |
+#     ## Summary
+#     {issue_body}
+#     Closes #{issue}
+
+# 路由决策 telemetry 仅保存到本地。
+# telemetry:
+#   routing_decisions: true       # 写入 .takt/events/（默认 false；可用 takt telemetry enable 或此 key 启用）
+```
+
+`language` 目前只接受 `en` 和 `ja`。本页的 `.zh-CN.md` 是文档 locale，不会新增运行时 UI 或 prompt 的中文支持。
+
+### 全局配置字段参考
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `language` | `"en"` \| `"ja"` | `"en"` | UI 语言 |
+| `logging.level` | `"debug"` \| `"info"` \| `"warn"` \| `"error"` | `"info"` | 日志级别 |
+| `logging.trace` | boolean | `false` | 启用 trace 级日志 |
+| `logging.debug` | boolean | `false` | 启用 debug 日志（`debug.log` + `prompts.jsonl`） |
+| `logging.provider_events` | boolean | `false` | 持久化 provider stream event |
+| `logging.usage_events` | boolean | `false` | 持久化 usage event 日志 |
+| `provider` | `"claude"` \| `"claude-sdk"` \| `"claude-terminal"` \| `"codex"` \| `"opencode"` \| `"deepseek-harness"` \| `"pi"` \| `"cursor"` \| `"copilot"` \| `"kiro"` \| `"mock"` | `"claude"` | 默认 AI provider；`deepseek-harness` 是官方 DeepSeek Harness Python SDK |
+| `model` | string | - | 默认 model 名称，原样传给 provider |
+| `branch_name_strategy` | `"romaji"` \| `"ai"` | `"romaji"` | 分支名生成策略 |
+| `prevent_sleep` | boolean | `false` | 阻止 macOS 空闲睡眠 |
+| `notification_sound` | boolean | `true` | 启用通知音 |
+| `notification_sound_events` | object | - | 各事件通知音开关 |
+| `concurrency` | number (1-10) | `1` | `takt run` 并行任务数 |
+| `task_poll_interval_ms` | number (100-5000) | `500` | 新任务轮询间隔 |
+| `interactive_preview_steps` | number (0-10) | `3` | 交互模式中的 step 预览数 |
+| `assistant.gherkin` | boolean | `false` | 在 assistant 生成的最终任务指令中组织关键行为和不变量 |
+| `auto_requeue_max_attempts` | 非负整数 | `0` | 失败 workflow task 的自动 requeue 上限；`0` 禁用 |
+| `ignore_exceed` | boolean | `false` | 配置 `takt run` 和 `takt watch` 的迭代上限绕过 |
+| `sync_project_local_takt_on_retry` | boolean | `true` | retry/re-execution 前将根项目 `.takt` 同步到 worktree |
+| `worktree_dir` | string | - | shared clone 目录，默认 `../{clone-name}` |
+| `allow_git_hooks` | boolean | `false` | 允许 TAKT 管理的自动 commit 运行 git hooks |
+| `allow_git_filters` | boolean | `false` | 允许 TAKT 管理的自动 commit 运行 git filters |
+| `auto_pr` | boolean | - | worktree 执行后自动创建 PR |
+| `draft_pr` | boolean | `false` | 将自动创建的 PR 设为 draft |
+| `minimal_output` | boolean | `false` | 抑制 AI 输出（用于 CI） |
+| `runtime` | object | - | 运行环境默认值，例如 `prepare: [gradle, node]` |
+| `provider_routing` | object | - | 按 raw persona、step tag 和 step 名称设置 provider/model/options 路由 |
+| `auto_routing` | object | - | 从 candidate pool 自动选择 provider/model |
+| `persona_providers` | object | - | 已弃用的按显示名称覆盖；新配置请使用 `provider_routing` |
+| `provider_options` | object | - | 全局 provider 专属选项 |
+| `provider_profiles` | object | - | provider 专属权限 profile |
+| `rate_limit_fallback` | object | - | 限流 fallback；`switch_chain` 按顺序列出切换到的 `{provider, model}` |
+| `anthropic_api_key` | string | - | Claude 的 Anthropic API key |
+| `openai_api_key` | string | - | Codex 的 OpenAI API key |
+| `gemini_api_key` | string | - | Gemini API key |
+| `google_api_key` | string | - | Google API key |
+| `groq_api_key` | string | - | Groq API key |
+| `openrouter_api_key` | string | - | OpenRouter API key |
+| `opencode_api_key` | string | - | OpenCode API key |
+| `cursor_api_key` | string | - | Cursor API key（可选；支持登录 session） |
+| `copilot_github_token` | string | - | Copilot CLI 认证所需 GitHub token |
+| `kiro_api_key` | string | - | Kiro API key |
+| `codex_cli_path` | string | - | Codex CLI 绝对路径覆盖 |
+| `claude_cli_path` | string | - | Claude Code CLI 绝对路径覆盖 |
+| `cursor_cli_path` | string | - | Cursor Agent CLI 绝对路径覆盖 |
+| `copilot_cli_path` | string | - | Copilot CLI 绝对路径覆盖 |
+| `kiro_cli_path` | string | - | Kiro CLI 绝对路径覆盖 |
+| `enable_builtin_workflows` | boolean | `true` | 是否启用 builtin workflow |
+| `disabled_builtins` | string[] | `[]` | 按 workflow `name` 禁用 builtin workflow |
+| `pipeline` | object | - | Pipeline 模板设置 |
+| `bookmarks_file` | string | - | bookmarks 文件路径 |
+| `auto_fetch` | boolean | `false` | 创建 clone 前 fetch remote |
+| `base_branch` | string | - | 创建 clone 的基分支，默认 remote 默认分支 |
+| `workflow_categories_file` | string | - | 分类文件路径，默认 overlay 使用 `workflow-categories.yaml` |
+| `vcs_provider` | `"github"` \| `"gitlab"` | 自动检测 | VCS provider |
+| `takt_providers` | object | - | TAKT 内部 provider 覆盖（`assistant` 也作为 Report fallback provider） |
+| `telemetry` | object | `{ routing_decisions: false }` | 仅本地的路由决策记录，默认关闭 |
+| `analytics` | object | disabled | 仅本地的 analytics 收集 |
+| `workflow_mcp_servers` | object | 全部 `false` | MCP server transport 策略 |
+| `workflow_arpeggio` | object | 全部 `false` | Arpeggio 自定义代码策略 |
+| `workflow_runtime_prepare` | object | `{ custom_scripts: false }` | Runtime prepare 策略 |
+| `workflow_command_gates` | object | `{ custom_scripts: false }` | Workflow YAML command quality gate 策略 |
+| `workflow_overrides` | object | - | workflow 级 `quality_gates` 与 `quality_gates_edit_only` 覆盖 |
+| `sync_conflict_resolver` | object | `{ auto_approve_tools: false }` | sync conflict resolver 策略 |
+| `observability` | object | disabled | opt-in OpenTelemetry 基础设施 |
+
+## 项目配置
+
+在 `.takt/config.yaml` 中设置项目专属配置。第一次在项目目录使用 TAKT 时会创建该文件。
+
+```yaml
+# .takt/config.yaml
+provider: claude              # 覆盖项目的 provider
+model: sonnet                 # 覆盖项目的 model
+auto_pr: true                 # worktree 执行后自动创建 PR
+concurrency: 2                # 此项目 takt run 的并行任务数（1-10）
+auto_requeue_max_attempts: 1  # takt run 期间失败 workflow task 的自动 requeue 次数
+ignore_exceed: false          # 对 takt run 和 takt watch 应用 --ignore-exceed
+# base_branch: main           # 创建 clone 的基分支（覆盖全局值，默认 remote 默认分支）
+
+# 仅项目配置支持的交互 assistant 初始上下文文件
+# assistant:
+#   gherkin: true              # 用 Markdown + 聚焦的 Gherkin 生成最终任务指令
+#   init_files:
+#     - docs/assistant-context.md
+#     - .takt/assistant-notes.md
+
+# provider 专属选项（旧版项目默认值；runtime.yaml 的 profile 现在拥有这些选项）
+# codex / claude / claude_terminal / cursor / copilot / kiro / pi 也支持
+#   guards.call_timeout_ms（未设置时为 60 分钟）。
+# provider_options:
+#   codex:
+#     network_access: true
+#   opencode:
+#     variant: high
+#     allowed_tools: [read, glob, grep, bash, websearch, webfetch]
+#     guards:
+#       profile: standard
+#       model_profiles:
+#         "opencode/big-pickle": minimal
+#         "lmstudio/*": standard
+#       call_timeout_ms: 3600000
+#       event_limit: 500000
+#       text_byte_limit: 1048576
+#       reasoning_byte_limit: 4194304
+#   kiro:
+#     agent: my-default-agent
+#   pi:
+#     extensions: [npm:pi-fff]
+#     no_skills: true
+#   deepseek_harness:
+#     # python_path 和 cordis 仅允许受信任的全局配置/环境变量；项目配置
+#     # 使用默认 python3，不能选择 Cordis 可执行配置。
+#     base_url: http://127.0.0.1:8787/v1
+#     session_root: .takt/deepseek-sessions
+#     max_tokens: 4096
+#     request_timeout_ms: 3600000
+#     shutdown_timeout_ms: 1000
+#     runtime_mode: exe
+#   claude_terminal:
+#     backend: tmux
+#     timeout_ms: 900000
+#     keep_session: false
+#     transcript_poll_interval_ms: 500
+
+# provider 专属权限 profile（项目级覆盖）
+# provider_profiles:
+#   codex:
+#     default_permission_mode: full
+#     step_permission_overrides:
+#       ai_review: readonly
+```
+
+项目配置在同时设置时覆盖全局配置。项目 schema 是严格的：`logging`、`disabled_builtins`、`enable_builtin_workflows`、通知设置、API key 和 CLI 路径等全局专属 key 写入 `.takt/config.yaml` 会在启动时触发配置验证错误。
+
+### Pi provider session 边界
+
+TAKT 的 Pi provider 在当前 TAKT 进程中使用嵌入式、内存中的 Pi SDK session。它不会写 Pi session JSONL，也不会读写 Pi CLI 全局 `settings.json`。因此 Pi 全局的默认 model、thinking level、shell 和 retry 选项不会自动继承到 TAKT。
+
+需要将 Pi 设为默认值时，请在 TAKT 配置中显式指定 model。Pi model 可以带 `:<thinking-level>` 后缀：
+
+```yaml
+# ~/.takt/config.yaml 或 .takt/config.yaml
+provider: pi
+model: provider/model:high
+```
+
+也可以在 workflow step 上设置 model 和 thinking level：
+
+```yaml
+steps:
+  - name: implement
+    provider: pi
+    model: provider/model:high
+```
+
+`provider` 和 `model` 声明选择 TAKT run 的 provider、model 和 thinking level；它们不会导入 Pi CLI 设置。Pi 认证由 Pi SDK credential store 或 provider 原生环境变量单独处理。`provider_options.pi` 是加载 `extensions` 和 `no_*` discovery 控制的独立路径；显式资源源只在本次 TAKT run 中临时解析，不会写入 Pi 设置。
+
+### Provider inactivity deadline 与 OpenCode execution guard
+
+所有 provider 都使用 `guards.call_timeout_ms` 作为没有可观察 provider event 时允许的最长时间。每个 stream/tool event、阶段完成和新的 provider attempt 都会重置计时器；累计执行时间没有上限。它适用于 `codex`、`opencode`、`claude`（包括 `claude-sdk`）、`claude_terminal`、`cursor`、`copilot`、`kiro` 和 `pi`。取值是 60,000 到 86,400,000 之间的整数毫秒，默认 3,600,000 ms（60 分钟）。`claude_terminal.timeout_ms` 为兼容性保留，仅在未设置 `guards.call_timeout_ms` 时使用。
+
+`provider_options.opencode.guards.profile` 默认是 `standard`。`minimal` 只关闭启发式循环检测；时间、资源上限、完整性和严格修正 guard 仍然强制启用。`model_profiles` 按解析出的 model 字符串以声明顺序选择 profile，唯一通配符是 `*`。guard leaf 在 provider-option 层之间独立合并；较高优先级的 `model_profiles` 值会替换较低优先级的完整 map。
+
+每次 OpenCode 调用都有 3,600,000 ms 的 provider-event 不活跃上限。只要持续收到 event，健康调用可以超过该时间。`event_limit` 默认 500,000，可由 `TAKT_OPENCODE_STREAM_EVENT_LIMIT` 覆盖；`text_byte_limit` 默认 1 MiB，`reasoning_byte_limit` 默认 4 MiB。
+
+TAKT 观察实际收到的 provider event，不会合成 keepalive。OpenCode 从 tool-start event 到终止 event 的期间视为 in-flight，并暂停普通不活跃检查；若终止 event 缺失或完全挂起，in-flight 状态在 `call_timeout_ms` 的六倍后过期并以 `PART_TIMEOUT` 结束。`guards.*` 下的无效数值会快速失败；实验性 `TAKT_OPENCODE_*` 覆盖中的无效值会忽略并使用默认值。旧的 `TAKT_OPENCODE_TOOL_ERROR_BUDGET`、`TAKT_OPENCODE_TOOL_SIGNATURE_ABSOLUTE`、`TAKT_OPENCODE_TOOL_SIGNATURE_REPEATS`、`TAKT_OPENCODE_TOOL_SUCCESS_REPEATS` 和 `TAKT_OPENCODE_TOOL_RESULT_STAGNATION_REPEATS` 不再控制 guard，会被忽略并发出一次性警告。
+
+### 项目配置字段参考
+
+项目配置接受大多数全局 key 并覆盖全局值，例如 `language`、`branch_name_strategy`、`minimal_output`、`task_poll_interval_ms`、`interactive_preview_steps`、`provider_routing`、`persona_providers`、`runtime`、`analytics`、`telemetry`、`rate_limit_fallback` 和 `workflow_overrides`。
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `provider` | provider 名称联合 | - | 覆盖具体 provider |
+| `model` | string | - | 覆盖 model 名称 |
+| `submodules` | `"all"` \| string[] | - | shared clone 中要初始化的 submodule |
+| `with_submodules` | boolean | - | `submodules: "all"` 的旧版布尔形式 |
+| `allow_git_hooks` | boolean | `false` | 自动 commit 时允许 git hooks |
+| `allow_git_filters` | boolean | `false` | 自动 commit 时允许 git filters |
+| `auto_pr` | boolean | - | worktree 执行后自动创建 PR |
+| `draft_pr` | boolean | `false`（来自全局） | 将自动创建的 PR 设为 draft |
+| `concurrency` | number (1-10) | `1`（来自全局） | `takt run` 并行任务数 |
+| `auto_requeue_max_attempts` | 非负整数 | `0` | 失败 workflow task 的自动 requeue 上限 |
+| `ignore_exceed` | boolean | `false` | `takt run` / `takt watch` 的迭代限制绕过 |
+| `base_branch` | string | - | 创建 clone 的基分支 |
+| `assistant.init_files` | string[] | - | 仅项目级的 assistant 初始上下文文件；必须是项目根内的相对路径，最多 16 个文件，每个最多 256 KiB，合计最多 1 MiB |
+| `assistant.gherkin` | boolean | `false` | 项目级的任务指令 Gherkin 设置 |
+| `provider_options` | object | - | provider 专属选项 |
+| `provider_profiles` | object | - | provider 专属权限 profile |
+| `vcs_provider` | `"github"` \| `"gitlab"` | 自动检测 | 覆盖全局 VCS provider |
+| `takt_providers` | object | - | TAKT 内部 provider 覆盖 |
+| `workflow_mcp_servers` | object | - | MCP transport 策略覆盖 |
+| `workflow_arpeggio` | object | - | Arpeggio 自定义代码策略覆盖 |
+| `workflow_runtime_prepare` | object | - | Runtime prepare 策略覆盖 |
+| `workflow_command_gates` | object | - | Workflow YAML command quality gate 策略覆盖 |
+| `sync_conflict_resolver` | object | - | Sync conflict resolver 策略覆盖 |
+| `observability` | object | - | 项目级 OpenTelemetry opt-in 覆盖 |
+
+### 任务执行配置的环境变量覆盖
+
+`auto_requeue_max_attempts` 和 `ignore_exceed` 也可以使用 `TAKT_AUTO_REQUEUE_MAX_ATTEMPTS` 和 `TAKT_IGNORE_EXCEED` 设置。解析顺序为：
+
+1. 环境变量
+2. 项目 `.takt/config.yaml`
+3. 全局 `~/.takt/config.yaml`
+4. 默认值
+
+`TAKT_AUTO_REQUEUE_MAX_ATTEMPTS` 必须解析为非负整数；非数字、负数和非整数会使配置验证失败。`TAKT_IGNORE_EXCEED` 只接受 `true` 或 `false`。
+
+## 环境变量覆盖
+
+大多数配置 key 都可以通过 `TAKT_` 加上大写、下划线连接的 key 路径覆盖：`logging.debug` 变成 `TAKT_LOGGING_DEBUG`，`telemetry.routing_decisions` 变成 `TAKT_TELEMETRY_ROUTING_DECISIONS`。常见例子包括 `TAKT_PROVIDER`、`TAKT_MODEL`、`TAKT_CONCURRENCY`、`TAKT_LOGGING_DEBUG`、`TAKT_TELEMETRY_ROUTING_DECISIONS` 和 `TAKT_OBSERVABILITY_ENABLED`。环境变量优先于对应文件值，并在拥有该 key 的配置层解析。
+
+除了配置 key 覆盖外，`TAKT_NOTIFY_WEBHOOK` 设置 Slack Incoming Webhook URL。设置后，TAKT 会在 pipeline 完成和 `takt run` 任务批次结束时发送 Slack 通知。
+
+## API Key 配置
+
+TAKT 支持 Claude、Codex、OpenCode、Pi、官方 DeepSeek Harness SDK、Cursor、Copilot 和 Kiro provider。Claude/Codex/OpenCode 使用各自 SDK credential，Pi 使用 Pi SDK credential store 或 provider 原生环境变量，DeepSeek Harness 使用官方 `DEEPSEEK_API_KEY`，Cursor 支持 API key 或已有 `cursor-agent login` session，Copilot 使用 GitHub token，Kiro 使用 API key。
+
+### 环境变量（推荐）
+
+```bash
+# Claude（Anthropic）
+export TAKT_ANTHROPIC_API_KEY=sk-ant-...
+
+# Codex（OpenAI）
+export TAKT_OPENAI_API_KEY=sk-...
+
+# OpenCode
+export TAKT_OPENCODE_API_KEY=...
+
+# Pi
+# 使用 Pi SDK credential store 或 provider 原生环境变量
+
+# 官方 DeepSeek Harness SDK（Python 3.10+ runtime）
+export DEEPSEEK_API_KEY=...
+# 可选：export DEEPSEEK_BASE_URL=https://...
+
+# Cursor Agent（如果已有 cursor-agent login session，则可选）
+export TAKT_CURSOR_API_KEY=...
+
+# GitHub Copilot CLI
+export TAKT_COPILOT_GITHUB_TOKEN=ghp_...
+
+# Kiro CLI（当 TAKT_KIRO_API_KEY 和 kiro_api_key 未设置时，也接受 KIRO_API_KEY）
+export TAKT_KIRO_API_KEY=...
+```
+
+### 配置文件
+
+```yaml
+# ~/.takt/config.yaml
+anthropic_api_key: sk-ant-...  # Claude
+openai_api_key: sk-...         # Codex
+opencode_api_key: ...          # OpenCode
+cursor_api_key: ...            # Cursor Agent（可选）
+copilot_github_token: ghp_...  # GitHub Copilot CLI
+kiro_api_key: ...              # Kiro CLI
+```
+
+### 优先级
+
+环境变量优先于 `config.yaml`。
+
+| Provider | 环境变量 | 配置 key |
+|----------|----------|----------|
+| Claude（Anthropic） | `TAKT_ANTHROPIC_API_KEY` | `anthropic_api_key` |
+| Codex（OpenAI） | `TAKT_OPENAI_API_KEY` | `openai_api_key` |
+| OpenCode | `TAKT_OPENCODE_API_KEY` | `opencode_api_key` |
+| Pi | Pi SDK credential store 或 provider 原生环境变量 | - |
+| DeepSeek Harness | `DEEPSEEK_API_KEY`（可选 `DEEPSEEK_BASE_URL`） | - |
+| Cursor Agent | `TAKT_CURSOR_API_KEY` | `cursor_api_key` |
+| GitHub Copilot CLI | `TAKT_COPILOT_GITHUB_TOKEN` | `copilot_github_token` |
+| Kiro CLI | `TAKT_KIRO_API_KEY`（`KIRO_API_KEY` fallback） | `kiro_api_key` |
+
+如果将 API key 写入配置文件，请勿将该文件 commit 到 Git；更推荐环境变量，并可将 `~/.takt/config.yaml` 加入全局 `.gitignore`。
+
+### 安全
+
+DeepSeek API key 只传给 Python bridge 环境，不会出现在命令参数或 workflow 生成的配置中。Windows 和 macOS x64 不支持 DeepSeek Harness。Cursor 已有 `cursor-agent login` session 时可以不设置 API key；Copilot 和 Kiro 仍需各自的 CLI。
+
+### CLI 路径覆盖
+
+```bash
+export TAKT_CLAUDE_CLI_PATH=/usr/local/bin/claude
+export TAKT_CODEX_CLI_PATH=/usr/local/bin/codex
+export TAKT_CURSOR_CLI_PATH=/usr/local/bin/cursor-agent
+export TAKT_COPILOT_CLI_PATH=/usr/local/bin/github-copilot-cli
+export TAKT_KIRO_CLI_PATH=/usr/local/bin/kiro-cli
+```
+
+```yaml
+# ~/.takt/config.yaml
+claude_cli_path: /usr/local/bin/claude
+codex_cli_path: /usr/local/bin/codex
+cursor_cli_path: /usr/local/bin/cursor-agent
+copilot_cli_path: /usr/local/bin/github-copilot-cli
+kiro_cli_path: /usr/local/bin/kiro-cli
+```
+
+路径必须是可执行文件的绝对路径。CLI 路径覆盖只属于全局配置，不要写入项目 `.takt/config.yaml`。
+
+## Model 解析
+
+启用 runtime 模式时，provider 和 model 由 `runtime.yaml` 管理，同时仍可使用 CLI 和环境变量覆盖。旧版模式继续支持 `config.yaml` 中的 provider、model 和 routing 设置。workflow YAML 不能选择 provider 或 model；其中的 `provider`、`model` 和内联 provider options 会在加载边界失败并给出迁移提示。
+
+### Provider 专属 model 说明
+
+- **Claude Code** 支持 `opus`、`sonnet`、`haiku`、`opusplan`、`default` 等别名和完整 model 名称；`model` 原样传给 provider CLI。可用 model 参见 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-code)。
+- **Codex** 通过 Codex SDK 原样使用 model 字符串；省略时默认 `codex`。
+- **OpenCode** 要求 `provider/model` 格式，例如 `opencode/big-pickle`；省略 model 会产生配置错误。
+- **Pi** 接受 `provider/model` 引用或能唯一匹配 Pi model 的裸 ID；识别到 `:<thinking-level>` 后缀时选择 Pi thinking level。
+- **Cursor Agent** 将 model 原样传给 `cursor-agent --model <model>`。
+- **GitHub Copilot CLI** 将 model 原样传给 `copilot --model <model>`。
+- **Kiro CLI** 将 model 原样传给 `kiro-cli chat --model <model>`。
+
+### 示例
+
+```yaml
+# ~/.takt/config.yaml
+provider: claude
+model: opus     # 所有 step 的默认 model（除非被覆盖）
+```
+
+workflow 的 `promotion` 只能推进 `runtime.yaml` 选择的 target ladder，不能包含 provider、model、provider-options 或 condition 字段。workflow 中用 `capabilities` 请求工具、网络、sandbox 或 skill 能力，但不选择 runtime。
+
+## Runtime Provider 配置（`runtime.yaml`）
+
+`runtime.yaml` 将 provider/model/options 从 workflow 中移出，使同一 workflow 可以在不同执行环境中运行而无需修改。固定读取两个路径，项目文件优先：
+
+1. `~/.takt/runtime.yaml`
+2. `<project>/.takt/runtime.yaml`
+
+Companion reviewer 默认禁用。使用顶层 `companion.enabled` 策略启用：
+
+```yaml
+version: 1
+companion:
+  enabled: true
+```
+
+全局与项目策略同时设置时使用逻辑 AND；项目的 `true` 不能重新启用全局禁用的 companion。省略的策略在层合并时是 neutral；两层都没有设置时 Companion 仍禁用。Companion target 和 provider capability 只在启用时解析/执行；禁用时仍会校验 companion 声明和 `targets.companions` 的结构，但不会解析或运行 companion provider。只有存在有效 `provider` section 时才启用 runtime 模式；只有 `version: 1` 的文件不会改变旧版 `config.yaml` provider 解析。
+
+### 配置示例
+
+```yaml
+version: 1
+
+provider:
+  defaults:
+    profile: sol-medium
+
+  profiles:
+    sol-high:
+      provider: codex
+      model: gpt-5.6-sol
+      options:
+        reasoning_effort: high
+    sol-medium:
+      provider: codex
+      model: gpt-5.6-sol
+      options:
+        reasoning_effort: medium
+    sol-low:
+      provider: codex
+      model: gpt-5.6-sol
+      options:
+        reasoning_effort: low
+    router:
+      provider: codex
+      model: gpt-5.6-luna
+      capabilities: readonly
+      permission_mode: readonly
+      options:
+        reasoning_effort: high
+
+  targets:
+    personas:
+      coder:
+        profile: sol-medium
+    tags:
+      high-stakes:
+        profile: sol-high
+    steps:
+      default/supervise:
+        profile: sol-high
+      default/implement:
+        pool: sol-pool
+    internal_agents:
+      selector:
+        profile: router
+      review-completion-judge:
+        profile: router
+
+  auto_routing:
+    strategy: balanced
+    router_profile: router
+    pools:
+      sol-pool:
+        candidates:
+          - profile: sol-high
+            tier: high
+          - profile: sol-medium
+            tier: medium
+          - profile: sol-low
+            tier: low
+        fallback_profile: sol-high
+```
+
+`provider.profiles` 保存命名的 provider/model/options 定义。`provider.defaults` 必须在每个有效 provider section 中选择一个固定 `profile` 或有序 `ladder`；不能指定 `pool`。`provider.targets.personas`、`provider.targets.tags` 和 `provider.targets.steps` 可以选择固定 profile、有序 ladder 或显式 auto-routing pool；`internal_agents` 只能使用固定 profile 或 ladder；`companions` 必须使用固定 profile。
+
+provider target 的覆盖优先级为：
+
+```text
+defaults
+  < personas
+  < tags
+  < steps
+```
+
+同一优先级的两个目标如果指定了不同 provider，会快速失败而不是静默选择其一。显式 CLI `--provider` / `--model` 是 runtime override，在两种模式下都可用。`provider.auto_routing` 只对显式选择 `pool` 的 target 生效，不存在隐式 default pool。
+
+### 解析优先级
+
+workflow agent 的 provider 覆盖顺序为：
+
+```text
+defaults
+  < personas
+  < tags
+  < steps
+```
+
+内部 `selector`、`assistant`、`loop-judge` 和 `review-completion-judge` 使用单独的顺序；未分配的 seat 使用普通默认解析：
+
+```text
+defaults
+  < internal_agents.<agent>
+```
+
+`provider.auto_routing` 的 candidate 引用 `provider.profiles`，不重复 provider/model/options。只对显式配置 `pool` 的 workflow target 自动路由；没有显式 pool 的 target、workflow 外操作和辅助处理使用 `provider.defaults`。
+
+### 从旧版 `config.yaml` 迁移
+
+runtime 与旧版 provider 设置不能混用：
+
+| 旧版设置 | Runtime 目标 |
+|----------|--------------|
+| `provider` / `model` | `provider.profiles` 中的 profile，并由 `provider.defaults` 引用 |
+| `provider_options` | `provider.profiles.*.options` |
+| `provider_routing.personas` | `provider.targets.personas` |
+| `provider_routing.tags` | `provider.targets.tags` |
+| `provider_routing.steps` | `provider.targets.steps` |
+| `persona_providers` | `provider.targets.personas` |
+| `takt_providers.selector` / `takt_providers.assistant` | `provider.targets.internal_agents` |
+| `auto_routing` | `provider.auto_routing` |
+| workflow 级 provider 设置 | `provider.targets.steps` |
+
+### 混合配置错误
+
+如果启用的 `runtime.yaml` provider section 与任意旧版 provider 设置共存，TAKT 会在 agent 运行前停止，并报告每个位置及对应迁移目标：
+
+```text
+检测到混合 provider 配置：启用的 runtime.yaml provider section 不能与旧版 provider 设置共存。
+请移除 runtime.yaml provider section，或迁移以下旧版设置：
+  - config.yaml:provider（global）→ provider.defaults + provider.profiles
+  - config.yaml:provider_routing → provider.targets
+```
+
+### 首次生成
+
+首次启动时，TAKT 会原子写入 `~/.takt/runtime.yaml`，不会覆盖已有文件，也不会自动生成项目 `.takt/runtime.yaml`。新环境会把选定的 provider/model 写入 `provider.profiles.default`，并设置 `provider.defaults.profile: default`。已有旧版 provider 设置的环境只会收到一个 inactive 的 `version: 1` 文件，因此迁移前行为不会改变。
+
+## Provider Profile
+
+Provider profile 可以为不同 provider 设置默认权限模式和按 step 的权限覆盖。
+
+### 权限模式
+
+| 模式 | 说明 | Claude | Codex | OpenCode | Pi | DeepSeek Harness | Cursor Agent | Copilot | Kiro CLI |
+|------|------|--------|-------|----------|----|------------------|--------------|---------|----------|
+| `readonly` | 只读，不修改文件 | `default` | `read-only` | `read-only` | `read`、`grep`、`find`、`ls` | Cordis 配置 | 默认 flags（无 `--force`） | 无权限 flags | `--trust-tools=read,grep` |
+| `edit` | 允许带确认的文件编辑 | `acceptEdits` | `workspace-write` | `workspace-write` | `read`、`grep`、`find`、`ls`、`edit`、`write`、`bash` | Cordis 配置 | 默认 flags（无 `--force`） | `--allow-all-tools --no-ask-user` | `--trust-tools=read,grep,write,shell` |
+| `full` | 绕过所有权限检查 | `bypassPermissions` | `danger-full-access` | `danger-full-access` | 所有注册 Pi 工具 | Cordis 配置 | `--force` | `--yolo` | `--trust-all-tools` |
+
+Pi 的权限模式是 SDK active-tool allowlist，而不是操作系统 sandbox；TAKT 不为 Pi 增加逐工具确认。使用 Pi 时请确保 workflow 输入和 extension 可信。
+
+### 配置
+
+```yaml
+# ~/.takt/config.yaml（全局）或 .takt/config.yaml（项目）
+provider_profiles:
+  codex:
+    default_permission_mode: full
+    step_permission_overrides:
+      ai_review: readonly
+  claude:
+    default_permission_mode: edit
+    step_permission_overrides:
+      implement: full
+```
+
+### 权限解析优先级
+
+权限解析顺序（先匹配者优先）：
+
+1. 项目 `provider_profiles.<provider>.step_permission_overrides.<step>`
+2. 全局 `provider_profiles.<provider>.step_permission_overrides.<step>`
+3. 项目 `provider_profiles.<provider>.default_permission_mode`
+4. 全局 `provider_profiles.<provider>.default_permission_mode`
+5. step `required_permission_mode`（作为最低下限）
+
+每个 provider 都有 builtin `default_permission_mode: edit`；如果项目和全局 profile 都没有设置，最终模式就是 `edit`，再根据 step 的 `required_permission_mode` 提高。
+
+## 旧版 `config.yaml` Provider Routing
+
+runtime 模式未启用时，可以通过 `provider_routing` 将 workflow step 路由到不同 provider、model 和 provider options，而不复制 workflow。runtime 模式应使用 `provider.targets`。
+
+```yaml
+# ~/.takt/config.yaml
+provider_routing:
+  personas:
+    coder:
+      provider: codex
+      model: gpt-5
+      provider_options:
+        codex:
+          reasoning_effort: high
+  tags:
+    implementation:
+      provider: codex
+      model: gpt-5
+    review:
+      provider: opencode
+      model: opencode/qwen3-coder-next
+    final-gate:
+      provider: codex
+      model: gpt-5
+      provider_options:
+        codex:
+          reasoning_effort: high
+    edit:
+      provider_options:
+        codex:
+          network_access: true
+  steps:
+    ai-antipattern-review-2nd:
+      provider: opencode
+      model: opencode/qwen3-coder-next
+```
+
+```yaml
+# workflow.yaml
+steps:
+  - name: implement
+    persona: coder
+    persona_name: implementation-coder
+    tags: [implementation, edit]
+```
+
+`provider_routing.personas` 使用 step 的原始 `persona` key；`persona_name` 只用于显示。`provider_routing.tags` 按 step 的 `tags` 匹配，多个 tag 按 step 中的书写顺序应用，后者覆盖相同 leaf。`provider_routing.steps` 使用 workflow step 的 `name`。每条 routing entry 至少包含 `provider`、`model` 或 `provider_options` 之一，空 `provider_options` 会被拒绝。
+
+旧版 step 解析优先级：
+
+```text
+显式 CLI / 环境变量覆盖
+> provider_routing.steps.<step.name>
+> provider_routing.tags.<tag>
+> provider_routing.personas.<raw persona key>
+> persona_providers.<persona display name>  # 已弃用
+> effective auto_routing
+> project .takt/config.yaml
+> global ~/.takt/config.yaml
+> provider default
+```
+
+provider 和 model 在每一层独立解析；只有 provider 的覆盖不会替换更高优先级的 model 覆盖。workflow YAML 没有 provider/model 层；workflow promotion 只推进 runtime target ladder。
+
+`persona_providers` 仍支持既有配置，但已弃用；它按 step 的 persona 显示名称匹配，该名称可能来自 `persona_name`，不一定是原始 `persona` key：
+
+```yaml
+persona_providers:
+  implementation-coder:
+    provider: codex
+    model: gpt-5
+    provider_options:
+      codex:
+        reasoning_effort: high
+```
+
+<a id="auto-routing"></a>
+
+## 自动路由
+
+旧版模式可以在项目或全局 `config.yaml` 中配置 `auto_routing`；runtime 模式使用 `runtime.yaml` 中的 `provider.auto_routing` 和 target profile。workflow YAML 不能启用或覆盖自动路由。
+
+```yaml
+provider: codex
+model: gpt-5.6-luna
+
+auto_routing:
+  strategy: balanced # cost | balanced | performance
+  router:
+    provider: codex
+    model: gpt-5.6-luna
+  candidates:
+    - name: advanced
+      description: Planning, final decisions, requirement-fulfillment judgment, and other advanced reasoning
+      provider: codex
+      model: gpt-5.6-sol
+      routing_tier: high
+    - name: coding
+      description: Implementation, tests, debugging, and refactoring
+      provider: codex
+      model: gpt-5.6-terra
+      routing_tier: medium
+    - name: lightweight
+      description: Formatting and small mechanical edits
+      provider: codex
+      model: gpt-5.6-luna
+      routing_tier: low
+  rules:
+    steps:
+      security-audit: advanced
+  default_pool: general
+  candidate_pools:
+    general:
+      candidates: [lightweight, coding, advanced]
+      fallback: advanced
+    implementation:
+      candidates: [coding, advanced]
+      fallback: advanced
+  pool_rules:
+    tags:
+      implementation: implementation
+```
+
+旧版模式中，顶层 `provider` 和 `model` 是默认值；candidate 只用于 workflow step 执行。没有 workflow-step 上下文的内部操作使用顶层默认值。Assistant 对话不走 auto routing，而解析 `takt_providers.assistant`，必要时回退到顶层 provider/model。runtime 模式下，只有显式选择 pool 的 persona、tag 或 step target 才自动路由。
+
+candidate 的 `routing_tier` 只能是 `high`、`medium` 或 `low`。CLI 可以用 `--auto-strategy cost|balanced|performance` 覆盖策略。路由决策默认不记录；启用 `telemetry.routing_decisions`（`takt telemetry enable` 或 `routing_decisions: true`）后，以 NDJSON 写入项目 `.takt/events/`，不会上传。
+
+provider option 也可以通过环境变量覆盖。例如 OpenCode model variant 使用 `TAKT_PROVIDER_OPTIONS_OPENCODE_VARIANT=high`；provider base URL 可使用 `TAKT_PROVIDER_OPTIONS_CODEX_BASE_URL=http://127.0.0.1:8787/v1` 或 `TAKT_PROVIDER_OPTIONS_CLAUDE_BASE_URL=http://127.0.0.1:8787`。DeepSeek Harness 可使用 `TAKT_PROVIDER_OPTIONS_DEEPSEEK_HARNESS_BASE_URL=http://127.0.0.1:8787/v1`；官方 SDK 读取 `DEEPSEEK_API_KEY` 和可选的 `DEEPSEEK_BASE_URL`，TAKT 只将其传给私有 Python bridge。其余 provider option 环境变量按同样的 key 路径规则解析。
+
+### Provider 专属选项
+
+runtime 模式中，执行选项放在 `provider.profiles.<name>.options`；workflow 中只使用 capability。旧版配置仍支持以下 provider-specific option。
+
+#### Provider Base URL（`base_url`）
+
+```yaml
+provider_options:
+  claude:
+    base_url: http://127.0.0.1:8787
+  codex:
+    base_url: http://127.0.0.1:8787/v1
+```
+
+`provider_options.claude.base_url` 会作为 `ANTHROPIC_BASE_URL` 传给 `claude` 和 `claude-sdk`；`provider_options.codex.base_url` 作为 `baseUrl` 传给 Codex SDK；`provider_options.deepseek_harness.base_url` 通过 `DEEPSEEK_BASE_URL` 传给官方 Python SDK。workflow 和项目配置只允许 loopback URL；非 loopback endpoint 必须放在全局配置或 `TAKT_PROVIDER_OPTIONS_*_BASE_URL` 环境变量中。
+
+#### DeepSeek Harness（`deepseek-harness`）
+
+`deepseek-harness` 在 Python 3.10+ 子进程中启动官方 `deepseek-harness-sdk`，通过逐行 JSON-RPC bridge 通信。请单独安装匹配的 runtime：
+
+```bash
+python3 -m pip install deepseek-harness-sdk deepseek-harness-runtime-bin
+```
+
+官方 runtime wheel 支持 Linux x64/arm64 和 macOS arm64；Windows 与 macOS x64 会快速失败，TAKT 不会 fallback。认证使用环境变量 `DEEPSEEK_API_KEY`，可选 `DEEPSEEK_BASE_URL`；API key 不会写入 workflow/config 或命令参数。
+
+```bash
+export DEEPSEEK_API_KEY=your-key
+export TAKT_DEEPSEEK_HARNESS_LIVE=1
+npm run test:deepseek-harness:live
+```
+
+```yaml
+provider: deepseek-harness
+model: deepseek-v4-flash
+provider_options:
+  deepseek_harness:
+    base_url: http://127.0.0.1:8787/v1  # 可选；项目/workflow 配置中使用 loopback
+    session_root: .takt/deepseek-sessions
+    max_tokens: 4096
+    request_timeout_ms: 3600000
+    shutdown_timeout_ms: 1000
+    runtime_mode: exe                  # exe 或 node；node 仅用于显式 SDK 开发模式
+```
+
+`python_path` 和 `cordis` 只允许来自受信任的全局配置或对应环境变量；项目设置使用默认 `python3`。`session_root` 和 `cordis` 相对配置的工作目录解析。带有 `session_key` 的 workflow 会复用 session；one-shot call 会立即关闭 bridge。官方 event 会转换成 TAKT 的 text、thinking、tool-use、tool-result、error 和 result event。system prompt、TAKT `allowed_tools`、MCP server map、图片附件、structured output、permission mode 和 `maxTurns` 不属于官方 SDK 调用，会被警告并忽略；工具组合请通过 Cordis 配置。
+
+#### 网络访问（`network_access`）
+
+provider sandbox 默认阻止 `npm install`、`pip install`、`gradle` 和 `mvn` 等网络命令。Codex：
+
+```yaml
+provider_options:
+  codex:
+    network_access: true
+```
+
+OpenCode 通过 `webfetch` / `websearch` 工具权限实现同一抽象：
+
+```yaml
+provider_options:
+  opencode:
+    network_access: true
+    allowed_tools: [read, glob, grep, bash, websearch, webfetch]
+```
+
+`network_access` 可以设置在 runtime profile 或 capability preset 中；旧版模式也可设置在 routing、项目或全局配置中。`TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS=true` 可作为覆盖。
+
+#### Codex 权限控制（`permission_control`）
+
+Codex 默认使用 TAKT 的权限映射，相当于 `permission_control: takt`，并将解析出的 TAKT `permission_mode` 传给 Codex SDK 的 `sandboxMode`。设置 `network_access` 时也会传入 `networkAccessEnabled`；省略时 Codex 保持默认 `false`。
+
+```yaml
+provider_options:
+  codex:
+    permission_control: codex
+```
+
+使用 `permission_control: codex` 时，TAKT 从每次 Codex 调用中省略 `sandboxMode` 和 `networkAccessEnabled`，由 Codex 的 `config.toml`、`default_permissions` 和 permission profile 决定实际权限。它不能与 `network_access` 同时设置；同时存在会快速失败。
+
+#### Codex Skill 继承（`skills`）
+
+TAKT workflow 默认不继承 repository 或 user Codex Skill。需要时显式启用：
+
+```yaml
+provider_options:
+  codex:
+    skills:
+      repo: true
+      user: false
+```
+
+`repo` 覆盖执行 CWD 到 repository root 之间的 `.agents/skills`；`user` 覆盖 `$HOME/.agents/skills` 和兼容路径 `$CODEX_HOME/skills`。这些设置不修改 Codex 配置，重试与恢复 session 也保持一致。
+
+#### Claude Skill 继承（`skills`）
+
+`claude-sdk`、`claude` 和 `claude-terminal` 默认关闭 filesystem Skill discovery。只有 workflow 有意依赖它们时才启用：
+
+```yaml
+provider_options:
+  claude:
+    skills:
+      enabled: true
+```
+
+`enabled: false` 时 SDK 收到 `skills: []`，CLI 使用 `--disable-slash-commands`；`enabled: true` 时不添加 Skill 选项，保留 Claude 默认 discovery。
+
+#### Claude Code Sandbox 控制（`allow_unsandboxed_commands`）
+
+`permission_mode: edit` 时，Claude SDK 将 Bash 放在 macOS Seatbelt sandbox 中。若 JVM 构建工具因 `Operation not permitted` 失败，可在保留文件编辑权限控制的同时允许 Bash 脱离 sandbox：
+
+```yaml
+provider_options:
+  claude:
+    sandbox:
+      allow_unsandboxed_commands: true
+```
+
+#### Pi 资源加载（`extensions`、`no_*`）
+
+```yaml
+provider_options:
+  pi:
+    extensions:
+      - npm:pi-fff
+      # - git:https://github.com/example/pi-extension
+      # - /absolute/path/to/local-extension
+    no_extensions: true       # 禁用 discovery，但仍加载上面的显式 extension
+    no_skills: true           # 禁用 Pi Skill discovery
+    no_prompt_templates: true # 禁用 Pi prompt-template discovery
+    no_themes: true           # 禁用 Pi theme discovery
+    no_context_files: true    # 禁用 Pi context-file discovery
+```
+
+显式资源只在 TAKT run 中临时解析，不会写入 Pi 设置；隐式项目本地 extension 不会被信任或加载。带有内嵌凭据或包含 secret 的 query 参数的 extension URL 会被拒绝。
+
+<a id="workflow-categories"></a>
+
+## Workflow 分类
+
+在 `takt` workflow 选择提示中使用分类组织 workflow：
+
+### 配置
+
+```yaml
+# ~/.takt/preferences/workflow-categories.yaml
+workflow_categories:
+  Development:
+    workflows: [default, simple]
+    Backend:
+      workflows: [dual-cqrs]
+    Frontend:
+      workflows: [dual]
+  Research:
+    workflows: [research, magi]
+
+show_others_category: true
+others_category_name: "Other Workflows"
+```
+
+规范 key 是顶层 `workflow_categories`，以及每个分类下列出 workflow 名称（workflow YAML 的 `name` 字段）的 `workflows` 数组。分类文件可以是 builtin `builtins/{lang}/workflow-categories.yaml`、用户 overlay `~/.takt/preferences/workflow-categories.yaml`，或由 `workflow_categories_file` 指定的路径；不能把 `workflow_categories` 直接写入 `~/.takt/config.yaml`。
+
+### 分类功能
+
+- **嵌套分类**：支持任意深度；除 `workflows` 外的 key 都作为子分类名称，不使用 `children:`。
+- **每类 workflow 列表**：`workflows:` 保存该分类显示的 workflow 名称。
+- **Others 分类**：收集未列入任何分类的 workflow，可用 `show_others_category: false` 关闭。
+- **Builtin 过滤**：用 `enable_builtin_workflows: false` 关闭全部 builtin，或用 `disabled_builtins: [name1, name2]` 关闭指定名称。
+
+### 重置分类
+
+重置为 builtin 默认分类：
+
+```bash
+takt reset categories
+```
+
+## Pipeline 模板
+
+### 配置
+
+Pipeline 模式（`--pipeline`）支持自定义分支名、commit message 和 PR body：
+
+```yaml
+# ~/.takt/config.yaml
+pipeline:
+  default_branch_prefix: "takt/"
+  commit_message_template: "feat: {title} (#{issue})"
+  pr_body_template: |
+    ## Summary
+    {issue_body}
+    Closes #{issue}
+```
+
+### 模板变量
+
+| 变量 | 可用位置 | 说明 |
+|------|----------|------|
+| `{title}` | commit message | Issue 标题 |
+| `{issue}` | commit message、PR body | Issue 编号 |
+| `{issue_body}` | PR body | Issue 正文 |
+| `{report}` | PR body | workflow 执行报告 |
+
+### Pipeline CLI 选项
+
+| 选项 | 说明 |
+|------|------|
+| `--pipeline` | 启用 pipeline（非交互）模式 |
+| `--auto-pr` | 执行后创建 PR |
+| `--draft` | 创建 draft PR（需要 `--auto-pr` 或 `auto_pr` 配置） |
+| `--skip-git` | 跳过分支创建、commit 和 push（仅执行 workflow） |
+| `--repo <owner/repo>` | 创建 PR 的仓库 |
+| `--auto-strategy <strategy>` | 覆盖自动路由策略（`cost`、`balanced`、`performance`） |
+| `-q, --quiet` | 最小输出模式（抑制 AI 输出） |
+
+## 调试
+
+### Debug 日志
+
+在全局 `~/.takt/config.yaml` 中启用：
+
+```yaml
+logging:
+  debug: true
+```
+
+debug 日志以 NDJSON 写入 `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log`，prompt/response 日志写入同目录的 `debug-{timestamp}-prompts.jsonl`。
+
+### 详细控制台输出
+
+```yaml
+# ~/.takt/config.yaml
+logging:
+  level: debug
+```
+
+`logging.level: debug` 会启用 CLI 的详细输出和上面的 debug logger；`logging.debug: true`、`logging.trace: true` 或 `logging.level: debug` 任一设置都可以生成 debug 产物。
+
+## Companion Provider Target
+
+Companion 需要有效的 `runtime.yaml` provider section。通过 `provider.targets.companions` 为每个引用的 companion 分配 profile；省略名称时使用 `provider.defaults`。Companion target 必须指定固定 profile，pool 和 ladder 会在解析 `runtime.yaml` 时被拒绝。
+
+```yaml
+version: 1
+provider:
+  profiles:
+    review:
+      provider: codex
+      model: gpt-5
+  defaults:
+    profile: review
+  targets:
+    companions:
+      security-reviewer:
+        profile: review
+```
+
+Companion 的 structured call 使用和其他 TAKT-owned structured agent 一样的 provider-neutral 新 session transport。具备原生 structured output 时直接使用，否则使用经过验证的 JSON fallback。Companion reviewer、moderator 和 selector 始终以 `readonly` 权限运行，不使用 resolved profile 上配置的权限模式。
+
+| Provider | Implementer tool event |
+|----------|------------------------|
+| `claude-sdk` | Live |
+| `codex` | Live |
+| `claude`（headless） | Live |
+| `claude-terminal` | turn 后 replay |
+| `mock` | 取决于 scenario |
+| `opencode` | Live |
+| `pi` | Live |
+| `cursor`、`copilot`、`kiro` | 不可用 |
+
+当 live tool event 不可用时，完成审查和 turn 边界的 finding 传递仍会运行。

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -394,6 +394,8 @@ TAKT 观察实际收到的 provider event，不会合成 keepalive。OpenCode �
 
 TAKT 支持 Claude、Codex、OpenCode、Pi、官方 DeepSeek Harness SDK、Cursor、Copilot 和 Kiro provider。Claude/Codex/OpenCode 使用各自 SDK credential，Pi 使用 Pi SDK credential store 或 provider 原生环境变量，DeepSeek Harness 使用官方 `DEEPSEEK_API_KEY`，Cursor 支持 API key 或已有 `cursor-agent login` session，Copilot 使用 GitHub token，Kiro 使用 API key。
 
+全局配置 schema 还保留了一些当前不能作为顶层 provider 选择的 legacy 或 provider integration API key 字段。这些字段本身不会启用 provider；请根据所选 provider，使用下文记录的认证环境变量或配置 key。
+
 ### 环境变量（推荐）
 
 ```bash

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -307,7 +307,7 @@ ignore_exceed: false          # 对 takt run 和 takt watch 应用 --ignore-exce
 #       ai_review: readonly
 ```
 
-项目配置在同时设置时覆盖全局配置。项目 schema 是严格的：`logging`、`disabled_builtins`、`enable_builtin_workflows`、通知设置、API key 和 CLI 路径等全局专属 key 写入 `.takt/config.yaml` 会在启动时触发配置验证错误。
+项目配置在同时设置时覆盖全局配置。项目 schema 是严格的：`logging`、`disabled_builtins`、`enable_builtin_workflows`、通知设置、API key 和 CLI 路径等全局专属 key 写入 `.takt/config.yaml` 会在启动时触发配置验证错误。Provider credential 应通过环境变量或全局 `~/.takt/config.yaml` 配置。
 
 ### Pi provider session 边界
 
@@ -334,13 +334,13 @@ steps:
 
 ### Provider inactivity deadline 与 OpenCode execution guard
 
-所有 provider 都使用 `guards.call_timeout_ms` 作为没有可观察 provider event 时允许的最长时间。每个 stream/tool event、阶段完成和新的 provider attempt 都会重置计时器；累计执行时间没有上限。它适用于 `codex`、`opencode`、`claude`（包括 `claude-sdk`）、`claude_terminal`、`cursor`、`copilot`、`kiro` 和 `pi`。取值是 60,000 到 86,400,000 之间的整数毫秒，默认 3,600,000 ms（60 分钟）。`claude_terminal.timeout_ms` 为兼容性保留，仅在未设置 `guards.call_timeout_ms` 时使用。
+所有 provider 都使用 `guards.call_timeout_ms` 作为没有可观察 provider event 时允许的最长时间。每个 stream/tool event、阶段完成和新的 provider attempt 都会重置计时器；累计执行时间没有上限。它适用于 `codex`、`opencode`、`claude`（包括 `claude-sdk`）、`claude_terminal`、`cursor`、`copilot`、`kiro` 和 `pi`。取值是 60,000 到 86,400,000 之间的整数毫秒，默认 3,600,000 ms（60 分钟）。通常的 `provider_options` profile 解析路径会将该值应用到 engine 的 parent-step deadline，并向所有 provider 传递同一个 `AbortSignal`。`claude_terminal.timeout_ms` 为兼容性保留，仅在未设置 `guards.call_timeout_ms` 时使用。
 
 `provider_options.opencode.guards.profile` 默认是 `standard`。`minimal` 只关闭启发式循环检测；时间、资源上限、完整性和严格修正 guard 仍然强制启用。`model_profiles` 按解析出的 model 字符串以声明顺序选择 profile，唯一通配符是 `*`。guard leaf 在 provider-option 层之间独立合并；较高优先级的 `model_profiles` 值会替换较低优先级的完整 map。
 
 每次 OpenCode 调用都有 3,600,000 ms 的 provider-event 不活跃上限。只要持续收到 event，健康调用可以超过该时间。`event_limit` 默认 500,000，可由 `TAKT_OPENCODE_STREAM_EVENT_LIMIT` 覆盖；`text_byte_limit` 默认 1 MiB，`reasoning_byte_limit` 默认 4 MiB。
 
-TAKT 观察实际收到的 provider event，不会合成 keepalive。OpenCode 从 tool-start event 到终止 event 的期间视为 in-flight，并暂停普通不活跃检查；若终止 event 缺失或完全挂起，in-flight 状态在 `call_timeout_ms` 的六倍后过期并以 `PART_TIMEOUT` 结束。`guards.*` 下的无效数值会快速失败；实验性 `TAKT_OPENCODE_*` 覆盖中的无效值会忽略并使用默认值。旧的 `TAKT_OPENCODE_TOOL_ERROR_BUDGET`、`TAKT_OPENCODE_TOOL_SIGNATURE_ABSOLUTE`、`TAKT_OPENCODE_TOOL_SIGNATURE_REPEATS`、`TAKT_OPENCODE_TOOL_SUCCESS_REPEATS` 和 `TAKT_OPENCODE_TOOL_RESULT_STAGNATION_REPEATS` 不再控制 guard，会被忽略并发出一次性警告。
+TAKT 观察实际收到的 provider event，不会合成 keepalive。OpenCode 从 tool-start event 到终止 event 的期间视为 in-flight，并暂停普通不活跃检查；若终止 event 缺失或完全挂起，in-flight 状态在 `call_timeout_ms` 的六倍后过期并以 `PART_TIMEOUT` 结束。`guards.*` 下的无效数值（包括通过 `TAKT_PROVIDER_OPTIONS_*` 设置的值）属于声明式配置，如果不是有效的正整数则会快速失败并报错；实验性 `TAKT_OPENCODE_*` 覆盖中的无效值会被忽略并使用默认值。旧的 `TAKT_OPENCODE_TOOL_ERROR_BUDGET`、`TAKT_OPENCODE_TOOL_SIGNATURE_ABSOLUTE`、`TAKT_OPENCODE_TOOL_SIGNATURE_REPEATS`、`TAKT_OPENCODE_TOOL_SUCCESS_REPEATS` 和 `TAKT_OPENCODE_TOOL_RESULT_STAGNATION_REPEATS` 不再控制 guard，会被忽略并发出一次性警告。
 
 ### 项目配置字段参考
 
@@ -360,7 +360,7 @@ TAKT 观察实际收到的 provider event，不会合成 keepalive。OpenCode �
 | `auto_requeue_max_attempts` | 非负整数 | `0` | 失败 workflow task 的自动 requeue 上限 |
 | `ignore_exceed` | boolean | `false` | `takt run` / `takt watch` 的迭代限制绕过 |
 | `base_branch` | string | - | 创建 clone 的基分支 |
-| `assistant.init_files` | string[] | - | 仅项目级的 assistant 初始上下文文件；必须是项目根内的相对路径，最多 16 个文件，每个最多 256 KiB，合计最多 1 MiB |
+| `assistant.init_files` | string[] | - | 仅项目级的 assistant 初始上下文文件。路径必须相对于项目根；绝对路径、解析到项目根之外的路径，以及 `.env*`、`.npmrc`、`.pypirc`、`.netrc`、`*.pem`、`*.key` 和 `.git/**` 等敏感文件模式会被拒绝。路径不存在、指向目录或文件不可读时会明确报错。最多 16 个文件，每个最多 256 KiB，合计最多 1 MiB。未设置或为空时，TAKT 不会自动发现 `CLAUDE.md`、`AGENT.md`、`AGENTS.md`、`TAKT.md` 或其他文件。 |
 | `assistant.gherkin` | boolean | `false` | 项目级的任务指令 Gherkin 设置 |
 | `provider_options` | object | - | provider 专属选项 |
 | `provider_profiles` | object | - | provider 专属权限 profile |

--- a/docs/external-integrations.ja.md
+++ b/docs/external-integrations.ja.md
@@ -1,6 +1,6 @@
 # External Integrations
 
-[English](./external-integrations.md)
+[English](./external-integrations.md) | [日本語](./external-integrations.ja.md) | [简体中文](./external-integrations.zh-CN.md)
 
 本ページはコミュニティ製サードパーティ統合のカタログです。公式の GitHub/GitLab 連携については [Configuration](./configuration.ja.md) と [CI/CD](./ci-cd.ja.md) を参照してください。
 

--- a/docs/external-integrations.md
+++ b/docs/external-integrations.md
@@ -1,6 +1,6 @@
 # External Integrations
 
-[日本語](./external-integrations.ja.md)
+[English](./external-integrations.md) | [日本語](./external-integrations.ja.md) | [简体中文](./external-integrations.zh-CN.md)
 
 This page is a catalog of community-built third-party integrations. For the official GitHub/GitLab integration, see [Configuration](./configuration.md) and [CI/CD](./ci-cd.md).
 

--- a/docs/external-integrations.zh-CN.md
+++ b/docs/external-integrations.zh-CN.md
@@ -1,0 +1,23 @@
+# 外部集成
+
+[English](./external-integrations.md) | [日本語](./external-integrations.ja.md) | [简体中文](./external-integrations.zh-CN.md)
+
+本页收录社区构建的第三方集成。官方 GitHub/GitLab 集成请参阅[配置](./configuration.zh-CN.md)和 [CI/CD](./ci-cd.md)。
+
+这些社区维护的示例可以在不修改 TAKT 核心的情况下扩展功能。它们不是 TAKT 官方支持的项目，列入此处也不表示背书；采用前请检查每个项目的许可证、依赖和安全状况。
+
+如果要添加集成，请提交包含单行说明和公开仓库链接的 PR。
+
+## 方法论工具包
+
+在 TAKT 之上实现软件开发方法的 bundle：包含 workflow、facet 和可通过一条命令安装的辅助脚本。
+
+| 集成 | 说明 |
+|------|------|
+| [j5ik2o/takt-sdd](https://github.com/j5ik2o/takt-sdd) | 面向 TAKT 的 Spec-Driven Development（SDD）方法论。提供 Requirements → Gap Analysis → Design → Tasks → Implementation → Validation workflow，以及 OpenSpec 风格的变更提案流程。它利用 TAKT 的阶段 gate、output contract 和审查循环，让定义清晰的 spec 忠实地转化为执行；阶段不能被静默跳过，偏差会回到 `fix`。与 provider 无关（Claude / Codex），使用 `npx create-takt-sdd` 安装。 |
+
+## 审计轨迹 / Receipt 签名
+
+| 集成 | 说明 |
+|------|------|
+| [ScopeBlind/examples/takt-workflow-receipts](https://github.com/ScopeBlind/examples/tree/main/takt-workflow-receipts) | 通过 step 的 `mcp_servers` 声明 MCP server，增加 Ed25519 签名 receipt 和 Cedar policy enforcement（必须先在 `workflow_mcp_servers` 配置策略中允许对应 transport）。Receipt 与 TAKT 的 NDJSON 日志并列保存，并可离线验证；不需要修改 TAKT 核心。 |

--- a/docs/index.html
+++ b/docs/index.html
@@ -176,6 +176,7 @@
         <a href="https://youtu.be/cfM9USMkh2Y" target="_blank" rel="noopener noreferrer" class="text-takt-300 hover:text-takt-200 underline underline-offset-4">Chapter 2</a>
         <a href="https://github.com/nrslib/takt/blob/main/docs/tutorial.md" target="_blank" rel="noopener noreferrer" class="text-takt-300 hover:text-takt-200 underline underline-offset-4">Written tutorial</a>
         <a href="https://github.com/nrslib/takt/blob/main/README.md#documentation" target="_blank" rel="noopener noreferrer" class="text-takt-300 hover:text-takt-200 underline underline-offset-4">All docs</a>
+        <a href="https://github.com/nrslib/takt/blob/main/docs/README.zh-CN.md" target="_blank" rel="noopener noreferrer" class="text-takt-300 hover:text-takt-200 underline underline-offset-4">简体中文文档</a>
       </div>
     </div>
   </section>

--- a/docs/task-management.ja.md
+++ b/docs/task-management.ja.md
@@ -1,4 +1,4 @@
-[English](./task-management.md)
+[English](./task-management.md) | [日本語](./task-management.ja.md) | [简体中文](./task-management.zh-CN.md)
 
 # タスク管理
 

--- a/docs/task-management.ja.md
+++ b/docs/task-management.ja.md
@@ -1,6 +1,6 @@
-[English](./task-management.md) | [日本語](./task-management.ja.md) | [简体中文](./task-management.zh-CN.md)
-
 # タスク管理
+
+[English](./task-management.md) | [日本語](./task-management.ja.md) | [简体中文](./task-management.zh-CN.md)
 
 ## 概要
 

--- a/docs/task-management.md
+++ b/docs/task-management.md
@@ -1,4 +1,4 @@
-[日本語](./task-management.ja.md)
+[English](./task-management.md) | [日本語](./task-management.ja.md) | [简体中文](./task-management.zh-CN.md)
 
 # Task Management
 

--- a/docs/task-management.md
+++ b/docs/task-management.md
@@ -1,6 +1,6 @@
-[English](./task-management.md) | [日本語](./task-management.ja.md) | [简体中文](./task-management.zh-CN.md)
-
 # Task Management
+
+[English](./task-management.md) | [日本語](./task-management.ja.md) | [简体中文](./task-management.zh-CN.md)
 
 ## Overview
 

--- a/docs/task-management.zh-CN.md
+++ b/docs/task-management.zh-CN.md
@@ -1,0 +1,366 @@
+# 任务管理
+
+[English](./task-management.md) | [日本語](./task-management.ja.md) | [简体中文](./task-management.zh-CN.md)
+
+## 概览
+
+TAKT 提供了用于积累多个任务并批量执行的任务管理流程：
+
+1. **`takt add`** — 通过 AI 对话完善任务要求，并保存到 `.takt/tasks.yaml`
+2. **积累任务** — 编辑 `order.md` 文件，附加参考材料
+3. **`takt run`** — 一次执行所有待处理任务（顺序或并行）
+4. **`takt list`** — 查看结果、合并分支、重试失败任务或追加指令
+
+每个任务可在隔离 clone 中执行，生成报告，并创建可以通过 `takt list` 合并或丢弃的分支。
+
+## 添加任务（`takt add`）
+
+使用 `takt add` 在 `.takt/tasks.yaml` 创建新任务条目：
+
+```bash
+# 使用内联文本添加任务
+takt add "Implement user authentication"
+
+# 从 GitHub Issue 添加任务
+takt add #28
+```
+
+添加任务时会询问：
+
+- **Workflow** — 执行时使用哪个 workflow
+- **Base branch** — 当前分支不是 `main`/`master` 时，是否使用当前分支作为基分支
+- **Worktree path** — 创建隔离 clone 的位置（回车自动选择，也可以指定路径）
+- **Branch name** — 自定义分支名（回车自动生成 `takt/{timestamp}-{slug}`）
+- **Auto-PR** — 成功执行后是否自动创建 pull request（默认 Yes）
+- **Draft PR** — 启用 Auto-PR 时，是否将 PR 创建为 draft（`Create as draft?`）
+
+### GitHub Issue 集成
+
+传入 Issue 引用（例如 `#28`）时，TAKT 通过 GitHub CLI（`gh`）获取 Issue 标题、正文、标签和评论，并将其作为任务内容。Issue 编号会记录到 `tasks.yaml`，也会反映在分支名中。
+
+**要求：** [GitHub CLI](https://cli.github.com/)（`gh`）必须已安装并完成认证。
+
+### 从交互模式保存任务
+
+也可以从交互模式保存任务。对话完善需求后，使用 `/save`（或提示出现时的 save action），将任务持久化到 `tasks.yaml`，而不是立即执行。
+
+### 从 MCP 客户端保存任务
+
+MCP 客户端可以使用 `takt-mcp` stdio server 保存待处理任务，无需调用 shell 命令。`takt_enqueue_task` 将待处理记录写入 `.takt/tasks.yaml`；可选的 `issue` 对象可以关联已有 Issue，或通过已配置的 TAKT Issue provider 创建 Issue。如果创建 Issue 后保存任务失败且已解析到 Issue 编号，Issue 会保持打开，MCP 错误结果会返回编号以便重试；如果无法解析编号，结果可能提供 Issue URL。工具要求绝对路径 `cwd` 和非空任务正文。使用 `takt run` 执行，使用 `takt watch` 监视和持续执行。输入字段详见 [CLI 参考](./cli-reference.zh-CN.md#mcp-server)。
+
+## 任务目录格式
+
+TAKT 将任务元数据存储在 `.takt/tasks.yaml`，并将每个任务的详细规格存储在 `.takt/tasks/{slug}/`。
+
+### `tasks.yaml` Schema
+
+```yaml
+tasks:
+  - name: add-auth-feature
+    status: pending
+    task_dir: .takt/tasks/20260201-015714-implement-user-authentication
+    workflow: default
+    created_at: "2026-02-01T01:57:14.000Z"
+    started_at: null
+    completed_at: null
+```
+
+字段：
+
+| 字段 | 说明 |
+|------|------|
+| `name` | AI 生成的任务 slug |
+| `status` | `pending`、`running`、`completed`、`failed`、`exceeded` 或 `pr_failed`（workflow 成功但 PR 创建/push 失败） |
+| `task_dir` | 包含 `order.md` 的任务目录路径 |
+| `workflow` | 执行时使用的 workflow 名称 |
+| `worktree` | `true`（自动）、路径字符串，或省略（在当前目录运行） |
+| `branch` | 分支名（省略时自动生成） |
+| `base_branch` | clone 和 PR 的基分支 |
+| `auto_pr` | 执行后是否自动创建 PR |
+| `draft_pr` | 自动创建的 PR 是否为 draft |
+| `issue` | 配置的 Issue provider 返回的 Issue 编号（如适用） |
+| `run_slug` | 最新 run 目录的 slug |
+| `failure` | 失败详情（`step`、`error`、`last_message`） |
+| `created_at` | ISO 8601 创建时间 |
+| `started_at` | ISO 8601 开始执行时间 |
+| `completed_at` | ISO 8601 完成执行时间 |
+
+`tasks.yaml` 还可能包含由 TAKT 内部管理的字段，如 `slug`、`source_run_slug`、`resume_mode`、`owner_pid`、`auto_requeue_count`、`exceeded_*` 等。
+
+### 任务目录布局
+
+```text
+.takt/
+  tasks/
+    20260201-015714-implement-user-authentication/
+      order.md          # 自动生成、可编辑的任务规格
+      schema.sql        # 可选的参考材料
+      wireframe.png     # 可选的参考材料
+  tasks.yaml            # 任务元数据记录
+  runs/
+    20260201-020152-implement-user-authentication-x7k2pq/
+      reports/           # 自动生成的执行报告
+      logs/              # NDJSON session 日志
+      context/           # snapshot（previous_responses 等）
+      operations/        # 操作 journal（journal.json）
+      meta.json          # run 元数据
+```
+
+每次执行都会为 run 目录单独生成 slug，并追加随机的 6 字符后缀，因此它与任务目录 slug 不同。可查看 `tasks.yaml` 中的 `run_slug` 或 `.takt/runs/` 下最新目录来定位 run。
+
+`takt add` 会自动创建 `.takt/tasks/{slug}/order.md`，并将 `task_dir` 引用保存到 `tasks.yaml`。执行前可以自由编辑 `order.md`，也可以向任务目录加入 SQL schema、wireframe 或 API spec 等补充文件。
+
+## 执行任务（`takt run`）
+
+执行 `.takt/tasks.yaml` 中所有待处理任务：
+
+```bash
+takt run
+
+# 忽略 workflow max_steps，直到其他停止条件出现
+takt run --ignore-exceed
+```
+
+`run` 命令会认领 pending 任务，并按配置的 workflow 执行。每个任务依次经历：
+
+1. 创建 clone（设置了 `worktree` 时）
+2. 在 clone/项目目录执行 workflow
+3. worktree 执行时自动 commit 和 push
+4. post-execution 流程（设置 `auto_pr` 时创建 PR）
+5. 将 `tasks.yaml` 状态更新为 `completed`、`failed` 或 `exceeded`
+
+不使用 `--ignore-exceed` 时，达到 workflow `max_steps` 的任务会变为 `exceeded`，并保存 `exceeded_max_steps`、`exceeded_current_iteration` 和 `resume_point` 等重试元数据。该选项只忽略迭代限制，不写入 exceeded retry metadata。
+
+MCP 客户端只负责加入队列；请使用 `takt run` 或 `takt watch` 执行任务。
+
+### 并行执行（Concurrency）
+
+默认顺序执行（`concurrency: 1`）。在 `~/.takt/config.yaml` 中配置：
+
+```yaml
+concurrency: 3              # 同时运行最多 3 个任务（1-10）
+task_poll_interval_ms: 500   # 新任务轮询间隔（100-5000ms）
+```
+
+当 concurrency 大于 1 时，TAKT 使用 worker pool：最多同时运行 N 个任务，在配置的间隔轮询新任务，worker 空闲后领取新任务，并为每个任务显示带颜色前缀的输出。Ctrl+C 会优雅关闭并等待正在执行的任务完成。
+
+### 中断任务清理
+
+如果 `takt run` 被中断（例如进程崩溃或 Ctrl+C），下一次运行 `takt run` 或 `takt watch` 时，仍为 `running` 的任务会自动标记为 `failed`。之后可显式 requeue 再次运行。
+
+### 自动 Requeue
+
+配置 `auto_requeue_max_attempts` 后，`takt run` 启动时会自动 requeue 失败的 workflow task，直到达到次数上限。默认值为 `0`（只手动 requeue）。详见[配置指南](./configuration.zh-CN.md)。
+
+## 监视任务（`takt watch`）
+
+运行常驻进程，监视 `.takt/tasks.yaml` 并自动执行出现的任务：
+
+```bash
+takt watch
+
+# 忽略 workflow max_steps，直到其他停止条件出现
+takt watch --ignore-exceed
+```
+
+watch 命令会：
+
+- 一直运行到 Ctrl+C（SIGINT）
+- 监视新的 `pending` 任务
+- 任务出现后立即执行
+- 启动时将中断的 `running` 任务标记为 `failed`
+- 退出时显示任务总数、成功数和失败数
+
+适合生产者-消费者流程：一个终端用 `takt add` 添加任务，另一个终端用 `takt watch` 自动执行。
+
+## 管理任务分支（`takt list`）
+
+交互式列出并管理任务分支：
+
+```bash
+takt list
+```
+
+列表按状态（pending、running、completed、failed、exceeded、pr_failed）组织任务，并显示创建日期和摘要。选择任务后会根据状态显示可用操作；列表底部还有一次删除所有任务的 **All Delete**。
+
+### 已完成任务的操作
+
+| 操作 | 说明 |
+|------|------|
+| **View diff** | 在 pager 中查看相对默认分支的完整 diff |
+| **Instruct** | 打开 AI 对话编写追加指令，然后重新执行 |
+| **Merge from root** | 将根分支 HEAD 合并到任务分支，使用 AI 辅助解决冲突 |
+| **Pull from remote** | 从 remote origin 拉取最新修改（仅 fast-forward） |
+| **Try merge** | squash merge（只 stage，不 commit，便于人工检查） |
+| **Merge & cleanup** | squash merge 并删除分支 |
+| **Delete** | 丢弃全部修改并删除分支 |
+
+### 失败任务的操作
+
+| 操作 | 说明 |
+|------|------|
+| **Requeue** | 选择 resume 或 restart 位置，将任务重新置为 `pending`，不打开对话 |
+| **Retry** | 打开带失败上下文的 retry 对话，然后重新执行 |
+| **Delete** | 删除失败任务记录 |
+
+### Pending 任务的操作
+
+| 操作 | 说明 |
+|------|------|
+| **Delete** | 从 `tasks.yaml` 删除待处理任务 |
+
+### Running 任务的操作
+
+| 操作 | 说明 |
+|------|------|
+| **Mark as failed** | 将卡住的 `running` 任务标记为 `failed` |
+
+### Exceeded 任务的操作
+
+| 操作 | 说明 |
+|------|------|
+| **Requeue** | 返回 `pending`，从停止处继续 |
+| **Delete** | 永久删除任务 |
+
+### PR-Failed 任务的操作
+
+`pr_failed` 表示 workflow 成功但 PR 创建或 push 失败。这类任务显示 PR 错误信息，并提供与已完成任务相同的操作。
+
+### Instruct 模式
+
+对已完成任务选择 **Instruct** 时，TAKT 会打开 AI 对话循环，并预加载：
+
+- 分支上下文（相对默认分支的 diff stat、commit history）
+- 上一次 run 的 session 数据（step 日志、report）
+- workflow 结构和 step 预览
+- 之前的 order 内容
+
+讨论需要的追加修改，准备好后使用 `/go`，再选择：
+
+- **Save as Task** — 使用新指令将任务重新置为 `pending`，稍后执行
+- **Continue editing** — 继续在对话中完善指令
+
+要立即重新执行，可使用 `/accept`（使用最新 assistant response）或 `/replay`（重新提交上一次 order）；使用 `/cancel` 放弃并返回列表。
+
+### Retry 模式
+
+选择失败任务的 **Retry** 时，TAKT 会：
+
+1. 显示失败详情（失败 step、错误消息、最后一条 agent 消息）
+2. 要求选择 workflow
+3. 要求选择起点：**Resume failed position** 或 **Restart from**
+4. 打开预加载失败上下文、run session 数据和 workflow 结构的 retry 对话
+5. 允许通过 AI 完善指令
+
+**Requeue** 使用相同的 workflow 和起点选择，但不打开对话，直接把任务保存为 `pending`。Retry 和 Requeue 都可以选择 **Resume**（从失败点继续，保留执行状态）或 **Restart**（从任意 step 新开始）；`workflow_call` 子 workflow 中的 step 也可以作为起点。
+
+重新排队后，执行使用新的 namespace，因此不会继承原有 ledger，而是从空 ledger 开始。
+
+`/go` 后 retry 对话提供与 Instruct 相同的 **Save as Task** / **Continue editing**，以及立即重新执行的 `/accept` 和 `/replay`；`/cancel` 会取消。Retry note 会追加到任务记录，并在多次 retry 中累积。
+
+### 非交互模式（`--non-interactive`）
+
+用于 CI/CD 脚本：
+
+```bash
+# 以文本列出所有任务
+takt list --non-interactive
+
+# 以 JSON 列出所有任务
+takt list --non-interactive --format json
+
+# 查看指定分支的 diff stat
+takt list --non-interactive --action diff --branch takt/my-branch
+
+# 合并指定分支
+takt list --non-interactive --action merge --branch takt/my-branch
+
+# 删除分支（需要 --yes）
+takt list --non-interactive --action delete --branch takt/my-branch --yes
+
+# Try merge（stage 但不 commit）
+takt list --non-interactive --action try --branch takt/my-branch
+```
+
+可用 action：`diff`、`sync`、`try`、`merge`、`delete`。
+
+## 任务目录工作流
+
+推荐的端到端流程：
+
+1. **`takt add`** — 创建任务；在 `.takt/tasks.yaml` 增加 pending 记录，并在 `.takt/tasks/{slug}/` 生成 `order.md`。
+2. **编辑 `order.md`** — 添加详细规格、参考材料或补充文件。
+3. **`takt run`**（或 `takt watch`）— 从 `tasks.yaml` 执行 pending 任务。
+4. **验证输出** — 检查 `.takt/runs/{run_slug}/reports/`；run slug 可从 `tasks.yaml` 的 `run_slug` 或 `.takt/runs/` 最新目录找到。
+5. **`takt list`** — 检查结果，合并成功分支，重试失败任务或追加指令。
+
+## 隔离执行（Isolated Clone）
+
+在任务配置中指定 `worktree` 后，每个任务会在由 `git clone` 创建的隔离 clone 中执行，保持主工作目录干净。
+
+### 配置选项
+
+| 设置 | 说明 |
+|------|------|
+| `worktree: true` | 在 `{project}/../takt-worktrees` 自动创建 clone；可由 `worktree_dir` 修改，父目录不可写时回退到项目内 `.takt/worktrees` |
+| `worktree: "/path/to/dir"` | 在指定路径创建 clone |
+| 省略 `worktree` | 在当前目录执行（默认） |
+| `branch: "feat/xxx"` | 使用指定分支；省略时自动生成 `takt/{timestamp}-{slug}` |
+
+### 工作原理
+
+TAKT 使用 `git clone --reference <main-repo> --dissociate` 创建带独立 `.git` 目录的 clone；reference 仓库是 shallow 时回退到普通 `git clone`。独立 `.git` 可防止 agent 工具沿 `gitdir:` 追溯主仓库，agent 完全在 clone 内工作。
+
+YAML 字段仍叫 `worktree` 是为了兼容；内部使用独立 clone，而不是 `git worktree`。
+
+### 临时生命周期
+
+1. **Create** — 执行前创建 clone
+2. **Execute** — 在 clone 中运行任务
+3. **Commit & Push** — 成功时自动 commit 和 push（设置 auto_pr 或类似发布选项时才 push 到 `origin`）
+4. **Preserve** — 执行后保留 clone，以便 instruct/retry
+5. **Cleanup** — 分支是持久产物，使用 `takt list` 合并或删除
+
+### 双工作目录
+
+| 目录 | 用途 |
+|------|------|
+| `cwd`（clone 路径） | agent 运行位置和 report 写入位置 |
+| `projectCwd`（项目根目录） | 日志和 session 数据存储位置 |
+
+worktree 执行期间，report 写入 `cwd/.takt/runs/{slug}/reports/`，防止 agent 发现主仓库路径。当 `cwd !== projectCwd` 时跳过 session resume，以避免跨目录污染。
+
+## Session 日志
+
+TAKT 以 NDJSON（Newline-Delimited JSON，`.jsonl`）写入 session 日志。每条记录以原子方式追加，因此进程崩溃时仍能保留部分日志。
+
+### 日志位置
+
+```text
+.takt/runs/{slug}/
+  logs/{sessionId}.jsonl   # 每次 workflow 执行的 NDJSON session 日志
+  meta.json                # run 元数据（task、workflow、起止时间、状态等）
+  operations/
+    journal.json           # 操作 journal（内部执行记录）
+  context/
+    previous_responses/
+      latest.md            # 上一次 response（自动继承）
+```
+
+启用 observability 时，`meta.json` 还包含完成或中止后打印的 Tempo TraceQL 查询。
+
+### Record 类型
+
+| 类型 | 说明 |
+|------|------|
+| `workflow_start` | 使用 task 和 workflow 初始化 workflow |
+| `step_start` | step 开始执行 |
+| `step_complete` | step 结果、状态、内容和匹配规则 |
+| `workflow_complete` | workflow 成功完成 |
+| `workflow_abort` | workflow 中止及原因 |
+
+### 实时监视
+
+```bash
+tail -f .takt/runs/{slug}/logs/{sessionId}.jsonl
+```

--- a/docs/tutorial.ja.md
+++ b/docs/tutorial.ja.md
@@ -1,4 +1,4 @@
-[English](./tutorial.md)
+[English](./tutorial.md) | [日本語](./tutorial.ja.md) | [简体中文](./tutorial.zh-CN.md)
 
 # チュートリアル
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,4 +1,4 @@
-[日本語](./tutorial.ja.md)
+[English](./tutorial.md) | [日本語](./tutorial.ja.md) | [简体中文](./tutorial.zh-CN.md)
 
 # Tutorial
 

--- a/docs/tutorial.zh-CN.md
+++ b/docs/tutorial.zh-CN.md
@@ -1,0 +1,337 @@
+[English](./tutorial.md) | [日本語](./tutorial.ja.md) | [简体中文](./tutorial.zh-CN.md)
+
+# 教程
+
+本教程通过分三个阶段改进一个小项目，带你走完 TAKT 的基本流程。
+
+示例项目是一个**迷你支出备忘录 UI**。第一阶段先构建一个小型前端，第二阶段增加实用功能，第三阶段打磨布局和交互细节。`default` workflow 是标准 workflow，包含较多审查和测试步骤，可能比较重，因此本教程先使用 `frontend-mini`。
+
+> **视频教程：** 可以通过以下实践视频按照同样的教程操作：
+> [Chapter 1](https://youtu.be/HUcFFvOy39I) 和
+> [Chapter 2](https://youtu.be/UIlM2iM-rmA)。
+
+## 示例项目
+
+你将构建一个在浏览器中运行的小型支出备忘录。
+
+1. **阶段 1：** 构建能够输入金额、类别和备注的最小 UI
+2. **阶段 2：** 增加总金额、类别筛选、删除和持久化
+3. **阶段 3：** 打磨移动端布局、空状态、焦点状态和视觉设计
+
+不要一次让 TAKT 完成全部内容，而是每次将一个阶段加入队列，检查结果，再提出下一项改进。
+
+## 1. 不使用 GitHub 开始
+
+首先将目标项目变成 Git 仓库。如果你已经在现有仓库中，可以跳过此步骤。
+
+```bash
+git init
+git add .
+git commit -m "initial commit"
+```
+
+TAKT 在执行期间会使用分支和任务工作区，因此从至少有一个 commit 的仓库开始更安全。
+
+如果还没有安装 TAKT，请使用 `npm install -g takt` 安装，并准备好 provider CLI（例如 Claude Code）或 API key。
+
+启动 TAKT：
+
+```bash
+takt
+```
+
+首次启动时，TAKT 会先询问默认 agent 和 workflow 使用的语言，再询问 provider，然后才显示 workflow 选择。
+
+选择 `frontend-mini` workflow。初始界面只列出分类；具体顺序可能因环境而异，但 `frontend-mini` 通常位于 `Mini` 或 `Frontend` 分类下。
+
+```text
+Select workflow:
+    📁 🚀 Quick Start/
+    📁 ✨ Simple/
+  ❯ 📁 ⚡ Mini/
+    📁 🎨 Frontend/
+```
+
+在 workflow 上按 `b` 可以收藏；收藏的 workflow 会以 `🎼 {name} [*]` 显示在此界面顶部。
+
+打开分类并选择 `frontend-mini`：
+
+```text
+Select workflow in ⚡ Mini:
+    🎼 simple-mini
+    🎼 default-mini
+  ❯ 🎼 frontend-mini
+    🎼 backend-mini
+    🎼 backend-cqrs-mini
+    🎼 dual-mini
+    🎼 dual-cqrs-mini
+```
+
+随后 TAKT 会询问交互模式。第一次请选择 **Assistant**。
+
+```text
+Select interactive mode:
+  ❯ Assistant
+    Persona
+    Quiet
+    Passthrough
+```
+
+## 2. 阶段 1：构建最小 UI
+
+向 TAKT 描述第一项任务：
+
+```text
+> I want to build a mini expense memo UI that runs in the browser.
+> For the first phase, it only needs fields for amount, category, and note, plus a list of added entries.
+> Keep it simple with index.html, CSS, and JavaScript.
+```
+
+TAKT 可能会提出澄清问题或整理任务。当范围明确后，使用 `/go` 生成任务指令。
+
+```text
+> /go This is phase 1, so do not add persistence or summaries yet. Keep it to the smallest usable UI.
+```
+
+生成任务指令后，TAKT 会显示操作菜单。选择 **Save as Task**：
+
+```text
+What would you like to do?
+    Execute now
+  ❯ Save as Task
+    Continue editing
+    Create Issue
+```
+
+`Save as Task` 会将生成的指令追加到 `.takt/tasks.yaml`。`Execute now` 会立即执行任务，并询问 `Create worktree?`（默认 Yes），因此默认也会在隔离 worktree 中运行。教程的常规流程是先排队，再使用 `takt run` 执行。
+
+选择 **Save as Task** 后，TAKT 会询问 worktree 设置。`Auto-create PR?` 默认是 Yes；如果不使用 GitHub，请回答 `n`。
+
+运行排队的任务：
+
+```bash
+takt run
+```
+
+执行结束后检查结果：
+
+```bash
+takt list
+```
+
+选择已完成的任务。TAKT 会显示该任务的操作。先选择 **View diff**，如果结果值得在本地尝试，再选择 **Try merge**。
+
+```text
+Action for takt/20260201-015714-mini-expense-memo-ui:
+  ❯ View diff
+    Instruct
+    Merge from root
+    Pull from remote
+    Try merge
+    Merge & cleanup
+    Delete
+```
+
+`Try merge` 会在不创建 commit 的情况下将任务分支的修改带入工作树。你可以在本地检查 UI 和 diff，满意后再手动 commit。
+
+```text
+Action for takt/20260201-015714-mini-expense-memo-ui:
+    View diff
+    Instruct
+    Merge from root
+    Pull from remote
+  ❯ Try merge
+    Merge & cleanup
+    Delete
+```
+
+## 3. 阶段 2：增加实用功能
+
+检查阶段 1 的结果后，排队下一项改进。可以从 `takt` 开始新任务，也可以在 `takt list` 中对已完成任务使用 **Instruct**。
+
+如果要在之前的结果上继续，请运行 `takt list`，选择已完成任务，再选择 **Instruct**：
+
+```text
+Action for takt/20260201-015714-mini-expense-memo-ui:
+    View diff
+  ❯ Instruct
+    Merge from root
+    Pull from remote
+    Try merge
+    Merge & cleanup
+    Delete
+```
+
+Instruct 模式会将之前的 diff 和执行报告作为上下文，让你讨论下一项变更。
+
+```text
+> For phase 2, add total amount, category filtering, and row deletion.
+> Save entries to LocalStorage so they are restored after reload.
+```
+
+准备好指令后使用 `/go`：
+
+```text
+> /go Add these features to the existing structure instead of rebuilding the UI from scratch.
+```
+
+再次选择 **Save as Task**：
+
+```text
+What would you like to do?
+  ❯ Save as Task
+    Continue editing
+```
+
+运行并检查结果：
+
+```bash
+takt run
+takt list
+```
+
+此时继续使用相同循环：需要在本地检查时选择 **View diff**、**Try merge**；结果需要再次修改时选择 **Instruct**。
+
+## 4. 阶段 3：打磨体验
+
+最后打磨 UI 和交互细节。这很适合使用 **Instruct**，因为 TAKT 可以将当前结果作为上下文。
+
+```text
+> For phase 3, make the UI work well on narrow mobile widths.
+> Add a useful empty state, visible focus styles, and clearer category styling.
+> Keep it as a practical everyday tool, not a marketing landing page.
+```
+
+使用 `/go` 完成指令：
+
+```text
+> /go
+```
+
+选择 **Save as Task**：
+
+```text
+What would you like to do?
+  ❯ Save as Task
+    Continue editing
+```
+
+运行任务：
+
+```bash
+takt run
+```
+
+使用 `takt list` 检查结果。满意后选择 **Merge & cleanup**；如果想先在工作树中检查变更，选择 **Try merge**。
+
+```text
+Action for takt/20260201-015714-mini-expense-memo-ui:
+    View diff
+    Instruct
+    Merge from root
+    Pull from remote
+    Try merge
+  ❯ Merge & cleanup
+    Delete
+```
+
+基本循环如下：
+
+```text
+takt
+  -> choose frontend-mini
+  -> talk with assistant
+  -> /go
+  -> Save as Task
+takt run
+takt list
+  -> View diff
+  -> Try merge or Merge & cleanup
+  -> use Instruct when you want to queue the next phase
+```
+
+## 5. 创建 GitHub Issue，再将其加入队列
+
+在 GitHub 仓库中工作时，可以让 TAKT 根据对话创建 GitHub Issue，然后将该 Issue 加入任务队列。
+
+请确认 GitHub CLI 已认证：
+
+```bash
+gh auth status
+```
+
+启动 TAKT 并选择 `frontend-mini`：
+
+```bash
+takt
+```
+
+与 TAKT 讨论 Issue 内容：
+
+```text
+> For phase 2 of the mini expense memo UI, I want to add total amount, category filtering, deletion, and LocalStorage persistence.
+> Please organize this into a GitHub Issue with acceptance criteria.
+```
+
+内容准备好后使用 `/go`：
+
+```text
+> /go
+```
+
+检查生成的任务指令并选择 **Create Issue**：
+
+```text
+What would you like to do?
+    Execute now
+    Save as Task
+    Continue editing
+  ❯ Create Issue
+```
+
+`Create Issue` 会在一个流程中创建 Issue 并保存任务：Issue 创建后会直接进入 worktree 设置提问，不会返回操作菜单。如果已经知道 Issue 编号，也可以使用 `takt add`：
+
+```bash
+takt add #1
+```
+
+然后继续本地流程：
+
+```bash
+takt run
+takt list
+```
+
+使用 GitHub Issue 可以将需求、讨论和实现任务关联起来，这对团队开发尤其有用。
+
+## 6. 用 Codex 创建 Issue，再交给 TAKT
+
+如果你在 TAKT 之外与 Codex 或其他开发助手交流并创建了 GitHub Issue，仍然可以将 Issue 编号交给 TAKT。
+
+假设 Codex 创建了 Issue `#1`：
+
+```bash
+takt add #1
+```
+
+`takt add #1` 会获取 GitHub Issue 的标题、正文和评论，并将其保存为待处理的 TAKT 任务。
+
+运行任务：
+
+```bash
+takt run
+```
+
+检查结果：
+
+```bash
+takt list
+```
+
+这样可以让日常使用的 AI 或 GitHub 讨论负责创建 Issue，而让 TAKT 负责实现、审查和修复循环。
+
+## 下一步
+
+- [任务管理](./task-management.zh-CN.md)：`takt add`、`takt run` 和 `takt list` 的详细说明
+- [CLI 参考](./cli-reference.zh-CN.md)：所有命令和选项
+- [配置指南](./configuration.zh-CN.md)：provider、model、workflow 和其他设置

--- a/docs/workflows.ja.md
+++ b/docs/workflows.ja.md
@@ -1,6 +1,6 @@
 # Workflow ガイド
 
-[English](./workflows.md)
+[English](./workflows.md) | [日本語](./workflows.ja.md) | [简体中文](./workflows.zh-CN.md)
 
 このガイドでは TAKT の workflow を作成・カスタマイズする方法を説明します。
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,6 +1,6 @@
 # Workflow Guide
 
-[日本語](./workflows.ja.md)
+[English](./workflows.md) | [日本語](./workflows.ja.md) | [简体中文](./workflows.zh-CN.md)
 
 This guide explains how to create and customize TAKT workflows.
 

--- a/docs/workflows.zh-CN.md
+++ b/docs/workflows.zh-CN.md
@@ -1,0 +1,949 @@
+# Workflow 指南
+
+[English](./workflows.md) | [日本語](./workflows.ja.md) | [简体中文](./workflows.zh-CN.md)
+
+本文说明如何创建和定制 TAKT workflow。
+
+## Workflow 基础
+
+workflow 是定义 AI agent 执行的 step 序列的 YAML 文件。每个 step 指定：
+
+- 使用哪个 persona
+- 提供哪些指令
+- 如何根据规则路由到下一步
+
+## 文件位置
+
+- builtin workflow 内置在 npm package 的 `dist/resources/`
+- `~/.takt/workflows/` — 用户 workflow（同名时覆盖 builtin）
+- 使用 `takt eject <workflow>` 将 builtin 复制到 `~/.takt/workflows/` 后定制
+
+## Workflow 分类
+
+要在 workflow 选择 UI 中使用分类，请配置 `workflow_categories`。详见[配置指南](./configuration.zh-CN.md#workflow-categories)。
+
+## 创建 Workflow 文件
+
+使用 `takt workflow init <name>` 在 `.takt/workflows/` 创建自定义 workflow scaffold；传入 `--global` 时创建到 `~/.takt/workflows/`。
+
+- `--template minimal`：生成带通用 step 路由的自包含 scaffold
+- `--template faceted`：生成 workflow 以及本地 persona/instruction facet 文件
+
+编辑后运行 `takt workflow doctor <name or path>`，在执行前验证引用、路由目标和不可达 step。
+
+## Workflow Schema
+
+```yaml
+name: my-workflow
+description: Optional description
+max_steps: 10
+initial_step: first-step          # 可选，默认第一个 step
+
+all_steps:
+  rules:
+    - findings-handling
+    - ref: careful-findings
+      position: before_instruction
+
+# Section map（key → 相对于 workflow YAML 的文件路径）
+personas:
+  planner: ../facets/personas/planner.md
+  coder: ../facets/personas/coder.md
+  reviewer: ../facets/personas/architecture-reviewer.md
+policies:
+  coding: ../facets/policies/coding.md
+  review: ../facets/policies/review.md
+knowledge:
+  architecture: ../facets/knowledge/architecture.md
+instructions:
+  plan: ../facets/instructions/plan.md
+  implement: ../facets/instructions/implement.md
+report_formats:
+  plan: ../facets/output-contracts/plan.md
+
+steps:
+  - name: step-name
+    session_key: shared-coder        # 可选：此 step 的显式 session key
+    persona: coder                   # persona key（引用 personas map）
+    persona_name: coder              # 显示名称（可选，不影响 provider_routing.personas）
+    tags: [implementation, edit]     # provider routing tag（可选）
+    policy: coding                   # policy key（单值或数组）
+    knowledge: architecture          # knowledge key（单值或数组）
+    instruction: implement           # instruction key（引用 instructions map）
+    edit: true                       # step 是否可以编辑文件
+    required_permission_mode: edit   # 最低权限：readonly、edit 或 full
+    capabilities: edit               # 可选 capability preset
+    rules:
+      - condition: "Implementation complete"
+        next: next-step
+      - condition: "Cannot proceed"
+        next: ABORT
+    instruction: |                   # 内联指令
+      Your instructions here with {variables}
+    output_contracts:                # Report 文件配置
+      report:
+        - name: 00-plan.md
+          format: plan               # 引用 report_formats map
+    quality_gates:                   # agent step 完成 gate
+      - "Review the implementation before finishing" # AI 指令
+      - type: command                # 机器执行的命令 gate
+        name: quality-check
+        command: "./.takt/quality-gates/check.sh"
+        cwd: "."
+        timeout_ms: 300000
+```
+
+step 通过 key 引用 section map（例如 `persona: coder`），而不是直接引用文件路径。section map 中的路径相对于 workflow YAML 所在目录解析。section map 可以省略；裸名称会按项目 `.takt/facets/<type>/` → 全局 `~/.takt/facets/<type>/` → `builtins/{lang}/facets/<type>/` 查找。只有需要自定义别名或显式文件路径时才需要 map。
+
+### Workflow-wide 规则（`all_steps.rules`）
+
+在 `all_steps.rules` 中声明应用于每个 agent step 的规则。每项可以是规则引用，也可以是带 `ref` 和可选 `position: before_instruction` 的对象。省略 `position` 时规则放在自动执行规则之后；`before_instruction` 会将它放到 `Instructions` section 之前。
+
+规则文件是 `workflows/rules/<ref>.md`，按项目 `.takt/workflows/rules/` → 全局 `~/.takt/workflows/rules/` → builtin 目录查找。适用性提示和规则标题每个 prompt 只渲染一次。它们只影响 Phase 1 agent instruction，不影响 output report、状态路由或 companion reviewer。被调用的 workflow 会先继承父 workflow 的规则，再叠加自己的 `all_steps.rules`。规则文件不能包含 required-output heading 或 `{report:...}` 引用；省略 `all_steps` 会保留原有 prompt 行为。
+
+### 可复用 Step Fragment
+
+在 `steps/` 目录下创建只包含一个 step 对象的根级 `<name>.yaml` 或 `<name>.yml`，再使用 `uses` 引用：
+
+```yaml
+steps:
+  - name: final-gate
+    uses: final-gate
+    rules:
+      - condition: COMPLETE
+        next: COMPLETE
+```
+
+例如 `.takt/steps/final-gate.yaml` 可以是：
+
+```yaml
+kind: workflow_call
+call: supervisor-final-gate
+```
+
+每个声明 `uses` 的具体 workflow step（包括 parallel 子 step）都必须在调用位置声明自己的非空规则。非 parallel 调用方使用 `rules` 数组；parallel 调用方使用下面的 rule tree。fragment 根部不能声明 `rules`，因为路由必须由知道目标 step 名称的 workflow 拥有；loader 不会复制、继承或合成 fallback 规则。
+
+Fragment 可以在根级 `params` 中声明类型化参数，调用方通过 `with` 绑定。支持的参数类型包括 `facet_ref`、`facet_ref[]`（配合 `facet_kind: policy`、`knowledge`、`instruction`、`persona` 或 `report_format`）、`workflow_ref` 和 `facet_pool_ref`。可调用 workflow 的参数还可以通过 `workflow_call.args` 传入。用 `{ $param: name }` 引用参数；嵌套 fragment 使用词法作用域，必须显式通过 `with` 转发，不能隐式捕获外层参数。
+
+Fragment 不支持可选参数或默认参数。loader 会在 schema validation 前消费 `params`、`with` 和参数引用，验证缺失/未知绑定、类型或 cardinality 不匹配，并保留 `workflow_call` fragment 自身的 `args`。未展开的 `$param`、不支持字段中的参数引用以及未知 facet 都会在加载时失败。
+
+可调用 workflow 可以通过 `facet_pool_ref` 参数选择子 workflow 的本地实现 pool，而无需复制 fragment 定义：
+
+```yaml
+subworkflow:
+  callable: true
+  params:
+    implementation_pool:
+      type: facet_pool_ref
+      default: coding-facets
+
+facet_pools:
+  coding-facets:
+    candidates:
+      - id: backend
+        description: Handle backend changes
+        knowledge: backend
+
+steps:
+  - name: implement
+    uses: implementation-step
+    with:
+      implementation_pool:
+        $param: implementation_pool
+    dynamic_facets:
+      pool:
+        $param: implementation_pool
+```
+
+当 fragment 展开为 parallel step 时，调用方必须提供严格的 rule tree：`self` 是 parallel parent 的规则数组，`parallel` 为每个唯一最终 child name 映射规则数组；必须恰好列出所有 child。
+
+```yaml
+steps:
+  - name: reviewers
+    uses: reviewers
+    rules:
+      self:
+        - condition: all("approved")
+          next: COMPLETE
+      parallel:
+        architecture:
+          - condition: approved
+          - condition: needs_fix
+        security:
+          - condition: approved
+          - condition: needs_fix
+```
+
+对象字段深合并；`parallel` 等数组整体替换。名称按调用方 `name` → fragment `name` → `uses` 最终名称解析。fragment 可以引用其他 fragment，但循环引用会失败。裸名称按项目、全局、所选语言 builtin 的 `steps/` 查找；`@owner/repo/name` 显式选择 repertoire package。最多展开 64 层、总计 512 个引用；每个 fragment 必须是可读的普通文件且不超过 1 MiB。绝对路径、遍历、符号链接逃逸、不可读文件、循环引用和未知引用都是配置错误。
+
+## 可用变量
+
+| 变量 | 说明 |
+|------|------|
+| `{task}` | 原始用户请求（自动注入） |
+| `{iteration}` | workflow 总 turn 数（执行的 step 总数） |
+| `{max_steps}` | 允许的最大 step 数 |
+| `{step_iteration}` | 当前 step 执行次数 |
+| `{previous_response}` | 上一个 step 的输出（自动注入） |
+| `{user_inputs}` | workflow 中额外的用户输入（自动注入） |
+| `{report_dir}` | report 目录路径，例如 `.takt/runs/20250126-143052-task-summary/reports` |
+| `{report:filename}` | 内联 `{report_dir}/filename` 内容 |
+| `{review_scope}` | TAKT 计算出的本任务变更文件列表 |
+
+`{review_scope}` 包括工作树中的 committed changes、未提交 changes 和未跟踪文件（忽略文件除外）；PR-derived run 还会加入 PR 的 `base...head` diff。非 Git 目录或未检测到变更时会明确说明，而不是返回空字符串。列表超过 200 个文件时会显示剩余数量。通用 builtin reviewer 会自动获得该变量。
+
+`{task}`、`{previous_response}` 和 `{user_inputs}` 会自动注入 instruction；只有需要控制它们在模板中位置时才需要显式占位符。
+
+## Rules
+
+Rules 决定每个 step 如何路由到下一个 step。instruction builder 会自动注入状态输出规则，让 agent 知道应输出哪些 tag。
+
+```yaml
+rules:
+  - condition: "Implementation complete"
+    next: review
+  - condition: "Cannot proceed"
+    next: ABORT
+    appendix: |
+      Explain what is blocking progress.
+```
+
+### Rule 条件类型
+
+| 类型 | 语法 | 说明 |
+|------|------|------|
+| Semantic label | `approved` | status judge 选择一次去重后的 label |
+| State predicate | `when(...)` | 确定性地评估 workflow state |
+| Aggregate | `all("X")` / `any("X")` | 聚合 parallel 子 step 结果 |
+| Combined | `approved && when(...)` | 同时要求 label 和 state predicate |
+| Aggregate + state | `all("X") && when(...)` / `any("X") && when(...)` | 同时要求 aggregate 和 state predicate |
+
+规则按 YAML 顺序计算，选择第一个匹配项；不会按规则类型优先，也没有 fallback transition。没有规则匹配时 workflow 以 `rule_no_match` 中止。
+
+### 特殊 `next` 值
+
+- `COMPLETE` — workflow 成功结束
+- `ABORT` — workflow 失败结束
+
+### `appendix`
+
+可选的 `appendix` 是该规则匹配时附加 AI 输出的模板，适合结构化错误报告或要求特定信息。
+
+### `interactive_only`
+
+`interactive_only: true` 的规则只在交互执行中考虑。`--pipeline` 或 `takt run` 等非交互运行会跳过它，就像该规则未声明一样。可用于需要人工输入的转移。
+
+## Step 类型
+
+TAKT 支持 Normal、Parallel、Dynamic Parallel、Arpeggio、Team Leader、Workflow Call 和 System 七种 step 类型。
+
+### Normal Step
+
+单个 agent 执行 step；前面示例都是 Normal step。
+
+### Parallel Step
+
+子 step 并发执行，parent 通过 `all()` / `any()` 聚合结果：
+
+```yaml
+  - name: reviewers
+    parallel:
+      - name: arch-review
+        session_key: arch-review
+        persona: architecture-reviewer
+        policy: review
+        knowledge: architecture
+        edit: false
+        rules:
+          - condition: approved
+          - condition: needs_fix
+        instruction: review-arch
+      - name: security-review
+        session_key: security-review
+        persona: security-reviewer
+        policy: review
+        edit: false
+        rules:
+          - condition: approved
+          - condition: needs_fix
+        instruction: review-security
+    rules:
+      - condition: all("approved")
+        next: COMPLETE
+      - condition: any("needs_fix")
+        next: fix
+```
+
+- `all("X")`：所有子 step 都匹配 X 时为真
+- `any("X")`：任意子 step 匹配 X 时为真
+- 子 step 的 `rules` 定义可能结果；`next` 可省略，由 parent 路由
+- parallel 子 step 不支持 `promotion`
+- parent 可设置 `concurrency: <N>`（最小 1）限制并发数；省略时全部同时启动
+
+### Dynamic Parallel Step
+
+`parallel` 也可以定义固定集合和可选 pool。进入 step 时 TAKT 运行内部 selector；selector 不是 workflow step，不能创建 agent 或改变 workflow。selector 使用新 session 和只读权限，只能使用 `Read`、`Glob`、`Grep`（provider 遵守 allowlist 时）。
+
+```yaml
+  - name: reviewers
+    parallel:
+      fixed:
+        - name: architecture
+          persona: architecture-reviewer
+          instruction: Review architecture
+          rules: [{ condition: approved }]
+      pool:
+        - name: frontend
+          persona: frontend-reviewer
+          description: Review frontend and UI changes
+          instruction: Review frontend
+          rules: [{ condition: approved }]
+        - name: backend
+          persona: backend-reviewer
+          description: Review API and persistence changes
+          instruction: Review backend
+          rules: [{ condition: approved }]
+      selection:
+        mode: replace
+    rules:
+      - condition: all("approved")
+        next: COMPLETE
+```
+
+`pool` 必须非空，且每个 pool item 都需要非空 `description`。`fixed` 总是运行，selector 只能选择展开后的 pool step name。`replace`（默认）在新 round 替换上一轮 pool selection；`cumulative` 保留之前选中的 item。恢复运行不会恢复保存的 selection，而是针对当前 pool 再次调用 selector。
+
+`all()` 和 `any()` 只聚合当前 round 的 fixed 与 selected pool item。selector 输出无效或选择未知项时，在任何 agent 启动前失败；没有 all-pool fallback。缺失/空 pool、重复展开名称、非 agent 子 step、无效 selection mode、provider 未解析、严格 structured output 无效或 fixed 加 selected 为空都会在执行前失败。Selector 输入包括任务、Report Directory 路径、目标 report 名称、相对 `HEAD` 的变更文件路径、candidate ID/description、`cumulative` 的上一轮 selection 以及是否首次进入/新 round。报告引用按当前 scope、resume snapshot 和父 scope 解析；读取工具只允许 `Read`、`Glob` 和 `Grep`。
+
+### Dynamic Facet Selection（Facet Pool）
+
+Normal agent step 或 parallel 子 step 可以在 agent 启动前从经过验证的 candidate pool 动态选择额外的 `policy` 和 `knowledge` facet。固定 facet 始终保留，只附加当前情况需要的 facet。
+
+在 workflow 顶层 `facet_pools` 定义 pool，再通过 step 的 `dynamic_facets` 引用。pool 可以内联，也可以使用外部资源文件。
+
+#### 内联 Pool
+
+内联 pool 中的 candidate facet 引用使用 workflow 自己的 `policies` / `knowledge` section map，或同一 facet 命名空间中的裸名称。
+
+```yaml
+name: backend-fix
+
+policies:
+  transaction-correctness: ../facets/policies/transaction-correctness.md
+  backward-compatibility: ../facets/policies/backward-compatibility.md
+knowledge:
+  backend-api: ../facets/knowledge/backend-api.md
+  database-transaction: ../facets/knowledge/database-transaction.md
+
+facet_pools:
+  fix:
+    candidates:
+      - id: backend
+        description: Handle API, repository, and server-side implementation
+        knowledge: backend-api
+      - id: transaction
+        description: Handle transaction boundaries, rollback, and concurrency control
+        policy: transaction-correctness
+        knowledge: database-transaction
+      - id: backward-compatibility
+        description: Preserve compatibility of public APIs and schemas
+        policy: backward-compatibility
+
+steps:
+  - name: fix
+    persona: coder
+    policy: [coding, testing]
+    knowledge: architecture
+    dynamic_facets:
+      pool: fix
+      max_selected: 4
+    instruction: fix
+    edit: true
+    rules:
+      - condition: Fix complete
+        next: review
+```
+
+#### Candidate contract
+
+每个 candidate 共享以下结构：
+
+```yaml
+- id: transaction
+  description: Handle transaction boundaries and rollback
+  policy:
+    - transaction-correctness
+  knowledge:
+    - database-transaction
+```
+
+`id` 必须在 pool 内非空且唯一；`description` 必须是非空字符串；`policy` 和 `knowledge` 可以是标量或非空数组，并且至少提供其中一个。一个 candidate 可以代表单个 facet 或小型 facet bundle，selector 可以选择多个 candidate。空选择表示不需要额外 facet，是合法结果；同一 pool 中任意 candidate 组合必须有效，MVP 不引入 `requires`、`conflicts_with` 或互斥组。`max_selected` 可选；未设置时最多可选择 pool 中的全部 candidate。selector 失败时没有隐式的全选或空选 fallback。
+
+#### Parallel 子 Step
+
+`dynamic_facets` 也可以放在 static parallel child、dynamic parallel 的 fixed 或 pool item 上。participant selector 先运行，只有被选中的 child 才执行 facet selector；所有适用 selector 完成后才启动 parallel child。
+
+```yaml
+facet_pools:
+  security-review:
+    candidates:
+      - id: web
+        description: Review HTTP and browser security boundaries
+        knowledge: [security-web, security-api]
+      - id: cli
+        description: Review command-line and local process boundaries
+        knowledge: security-local
+
+steps:
+  - name: reviewers
+    parallel:
+      pool:
+        - name: security-review
+          description: Review security for the selected system
+          persona: security-reviewer
+          knowledge: security
+          dynamic_facets:
+            pool: security-review
+            max_selected: 1
+          instruction: review-security
+          rules: [{ condition: approved }]
+      selection:
+        mode: replace
+    rules:
+      - condition: all("approved")
+        next: COMPLETE
+```
+
+无效 pool、candidate ID 或 `max_selected` 会阻止该 child 及同一 parent 下的 sibling 启动。对于嵌套 callable workflow，应让拥有该 pool 的顶层 workflow 选择狭窄的 adapter，而不要把 pool 参数扩散到每个可能的 callable target；未声明的 callable 参数会在加载时被拒绝。
+
+#### Facet composition
+
+动态 facet 的有效组合为：
+
+```text
+effective policy    = fixed policy    + selected dynamic policy
+effective knowledge = fixed knowledge + selected dynamic knowledge
+```
+
+固定 facet 在前，动态 facet 按 pool 定义顺序追加；selector 返回顺序不改变 facet 顺序。重复的同一 resolved facet 会去重，固定侧优先。安全、隐私、授权和强制质量条件应放在固定侧。动态 facet 不能修改 persona、instruction、provider、permission、MCP、tools 或 output contract。
+
+#### Rounds、session 与 resume
+
+每次重新进入同一 step 作为新 round 时都会重新选择并替换上一次动态 selection；没有 cumulative 模式：
+
+```text
+round 1: selects frontend
+round 2: selects transaction
+
+round 2 effective facets:
+  fixed + transaction
+```
+
+主 agent session 按 round 隔离；进程 resume 从空的 run-local selection 开始并重新调用 selector。动态选择变化只在下一次到达 step 时生效。selector 结果和解析后的有效 facet 集会在主 agent 启动前写入 runtime state；加载时内联和外部 pool 会统一为同一种 resolved pool，执行阶段不会根据来源分支。MVP 不支持执行期间热切换 facet。
+
+#### External pool
+
+外部 pool 可以这样引用：
+
+```yaml
+facet_pools:
+  fix:
+    uses: implementation-fix
+```
+
+`facet-pools/implementation-fix.yaml` 必须只定义一个 pool 资源；它的 facet 引用只在该文件自己的 section map 中解析：
+
+```yaml
+policies:
+  transaction-correctness: ../facets/policies/transaction-correctness.md
+  backward-compatibility: ../facets/policies/backward-compatibility.md
+
+knowledge:
+  backend-api: ../facets/knowledge/backend-api.md
+  database-transaction: ../facets/knowledge/database-transaction.md
+
+candidates:
+  - id: backend
+    description: Handle API, repository, and server-side implementation
+    knowledge: backend-api
+  - id: transaction
+    description: Handle transaction boundaries, rollback, and concurrency control
+    policy: transaction-correctness
+    knowledge: database-transaction
+  - id: backward-compatibility
+    description: Preserve compatibility of public APIs and schemas
+    policy: backward-compatibility
+```
+
+外部 pool 不支持嵌套 `uses`、`params` 或 `$param`，也不能与内联 `policies`、`knowledge`、`candidates` 混用。
+
+#### External pool lookup
+
+查找顺序是 repertoire package 本地、项目 `.takt/facet-pools/`、全局 `$TAKT_CONFIG_DIR/facet-pools/`、`builtins/<lang>/facet-pools/`、共享 builtin `builtins/facet-pools/`；每层先查 `<name>.yaml` 再查 `<name>.yml`。`@owner/repo/name` 显式选择 repertoire package。绝对路径、遍历、root-escaping symlink、不可读和过大的文件会被拒绝；来源和依赖资源会被跟踪，供 doctor、preview、eject 以及 repertoire install/remove 使用。
+
+#### Selector contract
+
+selector 使用新 session、只读权限和 `Read`/`Glob`/`Grep` 工具。输入包括用户请求、叶 workflow、workflow-call instance、step identity、round 信息、Report Directory 和 report 名称、调用时 `git diff HEAD` 对应的变更路径以及 candidate ID/description。candidate facet body 不会单独发送；selector 通过读取目标 prompt 和 report 获取所需上下文。输出必须是只含 `selected_ids` 和 `rationale` 的严格 JSON；未知/重复 ID、非数组和超出 `max_selected` 都会在主 agent 启动前失败，失败时没有 fallback。selector guidance 可以配置 `instruction`（必填）和 `persona`（可选）：
+
+```yaml
+steps:
+  - name: fix
+    dynamic_facets:
+      pool: implementation
+      selector:
+        persona: facet-selector
+        instruction: select-implement-facets
+  - name: reviewers
+    parallel:
+      fixed: []
+      pool:
+        - name: backend
+          persona: backend-reviewer
+          description: Review backend changes
+          instruction: Review the backend
+          rules: [{ condition: approved }]
+      selection:
+        mode: replace
+        selector:
+          persona: reviewer-selector
+          instruction: select-reviewers
+```
+
+#### Fail-fast conditions
+
+在执行前加载失败的情况包括：pool schema 无效、pool 为空、candidate ID 重复、description 缺失、candidate 同时没有 `policy` 和 `knowledge`、facet 引用未知、`uses` 与内联字段混用、外部 pool 隐式引用调用方 facet namespace、外部资源 lookup/trust/文件校验失败、`dynamic_facets.pool` 未知、`max_selected` 无效或超过 candidate 数量，以及 dynamic facet 写在非 agent step 或 parallel parent 上。selector provider 无法解析、structured output 未建立、`selected_ids` 不是数组，或出现非字符串/重复/未知 ID 时，也会在主 agent 启动前失败。
+
+#### Selector guidance
+
+配置 selector 时，`instruction` 必填、`persona` 可选；guidance 只描述如何选择 facet 或 participant ID。证据引用、只读 structured 执行和工具、输出契约、candidate 校验、selection mode 与权限绕过禁用仍由 TAKT 负责。selector 不能改变 selected agent 的 persona、instruction、provider、权限、tools、MCP 或 output contract。未知 selector key、空 selector、缺少 instruction 或无法解析的 persona/instruction 会在校验时失败。
+
+#### Packages、eject 与 authoring tools
+
+Repertoire package 可以安装/移除 `facet-pools/`；`takt workflow eject` 会复制外部 pool 及其 facet 依赖；`takt workflow doctor` 校验 pool、candidate 和 facet 引用；`takt workflow preview` 显示 pool 名称、candidate ID、引用的 facet 和来源。builtin en/ja pool（如果提供）应保持相同的 candidate ID 集合。
+
+### Arpeggio Step
+
+从 CSV、JSON 等 data source 读取数据，并以受限并发对每行应用相同 step 模板：
+
+```yaml
+  - name: batch-process
+    persona: coder
+    arpeggio:
+      source: csv
+      source_path: ./data/items.csv
+      batch_size: 5
+      concurrency: 3
+      template: ./templates/process.txt
+      max_retries: 2
+      retry_delay_ms: 1000
+      merge:
+        strategy: concat
+        separator: "\n---\n"
+      output_path: ./output/result.txt
+    rules:
+      - condition: "Processing complete"
+        next: COMPLETE
+```
+
+`merge.strategy` 可以是默认的 `concat` 或 `custom`。`concat` 拼接每行结果，不接受 `inline_js` 或 `file`；`custom` 必须提供其中一个。用于批量处理文件列表、Issue 列表或生成的测试用例。
+
+### Team Leader Step
+
+Team Leader agent 在运行时将任务分解成独立子部分，并把每部分派给 worker agent：
+
+```yaml
+  - name: implement
+    team_leader:
+      max_concurrency: 2
+      initial_max_parts: 2
+      timeout_ms: 600000
+      inspect_tools: [read, glob, grep]
+      part_tags: [coding]
+      part_persona: coder
+      part_edit: true
+      part_permission_mode: edit
+      part_allowed_tools: [Read, Glob, Grep, Edit, Write, Bash]
+    instruction: |
+      Decompose this task into independent subtasks.
+    rules:
+      - condition: "All parts completed"
+        next: review
+```
+
+`max_concurrency` 和兼容 key `max_parts` 最大为 3；均省略时默认 3。`initial_max_parts` 只限制第一批分解。每批完成后才请求下一批，因此同一批的 parts 不应互相依赖。`part_tags` 设置生成 part step 的 provider routing tags；省略时继承父 step 的 tags。`inspect_tools` 只控制分解阶段的只读工具，生成的 child part 工具由 `part_allowed_tools` 单独控制。
+
+### Workflow Call Step（Subworkflow）
+
+一个 step 调用另一个 workflow。子 workflow 在同一次 run 中运行，结果通过父级 `rules` 路由：
+
+```yaml
+  - name: peer-review
+    kind: workflow_call
+    call: peer-review
+    args:
+      impl_knowledge: cqrs-es
+    rules:
+      - condition: approved
+        next: COMPLETE
+      - condition: needs_fix
+        next: fix
+```
+
+子 workflow 可以通过 `subworkflow.params` 声明参数，父级用 `args` 传值。`workflow_call` 规则只能使用 `COMPLETE`、`ABORT` 或子 workflow 在 `subworkflow.returns` 中声明的 semantic return label。子 step 使用 `return:` 结束子 workflow，父级再按该 label 路由。
+
+`workflow_call` 不接受 provider、model、provider-options 或 routing override；子 workflow 继承父级已经解析的 runtime context，provider target/profile/options/routing 必须在 `runtime.yaml` 配置。`max_steps` 由根 workflow 拥有并在所有后代之间共享，workflow_call 本身不消耗预算。
+
+可调用 workflow 还可以通过 `vars` 传递非 facet 的执行上下文；agent instruction 用 `{var:name}` 读取。嵌套调用会继承字符串、有限数字和布尔值，重新声明同名 key 时覆盖父值；缺失值会渲染为 `unspecified`，instruction 可以据此显式定义安全 fallback。`workflow_call` 是 control node，不是 agent step。
+
+```yaml
+- name: follow-up-review
+  kind: workflow_call
+  call: peer-review-suite
+  vars:
+    review_mode: follow_up
+  rules:
+    - condition: COMPLETE
+      next: COMPLETE
+```
+
+### System Step
+
+System step 由 TAKT engine 执行，不启动 agent。使用 `kind: system` 或简写 `mode: system`，两者不能同时声明。System step 不能声明 `persona`、`instruction`、`provider`、`structured_output`、`output_contracts` 或 `quality_gates` 等 agent 字段。
+
+`system_inputs` 从 engine context 读取并通过 `as` 绑定名称；支持 `task_context`、`branch_context`、`pr_context`、`issue_context`、`task_queue_context`、`pr_list`、`pr_selection`、`issue_list` 和 `issue_selection`。绑定的值可通过 `when(context.<step>.<binding>...)` 使用，也可在后续 agent instruction 中使用 `{context:step.binding.field}`：
+
+```yaml
+  - name: route_context
+    mode: system
+    system_inputs:
+      - type: task_queue_context
+        source: current_project
+        as: active_queue
+        exclude_current_task: true
+      - type: pr_selection
+        source: current_project
+        as: selected_pr
+    rules:
+      - condition: when(context.route_context.active_queue.pending_count > 0)
+        next: wait_before_next_scan
+      - condition: when(context.route_context.selected_pr.exists == true)
+        next: plan_from_existing_pr
+```
+
+`effects` 执行 engine-side action：`enqueue_task`、`comment_pr`、`sync_with_root`、`resolve_conflicts_with_ai`、`merge_pr` 和 `close_pr`。每种 effect 在一个 step 中最多一次，结果通过 `when(effect.<step>.<type>.<field>)` 路由。
+
+```yaml
+  - name: prepare_merge
+    mode: system
+    effects:
+      - type: sync_with_root
+        pr: "{context:route_context.selected_pr.number}"
+    rules:
+      - condition: when(effect.prepare_merge.sync_with_root.success == true)
+        next: merge_pr
+      - condition: when(effect.prepare_merge.sync_with_root.conflicted == true)
+        next: resolve_conflicts
+```
+
+System step 可与 agent step 的 `structured_output` 配合：agent step 使用 `structured_output: { schema_ref: <name> }`，引用顶层 `schemas:` map；验证后的字段可用于 `when(structured.<step>.<field> ...)` 和 `{structured:step.field}`。`structured_output` 不属于 system step。
+
+## Output Contract（Report 文件）
+
+Step 可以在 report 目录生成 report 文件：
+
+```yaml
+# 使用 report_formats map 的单个 report
+output_contracts:
+  report:
+    - name: 00-plan.md
+      format: plan
+
+# 内联 format
+output_contracts:
+  report:
+    - name: 00-plan.md
+      format: |
+        # Plan
+        ...
+
+# 多个 report
+output_contracts:
+  report:
+    - name: 01-scope.md
+      format: scope
+    - name: 02-decisions.md
+      format: decisions
+```
+
+每项必须有 `name` 和 `format`。可选字段：`use_judge`（默认 `true`，决定 report 是否作为 Phase 3 status judgment 证据）和 `order`（替换默认 report-writing instruction 的 report-format facet）。需要 judgment 的规则至少保留一个 `use_judge` report。
+
+## Runtime Provider Promotion
+
+Workflow promotion 只推进 `runtime.yaml` 选择的 ladder。每项必须严格是 `{at: N}`；provider、model、provider-options 和 condition 字段会在加载时被拒绝：
+
+```yaml
+steps:
+  - name: review
+    persona: reviewer
+    promotion:
+      - at: 3
+      - at: 6
+```
+
+每个阶段的 provider/model/options 在 `runtime.yaml` 定义。parallel 子 step 不支持 promotion。
+
+## Step 选项
+
+| 选项 | 默认值 | 说明 |
+|------|--------|------|
+| `description` | - | step 描述；dynamic parallel pool item 必须使用非空值 |
+| `persona` | - | persona key 或裸 facet 名称 |
+| `persona_name` | - | 日志和 prompt 中的显示名，不影响 routing |
+| `session_key` | - | normal agent step 和 parallel 子 step 的显式 session key；provider 会追加到 runtime key |
+| `session` | `continue` | `continue` 恢复 session，`refresh` 不恢复，`compact` 恢复后在 Phase 1 前请求 provider 压缩 |
+| `requires_user_input` | `false` | 标记可等待用户输入的 normal agent step；需要交互模式和 input handler |
+| `tags` | - | 按顺序与配置中的 `provider_routing.tags` 匹配 |
+| `policy` | - | policy key 或数组 |
+| `knowledge` | - | knowledge key 或数组 |
+| `instruction` | - | instruction key |
+| `edit` | - | 是否可以编辑项目文件 |
+| `companion` | - | 与 normal agent step 并行运行 companion reviewer |
+| `completion_retry` | - | opt-in 的 reviewer 完整性检查与有界重试 |
+| `pass_previous_response` | `true` | 将上一个 step 输出传给 `{previous_response}` |
+| `capabilities` | - | capability preset；解析工具、网络、sandbox 和 skill，不选择 provider/model |
+| `mcp_servers` | - | step 级 MCP server 配置 |
+| `allow_git_commit` | `false` | 允许 instruction 中执行 `git add` / `commit` / `push` |
+| `required_permission_mode` | - | 最低权限：`readonly`、`edit` 或 `full` |
+| `output_contracts` | - | report 文件配置 |
+| `quality_gates` | - | agent step 完成 gate；字符串是 AI 指令，`type: command` 是机器 gate |
+
+`completion_retry` 是只接受对象的显式 opt-in，要求 `retry_instruction`，可选 `min_retry` 与 `max_retry`。`max_retry` 未设置时内部上限为 4；`review_completion` 仍是已弃用别名，不能与 `completion_retry` 同时使用。Provider 和 model 不是 workflow 字段，必须由 runtime profile/routing 提供；workflow 中写入已移除字段会在加载边界失败。
+
+## Workflow 级配置
+
+### `max_steps`
+
+run 的迭代预算必须是正整数，或用于持续循环 workflow 的 `infinite`：
+
+```yaml
+max_steps: infinite
+```
+
+根 workflow 拥有预算，可调用的子 workflow 不能声明自己的 `max_steps`。
+
+### `schemas`
+
+`structured_output.schema_ref` 映射到 schema 名称。文件按项目 `.takt/schemas/` → `~/.takt/schemas/` → bundled `schemas/` 查找：
+
+```yaml
+schemas:
+  followup-task: followup-task
+  pr-followup-task: pr-followup-task
+```
+
+### Provider Routing 与自动路由
+
+`auto_routing`、provider/model 默认值、provider options 和 routing 都不是 workflow YAML 字段。它们由 `runtime.yaml`（或保留的旧版 `config.yaml`）管理。workflow YAML 中唯一的 provider option surface 是 `capabilities`；`rate_limit_fallback` 也不能写进 workflow YAML。
+
+### `interactive_mode`
+
+`takt` 不带参数时使用的默认交互模式，可选 `assistant`（默认）、`grill-me`、`passthrough`、`quiet`、`persona`：
+
+```yaml
+interactive_mode: assistant
+```
+
+### 已移除的 Workflow 执行设置
+
+`workflow_config.provider`、`workflow_config.model`、`workflow_config.provider_options`、step `provider`/`model`/`provider_options`、`loop_monitors.judge` 的 provider 设置以及 `workflow_call.overrides` 都会被拒绝。请迁移到 `runtime.yaml`；`workflow_config.runtime.prepare` 仍然支持。
+
+### `capabilities`
+
+`capabilities` 可以在 workflow 顶层、step 或 parallel 子 step 使用。step 自己的值替换 workflow 默认值；数组按从左到右合并。常见 preset 是 `readonly`、`edit` 和 `enable-skills`，只能引用 capability preset，不能写内联 provider option。`system` 和 `workflow_call` 不接受 `capabilities`。preset 只能提供 `allowed_tools`、`network_access`、`sandbox` 和 `skills` 等能力 leaf；`effort`、`base_url`、`guards` 等质量或机器配置必须放入 `runtime.yaml`。
+
+```yaml
+capabilities: readonly
+
+steps:
+  - name: implement
+    capabilities: [edit, enable-skills]
+```
+
+### `workflow_config.runtime`
+
+在 workflow 执行前准备运行环境。builtin `node`/`gradle` preset 始终允许；自定义脚本需要 `workflow_runtime_prepare.custom_scripts: true`：
+
+```yaml
+workflow_config:
+  runtime:
+    prepare: [node, gradle, ./custom-script.sh]
+```
+
+### `loop_monitors`
+
+检测 step 间循环并让 AI judge 判断是否取得进展：
+
+```yaml
+loop_monitors:
+  - cycle: [review, fix]
+    ignore_steps: [verify]
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction: "Evaluate if the fix loop is making progress..."
+      rules:
+        - condition: "Progress is being made"
+          next: fix
+        - condition: "No progress"
+          next: ABORT
+```
+
+`loop_monitors.judge` 不接受 provider、model 或 provider-options；使用 `provider.targets.internal_agents.loop-judge` 的 runtime target 或触发 step 的 fallback。judge 始终使用新 session，因此不接受 `session_key`。限流 fallback 也必须在 runtime 或旧版 config 中配置。
+
+### `subworkflow`
+
+可调用 workflow 可以这样声明参数：
+
+```yaml
+subworkflow:
+  callable: true
+  visibility: internal
+  params:
+    impl_knowledge:
+      type: facet_ref[]
+      facet_kind: knowledge
+      default: []
+    supervisor_persona:
+      type: facet_ref
+      facet_kind: persona
+      default: supervisor
+    reviewer_suite:
+      type: workflow_ref
+      default: peer-review-suite-base
+```
+
+`facet_ref`、`facet_ref[]` 使用 `facet_kind`：`policy`、`knowledge`、`instruction`、`persona` 或 `report_format`。`workflow_ref` 用于 `call: { $param: reviewer_suite }`；`facet_pool_ref` 用于 `dynamic_facets.pool`；`companion_ref[]` 用于普通 agent step 的固定 companion。参数默认值可选，数组参数可以为空；`facet_ref[]` 在 `policy` 或 `knowledge` 中会在原位置展开，`facet_pool_ref` 必须是 child 顶层 `facet_pools` 的标量 key，`companion_ref[]` 的空数组会省略 `companion` 字段。未知 child-local pool、未展开参数、非数组 companion 参数和未知 companion 定义都会在执行前失败。
+
+## 示例
+
+### 简单实现 Workflow
+
+```yaml
+name: simple-impl
+max_steps: 5
+
+personas:
+  coder: ../facets/personas/coder.md
+
+steps:
+  - name: implement
+    persona: coder
+    edit: true
+    required_permission_mode: edit
+    capabilities: edit
+    rules:
+      - condition: Implementation complete
+        next: COMPLETE
+      - condition: Cannot proceed
+        next: ABORT
+    instruction: |
+      Implement the requested changes.
+```
+
+### 带审查的 Workflow
+
+```yaml
+name: with-review
+max_steps: 10
+
+personas:
+  coder: ../facets/personas/coder.md
+  reviewer: ../facets/personas/architecture-reviewer.md
+
+steps:
+  - name: implement
+    persona: coder
+    edit: true
+    required_permission_mode: edit
+    capabilities: edit
+    rules:
+      - condition: Implementation complete
+        next: review
+      - condition: Cannot proceed
+        next: ABORT
+    instruction: |
+      Implement the requested changes.
+
+  - name: review
+    persona: reviewer
+    edit: false
+    capabilities: readonly
+    rules:
+      - condition: Approved
+        next: COMPLETE
+      - condition: Needs fix
+        next: implement
+    instruction: |
+      Review the implementation for code quality and best practices.
+```
+
+### 在 Step 间传递数据
+
+```yaml
+personas:
+  planner: ../facets/personas/planner.md
+  coder: ../facets/personas/coder.md
+
+steps:
+  - name: analyze
+    persona: planner
+    edit: false
+    capabilities: readonly
+    rules:
+      - condition: Analysis complete
+        next: implement
+    instruction: |
+      Analyze this request and create a plan.
+
+  - name: implement
+    persona: coder
+    edit: true
+    pass_previous_response: true
+    required_permission_mode: edit
+    capabilities: edit
+    rules:
+      - condition: Implementation complete
+        next: COMPLETE
+    instruction: |
+      Implement based on this analysis:
+      {previous_response}
+```
+
+## Companion Reviewer
+
+在普通 agent step 上增加 `companion`，即可在主 agent 编辑时运行无状态、只读 reviewer。列表形式选择固定 reviewer；对象形式可以组合 fixed、启动时选择一次的 pool 和可选 moderator，最多同时运行三个 reviewer。
+
+Companion 默认禁用；在 `runtime.yaml` 设置 `companion.enabled: true` 才会运行 workflow 声明的 companion。
+
+```yaml
+- name: implement
+  persona: coder
+  companion:
+    fixed: [security-reviewer]
+    pool: [design-reviewer, frontend-reviewer]
+    moderator: adjudicator
+  rules:
+    - condition: implementation complete
+      next: final-review
+```
+
+workflow transition rule 不能引用 `companion.*` state。companion finding 和 failure 是 advisory diagnostic；主 workflow 仍由普通 semantic condition 和 Phase 3 judgment 控制。定义文件按 `.takt/companions/` → `~/.takt/companions/` → `builtins/{language}/companions/` 查找，只能包含名称、描述、facet 引用和 `interval_ms`，不能包含 provider/tool 设置；`interval_ms` 必须是 1 到 `2,147,483,647` 的正整数。
+
+TAKT 观察 mutating tool event，并在 quiet period 或强制间隔后审查当前累计 diff。每个 round 使用新的 finding list；可选 moderator 按 round-local index 接受或拒绝 finding。已接受 finding 以 NDJSON 写入 `.takt/runs/{run}/companion/{step}/{companion}.jsonl`。在 implementer 每个 turn 边界，未传递的 finding 会直接嵌入 follow-up prompt，然后清空内存缓冲；implementer 决定是否处理并说明不处理原因。完成时停止新触发、排空 review round，只有 diff digest 未审查时才执行 completion review。取消通过 workflow 或 step abort signal 终止 follow-up loop；follow-up 的错误、限流或 blocked 会停止 follow-up，并继续使用最近一次成功的 implementer response。
+
+## 最佳实践
+
+1. **控制迭代数** — 开发 workflow 通常使用 10-30 次
+2. **审查 step 使用 `edit: false`** — 防止 reviewer 修改代码
+3. **使用描述性 step 名称** — 便于阅读日志
+4. **逐步测试 workflow** — 从简单版本开始再增加复杂度
+5. **使用 `takt eject` 定制** — 先复制 builtin workflow，而不是从零编写

--- a/docs/workflows.zh-CN.md
+++ b/docs/workflows.zh-CN.md
@@ -69,7 +69,6 @@ steps:
     tags: [implementation, edit]     # provider routing tag（可选）
     policy: coding                   # policy key（单值或数组）
     knowledge: architecture          # knowledge key（单值或数组）
-    instruction: implement           # instruction key（引用 instructions map）
     edit: true                       # step 是否可以编辑文件
     required_permission_mode: edit   # 最低权限：readonly、edit 或 full
     capabilities: edit               # 可选 capability preset
@@ -355,7 +354,7 @@ steps:
     knowledge: architecture
     dynamic_facets:
       pool: fix
-      max_selected: 4
+      max_selected: 3
     instruction: fix
     edit: true
     rules:


### PR DESCRIPTION
## Summary
- add Simplified Chinese (`zh-CN`) README/tutorial/reference documentation
- add language-switch links and document translation coverage
- preserve existing commands, configuration keys, provider names, links, and code examples

Closes #1385

## Validation
- `git diff --check`
- lightweight local-link spot check: passed
- broad build/lint/test/E2E checks: intentionally skipped for this docs-only task


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - TAKT の README、CLI、設定、タスク管理、チュートリアル、ワークフロー、外部連携などに簡体字中国語版を追加しました。
  - 各言語ドキュメント間の切り替えリンクを拡充しました。
  - 中国語ドキュメントで、導入方法、設定、CLI 操作、ワークフロー、タスク管理、外部連携などを詳しく案内しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->