### PR TITLE
fix(interactive): enable Gherkin task instructions by default

### DIFF
--- a/builtins/en/config.yaml
+++ b/builtins/en/config.yaml
@@ -65,7 +65,7 @@ language: en        # UI language: en | ja
 # Interactive mode
 # interactive_preview_steps: 3 # Number of step previews in interactive mode (0-10)
 # assistant:
-#   gherkin: true              # Generate final task instructions as Markdown + focused Gherkin
+#   gherkin: true              # Generate final task instructions as Markdown + focused Gherkin (default: true; set false to disable)
 
 # Provider routing for workflow steps (recommended)
 # provider_routing:

--- a/builtins/ja/config.yaml
+++ b/builtins/ja/config.yaml
@@ -65,7 +65,7 @@ language: ja         # 表示言語: ja | en
 # インタラクティブモード
 # interactive_preview_steps: 3 # インタラクティブモードでの step プレビュー数 (0-10)
 # assistant:
-#   gherkin: true              # 最終指示書を Markdown + 要所の Gherkin で生成
+#   gherkin: true              # 最終指示書を Markdown + 要所の Gherkin で生成（デフォルト: true、無効化は false）
 
 # workflow step の provider routing（推奨）
 # provider_routing:

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -31,7 +31,7 @@ interactive_preview_steps: 3  # インタラクティブモードでの step プ
 auto_requeue_max_attempts: 0  # takt run 中の失敗 workflow task 自動 requeue 上限（非負整数、デフォルト: 0 = 無効）
 ignore_exceed: false          # takt run / takt watch で --ignore-exceed 相当を適用（デフォルト: false）
 assistant:
-  gherkin: false              # 最終指示書を Markdown + 要所の Gherkin で生成
+  gherkin: true               # 最終指示書を Markdown + 要所の Gherkin で生成（デフォルト: true、無効化は false）
 # auto_fetch: false           # クローン作成前にリモートを fetch（デフォルト: false）
 # base_branch: main           # クローン作成のベースブランチ（デフォルト: リモートのデフォルトブランチ）
 
@@ -190,7 +190,7 @@ assistant:
 | `concurrency` | number (1-10) | `1` | `takt run` の並列タスク数 |
 | `task_poll_interval_ms` | number (100-5000) | `500` | 新規タスクのポーリング間隔 |
 | `interactive_preview_steps` | number (0-10) | `3` | インタラクティブモードでの step プレビュー数 |
-| `assistant.gherkin` | boolean | `false` | assistant 対話から生成する最終指示書で、重要な観測可能動作、状態遷移、境界、失敗、不変条件を最小数の Gherkin Scenario に整理します。プロジェクト設定で明示した値がグローバル値より優先されます。 |
+| `assistant.gherkin` | boolean | `true` | assistant 対話から生成する最終指示書で、重要な観測可能動作、状態遷移、境界、失敗、不変条件を最小数の Gherkin Scenario に整理します。未設定時は有効で、プロジェクト設定で明示した値がグローバル値より優先されます。 |
 | `auto_requeue_max_attempts` | 非負整数 | `0` | `takt run` 中に失敗した workflow task を自動 requeue する上限回数。`0` で無効 |
 | `ignore_exceed` | boolean | `false` | `takt run` / `takt watch` の iteration 上限無視を設定します。CLI で `--ignore-exceed` を指定した場合は CLI 指定が優先されます |
 | `sync_project_local_takt_on_retry` | boolean | `true` | retry / 再実行前にルートの project-local `.takt` を worktree へ同期。`false` で worktree 側のコピーを維持 |
@@ -255,10 +255,11 @@ auto_requeue_max_attempts: 1  # takt run 中の失敗 workflow task 自動 reque
 ignore_exceed: false          # takt run / takt watch で --ignore-exceed 相当を適用
 # base_branch: main           # クローン作成のベースブランチ（グローバルを上書き、デフォルト: リモートのデフォルトブランチ）
 
-# インタラクティブ assistant モード専用の明示的な初期コンテキストファイル（project config 専用）
+# プロジェクト固有の assistant 設定
 # assistant:
-#   gherkin: true              # 最終指示書を Markdown + 要所の Gherkin で生成
+#   gherkin: true              # global 設定を上書き。false で無効化
 #   init_files:
+#     # project config 専用。インタラクティブ assistant モードの初期コンテキストファイル
 #     - docs/assistant-context.md
 #     - .takt/assistant-notes.md
 
@@ -397,7 +398,7 @@ terminal tool の完全一致反復は、廃止された累積検出ではなく
 | `ignore_exceed` | boolean | `false`（global 設定またはデフォルト由来） | `takt run` / `takt watch` の iteration 上限無視を設定します。CLI で `--ignore-exceed` を指定した場合は CLI 指定が優先されます |
 | `base_branch` | string | - | クローン作成のベースブランチ（グローバルを上書き、デフォルト: リモートのデフォルトブランチ） |
 | `assistant.init_files` | string[] | - | project config 専用のインタラクティブ assistant 初期コンテキストファイル。パスは project root 相対で指定します。絶対パス、project root 外へ解決されるパス、`.env*` / `.npmrc` / `.pypirc` / `.netrc` / `*.pem` / `*.key` / `.git/**` などの機密ファイルパターンは拒否されます。存在しないパス、ディレクトリ、読めないファイルは分かるエラーになります。最大16ファイルまで指定でき、1ファイルは256KiB、合計本文は1MiBまでです。未設定または空の場合、`CLAUDE.md`、`AGENT.md`、`AGENTS.md`、`TAKT.md` などは自動探索されません。assistant の provider/model だけを制御する `takt_providers.assistant` とは別設定です。 |
-| `assistant.gherkin` | boolean | `false` | グローバル設定を上書きする opt-in 設定です。quiet モードを含む assistant 対話から最終指示書を生成するとき、背景、範囲、実装詳細、設計意図、制約、確認方法は Markdown に残し、重要な観測可能動作、状態遷移、境界、失敗、不変条件だけを最小数の Gherkin Scenario で整理するよう要約エージェントへ指示します。未設定の場合はグローバル値、どちらも未設定の場合は `false` になります。 |
+| `assistant.gherkin` | boolean | `true`（global 設定またはデフォルト由来） | グローバル設定を上書きする設定です。quiet モードを含む assistant 対話から最終指示書を生成するとき、背景、範囲、実装詳細、設計意図、制約、確認方法は Markdown に残し、重要な観測可能動作、状態遷移、境界、失敗、不変条件だけを最小数の Gherkin Scenario で整理するよう要約エージェントへ指示します。未設定の場合はグローバル値、どちらも未設定の場合は `true` になります。`false` を明示すると無効化できます。 |
 | `provider_options` | object | - | provider 固有オプション |
 | `provider_profiles` | object | - | provider 固有のパーミッションプロファイル |
 | `vcs_provider` | `"github"` \| `"gitlab"` | 自動検出 | VCS プロバイダー（グローバルを上書き） |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ interactive_preview_steps: 3  # Step previews in interactive mode (0-10, default
 auto_requeue_max_attempts: 0  # Auto-requeue failed workflow tasks during takt run (non-negative integer, default: 0 = disabled)
 ignore_exceed: false          # Applies to takt run and takt watch like --ignore-exceed (default: false)
 assistant:
-  gherkin: false              # Generate final task instructions as Markdown + focused Gherkin
+  gherkin: true               # Generate final task instructions as Markdown + focused Gherkin (default: true; set false to disable)
 # auto_fetch: false           # Fetch remote before cloning (default: false)
 # base_branch: main           # Base branch for clone creation (default: remote default branch)
 
@@ -190,7 +190,7 @@ assistant:
 | `concurrency` | number (1-10) | `1` | Parallel task count for `takt run` |
 | `task_poll_interval_ms` | number (100-5000) | `500` | Polling interval for new tasks |
 | `interactive_preview_steps` | number (0-10) | `3` | Step previews in interactive mode |
-| `assistant.gherkin` | boolean | `false` | Organize important observable behavior, state transitions, boundaries, failures, and invariants in a minimal number of Gherkin scenarios in final task instructions generated from assistant conversations. An explicit project value overrides the global value. |
+| `assistant.gherkin` | boolean | `true` | Organize important observable behavior, state transitions, boundaries, failures, and invariants in a minimal number of Gherkin scenarios in final task instructions generated from assistant conversations. Gherkin is enabled when unset; an explicit project value overrides the global value. |
 | `auto_requeue_max_attempts` | non-negative integer | `0` | Maximum automatic requeue attempts for failed workflow tasks during `takt run`; `0` disables automatic requeue |
 | `ignore_exceed` | boolean | `false` | Configures iteration-limit bypass for `takt run` and `takt watch`; a CLI `--ignore-exceed` flag takes precedence when specified |
 | `sync_project_local_takt_on_retry` | boolean | `true` | Sync the root project-local `.takt` into the worktree before retry / re-execution; set `false` to keep the worktree copy |
@@ -255,10 +255,11 @@ auto_requeue_max_attempts: 1  # Auto-requeue failed workflow tasks during takt r
 ignore_exceed: false          # Applies to takt run and takt watch like --ignore-exceed
 # base_branch: main           # Base branch for clone creation (overrides global, default: remote default branch)
 
-# Explicit initial context files for interactive assistant mode only (project config only)
+# Project-specific assistant settings
 # assistant:
-#   gherkin: true              # Generate final task instructions as Markdown + focused Gherkin
+#   gherkin: true              # Override the global setting; set false to disable
 #   init_files:
+#     # Project config only; initial context files for interactive assistant mode
 #     - docs/assistant-context.md
 #     - .takt/assistant-notes.md
 
@@ -402,7 +403,7 @@ Project config accepts most global keys and overrides their global values (e.g. 
 | `ignore_exceed` | boolean | `false` (from global/default) | Configures iteration-limit bypass for `takt run` and `takt watch`; a CLI `--ignore-exceed` flag takes precedence when specified |
 | `base_branch` | string | - | Base branch for clone creation (overrides global, default: remote default branch) |
 | `assistant.init_files` | string[] | - | Project-only interactive assistant initial context files. Paths must be relative to the project root; absolute paths, paths resolving outside the project root, and sensitive file patterns such as `.env*`, `.npmrc`, `.pypirc`, `.netrc`, `*.pem`, `*.key`, and `.git/**` are rejected. Missing paths, directories, and unreadable files fail with a clear error. At most 16 files are allowed; each file is limited to 256 KiB and the combined content is limited to 1 MiB. When unset or empty, TAKT does not auto-discover `CLAUDE.md`, `AGENT.md`, `AGENTS.md`, `TAKT.md`, or other files. This is separate from `takt_providers.assistant`, which only controls the assistant provider/model. |
-| `assistant.gherkin` | boolean | `false` | Project override for final task instructions generated from assistant conversations, including quiet mode. When enabled, TAKT keeps background, scope, implementation details, design intent, constraints, and verification in Markdown, and asks the summarizer to use a minimal number of Gherkin scenarios only for important observable behavior, state transitions, boundaries, failures, and invariants. When unset, TAKT uses the global value; when both are unset, it defaults to `false`. |
+| `assistant.gherkin` | boolean | `true` (from global/default) | Project override for final task instructions generated from assistant conversations, including quiet mode. When enabled, TAKT keeps background, scope, implementation details, design intent, constraints, and verification in Markdown, and asks the summarizer to use a minimal number of Gherkin scenarios only for important observable behavior, state transitions, boundaries, failures, and invariants. When unset, TAKT uses the global value; when both are unset, it defaults to `true`. |
 | `provider_options` | object | - | Provider-specific options |
 | `provider_profiles` | object | - | Provider-specific permission profiles |
 | `vcs_provider` | `"github"` \| `"gitlab"` | auto-detect | VCS provider (overrides global) |

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -30,7 +30,7 @@ interactive_preview_steps: 3  # 交互模式中的 step 预览数（0-10，默�
 auto_requeue_max_attempts: 0  # takt run 期间失败 workflow task 的自动 requeue 次数（非负整数，默认 0 = 禁用）
 ignore_exceed: false          # 对 takt run 和 takt watch 应用 --ignore-exceed（默认 false）
 assistant:
-  gherkin: false              # 将最终任务指令生成为 Markdown + 聚焦的 Gherkin
+  gherkin: true               # 将最终任务指令生成为 Markdown + 聚焦的 Gherkin（默认启用；设为 false 可禁用）
 # auto_fetch: false           # 创建 clone 前 fetch remote（默认 false）
 # base_branch: main           # 创建 clone 的基分支（默认使用 remote 默认分支）
 
@@ -189,7 +189,7 @@ assistant:
 | `concurrency` | number (1-10) | `1` | `takt run` 并行任务数 |
 | `task_poll_interval_ms` | number (100-5000) | `500` | 新任务轮询间隔 |
 | `interactive_preview_steps` | number (0-10) | `3` | 交互模式中的 step 预览数 |
-| `assistant.gherkin` | boolean | `false` | 在 assistant 生成的最终任务指令中组织关键行为和不变量 |
+| `assistant.gherkin` | boolean | `true` | 在 assistant 生成的最终任务指令中组织关键行为和不变量；未设置时默认启用，项目中的显式值优先于全局值 |
 | `auto_requeue_max_attempts` | 非负整数 | `0` | 失败 workflow task 的自动 requeue 上限；`0` 禁用 |
 | `ignore_exceed` | boolean | `false` | 配置 `takt run` 和 `takt watch` 的迭代上限绕过 |
 | `sync_project_local_takt_on_retry` | boolean | `true` | retry/re-execution 前将根项目 `.takt` 同步到 worktree |
@@ -254,10 +254,11 @@ auto_requeue_max_attempts: 1  # takt run 期间失败 workflow task 的自动 re
 ignore_exceed: false          # 对 takt run 和 takt watch 应用 --ignore-exceed
 # base_branch: main           # 创建 clone 的基分支（覆盖全局值，默认 remote 默认分支）
 
-# 仅项目配置支持的交互 assistant 初始上下文文件
+# 项目专属的 assistant 设置
 # assistant:
-#   gherkin: true              # 用 Markdown + 聚焦的 Gherkin 生成最终任务指令
+#   gherkin: true              # 覆盖全局设置；设为 false 可禁用
 #   init_files:
+#     # 仅项目配置支持；交互 assistant 的初始上下文文件
 #     - docs/assistant-context.md
 #     - .takt/assistant-notes.md
 
@@ -361,7 +362,7 @@ TAKT 观察实际收到的 provider event，不会合成 keepalive。OpenCode �
 | `ignore_exceed` | boolean | `false` | `takt run` / `takt watch` 的迭代限制绕过 |
 | `base_branch` | string | - | 创建 clone 的基分支 |
 | `assistant.init_files` | string[] | - | 仅项目级的 assistant 初始上下文文件。路径必须相对于项目根；绝对路径、解析到项目根之外的路径，以及 `.env*`、`.npmrc`、`.pypirc`、`.netrc`、`*.pem`、`*.key` 和 `.git/**` 等敏感文件模式会被拒绝。路径不存在、指向目录或文件不可读时会明确报错。最多 16 个文件，每个最多 256 KiB，合计最多 1 MiB。未设置或为空时，TAKT 不会自动发现 `CLAUDE.md`、`AGENT.md`、`AGENTS.md`、`TAKT.md` 或其他文件。 |
-| `assistant.gherkin` | boolean | `false` | 项目级的任务指令 Gherkin 设置 |
+| `assistant.gherkin` | boolean | `true`（来自全局/默认值） | 项目级的任务指令 Gherkin 覆盖设置。未设置时使用全局值；全局也未设置时默认启用。显式设为 `false` 可禁用。 |
 | `provider_options` | object | - | provider 专属选项 |
 | `provider_profiles` | object | - | provider 专属权限 profile |
 | `vcs_provider` | `"github"` \| `"gitlab"` | 自动检测 | 覆盖全局 VCS provider |

--- a/src/__tests__/assistantConfig.test.ts
+++ b/src/__tests__/assistantConfig.test.ts
@@ -99,17 +99,21 @@ describe('assistantConfig', () => {
   });
 
   it.each([
-    ['global value', true, undefined, true],
+    ['no config', undefined, undefined, true],
+    ['global false', false, undefined, false],
+    ['global true', true, undefined, true],
     ['project false override', true, false, false],
     ['project true override', false, true, true],
   ] as const)(
     'should resolve Gherkin task instructions from %s',
     (_label, globalGherkin, projectGherkin, expected) => {
-      writeFileSync(
-        globalConfigPath,
-        ['language: en', 'assistant:', `  gherkin: ${globalGherkin}`].join('\n'),
-        'utf-8',
-      );
+      if (globalGherkin !== undefined) {
+        writeFileSync(
+          globalConfigPath,
+          ['language: en', 'assistant:', `  gherkin: ${globalGherkin}`].join('\n'),
+          'utf-8',
+        );
+      }
 
       if (projectGherkin !== undefined) {
         const configDir = getProjectConfigDir(projectDir);

--- a/src/__tests__/conversationLoop-resume.test.ts
+++ b/src/__tests__/conversationLoop-resume.test.ts
@@ -598,6 +598,41 @@ describe('/resume command', () => {
 // /go command: summary AI session isolation
 // =================================================================
 describe('/go command', () => {
+  it.each([
+    ['unset', undefined, true],
+    ['project false', false, false],
+  ] as const)('should apply %s to the real summary prompt', async (_label, projectGherkin, expectedEnabled) => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-gherkin-real-summary-'));
+    if (projectGherkin !== undefined) {
+      fs.mkdirSync(path.join(projectDir, '.takt'), { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDir, '.takt', 'config.yaml'),
+        ['assistant:', `  gherkin: ${projectGherkin}`].join('\n'),
+        'utf-8',
+      );
+    }
+    setupRawStdin(toRawInputs(['/go improve parser behavior']));
+    const { provider, capture } = createScenarioProvider([
+      { content: 'Generated task instruction.' },
+    ]);
+    const ctx = createSessionContext({
+      provider: provider as SessionContext['provider'],
+    });
+
+    try {
+      const result = await runConversationLoop(projectDir, ctx, defaultStrategy, undefined, undefined);
+
+      expect(result.action).toBe('execute');
+      if (expectedEnabled) {
+        expect(capture.prompts[0]).toContain('## Markdown + Gherkin Output Format');
+      } else {
+        expect(capture.prompts[0]).not.toContain('## Markdown + Gherkin Output Format');
+      }
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
   it('should include Markdown and Gherkin rules in assistant summaries when project config enables them', async () => {
     const buildSummaryPromptSpy = vi.spyOn(interactiveModule, 'buildSummaryPrompt');
     const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-gherkin-assistant-'));

--- a/src/__tests__/conversationLoop-resume.test.ts
+++ b/src/__tests__/conversationLoop-resume.test.ts
@@ -627,6 +627,8 @@ describe('/go command', () => {
         expect(capture.prompts[0]).toContain('## Markdown + Gherkin Output Format');
       } else {
         expect(capture.prompts[0]).not.toContain('## Markdown + Gherkin Output Format');
+        expect(capture.prompts[0]).not.toContain('Write these in a fenced `gherkin` block:');
+        expect(capture.prompts[0]).not.toContain('Do not duplicate the same requirement in Markdown and Gherkin');
       }
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });

--- a/src/__tests__/conversationSession.test.ts
+++ b/src/__tests__/conversationSession.test.ts
@@ -215,6 +215,8 @@ describe('conversation session application API', () => {
         expect(prompt).toContain('## Markdown + Gherkin Output Format');
       } else {
         expect(prompt).not.toContain('## Markdown + Gherkin Output Format');
+        expect(prompt).not.toContain('Write these in a fenced `gherkin` block:');
+        expect(prompt).not.toContain('Do not duplicate the same requirement in Markdown and Gherkin');
       }
     } finally {
       rmSync(projectDir, { recursive: true, force: true });

--- a/src/__tests__/conversationSession.test.ts
+++ b/src/__tests__/conversationSession.test.ts
@@ -15,6 +15,11 @@ vi.mock('../features/interactive/aiCaller.js', () => ({
   callAIWithRetry: (...args: unknown[]) => mockCallAIWithRetry(...args),
 }));
 
+vi.mock('../infra/config/global/globalConfig.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  loadGlobalConfig: vi.fn(() => ({ provider: 'mock', language: 'en' })),
+}));
+
 vi.mock('../features/interactive/interactiveApplication.js', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   buildConversationSummaryPrompt: (...args: unknown[]) => mockBuildSummaryPrompt(...args),
@@ -145,7 +150,7 @@ describe('conversation session application API', () => {
       'include progress updates',
       'en',
       'summary context',
-      false,
+      true,
     );
     expect(result).toEqual({
       kind: 'workflow_execution_requested',
@@ -159,7 +164,7 @@ describe('conversation session application API', () => {
   });
 
   it.each([
-    ['unset', undefined, false],
+    ['unset', undefined, true],
     ['enabled', true, true],
     ['disabled', false, false],
   ] as const)('should pass %s project Gherkin mode to ACP task instruction generation', async (_label, configured, expected) => {
@@ -178,6 +183,39 @@ describe('conversation session application API', () => {
       await session.createTaskInstruction({ userNote: 'implement ACP support' });
 
       expect(mockBuildSummaryPrompt.mock.calls[0]?.[4]).toBe(expected);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['unset', undefined, true],
+    ['project false', false, false],
+  ] as const)('should apply %s to the actual ACP summary prompt', async (_label, configured, expectedEnabled) => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'takt-gherkin-acp-prompt-'));
+    if (configured !== undefined) {
+      mkdirSync(join(projectDir, '.takt'), { recursive: true });
+      writeFileSync(
+        join(projectDir, '.takt', 'config.yaml'),
+        ['assistant:', `  gherkin: ${configured}`].join('\n'),
+        'utf-8',
+      );
+    }
+    const actualInteractiveApplication = await vi.importActual<typeof import('../features/interactive/interactiveApplication.js')>(
+      '../features/interactive/interactiveApplication.js',
+    );
+    mockBuildSummaryPrompt.mockImplementation(actualInteractiveApplication.buildConversationSummaryPrompt);
+
+    try {
+      const session = createSession(projectDir);
+      await session.createTaskInstruction({ userNote: 'implement ACP support' });
+
+      const prompt = mockCallAIWithRetry.mock.calls[0]?.[0];
+      if (expectedEnabled) {
+        expect(prompt).toContain('## Markdown + Gherkin Output Format');
+      } else {
+        expect(prompt).not.toContain('## Markdown + Gherkin Output Format');
+      }
     } finally {
       rmSync(projectDir, { recursive: true, force: true });
     }
@@ -206,7 +244,7 @@ describe('conversation session application API', () => {
       'worktree で実行できるように積んで',
       'en',
       'summary context',
-      false,
+      true,
     );
     expect(mockCallAIWithRetry).toHaveBeenCalledWith(
       'summary prompt',
@@ -407,7 +445,7 @@ describe('conversation session application API', () => {
       'summarize',
       'en',
       'summary context',
-      false,
+      true,
     );
   });
 });

--- a/src/__tests__/interactive-summary.test.ts
+++ b/src/__tests__/interactive-summary.test.ts
@@ -86,6 +86,7 @@ describe('buildSummaryPrompt', () => {
     expect(summary).not.toContain('## Markdown + Gherkin Output Format');
     expect(summary).not.toContain('Write these in a fenced `gherkin` block:');
     expect(summary).not.toContain('Do not duplicate the same requirement in Markdown and Gherkin');
+    expect(summary).toContain('Output only the final task instruction (no preamble).');
   });
 
 });

--- a/src/__tests__/interactive-summary.test.ts
+++ b/src/__tests__/interactive-summary.test.ts
@@ -84,6 +84,8 @@ describe('buildSummaryPrompt', () => {
     );
 
     expect(summary).not.toContain('## Markdown + Gherkin Output Format');
+    expect(summary).not.toContain('Write these in a fenced `gherkin` block:');
+    expect(summary).not.toContain('Do not duplicate the same requirement in Markdown and Gherkin');
   });
 
 });

--- a/src/__tests__/interactive-summary.test.ts
+++ b/src/__tests__/interactive-summary.test.ts
@@ -54,6 +54,38 @@ describe('buildSummaryPrompt', () => {
     expect(summary).toContain('Improve parser');
   });
 
+  it('includes the existing Gherkin output rules when enabled', () => {
+    const summary = buildSummaryPrompt(
+      [{ role: 'user', content: 'Improve parser' }],
+      false,
+      'en',
+      'No transcript',
+      'Conversation:',
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(summary).toContain('## Markdown + Gherkin Output Format');
+  });
+
+  it('keeps the existing Markdown-only output contract when disabled', () => {
+    const summary = buildSummaryPrompt(
+      [{ role: 'user', content: 'Improve parser' }],
+      false,
+      'en',
+      'No transcript',
+      'Conversation:',
+      undefined,
+      undefined,
+      undefined,
+      false,
+    );
+
+    expect(summary).not.toContain('## Markdown + Gherkin Output Format');
+  });
+
 });
 
 describe('buildSummaryActionOptions', () => {

--- a/src/__tests__/quietMode-session.test.ts
+++ b/src/__tests__/quietMode-session.test.ts
@@ -18,6 +18,10 @@ vi.mock('../features/interactive/conversationLoop.js', () => ({
   callAIWithRetry: vi.fn(),
 }));
 
+vi.mock('../infra/config/global/globalConfig.js', () => ({
+  loadGlobalConfig: vi.fn(() => ({ provider: 'mock', language: 'en' })),
+}));
+
 vi.mock('../features/interactive/sessionInitialization.js', () => ({
   initializeSession: vi.fn(),
 }));
@@ -98,6 +102,45 @@ beforeEach(() => {
 // =================================================================
 
 describe('quietMode: summary AI session isolation', () => {
+  it.each([
+    ['unset', undefined, true],
+    ['project false', false, false],
+  ] as const)('should apply %s to the actual quiet summary prompt', async (_label, configured, expectedEnabled) => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'takt-quiet-gherkin-prompt-'));
+    if (configured !== undefined) {
+      fs.mkdirSync(path.join(projectDir, '.takt'), { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDir, '.takt', 'config.yaml'),
+        ['assistant:', `  gherkin: ${configured}`].join('\n'),
+        'utf-8',
+      );
+    }
+    const actualInteractive = await vi.importActual<typeof import('../features/interactive/interactive.js')>(
+      '../features/interactive/interactive.js',
+    );
+    mockBuildSummaryPrompt.mockImplementation(actualInteractive.buildSummaryPrompt);
+    mockInitializeSession.mockReturnValue(createMockSessionContext(undefined));
+    mockCallAIWithRetry.mockResolvedValue({
+      result: { content: 'Generated task instruction.', success: true },
+      sessionId: undefined,
+    });
+    mockSelectPostSummaryAction.mockResolvedValue('execute');
+
+    try {
+      const result = await quietMode(projectDir, { userMessage: 'fix the bug' });
+
+      expect(result.action).toBe('execute');
+      const prompt = mockCallAIWithRetry.mock.calls[0]?.[0];
+      if (expectedEnabled) {
+        expect(prompt).toContain('## Markdown + Gherkin Output Format');
+      } else {
+        expect(prompt).not.toContain('## Markdown + Gherkin Output Format');
+      }
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
   it('should pass sessionId as undefined to callAIWithRetry even when ctx carries an active sessionId', async () => {
     // Given: initializeSession returns a ctx with an active session
     const ctxWithSession = createMockSessionContext('active-session-123');

--- a/src/__tests__/quietMode-session.test.ts
+++ b/src/__tests__/quietMode-session.test.ts
@@ -135,6 +135,8 @@ describe('quietMode: summary AI session isolation', () => {
         expect(prompt).toContain('## Markdown + Gherkin Output Format');
       } else {
         expect(prompt).not.toContain('## Markdown + Gherkin Output Format');
+        expect(prompt).not.toContain('Write these in a fenced `gherkin` block:');
+        expect(prompt).not.toContain('Do not duplicate the same requirement in Markdown and Gherkin');
       }
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });

--- a/src/features/interactive/taskInstructionFormat.ts
+++ b/src/features/interactive/taskInstructionFormat.ts
@@ -6,5 +6,5 @@ export function shouldUseGherkinTaskInstructions(projectDir: string): boolean {
   if (projectValue !== undefined) {
     return projectValue;
   }
-  return loadGlobalConfig().assistant?.gherkin === true;
+  return loadGlobalConfig().assistant?.gherkin ?? true;
 }

--- a/src/shared/prompts/en/score_summary_gherkin_instructions.md
+++ b/src/shared/prompts/en/score_summary_gherkin_instructions.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD041 -->
 <!--
   template: score_summary_gherkin_instructions
-  role: opt-in Markdown and Gherkin rules for conversation-to-task summarization
+  role: conditional Markdown and Gherkin rules for conversation-to-task summarization
   vars: none
   caller: features/interactive
 -->

--- a/src/shared/prompts/ja/score_summary_gherkin_instructions.md
+++ b/src/shared/prompts/ja/score_summary_gherkin_instructions.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD041 -->
 <!--
   template: score_summary_gherkin_instructions
-  role: conversation-to-task summarization 用の opt-in Markdown + Gherkin 規則
+  role: conversation-to-task summarization 用の条件付き Markdown + Gherkin 規則
   vars: none
   caller: features/interactive
 -->


### PR DESCRIPTION
## Summary

- `assistant.gherkin` をデフォルト有効にする
- プロジェクト設定の明示値を優先し、`false` の明示で無効化する
- `/go`、quiet、ACP の要約プロンプトで既存の Gherkin 出力規則を設定に従って適用する
- 英語・日本語・中国語の設定ドキュメントと回帰テストを更新する

## Verification

- `npm test` passed
- `npm run build` passed
- `npm run lint` passed
- 対象テスト（設定解決、`/go`、quiet、ACP、要約プロンプト、分類契約）passed
- `npm run test:it` は変更箇所外の `mcp-entrypoint.integration.test.ts` の `McpError: Connection closed` 以外が通過。対象テスト単体でも同じ失敗を再現


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Gherkin形式のタスク指示と要約出力が、デフォルトで有効になりました。
  * プロジェクト設定で `false` を指定すると、Gherkin形式を無効化できます。

* **ドキュメント**
  * グローバル設定とプロジェクト設定における既定値、優先順位、無効化方法の説明を更新しました。

* **テスト**
  * 未設定時の有効化、設定による無効化、プロジェクト設定の上書きを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->