### PR TITLE
fix: 子プロセスstdioのerror未処理を共通ガードで横断的に解消する

### DIFF
--- a/src/__tests__/child-process-guard.test.ts
+++ b/src/__tests__/child-process-guard.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { guardChildProcessStreams } from '../shared/utils/child-process-guard.js';
+
+function makeFakeChild(): ChildProcess {
+  const proc = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
+  proc.stdin = new EventEmitter() as NodeJS.ReadableStream;
+  proc.stdout = new EventEmitter() as NodeJS.ReadableStream;
+  proc.stderr = new EventEmitter() as NodeJS.ReadableStream;
+  return proc as ChildProcess;
+}
+
+describe('guardChildProcessStreams', () => {
+  it('forwards process errors with the process source', () => {
+    const child = makeFakeChild();
+    const onError = vi.fn();
+    const teardown = guardChildProcessStreams(child, onError);
+
+    const error = new Error('spawn failed');
+    child.emit('error', error);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error, 'process');
+    teardown();
+  });
+
+  it('forwards stdout stream errors with the stdout source', () => {
+    const child = makeFakeChild();
+    const onError = vi.fn();
+    const teardown = guardChildProcessStreams(child, onError);
+
+    const error = new Error('stdout broke');
+    (child.stdout as EventEmitter).emit('error', error);
+
+    expect(onError).toHaveBeenCalledWith(error, 'stdout');
+    teardown();
+  });
+
+  it('forwards stderr stream errors with the stderr source', () => {
+    const child = makeFakeChild();
+    const onError = vi.fn();
+    const teardown = guardChildProcessStreams(child, onError);
+
+    const error = new Error('stderr broke');
+    (child.stderr as EventEmitter).emit('error', error);
+
+    expect(onError).toHaveBeenCalledWith(error, 'stderr');
+    teardown();
+  });
+
+  it('forwards stdin stream errors with the stdin source', () => {
+    const child = makeFakeChild();
+    const onError = vi.fn();
+    const teardown = guardChildProcessStreams(child, onError);
+
+    const error = new Error('stdin broke');
+    (child.stdin as EventEmitter).emit('error', error);
+
+    expect(onError).toHaveBeenCalledWith(error, 'stdin');
+    teardown();
+  });
+
+  it('does not register listeners for missing stdio streams', () => {
+    const proc = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
+    proc.stdin = null;
+    proc.stdout = null;
+    proc.stderr = null;
+    const child = proc as ChildProcess;
+
+    const onError = vi.fn();
+    const teardown = guardChildProcessStreams(child, onError);
+
+    child.emit('error', new Error('only process'));
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenLastCalledWith(expect.any(Error), 'process');
+    teardown();
+  });
+
+  it('stops forwarding errors after teardown', () => {
+    const child = makeFakeChild();
+    const onError = vi.fn();
+    const teardown = guardChildProcessStreams(child, onError);
+
+    // Add a no-op 'error' listener so bare EventEmitter does not throw when
+    // we emit 'error' with no other listener present after teardown.
+    child.on('error', () => undefined);
+    (child.stdout as EventEmitter).on('error', () => undefined);
+    (child.stderr as EventEmitter).on('error', () => undefined);
+    (child.stdin as EventEmitter).on('error', () => undefined);
+
+    teardown();
+    expect(() => {
+      child.emit('error', new Error('after teardown'));
+      (child.stdout as EventEmitter).emit('error', new Error('stdout after teardown'));
+      (child.stderr as EventEmitter).emit('error', new Error('stderr after teardown'));
+      (child.stdin as EventEmitter).emit('error', new Error('stdin after teardown'));
+    }).not.toThrow();
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('is safe to call teardown multiple times', () => {
+    const child = makeFakeChild();
+    const onError = vi.fn();
+    const teardown = guardChildProcessStreams(child, onError);
+
+    expect(() => {
+      teardown();
+      teardown();
+      teardown();
+    }).not.toThrow();
+  });
+});

--- a/src/__tests__/child-process-guard.test.ts
+++ b/src/__tests__/child-process-guard.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import type { ChildProcess } from 'node:child_process';
 import { guardChildProcessStreams } from '../shared/utils/child-process-guard.js';
 
 function makeFakeChild(): ChildProcess {
   const proc = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
-  proc.stdin = new EventEmitter() as NodeJS.ReadableStream;
-  proc.stdout = new EventEmitter() as NodeJS.ReadableStream;
-  proc.stderr = new EventEmitter() as NodeJS.ReadableStream;
+  proc.stdin = new PassThrough();
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
   return proc as ChildProcess;
 }
 

--- a/src/__tests__/claude-headless-stdio-guard.test.ts
+++ b/src/__tests__/claude-headless-stdio-guard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import type { ChildProcess } from 'node:child_process';
 
 vi.mock('node:child_process', () => ({
@@ -13,22 +14,18 @@ import type { ClaudeHeadlessCallOptions } from '../infra/claude-headless/types.j
 function stubSpawn(opts: {
   stdoutError?: Error;
   stderrError?: Error;
-  stdinError?: Error;
   closeCode?: number | null;
 }): void {
   vi.mocked(spawn).mockImplementation(() => {
-    const stdout = new EventEmitter();
-    const stderr = new EventEmitter();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
     const proc = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
-    proc.stdout = stdout as NodeJS.ReadableStream;
-    proc.stderr = stderr as NodeJS.ReadableStream;
-    proc.stdin = new EventEmitter() as NodeJS.WritableStream;
+    proc.stdout = stdout;
+    proc.stderr = stderr;
+    proc.stdin = null;
     proc.kill = vi.fn() as unknown as ChildProcess['kill'];
 
     queueMicrotask(() => {
-      if (opts.stdinError) {
-        (proc.stdin as EventEmitter).emit('error', opts.stdinError);
-      }
       if (opts.stdoutError) {
         stdout.emit('error', opts.stdoutError);
       }
@@ -73,16 +70,16 @@ describe('runHeadlessCli stdio guard', () => {
     );
   });
 
-  it('rejects with a failure when stdin emits a stream error', async () => {
+  it('guards stdout and stderr even though the headless spawn has no stdin', async () => {
     stubSpawn({
-      stdinError: new Error('stdin pipe closed'),
+      stdoutError: new Error('stdout pipe closed'),
       closeCode: 1,
     });
 
     const options: ClaudeHeadlessCallOptions = { cwd: '/tmp' };
 
     await expect(runHeadlessCli(['-p', '--', 'prompt'], options)).rejects.toThrow(
-      /stdin stream error: stdin pipe closed/u,
+      /stdout stream error: stdout pipe closed/u,
     );
   });
 });

--- a/src/__tests__/claude-headless-stdio-guard.test.ts
+++ b/src/__tests__/claude-headless-stdio-guard.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from 'node:child_process';
+import { runHeadlessCli } from '../infra/claude-headless/headless-spawn.js';
+import type { ClaudeHeadlessCallOptions } from '../infra/claude-headless/types.js';
+
+function stubSpawn(opts: {
+  stdoutError?: Error;
+  stderrError?: Error;
+  stdinError?: Error;
+  closeCode?: number | null;
+}): void {
+  vi.mocked(spawn).mockImplementation(() => {
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const proc = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
+    proc.stdout = stdout as NodeJS.ReadableStream;
+    proc.stderr = stderr as NodeJS.ReadableStream;
+    proc.stdin = new EventEmitter() as NodeJS.WritableStream;
+    proc.kill = vi.fn() as unknown as ChildProcess['kill'];
+
+    queueMicrotask(() => {
+      if (opts.stdinError) {
+        (proc.stdin as EventEmitter).emit('error', opts.stdinError);
+      }
+      if (opts.stdoutError) {
+        stdout.emit('error', opts.stdoutError);
+      }
+      if (opts.stderrError) {
+        stderr.emit('error', opts.stderrError);
+      }
+      proc.emit('close', opts.closeCode ?? 1, null);
+    });
+
+    return proc as ChildProcess;
+  });
+}
+
+describe('runHeadlessCli stdio guard', () => {
+  beforeEach(() => {
+    vi.mocked(spawn).mockReset();
+  });
+
+  it('rejects with a failure without crashing the parent process when stdout emits a stream error', async () => {
+    stubSpawn({
+      stdoutError: new Error('stdout pipe closed'),
+      closeCode: null,
+    });
+
+    const options: ClaudeHeadlessCallOptions = { cwd: '/tmp' };
+
+    await expect(runHeadlessCli(['-p', '--', 'prompt'], options)).rejects.toThrow(
+      /stdout stream error: stdout pipe closed/u,
+    );
+  });
+
+  it('rejects with a failure when stderr emits a stream error', async () => {
+    stubSpawn({
+      stderrError: new Error('stderr pipe closed'),
+      closeCode: 1,
+    });
+
+    const options: ClaudeHeadlessCallOptions = { cwd: '/tmp' };
+
+    await expect(runHeadlessCli(['-p', '--', 'prompt'], options)).rejects.toThrow(
+      /stderr stream error: stderr pipe closed/u,
+    );
+  });
+
+  it('rejects with a failure when stdin emits a stream error', async () => {
+    stubSpawn({
+      stdinError: new Error('stdin pipe closed'),
+      closeCode: 1,
+    });
+
+    const options: ClaudeHeadlessCallOptions = { cwd: '/tmp' };
+
+    await expect(runHeadlessCli(['-p', '--', 'prompt'], options)).rejects.toThrow(
+      /stdin stream error: stdin pipe closed/u,
+    );
+  });
+});

--- a/src/__tests__/claude-terminal-tmux-backend.test.ts
+++ b/src/__tests__/claude-terminal-tmux-backend.test.ts
@@ -33,23 +33,35 @@ function createExecFileError(message: string, code: number, stderr: string): Err
   return Object.assign(new Error(message), { code, stderr });
 }
 
-function createSpawnChild(stdinWrites: string[], exitCode: number, stderrText: string) {
+function createSpawnChild(
+  stdinWrites: string[],
+  exitCode: number,
+  stderrText: string,
+  streamError?: { stream: 'stdin' | 'stderr'; error: Error },
+) {
   const child = new EventEmitter() as EventEmitter & {
     stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
-    stdin: { end: ReturnType<typeof vi.fn> };
+    stdin: EventEmitter & { end: ReturnType<typeof vi.fn> };
+    kill: ReturnType<typeof vi.fn>;
   };
   const stderr = new EventEmitter() as EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+  const stdin = new EventEmitter() as EventEmitter & { end: ReturnType<typeof vi.fn> };
   stderr.setEncoding = vi.fn();
   child.stderr = stderr;
-  child.stdin = {
-    end: vi.fn((text: string) => {
-      stdinWrites.push(text);
-      if (stderrText.length > 0) {
-        stderr.emit('data', stderrText);
-      }
-      queueMicrotask(() => child.emit('close', exitCode));
-    }),
-  };
+  child.kill = vi.fn(() => true);
+  child.stdin = stdin;
+  stdin.end = vi.fn((text: string) => {
+    stdinWrites.push(text);
+    if (stderrText.length > 0) {
+      stderr.emit('data', stderrText);
+    }
+    if (streamError?.stream === 'stdin') {
+      stdin.emit('error', streamError.error);
+    } else if (streamError?.stream === 'stderr') {
+      stderr.emit('error', streamError.error);
+    }
+    queueMicrotask(() => child.emit('close', exitCode));
+  });
   return child;
 }
 
@@ -181,6 +193,22 @@ describe('TmuxTerminalBackend', () => {
       ['send-keys', '-t', 'takt-session', 'Enter'],
       ['delete-buffer', '-b', 'takt-session-prompt'],
     ]);
+  });
+
+  it('Given a tmux stdio error, When pasteText is called, Then the stream failure is returned and the child is terminated', async () => {
+    const backend = new TmuxTerminalBackend();
+    const stdinWrites: string[] = [];
+    const childError = new Error('tmux pipe closed');
+    let child: ReturnType<typeof createSpawnChild> | undefined;
+    mockSpawn.mockImplementation(() => {
+      child = createSpawnChild(stdinWrites, 0, '', { stream: 'stderr', error: childError });
+      return child;
+    });
+
+    await expect(backend.pasteText({ id: 'tmux-session', name: 'takt-session' }, 'implement task'))
+      .rejects.toThrow('tmux stderr stream error: tmux pipe closed');
+
+    expect(child?.kill).toHaveBeenCalledOnce();
   });
 
   it('Given Claude pane is still busy, When pasteText is called, Then prompt is not pasted until input is ready', async () => {

--- a/src/__tests__/kiro-client.test.ts
+++ b/src/__tests__/kiro-client.test.ts
@@ -28,13 +28,14 @@ import { callKiro } from '../infra/kiro/client.js';
 type SpawnScenario = {
   stdout?: string;
   stderr?: string;
+  stdinError?: Partial<NodeJS.ErrnoException> & { message: string };
   code?: number | null;
   signal?: NodeJS.Signals | null;
   error?: Partial<NodeJS.ErrnoException> & { message: string };
 };
 
 type MockChildProcess = EventEmitter & {
-  stdin: { end: ReturnType<typeof vi.fn> };
+  stdin: EventEmitter & { end: ReturnType<typeof vi.fn> };
   stdout: EventEmitter;
   stderr: EventEmitter;
   kill: ReturnType<typeof vi.fn>;
@@ -108,7 +109,8 @@ function restoreEnv(): void {
 
 function createMockChildProcess(): MockChildProcess {
   const child = new EventEmitter() as MockChildProcess;
-  child.stdin = { end: vi.fn() };
+  child.stdin = new EventEmitter() as EventEmitter & { end: ReturnType<typeof vi.fn> };
+  child.stdin.end = vi.fn();
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
   child.kill = vi.fn(() => true);
@@ -118,6 +120,11 @@ function createMockChildProcess(): MockChildProcess {
 function mockSpawnWithScenario(scenario: SpawnScenario): void {
   mockSpawn.mockImplementation((_cmd: string, _args: string[], _options: object) => {
     const child = createMockChildProcess();
+    child.stdin.end.mockImplementation(() => {
+      if (scenario.stdinError) {
+        child.stdin.emit('error', Object.assign(new Error(scenario.stdinError.message), scenario.stdinError));
+      }
+    });
 
     queueMicrotask(() => {
       if (scenario.stdout) {
@@ -733,6 +740,17 @@ describe('callKiro', () => {
     expect(result.content).toContain('kiro-cli binary not found');
     expect(result.error).toContain('kiro-cli binary not found');
     expect(result.content).toContain('TAKT_KIRO_CLI_PATH');
+  });
+
+  it('Given stdin emits an error while closing input, When called, Then returns the stream failure', async () => {
+    mockSpawnWithScenario({
+      stdinError: { message: 'stdin pipe closed' },
+    });
+
+    const result = await callKiro('coder', 'implement feature', { cwd: '/repo' });
+
+    expect(result.status).toBe('error');
+    expect(result.content).toContain('kiro-cli stdin stream error: stdin pipe closed');
   });
 
   it('Given authentication stderr, When command fails, Then returns an authentication error without exposing the key', async () => {

--- a/src/__tests__/kiro-provider-integration.test.ts
+++ b/src/__tests__/kiro-provider-integration.test.ts
@@ -17,7 +17,7 @@ import { invalidateGlobalConfigCache } from '../infra/config/global/globalConfig
 import { KiroProvider } from '../infra/providers/kiro.js';
 
 type MockChildProcess = EventEmitter & {
-  stdin: { end: ReturnType<typeof vi.fn> };
+  stdin: EventEmitter & { end: ReturnType<typeof vi.fn> };
   stdout: EventEmitter;
   stderr: EventEmitter;
   kill: ReturnType<typeof vi.fn>;
@@ -25,7 +25,8 @@ type MockChildProcess = EventEmitter & {
 
 function createMockChildProcess(): MockChildProcess {
   const child = new EventEmitter() as MockChildProcess;
-  child.stdin = { end: vi.fn() };
+  child.stdin = new EventEmitter() as EventEmitter & { end: ReturnType<typeof vi.fn> };
+  child.stdin.end = vi.fn();
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
   child.kill = vi.fn(() => true);

--- a/src/infra/claude-headless/headless-spawn.ts
+++ b/src/infra/claude-headless/headless-spawn.ts
@@ -1,4 +1,4 @@
-import { crossSpawn } from '../../shared/utils/index.js';
+import { crossSpawn, guardChildProcessStreams } from '../../shared/utils/index.js';
 import { buildEnvWithNestedObservabilitySnapshot } from '../../shared/telemetry/index.js';
 import { containsRateLimitMarker } from '../rate-limit/detection.js';
 import {
@@ -104,6 +104,7 @@ export function runHeadlessCli(
       if (options.abortSignal) {
         options.abortSignal.removeEventListener('abort', abortHandler);
       }
+      guardTeardown();
     };
 
     const resolveOnce = (result: { stdout: string; stderr: string }): void => {
@@ -115,11 +116,14 @@ export function runHeadlessCli(
       resolve(result);
     };
 
-    const rejectOnce = (error: ExecError): void => {
+    const rejectOnce = (error: ExecError, terminateChild = false): void => {
       if (settled) {
         return;
       }
       settled = true;
+      if (terminateChild) {
+        child.kill('SIGTERM');
+      }
       cleanup();
       reject(error);
     };
@@ -210,13 +214,23 @@ export function runHeadlessCli(
 
     child.stderr?.on('data', (chunk: Buffer | string) => appendChunk('stderr', chunk));
 
-    child.on('error', (error: NodeJS.ErrnoException) => {
+    const guardTeardown = guardChildProcessStreams(child, (error, source) => {
+      if (source === 'process') {
+        rejectOnce(
+          createExecError(error.message, {
+            code: (error as NodeJS.ErrnoException).code,
+            stdout,
+            stderr,
+          }),
+        );
+        return;
+      }
       rejectOnce(
-        createExecError(error.message, {
-          code: error.code,
+        createExecError(`Claude CLI ${source} stream error: ${error.message}`, {
           stdout,
           stderr,
         }),
+        true,
       );
     });
 

--- a/src/infra/claude-terminal/tmux-backend.ts
+++ b/src/infra/claude-terminal/tmux-backend.ts
@@ -3,7 +3,7 @@ import type { ExecFileException } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { promisify } from 'node:util';
 import { stripAnsi } from '../../shared/utils/text.js';
-import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
+import { createLogger, getErrorMessage, guardChildProcessStreams } from '../../shared/utils/index.js';
 import {
   buildEnvWithNestedObservabilitySnapshot,
   pickNestedObservabilityEnv,
@@ -115,13 +115,35 @@ async function loadBuffer(bufferName: string, text: string): Promise<void> {
     child.stderr?.on('data', (chunk: string) => {
       stderr += chunk;
     });
-    child.on('error', (error) => reject(formatTmuxError(error)));
+    let settled = false;
+    const resolveOnce = (): void => {
+      if (settled) return;
+      settled = true;
+      guardTeardown();
+      resolve();
+    };
+    const rejectOnce = (error: Error, terminateChild = false): void => {
+      if (settled) return;
+      settled = true;
+      if (terminateChild) {
+        child.kill();
+      }
+      guardTeardown();
+      reject(error);
+    };
+    const guardTeardown = guardChildProcessStreams(child, (error, source) => {
+      const failure = source === 'process'
+        ? formatTmuxError(error)
+        : new Error(`tmux ${source} stream error: ${error.message}`);
+      rejectOnce(failure, true);
+    });
     child.on('close', (code) => {
+      if (settled) return;
       if (code === 0) {
-        resolve();
+        resolveOnce();
         return;
       }
-      reject(new Error(`tmux load-buffer failed (${code}): ${stderr.trim()}`));
+      rejectOnce(new Error(`tmux load-buffer failed (${code}): ${stderr.trim()}`));
     });
     child.stdin.end(text);
   });

--- a/src/infra/cursor/client.ts
+++ b/src/infra/cursor/client.ts
@@ -3,7 +3,7 @@
  */
 
 import type { AgentResponse } from '../../core/models/index.js';
-import { crossSpawn, getErrorMessage } from '../../shared/utils/index.js';
+import { crossSpawn, getErrorMessage, guardChildProcessStreams } from '../../shared/utils/index.js';
 import { buildEnvWithNestedObservabilitySnapshot } from '../../shared/telemetry/index.js';
 import { AGENT_FAILURE_CATEGORIES, type AgentFailureCategory } from '../../shared/types/agent-failure.js';
 import type { CursorCallOptions } from './types.js';
@@ -135,6 +135,7 @@ function execCursor(args: string[], options: CursorCallOptions): Promise<CursorE
       if (options.abortSignal) {
         options.abortSignal.removeEventListener('abort', abortHandler);
       }
+      guardTeardown();
     };
 
     const resolveOnce = (result: CursorExecResult): void => {
@@ -144,9 +145,12 @@ function execCursor(args: string[], options: CursorCallOptions): Promise<CursorE
       resolve(result);
     };
 
-    const rejectOnce = (error: CursorExecError): void => {
+    const rejectOnce = (error: CursorExecError, terminateChild = false): void => {
       if (settled) return;
       settled = true;
+      if (terminateChild) {
+        child.kill('SIGTERM');
+      }
       cleanup();
       reject(error);
     };
@@ -186,12 +190,19 @@ function execCursor(args: string[], options: CursorCallOptions): Promise<CursorE
     child.stdout?.on('data', (chunk: Buffer | string) => appendChunk('stdout', chunk));
     child.stderr?.on('data', (chunk: Buffer | string) => appendChunk('stderr', chunk));
 
-    child.on('error', (error: NodeJS.ErrnoException) => {
-      rejectOnce(createExecError(error.message, {
-        code: error.code,
+    const guardTeardown = guardChildProcessStreams(child, (error, source) => {
+      if (source === 'process') {
+        rejectOnce(createExecError(error.message, {
+          code: (error as NodeJS.ErrnoException).code,
+          stdout,
+          stderr,
+        }));
+        return;
+      }
+      rejectOnce(createExecError(`cursor-agent ${source} stream error: ${error.message}`, {
         stdout,
         stderr,
-      }));
+      }), true);
     });
 
     child.on('close', (code: number | null, signal: NodeJS.Signals | null) => {

--- a/src/infra/kiro/process.ts
+++ b/src/infra/kiro/process.ts
@@ -1,4 +1,4 @@
-import { crossSpawn } from '../../shared/utils/index.js';
+import { crossSpawn, guardChildProcessStreams } from '../../shared/utils/index.js';
 import { pickNestedObservabilityEnv } from '../../shared/telemetry/index.js';
 import type { KiroCallOptions } from './types.js';
 
@@ -112,8 +112,6 @@ export function execKiro(
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    child.stdin?.end();
-
     let stdout = '';
     let stderr = '';
     let stdoutBytes = 0;
@@ -158,6 +156,7 @@ export function execKiro(
       if (options.abortSignal) {
         options.abortSignal.removeEventListener('abort', abortHandler);
       }
+      guardTeardown();
     };
 
     const rejectOnce = (error: KiroExecError): void => {
@@ -169,8 +168,8 @@ export function execKiro(
 
     const rejectAfterTermination = (error: KiroExecError): void => {
       if (settled) return;
-      terminateChild();
       settled = true;
+      terminateChild();
       cleanup();
       reject(error);
     };
@@ -215,9 +214,16 @@ export function execKiro(
     child.stdout?.on('data', (chunk: Buffer | string) => appendChunk('stdout', chunk));
     child.stderr?.on('data', (chunk: Buffer | string) => appendChunk('stderr', chunk));
 
-    child.on('error', (error: NodeJS.ErrnoException) => {
-      rejectOnce(createExecError(error.message, {
-        code: error.code,
+    const guardTeardown = guardChildProcessStreams(child, (error, source) => {
+      if (source === 'process') {
+        rejectOnce(createExecError(error.message, {
+          code: (error as NodeJS.ErrnoException).code,
+          stdout,
+          stderr,
+        }));
+        return;
+      }
+      rejectAfterTermination(createExecError(`kiro-cli ${source} stream error: ${error.message}`, {
         stdout,
         stderr,
       }));
@@ -261,5 +267,7 @@ export function execKiro(
         options.abortSignal.addEventListener('abort', abortHandler, { once: true });
       }
     }
+
+    child.stdin?.end();
   });
 }

--- a/src/infra/task/clone-exec.ts
+++ b/src/infra/task/clone-exec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execFileSync, spawn } from 'node:child_process';
-import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
+import { createLogger, getErrorMessage, guardChildProcessStreams } from '../../shared/utils/index.js';
 import {
   toCloneBaseRef,
   toLocalBranchRef,
@@ -351,6 +351,7 @@ export function runGitCommandAbortable(
       if (abortSignal) {
         abortSignal.removeEventListener('abort', onAbort);
       }
+      guardTeardown();
     };
 
     const resolveOnce = (): void => {
@@ -362,11 +363,14 @@ export function runGitCommandAbortable(
       resolve({ stdout, stderr });
     };
 
-    const rejectOnce = (error: Error): void => {
+    const rejectOnce = (error: Error, terminateChild = false): void => {
       if (settled) {
         return;
       }
       settled = true;
+      if (terminateChild) {
+        terminateProcessGroup(child, 'SIGTERM');
+      }
       cleanup();
       reject(error);
     };
@@ -389,8 +393,13 @@ export function runGitCommandAbortable(
     child.stderr?.on('data', (chunk) => {
       stderr += chunk.toString('utf-8');
     });
-    child.on('error', (error) => {
-      rejectOnce(error);
+    const guardTeardown = guardChildProcessStreams(child, (error, source) => {
+      rejectOnce(
+        source === 'process'
+          ? error
+          : new Error(`git ${args[0]} ${source} stream error: ${error.message}`),
+        source !== 'process',
+      );
     });
     child.on('close', (code) => {
       if (abortSignal?.aborted) {

--- a/src/infra/task/companion-git-diff-reader.ts
+++ b/src/infra/task/companion-git-diff-reader.ts
@@ -10,6 +10,7 @@ import type {
   CompanionDiffReader,
 } from '../../core/workflow/companion/diff-reader.js';
 import { buildSafeGitEnvironment } from './git-environment.js';
+import { guardChildProcessStreams } from '../../shared/utils/index.js';
 
 const MAX_COMPANION_DIFF_BYTES = 512 * 1024;
 const MAX_GITLINK_PATHS_PER_COMMAND = 64;
@@ -196,10 +197,16 @@ class BoundedGitRunner {
         }
         stderr.push(chunk);
       });
-      child.on('error', (error) => fail(new CompanionDiffResourceError('git_failure', error.message)));
+      const guardTeardown = guardChildProcessStreams(child, (error, source) => {
+        fail(new CompanionDiffResourceError(
+          'git_failure',
+          source === 'process' ? error.message : `git ${source} stream error: ${error.message}`,
+        ));
+      });
       child.on('close', (code) => {
         clearTimeout(timer);
         this.signal?.removeEventListener('abort', onAbort);
+        guardTeardown();
         if (failure !== undefined) reject(failure);
         else if (code === 0) resolvePromise();
         else reject(new CompanionDiffResourceError('git_failure', gitErrorMessage(args, stderr)));

--- a/src/shared/utils/child-process-guard.ts
+++ b/src/shared/utils/child-process-guard.ts
@@ -1,0 +1,62 @@
+/**
+ * Guards a spawned child process and its stdio streams against unhandled
+ * 'error' events. Attaches a single 'error' listener to the process and to
+ * each present stdio stream (stdin/stdout/stderr), forwarding every emitted
+ * error to the supplied callback along with the stream that produced it.
+ *
+ * The helper does not terminate the process; routing the error to the
+ * caller's existing failure path is the callback's responsibility.
+ *
+ * Returns a teardown function that removes every listener it registered. The
+ * teardown function is idempotent and safe to call multiple times.
+ */
+
+import type { ChildProcess } from 'node:child_process';
+
+export type ChildProcessStreamSource = 'process' | 'stdin' | 'stdout' | 'stderr';
+
+type ChildProcessStreamErrorHandler = (error: Error, source: ChildProcessStreamSource) => void;
+
+type RegisteredListener = {
+  emitter: NodeJS.EventEmitter;
+  handler: (error: Error) => void;
+};
+
+export function guardChildProcessStreams(
+  child: ChildProcess,
+  onError: ChildProcessStreamErrorHandler,
+): () => void {
+  let tornDown = false;
+
+  const listeners: RegisteredListener[] = [];
+
+  const register = (
+    emitter: NodeJS.EventEmitter | null | undefined,
+    source: ChildProcessStreamSource,
+  ): void => {
+    if (emitter === null || emitter === undefined) {
+      return;
+    }
+    const handler = (error: Error): void => {
+      onError(error, source);
+    };
+    emitter.on('error', handler);
+    listeners.push({ emitter, handler });
+  };
+
+  register(child, 'process');
+  register(child.stdin, 'stdin');
+  register(child.stdout, 'stdout');
+  register(child.stderr, 'stderr');
+
+  return function teardown(): void {
+    if (tornDown) {
+      return;
+    }
+    tornDown = true;
+    for (const { emitter, handler } of listeners) {
+      emitter.removeListener('error', handler);
+    }
+    listeners.length = 0;
+  };
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -2,6 +2,7 @@
  * Shared utilities module - exports utility functions
  */
 
+export * from './child-process-guard.js';
 export * from './debug.js';
 export * from './delay.js';
 export * from './entrypoint.js';


### PR DESCRIPTION
## 背景

opencode のサーバ子プロセスで「'error' リスナーのない stdio(Socket)への書き込みが EPIPE となり、unhandled 'error' event でプロセス全体が墜落する」事故が実走で発生した(#1410 で opencode は修正済み)。

横断監査の結果、TAKT が自前で spawn する他の子プロセスも同型だった: child 本体には 'error' リスナーがあるが、stdin / stdout / stderr の各ストリームには無く、ストリーム側の 'error' はプロセスを落とす。

## 変更内容

- `src/shared/utils/child-process-guard.ts` に `guardChildProcessStreams(child, onError)` を新設
  - child 本体と存在する stdio へ 'error' リスナーを装着し、`onError(error, source)` へ伝播(source: process / stdin / stdout / stderr)
  - 解除関数を返す(装着したリスナーのみ解除、多重解除は安全)
  - spawn 自体は抱き込まない(呼び出し側の spawn 方法は不変)
- 適用: claude-headless / cursor / kiro / claude-terminal(tmux)/ clone-exec / companion-git-diff-reader の6箇所
  - stdio エラーはその呼び出しの失敗(pending Promise の reject と子プロセス終了)へ接続し、プロセスは殺さない
  - 既存の child 'error' ハンドラはヘルパー経由へ集約(二重通知なし)
- opencode の server-process(#1410)の同ヘルパーへの乗せ替えは、#1410 マージ後の後続 PR で行う

## テスト

- ヘルパー単体(装着・伝播・解除・多重解除・解除後の非転送)9件
- claude-headless の「stdio エラーでプロセスが死なず呼び出し失敗になる」境界テスト3件
- 既存回帰: 対応ユニット 7ファイル189件、light IT 2ファイル58件、companion IT 30件、lint、build、releaseVerificationWiring 17件すべて緑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - CLI、Git、ターミナル、Cursor、Kiroなどで、子プロセスと標準入出力ストリームのエラーを適切に処理するよう改善。
  - ストリームエラー発生時も親プロセスのクラッシュを防ぎ、子プロセスを安全に終了してエラーを返すよう変更。
  - エラーや終了処理の重複を防止し、標準出力・標準エラーの情報を保持。

- **テスト**
  - 各種子プロセス・ストリームエラー、終了処理、欠落した入出力の動作検証を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->