### PR TITLE
[#1425] add-codex-fast-mode-1

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1013,6 +1013,27 @@ provider_options:
 
 runtime profile または capability preset で設定できます。legacy モードでは `provider_routing`、deprecated の `persona_providers`、project、global config からも設定できます。環境変数 `TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS=true` でも上書きできます。
 
+#### Codex の fast mode (`fast_mode`)
+
+`provider_options.codex.fast_mode` で Codex の fast mode を明示的に設定できます。
+
+```yaml
+provider_options:
+  codex:
+    fast_mode: true
+```
+
+`true` と `false` はどちらも明示値として扱われます。省略した場合、TAKT は
+`features.fast_mode` を Codex に渡さず、Codex 自身の既定値を維持します。環境変数では
+`TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE=true` または
+`TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE=false` を使用できます。
+
+この設定は既存の provider option leaf の解決順序と source attribution に従います。
+runtime profile、`provider_routing.personas`、`provider_routing.tags`、
+`provider_routing.steps`、project または global の `provider_options`、環境変数 override
+から設定できます。`takt exec` の assistant session も、解決済み runtime default の
+provider options を使用します。
+
 #### Codex の permission control (`permission_control`)
 
 Codex はデフォルトで TAKT の permission mode マッピングを使います。これは `permission_control: takt` と同じで、解決済みの TAKT `permission_mode` を Codex SDK の `sandboxMode` へ渡します。`network_access` を指定した場合は `networkAccessEnabled` にも渡します。省略時は Codex の既定値（`false`）を維持します。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1059,6 +1059,25 @@ legacy mode it can also be set through `provider_routing`, deprecated
 `persona_providers`, project, or global config. The environment variable
 `TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS=true` also works as an override.
 
+#### Codex fast mode (`fast_mode`)
+
+Set the optional Codex fast-mode feature explicitly with `provider_options.codex.fast_mode`:
+
+```yaml
+provider_options:
+  codex:
+    fast_mode: true
+```
+
+Both `true` and `false` are explicit values. If the setting is omitted, TAKT does not send
+`features.fast_mode` to Codex and Codex keeps its own default. The environment override is
+`TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE=true` or `TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE=false`.
+
+The setting follows the existing provider-option leaf resolution and source attribution. It can
+come from a runtime profile, `provider_routing.personas`, `provider_routing.tags`,
+`provider_routing.steps`, project or global `provider_options`, or the environment override.
+`takt exec` uses the resolved runtime default provider options for its assistant session as well.
+
 #### Codex permission control (`permission_control`)
 
 Codex uses TAKT's permission mode mapping by default. This is equivalent to `permission_control: takt` and passes the resolved TAKT `permission_mode` to the Codex SDK as `sandboxMode`. `network_access`, when set, is also passed as `networkAccessEnabled`; when omitted, Codex keeps its default (`false`).

--- a/src/__tests__/codex-structured-output.test.ts
+++ b/src/__tests__/codex-structured-output.test.ts
@@ -12,6 +12,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CodexCallOptions } from '../infra/codex/types.js';
 
+const { mockBuildCodexSkillConfig } = vi.hoisted(() => ({
+  mockBuildCodexSkillConfig: vi.fn(),
+}));
+
 // ===== Codex SDK mock =====
 
 let mockEvents: Array<Record<string, unknown>> = [];
@@ -48,12 +52,17 @@ vi.mock('@openai/codex-sdk', () => {
   };
 });
 
+vi.mock('../infra/codex/skill-config.js', () => ({
+  buildCodexSkillConfig: mockBuildCodexSkillConfig,
+}));
+
 // CodexClient は @openai/codex-sdk をインポートするため、mock 後にインポート
 const { CodexClient } = await import('../infra/codex/client.js');
 
 describe('CodexClient — structuredOutput 抽出', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockBuildCodexSkillConfig.mockReset();
     mockEvents = [];
     lastThreadOptions = undefined;
     lastTurnOptions = undefined;
@@ -436,10 +445,16 @@ describe('CodexClient — structuredOutput 抽出', () => {
       { type: 'thread.started', thread_id: 'thread-1' },
       { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
     ];
+    mockBuildCodexSkillConfig.mockReturnValue({
+      skills: {
+        config: [{ path: '/tmp/example/SKILL.md', enabled: false }],
+      },
+    });
     const callOptions: CodexCallOptions = {
       cwd: '/tmp',
       fastMode,
       reasoningEffort: 'high',
+      skills: { repo: false, user: false },
     };
 
     const client = new CodexClient();
@@ -447,6 +462,9 @@ describe('CodexClient — structuredOutput 抽出', () => {
 
     expect(lastCodexConstructorOptions).toMatchObject({
       config: {
+        skills: {
+          config: [{ path: '/tmp/example/SKILL.md', enabled: false }],
+        },
         features: { fast_mode: fastMode },
         model_reasoning_effort: 'high',
         model_reasoning_summary: 'auto',
@@ -459,12 +477,24 @@ describe('CodexClient — structuredOutput 抽出', () => {
       { type: 'thread.started', thread_id: 'thread-1' },
       { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
     ];
+    mockBuildCodexSkillConfig.mockReturnValue({
+      skills: {
+        config: [{ path: '/tmp/example/SKILL.md', enabled: false }],
+      },
+    });
 
     const client = new CodexClient();
-    await client.call('coder', 'prompt', { cwd: '/tmp', reasoningEffort: 'high' });
+    await client.call('coder', 'prompt', {
+      cwd: '/tmp',
+      reasoningEffort: 'high',
+      skills: { repo: false, user: false },
+    });
 
     expect(lastCodexConstructorOptions).toMatchObject({
       config: {
+        skills: {
+          config: [{ path: '/tmp/example/SKILL.md', enabled: false }],
+        },
         model_reasoning_effort: 'high',
         model_reasoning_summary: 'auto',
       },

--- a/src/__tests__/codex-structured-output.test.ts
+++ b/src/__tests__/codex-structured-output.test.ts
@@ -431,6 +431,47 @@ describe('CodexClient — structuredOutput 抽出', () => {
     });
   });
 
+  it.each([true, false])('fastMode=%s は Codex config の features.fast_mode に反映される', async (fastMode) => {
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+    const callOptions: CodexCallOptions = {
+      cwd: '/tmp',
+      fastMode,
+      reasoningEffort: 'high',
+    };
+
+    const client = new CodexClient();
+    await client.call('coder', 'prompt', callOptions);
+
+    expect(lastCodexConstructorOptions).toMatchObject({
+      config: {
+        features: { fast_mode: fastMode },
+        model_reasoning_effort: 'high',
+        model_reasoning_summary: 'auto',
+      },
+    });
+  });
+
+  it('fastMode 未指定時は Codex config に features.fast_mode を追加しない', async () => {
+    mockEvents = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      { type: 'turn.completed', usage: { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 } },
+    ];
+
+    const client = new CodexClient();
+    await client.call('coder', 'prompt', { cwd: '/tmp', reasoningEffort: 'high' });
+
+    expect(lastCodexConstructorOptions).toMatchObject({
+      config: {
+        model_reasoning_effort: 'high',
+        model_reasoning_summary: 'auto',
+      },
+    });
+    expect(lastCodexConstructorOptions?.config).not.toHaveProperty('features.fast_mode');
+  });
+
   it('codexPathOverride が Codex constructor options に反映される', async () => {
     mockEvents = [
       { type: 'thread.started', thread_id: 'thread-1' },

--- a/src/__tests__/config-env-overrides.test.ts
+++ b/src/__tests__/config-env-overrides.test.ts
@@ -49,6 +49,8 @@ describe('config traced env overrides', () => {
   it('dotted path から traced-config 用の env 名を生成する', () => {
     expect(envVarNameFromPath('provider_options.claude.sandbox.allow_unsandboxed_commands'))
       .toBe('TAKT_PROVIDER_OPTIONS_CLAUDE_SANDBOX_ALLOW_UNSANDBOXED_COMMANDS');
+    expect(envVarNameFromPath('provider_options.codex.fast_mode'))
+      .toBe('TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE');
   });
 
   it('global config はホワイトリストされた env のみを反映する', () => {
@@ -102,6 +104,40 @@ describe('config traced env overrides', () => {
 
     expect(config.providerOptions).toEqual({
       codex: { networkAccess: true },
+    });
+  });
+
+  it.each([
+    { configValue: true, envValue: 'false', expectedValue: false },
+    { configValue: false, envValue: 'true', expectedValue: true },
+  ])('project config は Codex fast_mode の boolean env override を反映する', ({ configValue, envValue, expectedValue }) => {
+    const projectDir = join(testRoot, `project-codex-fast-mode-${envValue}`);
+    const configDir = getProjectConfigDir(projectDir);
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'config.yaml'),
+      ['provider_options:', '  codex:', `    fast_mode: ${configValue}`].join('\n'),
+      'utf-8',
+    );
+    process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE = envValue;
+
+    const config = loadProjectConfig(projectDir);
+
+    expect(config.providerOptions).toEqual({
+      codex: { fastMode: expectedValue },
+    });
+  });
+
+  it('global config は Codex fast_mode の明示値を読み込む', () => {
+    mkdirSync(globalTaktDir, { recursive: true });
+    writeFileSync(
+      globalConfigPath,
+      ['provider_options:', '  codex:', '    fast_mode: false'].join('\n'),
+      'utf-8',
+    );
+
+    expect(loadGlobalConfig().providerOptions).toEqual({
+      codex: { fastMode: false },
     });
   });
 

--- a/src/__tests__/config-normalizers-provider-options.test.ts
+++ b/src/__tests__/config-normalizers-provider-options.test.ts
@@ -5,6 +5,20 @@ import {
   normalizeTaktSelectorProvider,
 } from '../infra/config/configNormalizers.js';
 import { normalizeProviderOptions } from '../infra/config/providerOptions.js';
+import { StepProviderOptionsObjectSchema } from '../core/models/schema-base.js';
+import type { StepProviderOptions } from '../core/models/workflow-provider-options.js';
+
+describe('Codex fast mode provider option schema', () => {
+  it.each([true, false])('accepts an explicit boolean value: %s', (fastMode) => {
+    expect(StepProviderOptionsObjectSchema.parse({ codex: { fast_mode: fastMode } })).toEqual({
+      codex: { fast_mode: fastMode },
+    });
+  });
+
+  it('rejects a non-boolean fast mode value', () => {
+    expect(() => StepProviderOptionsObjectSchema.parse({ codex: { fast_mode: 'true' } })).toThrow();
+  });
+});
 
 describe('denormalizeProviderOptions', () => {
   it('should convert camelCase provider options into persisted snake_case format', () => {
@@ -146,6 +160,14 @@ describe('denormalizeProviderOptions', () => {
         permissionControl: 'codex',
       },
     });
+    expect(denormalizeProviderOptions(normalizedProviderOptions)).toEqual(rawProviderOptions);
+  });
+
+  it.each([true, false])('should normalize and denormalize Codex fast_mode=%s', (fastMode) => {
+    const rawProviderOptions = { codex: { fast_mode: fastMode } };
+    const normalizedProviderOptions = normalizeProviderOptions(rawProviderOptions);
+
+    expect(normalizedProviderOptions).toEqual({ codex: { fastMode } });
     expect(denormalizeProviderOptions(normalizedProviderOptions)).toEqual(rawProviderOptions);
   });
 
@@ -417,6 +439,24 @@ describe('buildRawTaktProvidersOrThrow', () => {
             max_tokens: 4096,
           },
         },
+      },
+    });
+  });
+
+  it.each([true, false])('should preserve Codex fastMode=%s through the strict normalized selector schema', (fastMode) => {
+    const providerOptions: StepProviderOptions = {
+      codex: { fastMode },
+    };
+
+    expect(buildRawTaktProvidersOrThrow({
+      selector: {
+        provider: 'codex',
+        providerOptions,
+      },
+    })).toEqual({
+      selector: {
+        provider: 'codex',
+        provider_options: { codex: { fast_mode: fastMode } },
       },
     });
   });

--- a/src/__tests__/engine-workflow-call.test.ts
+++ b/src/__tests__/engine-workflow-call.test.ts
@@ -893,7 +893,7 @@ steps:
     expect(options?.providerOptions).toEqual({ claude: { allowedTools: ['Read'] } });
     expect(startedProviderInfo[0]?.providerOptions).toEqual({ claude: { allowedTools: ['Read'] } });
     expect(startedProviderInfo[0]?.providerOptionsSources).toEqual({
-      'claude.allowedTools': 'default',
+      'claude.allowedTools': 'runtime-v1',
     });
   });
 

--- a/src/__tests__/exec-command.test.ts
+++ b/src/__tests__/exec-command.test.ts
@@ -31,6 +31,7 @@ vi.mock('../infra/config/index.js', () => ({
     enableBuiltinWorkflows: true,
     language: 'en',
   })),
+  resolveNonWorkflowProviderModel: vi.fn(() => ({ runtimeManaged: false })),
   resolveNonWorkflowProviderOptions: vi.fn((_cwd: string, options?: unknown) => options),
 }));
 

--- a/src/__tests__/options-builder.test.ts
+++ b/src/__tests__/options-builder.test.ts
@@ -535,6 +535,80 @@ describe('OptionsBuilder.buildBaseOptions', () => {
     });
   });
 
+  it.each([
+    { profileFastMode: false, configFastMode: true },
+    { profileFastMode: true, configFastMode: false },
+  ])('uses the config/env winner for runtime profile options and its source', ({
+    profileFastMode,
+    configFastMode,
+  }) => {
+    const step = createStep();
+    const builder = createBuilder(step, {
+      providerSource: 'runtime-v1',
+      providerOptionsProviderSource: 'runtime-v1',
+      providerOptions: { codex: { fastMode: profileFastMode } },
+      configProviderOptions: { codex: { fastMode: configFastMode } },
+      providerOptionsSource: 'env',
+      providerOptionsOriginResolver: (path: string) => (
+        path === 'codex.fastMode' ? 'env' : 'default'
+      ),
+    });
+
+    const providerInfo = builder.resolveStepProviderModel(step);
+
+    expect(providerInfo.providerOptions).toEqual({ codex: { fastMode: configFastMode } });
+    expect(providerInfo.providerOptionsSources).toEqual({
+      'codex.fastMode': 'env',
+    });
+  });
+
+  it('attributes an explicit runtime profile option to runtime-v1', () => {
+    const step = createStep();
+    const builder = createBuilder(step, {
+      providerSource: 'runtime-v1',
+      providerOptionsProviderSource: 'runtime-v1',
+      providerOptions: { codex: { fastMode: false } },
+    });
+
+    const providerInfo = builder.resolveStepProviderModel(step);
+
+    expect(providerInfo.providerOptions).toEqual({ codex: { fastMode: false } });
+    expect(providerInfo.providerOptionsSources).toEqual({
+      'codex.fastMode': 'runtime-v1',
+    });
+  });
+
+  it('attributes profile options included by a runtime-resolved provider layer', () => {
+    const step = createStep();
+    const builder = createBuilder(step, {
+      providerSource: 'auto.fallback',
+      providerOptionsProviderSource: 'auto.fallback',
+      providerOptions: { codex: { fastMode: false } },
+    });
+
+    const providerInfo = builder.resolveStepProviderModel(step, {
+      providerInfo: {
+        provider: 'codex',
+        model: 'gpt-auto',
+        providerSource: 'auto.fallback',
+        modelSource: 'auto.fallback',
+        providerOptions: { codex: { networkAccess: true } },
+      },
+      teamLeaderPart: { partAllowedTools: [] },
+    });
+
+    expect(providerInfo.providerOptions).toEqual({
+      codex: {
+        fastMode: false,
+        networkAccess: true,
+      },
+    });
+    expect(providerInfo.providerOptionsSources).toEqual({
+      'codex.fastMode': 'auto.fallback',
+      'codex.networkAccess': 'auto.fallback',
+    });
+  });
+
   it('buildBaseOptions は takt-default の implement でも process safety を workflowMeta に含めない', () => {
     const step = createStep({ name: 'implement' });
     const builder = createBuilder(step, {

--- a/src/__tests__/provider-options-resolution.test.ts
+++ b/src/__tests__/provider-options-resolution.test.ts
@@ -59,6 +59,82 @@ describe('resolveEffectiveProviderOptions', () => {
     });
   });
 
+  it.each([true, false])('preserves Codex fastMode=%s when a later layer overrides it', (fastMode) => {
+    expect(mergeProviderOptions(
+      asProviderOptions({ codex: { fastMode: true } }),
+      asProviderOptions({ codex: { fastMode } }),
+    )).toEqual({ codex: { fastMode } });
+  });
+
+  it('does not create a Codex fastMode value when it is omitted', () => {
+    expect(mergeProviderOptions(asProviderOptions({ codex: { networkAccess: true } })))
+      .toEqual({ codex: { networkAccess: true } });
+  });
+
+  it.each([true, false])('resolves Codex fastMode=%s from the step before persona and config', (fastMode) => {
+    const configOptions = asProviderOptions({ codex: { fastMode: !fastMode } });
+    const personaOptions = asProviderOptions({ codex: { fastMode: !fastMode } });
+    const stepOptions = asProviderOptions({ codex: { fastMode } });
+
+    expect(resolveEffectiveProviderOptions(
+      'project',
+      undefined,
+      configOptions,
+      stepOptions,
+      personaOptions,
+    )).toEqual({ codex: { fastMode } });
+    expect(resolveProviderOptionSource(
+      'codex.fastMode',
+      stepOptions,
+      [],
+      configOptions,
+      undefined,
+      'project',
+    )).toBe('step');
+  });
+
+  it('resolves Codex fastMode from persona when the step does not set it', () => {
+    const personaOptions = asProviderOptions({ codex: { fastMode: false } });
+    const configOptions = asProviderOptions({ codex: { fastMode: true } });
+
+    expect(resolveEffectiveProviderOptions(
+      'project',
+      undefined,
+      configOptions,
+      undefined,
+      personaOptions,
+    )).toEqual({ codex: { fastMode: false } });
+    expect(resolveProviderOptionSource(
+      'codex.fastMode',
+      undefined,
+      [{ source: 'persona_providers', options: personaOptions }],
+      configOptions,
+      undefined,
+      'project',
+    )).toBe('persona_providers');
+  });
+
+  it('keeps an env-origin Codex fastMode value ahead of lower-priority layers', () => {
+    const configOptions = asProviderOptions({ codex: { fastMode: true } });
+    const stepOptions = asProviderOptions({ codex: { fastMode: false } });
+    const originResolver = (path: string) => (path === 'codex.fastMode' ? 'env' : 'local');
+
+    expect(resolveEffectiveProviderOptions(
+      'project',
+      originResolver,
+      configOptions,
+      stepOptions,
+    )).toEqual({ codex: { fastMode: true } });
+    expect(resolveProviderOptionSource(
+      'codex.fastMode',
+      stepOptions,
+      [],
+      configOptions,
+      originResolver,
+      'project',
+    )).toBe('env');
+  });
+
   it('Codex Skill inheritance is resolved independently per scope', () => {
     const result = resolveEffectiveProviderOptions(
       'project',
@@ -630,7 +706,7 @@ describe('resolveProviderOptionsSources (all paths)', () => {
     const result = resolveProviderOptionsSources(
       { claude: { effort: 'xhigh' } },
       [{ source: 'persona_providers', options: {
-        codex: { permissionControl: 'codex', reasoningEffort: 'high' },
+        codex: { fastMode: false, permissionControl: 'codex', reasoningEffort: 'high' },
       } }],
       { copilot: { effort: 'medium' } },
       undefined,
@@ -638,6 +714,7 @@ describe('resolveProviderOptionsSources (all paths)', () => {
     );
     expect(result).toEqual({
       'claude.effort': 'step',
+      'codex.fastMode': 'persona_providers',
       'codex.permissionControl': 'persona_providers',
       'codex.reasoningEffort': 'persona_providers',
       'copilot.effort': 'global',
@@ -764,6 +841,7 @@ describe('providerOptionsContract', () => {
     expect(envPaths).toEqual(new Set([
       'provider_options',
       'provider_options.codex.base_url',
+      'provider_options.codex.fast_mode',
       'provider_options.codex.network_access',
       'provider_options.codex.permission_control',
       'provider_options.codex.reasoning_effort',
@@ -812,6 +890,7 @@ describe('providerOptionsContract', () => {
       'provider_options.pi.no_context_files',
     ]));
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.codex.base_url');
+    expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.codex.fast_mode');
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.claude.base_url');
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.claude.allowed_tools');
     expect(PROVIDER_OPTIONS_TRACE_PATHS).toContain('provider_options.claude.skills.enabled');
@@ -858,6 +937,8 @@ describe('providerOptionsContract', () => {
   it('maps internal provider option paths to traced-config paths', () => {
     expect(toProviderOptionsTracePath('codex.baseUrl'))
       .toBe('provider_options.codex.base_url');
+    expect(toProviderOptionsTracePath('codex.fastMode'))
+      .toBe('provider_options.codex.fast_mode');
     expect(toProviderOptionsTracePath('claude.baseUrl'))
       .toBe('provider_options.claude.base_url');
     expect(toProviderOptionsTracePath('claude.sandbox.allowUnsandboxedCommands'))
@@ -908,6 +989,7 @@ describe('providerOptionsContract', () => {
     expect(getPresentProviderOptionPaths({
       codex: {
         baseUrl: 'http://127.0.0.1:8787/v1',
+        fastMode: false,
         networkAccess: true,
         permissionControl: 'takt',
         reasoningEffort: 'high',
@@ -931,6 +1013,7 @@ describe('providerOptionsContract', () => {
       cursor: { guards: { callTimeoutMs: 360_000 } },
     } as Parameters<typeof getPresentProviderOptionPaths>[0])).toEqual([
       'codex.baseUrl',
+      'codex.fastMode',
       'codex.networkAccess',
       'codex.permissionControl',
       'codex.reasoningEffort',
@@ -1141,6 +1224,7 @@ describe('claude_terminal provider_options normalization', () => {
       'opencode.guards.eventLimit',
       'claude.guards.callTimeoutMs',
       'codex.guards.callTimeoutMs',
+      'codex.fastMode',
       'copilot.guards.callTimeoutMs',
       'kiro.guards.callTimeoutMs',
       'cursor.guards.callTimeoutMs',

--- a/src/__tests__/provider-structured-output.test.ts
+++ b/src/__tests__/provider-structured-output.test.ts
@@ -340,6 +340,27 @@ describe('CodexProvider — structured output', () => {
     expect(opts).toHaveProperty('reasoningEffort', 'high');
   });
 
+  it.each([true, false])('provider_options.codex.fastMode=%s を通常・isolated structured callへ渡す', async (fastMode) => {
+    mockCallCodex.mockResolvedValue(doneResponse('coder'));
+    const providerOptions: StepProviderOptions = {
+      codex: { fastMode },
+    };
+    const provider = new CodexProvider();
+
+    await provider.setup({ name: 'coder' }).call('prompt', {
+      cwd: '/tmp',
+      providerOptions,
+    });
+    await provider.setupIsolatedStructured({ name: 'selector' }).call('prompt', {
+      cwd: '/tmp',
+      providerOptions,
+      outputSchema: SCHEMA,
+    });
+
+    expect(mockCallCodex.mock.calls[0]?.[2]).toHaveProperty('fastMode', fastMode);
+    expect(mockCallCodex.mock.calls[1]?.[2]).toHaveProperty('fastMode', fastMode);
+  });
+
   it('provider_options.codex.baseUrl を callCodex に渡す', async () => {
     mockCallCodex.mockResolvedValue(doneResponse('coder'));
     const providerOptions = {

--- a/src/__tests__/runtime-provider-environment.test.ts
+++ b/src/__tests__/runtime-provider-environment.test.ts
@@ -150,6 +150,38 @@ describe('compileRuntimeProviderEnvironment (profile options)', () => {
     });
   });
 
+  it('carries Codex fast_mode through defaults and persona/tag/step routing entries', () => {
+    const section: RuntimeProviderSection = {
+      defaults: { profile: 'base' },
+      profiles: {
+        base: { provider: 'codex', model: 'base-m', options: { fast_mode: true } },
+        persona: { provider: 'codex', model: 'persona-m', options: { fast_mode: false } },
+        tag: { provider: 'codex', model: 'tag-m', options: { fast_mode: true } },
+        step: { provider: 'codex', model: 'step-m', options: { fast_mode: false } },
+      },
+      targets: {
+        personas: { coder: { profile: 'persona' } },
+        tags: { 'high-stakes': { profile: 'tag' } },
+        steps: { 'wf/impl': { profile: 'step' } },
+      },
+    };
+
+    const env = compileRuntimeProviderEnvironment(section);
+
+    expect(env.providerOptions).toEqual({ codex: { fastMode: true } });
+    expect(env.personaProviders).toEqual({
+      coder: { provider: 'codex', model: 'persona-m', providerOptions: { codex: { fastMode: false } } },
+    });
+    expect(env.providerRouting).toEqual({
+      tags: {
+        'high-stakes': { provider: 'codex', model: 'tag-m', providerOptions: { codex: { fastMode: true } } },
+      },
+      steps: {
+        'wf/impl': { provider: 'codex', model: 'step-m', providerOptions: { codex: { fastMode: false } } },
+      },
+    });
+  });
+
   it('allows a DeepSeek Python executable override from a global runtime profile', () => {
     const section: RuntimeProviderSection = {
       defaults: { profile: 'p' },

--- a/src/__tests__/runtime-provider-nonworkflow-seam.integration.test.ts
+++ b/src/__tests__/runtime-provider-nonworkflow-seam.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -6,6 +6,9 @@ import { stringify as stringifyYaml } from 'yaml';
 import { resolveRuntimeNonWorkflowProvider } from '../infra/config/runtime-provider/internal-agents.js';
 import { resolveNonWorkflowProviderModel } from '../infra/config/nonWorkflowProvider.js';
 import { initializeSession } from '../features/interactive/sessionInitialization.js';
+import { askExecAssistant, createExecSessionContext } from '../features/exec/assistantSession.js';
+import { DEFAULT_EXEC_CONFIG } from '../features/exec/defaults.js';
+import type { ResolvedExecConfig } from '../features/exec/types.js';
 import {
   getGlobalConfigDir,
   getGlobalConfigPath,
@@ -15,6 +18,16 @@ import {
 } from '../infra/config/index.js';
 import { RUNTIME_PROVIDER_FILENAME } from '../infra/config/runtime-provider/constants.js';
 import type { RuntimeProviderFile } from '../infra/config/runtime-provider/schema.js';
+
+const { mockCallCodex, mockCallCodexCustom } = vi.hoisted(() => ({
+  mockCallCodex: vi.fn(),
+  mockCallCodexCustom: vi.fn(),
+}));
+
+vi.mock('../infra/codex/index.js', () => ({
+  callCodex: mockCallCodex,
+  callCodexCustom: mockCallCodexCustom,
+}));
 
 /**
  * Integration coverage for the non-workflow provider seam reading the runtime.yaml `defaults`
@@ -148,6 +161,146 @@ describe('runtime.yaml non-workflow provider resolution', () => {
     expect(ctx.model).toBe('gpt-default');
     expect(ctx.providerOptions).toEqual({ codex: { reasoningEffort: 'high' } });
     expect(ctx.permissionMode).toBe('readonly');
+  });
+
+  it.each([false, true])(
+    'flows runtime defaults fast_mode=%s into the exec assistant terminal',
+    async (profileFastMode) => {
+      writeGlobalRuntimeFile({
+        version: 1,
+        provider: {
+          defaults: { profile: 'default' },
+          profiles: {
+            default: {
+              provider: 'codex',
+              model: 'gpt-default',
+              options: { fast_mode: profileFastMode },
+            },
+          },
+        },
+      });
+      const previousFastMode = process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+      delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+      invalidate();
+
+      try {
+        const config: ResolvedExecConfig = {
+          ...DEFAULT_EXEC_CONFIG,
+          session: { provider: 'codex', model: 'gpt-default' },
+          workers: DEFAULT_EXEC_CONFIG.workers.map((worker) => ({ ...worker, provider: 'codex' })),
+          reviews: DEFAULT_EXEC_CONFIG.reviews.map((review) => ({ ...review, provider: 'codex' })),
+        };
+        const ctx = createExecSessionContext(projectCwd, config);
+
+        expect(ctx.providerOptions).toMatchObject({
+          codex: {
+            fastMode: profileFastMode,
+            skills: { repo: true, user: true },
+          },
+        });
+
+        mockCallCodexCustom.mockReset();
+        mockCallCodexCustom.mockResolvedValue({
+          content: 'done',
+          sessionId: 'exec-session',
+          status: 'completed',
+        });
+        const result = await askExecAssistant(
+          projectCwd,
+          ctx,
+          'prompt',
+          'system',
+          { outputMode: 'silent', persistSession: false },
+        );
+
+        expect(result.content).toBe('done');
+        expect(mockCallCodexCustom.mock.calls[0]?.[3]).toMatchObject({
+          fastMode: profileFastMode,
+        });
+      } finally {
+        if (previousFastMode === undefined) {
+          delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+        } else {
+          process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE = previousFastMode;
+        }
+        invalidate();
+      }
+    },
+  );
+
+  it.each([
+    { profileFastMode: false, envFastMode: true },
+    { profileFastMode: true, envFastMode: false },
+  ])('lets config/env options win over the exec runtime profile, including network access', async ({
+    profileFastMode,
+    envFastMode,
+  }) => {
+    writeGlobalRuntimeFile({
+      version: 1,
+      provider: {
+        defaults: { profile: 'default' },
+        profiles: {
+          default: {
+            provider: 'codex',
+            model: 'gpt-default',
+            options: { fast_mode: profileFastMode, network_access: true },
+          },
+        },
+      },
+    });
+    const previousFastMode = process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+    const previousNetworkAccess = process.env.TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS;
+    process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE = String(envFastMode);
+    process.env.TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS = 'false';
+    invalidate();
+    try {
+      const config: ResolvedExecConfig = {
+        ...DEFAULT_EXEC_CONFIG,
+        session: { provider: 'codex', model: 'gpt-default' },
+        workers: DEFAULT_EXEC_CONFIG.workers.map((worker) => ({ ...worker, provider: 'codex' })),
+        reviews: DEFAULT_EXEC_CONFIG.reviews.map((review) => ({ ...review, provider: 'codex' })),
+      };
+      const ctx = createExecSessionContext(projectCwd, config);
+
+      expect(ctx.providerOptions).toMatchObject({
+        codex: {
+          fastMode: envFastMode,
+          networkAccess: false,
+        },
+      });
+
+      mockCallCodexCustom.mockReset();
+      mockCallCodexCustom.mockResolvedValue({
+        content: 'done',
+        sessionId: 'exec-session',
+        status: 'completed',
+      });
+      const result = await askExecAssistant(
+        projectCwd,
+        ctx,
+        'prompt',
+        'system',
+        { outputMode: 'silent', persistSession: false },
+      );
+
+      expect(result.content).toBe('done');
+      expect(mockCallCodexCustom.mock.calls[0]?.[3]).toMatchObject({
+        fastMode: envFastMode,
+        networkAccess: false,
+      });
+    } finally {
+      if (previousFastMode === undefined) {
+        delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+      } else {
+        process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE = previousFastMode;
+      }
+      if (previousNetworkAccess === undefined) {
+        delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS;
+      } else {
+        process.env.TAKT_PROVIDER_OPTIONS_CODEX_NETWORK_ACCESS = previousNetworkAccess;
+      }
+      invalidate();
+    }
   });
 
   it('treats an env-source provider as an override that drops the runtime model/options', () => {

--- a/src/__tests__/runtime-provider-seam.integration.test.ts
+++ b/src/__tests__/runtime-provider-seam.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { stringify as stringifyYaml } from 'yaml';
@@ -9,6 +9,11 @@ import {
 } from '../infra/config/runtime-provider/provider-environment.js';
 import type { LegacyProviderEnvironmentInput } from '../infra/config/runtime-provider/environment.js';
 import type { LegacyProviderSignal } from '../infra/config/runtime-provider/mode.js';
+import {
+  invalidateAllResolvedConfigCache,
+  invalidateGlobalConfigCache,
+  resolveProviderOptionsWithTrace,
+} from '../infra/config/index.js';
 import { getGlobalConfigDir } from '../infra/config/paths.js';
 import { RUNTIME_PROVIDER_FILENAME } from '../infra/config/runtime-provider/constants.js';
 
@@ -43,6 +48,7 @@ import type { WorkflowConfig, WorkflowStep } from '../core/models/index.js';
 import type { StructuredCaller } from '../agents/structured-caller.js';
 import { WorkflowEngine } from '../core/workflow/index.js';
 import { runAgent } from '../agents/runner.js';
+import { runWorkflowExecution } from '../features/tasks/execute/workflowExecutionApi.js';
 import {
   applyDefaultMocks,
   cleanupWorkflowEngine,
@@ -126,6 +132,74 @@ describe('resolveCompiledProviderEnvironment seam', () => {
       tags: { 'high-stakes': { provider: 'claude', model: 'sonnet' } },
       steps: { 'wf/impl': { provider: 'cursor', model: 'cur-m' } },
     });
+  });
+
+  it('carries runtime profile fast_mode through the compiled defaults and routing entries', () => {
+    writeGlobalRuntimeFile({
+      version: 1,
+      provider: {
+        defaults: { profile: 'default' },
+        profiles: {
+          default: { provider: 'codex', model: 'gpt-default', options: { fast_mode: false } },
+          persona: { provider: 'codex', model: 'gpt-persona', options: { fast_mode: true } },
+          tag: { provider: 'codex', model: 'gpt-tag', options: { fast_mode: false } },
+          step: { provider: 'codex', model: 'gpt-step', options: { fast_mode: true } },
+        },
+        targets: {
+          personas: { coder: { profile: 'persona' } },
+          tags: { 'high-stakes': { profile: 'tag' } },
+          steps: { 'wf/impl': { profile: 'step' } },
+        },
+      },
+    });
+
+    const env = resolveCompiledProviderEnvironment({
+      projectCwd,
+      legacy: legacyInput,
+      legacySignals: [],
+    });
+
+    expect(env.providerOptions).toEqual({ codex: { fastMode: false } });
+    expect(env.personaProviders?.coder?.providerOptions).toEqual({ codex: { fastMode: true } });
+    expect(env.providerRouting?.tags?.['high-stakes']?.providerOptions)
+      .toEqual({ codex: { fastMode: false } });
+    expect(env.providerRouting?.steps?.['wf/impl']?.providerOptions)
+      .toEqual({ codex: { fastMode: true } });
+  });
+
+  it.each([true, false])('keeps config/env provider options separate from runtime profile options (%s)', (envFastMode) => {
+    writeGlobalRuntimeFile({
+      version: 1,
+      provider: {
+        defaults: { profile: 'default' },
+        profiles: {
+          default: { provider: 'codex', model: 'gpt-default', options: { fast_mode: false } },
+        },
+      },
+    });
+    const previous = process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+    process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE = String(envFastMode);
+    invalidateGlobalConfigCache();
+    invalidateAllResolvedConfigCache();
+    try {
+      const configProviderOptions = resolveProviderOptionsWithTrace(projectCwd).value;
+      const resolved = resolveRuntimeEnvironment({
+        projectCwd,
+        legacy: { ...legacyInput, providerOptions: configProviderOptions },
+        legacySignals: [],
+      });
+
+      expect(resolved.providerEnvironment.providerOptions).toEqual({ codex: { fastMode: false } });
+      expect(resolved.configProviderOptions?.codex?.fastMode).toBe(envFastMode);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+      } else {
+        process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE = previous;
+      }
+      invalidateGlobalConfigCache();
+      invalidateAllResolvedConfigCache();
+    }
   });
 
   it('resolves explicit capabilities and permission_mode while leaving omitted profiles unconstrained', () => {
@@ -624,4 +698,145 @@ describe('providerLadders end-to-end from runtime.yaml (issue #1208)', () => {
       resolvedModel: 'opus',
     });
   });
+});
+
+describe('runtime provider options through workflow execution', () => {
+  let workflowProjectCwd: string;
+  let runtimeConfigDir: string;
+  let originalConfigDir: string | undefined;
+  let originalFastMode: string | undefined;
+  let originalProvider: string | undefined;
+  let originalModel: string | undefined;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    applyDefaultMocks();
+    workflowProjectCwd = mkdtempSync(join(tmpdir(), 'takt-seam-workflow-'));
+    runtimeConfigDir = mkdtempSync(join(tmpdir(), 'takt-seam-config-'));
+    mkdirSync(join(workflowProjectCwd, '.takt', 'workflows', 'personas'), { recursive: true });
+    writeFileSync(
+      join(workflowProjectCwd, '.takt', 'workflows', 'runtime-provider-handoff.yaml'),
+      [
+        'name: runtime-provider-handoff',
+        'description: runtime provider option handoff integration test',
+        'max_steps: 1',
+        'initial_step: plan',
+        'steps:',
+        '  - name: plan',
+        '    persona: ./personas/planner.md',
+        '    instruction: "{task}"',
+        '    rules:',
+        '      - condition: when(true)',
+        '        next: COMPLETE',
+      ].join('\n'),
+      'utf-8',
+    );
+    writeFileSync(
+      join(workflowProjectCwd, '.takt', 'workflows', 'personas', 'planner.md'),
+      'You are planner.',
+      'utf-8',
+    );
+
+    originalConfigDir = process.env.TAKT_CONFIG_DIR;
+    originalFastMode = process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+    originalProvider = process.env.TAKT_PROVIDER;
+    originalModel = process.env.TAKT_MODEL;
+    process.env.TAKT_CONFIG_DIR = runtimeConfigDir;
+    delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+    delete process.env.TAKT_PROVIDER;
+    delete process.env.TAKT_MODEL;
+    invalidateGlobalConfigCache();
+    invalidateAllResolvedConfigCache();
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.TAKT_CONFIG_DIR;
+    } else {
+      process.env.TAKT_CONFIG_DIR = originalConfigDir;
+    }
+    if (originalFastMode === undefined) {
+      delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+    } else {
+      process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE = originalFastMode;
+    }
+    if (originalProvider === undefined) {
+      delete process.env.TAKT_PROVIDER;
+    } else {
+      process.env.TAKT_PROVIDER = originalProvider;
+    }
+    if (originalModel === undefined) {
+      delete process.env.TAKT_MODEL;
+    } else {
+      process.env.TAKT_MODEL = originalModel;
+    }
+    invalidateGlobalConfigCache();
+    invalidateAllResolvedConfigCache();
+    rmSync(workflowProjectCwd, { recursive: true, force: true });
+    rmSync(runtimeConfigDir, { recursive: true, force: true });
+  });
+
+  it.each([
+    [false, true],
+    [true, false],
+  ])(
+    'hands the environment winner to workflow consumers (profile=%s, env=%s)',
+    async (profileFastMode, envFastMode) => {
+      writeGlobalRuntimeFile({
+        version: 1,
+        provider: {
+          defaults: { profile: 'default' },
+          profiles: {
+            default: {
+              provider: 'codex',
+              model: 'gpt-runtime',
+              options: { fast_mode: profileFastMode },
+            },
+          },
+        },
+      });
+      process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE = String(envFastMode);
+      invalidateGlobalConfigCache();
+      invalidateAllResolvedConfigCache();
+      mockRunAgentSequence([makeResponse({ persona: 'planner', content: 'done' })]);
+      mockRuleEvaluationSequence([{ index: 0, method: 'phase3_tag' }]);
+
+      try {
+        const result = await runWorkflowExecution({
+          task: 'test runtime provider option handoff',
+          cwd: workflowProjectCwd,
+          projectCwd: workflowProjectCwd,
+          workflowIdentifier: 'runtime-provider-handoff',
+          outputMode: 'silent',
+        });
+
+        expect(result.success).toBe(true);
+        expect(vi.mocked(runAgent)).toHaveBeenCalledTimes(1);
+        const agentOptions = vi.mocked(runAgent).mock.calls[0]?.[2];
+        expect(agentOptions?.resolvedProviderOptions).toMatchObject({
+          codex: { fastMode: envFastMode },
+        });
+
+        const ndjsonLogPath = result.ndjsonLogPath;
+        expect(ndjsonLogPath).toBeDefined();
+        const records = readFileSync(ndjsonLogPath!, 'utf-8')
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line) as Record<string, unknown>);
+        const stepStart = records.find((record) => record.type === 'step_start');
+        expect(stepStart).toMatchObject({
+          providerOptions: { codex: { fastMode: envFastMode } },
+          providerOptionsSources: { 'codex.fastMode': 'env' },
+        });
+      } finally {
+        if (originalFastMode === undefined) {
+          delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
+        } else {
+          process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE = originalFastMode;
+        }
+        invalidateGlobalConfigCache();
+        invalidateAllResolvedConfigCache();
+      }
+    },
+  );
 });

--- a/src/__tests__/runtime-provider-seam.integration.test.ts
+++ b/src/__tests__/runtime-provider-seam.integration.test.ts
@@ -702,8 +702,6 @@ describe('providerLadders end-to-end from runtime.yaml (issue #1208)', () => {
 
 describe('runtime provider options through workflow execution', () => {
   let workflowProjectCwd: string;
-  let runtimeConfigDir: string;
-  let originalConfigDir: string | undefined;
   let originalFastMode: string | undefined;
   let originalProvider: string | undefined;
   let originalModel: string | undefined;
@@ -712,7 +710,6 @@ describe('runtime provider options through workflow execution', () => {
     vi.resetAllMocks();
     applyDefaultMocks();
     workflowProjectCwd = mkdtempSync(join(tmpdir(), 'takt-seam-workflow-'));
-    runtimeConfigDir = mkdtempSync(join(tmpdir(), 'takt-seam-config-'));
     mkdirSync(join(workflowProjectCwd, '.takt', 'workflows', 'personas'), { recursive: true });
     writeFileSync(
       join(workflowProjectCwd, '.takt', 'workflows', 'runtime-provider-handoff.yaml'),
@@ -737,11 +734,9 @@ describe('runtime provider options through workflow execution', () => {
       'utf-8',
     );
 
-    originalConfigDir = process.env.TAKT_CONFIG_DIR;
     originalFastMode = process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
     originalProvider = process.env.TAKT_PROVIDER;
     originalModel = process.env.TAKT_MODEL;
-    process.env.TAKT_CONFIG_DIR = runtimeConfigDir;
     delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
     delete process.env.TAKT_PROVIDER;
     delete process.env.TAKT_MODEL;
@@ -750,11 +745,6 @@ describe('runtime provider options through workflow execution', () => {
   });
 
   afterEach(() => {
-    if (originalConfigDir === undefined) {
-      delete process.env.TAKT_CONFIG_DIR;
-    } else {
-      process.env.TAKT_CONFIG_DIR = originalConfigDir;
-    }
     if (originalFastMode === undefined) {
       delete process.env.TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE;
     } else {
@@ -773,7 +763,6 @@ describe('runtime provider options through workflow execution', () => {
     invalidateGlobalConfigCache();
     invalidateAllResolvedConfigCache();
     rmSync(workflowProjectCwd, { recursive: true, force: true });
-    rmSync(runtimeConfigDir, { recursive: true, force: true });
   });
 
   it.each([

--- a/src/__tests__/runtime-yaml-boundary-capabilities-resolution.test.ts
+++ b/src/__tests__/runtime-yaml-boundary-capabilities-resolution.test.ts
@@ -66,6 +66,13 @@ describe('CT-CAP-3 capability-set leaf purification', () => {
     ])).toThrow(/capabilit|effort|capability leaf/i);
   });
 
+  it('should reject Codex fast_mode from a capability-set', () => {
+    writeCapabilitySet('fast-mode', 'codex:\n  fast_mode: true\n');
+    expect(() => normalize({}, [
+      { name: 'implement', instruction: '{task}', capabilities: 'provider-options/fast-mode.yaml' },
+    ])).toThrow(/codex\.fastMode.*not a capability leaf|resolved to no capability options/);
+  });
+
   it('should accept a capability-set when it carries only capability leaves', () => {
     writeCapabilitySet('caps', 'codex:\n  network_access: true\n  skills:\n    repo: true\n');
     expect(() => normalize({}, [

--- a/src/__tests__/workflowExecutionEvents.test.ts
+++ b/src/__tests__/workflowExecutionEvents.test.ts
@@ -1134,6 +1134,66 @@ describe('bindWorkflowExecutionEvents', () => {
     expect(infoText).not.toContain('127.0.0.1:8787');
   });
 
+  it.each([
+    { fastMode: true, label: 'enabled' },
+    { fastMode: false, label: 'disabled' },
+  ])('verbose 時に Codex fast mode=%s と解決ソースを表示する', ({ fastMode, label }) => {
+    resetDebugLogger();
+    setVerboseConsole(true);
+    try {
+      const { engine, out } = createBridgeHarness({
+        currentProvider: 'codex',
+        configuredModel: 'gpt-5.2',
+      });
+      const step = {
+        name: 'review',
+        personaDisplayName: 'Reviewer',
+        instruction: '',
+      } as WorkflowStep;
+
+      engine.emit('step:start', step, 1, 'instruction', {
+        provider: 'codex',
+        model: 'gpt-5.2',
+        providerOptions: { codex: { fastMode } },
+        providerOptionsSources: { 'codex.fastMode': 'project' },
+      }, 'parent', step.name);
+
+      const infoLines = out.info.mock.calls.map(([value]) => String(value));
+      expect(infoLines).toContain(`Fast mode: ${label} (source: project)`);
+    } finally {
+      resetDebugLogger();
+    }
+  });
+
+  it('Codex fast mode が未指定ならサマリー行を表示しない', () => {
+    resetDebugLogger();
+    setVerboseConsole(true);
+    try {
+      const { engine, out } = createBridgeHarness({
+        currentProvider: 'codex',
+        configuredModel: 'gpt-5.2',
+      });
+      const step = {
+        name: 'review',
+        personaDisplayName: 'Reviewer',
+        instruction: '',
+      } as WorkflowStep;
+
+      engine.emit('step:start', step, 1, 'instruction', {
+        provider: 'codex',
+        model: 'gpt-5.2',
+        providerOptions: { codex: { reasoningEffort: 'high' } },
+      }, 'parent', step.name);
+
+      const fastModeLines = out.info.mock.calls
+        .map(([value]) => String(value))
+        .filter((line) => line.startsWith('Fast mode:'));
+      expect(fastModeLines).toEqual([]);
+    } finally {
+      resetDebugLogger();
+    }
+  });
+
   it('verbose 時に Claude SDK base URL を伏せて解決ソースを表示する', () => {
     resetDebugLogger();
     setVerboseConsole(true);

--- a/src/__tests__/workflowSpans.test.ts
+++ b/src/__tests__/workflowSpans.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import type { WorkflowStep } from '../core/models/types.js';
-import type { StepRunResult } from '../core/workflow/types.js';
+import type { StepProviderInfo, StepRunResult } from '../core/workflow/types.js';
 import { normalizeRule } from '../infra/config/loaders/workflowRuleNormalizer.js';
 import { TeamLeaderPartCancellation } from '../core/workflow/engine/team-leader-part-cancellation.js';
 
@@ -875,16 +875,27 @@ describe('workflow OpenTelemetry spans', () => {
         providerOptions: {
           codex: {
             baseUrl: 'http://user:token@127.0.0.1:8787/v1?api_key=secret',
+            fastMode: false,
             reasoningEffort: 'high',
           },
         },
-        providerOptionsSources: { 'codex.baseUrl': 'workflow', 'codex.reasoningEffort': 'project' },
+        providerOptionsSources: {
+          'codex.baseUrl': 'workflow',
+          'codex.fastMode': 'project',
+          'codex.reasoningEffort': 'project',
+        },
       },
     }, async () => makeDoneResult());
 
     expect(spans[0]?.attributes).toMatchObject({
-      'takt.provider.options': JSON.stringify({ codex: { baseUrl: '[configured]', reasoningEffort: 'high' } }),
-      'takt.provider.options_sources': JSON.stringify({ 'codex.baseUrl': 'workflow', 'codex.reasoningEffort': 'project' }),
+      'takt.provider.options': JSON.stringify({
+        codex: { baseUrl: '[configured]', fastMode: false, reasoningEffort: 'high' },
+      }),
+      'takt.provider.options_sources': JSON.stringify({
+        'codex.baseUrl': 'workflow',
+        'codex.fastMode': 'project',
+        'codex.reasoningEffort': 'project',
+      }),
     });
   });
 

--- a/src/core/models/schema-base.ts
+++ b/src/core/models/schema-base.ts
@@ -84,6 +84,7 @@ const CodexProviderOptionShape = {
   network_access: z.boolean().optional(),
   permission_control: z.enum(['takt', 'codex']).optional(),
   reasoning_effort: ProviderEffortSchema.optional(),
+  fast_mode: z.boolean().optional(),
   skills: z.object(CodexSkillsShape).optional(),
   guards: ProviderGuardOptionsSchema.optional(),
 };
@@ -610,6 +611,7 @@ const NormalizedStepProviderOptionsSchema = z.object({
     networkAccess: z.boolean().optional(),
     permissionControl: z.enum(['takt', 'codex']).optional(),
     reasoningEffort: ProviderEffortSchema.optional(),
+    fastMode: z.boolean().optional(),
     guards: z.object({
       callTimeoutMs: z.number().int().min(60_000).max(86_400_000).optional(),
     }).strict().optional(),

--- a/src/core/models/workflow-provider-options.ts
+++ b/src/core/models/workflow-provider-options.ts
@@ -30,6 +30,7 @@ export interface CodexProviderOptions {
   networkAccess?: boolean;
   permissionControl?: CodexPermissionControl;
   reasoningEffort?: CodexReasoningEffort;
+  fastMode?: boolean;
   guards?: ProviderGuardOptions;
   skills?: {
     repo?: boolean;

--- a/src/core/workflow/engine/OptionsBuilder.ts
+++ b/src/core/workflow/engine/OptionsBuilder.ts
@@ -271,9 +271,8 @@ export class OptionsBuilder {
     resolvedProviderInfo: Pick<StepProviderInfo, 'provider' | 'model' | 'providerSource'>,
   ) {
     const resolvedProviderSource = resolvedProviderInfo.providerSource;
-    const baseProviderOptions = this.resolveProfileScopedBaseProviderOptions(resolvedProviderSource);
-    const profileLayers = this.resolveProfileScopedProviderOptionLayers(step, resolvedProviderSource);
-    const tracedLayers = profileLayers;
+    const baseProviderOptions = this.resolveConfigProviderOptions();
+    const tracedLayers = this.resolveProviderOptionLayersForStep(step, resolvedProviderSource);
     const providerOptionsSources = resolveProviderOptionsSources(
       this.resolveIdentityAwareDirectStepProviderOptions(step, resolvedProviderInfo),
       tracedLayers,
@@ -294,8 +293,8 @@ export class OptionsBuilder {
     if (!runtime.providerInfo?.providerOptions || !isAutoProviderOptionsSource(runtimeSource)) {
       return undefined;
     }
-    const baseProviderOptions = this.resolveProfileScopedBaseProviderOptions(runtimeSource);
-    const profileLayers = this.resolveProfileScopedProviderOptionLayers(step, runtimeSource);
+    const baseProviderOptions = this.resolveConfigProviderOptions();
+    const profileLayers = this.resolveProviderOptionLayersForStep(step, runtimeSource);
     const providerOptionsSources = resolveProviderOptionsSources(
       this.resolveIdentityAwareDirectStepProviderOptions(step, runtime.providerInfo),
       [
@@ -325,14 +324,19 @@ export class OptionsBuilder {
         resolvedProviderInfo.providerSource,
       ).map((layer) => layer.options),
     );
+    const runtimeProfileProviderOptions = this.resolveRuntimeProfileProviderOptions(
+      resolvedProviderInfo.providerSource,
+    );
+    const profileProviderOptions = mergeProviderOptions(
+      runtimeProfileProviderOptions,
+      middleProviderOptions,
+    );
     const directStepProviderOptions = this.resolveIdentityAwareDirectStepProviderOptions(
       step,
       resolvedProviderInfo,
     );
     const runtimeProviderOptions = runtime?.providerInfo?.providerOptions;
-    const baseProviderOptions = this.resolveProfileScopedBaseProviderOptions(
-      resolvedProviderInfo.providerSource,
-    );
+    const baseProviderOptions = this.resolveConfigProviderOptions();
 
     if (runtimeProviderOptions && !runtime.teamLeaderPart) {
       if (runtime.providerInfo?.providerSource !== 'promotion') {
@@ -354,7 +358,7 @@ export class OptionsBuilder {
         this.engineOptions.providerOptionsOriginResolver,
         baseProviderOptions,
         stepProviderOptions,
-        middleProviderOptions,
+        profileProviderOptions,
       );
     }
 
@@ -371,7 +375,7 @@ export class OptionsBuilder {
         stepProviderOptions,
         resolvedProviderInfo.provider,
         runtime.teamLeaderPart.partAllowedTools,
-        middleProviderOptions,
+        profileProviderOptions,
       );
     }
 
@@ -380,17 +384,35 @@ export class OptionsBuilder {
       this.engineOptions.providerOptionsOriginResolver,
       baseProviderOptions,
       directStepProviderOptions,
-      middleProviderOptions,
+      profileProviderOptions,
     );
   }
 
-  private resolveProfileScopedBaseProviderOptions(
+  private resolveConfigProviderOptions(): StepProviderOptions | undefined {
+    return this.engineOptions.providerOptionsProviderSource === undefined
+      ? this.engineOptions.providerOptions
+      : this.engineOptions.configProviderOptions;
+  }
+
+  private resolveRuntimeProfileProviderOptions(
     resolvedProviderSource: StepProviderInfo['providerSource'],
   ): StepProviderOptions | undefined {
     const profileSource = this.engineOptions.providerOptionsProviderSource;
-    return profileSource === undefined || profileSource === resolvedProviderSource
+    return profileSource !== undefined && profileSource === resolvedProviderSource
       ? this.engineOptions.providerOptions
       : undefined;
+  }
+
+  private resolveProviderOptionLayersForStep(
+    step: WorkflowStep,
+    resolvedProviderSource: StepProviderInfo['providerSource'],
+  ): ProviderOptionsLayer[] {
+    const profileSource = this.engineOptions.providerOptionsProviderSource;
+    const profileOptions = this.resolveRuntimeProfileProviderOptions(resolvedProviderSource);
+    const profileLayers = this.resolveProfileScopedProviderOptionLayers(step, resolvedProviderSource);
+    return profileSource === undefined || profileOptions === undefined
+      ? profileLayers
+      : [{ source: profileSource, options: profileOptions }, ...profileLayers];
   }
 
   private resolveProfileScopedProviderOptionLayers(

--- a/src/core/workflow/types.ts
+++ b/src/core/workflow/types.ts
@@ -577,6 +577,8 @@ export interface WorkflowEngineOptions {
   rateLimitFallback?: RateLimitFallbackConfig;
   /** Resolved provider options */
   providerOptions?: StepProviderOptions;
+  /** Provider options resolved from config.yaml and environment variables. */
+  configProviderOptions?: StepProviderOptions;
   /** Provider source whose runtime profile supplied providerOptions; absent for shared config options. */
   providerOptionsProviderSource?: ProviderResolutionSource;
   /** Permission mode from the runtime defaults profile. */

--- a/src/features/exec/assistantSession.ts
+++ b/src/features/exec/assistantSession.ts
@@ -1,9 +1,11 @@
 import { getProvider } from '../../infra/providers/index.js';
 import type { ProviderType } from '../../infra/providers/index.js';
 import {
+  resolveNonWorkflowProviderModel,
   resolveNonWorkflowProviderOptions,
   resolveWorkflowConfigValues,
 } from '../../infra/config/index.js';
+import { mergeProviderOptions } from '../../infra/config/providerOptions.js';
 import type { PermissionMode, StepProviderOptions } from '../../core/models/index.js';
 import type { ImageAttachmentReference } from '../../shared/types/image-attachments.js';
 import { callAIWithRetry, type SessionContext } from '../interactive/aiCaller.js';
@@ -63,10 +65,18 @@ export function createExecSessionContext(
   codexSkillInheritance: ExecCodexSkillInheritance = resolveExecCodexSkillInheritance(cwd),
 ): ExecSessionContext {
   const resolvedConfig = resolveWorkflowConfigValues(cwd, ['enableBuiltinWorkflows', 'language']);
-  const providerOptions = resolveNonWorkflowProviderOptions(
-    cwd,
-    withCodexSkillInheritance(buildSessionProviderOptions(config.session), codexSkillInheritance),
+  const sessionProviderOptions = withCodexSkillInheritance(
+    buildSessionProviderOptions(config.session),
+    codexSkillInheritance,
   );
+  const runtimeProvider = resolveNonWorkflowProviderModel(cwd);
+  const providerOptions = runtimeProvider.runtimeManaged
+    && runtimeProvider.provider === config.session.provider
+    ? resolveNonWorkflowProviderOptions(
+        cwd,
+        mergeProviderOptions(runtimeProvider.providerOptions, sessionProviderOptions),
+      )
+    : resolveNonWorkflowProviderOptions(cwd, sessionProviderOptions);
   return {
     provider: getProvider(config.session.provider as ProviderType),
     providerType: config.session.provider,

--- a/src/features/tasks/execute/workflowExecution.ts
+++ b/src/features/tasks/execute/workflowExecution.ts
@@ -401,6 +401,7 @@ async function executeWorkflowInternal(
         reportFallbackProvider: options.reportFallbackProvider,
         rateLimitFallback: bootstrap.rateLimitFallback,
         providerOptions: bootstrap.providerOptions,
+        configProviderOptions: bootstrap.configProviderOptions,
         providerOptionsProviderSource: bootstrap.providerOptionsProviderSource,
         providerPermissionMode: bootstrap.providerPermissionMode,
         selectorProvider: bootstrap.selectorProvider,

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -129,6 +129,7 @@ export interface WorkflowExecutionBootstrap {
   companionProviders: Readonly<Record<string, ProviderRoutingEntry>>;
   providerRoutingTagConflictPolicy: TagRoutingConflictPolicy;
   providerOptions: WorkflowExecutionOptions['providerOptions'];
+  configProviderOptions: WorkflowExecutionOptions['providerOptions'];
   providerOptionsProviderSource: ProviderResolutionSource | undefined;
   providerPermissionMode: PermissionMode | undefined;
   autoRouting: WorkflowExecutionOptions['autoRouting'];
@@ -751,6 +752,7 @@ export async function createWorkflowExecutionBootstrap(
     companionProviders,
     providerRoutingTagConflictPolicy,
     providerOptions: effectiveProviderOptions,
+    configProviderOptions: resolvedRuntimeEnvironment.configProviderOptions,
     providerOptionsProviderSource: resolvedRuntimeEnvironment.providerConfigMode === 'runtime-v1'
       ? currentProviderSource
       : undefined,

--- a/src/features/tasks/execute/workflowExecutionEvents.ts
+++ b/src/features/tasks/execute/workflowExecutionEvents.ts
@@ -349,6 +349,10 @@ function emitProviderOptionLines(
     if (effort !== undefined) {
       out.info(`Reasoning effort: ${effort}${sourceSuffix('codex.reasoningEffort', sources, showSource)}`);
     }
+    const fastMode = options.codex?.fastMode;
+    if (fastMode !== undefined) {
+      out.info(`Fast mode: ${fastMode ? 'enabled' : 'disabled'}${sourceSuffix('codex.fastMode', sources, showSource)}`);
+    }
   } else if (stepProvider === 'opencode') {
     const variant = options.opencode?.variant;
     if (variant !== undefined) {

--- a/src/infra/codex/client.ts
+++ b/src/infra/codex/client.ts
@@ -408,6 +408,9 @@ export class CodexClient {
       ...(options.reasoningEffort === undefined
         ? {}
         : { model_reasoning_effort: options.reasoningEffort }),
+      ...(options.fastMode === undefined
+        ? {}
+        : { features: { fast_mode: options.fastMode } }),
       model_reasoning_summary: 'auto',
       ...(shellPath === undefined
         ? {}

--- a/src/infra/codex/types.ts
+++ b/src/infra/codex/types.ts
@@ -30,6 +30,7 @@ export interface CodexCallOptions {
   sessionId?: string;
   model?: string;
   reasoningEffort?: CodexReasoningEffort;
+  fastMode?: boolean;
   systemPrompt?: string;
   /** Permission mode for the TAKT-controlled sandbox */
   permissionMode?: PermissionMode;

--- a/src/infra/config/configNormalizers.ts
+++ b/src/infra/config/configNormalizers.ts
@@ -667,6 +667,7 @@ export function denormalizeProviderOptions(
     || providerOptions.codex?.networkAccess !== undefined
     || providerOptions.codex?.permissionControl !== undefined
     || providerOptions.codex?.reasoningEffort !== undefined
+    || providerOptions.codex?.fastMode !== undefined
     || providerOptions.codex?.guards?.callTimeoutMs !== undefined
     || providerOptions.codex?.skills?.repo !== undefined
     || providerOptions.codex?.skills?.user !== undefined
@@ -683,6 +684,9 @@ export function denormalizeProviderOptions(
         : {}),
       ...(providerOptions.codex.reasoningEffort !== undefined
         ? { reasoning_effort: providerOptions.codex.reasoningEffort }
+        : {}),
+      ...(providerOptions.codex.fastMode !== undefined
+        ? { fast_mode: providerOptions.codex.fastMode }
         : {}),
       ...(providerOptions.codex.skills?.repo !== undefined || providerOptions.codex.skills?.user !== undefined
         ? {

--- a/src/infra/config/providerOptions.ts
+++ b/src/infra/config/providerOptions.ts
@@ -34,6 +34,7 @@ type RawProviderOptions = {
     network_access?: boolean;
     permission_control?: CodexPermissionControl;
     reasoning_effort?: CodexReasoningEffort;
+    fast_mode?: boolean;
     guards?: RawProviderGuardOptions;
     skills?: {
       repo?: boolean;
@@ -337,6 +338,7 @@ export function normalizeProviderOptions(
     || options.codex?.network_access !== undefined
     || options.codex?.permission_control !== undefined
     || options.codex?.reasoning_effort !== undefined
+    || options.codex?.fast_mode !== undefined
     || options.codex?.guards !== undefined
     || options.codex?.skills?.repo !== undefined
     || options.codex?.skills?.user !== undefined
@@ -355,6 +357,9 @@ export function normalizeProviderOptions(
         : {}),
       ...(options.codex.reasoning_effort !== undefined
         ? { reasoningEffort: options.codex.reasoning_effort }
+        : {}),
+      ...(options.codex.fast_mode !== undefined
+        ? { fastMode: options.codex.fast_mode }
         : {}),
       ...(options.codex.guards?.call_timeout_ms !== undefined
         ? { guards: { callTimeoutMs: options.codex.guards.call_timeout_ms } }
@@ -653,6 +658,9 @@ export function mergeProviderOptions(
           : {}),
         ...(layer.codex.reasoningEffort !== undefined
           ? { reasoningEffort: layer.codex.reasoningEffort }
+          : {}),
+        ...(layer.codex.fastMode !== undefined
+          ? { fastMode: layer.codex.fastMode }
           : {}),
         ...(layer.codex.guards !== undefined
           ? { guards: { ...result.codex?.guards, ...layer.codex.guards } }
@@ -1049,6 +1057,12 @@ export function resolveEffectiveProviderOptions(
     stepOptions?.codex?.reasoningEffort,
     resolveProviderOptionOrigin(originResolver, 'codex.reasoningEffort', source),
   );
+  const codexFastMode = selectProviderValue(
+    resolvedConfigOptions.codex?.fastMode,
+    personaOptions?.codex?.fastMode,
+    stepOptions?.codex?.fastMode,
+    resolveProviderOptionOrigin(originResolver, 'codex.fastMode', source),
+  );
   const codexBaseUrl = selectProviderValueByScope(
     resolvedConfigOptions.codex?.baseUrl,
     personaOptions?.codex?.baseUrl,
@@ -1281,6 +1295,7 @@ export function resolveEffectiveProviderOptions(
       || codexNetworkAccess !== undefined
       || codexPermissionControl !== undefined
       || codexReasoningEffort !== undefined
+      || codexFastMode !== undefined
       || codexCallTimeoutMs !== undefined
       || codexRepoSkills !== undefined
       || codexUserSkills !== undefined
@@ -1290,6 +1305,7 @@ export function resolveEffectiveProviderOptions(
             ...(codexNetworkAccess !== undefined ? { networkAccess: codexNetworkAccess } : {}),
             ...(codexPermissionControl !== undefined ? { permissionControl: codexPermissionControl } : {}),
             ...(codexReasoningEffort !== undefined ? { reasoningEffort: codexReasoningEffort } : {}),
+            ...(codexFastMode !== undefined ? { fastMode: codexFastMode } : {}),
             ...(codexCallTimeoutMs !== undefined
               ? { guards: { callTimeoutMs: codexCallTimeoutMs } }
               : {}),
@@ -1582,6 +1598,7 @@ export const PROVIDER_OPTION_PATHS = [
   'claude.skills.enabled',
   'claude.guards.callTimeoutMs',
   'codex.baseUrl',
+  'codex.fastMode',
   'codex.networkAccess',
   'codex.permissionControl',
   'codex.reasoningEffort',

--- a/src/infra/config/providerOptionsContract.ts
+++ b/src/infra/config/providerOptionsContract.ts
@@ -4,6 +4,7 @@ import type { EnvSpec } from './env/config-env-overrides.js';
 const PROVIDER_OPTIONS_ENV_SPEC_ENTRIES = [
   { path: 'provider_options', type: 'json' },
   { path: 'provider_options.codex.base_url', type: 'string' },
+  { path: 'provider_options.codex.fast_mode', type: 'boolean' },
   { path: 'provider_options.codex.network_access', type: 'boolean' },
   { path: 'provider_options.codex.permission_control', type: 'string' },
   { path: 'provider_options.codex.reasoning_effort', type: 'string' },
@@ -56,6 +57,7 @@ const PROVIDER_OPTIONS_TRACE_PATH_ENTRIES = [
   'provider_options',
   'provider_options.codex',
   'provider_options.codex.base_url',
+  'provider_options.codex.fast_mode',
   'provider_options.codex.network_access',
   'provider_options.codex.permission_control',
   'provider_options.codex.reasoning_effort',
@@ -132,6 +134,7 @@ const PROVIDER_OPTIONS_FILE_PREFERRED_ENV_PATH_ENTRIES = [
 
 const PROVIDER_OPTIONS_INTERNAL_PATH_ENTRIES = [
   'codex.baseUrl',
+  'codex.fastMode',
   'codex.networkAccess',
   'codex.permissionControl',
   'codex.reasoningEffort',

--- a/src/infra/config/runtime-provider/provider-environment.ts
+++ b/src/infra/config/runtime-provider/provider-environment.ts
@@ -37,12 +37,15 @@ import {
 } from '../index.js';
 import { resolveEffectiveAutoRouting } from '../../../core/workflow/auto-routing/effective-auto-routing.js';
 import type { WorkflowConfig } from '../../../core/models/index.js';
+import type { StepProviderOptions } from '../../../core/models/workflow-types.js';
 import { getEffectiveRuntimeProviderFile } from './schema.js';
 import { createRuntimeProviderResolutionContext } from './resolution-context.js';
 import { DEFAULT_COMPANION_ENABLED } from '../../../shared/constants.js';
 
 export interface ResolvedRuntimeEnvironment {
   providerEnvironment: CompiledProviderEnvironment;
+  /** Provider options resolved from config.yaml and environment variables. */
+  configProviderOptions?: StepProviderOptions;
   companionEnabled: boolean;
   providerConfigMode: ProviderConfigMode;
 }
@@ -111,6 +114,7 @@ export function resolveRuntimeEnvironment(
         modelSource: input.legacy.modelSource,
       },
     ),
+    configProviderOptions: input.legacy.providerOptions,
     companionEnabled,
     providerConfigMode: mode,
   };

--- a/src/infra/providers/codex.ts
+++ b/src/infra/providers/codex.ts
@@ -24,6 +24,7 @@ function toCodexOptions(options: ProviderCallOptions): CodexCallOptions {
     sessionId: options.sessionId,
     model: options.model,
     reasoningEffort: options.providerOptions?.codex?.reasoningEffort,
+    fastMode: options.providerOptions?.codex?.fastMode,
     permissionMode: options.permissionMode,
     permissionControl: options.providerOptions?.codex?.permissionControl,
     networkAccess: options.providerOptions?.codex?.networkAccess,


### PR DESCRIPTION
## Summary

# Issue #1325: Codex provider の `fast_mode` 設定追加

## 背景・目的

TAKT の Codex provider options に `fast_mode` を追加し、workflow の設定から Codex の `features.fast_mode` を制御できるようにする。

既存の provider-options 設定経路、Codex 呼び出し経路、設定の優先順位、source attribution、実行サマリーおよび trace に一貫して対応させる。

前回の実行は `Workflow aborted by step transition` で失敗しているため、実装完了とは扱わない。開始時に現在の checkout に未完了の変更がないか確認し、必要に応じて整理してから実装する。

## 確定仕様・制約

- `provider_options.codex.fast_mode?: boolean` を追加する。
- 未指定と明示的な `false` を区別する。
- `fast_mode` は既存の provider option として扱う。
- runtime profile、persona/tag/step routing、project/global config、環境変数、`takt exec` から設定できるようにする。
- 環境変数名は `TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE` とする。
- 既存の provider-options の優先順位と source attribution に従う。
- 通常の Codex 呼び出しと isolated structured 呼び出しを含む、共有 Codex client 経由のすべての呼び出しに適用する。
- strict/structured 専用の仕組みは追加しない。
- capability preset では扱わない。
- 明示値がある場合は、実行サマリーと既存 trace に値および source を記録する。
- 非対話 `codex exec` における速度やモデル挙動への実効性は、今回の受け入れ条件に含めない。

## 作業範囲

### 優先度: 高 — `core/models/schema-base.js`

Codex の raw/normalized `provider_options` schema に、任意の boolean フィールド `fast_mode` を追加する。

既存の schema、正規化、merge、source attribution の契約に合わせ、未指定を暗黙の `false` に変換しない。

### 優先度: 高 — provider-options の正規化・merge・source attribution モジュール

既存の `reasoningEffort` や `skills` と同じ設定伝播経路を利用して、`fast_mode` を各設定層から解決できるようにする。

対象とする設定経路:

- runtime profile
- persona/tag/step routing
- project/global config
- `TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE`
- `takt exec`

既存の優先順位を維持し、解決元を source attribution に残す。環境変数は既存の boolean 環境変数パーサーおよび命名規約に従う。

### 優先度: 高 — `infra/providers/codex.js`

`toCodexOptions` で解決済みの `fast_mode` を共有 Codex 呼び出し設定へ渡す。

通常の agent 経路、isolated structured 経路など、`toCodexOptions` を利用するすべての Codex 呼び出しで同じ設定結果になるようにする。

### 優先度: 高 — `infra/codex/client.js`

既存の `CodexOptions.config` / `codexConfig` 経路を利用して、Codex の設定へ `features.fast_mode` を反映する。

既存の Codex 設定項目を保持したまま、`fast_mode` の解決結果だけを追加できる構造にする。

### 優先度: 高 — 実行サマリーおよび trace/span の観測処理

既存の provider option 観測処理を拡張する。

- 明示値が解決された場合、実行サマリーに `Fast mode: enabled/disabled` と source を表示する。
- 明示値が解決された場合、既存 trace/span に値と source を記録する。
- 未指定時は、fast mode のサマリー表示を追加しない。
- 表示形式と source 名は既存の実行サマリー・trace の規約に合わせる。

### 優先度: 高 — 関連テストモジュール

既存の schema、provider-options 解決、環境変数、Codex option 変換、実行サマリー、trace のテストを拡張する。

少なくとも以下を検証する。

- optional boolean として schema を通ること
- 未指定と明示 `false` が区別されること
- 設定層ごとの解決と既存優先順位
- source attribution
- Codex config への伝播
- 通常経路と isolated structured 経路の設定一致
- 実行サマリーおよび trace の観測

### 優先度: 中 — ドキュメント

以下を更新する。

- `docs/configuration.md`
- `docs/configuration.ja.md`

provider options の説明に、`fast_mode` の設定方法、環境変数名、未指定と明示値の扱い、設定可能な既存経路を追加する。capability preset の設定としては記載しない。

## 受け入れ条件

```gherkin
# language: ja
機能: Codex provider の fast mode 設定伝播

  ルール: 明示された fast_mode だけを Codex 設定へ反映する

    シナリオアウトライン: 明示値を Codex 設定へ渡す
      前提 Codex provider option に fast_mode が "<value>" として解決されている
      もし Codex 呼び出しのオプションを構築すると
      ならば Codex 設定に features.fast_mode が "<value>" として含まれる

      例:
        | value |
        | true  |
        | false |

    シナリオ: fast_mode が未指定なら Codex 設定を上書きしない
      前提 すべての設定層で Codex provider option の fast_mode が未指定である
      もし Codex 呼び出しのオプションを構築すると
      ならば Codex 設定に features.fast_mode が含まれない

  ルール: 既存の設定経路と Codex 呼び出し経路で同じ解決結果を使う

    シナリオアウトライン: 既存の provider-options 経路から fast_mode を設定できる
      前提 fast_mode が "<source>" で指定されている
      もし provider options を解決すると
      ならば fast_mode が既存の優先順位で解決され、指定元が source として識別できる

      例:
        | source |
        | runtime profile |
        | persona/tag/step routing |
        | project/global config |
        | TAKT_PROVIDER_OPTIONS_CODEX_FAST_MODE |
        | takt exec |

    シナリオ: 通常の Codex 呼び出しと isolated structured 呼び出しで同じ設定を使う
      前提 同じ provider options が通常経路と isolated structured 経路に解決されている
      もし両方の Codex 呼び出しオプションを構築すると
      ならば両方の Codex 設定に同じ features.fast_mode の値が含まれる

  ルール: 明示値の解決結果を観測できる

    シナリオ: 明示値を実行サマリーと trace に記録する
      前提 fast_mode が明示値として解決され、source が識別できる
      もし実行サマリーと既存 trace を生成すると
      ならば実行サマリーに Fast mode の enabled または disabled と source が表示され、trace にも値と source が記録される

    シナリオ: 未指定の fast_mode を実行サマリーに表示しない
      前提 fast_mode が未指定である
      もし実行サマリーを生成すると
      ならば fast mode の表示を含まない
```

## 確認方法

- 前回失敗実行による部分変更の有無を確認する。
- 関連する schema、設定解決、Codex option 変換、観測処理のテストを実行する。
- 変更したテストが integration または heavy integration に分類される場合は、リポジトリの分類ルールに従って対象テストを個別実行する。
- `npm run build` と `npm run lint` を実行する。
- 上記 Gherkin の各振る舞いを満たすことを確認する。
- `codex exec` における速度やモデル挙動の変化は検証対象にしない。

## やらないこと

- fast mode の既定値を変更しない。
- strict/structured 専用の設定機構を追加しない。
- capability preset に `fast_mode` を追加しない。
- `codex exec` の速度向上やモデル挙動を保証しない。

## Open Questions

- 非対話の `codex exec` で `fast_mode` が実際の速度やモデル挙動に作用するかは未確認。ただし、今回の実装および受け入れ条件では扱わない。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #1425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Codex の fast mode を `true`／`false` で設定できるようになりました。
  * 設定ファイルや環境変数から指定でき、ワークフローおよび `takt exec` に反映されます。
  * 詳細表示で、fast mode の有効・無効状態と設定元を確認できます。
  * 未指定時は Codex 本来の既定値が維持されます。

* **ドキュメント**
  * fast mode の設定方法、優先順位、未指定時の動作を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->