### PR TITLE
fix(opencode): サーバ子プロセスのstdioエラーを局所処理しEPIPEによるプロセス墜落を解消する

### DIFF
--- a/src/__tests__/helpers/opencode-server-process-test-helpers.ts
+++ b/src/__tests__/helpers/opencode-server-process-test-helpers.ts
@@ -1,0 +1,42 @@
+export interface OpenCodeServerTestStartOptions {
+  port: number;
+  timeoutMs: number;
+  config: Record<string, unknown>;
+}
+
+interface OpenCodeSdkStartOptions {
+  port: number;
+  timeout: number;
+  config: Record<string, unknown>;
+}
+
+interface OpenCodeSdkServer {
+  close: () => void;
+  onError?: (listener: (error: Error) => void) => () => void;
+}
+
+interface OpenCodeSdkStartResult<TClient> {
+  client: TClient;
+  server: OpenCodeSdkServer;
+}
+
+export function createOpenCodeServerStartMock<TClient>(
+  createOpencode: (options: OpenCodeSdkStartOptions) => Promise<OpenCodeSdkStartResult<TClient>>,
+): (options: OpenCodeServerTestStartOptions) => Promise<{
+  client: TClient;
+  close: () => void;
+  onError: (listener: (error: Error) => void) => () => void;
+}> {
+  return async (options) => {
+    const result = await createOpencode({
+      port: options.port,
+      timeout: options.timeoutMs,
+      config: options.config,
+    });
+    return {
+      client: result.client,
+      close: result.server.close,
+      onError: (listener) => result.server.onError?.(listener) ?? (() => {}),
+    };
+  };
+}

--- a/src/__tests__/opencode-client-cleanup.test.ts
+++ b/src/__tests__/opencode-client-cleanup.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 import {
   OPENCODE_STREAM_EVENT_LIMIT,
   OPENCODE_STREAM_ID_LIMIT,
@@ -39,6 +40,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 describe('OpenCodeClient stream cleanup', () => {
@@ -1230,5 +1235,61 @@ describe('OpenCodeClient stream cleanup', () => {
     expect(sessionCreate).toHaveBeenCalledTimes(2);
     expect(promptAsync).toHaveBeenCalledTimes(2);
     expect(subscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('should propagate an EPIPE from the OpenCode server stdio to AgentResponse.error', async () => {
+    const { OpenCodeClient } = await import('../infra/opencode/client.js');
+    const sessionId = 'session-epipe-on-stream-error';
+    let serverErrorListener: ((error: Error) => void) | undefined;
+    let stream: StallingEventStream | undefined;
+    const sessionAbort = successfulSessionAbort();
+    const serverOnError = vi.fn((listener: (error: Error) => void) => {
+      serverErrorListener = listener;
+      return () => {
+        if (serverErrorListener === listener) serverErrorListener = undefined;
+      };
+    });
+    const promptAsync = vi.fn().mockImplementation(() => {
+      queueMicrotask(() => {
+        serverErrorListener?.(Object.assign(new Error('OpenCode server stderr stream failed: write EPIPE'), { code: 'EPIPE' }));
+      });
+      return Promise.resolve(undefined);
+    });
+
+    createOpencodeMock.mockResolvedValue({
+      client: {
+        instance: { dispose: vi.fn() },
+        session: {
+          create: vi.fn().mockResolvedValue({ data: { id: sessionId } }),
+          promptAsync,
+          abort: sessionAbort,
+        },
+        event: {
+          subscribe: vi.fn().mockImplementation((_input: unknown, options: { signal: AbortSignal }) => {
+            stream = new StallingEventStream({
+              type: 'message.part.updated',
+              properties: {
+                part: { id: 'part-epipe', sessionID: sessionId, type: 'text', text: 'partial' },
+                delta: 'partial',
+              },
+            }, options.signal);
+            return Promise.resolve({ stream });
+          }),
+        },
+        permission: { reply: vi.fn() },
+      },
+      server: { close: vi.fn(), onError: serverOnError },
+    });
+
+    const client = new OpenCodeClient();
+    const result = await Promise.race([
+      client.call('coder', 'hello', { cwd: '/tmp', model: 'opencode/big-pickle' }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timed out')), 500)),
+    ]);
+
+    expect(serverOnError).toHaveBeenCalledOnce();
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('OpenCode server stderr stream failed: write EPIPE');
+    expect(stream?.returnSpy).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/opencode-client-compaction.test.ts
+++ b/src/__tests__/opencode-client-compaction.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 
 const { createOpencodeMock } = vi.hoisted(() => ({
   createOpencodeMock: vi.fn(),
@@ -23,6 +24,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 const { OpenCodeClient, resetSharedServer } = await import('../infra/opencode/client.js');

--- a/src/__tests__/opencode-client-env.test.ts
+++ b/src/__tests__/opencode-client-env.test.ts
@@ -1,5 +1,6 @@
 import { context, propagation, ROOT_CONTEXT, trace } from '@opentelemetry/api';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 import {
   deferred,
   successfulSessionAbort,
@@ -32,6 +33,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 describe('OpenCodeClient child process env', () => {

--- a/src/__tests__/opencode-client-permission.test.ts
+++ b/src/__tests__/opencode-client-permission.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 import { AskUserQuestionDeniedError } from '../core/workflow/ask-user-question-error.js';
 import {
   MockEventStream,
@@ -31,6 +32,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 describe('OpenCodeClient permissions', () => {

--- a/src/__tests__/opencode-client-queue.test.ts
+++ b/src/__tests__/opencode-client-queue.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 import type { AgentResponse } from '../core/models/response.js';
 import {
   MockEventStream,
@@ -31,6 +32,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 describe('OpenCodeClient session queue', () => {

--- a/src/__tests__/opencode-client-retry.test.ts
+++ b/src/__tests__/opencode-client-retry.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -139,6 +140,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 const { OpenCodeClient, resetSharedServer } = await import('../infra/opencode/client.js');

--- a/src/__tests__/opencode-client-shared-server.test.ts
+++ b/src/__tests__/opencode-client-shared-server.test.ts
@@ -64,6 +64,46 @@ describe('OpenCodeClient shared server', () => {
     resetSharedServer();
   });
 
+  it('should discard a server invalidated while its error listener is registered', async () => {
+    const {
+      acquireOpenCodeClient,
+      OpenCodeSharedServerInvalidationError,
+      resetSharedServerPool,
+    } = await import('../infra/opencode/server-pool.js');
+    const startupRuntimeError = new Error('server failed before listener registration');
+    const firstServerClose = vi.fn();
+    const secondServerClose = vi.fn();
+    const secondClient = {};
+
+    createOpencodeMock
+      .mockResolvedValueOnce({
+        client: {},
+        server: {
+          close: firstServerClose,
+          onError: (listener: (error: Error) => void) => {
+            listener(startupRuntimeError);
+            return () => {};
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        client: secondClient,
+        server: { close: secondServerClose },
+      });
+
+    await expect(acquireOpenCodeClient('opencode/model', undefined, undefined))
+      .rejects.toBeInstanceOf(OpenCodeSharedServerInvalidationError);
+
+    const acquired = await acquireOpenCodeClient('opencode/model', undefined, undefined);
+
+    expect(acquired.client).toBe(secondClient);
+    expect(createOpencodeMock).toHaveBeenCalledTimes(2);
+    acquired.release();
+    resetSharedServerPool();
+    expect(firstServerClose).toHaveBeenCalledOnce();
+    expect(secondServerClose).toHaveBeenCalledOnce();
+  });
+
   it('should release the shared OpenCode client once when session.create returns no id', async () => {
     const { OpenCodeClient, resetSharedServer } = await import('../infra/opencode/client.js');
     resetSharedServer();

--- a/src/__tests__/opencode-client-shared-server.test.ts
+++ b/src/__tests__/opencode-client-shared-server.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { resetDebugLogger, setVerboseConsole } from '../shared/utils/index.js';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 import {
   MockEventStream,
   deferred,
@@ -35,6 +36,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 vi.mock('../shared/utils/index.js', async (importOriginal) => {

--- a/src/__tests__/opencode-client-structured-output.test.ts
+++ b/src/__tests__/opencode-client-structured-output.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 import {
   MockEventStream,
   textPartUpdated,
@@ -36,6 +37,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 describe('OpenCodeClient structured output', () => {

--- a/src/__tests__/opencode-client-tool-loop.test.ts
+++ b/src/__tests__/opencode-client-tool-loop.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 import {
   MockEventStream,
   textPartUpdated,
@@ -36,6 +37,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 describe('OpenCodeClient tool loop recovery', () => {

--- a/src/__tests__/opencode-server-process.test.ts
+++ b/src/__tests__/opencode-server-process.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { crossSpawnMock, createClientMock } = vi.hoisted(() => ({
   crossSpawnMock: vi.fn(),
@@ -17,44 +17,260 @@ vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencodeClient: createClientMock,
 }));
 
-describe('OpenCode server process', () => {
-  it('should convert child stdio EPIPE into a server error without an unhandled event', async () => {
-    const stdin = new EventEmitter();
-    const stdout = new EventEmitter();
-    const stderr = new EventEmitter();
-    const child = Object.assign(new EventEmitter(), {
-      stdin,
-      stdout,
-      stderr,
-      exitCode: null,
-      signalCode: null,
-      kill: vi.fn(() => true),
-    }) as unknown as ChildProcess;
-    const client = {};
-    crossSpawnMock.mockReturnValue(child);
-    createClientMock.mockReturnValue(client);
+interface TestChildProcess {
+  child: ChildProcess;
+  stdin: EventEmitter;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+}
 
-    const { startOpenCodeServer } = await import('../infra/opencode/server-process.js');
-    const startPromise = startOpenCodeServer({
-      port: 62000,
-      timeoutMs: 100,
-      config: { model: 'opencode/model' },
-    });
-    stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000\n');
+interface MutableChildProcessState {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill: (signal?: number | NodeJS.Signals) => boolean;
+}
+
+function createTestChildProcess(markTerminatedOnSigterm = true): TestChildProcess {
+  const stdin = new EventEmitter();
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const rawChild = Object.assign(new EventEmitter(), {
+    stdin,
+    stdout,
+    stderr,
+    exitCode: null,
+    signalCode: null,
+  });
+  const state = rawChild as unknown as MutableChildProcessState;
+  const kill = vi.fn((signal?: number | NodeJS.Signals) => {
+    if (markTerminatedOnSigterm && signal === 'SIGTERM') state.signalCode = 'SIGTERM';
+    return true;
+  });
+  state.kill = kill;
+  return {
+    child: rawChild as unknown as ChildProcess,
+    stdin,
+    stdout,
+    stderr,
+    kill,
+  };
+}
+
+function emitExit(testChild: TestChildProcess, code: number | null, signal: NodeJS.Signals | null): void {
+  const state = testChild.child as unknown as MutableChildProcessState;
+  state.exitCode = code;
+  state.signalCode = signal;
+  testChild.child.emit('exit', code, signal);
+}
+
+async function getStartOpenCodeServer(): Promise<typeof import('../infra/opencode/server-process.js').startOpenCodeServer> {
+  const module = await import('../infra/opencode/server-process.js');
+  return module.startOpenCodeServer;
+}
+
+function startOptions(timeoutMs = 100): {
+  port: number;
+  timeoutMs: number;
+  config: Record<string, unknown>;
+} {
+  return {
+    port: 62000,
+    timeoutMs,
+    config: { model: 'opencode/model' },
+  };
+}
+
+async function expectPromisePending(promise: Promise<unknown>): Promise<void> {
+  let settled = false;
+  void promise.then(
+    () => { settled = true; },
+    () => { settled = true; },
+  );
+  await Promise.resolve();
+  expect(settled).toBe(false);
+}
+
+describe('OpenCode server process', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    crossSpawnMock.mockReset();
+    createClientMock.mockReset();
+  });
+
+  it.each(['stdin', 'stdout', 'stderr'] as const)(
+    'should report a %s EPIPE after startup through onError',
+    async (streamName) => {
+      const testChild = createTestChildProcess();
+      const client = {};
+      crossSpawnMock.mockReturnValue(testChild.child);
+      createClientMock.mockReturnValue(client);
+
+      const startOpenCodeServer = await getStartOpenCodeServer();
+      const startPromise = startOpenCodeServer(startOptions());
+      testChild.stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000\n');
+      const server = await startPromise;
+      const errors: Error[] = [];
+      server.onError((error) => errors.push(error));
+
+      const stream = testChild[streamName];
+      stream.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.message).toBe(`OpenCode server ${streamName} stream failed: write EPIPE`);
+      expect(createClientMock).toHaveBeenCalledWith({ baseUrl: 'http://127.0.0.1:62000' });
+
+      server.close();
+      expect(testChild.kill).toHaveBeenCalledWith('SIGTERM');
+    },
+  );
+
+  it('should wait for a complete stdout line before parsing a server URL', async () => {
+    const testChild = createTestChildProcess();
+    crossSpawnMock.mockReturnValue(testChild.child);
+    createClientMock.mockReturnValue({});
+
+    const startOpenCodeServer = await getStartOpenCodeServer();
+    const startPromise = startOpenCodeServer(startOptions());
+    testChild.stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000');
+    await expectPromisePending(startPromise);
+
+    testChild.stdout.emit('data', '\n');
+    const server = await startPromise;
+
+    expect(createClientMock).toHaveBeenCalledWith({ baseUrl: 'http://127.0.0.1:62000' });
+    server.close();
+  });
+
+  it('should wait for the rest of an incomplete listening line instead of failing', async () => {
+    const testChild = createTestChildProcess();
+    crossSpawnMock.mockReturnValue(testChild.child);
+    createClientMock.mockReturnValue({});
+
+    const startOpenCodeServer = await getStartOpenCodeServer();
+    const startPromise = startOpenCodeServer(startOptions());
+    testChild.stdout.emit('data', 'opencode server listening');
+    await expectPromisePending(startPromise);
+
+    testChild.stdout.emit('data', ' on http://127.0.0.1:62000\n');
+    const server = await startPromise;
+
+    expect(createClientMock).toHaveBeenCalledWith({ baseUrl: 'http://127.0.0.1:62000' });
+    server.close();
+  });
+
+  it('should sanitize server output included in a startup failure', async () => {
+    const testChild = createTestChildProcess();
+    const secret = 'server-output-api-key-secret';
+    crossSpawnMock.mockReturnValue(testChild.child);
+    createClientMock.mockReturnValue({});
+
+    const startOpenCodeServer = await getStartOpenCodeServer();
+    const startPromise = startOpenCodeServer(startOptions());
+    testChild.stderr.emit('data', `server config: apiKey=${secret}\n`);
+    emitExit(testChild, 1, null);
+
+    const error = await startPromise.catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('[REDACTED]');
+    expect((error as Error).message).not.toContain(secret);
+  });
+
+  it('should fail startup when a child stdio stream emits an error', async () => {
+    const testChild = createTestChildProcess();
+    crossSpawnMock.mockReturnValue(testChild.child);
+
+    const startOpenCodeServer = await getStartOpenCodeServer();
+    const startPromise = startOpenCodeServer(startOptions());
+    testChild.stdin.emit('error', new Error('startup stdin failed'));
+
+    await expect(startPromise).rejects.toThrow('OpenCode server stdin stream failed: startup stdin failed');
+    expect(testChild.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('should fail startup after the configured timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const testChild = createTestChildProcess();
+      crossSpawnMock.mockReturnValue(testChild.child);
+
+      const startOpenCodeServer = await getStartOpenCodeServer();
+      const startPromise = startOpenCodeServer(startOptions(20));
+      const rejection = expect(startPromise).rejects.toThrow(
+        'Timeout waiting for OpenCode server to start after 20ms',
+      );
+      await vi.advanceTimersByTimeAsync(20);
+
+      await rejection;
+      expect(testChild.kill).toHaveBeenCalledWith('SIGTERM');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should propagate a child exit after startup through onError', async () => {
+    const testChild = createTestChildProcess();
+    crossSpawnMock.mockReturnValue(testChild.child);
+    createClientMock.mockReturnValue({});
+
+    const startOpenCodeServer = await getStartOpenCodeServer();
+    const startPromise = startOpenCodeServer(startOptions());
+    testChild.stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000\n');
     const server = await startPromise;
     const errors: Error[] = [];
-
     server.onError((error) => errors.push(error));
-    stderr.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
 
-    expect(stdout.listenerCount('error')).toBe(1);
-    expect(stderr.listenerCount('error')).toBe(1);
-    expect(stdin.listenerCount('error')).toBe(1);
+    emitExit(testChild, 1, null);
+
     expect(errors).toHaveLength(1);
-    expect(errors[0]?.message).toBe('OpenCode server stderr stream failed: write EPIPE');
-    expect(createClientMock).toHaveBeenCalledWith({ baseUrl: 'http://127.0.0.1:62000' });
+    expect(errors[0]?.message).toContain('OpenCode server exited with code 1');
+  });
 
+  it('should not notify listeners for events emitted after close', async () => {
+    const testChild = createTestChildProcess();
+    crossSpawnMock.mockReturnValue(testChild.child);
+    createClientMock.mockReturnValue({});
+
+    const startOpenCodeServer = await getStartOpenCodeServer();
+    const startPromise = startOpenCodeServer(startOptions());
+    testChild.stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000\n');
+    const server = await startPromise;
+    const errors: Error[] = [];
+    server.onError((error) => errors.push(error));
     server.close();
-    expect(child.kill).toHaveBeenCalledOnce();
+
+    testChild.stdin.on('error', () => {});
+    testChild.stdout.on('error', () => {});
+    testChild.stderr.on('error', () => {});
+    testChild.child.on('error', () => {});
+    testChild.stdin.emit('error', new Error('stdin after close'));
+    testChild.stdout.emit('error', new Error('stdout after close'));
+    testChild.stderr.emit('error', new Error('stderr after close'));
+    testChild.stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000\n');
+    testChild.child.emit('error', new Error('child after close'));
+    testChild.child.emit('exit', 1, null);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should escalate a non-terminating child from SIGTERM to SIGKILL', async () => {
+    vi.useFakeTimers();
+    try {
+      const testChild = createTestChildProcess(false);
+      crossSpawnMock.mockReturnValue(testChild.child);
+      createClientMock.mockReturnValue({});
+
+      const startOpenCodeServer = await getStartOpenCodeServer();
+      const startPromise = startOpenCodeServer(startOptions());
+      testChild.stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000\n');
+      const server = await startPromise;
+      server.close();
+
+      expect(testChild.kill).toHaveBeenCalledWith('SIGTERM');
+      await vi.advanceTimersByTimeAsync(500);
+      expect(testChild.kill).toHaveBeenCalledWith('SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/__tests__/opencode-server-process.test.ts
+++ b/src/__tests__/opencode-server-process.test.ts
@@ -118,12 +118,30 @@ describe('OpenCode server process', () => {
 
       expect(errors).toHaveLength(1);
       expect(errors[0]?.message).toBe(`OpenCode server ${streamName} stream failed: write EPIPE`);
-      expect(createClientMock).toHaveBeenCalledWith({ baseUrl: 'http://127.0.0.1:62000' });
 
       server.close();
-      expect(testChild.kill).toHaveBeenCalledWith('SIGTERM');
     },
   );
+
+  it('should include recent post-startup output in an unexpected exit error', async () => {
+    const testChild = createTestChildProcess();
+    crossSpawnMock.mockReturnValue(testChild.child);
+    createClientMock.mockReturnValue({});
+
+    const startOpenCodeServer = await getStartOpenCodeServer();
+    const startPromise = startOpenCodeServer(startOptions());
+    testChild.stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000\n');
+    const server = await startPromise;
+    const errors: Error[] = [];
+    server.onError((error) => errors.push(error));
+
+    testChild.stderr.emit('data', 'FATAL: model backend unreachable\n');
+    testChild.child.emit('exit', 1, null);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toContain('FATAL: model backend unreachable');
+    server.close();
+  });
 
   it('should wait for a complete stdout line before parsing a server URL', async () => {
     const testChild = createTestChildProcess();

--- a/src/__tests__/opencode-server-process.test.ts
+++ b/src/__tests__/opencode-server-process.test.ts
@@ -143,6 +143,28 @@ describe('OpenCode server process', () => {
     server.close();
   });
 
+  it('should keep only the bounded tail of post-startup output in an exit error', async () => {
+    const testChild = createTestChildProcess();
+    crossSpawnMock.mockReturnValue(testChild.child);
+    createClientMock.mockReturnValue({});
+
+    const startOpenCodeServer = await getStartOpenCodeServer();
+    const startPromise = startOpenCodeServer(startOptions());
+    testChild.stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000\n');
+    const server = await startPromise;
+    const errors: Error[] = [];
+    server.onError((error) => errors.push(error));
+
+    testChild.stderr.emit('data', `OLD-HEAD ${'x'.repeat(2100)}`);
+    testChild.stderr.emit('data', 'RECENT-TAIL\n');
+    testChild.child.emit('exit', 1, null);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).not.toContain('OLD-HEAD');
+    expect(errors[0]?.message).toContain('RECENT-TAIL');
+    server.close();
+  });
+
   it('should wait for a complete stdout line before parsing a server URL', async () => {
     const testChild = createTestChildProcess();
     crossSpawnMock.mockReturnValue(testChild.child);

--- a/src/__tests__/opencode-server-process.test.ts
+++ b/src/__tests__/opencode-server-process.test.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { describe, expect, it, vi } from 'vitest';
+
+const { crossSpawnMock, createClientMock } = vi.hoisted(() => ({
+  crossSpawnMock: vi.fn(),
+  createClientMock: vi.fn(),
+}));
+
+vi.unmock('../infra/opencode/server-process.js');
+
+vi.mock('../shared/utils/spawn.js', () => ({
+  crossSpawn: crossSpawnMock,
+}));
+
+vi.mock('@opencode-ai/sdk/v2', () => ({
+  createOpencodeClient: createClientMock,
+}));
+
+describe('OpenCode server process', () => {
+  it('should convert child stdio EPIPE into a server error without an unhandled event', async () => {
+    const stdin = new EventEmitter();
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const child = Object.assign(new EventEmitter(), {
+      stdin,
+      stdout,
+      stderr,
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(() => true),
+    }) as unknown as ChildProcess;
+    const client = {};
+    crossSpawnMock.mockReturnValue(child);
+    createClientMock.mockReturnValue(client);
+
+    const { startOpenCodeServer } = await import('../infra/opencode/server-process.js');
+    const startPromise = startOpenCodeServer({
+      port: 62000,
+      timeoutMs: 100,
+      config: { model: 'opencode/model' },
+    });
+    stdout.emit('data', 'opencode server listening on http://127.0.0.1:62000\n');
+    const server = await startPromise;
+    const errors: Error[] = [];
+
+    server.onError((error) => errors.push(error));
+    stderr.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+
+    expect(stdout.listenerCount('error')).toBe(1);
+    expect(stderr.listenerCount('error')).toBe(1);
+    expect(stdin.listenerCount('error')).toBe(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toBe('OpenCode server stderr stream failed: write EPIPE');
+    expect(createClientMock).toHaveBeenCalledWith({ baseUrl: 'http://127.0.0.1:62000' });
+
+    server.close();
+    expect(child.kill).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/opencode-stream-handler.test.ts
+++ b/src/__tests__/opencode-stream-handler.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { createOpenCodeServerStartMock } from './helpers/opencode-server-process-test-helpers.js';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -1020,6 +1021,10 @@ vi.mock('node:net', () => ({
 
 vi.mock('@opencode-ai/sdk/v2', () => ({
   createOpencode: createOpencodeMock,
+}));
+
+vi.mock('../infra/opencode/server-process.js', () => ({
+  startOpenCodeServer: createOpenCodeServerStartMock(createOpencodeMock),
 }));
 
 // createLogger 以外の実エクスポートはそのまま使う。debug だけをスパイに

--- a/src/infra/opencode/server-pool.ts
+++ b/src/infra/opencode/server-pool.ts
@@ -26,6 +26,7 @@ interface SharedServer {
   key: string;
   client: OpencodeClient;
   close: () => void;
+  onError: (listener: (error: Error) => void) => () => void;
   invalidated: boolean;
   invalidationController: AbortController;
   sessionBusy: Set<string>;
@@ -178,12 +179,12 @@ async function createSharedServer(
     key,
     client: openCodeServer.client,
     close,
+    onError: openCodeServer.onError,
     invalidated: false,
     invalidationController: new AbortController(),
     sessionBusy: new Set(),
     sessionQueues: new Map(),
   };
-  openCodeServer.onError((error) => invalidateSharedServer(sharedServer, error));
   return sharedServer;
 }
 
@@ -208,6 +209,7 @@ export async function acquireOpenCodeClient(
   entry.initPromise = createSharedServer(key, model, apiKey, childProcessEnv)
     .then((server) => {
       entry.server = server;
+      server.onError((error) => invalidateSharedServer(server, error));
       return server;
     })
     .finally(() => {

--- a/src/infra/opencode/server-pool.ts
+++ b/src/infra/opencode/server-pool.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process';
 import { createServer } from 'node:net';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createOpencode } from '@opencode-ai/sdk/v2';
+import type { OpencodeClient as SdkOpencodeClient } from '@opencode-ai/sdk/v2';
 import { loadTemplate } from '../../shared/prompts/index.js';
 import {
   getNestedObservabilityEnvFingerprint,
@@ -11,6 +11,7 @@ import {
 import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
 import { sanitizeSensitiveText } from '../../shared/utils/sensitiveText.js';
 import { versionAllowsListToolShim } from './list-tool-shim-guard.js';
+import { startOpenCodeServer } from './server-process.js';
 
 const OPENCODE_STREAM_ABORTED_MESSAGE = 'OpenCode execution aborted';
 const OPENCODE_SERVER_START_TIMEOUT_MS = 60_000;
@@ -19,7 +20,7 @@ const TAKT_AGENT_REVIEW = 'takt-review';
 const TAKT_AGENT_REPORT = 'takt-report';
 const log = createLogger('opencode-sdk');
 
-export type OpencodeClient = Awaited<ReturnType<typeof createOpencode>>['client'];
+export type OpencodeClient = SdkOpencodeClient;
 
 interface SharedServer {
   key: string;
@@ -132,9 +133,10 @@ async function createSharedServer(
 ): Promise<SharedServer> {
   const port = await getFreePort();
   const registerListToolShim = await shouldRegisterListToolShim();
-  const { client, server } = await runWithNestedObservabilityProcessEnv(childProcessEnv, () =>
-    createOpencode({
+  const openCodeServer = await runWithNestedObservabilityProcessEnv(childProcessEnv, () =>
+    startOpenCodeServer({
       port,
+      timeoutMs: OPENCODE_SERVER_START_TIMEOUT_MS,
       config: {
         model,
         small_model: model,
@@ -162,26 +164,27 @@ async function createSharedServer(
           },
         },
       },
-      timeout: OPENCODE_SERVER_START_TIMEOUT_MS,
-    })
+    }),
   );
   const close = (): void => {
     try {
-      server.close();
+      openCodeServer.close();
     } catch (error) {
       log.debug(`Failed to close OpenCode server: ${sanitizeSensitiveText(getErrorMessage(error))}`, { model });
     }
   };
   log.debug('OpenCode server started', { model, port });
-  return {
+  const sharedServer: SharedServer = {
     key,
-    client,
+    client: openCodeServer.client,
     close,
     invalidated: false,
     invalidationController: new AbortController(),
     sessionBusy: new Set(),
     sessionQueues: new Map(),
   };
+  openCodeServer.onError((error) => invalidateSharedServer(sharedServer, error));
+  return sharedServer;
 }
 
 export async function acquireOpenCodeClient(

--- a/src/infra/opencode/server-process.ts
+++ b/src/infra/opencode/server-process.ts
@@ -65,6 +65,10 @@ export async function startOpenCodeServer(
   );
 
   let output = '';
+  const OUTPUT_TAIL_MAX_CHARS = 2000;
+  const appendOutput = (text: string): void => {
+    output = (output + text).slice(-OUTPUT_TAIL_MAX_CHARS);
+  };
   let started = false;
   let closing = false;
   let runtimeError: Error | undefined;
@@ -118,14 +122,13 @@ export async function startOpenCodeServer(
       started = true;
       settled = true;
       if (timeoutId !== undefined) clearTimeout(timeoutId);
-      removeStartupDataListeners();
       resolve(serverUrl);
     };
 
     const onOutput = (stream: 'stdout' | 'stderr') => (chunk: Buffer | string): void => {
-      if (started || settled) return;
       const text = chunk.toString();
-      output += text;
+      appendOutput(text);
+      if (started || settled) return;
       const buffered = stream === 'stdout' ? stdoutLineBuffer + text : stderrLineBuffer + text;
       const lines = buffered.split('\n');
       const incompleteLine = lines.pop() ?? '';

--- a/src/infra/opencode/server-process.ts
+++ b/src/infra/opencode/server-process.ts
@@ -1,0 +1,160 @@
+import type { ChildProcess } from 'node:child_process';
+import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk/v2';
+import { getErrorMessage } from '../../shared/utils/error.js';
+import { crossSpawn } from '../../shared/utils/spawn.js';
+
+const OPENCODE_SERVER_HOSTNAME = '127.0.0.1';
+
+export interface OpenCodeServerStartOptions {
+  port: number;
+  timeoutMs: number;
+  config: Record<string, unknown>;
+}
+
+export interface OpenCodeServerProcess {
+  client: OpencodeClient;
+  close: () => void;
+  onError: (listener: (error: Error) => void) => () => void;
+}
+
+type ServerErrorListener = (error: Error) => void;
+
+function stopChild(child: ChildProcess): void {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  try {
+    child.kill();
+  } catch {
+    // The child can exit between the state check and kill call.
+  }
+}
+
+function formatServerExitError(output: string, code: number | null, signal: NodeJS.Signals | null): Error {
+  const cause = code === null ? String(signal) : String(code);
+  const detail = output.trim() === '' ? '' : `\nServer output: ${output}`;
+  return new Error(`OpenCode server exited with code ${cause}${detail}`);
+}
+
+function formatStreamError(stream: string, error: unknown): Error {
+  return new Error(`OpenCode server ${stream} stream failed: ${getErrorMessage(error)}`);
+}
+
+export async function startOpenCodeServer(
+  options: OpenCodeServerStartOptions,
+): Promise<OpenCodeServerProcess> {
+  const child = crossSpawn(
+    'opencode',
+    ['serve', `--hostname=${OPENCODE_SERVER_HOSTNAME}`, `--port=${options.port}`],
+    {
+      env: {
+        ...process.env,
+        OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config),
+      },
+    },
+  );
+
+  let output = '';
+  let started = false;
+  let closing = false;
+  let runtimeError: Error | undefined;
+  const errorListeners = new Set<ServerErrorListener>();
+  let failStartup: ((error: Error) => void) | undefined;
+
+  const notifyRuntimeError = (error: Error): void => {
+    if (runtimeError !== undefined || closing) return;
+    runtimeError = error;
+    for (const listener of errorListeners) listener(error);
+  };
+
+  const onChildStreamError = (stream: string) => (error: unknown): void => {
+    const streamError = formatStreamError(stream, error);
+    if (started) notifyRuntimeError(streamError);
+    else failStartup?.(streamError);
+  };
+
+  child.stdin?.on('error', onChildStreamError('stdin'));
+  child.stdout?.on('error', onChildStreamError('stdout'));
+  child.stderr?.on('error', onChildStreamError('stderr'));
+
+  const url = await new Promise<string>((resolve, reject) => {
+    let settled = false;
+    const timeoutId = setTimeout(() => {
+      const error = new Error(`Timeout waiting for OpenCode server to start after ${options.timeoutMs}ms`);
+      fail(error);
+    }, options.timeoutMs);
+
+    const fail = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      closing = true;
+      stopChild(child);
+      reject(error);
+    };
+    failStartup = fail;
+
+    child.on('error', (error) => {
+      if (started) notifyRuntimeError(formatStreamError('process', error));
+      else fail(error instanceof Error ? error : new Error(String(error)));
+    });
+    child.on('exit', (code, signal) => {
+      if (started) {
+        if (!closing) notifyRuntimeError(formatServerExitError(output, code, signal));
+        return;
+      }
+      fail(formatServerExitError(output, code, signal));
+    });
+
+    const onOutput = (chunk: Buffer | string): void => {
+      if (started || settled) return;
+      output += chunk.toString();
+      for (const line of output.split('\n')) {
+        if (!line.startsWith('opencode server listening')) continue;
+        const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
+        if (!match) {
+          fail(new Error(`Failed to parse server url from output: ${line}`));
+          return;
+        }
+        const serverUrl = match[1];
+        if (serverUrl === undefined) {
+          fail(new Error(`Failed to parse server url from output: ${line}`));
+          return;
+        }
+        started = true;
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve(serverUrl);
+        return;
+      }
+    };
+
+    child.stdout?.on('data', onOutput);
+    child.stderr?.on('data', onOutput);
+  });
+
+  failStartup = undefined;
+
+  try {
+    const client = createOpencodeClient({ baseUrl: url });
+    return {
+      client,
+      close: () => {
+        if (closing) return;
+        closing = true;
+        errorListeners.clear();
+        stopChild(child);
+      },
+      onError: (listener) => {
+        if (runtimeError !== undefined) {
+          listener(runtimeError);
+          return () => {};
+        }
+        errorListeners.add(listener);
+        return () => errorListeners.delete(listener);
+      },
+    };
+  } catch (error) {
+    closing = true;
+    stopChild(child);
+    throw error;
+  }
+}

--- a/src/infra/opencode/server-process.ts
+++ b/src/infra/opencode/server-process.ts
@@ -1,9 +1,11 @@
 import type { ChildProcess } from 'node:child_process';
 import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk/v2';
 import { getErrorMessage } from '../../shared/utils/error.js';
+import { sanitizeSensitiveText } from '../../shared/utils/sensitiveText.js';
 import { crossSpawn } from '../../shared/utils/spawn.js';
 
 const OPENCODE_SERVER_HOSTNAME = '127.0.0.1';
+const CHILD_TERMINATION_GRACE_MS = 500;
 
 export interface OpenCodeServerStartOptions {
   port: number;
@@ -22,20 +24,30 @@ type ServerErrorListener = (error: Error) => void;
 function stopChild(child: ChildProcess): void {
   if (child.exitCode !== null || child.signalCode !== null) return;
   try {
-    child.kill();
+    if (!child.kill('SIGTERM')) return;
   } catch {
     // The child can exit between the state check and kill call.
+    return;
   }
+  const killTimer = setTimeout(() => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // The child can exit between the state check and kill call.
+    }
+  }, CHILD_TERMINATION_GRACE_MS);
+  killTimer.unref();
 }
 
 function formatServerExitError(output: string, code: number | null, signal: NodeJS.Signals | null): Error {
   const cause = code === null ? String(signal) : String(code);
-  const detail = output.trim() === '' ? '' : `\nServer output: ${output}`;
+  const detail = output.trim() === '' ? '' : `\nServer output: ${sanitizeSensitiveText(output)}`;
   return new Error(`OpenCode server exited with code ${cause}${detail}`);
 }
 
 function formatStreamError(stream: string, error: unknown): Error {
-  return new Error(`OpenCode server ${stream} stream failed: ${getErrorMessage(error)}`);
+  return new Error(`OpenCode server ${stream} stream failed: ${sanitizeSensitiveText(getErrorMessage(error))}`);
 }
 
 export async function startOpenCodeServer(
@@ -57,7 +69,7 @@ export async function startOpenCodeServer(
   let closing = false;
   let runtimeError: Error | undefined;
   const errorListeners = new Set<ServerErrorListener>();
-  let failStartup: ((error: Error) => void) | undefined;
+  let removeProcessListeners: () => void = () => {};
 
   const notifyRuntimeError = (error: Error): void => {
     if (runtimeError !== undefined || closing) return;
@@ -65,73 +77,114 @@ export async function startOpenCodeServer(
     for (const listener of errorListeners) listener(error);
   };
 
-  const onChildStreamError = (stream: string) => (error: unknown): void => {
-    const streamError = formatStreamError(stream, error);
-    if (started) notifyRuntimeError(streamError);
-    else failStartup?.(streamError);
-  };
-
-  child.stdin?.on('error', onChildStreamError('stdin'));
-  child.stdout?.on('error', onChildStreamError('stdout'));
-  child.stderr?.on('error', onChildStreamError('stderr'));
-
   const url = await new Promise<string>((resolve, reject) => {
     let settled = false;
-    const timeoutId = setTimeout(() => {
-      const error = new Error(`Timeout waiting for OpenCode server to start after ${options.timeoutMs}ms`);
-      fail(error);
-    }, options.timeoutMs);
+    let stdoutLineBuffer = '';
+    let stderrLineBuffer = '';
+    let removeStartupDataListeners: () => void = () => {};
 
     const fail = (error: Error): void => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeoutId);
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
       closing = true;
+      removeProcessListeners();
       stopChild(child);
       reject(error);
     };
-    failStartup = fail;
 
-    child.on('error', (error) => {
-      if (started) notifyRuntimeError(formatStreamError('process', error));
-      else fail(error instanceof Error ? error : new Error(String(error)));
-    });
-    child.on('exit', (code, signal) => {
-      if (started) {
-        if (!closing) notifyRuntimeError(formatServerExitError(output, code, signal));
+    const onChildStreamError = (stream: string) => (error: unknown): void => {
+      const streamError = formatStreamError(stream, error);
+      if (started) notifyRuntimeError(streamError);
+      else fail(streamError);
+    };
+
+    const onStdinError = onChildStreamError('stdin');
+    const onStdoutError = onChildStreamError('stdout');
+    const onStderrError = onChildStreamError('stderr');
+
+    const processOutputLine = (line: string): void => {
+      if (started || settled || !line.startsWith('opencode server listening')) return;
+      const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
+      if (!match) {
+        fail(new Error(`Failed to parse server url from output: ${line}`));
         return;
       }
-      fail(formatServerExitError(output, code, signal));
-    });
-
-    const onOutput = (chunk: Buffer | string): void => {
-      if (started || settled) return;
-      output += chunk.toString();
-      for (const line of output.split('\n')) {
-        if (!line.startsWith('opencode server listening')) continue;
-        const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
-        if (!match) {
-          fail(new Error(`Failed to parse server url from output: ${line}`));
-          return;
-        }
-        const serverUrl = match[1];
-        if (serverUrl === undefined) {
-          fail(new Error(`Failed to parse server url from output: ${line}`));
-          return;
-        }
-        started = true;
-        settled = true;
-        clearTimeout(timeoutId);
-        resolve(serverUrl);
+      const serverUrl = match[1];
+      if (serverUrl === undefined) {
+        fail(new Error(`Failed to parse server url from output: ${line}`));
         return;
+      }
+      started = true;
+      settled = true;
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      removeStartupDataListeners();
+      resolve(serverUrl);
+    };
+
+    const onOutput = (stream: 'stdout' | 'stderr') => (chunk: Buffer | string): void => {
+      if (started || settled) return;
+      const text = chunk.toString();
+      output += text;
+      const buffered = stream === 'stdout' ? stdoutLineBuffer + text : stderrLineBuffer + text;
+      const lines = buffered.split('\n');
+      const incompleteLine = lines.pop() ?? '';
+      if (stream === 'stdout') stdoutLineBuffer = incompleteLine;
+      else stderrLineBuffer = incompleteLine;
+      for (const line of lines) {
+        processOutputLine(line);
+        if (started || settled) return;
       }
     };
 
-    child.stdout?.on('data', onOutput);
-    child.stderr?.on('data', onOutput);
-  });
+    const onStdoutData = onOutput('stdout');
+    const onStderrData = onOutput('stderr');
+    const onChildError = (error: unknown): void => {
+      if (started) {
+        notifyRuntimeError(formatStreamError('process', error));
+        closing = true;
+        removeProcessListeners();
+        return;
+      }
+      fail(error instanceof Error ? error : new Error(String(error)));
+    };
+    const onChildExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      if (started) {
+        if (!closing) {
+          notifyRuntimeError(formatServerExitError(output, code, signal));
+          closing = true;
+        }
+        removeProcessListeners();
+        return;
+      }
+      fail(formatServerExitError(output, code, signal));
+    };
 
-  failStartup = undefined;
+    removeStartupDataListeners = (): void => {
+      child.stdout?.removeListener('data', onStdoutData);
+      child.stderr?.removeListener('data', onStderrData);
+    };
+    removeProcessListeners = (): void => {
+      removeStartupDataListeners();
+      child.stdin?.removeListener('error', onStdinError);
+      child.stdout?.removeListener('error', onStdoutError);
+      child.stderr?.removeListener('error', onStderrError);
+      child.removeListener('error', onChildError);
+      child.removeListener('exit', onChildExit);
+    };
+
+    const timeoutId = setTimeout(() => {
+      fail(new Error(`Timeout waiting for OpenCode server to start after ${options.timeoutMs}ms`));
+    }, options.timeoutMs);
+
+    child.stdin?.on('error', onStdinError);
+    child.stdout?.on('error', onStdoutError);
+    child.stderr?.on('error', onStderrError);
+    child.on('error', onChildError);
+    child.on('exit', onChildExit);
+    child.stdout?.on('data', onStdoutData);
+    child.stderr?.on('data', onStderrData);
+  });
 
   try {
     const client = createOpencodeClient({ baseUrl: url });
@@ -141,6 +194,7 @@ export async function startOpenCodeServer(
         if (closing) return;
         closing = true;
         errorListeners.clear();
+        removeProcessListeners();
         stopChild(child);
       },
       onError: (listener) => {
@@ -154,6 +208,8 @@ export async function startOpenCodeServer(
     };
   } catch (error) {
     closing = true;
+    errorListeners.clear();
+    removeProcessListeners();
     stopChild(child);
     throw error;
   }


### PR DESCRIPTION
## 背景

team_leader の part(opencode / ollama-cloud)実行がストリームエラーを出した直後、'error' リスナーのない Socket への write が EPIPE となり、unhandled 'error' event で takt run プロセス全体が墜落した(実走で発生)。

```
Error: write EPIPE
Emitted 'error' event on Socket instance
{ errno: -32, code: 'EPIPE', syscall: 'write' }
```

プロバイダのエラーは AgentResponse.error に表面化させ、ワークフロー全体を殺さないという設計原則からの逸脱。

## 原因

OpenCode SDK の `createOpencode` はサーバ子プロセスを生成するが、その stdio に 'data' リスナーしか登録しない(SDK 内部のため利用側からハンドラを足せない)。サーバ側が接続を閉じた競合状態で stdio への書き込みが EPIPE となり、未処理の 'error' イベントとしてプロセスを落とす。

## 変更内容

- `server-process.ts` を新設し、`opencode serve --hostname --port` を自前で spawn する。子プロセス本体と stdin/stdout/stderr のすべてに局所 'error' リスナーを装着
- stdio エラーは共有サーバの無効化(server-pool)へ接続し、実行中の呼び出しは既存の attempt-runner の失敗分類を通じて `AgentResponse.error` に表面化する(リトライ層と team_leader の part 再発行が従来どおり機能する)
- SDK クライアント(`createOpencodeClient`)による HTTP 接続は従来のまま
- グローバルな process ハンドラは追加しない(局所処理のみ)

## テスト

- 新設: サーバ子プロセスの stdio EPIPE を発火させ、プロセスが死なずエラーが伝播することの境界テスト
- 既存の opencode 系スイート10ファイル(cleanup 27 / compaction 21 / env 7 / permission 19 / queue 13 / retry 21 / shared-server 21 / structured-output 20 / tool-loop 28 / stream-handler 81)すべて緑
- lint / build / releaseVerificationWiring 17件 緑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - サーバー起動時のエラー、通信ストリーム異常、起動タイムアウトを適切に検知・通知できるようになりました。
  - 起動URLの取得失敗や異常終了を処理し、関連リソースを確実に解放します。
  - ストリームの`EPIPE`エラーを伝播し、安全にクリーンアップします。
  - サーバー停止時の強制終了や、不要なエラー通知にも対応しました。

- **信頼性向上**
  - 共有サーバーで障害が発生した場合、自動的に無効化して新しいサーバーへ切り替えます。

- **テスト**
  - サーバーの起動・終了、エラー伝播、共有利用に関するテストを拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->