### PR TITLE
fix(pi): prefer user/project npm extensions over temporary install

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1156,7 +1156,9 @@ provider_options:
 ```
 
 - `extensions` には npm package、Git source、local path を指定できます。
-- 明示した source は TAKT 実行時に temporary resolution され、Pi settings には永続化されません。
+- 明示した npm source は既存の user scope install を再利用し、利用できない、または読み込めない場合だけ temporary resolution に fallback します。user scope への新規 install は行いません。
+- npm 以外の明示した source は TAKT 実行時に temporary resolution されます。
+- 明示した source は Pi settings には永続化されません。
 - `no_extensions` は extension 探索を無効にしますが、`extensions` に列挙した source は読み込みます。
 - その他の `no_*` オプションはそれぞれ対応するリソース種別の探索を無効にします。
 - 暗黙の project-local Pi extension は信頼せず、読み込みません。

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1156,12 +1156,12 @@ provider_options:
 ```
 
 - `extensions` には npm package、Git source、local path を指定できます。
-- 明示した npm source は既存の user scope install を再利用し、利用できない、または読み込めない場合だけ temporary resolution に fallback します。user scope への新規 install は行いません。
+- version 指定のない明示 npm source は既存の project scope install、user scope install の順に再利用します。どちらも有効な resource に解決できない場合だけ temporary resolution に fallback し、永続 scope への新規 install は行いません。version 指定付き npm source は常に temporary resolution されます。
 - npm 以外の明示した source は TAKT 実行時に temporary resolution されます。
 - 明示した source は Pi settings には永続化されません。
 - `no_extensions` は extension 探索を無効にしますが、`extensions` に列挙した source は読み込みます。
-- その他の `no_*` オプションはそれぞれ対応するリソース種別の探索を無効にします。
-- 暗黙の project-local Pi extension は信頼せず、読み込みません。
+- その他の `no_*` オプションは、それぞれ対応するリソース種別の探索を無効にします。
+- 暗黙の project-local Pi resource は信頼せず、読み込みません。project package storage から再利用するのは、明示した npm source に対して検出した絶対 path だけです。
 - 明示した extension は TAKT process 内で実行されるため、信頼できる local path と package source だけを設定してください。
 - 認証情報を埋め込んだ URL や secret 系 query parameter を含む extension URL は拒否します。
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1210,12 +1210,12 @@ provider_options:
 ```
 
 - `extensions` accepts npm packages, Git sources, and local paths.
-- Existing user-scope installs are reused for explicit npm sources; when one is unavailable or not loadable, TAKT falls back to temporary resolution without installing into the user scope.
+- Bare explicit npm sources reuse an existing project-scope install first, then an existing user-scope install; when neither can be resolved to enabled resources, TAKT falls back to temporary resolution without installing into either persistent scope. Version-qualified npm sources are always resolved temporarily.
 - Explicit non-npm sources are resolved temporarily for the TAKT run.
 - Explicit sources are not persisted into Pi settings.
 - `no_extensions` disables extension discovery but still loads the sources listed in `extensions`.
 - The other `no_*` options disable discovery of their respective resource types.
-- Implicit project-local Pi extensions are not trusted or loaded.
+- Implicit project-local Pi resources are not trusted or loaded; only the absolute path discovered for an explicitly configured npm source can be reused from project package storage.
 - Explicit extensions execute inside the TAKT process, so configure only trusted local paths and package sources.
 - Extension URLs containing embedded credentials or secret-bearing query parameters are rejected.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1210,7 +1210,9 @@ provider_options:
 ```
 
 - `extensions` accepts npm packages, Git sources, and local paths.
-- Explicit sources are resolved temporarily for the TAKT run and are not persisted into Pi settings.
+- Existing user-scope installs are reused for explicit npm sources; when one is unavailable or not loadable, TAKT falls back to temporary resolution without installing into the user scope.
+- Explicit non-npm sources are resolved temporarily for the TAKT run.
+- Explicit sources are not persisted into Pi settings.
 - `no_extensions` disables extension discovery but still loads the sources listed in `extensions`.
 - The other `no_*` options disable discovery of their respective resource types.
 - Implicit project-local Pi extensions are not trusted or loaded.

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -955,7 +955,7 @@ provider_options:
     no_context_files: true    # 禁用 Pi context-file discovery
 ```
 
-显式资源只在 TAKT run 中临时解析，不会写入 Pi 设置；隐式项目本地 extension 不会被信任或加载。带有内嵌凭据或包含 secret 的 query 参数的 extension URL 会被拒绝。
+没有版本限定的显式 npm source 会依次复用已有的 project scope、user scope 安装；两者都无法解析为启用的资源时，才使用 temporary resolution，并且不会向持久 scope 安装。带版本限定的 npm source 始终使用 temporary resolution。显式资源不会写入 Pi 设置；隐式 project-local Pi 资源不会被信任或加载，只有为显式 npm source 检测到的绝对路径可以从 project package storage 复用。带有内嵌凭据或包含 secret 的 query 参数的 extension URL 会被拒绝。
 
 <a id="workflow-categories"></a>
 

--- a/scripts/pi-sdk-cross-platform-smoke.mjs
+++ b/scripts/pi-sdk-cross-platform-smoke.mjs
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import process from 'node:process';
 import {
   createAgentSession,
+  DefaultPackageManager,
   DefaultResourceLoader,
   ModelRuntime,
   SessionManager,
@@ -30,6 +31,9 @@ const root = await mkdtemp(join(tmpdir(), 'takt-pi-sdk-'));
 const cwd = join(root, 'project');
 const agentDir = join(root, 'agent');
 const extensionPath = join(root, 'platform-probe.js');
+const projectPackageRoot = join(cwd, '.pi', 'npm', 'node_modules', 'project-probe');
+const projectExtensionPath = join(projectPackageRoot, 'index.js');
+const implicitExtensionPath = join(cwd, '.pi', 'extensions', 'implicit-probe.js');
 
 try {
   await mkdir(cwd, { recursive: true });
@@ -51,13 +55,75 @@ export default function platformProbe(pi) {
 }
 `, 'utf8');
 
+  await mkdir(projectPackageRoot, { recursive: true });
+  await writeFile(join(projectPackageRoot, 'package.json'), JSON.stringify({
+    name: 'project-probe',
+    version: '1.0.0',
+    type: 'module',
+    pi: { extensions: ['./index.js'] },
+  }, null, 2), 'utf8');
+  await writeFile(projectExtensionPath, `
+export default function projectProbe(pi) {
+  pi.on('session_start', () => {
+    pi.registerTool({
+      name: 'project_probe',
+      label: 'Project probe',
+      description: 'Explicit project package probe',
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        return { content: [{ type: 'text', text: 'ok' }], details: {} };
+      },
+    });
+  });
+}
+`, 'utf8');
+  await mkdir(join(cwd, '.pi', 'extensions'), { recursive: true });
+  await writeFile(implicitExtensionPath, `
+export default function implicitProbe(pi) {
+  pi.on('session_start', () => {
+    pi.registerTool({
+      name: 'implicit_project_probe',
+      label: 'Implicit project probe',
+      description: 'Must stay disabled',
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        return { content: [{ type: 'text', text: 'unexpected' }], details: {} };
+      },
+    });
+  });
+}
+`, 'utf8');
+
   const settingsManager = SettingsManager.inMemory({}, { projectTrusted: false });
+  const projectLookupSettings = SettingsManager.inMemory({}, { projectTrusted: true });
+  const projectLookupManager = new DefaultPackageManager({
+    cwd,
+    agentDir,
+    settingsManager: projectLookupSettings,
+  });
+  const projectInstallPath = projectLookupManager.getInstalledPath('npm:project-probe', 'project');
+  assert.equal(projectInstallPath, projectPackageRoot);
+
+  const operationalPackageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
+  const projectResources = await operationalPackageManager.resolveExtensionSources(
+    [projectInstallPath],
+    { temporary: true },
+  );
+  assert.deepEqual(
+    projectResources.extensions.filter((resource) => resource.enabled).map((resource) => resource.path),
+    [projectExtensionPath],
+  );
+  assert.equal(await pathExists(join(agentDir, 'tmp', 'extensions', 'npm')), false);
+
   const resourceLoader = new DefaultResourceLoader({
     cwd,
     agentDir,
     settingsManager,
-    additionalExtensionPaths: [extensionPath],
-    noExtensions: true,
+    additionalExtensionPaths: [
+      extensionPath,
+      ...projectResources.extensions.filter((resource) => resource.enabled).map((resource) => resource.path),
+    ],
+    noExtensions: false,
     noSkills: true,
     noPromptTemplates: true,
     noThemes: true,
@@ -92,6 +158,8 @@ export default function platformProbe(pi) {
   });
   assert.deepEqual(runtimeErrors, []);
   assert.equal(session.getAllTools().some((tool) => tool.name === 'platform_probe'), true);
+  assert.equal(session.getAllTools().some((tool) => tool.name === 'project_probe'), true);
+  assert.equal(session.getAllTools().some((tool) => tool.name === 'implicit_project_probe'), false);
   session.setActiveToolsByName(['platform_probe']);
   assert.deepEqual(session.getActiveToolNames(), ['platform_probe']);
   session.dispose();
@@ -99,6 +167,7 @@ export default function platformProbe(pi) {
   for (const file of ['auth.json', 'models.json', 'models-store.json', 'settings.json']) {
     assert.equal(await pathExists(join(agentDir, file)), false, `${file} must stay in memory`);
   }
+  assert.equal(await pathExists(join(cwd, '.pi', 'settings.json')), false);
   console.log(`pi-sdk-cross-platform-smoke: ok (${process.platform}/${process.arch})`);
 } finally {
   await rm(root, { recursive: true, force: true });

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -72,6 +72,9 @@ const mocks = vi.hoisted(() => {
     getInstalledPath: vi.fn(() => undefined as string | undefined),
     resolveExtensionSources: vi.fn(async () => ({ extensions: [], skills: [], prompts: [], themes: [] })),
   };
+  const projectPackageLookup = {
+    getInstalledPath: vi.fn(() => undefined as string | undefined),
+  };
   const sessionManager = {
     inMemory: vi.fn(() => ({ newSession: vi.fn() })),
   };
@@ -88,6 +91,7 @@ const mocks = vi.hoisted(() => {
     session,
     modelRuntime,
     packageManager,
+    projectPackageLookup,
     createAgentSession: vi.fn(async () => {
       session.sessionId = `sdk-session-${++sessionSequence}`;
       return { session, extensionsResult: extensionResult() };
@@ -101,8 +105,12 @@ const mocks = vi.hoisted(() => {
       };
     }),
     createBashToolDefinition: vi.fn(() => ({ name: 'bash' })),
-    packageManagerConstructor: vi.fn(() => packageManager),
-    settingsManagerInMemory: vi.fn(() => ({})),
+    packageManagerConstructor: vi.fn(({ settingsManager }: { settingsManager: { projectTrusted?: boolean } }) => (
+      settingsManager.projectTrusted ? projectPackageLookup : packageManager
+    )),
+    settingsManagerInMemory: vi.fn((_settings: unknown, options?: { projectTrusted?: boolean }) => ({
+      projectTrusted: options?.projectTrusted,
+    })),
     sessionManager,
     getAgentDir: vi.fn(() => path.join(tmpdir(), 'pi-agent-test')),
     getPromptOptions: () => promptOptions,
@@ -125,9 +133,13 @@ const mocks = vi.hoisted(() => {
       mocks.session.getLastAssistantText.mockClear();
       mocks.createAgentSession.mockClear();
       mocks.resourceLoader.mockClear();
+      mocks.packageManagerConstructor.mockClear();
+      mocks.settingsManagerInMemory.mockClear();
       mocks.packageManager.getInstalledPath.mockReset();
       mocks.packageManager.getInstalledPath.mockReturnValue(undefined);
       mocks.packageManager.resolveExtensionSources.mockClear();
+      mocks.projectPackageLookup.getInstalledPath.mockReset();
+      mocks.projectPackageLookup.getInstalledPath.mockReturnValue(undefined);
       mocks.modelRuntime.getModel.mockClear();
       mocks.modelRuntime.getModels.mockClear();
       mocks.modelRuntime.registerProvider.mockClear();
@@ -221,11 +233,8 @@ describe('Pi SDK client', () => {
       prompts: [],
       themes: [],
     };
-    mocks.packageManager.getInstalledPath.mockImplementation((_source, scope) => {
-      if (scope === 'project') {
-        throw new Error('project scope is not trusted');
-      }
-      return undefined;
+    mocks.projectPackageLookup.getInstalledPath.mockImplementation(() => {
+      throw new Error('project lookup failed');
     });
     mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(temporary);
 
@@ -241,13 +250,11 @@ describe('Pi SDK client', () => {
       },
     });
 
-    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
-      1,
+    expect(mocks.projectPackageLookup.getInstalledPath).toHaveBeenCalledWith(
       'npm:example-extension',
       'project',
     );
-    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
-      2,
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenCalledWith(
       'npm:example-extension',
       'user',
     );
@@ -289,13 +296,11 @@ describe('Pi SDK client', () => {
     });
 
     expect(response.status).toBe('done');
-    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
-      1,
+    expect(mocks.projectPackageLookup.getInstalledPath).toHaveBeenCalledWith(
       'npm:example-extension',
       'project',
     );
-    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
-      2,
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenCalledWith(
       'npm:example-extension',
       'user',
     );
@@ -322,39 +327,182 @@ describe('Pi SDK client', () => {
 
   it('reuses an existing project-scope npm extension before checking user scope', async () => {
     mocks.resetTransient();
-    const projectInstallPath = path.join(tmpdir(), 'takt-project', '.takt', 'npm', 'node_modules', 'example-extension');
+    const projectRoot = mkdtempSync(path.join(tmpdir(), 'takt-pi-project-relative-'));
+    const relativeProjectCwd = path.relative(process.cwd(), projectRoot);
+    const projectInstallPath = path.join(relativeProjectCwd, '.pi', 'npm', 'node_modules', 'example-extension');
+    mkdirSync(path.resolve(projectInstallPath), { recursive: true });
     const projectScope = {
       extensions: [{ enabled: true, path: path.join(tmpdir(), 'project-extension.ts') }],
       skills: [],
       prompts: [],
       themes: [],
     };
-    mocks.packageManager.getInstalledPath.mockImplementation((_source, scope) => (
-      scope === 'project' ? projectInstallPath : undefined
-    ));
+    mocks.projectPackageLookup.getInstalledPath.mockReturnValue(projectInstallPath);
     mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(projectScope);
 
+    try {
+      const response = await callPi('worker', 'use the extension', {
+        ...sessionOptions('pi-sdk-project-scope-extension'),
+        cwd: relativeProjectCwd,
+        providerOptions: {
+          extensions: ['  npm:example-extension  '],
+        },
+      });
+
+      expect(response.status).toBe('done');
+      expect(mocks.projectPackageLookup.getInstalledPath).toHaveBeenCalledOnce();
+      expect(mocks.projectPackageLookup.getInstalledPath).toHaveBeenCalledWith(
+        'npm:example-extension',
+        'project',
+      );
+      expect(mocks.packageManager.getInstalledPath).not.toHaveBeenCalled();
+      expect(mocks.settingsManagerInMemory).toHaveBeenCalledWith({}, { projectTrusted: true });
+      expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
+      expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
+        [path.resolve(projectInstallPath)],
+        { temporary: true },
+      );
+      expect(mocks.getLoaderOptions()).toMatchObject({
+        additionalExtensionPaths: [path.join(tmpdir(), 'project-extension.ts')],
+      });
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('falls through an unusable project install to an existing user install', async () => {
+    mocks.resetTransient();
+    const projectRoot = mkdtempSync(path.join(tmpdir(), 'takt-pi-project-empty-'));
+    const projectInstallPath = path.join(projectRoot, '.pi', 'npm', 'node_modules', 'example-extension');
+    mkdirSync(projectInstallPath, { recursive: true });
+    const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'example-extension');
+    const empty = { extensions: [], skills: [], prompts: [], themes: [] };
+    const userScope = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'user-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.projectPackageLookup.getInstalledPath.mockReturnValue(projectInstallPath);
+    mocks.packageManager.getInstalledPath.mockReturnValue(userInstallPath);
+    mocks.packageManager.resolveExtensionSources
+      .mockResolvedValueOnce(empty)
+      .mockResolvedValueOnce(userScope);
+
+    try {
+      const response = await callPi('worker', 'use the extension', {
+        ...sessionOptions('pi-sdk-project-empty-user-fallback'),
+        cwd: projectRoot,
+        providerOptions: { extensions: ['npm:example-extension'] },
+      });
+
+      expect(response.status).toBe('done');
+      expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+        1,
+        [projectInstallPath],
+        { temporary: true },
+      );
+      expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+        2,
+        [userInstallPath],
+        { temporary: true },
+      );
+      expect(mocks.getLoaderOptions()).toMatchObject({
+        additionalExtensionPaths: [path.join(tmpdir(), 'user-extension.ts')],
+      });
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a project package symlink whose target is outside project package storage', async () => {
+    mocks.resetTransient();
+    const projectRoot = mkdtempSync(path.join(tmpdir(), 'takt-pi-project-symlink-'));
+    const outsideRoot = mkdtempSync(path.join(tmpdir(), 'outside-project-storage-'));
+    const projectPackageRoot = path.join(projectRoot, '.pi', 'npm', 'node_modules');
+    const escapedProjectPath = path.join(projectPackageRoot, 'example-extension');
+    mkdirSync(projectPackageRoot, { recursive: true });
+    symlinkSync(outsideRoot, escapedProjectPath, process.platform === 'win32' ? 'junction' : 'dir');
+    const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'example-extension');
+    const userScope = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'user-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.projectPackageLookup.getInstalledPath.mockReturnValue(escapedProjectPath);
+    mocks.packageManager.getInstalledPath.mockReturnValue(userInstallPath);
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(userScope);
+
+    try {
+      const response = await callPi('worker', 'use the extension', {
+        ...sessionOptions('pi-sdk-project-storage-escape'),
+        cwd: projectRoot,
+        providerOptions: { extensions: ['npm:example-extension'] },
+      });
+
+      expect(response.status).toBe('done');
+      expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
+        [escapedProjectPath],
+        { temporary: true },
+      );
+      expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
+        [userInstallPath],
+        { temporary: true },
+      );
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+      rmSync(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    'npm:example-extension@1.2.3',
+    'npm:example-extension@^1.0.0',
+    'npm:@example/extension@latest',
+  ])('resolves version-qualified npm source %s temporarily without existing-install lookup', async (source) => {
+    mocks.resetTransient();
+    const temporary = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'versioned-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(temporary);
+
     const response = await callPi('worker', 'use the extension', {
-      ...sessionOptions('pi-sdk-project-scope-extension'),
-      providerOptions: {
-        extensions: ['npm:example-extension'],
-      },
+      ...sessionOptions(`pi-sdk-versioned-${source}`),
+      providerOptions: { extensions: [source] },
     });
 
     expect(response.status).toBe('done');
-    expect(mocks.packageManager.getInstalledPath).toHaveBeenCalledOnce();
-    expect(mocks.packageManager.getInstalledPath).toHaveBeenCalledWith(
-      'npm:example-extension',
-      'project',
-    );
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
+    expect(mocks.projectPackageLookup.getInstalledPath).not.toHaveBeenCalled();
+    expect(mocks.packageManager.getInstalledPath).not.toHaveBeenCalled();
     expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
-      [projectInstallPath],
+      [source],
       { temporary: true },
     );
-    expect(mocks.getLoaderOptions()).toMatchObject({
-      additionalExtensionPaths: [path.join(tmpdir(), 'project-extension.ts')],
+  });
+
+  it.each([
+    'npm:../../../../evil',
+    'npm:..\\..\\evil',
+    'npm:foo/bar',
+    'npm:@scope/../../evil',
+    'npm:@/evil',
+  ])('rejects unsafe npm package source %s before package lookup or resolution', async (source) => {
+    mocks.resetTransient();
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions(`pi-sdk-unsafe-npm-${source}`),
+      providerOptions: { extensions: [source] },
     });
+
+    expect(response.status).toBe('error');
+    expect(response.error).toContain('valid package name');
+    expect(mocks.projectPackageLookup.getInstalledPath).not.toHaveBeenCalled();
+    expect(mocks.packageManager.getInstalledPath).not.toHaveBeenCalled();
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalled();
   });
 
   it('falls back to temporary when an existing user-scope npm extension has no resources', async () => {
@@ -503,13 +651,11 @@ describe('Pi SDK client', () => {
 
     expect(response.status).toBe('error');
     expect(response.failureCategory).toBe('external_abort');
-    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
-      1,
+    expect(mocks.projectPackageLookup.getInstalledPath).toHaveBeenCalledWith(
       'npm:example-extension',
       'project',
     );
-    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
-      2,
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenCalledWith(
       'npm:example-extension',
       'user',
     );

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -329,6 +329,117 @@ describe('Pi SDK client', () => {
     });
   });
 
+  it('falls through when a higher npm scope resolves only disabled resources', async () => {
+    mocks.resetTransient();
+    const disabledOnly = {
+      extensions: [{ enabled: false, path: path.join(tmpdir(), 'disabled-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    const temporary = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'temporary-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.resolveExtensionSources
+      .mockResolvedValueOnce(disabledOnly)
+      .mockResolvedValueOnce(disabledOnly)
+      .mockResolvedValueOnce(temporary);
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-disabled-only-fallback'),
+      providerOptions: {
+        extensions: ['npm:example-extension'],
+      },
+    });
+
+    expect(response.status).toBe('done');
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      1,
+      ['npm:example-extension'],
+      { local: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      2,
+      ['npm:example-extension'],
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      3,
+      ['npm:example-extension'],
+      { temporary: true },
+    );
+    expect(mocks.getLoaderOptions()).toMatchObject({
+      additionalExtensionPaths: [path.join(tmpdir(), 'temporary-extension.ts')],
+    });
+  });
+
+  it.each([
+    { label: 'git', source: 'git:https://example.invalid/extension.git' },
+    { label: 'local path', source: './local-extension.ts' },
+  ])('resolves non-npm $label sources via temporary scope only', async ({ source }) => {
+    mocks.resetTransient();
+    const temporary = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'temporary-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(temporary);
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions(`pi-sdk-temporary-${source}`),
+      providerOptions: {
+        extensions: [source],
+      },
+    });
+
+    expect(response.status).toBe('done');
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
+      [source],
+      { temporary: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
+      [source],
+      { local: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith([source]);
+    expect(mocks.getLoaderOptions()).toMatchObject({
+      additionalExtensionPaths: [path.join(tmpdir(), 'temporary-extension.ts')],
+    });
+  });
+
+  it.each([
+    { label: 'git', source: 'git:https://example.invalid/missing-extension.git' },
+    { label: 'local path', source: './missing-extension.ts' },
+  ])('fails closed when a non-npm $label source resolves to no resources', async ({ source }) => {
+    mocks.resetTransient();
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce({
+      extensions: [],
+      skills: [],
+      prompts: [],
+      themes: [],
+    });
+
+    const response = await callPi('worker', 'load extension', {
+      ...sessionOptions(`pi-sdk-temporary-missing-${source}`),
+      providerOptions: {
+        extensions: [source],
+      },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.error).toContain('Pi extension source could not be resolved');
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
+      [source],
+      { temporary: true },
+    );
+    expect(mocks.resourceLoader).not.toHaveBeenCalled();
+  });
+
   it('maps read-only permissions and native image attachments to SDK options', async () => {
     mocks.resetTransient();
     const imageDir = mkdtempSync(path.join(tmpdir(), 'pi-client-image-'));

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -210,14 +210,19 @@ describe('Pi SDK client', () => {
     expect(mocks.createAgentSession.mock.calls.at(-1)?.[0]).not.toHaveProperty('tools');
   });
 
-  it('resolves temporary extension sources into the SDK resource loader', async () => {
+  it('falls back to temporary npm extension sources when user and project scopes are empty', async () => {
     mocks.resetTransient();
-    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce({
+    const empty = { extensions: [], skills: [], prompts: [], themes: [] };
+    const temporary = {
       extensions: [{ enabled: true, path: path.join(tmpdir(), 'extension.ts') }],
       skills: [{ enabled: true, path: path.join(tmpdir(), 'SKILL.md') }],
       prompts: [],
       themes: [],
-    });
+    };
+    mocks.packageManager.resolveExtensionSources
+      .mockResolvedValueOnce(empty)
+      .mockResolvedValueOnce(empty)
+      .mockResolvedValueOnce(temporary);
 
     await callPi('worker', 'use the extension', {
       ...sessionOptions('pi-sdk-extension'),
@@ -231,7 +236,17 @@ describe('Pi SDK client', () => {
       },
     });
 
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      1,
+      ['npm:example-extension'],
+      { local: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      2,
+      ['npm:example-extension'],
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      3,
       ['npm:example-extension'],
       { temporary: true },
     );
@@ -243,6 +258,74 @@ describe('Pi SDK client', () => {
       noPromptTemplates: true,
       noThemes: true,
       noContextFiles: true,
+    });
+  });
+
+  it('prefers a loadable user-scope npm extension over temporary install', async () => {
+    mocks.resetTransient();
+    const empty = { extensions: [], skills: [], prompts: [], themes: [] };
+    const userScope = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'user-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.resolveExtensionSources
+      .mockResolvedValueOnce(empty)
+      .mockResolvedValueOnce(userScope);
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-user-scope-extension'),
+      providerOptions: {
+        extensions: ['npm:pi-cursor-sdk'],
+      },
+    });
+
+    expect(response.status).toBe('done');
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledTimes(2);
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      1,
+      ['npm:pi-cursor-sdk'],
+      { local: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      2,
+      ['npm:pi-cursor-sdk'],
+    );
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
+      ['npm:pi-cursor-sdk'],
+      { temporary: true },
+    );
+    expect(mocks.getLoaderOptions()).toMatchObject({
+      additionalExtensionPaths: [path.join(tmpdir(), 'user-extension.ts')],
+    });
+  });
+
+  it('prefers a loadable project-scope npm extension before user and temporary scopes', async () => {
+    mocks.resetTransient();
+    const projectScope = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'project-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(projectScope);
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-project-scope-extension'),
+      providerOptions: {
+        extensions: ['npm:pi-cursor-sdk'],
+      },
+    });
+
+    expect(response.status).toBe('done');
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
+      ['npm:pi-cursor-sdk'],
+      { local: true },
+    );
+    expect(mocks.getLoaderOptions()).toMatchObject({
+      additionalExtensionPaths: [path.join(tmpdir(), 'project-extension.ts')],
     });
   });
 

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -301,6 +301,41 @@ describe('Pi SDK client', () => {
     });
   });
 
+  it('stops extension resolution after project scope rejects when abort is requested', async () => {
+    mocks.resetTransient();
+    const abortController = new AbortController();
+    mocks.packageManager.resolveExtensionSources.mockImplementationOnce(async () => {
+      abortController.abort('cancelled during project scope rejection');
+      throw new Error('project scope failed');
+    });
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-project-reject-abort'),
+      abortSignal: abortController.signal,
+      providerOptions: {
+        extensions: ['npm:example-extension'],
+      },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.failureCategory).toBe('external_abort');
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledTimes(1);
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      1,
+      ['npm:example-extension'],
+      { local: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
+      ['npm:example-extension'],
+    );
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
+      ['npm:example-extension'],
+      { temporary: true },
+    );
+    expect(mocks.resourceLoader).not.toHaveBeenCalled();
+    expect(mocks.createAgentSession).not.toHaveBeenCalled();
+  });
+
   it('uses user-scope npm extension when project scope rejects', async () => {
     mocks.resetTransient();
     const userScope = {

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -261,6 +261,85 @@ describe('Pi SDK client', () => {
     });
   });
 
+  it('falls back to temporary npm extension sources when project and user scopes reject', async () => {
+    mocks.resetTransient();
+    const temporary = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'temporary-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.resolveExtensionSources
+      .mockRejectedValueOnce(new Error('project scope failed'))
+      .mockRejectedValueOnce(new Error('user scope failed'))
+      .mockResolvedValueOnce(temporary);
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-reject-fallback'),
+      providerOptions: {
+        extensions: ['npm:example-extension'],
+      },
+    });
+
+    expect(response.status).toBe('done');
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      1,
+      ['npm:example-extension'],
+      { local: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      2,
+      ['npm:example-extension'],
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      3,
+      ['npm:example-extension'],
+      { temporary: true },
+    );
+    expect(mocks.getLoaderOptions()).toMatchObject({
+      additionalExtensionPaths: [path.join(tmpdir(), 'temporary-extension.ts')],
+    });
+  });
+
+  it('uses user-scope npm extension when project scope rejects', async () => {
+    mocks.resetTransient();
+    const userScope = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'user-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.resolveExtensionSources
+      .mockRejectedValueOnce(new Error('project scope failed'))
+      .mockResolvedValueOnce(userScope);
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-project-reject-user-scope'),
+      providerOptions: {
+        extensions: ['npm:pi-cursor-sdk'],
+      },
+    });
+
+    expect(response.status).toBe('done');
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledTimes(2);
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      1,
+      ['npm:pi-cursor-sdk'],
+      { local: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      2,
+      ['npm:pi-cursor-sdk'],
+    );
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
+      ['npm:pi-cursor-sdk'],
+      { temporary: true },
+    );
+    expect(mocks.getLoaderOptions()).toMatchObject({
+      additionalExtensionPaths: [path.join(tmpdir(), 'user-extension.ts')],
+    });
+  });
+
   it('prefers a loadable user-scope npm extension over temporary install', async () => {
     mocks.resetTransient();
     const empty = { extensions: [], skills: [], prompts: [], themes: [] };

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -69,6 +69,7 @@ const mocks = vi.hoisted(() => {
   };
 
   const packageManager = {
+    getInstalledPath: vi.fn(() => undefined as string | undefined),
     resolveExtensionSources: vi.fn(async () => ({ extensions: [], skills: [], prompts: [], themes: [] })),
   };
   const sessionManager = {
@@ -124,6 +125,8 @@ const mocks = vi.hoisted(() => {
       mocks.session.getLastAssistantText.mockClear();
       mocks.createAgentSession.mockClear();
       mocks.resourceLoader.mockClear();
+      mocks.packageManager.getInstalledPath.mockReset();
+      mocks.packageManager.getInstalledPath.mockReturnValue(undefined);
       mocks.packageManager.resolveExtensionSources.mockClear();
       mocks.modelRuntime.getModel.mockClear();
       mocks.modelRuntime.getModels.mockClear();
@@ -210,19 +213,21 @@ describe('Pi SDK client', () => {
     expect(mocks.createAgentSession.mock.calls.at(-1)?.[0]).not.toHaveProperty('tools');
   });
 
-  it('falls back to temporary npm extension sources when user and project scopes are empty', async () => {
+  it('resolves npm extension sources temporarily when no user install exists', async () => {
     mocks.resetTransient();
-    const empty = { extensions: [], skills: [], prompts: [], themes: [] };
     const temporary = {
       extensions: [{ enabled: true, path: path.join(tmpdir(), 'extension.ts') }],
       skills: [{ enabled: true, path: path.join(tmpdir(), 'SKILL.md') }],
       prompts: [],
       themes: [],
     };
-    mocks.packageManager.resolveExtensionSources
-      .mockResolvedValueOnce(empty)
-      .mockResolvedValueOnce(empty)
-      .mockResolvedValueOnce(temporary);
+    mocks.packageManager.getInstalledPath.mockImplementation((_source, scope) => {
+      if (scope === 'project') {
+        throw new Error('project scope is not trusted');
+      }
+      return undefined;
+    });
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(temporary);
 
     await callPi('worker', 'use the extension', {
       ...sessionOptions('pi-sdk-extension'),
@@ -236,17 +241,18 @@ describe('Pi SDK client', () => {
       },
     });
 
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
       1,
-      ['npm:example-extension'],
-      { local: true },
+      'npm:example-extension',
+      'project',
     );
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
       2,
-      ['npm:example-extension'],
+      'npm:example-extension',
+      'user',
     );
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
-      3,
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
       ['npm:example-extension'],
       { temporary: true },
     );
@@ -261,21 +267,115 @@ describe('Pi SDK client', () => {
     });
   });
 
-  it('falls back to temporary npm extension sources when project and user scopes reject', async () => {
+  it('reuses an existing user-scope npm extension without resolving the npm source', async () => {
     mocks.resetTransient();
+    const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'example-extension');
+    const userScope = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'user-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.getInstalledPath.mockImplementation((_source, scope) => (
+      scope === 'user' ? userInstallPath : undefined
+    ));
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(userScope);
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-user-scope-extension'),
+      providerOptions: {
+        extensions: ['npm:example-extension'],
+      },
+    });
+
+    expect(response.status).toBe('done');
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
+      1,
+      'npm:example-extension',
+      'project',
+    );
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
+      2,
+      'npm:example-extension',
+      'user',
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
+      [userInstallPath],
+      { temporary: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
+      ['npm:example-extension'],
+      { local: true },
+    );
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
+      ['npm:example-extension'],
+    );
+    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
+      ['npm:example-extension'],
+      { temporary: true },
+    );
+    expect(mocks.getLoaderOptions()).toMatchObject({
+      additionalExtensionPaths: [path.join(tmpdir(), 'user-extension.ts')],
+    });
+  });
+
+  it('reuses an existing project-scope npm extension before checking user scope', async () => {
+    mocks.resetTransient();
+    const projectInstallPath = path.join(tmpdir(), 'takt-project', '.takt', 'npm', 'node_modules', 'example-extension');
+    const projectScope = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'project-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.getInstalledPath.mockImplementation((_source, scope) => (
+      scope === 'project' ? projectInstallPath : undefined
+    ));
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(projectScope);
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-project-scope-extension'),
+      providerOptions: {
+        extensions: ['npm:example-extension'],
+      },
+    });
+
+    expect(response.status).toBe('done');
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenCalledOnce();
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenCalledWith(
+      'npm:example-extension',
+      'project',
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
+      [projectInstallPath],
+      { temporary: true },
+    );
+    expect(mocks.getLoaderOptions()).toMatchObject({
+      additionalExtensionPaths: [path.join(tmpdir(), 'project-extension.ts')],
+    });
+  });
+
+  it('falls back to temporary when an existing user-scope npm extension has no resources', async () => {
+    mocks.resetTransient();
+    const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'example-extension');
+    const empty = { extensions: [], skills: [], prompts: [], themes: [] };
     const temporary = {
       extensions: [{ enabled: true, path: path.join(tmpdir(), 'temporary-extension.ts') }],
       skills: [],
       prompts: [],
       themes: [],
     };
+    mocks.packageManager.getInstalledPath.mockImplementation((_source, scope) => (
+      scope === 'user' ? userInstallPath : undefined
+    ));
     mocks.packageManager.resolveExtensionSources
-      .mockRejectedValueOnce(new Error('project scope failed'))
-      .mockRejectedValueOnce(new Error('user scope failed'))
+      .mockResolvedValueOnce(empty)
       .mockResolvedValueOnce(temporary);
 
     const response = await callPi('worker', 'use the extension', {
-      ...sessionOptions('pi-sdk-reject-fallback'),
+      ...sessionOptions('pi-sdk-user-empty-fallback'),
       providerOptions: {
         extensions: ['npm:example-extension'],
       },
@@ -284,15 +384,11 @@ describe('Pi SDK client', () => {
     expect(response.status).toBe('done');
     expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
       1,
-      ['npm:example-extension'],
-      { local: true },
+      [userInstallPath],
+      { temporary: true },
     );
     expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
       2,
-      ['npm:example-extension'],
-    );
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
-      3,
       ['npm:example-extension'],
       { temporary: true },
     );
@@ -301,150 +397,48 @@ describe('Pi SDK client', () => {
     });
   });
 
-  it('stops extension resolution after project scope rejects when abort is requested', async () => {
+  it('falls back to temporary when an existing user-scope npm extension rejects', async () => {
     mocks.resetTransient();
-    const abortController = new AbortController();
-    mocks.packageManager.resolveExtensionSources.mockImplementationOnce(async () => {
-      abortController.abort('cancelled during project scope rejection');
-      throw new Error('project scope failed');
-    });
+    const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'example-extension');
+    const temporary = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'temporary-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.getInstalledPath.mockImplementation((_source, scope) => (
+      scope === 'user' ? userInstallPath : undefined
+    ));
+    mocks.packageManager.resolveExtensionSources
+      .mockRejectedValueOnce(new Error('user scope failed'))
+      .mockResolvedValueOnce(temporary);
 
     const response = await callPi('worker', 'use the extension', {
-      ...sessionOptions('pi-sdk-project-reject-abort'),
-      abortSignal: abortController.signal,
+      ...sessionOptions('pi-sdk-user-reject-fallback'),
       providerOptions: {
         extensions: ['npm:example-extension'],
       },
     });
 
-    expect(response.status).toBe('error');
-    expect(response.failureCategory).toBe('external_abort');
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledTimes(1);
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
-      1,
-      ['npm:example-extension'],
-      { local: true },
-    );
-    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
-      ['npm:example-extension'],
-    );
-    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
-      ['npm:example-extension'],
-      { temporary: true },
-    );
-    expect(mocks.resourceLoader).not.toHaveBeenCalled();
-    expect(mocks.createAgentSession).not.toHaveBeenCalled();
-  });
-
-  it('uses user-scope npm extension when project scope rejects', async () => {
-    mocks.resetTransient();
-    const userScope = {
-      extensions: [{ enabled: true, path: path.join(tmpdir(), 'user-extension.ts') }],
-      skills: [],
-      prompts: [],
-      themes: [],
-    };
-    mocks.packageManager.resolveExtensionSources
-      .mockRejectedValueOnce(new Error('project scope failed'))
-      .mockResolvedValueOnce(userScope);
-
-    const response = await callPi('worker', 'use the extension', {
-      ...sessionOptions('pi-sdk-project-reject-user-scope'),
-      providerOptions: {
-        extensions: ['npm:pi-cursor-sdk'],
-      },
-    });
-
     expect(response.status).toBe('done');
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledTimes(2);
     expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
       1,
-      ['npm:pi-cursor-sdk'],
-      { local: true },
+      [userInstallPath],
+      { temporary: true },
     );
     expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
       2,
-      ['npm:pi-cursor-sdk'],
-    );
-    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
-      ['npm:pi-cursor-sdk'],
+      ['npm:example-extension'],
       { temporary: true },
     );
     expect(mocks.getLoaderOptions()).toMatchObject({
-      additionalExtensionPaths: [path.join(tmpdir(), 'user-extension.ts')],
+      additionalExtensionPaths: [path.join(tmpdir(), 'temporary-extension.ts')],
     });
   });
 
-  it('prefers a loadable user-scope npm extension over temporary install', async () => {
+  it('falls back to temporary when an existing user-scope npm extension has no enabled resources', async () => {
     mocks.resetTransient();
-    const empty = { extensions: [], skills: [], prompts: [], themes: [] };
-    const userScope = {
-      extensions: [{ enabled: true, path: path.join(tmpdir(), 'user-extension.ts') }],
-      skills: [],
-      prompts: [],
-      themes: [],
-    };
-    mocks.packageManager.resolveExtensionSources
-      .mockResolvedValueOnce(empty)
-      .mockResolvedValueOnce(userScope);
-
-    const response = await callPi('worker', 'use the extension', {
-      ...sessionOptions('pi-sdk-user-scope-extension'),
-      providerOptions: {
-        extensions: ['npm:pi-cursor-sdk'],
-      },
-    });
-
-    expect(response.status).toBe('done');
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledTimes(2);
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
-      1,
-      ['npm:pi-cursor-sdk'],
-      { local: true },
-    );
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
-      2,
-      ['npm:pi-cursor-sdk'],
-    );
-    expect(mocks.packageManager.resolveExtensionSources).not.toHaveBeenCalledWith(
-      ['npm:pi-cursor-sdk'],
-      { temporary: true },
-    );
-    expect(mocks.getLoaderOptions()).toMatchObject({
-      additionalExtensionPaths: [path.join(tmpdir(), 'user-extension.ts')],
-    });
-  });
-
-  it('prefers a loadable project-scope npm extension before user and temporary scopes', async () => {
-    mocks.resetTransient();
-    const projectScope = {
-      extensions: [{ enabled: true, path: path.join(tmpdir(), 'project-extension.ts') }],
-      skills: [],
-      prompts: [],
-      themes: [],
-    };
-    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(projectScope);
-
-    const response = await callPi('worker', 'use the extension', {
-      ...sessionOptions('pi-sdk-project-scope-extension'),
-      providerOptions: {
-        extensions: ['npm:pi-cursor-sdk'],
-      },
-    });
-
-    expect(response.status).toBe('done');
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
-      ['npm:pi-cursor-sdk'],
-      { local: true },
-    );
-    expect(mocks.getLoaderOptions()).toMatchObject({
-      additionalExtensionPaths: [path.join(tmpdir(), 'project-extension.ts')],
-    });
-  });
-
-  it('falls through when a higher npm scope resolves only disabled resources', async () => {
-    mocks.resetTransient();
+    const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'example-extension');
     const disabledOnly = {
       extensions: [{ enabled: false, path: path.join(tmpdir(), 'disabled-extension.ts') }],
       skills: [],
@@ -457,13 +451,15 @@ describe('Pi SDK client', () => {
       prompts: [],
       themes: [],
     };
+    mocks.packageManager.getInstalledPath.mockImplementation((_source, scope) => (
+      scope === 'user' ? userInstallPath : undefined
+    ));
     mocks.packageManager.resolveExtensionSources
-      .mockResolvedValueOnce(disabledOnly)
       .mockResolvedValueOnce(disabledOnly)
       .mockResolvedValueOnce(temporary);
 
     const response = await callPi('worker', 'use the extension', {
-      ...sessionOptions('pi-sdk-disabled-only-fallback'),
+      ...sessionOptions('pi-sdk-user-disabled-fallback'),
       providerOptions: {
         extensions: ['npm:example-extension'],
       },
@@ -472,21 +468,59 @@ describe('Pi SDK client', () => {
     expect(response.status).toBe('done');
     expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
       1,
-      ['npm:example-extension'],
-      { local: true },
+      [userInstallPath],
+      { temporary: true },
     );
     expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
       2,
-      ['npm:example-extension'],
-    );
-    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
-      3,
       ['npm:example-extension'],
       { temporary: true },
     );
     expect(mocks.getLoaderOptions()).toMatchObject({
       additionalExtensionPaths: [path.join(tmpdir(), 'temporary-extension.ts')],
     });
+  });
+
+  it('stops extension resolution after existing user-scope resolution aborts', async () => {
+    mocks.resetTransient();
+    const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'example-extension');
+    const abortController = new AbortController();
+    mocks.packageManager.getInstalledPath.mockImplementation((_source, scope) => (
+      scope === 'user' ? userInstallPath : undefined
+    ));
+    mocks.packageManager.resolveExtensionSources.mockImplementationOnce(async () => {
+      abortController.abort('cancelled during user-scope resolution');
+      throw new Error('user scope failed');
+    });
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-user-resolution-abort'),
+      abortSignal: abortController.signal,
+      providerOptions: {
+        extensions: ['npm:example-extension'],
+      },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.failureCategory).toBe('external_abort');
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
+      1,
+      'npm:example-extension',
+      'project',
+    );
+    expect(mocks.packageManager.getInstalledPath).toHaveBeenNthCalledWith(
+      2,
+      'npm:example-extension',
+      'user',
+    );
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledTimes(1);
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+      1,
+      [userInstallPath],
+      { temporary: true },
+    );
+    expect(mocks.resourceLoader).not.toHaveBeenCalled();
+    expect(mocks.createAgentSession).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/infra/pi/client.ts
+++ b/src/infra/pi/client.ts
@@ -272,35 +272,45 @@ async function resolveExtensionSourcePaths(
     return sourcePaths;
   }
 
-  const scopeAttempts: Array<() => Promise<ResolvedPaths>> = [
-    () => packageManager.resolveExtensionSources([source], { local: true }),
-    () => packageManager.resolveExtensionSources([source]),
-    () => packageManager.resolveExtensionSources([source], { temporary: true }),
-  ];
-  for (let scopeIndex = 0; scopeIndex < scopeAttempts.length; scopeIndex++) {
-    const attempt = scopeAttempts[scopeIndex]!;
-    const isTemporaryScope = scopeIndex === scopeAttempts.length - 1;
-    let sourcePaths: ResolvedPaths;
-    if (isTemporaryScope) {
-      sourcePaths = await attempt();
-    } else {
-      try {
-        sourcePaths = await attempt();
-      } catch {
-        if (isAbortRequested(abortSignal)) {
-          throw new Error('Pi session aborted');
-        }
-        continue;
-      }
+  for (const scope of ['project', 'user'] as const) {
+    let installedPath: string | undefined;
+    try {
+      installedPath = packageManager.getInstalledPath(source, scope);
+    } catch {
+      // Project lookup can reject when project trust is disabled. A scope lookup
+      // failure must not prevent checking the next scope or the temporary fallback.
     }
     if (isAbortRequested(abortSignal)) {
       throw new Error('Pi session aborted');
     }
-    if (countEnabledResolvedResources(sourcePaths) > 0) {
-      return sourcePaths;
+
+    if (installedPath) {
+      try {
+        // Resolve the discovered absolute path as a local source. Passing the original
+        // npm spec here would make the SDK install a missing package into that scope.
+        const sourcePaths = await packageManager.resolveExtensionSources(
+          [installedPath],
+          { temporary: true },
+        );
+        if (isAbortRequested(abortSignal)) {
+          throw new Error('Pi session aborted');
+        }
+        if (countEnabledResolvedResources(sourcePaths) > 0) {
+          return sourcePaths;
+        }
+      } catch {
+        if (isAbortRequested(abortSignal)) {
+          throw new Error('Pi session aborted');
+        }
+      }
     }
   }
-  return { extensions: [], skills: [], prompts: [], themes: [] };
+
+  const sourcePaths = await packageManager.resolveExtensionSources([source], { temporary: true });
+  if (isAbortRequested(abortSignal)) {
+    throw new Error('Pi session aborted');
+  }
+  return sourcePaths;
 }
 
 async function resolvePiResources(

--- a/src/infra/pi/client.ts
+++ b/src/infra/pi/client.ts
@@ -248,11 +248,11 @@ function enabledResourcePaths(paths: ResolvedPaths, key: keyof ResolvedPaths): s
     .map((resource) => resource.path);
 }
 
-function countResolvedResources(paths: ResolvedPaths): number {
-  return paths.extensions.length
-    + paths.skills.length
-    + paths.prompts.length
-    + paths.themes.length;
+function countEnabledResolvedResources(paths: ResolvedPaths): number {
+  return enabledResourcePaths(paths, 'extensions').length
+    + enabledResourcePaths(paths, 'skills').length
+    + enabledResourcePaths(paths, 'prompts').length
+    + enabledResourcePaths(paths, 'themes').length;
 }
 
 function isNpmExtensionSource(source: string): boolean {
@@ -282,7 +282,7 @@ async function resolveExtensionSourcePaths(
     if (isAbortRequested(abortSignal)) {
       throw new Error('Pi session aborted');
     }
-    if (countResolvedResources(sourcePaths) > 0) {
+    if (countEnabledResolvedResources(sourcePaths) > 0) {
       return sourcePaths;
     }
   }
@@ -309,7 +309,7 @@ async function resolvePiResources(
       source,
       options.abortSignal,
     );
-    if (countResolvedResources(sourcePaths) === 0) {
+    if (countEnabledResolvedResources(sourcePaths) === 0) {
       throw new Error('Pi extension source could not be resolved');
     }
     resolved.extensions.push(...sourcePaths.extensions);

--- a/src/infra/pi/client.ts
+++ b/src/infra/pi/client.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import * as path from 'node:path';
 import {
   createBashToolDefinition,
@@ -198,6 +199,9 @@ function resolvePiModel(
 function assertSafeExtensionSources(sources: readonly string[]): void {
   for (const source of sources) {
     const trimmedSource = source.trim();
+    if (trimmedSource.startsWith('npm:') && !getSafeNpmPackageName(trimmedSource)) {
+      throw new Error('Pi npm extension sources must use a valid package name');
+    }
     const candidate = trimmedSource.startsWith('git:') && !trimmedSource.startsWith('git://')
       ? trimmedSource.slice('git:'.length)
       : trimmedSource;
@@ -259,12 +263,78 @@ function isNpmExtensionSource(source: string): boolean {
   return source.trim().startsWith('npm:');
 }
 
+function getSafeNpmPackageName(source: string): string | undefined {
+  const spec = source.trim().slice('npm:'.length);
+  const versionDelimiter = spec.startsWith('@')
+    ? spec.indexOf('@', spec.indexOf('/') + 1)
+    : spec.indexOf('@');
+  const packageName = versionDelimiter >= 0 ? spec.slice(0, versionDelimiter) : spec;
+  const unscopedName = /^[a-z0-9][a-z0-9._~-]*$/u;
+  const scopedName = /^@[a-z0-9][a-z0-9._~-]*\/[a-z0-9][a-z0-9._~-]*$/u;
+  return unscopedName.test(packageName) || scopedName.test(packageName)
+    ? packageName
+    : undefined;
+}
+
+function isVersionQualifiedNpmExtensionSource(source: string): boolean {
+  const spec = source.trim().slice('npm:'.length);
+  return spec.startsWith('@') ? spec.indexOf('@', 1) >= 0 : spec.includes('@');
+}
+
+interface InstalledPackageLookup {
+  getInstalledPath(source: string): string | undefined;
+}
+
+type ExtensionPackageManager = Pick<
+  DefaultPackageManager,
+  'getInstalledPath' | 'resolveExtensionSources'
+>;
+
+function createProjectInstalledPackageLookup(
+  cwd: string,
+  agentDir: string,
+): InstalledPackageLookup {
+  // This manager exists only to pass the SDK's project-storage trust guard for
+  // a read-only existence lookup. Its settings are in-memory, it is never given
+  // to the resource loader, and no mutating or resolving methods escape.
+  const lookupSettingsManager = SettingsManager.inMemory({}, { projectTrusted: true });
+  const lookupPackageManager = new DefaultPackageManager({
+    cwd,
+    agentDir,
+    settingsManager: lookupSettingsManager,
+  });
+  const projectPackageRoot = path.resolve(cwd, '.pi', 'npm', 'node_modules');
+  return {
+    getInstalledPath: (source) => {
+      const installedPath = lookupPackageManager.getInstalledPath(source, 'project');
+      if (!installedPath) {
+        return undefined;
+      }
+      let canonicalProjectPackageRoot: string;
+      let canonicalInstalledPath: string;
+      try {
+        canonicalProjectPackageRoot = realpathSync(projectPackageRoot);
+        canonicalInstalledPath = realpathSync(installedPath);
+      } catch {
+        return undefined;
+      }
+      const relativePath = path.relative(canonicalProjectPackageRoot, canonicalInstalledPath);
+      if (relativePath === '' || relativePath === '..' || relativePath.startsWith(`..${path.sep}`)
+        || path.isAbsolute(relativePath)) {
+        return undefined;
+      }
+      return canonicalInstalledPath;
+    },
+  };
+}
+
 async function resolveExtensionSourcePaths(
-  packageManager: DefaultPackageManager,
+  packageManager: ExtensionPackageManager,
+  projectLookup: InstalledPackageLookup,
   source: string,
   abortSignal: AbortSignal | undefined,
 ): Promise<ResolvedPaths> {
-  if (!isNpmExtensionSource(source)) {
+  if (!isNpmExtensionSource(source) || isVersionQualifiedNpmExtensionSource(source)) {
     const sourcePaths = await packageManager.resolveExtensionSources([source], { temporary: true });
     if (isAbortRequested(abortSignal)) {
       throw new Error('Pi session aborted');
@@ -272,13 +342,19 @@ async function resolveExtensionSourcePaths(
     return sourcePaths;
   }
 
-  for (const scope of ['project', 'user'] as const) {
+  const existingInstallLookups: InstalledPackageLookup[] = [
+    projectLookup,
+    {
+      getInstalledPath: (npmSource) => packageManager.getInstalledPath(npmSource, 'user'),
+    },
+  ];
+  for (const lookup of existingInstallLookups) {
     let installedPath: string | undefined;
     try {
-      installedPath = packageManager.getInstalledPath(source, scope);
+      installedPath = lookup.getInstalledPath(source);
     } catch {
-      // Project lookup can reject when project trust is disabled. A scope lookup
-      // failure must not prevent checking the next scope or the temporary fallback.
+      // A read-only lookup failure must not prevent checking the next existing
+      // install or the temporary fallback.
     }
     if (isAbortRequested(abortSignal)) {
       throw new Error('Pi session aborted');
@@ -319,17 +395,19 @@ async function resolvePiResources(
   options: PiCallOptions,
   settingsManager: SettingsManager,
 ): Promise<ResolvedPaths> {
-  const sources = options.providerOptions?.extensions ?? [];
+  const sources = (options.providerOptions?.extensions ?? []).map((source) => source.trim());
   if (sources.length === 0) {
     return { extensions: [], skills: [], prompts: [], themes: [] };
   }
 
   assertSafeExtensionSources(sources);
   const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
+  const projectLookup = createProjectInstalledPackageLookup(cwd, agentDir);
   const resolved: ResolvedPaths = { extensions: [], skills: [], prompts: [], themes: [] };
   for (const source of sources) {
     const sourcePaths = await resolveExtensionSourcePaths(
       packageManager,
+      projectLookup,
       source,
       options.abortSignal,
     );
@@ -631,8 +709,8 @@ async function createPiSession(
     throw new Error('Pi session aborted');
   }
   // Explicit provider options are trusted input. Project-local Pi resources are
-  // not: keep implicit .pi discovery disabled while still loading temporary
-  // extension sources passed through additionalExtensionPaths.
+  // not: keep implicit .pi discovery disabled while loading only explicitly
+  // resolved extension paths through additionalExtensionPaths.
   const settingsManager = SettingsManager.inMemory({}, { projectTrusted: false });
   const runtime = await createModelRuntime(agentDir);
   if (isAbortRequested(options.abortSignal)) {

--- a/src/infra/pi/client.ts
+++ b/src/infra/pi/client.ts
@@ -248,6 +248,47 @@ function enabledResourcePaths(paths: ResolvedPaths, key: keyof ResolvedPaths): s
     .map((resource) => resource.path);
 }
 
+function countResolvedResources(paths: ResolvedPaths): number {
+  return paths.extensions.length
+    + paths.skills.length
+    + paths.prompts.length
+    + paths.themes.length;
+}
+
+function isNpmExtensionSource(source: string): boolean {
+  return source.trim().startsWith('npm:');
+}
+
+async function resolveExtensionSourcePaths(
+  packageManager: DefaultPackageManager,
+  source: string,
+  abortSignal: AbortSignal | undefined,
+): Promise<ResolvedPaths> {
+  if (!isNpmExtensionSource(source)) {
+    const sourcePaths = await packageManager.resolveExtensionSources([source], { temporary: true });
+    if (isAbortRequested(abortSignal)) {
+      throw new Error('Pi session aborted');
+    }
+    return sourcePaths;
+  }
+
+  const scopeAttempts: Array<() => Promise<ResolvedPaths>> = [
+    () => packageManager.resolveExtensionSources([source], { local: true }),
+    () => packageManager.resolveExtensionSources([source]),
+    () => packageManager.resolveExtensionSources([source], { temporary: true }),
+  ];
+  for (const attempt of scopeAttempts) {
+    const sourcePaths = await attempt();
+    if (isAbortRequested(abortSignal)) {
+      throw new Error('Pi session aborted');
+    }
+    if (countResolvedResources(sourcePaths) > 0) {
+      return sourcePaths;
+    }
+  }
+  return { extensions: [], skills: [], prompts: [], themes: [] };
+}
+
 async function resolvePiResources(
   cwd: string,
   agentDir: string,
@@ -263,15 +304,12 @@ async function resolvePiResources(
   const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
   const resolved: ResolvedPaths = { extensions: [], skills: [], prompts: [], themes: [] };
   for (const source of sources) {
-    const sourcePaths = await packageManager.resolveExtensionSources([source], { temporary: true });
-    if (isAbortRequested(options.abortSignal)) {
-      throw new Error('Pi session aborted');
-    }
-    const resolvedCount = sourcePaths.extensions.length
-      + sourcePaths.skills.length
-      + sourcePaths.prompts.length
-      + sourcePaths.themes.length;
-    if (resolvedCount === 0) {
+    const sourcePaths = await resolveExtensionSourcePaths(
+      packageManager,
+      source,
+      options.abortSignal,
+    );
+    if (countResolvedResources(sourcePaths) === 0) {
       throw new Error('Pi extension source could not be resolved');
     }
     resolved.extensions.push(...sourcePaths.extensions);

--- a/src/infra/pi/client.ts
+++ b/src/infra/pi/client.ts
@@ -277,8 +277,22 @@ async function resolveExtensionSourcePaths(
     () => packageManager.resolveExtensionSources([source]),
     () => packageManager.resolveExtensionSources([source], { temporary: true }),
   ];
-  for (const attempt of scopeAttempts) {
-    const sourcePaths = await attempt();
+  for (let scopeIndex = 0; scopeIndex < scopeAttempts.length; scopeIndex++) {
+    const attempt = scopeAttempts[scopeIndex]!;
+    const isTemporaryScope = scopeIndex === scopeAttempts.length - 1;
+    let sourcePaths: ResolvedPaths;
+    if (isTemporaryScope) {
+      sourcePaths = await attempt();
+    } else {
+      try {
+        sourcePaths = await attempt();
+      } catch {
+        if (isAbortRequested(abortSignal)) {
+          throw new Error('Pi session aborted');
+        }
+        continue;
+      }
+    }
     if (isAbortRequested(abortSignal)) {
       throw new Error('Pi session aborted');
     }


### PR DESCRIPTION
## Summary
- `resolvePiResources` で `npm:…` source を **project → user → temporary** の順に解決する（Proposal A）
- 健全な user/project install があるとき、壊れた temporary npm 木を踏まない
- 非 `npm:` source は従来どおり temporary のみ

## Why
Pi temporary install（`~/.pi/agent/tmp/extensions/npm/<hash>/`）が壊れると worker が `getDefaultStateRoot is not a function` で即死する。認証不足ではない。同じマシンの user scope では動く。

Closes #1422

## Test plan
- [x] `npm test -- src/__tests__/pi-client.test.ts`（33 passed）
- [x] CI on this PR
- [x] （任意）壊れた temporary 木 + 健全な user-scope `npm:pi-cursor-sdk` で `callPi` 起動確認

## Non-goals
- `.takt` への API キー直書きなし
- Pi package-manager 本体の依存解決修正なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - npm 拡張機能をプロジェクト、ユーザー、テンポラリーの順に解決するようになりました。
  - 利用可能な既存インストールを再利用し、不要なテンポラリー解決を行わなくなりました。
  - リソースが無効または解決に失敗した場合は、テンポラリーへフォールバックします。
  - Git URL とローカルパスはテンポラリーで解決されます。
  - 解決中の中断時は後続処理を停止します。

- **ドキュメント**
  - 拡張機能ソースの解決・フォールバック仕様を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->