### PR TITLE
fix: tolerate markdown-rendered json fences in structured output parsing

### DIFF
--- a/src/__tests__/structured-output-object-parser.test.ts
+++ b/src/__tests__/structured-output-object-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseStructuredOutputObject } from '../agents/structured-caller/shared.js';
+import { parseLastJsonBlock, parseStructuredOutputObject } from '../agents/structured-caller/shared.js';
 
 describe('parseStructuredOutputObject', () => {
   it.each([
@@ -47,5 +47,19 @@ describe('parseStructuredOutputObject', () => {
     ['marker without object', 'json\nnot an object'],
   ])('still rejects rendered-fence candidates that are not valid JSON: $0', (_name, content) => {
     expect(() => parseStructuredOutputObject(content)).toThrow('Response must include a ```json ... ``` block');
+  });
+
+  it('keeps object-only enforcement for rendered fences, matching fenced arrays', () => {
+    expect(() => parseStructuredOutputObject('json\n[{"id":1}]')).toThrow('Structured output JSON must be an object');
+    expect(() => parseStructuredOutputObject('```json\n[{"id":1}]\n```')).toThrow('Structured output JSON must be an object');
+  });
+});
+
+describe('parseLastJsonBlock rendered fences', () => {
+  it.each([
+    ['array', 'json\n[{"id":1},{"id":2}]', [{ id: 1 }, { id: 2 }]],
+    ['object with nested arrays and bracket in string', 'json\n{"a":[1,{"b":"]"}]}', { a: [1, { b: ']' }] }],
+  ])('accepts markdown-rendered %s', (_name, content, expected) => {
+    expect(parseLastJsonBlock(content)).toEqual(expected);
   });
 });

--- a/src/__tests__/structured-output-object-parser.test.ts
+++ b/src/__tests__/structured-output-object-parser.test.ts
@@ -29,4 +29,23 @@ describe('parseStructuredOutputObject', () => {
   ])('rejects unsafe non-whole response: %s', (content) => {
     expect(() => parseStructuredOutputObject(content)).toThrow();
   });
+
+  // kiro-cli renders markdown before printing: fence chars are consumed and only `json\n{...}` survives.
+  it.each([
+    ['bare rendered fence', 'json\n{"step":1,"reason":"ok"}', { step: 1, reason: 'ok' }],
+    ['rendered fence after prose', 'explanation\njson\n{"step":1,"reason":"ok"}', { step: 1, reason: 'ok' }],
+    ['rendered fence with trailing prose', 'json\n{"step":1}\ntrailing note', { step: 1 }],
+    ['last rendered fence', 'json\n{"step":1}\nmore\njson\n{"step":2}', { step: 2 }],
+    ['nested braces and quoted braces', 'json\n{"step":1,"reason":"has { and } and \\"quotes\\"","inner":{"a":1}}', { step: 1, reason: 'has { and } and "quotes"', inner: { a: 1 } }],
+  ])('accepts markdown-rendered fence: $0', (_name, content, expected) => {
+    expect(parseStructuredOutputObject(content)).toEqual(expected);
+  });
+
+  it.each([
+    ['broken JSON after marker', 'json\n{broken'],
+    ['unterminated object after marker', 'json\n{"step":1'],
+    ['marker without object', 'json\nnot an object'],
+  ])('still rejects rendered-fence candidates that are not valid JSON: $0', (_name, content) => {
+    expect(() => parseStructuredOutputObject(content)).toThrow('Response must include a ```json ... ``` block');
+  });
 });

--- a/src/agents/structured-caller/shared.ts
+++ b/src/agents/structured-caller/shared.ts
@@ -22,13 +22,17 @@ export function parseLastJsonBlock(content: string): unknown {
 }
 
 function extractRenderedFenceJson(content: string): string | undefined {
-  const markerRegex = /(?:^|\n)\s*json\s*\n\s*\{/g;
+  const markerRegex = /(?:^|\n)\s*json\s*\n\s*[[{]/g;
   let result: string | undefined;
   let match: RegExpExecArray | null;
 
   while ((match = markerRegex.exec(content)) !== null) {
-    const start = content.indexOf('{', match.index);
-    const candidate = readBalancedJsonObject(content, start);
+    const objectStart = content.indexOf('{', match.index);
+    const arrayStart = content.indexOf('[', match.index);
+    const start = objectStart === -1 || (arrayStart !== -1 && arrayStart < objectStart)
+      ? arrayStart
+      : objectStart;
+    const candidate = readBalancedJson(content, start);
     if (candidate !== undefined) {
       result = candidate;
     }
@@ -37,7 +41,7 @@ function extractRenderedFenceJson(content: string): string | undefined {
   return result;
 }
 
-function readBalancedJsonObject(content: string, start: number): string | undefined {
+function readBalancedJson(content: string, start: number): string | undefined {
   let depth = 0;
   let inString = false;
   let escaped = false;
@@ -59,9 +63,9 @@ function readBalancedJsonObject(content: string, start: number): string | undefi
     if (inString) {
       continue;
     }
-    if (ch === '{') {
+    if (ch === '{' || ch === '[') {
       depth++;
-    } else if (ch === '}') {
+    } else if (ch === '}' || ch === ']') {
       depth--;
       if (depth === 0) {
         const candidate = content.slice(start, i + 1);

--- a/src/agents/structured-caller/shared.ts
+++ b/src/agents/structured-caller/shared.ts
@@ -10,10 +10,72 @@ export function parseLastJsonBlock(content: string): unknown {
   }
 
   if (!lastJsonBlock) {
+    // Markdown-rendering CLIs (kiro-cli) consume the ``` fence chars, leaving only `json\n{...}`.
+    lastJsonBlock = extractRenderedFenceJson(content);
+  }
+
+  if (!lastJsonBlock) {
     throw new Error('Response must include a ```json ... ``` block');
   }
 
   return JSON.parse(lastJsonBlock) as unknown;
+}
+
+function extractRenderedFenceJson(content: string): string | undefined {
+  const markerRegex = /(?:^|\n)\s*json\s*\n\s*\{/g;
+  let result: string | undefined;
+  let match: RegExpExecArray | null;
+
+  while ((match = markerRegex.exec(content)) !== null) {
+    const start = content.indexOf('{', match.index);
+    const candidate = readBalancedJsonObject(content, start);
+    if (candidate !== undefined) {
+      result = candidate;
+    }
+  }
+
+  return result;
+}
+
+function readBalancedJsonObject(content: string, start: number): string | undefined {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < content.length; i++) {
+    const ch = content[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = inString;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) {
+      continue;
+    }
+    if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        const candidate = content.slice(start, i + 1);
+        try {
+          JSON.parse(candidate);
+          return candidate;
+        } catch {
+          return undefined;
+        }
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function requireJsonObject(value: unknown): Record<string, unknown> {


### PR DESCRIPTION
Fixes #1413

## Background

`kiro-cli chat` renders markdown before printing: triple-backtick fence characters are consumed and only the `json` info string reaches stdout. After `stripAnsi`, TAKT receives `json\n{...}` instead of the ```` ```json ... ``` ```` block the model actually emitted. Every prompt-based structured call on the kiro provider (Phase 3 status judgment, tag judge stage, dynamic selectors, `team_leader` decomposition) therefore fails in `parseLastJsonBlock` with `Response must include a ```json ... ``` block`, and since these paths run through `executeStructuredAgent`, the error propagates and aborts the workflow. Details and live reproduction in #1413.

## Change

`src/agents/structured-caller/shared.ts`: when no fenced block is found, `parseLastJsonBlock` falls back to the rendered-fence signature — a standalone `json` line immediately followed by `{` or `[` — and extracts the balanced JSON value after it (string-aware bracket scan, candidate must `JSON.parse`). Last matching block wins, mirroring the fenced behavior. Arrays are accepted at the `parseLastJsonBlock` level for parity with the fenced path; `parseStructuredOutputObject` still enforces object-only, exactly as it does for fenced arrays.

The fallback activates only on that marker, so existing strict rejections are preserved: `explanation\n{"step":1}`, `{"step":1};`, `{"step":1}{"reason":"next"}` etc. still throw.

## Validation

- `src/__tests__/structured-output-object-parser.test.ts`: 11 new cases — rendered fence bare / after prose / with trailing prose / last-wins / nested braces and quoted braces / arrays / object-only enforcement parity; broken or unterminated JSON after the marker still throws.
- `npm test -- src/__tests__/structured-output-object-parser.test.ts` — 25 passed.
- Neighboring suites (`structured-caller-default`, `status-judgment-phase-structured-caller`, `structured-agent-transport`, `task-decomposer`) — 29 passed.
- `tsc --noEmit` clean; full lint/test matrix green on CI for the first commit.
- Field-verified on a patched 0.59.1 install: a `review-fix-backend` pipeline that previously aborted at the first Phase 3 judgment ran through 7 iterations with kiro judges succeeding at stage 1 (`structured_output`) every time, including the exact payload shape from the original failing run (`json\n{ "step": 1, "reason": "..." }`).

## Follow-up observed in the field (out of scope here)

With this fallback active, two further kiro aborts showed a different failure: kiro-cli's *stdout* omitted the JSON block entirely even though kiro's own conversation store held a valid fenced block as the model's final message (verified by extracting the transcript from `conversations_v2` and replaying its rendered form through this parser — it parses). That is a kiro-cli output bug this parser cannot compensate for; noted in #1413 for tracking. Both cases were large-instruction (~140KB) dynamic selector calls with a tool call before the final answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - Markdownのコードフェンスが除去されたJSON形式の応答も、正しく解析できるようになりました。
  - 配列やネスト構造、文字列内の括弧を含むJSONの解析精度を向上しました。
  - 無効なJSONやJSON以外の値は、従来どおり適切に処理されます。

- **テスト**
  - 複数のJSON形式やエッジケースに対する検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->