### PR TITLE
fix(codex): SDK内部のspawnをガードしstdin EPIPEによるプロセス墜落を解消する

### DIFF
--- a/scripts/test-classification.mjs
+++ b/scripts/test-classification.mjs
@@ -186,6 +186,7 @@ export const fileSystemIntegrationTestFiles = Object.freeze([
   'src/__tests__/clipboardImage.test.ts',
   'src/__tests__/codex-client-retry.test.ts',
   'src/__tests__/codex-skill-config.test.ts',
+  'src/__tests__/codex-spawn-guard.test.ts',
   'src/__tests__/conversationLoop-resume.test.ts',
   'src/__tests__/conversationSession.test.ts',
   'src/__tests__/copilot-client.test.ts',

--- a/src/__tests__/codex-spawn-guard.test.ts
+++ b/src/__tests__/codex-spawn-guard.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { spawn as esmSpawn } from 'node:child_process';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import '../infra/codex/codex-spawn-guard.js';
+
+type SpawnFunction = (
+  command: string,
+  argsOrOptions?: readonly string[] | SpawnOptions,
+  options?: SpawnOptions,
+) => ChildProcess;
+
+type FakeExecutableMode = 'exit' | 'epipe' | 'hang';
+
+const require = createRequire(import.meta.url);
+const childProcessModule = require('node:child_process') as { spawn: SpawnFunction };
+const tempRoots = new Set<string>();
+
+function makeFakeExecutable(name: string, mode: FakeExecutableMode = 'exit'): string {
+  const dir = mkdtempSync(join(tmpdir(), 'takt-codex-guard-'));
+  tempRoots.add(dir);
+  const fileName = process.platform === 'win32' ? `${name}.cmd` : name;
+  const file = join(dir, fileName);
+  if (process.platform === 'win32') {
+    writeFileSync(file, '@echo off\r\nexit /b 0\r\n');
+  } else {
+    const script = mode === 'exit'
+      ? '#!/bin/sh\nexit 0\n'
+      : mode === 'epipe'
+        ? '#!/bin/sh\nexec 0<&-\nsleep 0.2\nexit 42\n'
+        : '#!/bin/sh\nexec 0<&-\nwhile :; do :; done\n';
+    writeFileSync(file, script);
+    chmodSync(file, 0o755);
+  }
+  return file;
+}
+
+function cleanupTempRoots(): void {
+  for (const root of tempRoots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  tempRoots.clear();
+}
+
+function spawnOptions(): SpawnOptions {
+  return {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...(process.platform === 'win32' ? { shell: true } : {}),
+  };
+}
+
+function waitForClose(child: ChildProcess): Promise<{
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}> {
+  return new Promise((resolve) => {
+    child.once('close', (code, signal) => resolve({ code, signal }));
+  });
+}
+
+async function runCodex(executablePath: string): Promise<void> {
+  const { Codex } = await import('@openai/codex-sdk');
+  const thread = new Codex({ codexPathOverride: executablePath }).startThread();
+  const streamed = await thread.runStreamed('x'.repeat(1024 * 1024));
+  for await (const _event of streamed.events) {
+    void _event;
+  }
+}
+
+describe('codex-spawn-guard', () => {
+  afterEach(() => {
+    cleanupTempRoots();
+  });
+
+  it('synchronizes the CJS patch into ESM child_process bindings', () => {
+    expect(childProcessModule.spawn).toBe(esmSpawn);
+  });
+
+  it('attaches and removes stdio listeners independently for parallel Codex spawns', async () => {
+    const children = [
+      childProcessModule.spawn(makeFakeExecutable('codex'), [], spawnOptions()),
+      childProcessModule.spawn(makeFakeExecutable('codex'), [], spawnOptions()),
+    ];
+
+    for (const child of children) {
+      expect(child.stdin).not.toBeNull();
+      expect((child.stdin as EventEmitter).listenerCount('error')).toBeGreaterThan(0);
+      expect((child.stdout as EventEmitter).listenerCount('error')).toBeGreaterThan(0);
+      expect((child.stderr as EventEmitter).listenerCount('error')).toBeGreaterThan(0);
+      expect((child as EventEmitter).listenerCount('error')).toBeGreaterThan(0);
+    }
+
+    await Promise.all(children.map(waitForClose));
+    for (const child of children) {
+      expect((child.stdin as EventEmitter).listenerCount('error')).toBe(0);
+      expect((child.stdout as EventEmitter).listenerCount('error')).toBe(0);
+      expect((child.stderr as EventEmitter).listenerCount('error')).toBe(0);
+      expect((child as EventEmitter).listenerCount('error')).toBe(0);
+    }
+  });
+
+  it('does not alter non-Codex spawns or the spawn(command, options) overload', async () => {
+    const environment = { ...process.env };
+    delete environment.CODEX_INTERNAL_ORIGINATOR_OVERRIDE;
+    const child = childProcessModule.spawn(
+      makeFakeExecutable('other'),
+      ['exec', '--experimental-json'],
+      { ...spawnOptions(), env: environment },
+    );
+    const overloadChild = childProcessModule.spawn(makeFakeExecutable('other-overload'), spawnOptions());
+
+    for (const spawnedChild of [child, overloadChild]) {
+      expect(spawnedChild.stdin).not.toBeNull();
+      expect((spawnedChild.stdin as EventEmitter).listenerCount('error')).toBe(0);
+      expect((spawnedChild.stdout as EventEmitter).listenerCount('error')).toBe(0);
+      expect((spawnedChild.stderr as EventEmitter).listenerCount('error')).toBe(0);
+    }
+
+    await Promise.all([waitForClose(child), waitForClose(overloadChild)]);
+  });
+
+  it.skipIf(process.platform === 'win32')('handles a real EPIPE and terminates a stuck Codex child', async () => {
+    const child = childProcessModule.spawn(makeFakeExecutable('codex', 'hang'), [], spawnOptions());
+    const stdin = child.stdin;
+    expect(stdin).not.toBeNull();
+    if (!stdin) {
+      throw new Error('Codex fixture must have a stdin pipe');
+    }
+
+    const epipe = new Promise<Error>((resolve) => {
+      stdin.once('error', resolve);
+    });
+    stdin.write('x'.repeat(1024 * 1024));
+    stdin.end();
+
+    await expect(epipe).resolves.toMatchObject({ code: 'EPIPE' });
+    const result = await waitForClose(child);
+
+    expect(result.signal).toBe('SIGTERM');
+    expect(stdin.listenerCount('error')).toBe(0);
+  });
+
+  it.skipIf(process.platform === 'win32')('protects the actual SDK ESM spawn binding for a renamed Codex executable', async () => {
+    const codexPath = makeFakeExecutable('renamed-codex', 'epipe');
+
+    await expect(runCodex(codexPath)).rejects.toThrow(/Codex Exec exited with/);
+  });
+});

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -4,6 +4,7 @@
  * Uses @openai/codex-sdk for native TypeScript integration.
  */
 
+import './codex-spawn-guard.js';
 import {
   Codex,
   type CodexOptions,

--- a/src/infra/codex/codex-spawn-guard.ts
+++ b/src/infra/codex/codex-spawn-guard.ts
@@ -1,0 +1,126 @@
+/**
+ * Guards the Codex SDK's internal `child_process.spawn` against unhandled
+ * 'error' events on stdio streams.
+ *
+ * The SDK spawns the Codex CLI binary and writes the turn input to the
+ * child's stdin immediately. When the child exits before the write completes,
+ * the write fails with EPIPE and the 'error' event on stdin has no listener,
+ * crashing the host process. The SDK only attaches an 'error' listener to
+ * the ChildProcess itself, not to its stdio streams.
+ *
+ * This module patches `child_process.spawn` at the CJS module layer and
+ * synchronizes Node's ESM built-in bindings. The wrapper only activates for
+ * Codex binary names or the SDK's argument and environment markers; every
+ * other spawn passes through untouched.
+ *
+ * For matching spawns, `guardChildProcessStreams` attaches 'error' listeners
+ * on the process and each stdio stream. The guard logs and swallows the
+ * error, terminates the child when a stream fails, and tears down listeners
+ * on child close. The SDK can then surface `Codex Exec exited with ...`
+ * through the existing provider-error classification.
+ */
+
+import { basename } from 'node:path';
+import { createRequire, syncBuiltinESMExports } from 'node:module';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { guardChildProcessStreams } from '../../shared/utils/child-process-guard.js';
+import { createLogger } from '../../shared/utils/debug.js';
+
+const log = createLogger('codex-spawn-guard');
+
+const CODEX_BINARY_BASENAMES = new Set(['codex', 'codex.exe', 'codex.cmd']);
+const CODEX_SDK_ARGUMENT_PREFIX = ['exec', '--experimental-json'] as const;
+const CODEX_SDK_ORIGINATOR_ENV = 'CODEX_INTERNAL_ORIGINATOR_OVERRIDE';
+
+type SpawnFn = (
+  command: string,
+  argsOrOptions?: readonly string[] | SpawnOptions,
+  options?: SpawnOptions,
+) => ChildProcess;
+
+let installed = false;
+
+function isArgumentList(
+  value: readonly string[] | SpawnOptions | undefined,
+): value is readonly string[] {
+  return Array.isArray(value);
+}
+
+function isCodexSpawn(
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions | undefined,
+): boolean {
+  const commandBasename = basename(command).toLowerCase();
+  return CODEX_BINARY_BASENAMES.has(commandBasename)
+    || (args[0] === CODEX_SDK_ARGUMENT_PREFIX[0]
+      && args[1] === CODEX_SDK_ARGUMENT_PREFIX[1]
+      && options?.env !== undefined
+      && Object.hasOwn(options.env, CODEX_SDK_ORIGINATOR_ENV));
+}
+
+export function installCodexSpawnGuard(): void {
+  if (installed) {
+    return;
+  }
+  const require = createRequire(import.meta.url);
+  const childProcessModule = require('node:child_process') as {
+    spawn: SpawnFn;
+  };
+  const originalSpawn = childProcessModule.spawn;
+
+  const guardedSpawn: SpawnFn = (command, argsOrOptions, options) => {
+    const child = originalSpawn(command, argsOrOptions, options);
+    const args = isArgumentList(argsOrOptions) ? argsOrOptions : [];
+    if (!isCodexSpawn(command, args, options)) {
+      return child;
+    }
+
+    let streamFailureHandled = false;
+    const teardown = guardChildProcessStreams(child, (error, source) => {
+      log.debug('Swallowed stdio error from Codex child process', {
+        source,
+        message: error.message,
+        code: (error as NodeJS.ErrnoException).code,
+      });
+
+      if (source === 'process' || streamFailureHandled) {
+        return;
+      }
+      streamFailureHandled = true;
+      if (child.exitCode !== null || child.signalCode !== null || child.killed) {
+        return;
+      }
+      try {
+        child.kill();
+      } catch (killError) {
+        log.debug('Failed to terminate Codex child after stdio error', {
+          message: killError instanceof Error ? killError.message : String(killError),
+        });
+      }
+    });
+
+    let settled = false;
+    const finalize = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.removeListener('close', onClose);
+      child.removeListener('error', onError);
+      teardown();
+    };
+    const onClose = (): void => finalize();
+    const onError = (): void => finalize();
+    child.on('close', onClose);
+    child.on('error', onError);
+
+    return child;
+  };
+
+  childProcessModule.spawn = guardedSpawn;
+  syncBuiltinESMExports();
+  installed = true;
+}
+
+installCodexSpawnGuard();


### PR DESCRIPTION
## 背景

codex 実行の直後に takt run プロセス全体が墜落する事故が本番で2回発生した。

```
[DEBUG] [codex-sdk] Executing Codex thread
node:events:486  throw er; // Unhandled 'error' event
Error: write EPIPE ... Emitted 'error' event on Socket instance
```

原因は `@openai/codex-sdk` 内部(dist/index.js:252-263)にある。

```js
const child = spawn(this.executablePath, commandArgs, { env, signal });
child.once("error", (err) => spawnError = err);   // child 本体のみ
child.stdin.write(args.input);                     // stdin に 'error' リスナーがない
```

codex 子プロセスが早期終了していると write が EPIPE となり、リスナー不在の 'error' イベントでホストプロセスが死ぬ。SDK 側のバグであり、TAKT からは SDK 内部に手を入れられない。

## 変更内容

`src/infra/codex/codex-spawn-guard.ts` を新設し、codex 実行の spawn だけを対象にガードを掛ける。

- CJS モジュール層で `child_process.spawn` を差し替え、`syncBuiltinESMExports()` で SDK の ESM named binding にも反映する(CJS 差し替えだけでは ESM 側が元の関数を保持するため効かないことを実地検証済み)
- 対象の限定は「codex バイナリ名(codex / codex.exe)」または「SDK 固有の引数列(`exec --experimental-json`)と環境変数マーカー」の一致で行う。git / gh / opencode などの spawn は素通しする
- 一致した子プロセスには #1411 の `guardChildProcessStreams` を適用。EPIPE でプロセスは死なず、SDK 自身の終了処理が `Codex Exec exited with ...` を投げて既存のプロバイダエラー分類(AgentResponse.error)へ乗る
- リスナーは子プロセス終了時に解除する(並列実行でも漏れない)
- グローバルな uncaughtException ハンドラは追加しない

## テスト

- 実際の `@openai/codex-sdk` の spawn 経路で EPIPE を発火させ、プロセスが死なず SDK のエラー経路に到達することを検証
- spawn のオーバーロード、並列実行、リスナー解除、対象外コマンドの素通しを検証
- codex-spawn-guard 5件、codex-client、lint、build、releaseVerificationWiring 17件すべて緑

## 上流

SDK 側の欠陥なので openai/codex への報告も別途行う価値がある。