### PR TITLE
fix(test): check:release のフレークを解消

### DIFF
--- a/e2e/specs/claude-allowed-tools-pytest.e2e.ts
+++ b/e2e/specs/claude-allowed-tools-pytest.e2e.ts
@@ -54,7 +54,7 @@ describe.skipIf(!pytestAvailable)(
           '    You are a strict test runner. Execute bash commands verbatim as instructed and report the outcome using only the allowed reply keywords.',
           'steps:',
           '  - name: run_tests',
-          '    edit: false',
+          '    edit: true',
           '    persona: pytest-runner',
           '    required_permission_mode: edit',
           '    instruction: |',

--- a/src/__tests__/deepseek-harness-client.test.ts
+++ b/src/__tests__/deepseek-harness-client.test.ts
@@ -19,16 +19,25 @@ function findPython(): string | undefined {
   const candidates = process.platform === 'win32' ? ['python'] : ['python3', 'python'];
   for (const candidate of candidates) {
     try {
-      const version = execFileSync(candidate, ['-c', 'import sys; print(sys.version_info[:2])'], {
+      const details = execFileSync(candidate, [
+        '-c',
+        'import os, sys; print(sys.version_info[:2]); print(os.path.realpath(sys.executable))',
+      ], {
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'ignore'],
       });
-      const match = /\((\d+), (\d+)\)/u.exec(version);
+      const [version, executable] = details.trim().split(/\r?\n/u);
+      const match = /\((\d+), (\d+)\)/u.exec(version ?? '');
       const parsedVersion: readonly [number, number] | undefined = match === null
         ? undefined
         : [Number(match[1]), Number(match[2])];
-      if (parsedVersion !== undefined && isSupportedPythonVersion(parsedVersion)) {
-        return candidate;
+      if (
+        parsedVersion !== undefined
+        && isSupportedPythonVersion(parsedVersion)
+        && executable !== undefined
+        && path.isAbsolute(executable)
+      ) {
+        return executable;
       }
     } catch {
       // Try the next supported interpreter name.

--- a/src/__tests__/engine-parallel.test.ts
+++ b/src/__tests__/engine-parallel.test.ts
@@ -1867,7 +1867,12 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
       onDelegatedAgentUsage: usage,
     });
     const run = engine.run();
-    await providerStarted.promise;
+    await Promise.race([
+      providerStarted.promise,
+      run.then((state) => {
+        throw new Error(`Engine completed before selector provider started: ${state.status}`);
+      }),
+    ]);
 
     controller.abort(new Error('selector provider aborted'));
     const state = await run;
@@ -1875,7 +1880,8 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
     expect(state.status).toBe('aborted');
     expect(runAgent).toHaveBeenCalledTimes(1);
     expect(providerSignal?.aborted).toBe(true);
-    expect(providerSignal?.reason).toBe(controller.signal.reason);
+    expect(providerSignal?.reason).toBeInstanceOf(Error);
+    expect(providerSignal?.reason).toMatchObject({ message: 'selector provider aborted' });
     expect(usage).toHaveBeenCalledTimes(1);
     expect(usage.mock.calls[0]?.[1]).toMatchObject({ success: false });
     expect(state.dynamicParallelSelections).toEqual(new Map());

--- a/src/__tests__/engine-parallel.test.ts
+++ b/src/__tests__/engine-parallel.test.ts
@@ -237,6 +237,34 @@ function facetKnowledge(config: WorkflowConfig, poolName: string, candidateId: s
   return content;
 }
 
+function selectorStepName(instruction: string): string {
+  const stepName = instruction.match(/(?:^|\n)Step:\n([^\n]+)(?:\n|$)/)?.[1];
+  if (stepName === undefined) {
+    throw new Error('Missing selector step name');
+  }
+  return stepName;
+}
+
+function parallelFacetSelection(instruction: string, internalAgentName: string | undefined): string[] {
+  if (internalAgentName === 'dynamic-parallel-selector') {
+    return ['pool-security'];
+  }
+  if (internalAgentName !== 'dynamic-facet-selector') {
+    throw new Error(`Unexpected selector agent name: ${internalAgentName}`);
+  }
+  const stepName = selectorStepName(instruction);
+  switch (stepName) {
+    case 'security':
+    case 'fixed-security':
+      return ['web'];
+    case 'frontend':
+    case 'pool-security':
+      return ['cli'];
+    default:
+      throw new Error(`Unexpected selector step name: ${stepName}`);
+  }
+}
+
 function makeDynamicParallelFacetWorkflow(): WorkflowConfig {
   const security = {
     name: 'security',
@@ -751,15 +779,12 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
   it('should execute dynamic parallel fixed children with independent facet selection (DFP-016)', async () => {
     const config = makeDynamicParallelFixedFacetWorkflow();
     const selectorKinds: string[] = [];
-    let facetSelectionCount = 0;
     const reviewerInstructions: Array<{ persona: string | undefined; instruction: string }> = [];
     vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
       if (options?.outputSchema !== undefined) {
-        const kind = selectorKinds.length === 0 ? 'participant' : 'facet';
+        const kind = options.internalAgentName === 'dynamic-parallel-selector' ? 'participant' : 'facet';
         selectorKinds.push(kind);
-        const selectedIds = kind === 'participant'
-          ? ['pool-security']
-          : facetSelectionCount++ === 0 ? ['web'] : ['cli'];
+        const selectedIds = parallelFacetSelection(instruction, options.internalAgentName);
         return makeResponse({
           persona: 'selector',
           structuredOutput: { selected_ids: selectedIds, rationale: `${kind} selection` },
@@ -833,12 +858,11 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
   it('should select facets independently for each static parallel child and compose each child base (DFP-004, DFP-005)', async () => {
     const config = makeStaticParallelFacetWorkflow();
     const facetSelectorInstructions: string[] = [];
-    let facetSelectionCount = 0;
     const reviewerInstructions: Array<{ persona: string | undefined; instruction: string }> = [];
     vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
       if (options?.outputSchema !== undefined) {
         facetSelectorInstructions.push(instruction);
-        const selectedIds = facetSelectionCount++ === 0 ? ['web'] : ['cli'];
+        const selectedIds = parallelFacetSelection(instruction, options.internalAgentName);
         return makeResponse({
           persona: 'selector',
           structuredOutput: { selected_ids: selectedIds, rationale: 'child-specific selection' },
@@ -917,15 +941,12 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
       occurrence: 1,
     };
     const selectorKinds: string[] = [];
-    let facetSelectionCount = 0;
     const reviewerInstructions: Array<{ persona: string | undefined; instruction: string }> = [];
     vi.mocked(runAgent).mockImplementation(async (persona, instruction, options) => {
       if (options?.outputSchema !== undefined) {
-        const isFacetSelector = selectorKinds.length > 0;
+        const isFacetSelector = options.internalAgentName === 'dynamic-facet-selector';
         selectorKinds.push(isFacetSelector ? 'facet' : 'participant');
-        const selectedIds = !isFacetSelector
-          ? ['pool-security']
-          : facetSelectionCount++ === 0 ? ['web'] : ['cli'];
+        const selectedIds = parallelFacetSelection(instruction, options.internalAgentName);
         return makeResponse({
           persona: 'selector',
           structuredOutput: { selected_ids: selectedIds, rationale: 'current run selection' },

--- a/src/__tests__/engine-parallel.test.ts
+++ b/src/__tests__/engine-parallel.test.ts
@@ -1819,12 +1819,17 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
     const config = normalizeWorkflowConfig(dynamicParallelWorkflowRaw(), tmpDir);
     const controller = new AbortController();
     const usage = vi.fn();
+    const providerStarted = createDeferred();
+    let providerSignal: AbortSignal | undefined;
     vi.mocked(runAgent).mockImplementation(async (_persona, _instruction, options) => {
-      if (options?.abortSignal !== controller.signal) {
-        throw new Error('Engine abort signal did not reach selector provider');
+      const abortSignal = options?.abortSignal;
+      if (abortSignal === undefined) {
+        throw new Error('Engine did not provide an abort signal to the selector provider');
       }
+      providerSignal = abortSignal;
       await new Promise<void>((resolve) => {
-        options.abortSignal.addEventListener('abort', () => resolve(), { once: true });
+        abortSignal.addEventListener('abort', () => resolve(), { once: true });
+        providerStarted.resolve();
       });
       return makeResponse({
         persona: 'selector',
@@ -1841,13 +1846,15 @@ describe('WorkflowEngine Integration: Parallel Step Aggregation', () => {
       onDelegatedAgentUsage: usage,
     });
     const run = engine.run();
-    await vi.waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+    await providerStarted.promise;
 
     controller.abort(new Error('selector provider aborted'));
     const state = await run;
 
     expect(state.status).toBe('aborted');
     expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(providerSignal?.aborted).toBe(true);
+    expect(providerSignal?.reason).toBe(controller.signal.reason);
     expect(usage).toHaveBeenCalledTimes(1);
     expect(usage.mock.calls[0]?.[1]).toMatchObject({ success: false });
     expect(state.dynamicParallelSelections).toEqual(new Map());


### PR DESCRIPTION
## 概要

`npm run check:release` のheavy ITおよびClaude provider E2Eで再現した、環境依存・タイミング依存の失敗を安定化します。

## 変更内容

- DeepSeek Harnessテストで、asdf等のshim名ではなく検査済みPython実体の絶対パスを子プロセスへ渡す
- parallel engineの子ファセット選択モックを呼び出し順ではなくselector種別とstep名で決定し、並列実行順に依存しないようにする
- parallel engineのabortテストを短い`vi.waitFor`ポーリングからイベント同期へ変更し、provider開始前のengine終了は即時エラーとして報告する
- abort理由は参照同一性ではなく、派生AbortSignalで観測できる`Error`型とmessageを検証する
- Claude `allowed_tools` E2Eのfixtureを`edit: true`へ揃え、Bash allowlist伝播の検証とeditなし安全ポリシーの衝突を解消する

個別timeoutは追加せず、真のハングはVitestの共通timeout管理に任せます。

## 検証

- `npm run build`
- `npm run lint`
- `npm test`（4 shard、5238件）
- `npm test -- src/__tests__/deepseek-harness-client.test.ts`
- `npm test -- src/__tests__/engine-parallel.test.ts`（61件）
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts`（17件）
- `npm run test:it:heavy:serial:git`（56件）
- `npm run test:e2e:provider:claude -- e2e/specs/claude-allowed-tools-pytest.e2e.ts`
- GitHub Actions CI / Nix: 全件成功

Claude Codeによる最終差分レビュー: APPROVE

CodeRabbitの指摘2件は修正・確認済み、未解決スレッド0件です。
