### PR TITLE
fix(opencode): exact repeat検知をツールガード回復経路に乗せ即死を解消する

### DIFF
--- a/src/__tests__/opencode-tool-guard.test.ts
+++ b/src/__tests__/opencode-tool-guard.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   createToolGuardRecoveryState,
   markToolGuardCorrectionPending,
+  markToolGuardFreshSessionUsed,
   shouldIssueToolGuardCorrection,
 } from '../infra/opencode/tool-guard.js';
 import {
@@ -25,6 +26,7 @@ import { ExactLoopGuard } from '../infra/opencode/guards/integrity-guards.js';
 import { SensitiveBudgetGuard } from '../infra/opencode/guards/resource-guards.js';
 import { STALE_IN_FLIGHT_TOOL_FACTOR } from '../infra/opencode/guards/time-guards.js';
 import { createBoundedSensitiveValues } from '../shared/utils/sensitiveText.js';
+import { buildToolGuardCorrectionPrompt, buildToolGuardRetryPrompt } from '../infra/opencode/tool-guard.js';
 
 const DEPRECATED_ENV_KEYS = [
   'TAKT_OPENCODE_TOOL_ERROR_BUDGET',
@@ -283,6 +285,43 @@ describe('OpenCode guard suite', () => {
     expect(suite.onEvent(completedTool('call-12', { filePath: 'a.ts' }, 'same')).failure).toMatchObject({
       guardId: 'exact-repeat-streak',
     });
+  });
+
+  it('exact repeat streak 発火時は recoveryFailure として exact_repeat_loop を表出する', () => {
+    const suite = resolveOpenCodeGuardSuite(undefined, 'opencode/big-pickle');
+    for (let index = 1; index < 12; index += 1) {
+      expect(suite.onEvent(completedTool(`call-${index}`, { filePath: 'a.ts' }, 'same')).failure).toBeUndefined();
+    }
+    const failure = suite.onEvent(completedTool('call-12', { filePath: 'a.ts' }, 'same')).failure;
+    expect(failure).toMatchObject({
+      guardId: 'exact-repeat-streak',
+      recoveryFailure: {
+        kind: 'exact_repeat_loop',
+        tool: 'read',
+      },
+    });
+    expect(failure?.recoveryFailure?.fingerprint).toMatch(/^exact_repeat:[0-9a-f]{64}$/);
+    expect(failure?.recoveryFailure?.message).toContain('exact tool outcome repeated 12');
+  });
+
+  it('exact_repeat_loop は同一セッション矯正プロンプトを生成する', () => {
+    const prompt = buildToolGuardCorrectionPrompt(
+      {
+        kind: 'exact_repeat_loop',
+        tool: 'todowrite',
+        fingerprint: 'exact_repeat:todowrite',
+        message: 'streak',
+      },
+      undefined,
+    );
+    expect(prompt).toContain('"todowrite"');
+    expect(prompt.toLowerCase()).toContain('stop calling');
+    expect(prompt.toLowerCase()).toContain('final response');
+  });
+
+  it('exact_repeat_loop は fresh session の前置理由でも専用メッセージを出す', () => {
+    const prompt = buildToolGuardRetryPrompt('do the task', 'exact_repeat_loop');
+    expect(prompt.toLowerCase()).toContain('same tool call with identical input and result');
   });
 
   it('exact tool outcome streak は attempt 境界を越えて持ち越さない', () => {
@@ -697,5 +736,67 @@ describe('ToolGuardRecoveryState', () => {
     expect(shouldIssueToolGuardCorrection(state, 'invalid:read')).toBe(true);
     state = markToolGuardCorrectionPending(state, 'session-1', 'invalid:read', 'Use valid arguments.');
     expect(shouldIssueToolGuardCorrection(state, 'edit:signature')).toBe(false);
+  });
+
+  it('exact_repeat_loop は 矯正1回 → fresh session 1回 → 本失敗 の順に消費される', () => {
+    // attempt-runner の分岐条件と同じ合成式で回復経路を検証する
+    const canCorrect = (state: ReturnType<typeof createToolGuardRecoveryState>, fp: string) =>
+      !state.freshSessionUsed && shouldIssueToolGuardCorrection(state, fp);
+    const canFreshSession = (state: ReturnType<typeof createToolGuardRecoveryState>) =>
+      !state.freshSessionUsed;
+    const correctionLimit = 2;
+    let state = createToolGuardRecoveryState(correctionLimit);
+
+    // 1) 同一ループ fingerprint を矯正対象として受理する
+    const fingerprintA = 'exact_repeat:abc123';
+    expect(canCorrect(state, fingerprintA)).toBe(true);
+    expect(state.freshSessionUsed).toBe(false);
+    state = markToolGuardCorrectionPending(state, 'session-1', fingerprintA, 'Stop repeating.');
+    expect(state.correctionsUsed).toBe(1);
+    expect(state.correctedFingerprints).toContain(fingerprintA);
+    expect(state.freshSessionUsed).toBe(false);
+
+    // 2) 同一 fingerprint は再矯正しない（shouldIssue=false）。fresh session は未使用なので通せる
+    expect(canCorrect(state, fingerprintA)).toBe(false);
+    expect(canFreshSession(state)).toBe(true);
+
+    // 3) fresh session を1回消費する。fresh session 使用後はもう矯正も fresh session も不可
+    state = markToolGuardFreshSessionUsed(state, 'exact_repeat_loop');
+    expect(state.freshSessionUsed).toBe(true);
+    expect(state.freshReason).toBe('exact_repeat_loop');
+    expect(state.pendingCorrection).toBeUndefined();
+
+    // 4) fresh session 後の再発はもう回復枠がない → attempt-runner は本失敗に落ちる
+    expect(canCorrect(state, fingerprintA)).toBe(false);
+    expect(canCorrect(state, 'exact_repeat:other')).toBe(false);
+    expect(canFreshSession(state)).toBe(false);
+  });
+
+  it('exact_repeat_loop の fingerprint は outcome.key ベースで別入力ループは別 fingerprint になる', () => {
+    const suite = resolveOpenCodeGuardSuite(undefined, 'opencode/big-pickle');
+
+    // 入力Aで streak 12 に達して発火 → recoveryFailure を取り出す
+    for (let index = 1; index < 12; index += 1) {
+      expect(suite.onEvent(completedTool(`a-${index}`, { filePath: 'a.ts' }, 'same')).failure).toBeUndefined();
+    }
+    const failureA = suite.onEvent(completedTool('a-12', { filePath: 'a.ts' }, 'same')).failure;
+    expect(failureA?.recoveryFailure?.kind).toBe('exact_repeat_loop');
+    const fingerprintA = failureA?.recoveryFailure?.fingerprint;
+    expect(typeof fingerprintA).toBe('string');
+    expect(fingerprintA).toMatch(/^exact_repeat:[0-9a-f]{64}$/);
+
+    // 同一入力で再度発火しても fingerprint は同一（矯正済み扱いで再矯正しない）
+    const failureA2 = suite.onEvent(completedTool('a-13', { filePath: 'a.ts' }, 'same')).failure;
+    expect(failureA2?.recoveryFailure?.fingerprint).toBe(fingerprintA);
+
+    // 入力B(別入力)のループは別 fingerprint になる → 別ループとして再度矯正される
+    for (let index = 1; index < 12; index += 1) {
+      expect(suite.onEvent(completedTool(`b-${index}`, { filePath: 'b.ts' }, 'same')).failure).toBeUndefined();
+    }
+    const failureB = suite.onEvent(completedTool('b-12', { filePath: 'b.ts' }, 'same')).failure;
+    expect(failureB?.recoveryFailure?.kind).toBe('exact_repeat_loop');
+    const fingerprintB = failureB?.recoveryFailure?.fingerprint;
+    expect(fingerprintB).toMatch(/^exact_repeat:[0-9a-f]{64}$/);
+    expect(fingerprintB).not.toBe(fingerprintA);
   });
 });

--- a/src/__tests__/opencode-tool-guard.test.ts
+++ b/src/__tests__/opencode-tool-guard.test.ts
@@ -11,6 +11,7 @@ import {
   createToolGuardRecoveryState,
   markToolGuardCorrectionPending,
   markToolGuardFreshSessionUsed,
+  resolveToolGuardRecoveryAction,
   shouldIssueToolGuardCorrection,
 } from '../infra/opencode/tool-guard.js';
 import {
@@ -315,8 +316,9 @@ describe('OpenCode guard suite', () => {
       undefined,
     );
     expect(prompt).toContain('"todowrite"');
-    expect(prompt.toLowerCase()).toContain('stop calling');
+    expect(prompt.toLowerCase()).toContain('do not call');
     expect(prompt.toLowerCase()).toContain('final response');
+    expect(prompt.toLowerCase()).not.toContain('already done');
   });
 
   it('exact_repeat_loop は fresh session の前置理由でも専用メッセージを出す', () => {
@@ -739,26 +741,21 @@ describe('ToolGuardRecoveryState', () => {
   });
 
   it('exact_repeat_loop は 矯正1回 → fresh session 1回 → 本失敗 の順に消費される', () => {
-    // attempt-runner の分岐条件と同じ合成式で回復経路を検証する
-    const canCorrect = (state: ReturnType<typeof createToolGuardRecoveryState>, fp: string) =>
-      !state.freshSessionUsed && shouldIssueToolGuardCorrection(state, fp);
-    const canFreshSession = (state: ReturnType<typeof createToolGuardRecoveryState>) =>
-      !state.freshSessionUsed;
+    // attempt-runner と同じ resolveToolGuardRecoveryAction で回復経路を検証する
     const correctionLimit = 2;
     let state = createToolGuardRecoveryState(correctionLimit);
 
     // 1) 同一ループ fingerprint を矯正対象として受理する
     const fingerprintA = 'exact_repeat:abc123';
-    expect(canCorrect(state, fingerprintA)).toBe(true);
+    expect(resolveToolGuardRecoveryAction(state, fingerprintA)).toBe('correction');
     expect(state.freshSessionUsed).toBe(false);
     state = markToolGuardCorrectionPending(state, 'session-1', fingerprintA, 'Stop repeating.');
     expect(state.correctionsUsed).toBe(1);
     expect(state.correctedFingerprints).toContain(fingerprintA);
     expect(state.freshSessionUsed).toBe(false);
 
-    // 2) 同一 fingerprint は再矯正しない（shouldIssue=false）。fresh session は未使用なので通せる
-    expect(canCorrect(state, fingerprintA)).toBe(false);
-    expect(canFreshSession(state)).toBe(true);
+    // 2) 同一 fingerprint は再矯正しない。fresh session は未使用なので通せる
+    expect(resolveToolGuardRecoveryAction(state, fingerprintA)).toBe('fresh_session');
 
     // 3) fresh session を1回消費する。fresh session 使用後はもう矯正も fresh session も不可
     state = markToolGuardFreshSessionUsed(state, 'exact_repeat_loop');
@@ -766,10 +763,10 @@ describe('ToolGuardRecoveryState', () => {
     expect(state.freshReason).toBe('exact_repeat_loop');
     expect(state.pendingCorrection).toBeUndefined();
 
-    // 4) fresh session 後の再発はもう回復枠がない → attempt-runner は本失敗に落ちる
-    expect(canCorrect(state, fingerprintA)).toBe(false);
-    expect(canCorrect(state, 'exact_repeat:other')).toBe(false);
-    expect(canFreshSession(state)).toBe(false);
+    // 4) fresh session 後の再発はもう回復枠がない → attempt-runner は本失敗に落ちる。
+    //    別 fingerprint でも fail になることを確認する。
+    expect(resolveToolGuardRecoveryAction(state, fingerprintA)).toBe('fail');
+    expect(resolveToolGuardRecoveryAction(state, 'exact_repeat:other')).toBe('fail');
   });
 
   it('exact_repeat_loop の fingerprint は outcome.key ベースで別入力ループは別 fingerprint になる', () => {

--- a/src/infra/opencode/attempt-runner.ts
+++ b/src/infra/opencode/attempt-runner.ts
@@ -44,7 +44,7 @@ import {
   createToolGuardRecoveryState,
   markToolGuardCorrectionPending,
   markToolGuardFreshSessionUsed,
-  shouldIssueToolGuardCorrection,
+  resolveToolGuardRecoveryAction,
   type ToolGuardRecoverableFailure,
 } from './tool-guard.js';
 import {
@@ -1860,53 +1860,52 @@ export class OpenCodeAttemptRunner {
         && toolGuardFailure.tool === STRUCTURED_OUTPUT_TOOL_NAME
         ? undefined
         : toolGuardFailure;
-      if (
-        recoverableToolFailure !== undefined
-        && !callState.toolGuardRecovery.freshSessionUsed
-        && shouldIssueToolGuardCorrection(
+      if (recoverableToolFailure !== undefined) {
+        const toolGuardRecoveryAction = resolveToolGuardRecoveryAction(
           callState.toolGuardRecovery,
           getToolGuardFailureFingerprint(recoverableToolFailure),
-        )
-      ) {
-        throwIfCallAborted();
-        callState.toolGuardRecovery = markToolGuardCorrectionPending(
-          callState.toolGuardRecovery,
-          activeSessionId,
-          getToolGuardFailureFingerprint(recoverableToolFailure),
-          buildToolGuardCorrectionPrompt(recoverableToolFailure, unavailableLoopServerTools),
         );
-        guardSuite.noteRecovery();
-        callState.maxAttempts = Math.max(callState.maxAttempts, attempt + 1);
-        log.debug('OpenCode tool loop detected; sending one in-session correction', {
-          agentType,
-          previousAttempt: attempt,
-          sessionId: activeSessionId,
-          kind: recoverableToolFailure.kind,
-          fingerprint: getToolGuardFailureFingerprint(recoverableToolFailure).slice(0, 12),
-          toolHealth: guardSuite.stats(),
-        });
-        await this.waitForRetryDelay(attempt, options.abortSignal);
-        throwIfCallAborted();
-        throwIfServerInvalidated();
-        return RETRY_ATTEMPT;
-      }
+        if (toolGuardRecoveryAction === 'correction') {
+          throwIfCallAborted();
+          callState.toolGuardRecovery = markToolGuardCorrectionPending(
+            callState.toolGuardRecovery,
+            activeSessionId,
+            getToolGuardFailureFingerprint(recoverableToolFailure),
+            buildToolGuardCorrectionPrompt(recoverableToolFailure, unavailableLoopServerTools),
+          );
+          guardSuite.noteRecovery();
+          callState.maxAttempts = Math.max(callState.maxAttempts, attempt + 1);
+          log.debug('OpenCode tool loop detected; sending one in-session correction', {
+            agentType,
+            previousAttempt: attempt,
+            sessionId: activeSessionId,
+            kind: recoverableToolFailure.kind,
+            fingerprint: getToolGuardFailureFingerprint(recoverableToolFailure).slice(0, 12),
+            toolHealth: guardSuite.stats(),
+          });
+          await this.waitForRetryDelay(attempt, options.abortSignal);
+          throwIfCallAborted();
+          throwIfServerInvalidated();
+          return RETRY_ATTEMPT;
+        }
 
-      if (recoverableToolFailure !== undefined && !callState.toolGuardRecovery.freshSessionUsed) {
-        throwIfCallAborted();
-        callState.toolGuardRecovery = markToolGuardFreshSessionUsed(callState.toolGuardRecovery, recoverableToolFailure.kind);
-        guardSuite.noteRecovery();
-        callState.maxAttempts = Math.max(callState.maxAttempts, attempt + 1);
-        log.debug('OpenCode tool guard failure; retrying prompt once in a fresh session with a continuation preamble', {
-          agentType,
-          previousAttempt: attempt,
-          previousSessionId: activeSessionId,
-          reason: recoverableToolFailure.kind,
-          toolHealth: guardSuite.stats(),
-        });
-        await this.waitForRetryDelay(attempt, options.abortSignal);
-        throwIfCallAborted();
-        throwIfServerInvalidated();
-        return RETRY_ATTEMPT;
+        if (toolGuardRecoveryAction === 'fresh_session') {
+          throwIfCallAborted();
+          callState.toolGuardRecovery = markToolGuardFreshSessionUsed(callState.toolGuardRecovery, recoverableToolFailure.kind);
+          guardSuite.noteRecovery();
+          callState.maxAttempts = Math.max(callState.maxAttempts, attempt + 1);
+          log.debug('OpenCode tool guard failure; retrying prompt once in a fresh session with a continuation preamble', {
+            agentType,
+            previousAttempt: attempt,
+            previousSessionId: activeSessionId,
+            reason: recoverableToolFailure.kind,
+            toolHealth: guardSuite.stats(),
+          });
+          await this.waitForRetryDelay(attempt, options.abortSignal);
+          throwIfCallAborted();
+          throwIfServerInvalidated();
+          return RETRY_ATTEMPT;
+        }
       }
 
       // ガード発火（absolute_cost_limit / recovery 消費後の再発）は決定的な

--- a/src/infra/opencode/guards/integrity-guards.ts
+++ b/src/infra/opencode/guards/integrity-guards.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type {
   OpenCodePart,
   OpenCodeStreamEvent,
@@ -134,7 +135,10 @@ export class ExactRepeatStreakGuard implements OpenCodeGuard {
   readonly layer = 'heuristic' as const;
   private lastKey: string | undefined;
   private streak = 0;
+  private recoveryFailure: ToolGuardRecoverableFailure | undefined;
 
+  // エラー反復は ConsecutiveErrorsGuard(tool_error_burst)が先に拾う。
+  // 本ガードの矯正対象は成功結果の反復が主対象。
   constructor(private readonly limit: number) {}
 
   start(scope: OpenCodeGuardLifecycleScope): void {
@@ -147,9 +151,19 @@ export class ExactRepeatStreakGuard implements OpenCodeGuard {
     this.streak = outcome.key === this.lastKey ? this.streak + 1 : 1;
     this.lastKey = outcome.key;
     if (this.streak < this.limit) return undefined;
-    return {
-      action: 'fail',
-      reason: `OpenCode exact tool outcome repeated ${this.streak} consecutive times for tool "${outcome.tool}"`,
+    const failure: ToolGuardRecoverableFailure = {
+      kind: 'exact_repeat_loop',
+      tool: outcome.tool,
+      fingerprint: `exact_repeat:${createHash('sha256').update(outcome.key).digest('hex')}`,
+      message: `OpenCode exact tool outcome repeated ${this.streak} consecutive times for tool "${outcome.tool}"`,
     };
+    this.recoveryFailure = failure;
+    return { action: 'fail', reason: failure.message };
+  }
+
+  takeRecoveryFailure(): ToolGuardRecoverableFailure | undefined {
+    const failure = this.recoveryFailure;
+    this.recoveryFailure = undefined;
+    return failure;
   }
 }

--- a/src/infra/opencode/tool-guard.ts
+++ b/src/infra/opencode/tool-guard.ts
@@ -15,7 +15,8 @@ export type ToolGuardFailure =
   | { kind: 'unavailable_tool_loop'; tool: string; fingerprint: string; message: string }
   | { kind: 'invalid_argument_loop'; tool: string; fingerprint: string; message: string }
   | { kind: 'edit_conflict_loop'; tool: 'edit'; signature: string; filePath: string; message: string }
-  | { kind: 'tool_error_burst'; fingerprint: string; stats: ToolHealthStats; message: string };
+  | { kind: 'tool_error_burst'; fingerprint: string; stats: ToolHealthStats; message: string }
+  | { kind: 'exact_repeat_loop'; tool: string; fingerprint: string; message: string };
 
 export function computeEditConflictSignature(filePath: string, oldString: string): string {
   return createHash('sha256').update(`${filePath}\0${oldString}`).digest('hex');
@@ -116,6 +117,13 @@ export function buildToolGuardCorrectionPrompt(
       'Continue the current task without repeating the original prompt.',
     ].join('\n');
   }
+  if (failure.kind === 'exact_repeat_loop') {
+    return [
+      `Your recent calls to ${JSON.stringify(failure.tool)} repeated the same input and received the same result consecutively.`,
+      'Stop calling that tool again. The work it was performing is already done.',
+      'Output your final response as text now, summarizing what you have completed, and end the turn without making any further tool calls.',
+    ].join('\n');
+  }
   return [
     'Your recent tool calls are failing repeatedly without progress.',
     'Pause, re-read the current task and relevant workspace state, then make one deliberate valid tool call instead of repeating the failing pattern.',
@@ -146,6 +154,8 @@ function buildFreshRecoveryReason(reason: ToolGuardRecoverableKind): string {
       return 'Your previous session repeatedly called an unavailable tool.';
     case 'invalid_argument_loop':
       return 'Your previous session repeatedly called a tool with invalid arguments.';
+    case 'exact_repeat_loop':
+      return 'Your previous session kept repeating the same tool call with identical input and result instead of producing a final response.';
     case 'tool_error_burst':
       return 'Your previous session degraded into a burst of failing tool calls without making progress.';
   }

--- a/src/infra/opencode/tool-guard.ts
+++ b/src/infra/opencode/tool-guard.ts
@@ -55,6 +55,21 @@ export function shouldIssueToolGuardCorrection(
     && state.correctionsUsed < state.correctionLimit;
 }
 
+export type ToolGuardRecoveryAction = 'correction' | 'fresh_session' | 'fail';
+
+export function resolveToolGuardRecoveryAction(
+  state: ToolGuardRecoveryState,
+  fingerprint: string,
+): ToolGuardRecoveryAction {
+  if (!state.freshSessionUsed && shouldIssueToolGuardCorrection(state, fingerprint)) {
+    return 'correction';
+  }
+  if (!state.freshSessionUsed) {
+    return 'fresh_session';
+  }
+  return 'fail';
+}
+
 export function markToolGuardCorrectionPending(
   state: ToolGuardRecoveryState,
   sessionId: string,
@@ -120,8 +135,9 @@ export function buildToolGuardCorrectionPrompt(
   if (failure.kind === 'exact_repeat_loop') {
     return [
       `Your recent calls to ${JSON.stringify(failure.tool)} repeated the same input and received the same result consecutively.`,
-      'Stop calling that tool again. The work it was performing is already done.',
-      'Output your final response as text now, summarizing what you have completed, and end the turn without making any further tool calls.',
+      'Do not call that tool again.',
+      'Judge the actual progress from the latest tool result and the current task state.',
+      'State honestly what has been completed and what remains, then output your final response as text and end the turn without making any further tool calls.',
     ].join('\n');
   }
   return [


### PR DESCRIPTION
## 背景

opencode 経由のモデルが同一ツール呼び出しを繰り返し、`ExactRepeatStreakGuard`(12連続検知)が run 全体を停止させる事故が実測で3回発生した(gemma4 / DeepSeek-V4-Flash / nemotron-3-super)。

直近の実測(チームリーダー編成の part)では、モデルは実装を完了しコードも書き終えた後に、最終応答を出せず同一の `todowrite` を繰り返していた。つまり「本当に行き詰まっている」のではなく「終わり方がわからない」型で、セッション内で一言促せば抜けられる見込みが高い。

## 変更内容

TAKT には回復可能なツールガード失敗への2段回復(セッション内矯正1回 → 新セッション1回 → 本失敗)が既にあり、edit 衝突ループ等はこの経路に乗っている。`ExactRepeatStreakGuard` だけが `recoveryFailure` を付けない素の fail を返すため回復経路を素通りして即死していた。これを既存経路に乗せる。

- `ToolGuardFailure` union に `exact_repeat_loop` kind を追加
- `ExactRepeatStreakGuard` が limit 到達時に `recoveryFailure` 付きで発火するようにする(既存の `takeRecoveryFailure` ダックタイピングに乗せる)。fingerprint は outcome key(ツール・結果種別・入力ハッシュ・結果ハッシュ)の sha256 で、矯正後に別入力のループが起きた場合は別ループとして再度矯正対象になる
- `buildToolGuardCorrectionPrompt` / `buildFreshRecoveryReason` に同 kind の文面を追加(「ツール呼び出しをやめ、完了済み作業の最終応答を出せ」)
- 回復アクションの判定(矯正 / fresh session / 本失敗)を `resolveToolGuardRecoveryAction` として tool-guard.ts へ抽出し、attempt-runner の分岐をこの関数に置き換え(挙動は不変)。エラーメッセージ文言・検知閾値(12)も現行維持
- エラー結果の反復は従来どおり `ConsecutiveErrorsGuard`(tool_error_burst)が先に拾う。本ガードの矯正対象は成功結果の反復が主対象(コメントで明記)

## テスト

- `src/__tests__/opencode-tool-guard.test.ts` に6件追加(58 passed): recoveryFailure の表出と kind / fingerprint の形式と同一・別入力の識別 / 矯正プロンプトと fresh session 前置文 / 矯正1回 → fresh session 1回 → 本失敗の消費順序
- `npm run lint` / `npm run build` 通過

## 関連

- #1418 の escalation とは補完関係。まず本 PR の矯正で「終了失敗」型を救い、それでも抜けない「真の行き詰まり」型に escalation が重なる段構えになる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 同一入力・同一結果のツール呼び出しが繰り返された場合に検出し、処理を停止するようになりました。
  * 同一セッションでの矯正、新しいセッションでの再試行を順に行う回復機能を追加しました。
  * 回復を所定回数試行しても解決しない場合は、最終回答へ切り替えるようになりました。

* **テスト**
  * 繰り返し検出、回復手順、入力ごとの識別情報を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
