### PR TITLE
[#1430] add-loop-analysis

### DIFF
--- a/builtins/en/facets/instructions/loop-analysis-review.md
+++ b/builtins/en/facets/instructions/loop-analysis-review.md
@@ -1,0 +1,18 @@
+Review the loop-analysis report below.
+
+{report:loop-analysis.md}
+
+**Purpose:** Remove over-specialized proposals. Analyzing agents tend to propose prompt changes that only fit the single run they read; those changes degrade the prompt for every other run.
+
+**Review each adopted proposal and reject it when:**
+- It only applies to the analyzed run's specific task, domain, or incidental context, and would not generalize to other runs
+- It duplicates what the target facet file already says
+- Its amendment text does not match the log evidence it cites
+
+**Verdict:**
+- `approved`: every adopted proposal is general, non-redundant, and evidence-backed
+- `rejected`: at least one proposal fails the checks above
+
+When rejecting, list each rejected proposal with the concrete reason (over-specialized, redundant, or ungrounded) so the analyzer can revise it. Do not rewrite proposals yourself.
+
+**Final report:** Whether you approve or reject, finalize the report. Rewrite `loop-analysis.md` according to the supplied output contract so it carries the adopted proposals and every rejected proposal with its rejection reason, including the rejections from this review. This review is the last writer of the report: even when the rework loop reaches its limit, the file must still show the final verdict's rejections and their reasons.

--- a/builtins/en/facets/instructions/loop-analysis.md
+++ b/builtins/en/facets/instructions/loop-analysis.md
@@ -1,0 +1,19 @@
+Analyze the finished workflow run given in the task and propose prompt improvements that reduce unnecessary loops.
+
+**Input:** The task names the finished run's directory. It contains the session logs under `logs/` (JSONL), `trace.md`, and the run's reports under `reports/`. Read them before proposing anything.
+
+**Analysis:**
+1. Reconstruct what the run was trying to do and how its iterations progressed.
+2. Identify loop patterns: repeated identical tool calls, files read again without new need, retry cycles without changed strategy, rework loops between steps, iterations that made no observable progress.
+3. For each loop, find the prompt-level cause: the instruction, persona, policy, knowledge, or output contract whose text failed to prevent it.
+
+**Proposals:**
+- Each proposal names the concrete facet file path (persona / policy / knowledge / instruction / output-contract) and the exact amendment: the text to add or the change to make.
+- Each proposal cites the observed loop as evidence.
+- Propose only changes that would help runs beyond this one.
+
+**Rework after a review rejection:**
+- The previous reviewer response lists rejected proposals with reasons.
+- Keep adopted proposals stable, revise or drop rejected ones, and record every rejected proposal with its rejection reason in the report's rejected section.
+
+Write the report to `loop-analysis.md` according to the supplied output contract.

--- a/builtins/en/facets/output-contracts/loop-analysis.md
+++ b/builtins/en/facets/output-contracts/loop-analysis.md
@@ -1,0 +1,21 @@
+```markdown
+# Loop Analysis Report
+
+## Source Run
+{Run directory path}
+
+## Observed Loops
+| Loop | Evidence | Prompt-level cause |
+|------|----------|--------------------|
+| {Repeated behavior} | {Log / trace reference} | {Facet text that failed to prevent it} |
+
+## Adopted Proposals
+| Facet file | Amendment |
+|------------|-----------|
+| {facet file path} | {Text to add or change} |
+
+## Rejected Proposals
+| Facet file | Proposal | Rejection reason |
+|------------|----------|------------------|
+| {facet file path} | {What was proposed} | {Why the reviewer rejected it} |
+```

--- a/builtins/en/facets/personas/loop-analysis-reviewer.md
+++ b/builtins/en/facets/personas/loop-analysis-reviewer.md
@@ -1,0 +1,23 @@
+# Loop Analysis Reviewer
+
+You are a reviewer of loop-analysis proposals. Your purpose is to remove over-specialized proposals: analyzing agents tend to propose prompt changes that only fit the single run they just read, and those changes degrade the prompt for every other run.
+
+## Role Boundaries
+
+**Do:**
+- Read the analysis report and judge each proposal on its generality
+- Reject proposals that only apply to the analyzed run's specific task, domain, or incidental context
+- Reject proposals that duplicate what the target facet already says
+- Reject proposals whose amendment text does not match the cited log evidence
+- Approve proposals that address a general prompt weakness any run could hit
+
+**Don't:**
+- Rewrite proposals yourself; rejection feedback goes back to the analyzer
+- Reject a proposal for style alone
+- Approve everything by default; your job is to filter
+
+## Behavioral Principles
+
+- Judge each proposal independently, then give one verdict for the whole report
+- When rejecting, state per proposal why it is over-specialized, redundant, or ungrounded
+- Approve when every remaining proposal is general, non-redundant, and evidence-backed

--- a/builtins/en/facets/personas/loop-analyzer.md
+++ b/builtins/en/facets/personas/loop-analyzer.md
@@ -1,0 +1,24 @@
+# Loop Analyzer
+
+You are a run-log analyst for an AI agent orchestration system. You read the artifacts of a finished workflow run and identify where the agents looped unnecessarily, then propose concrete prompt improvements that would have prevented those loops.
+
+## Role Boundaries
+
+**Do:**
+- Read the run's session logs, trace, and reports
+- Identify concrete loop patterns: repeated tool calls, re-read files, retry cycles, rework loops, stagnating iterations
+- Trace each loop back to the prompt text that failed to prevent it
+- Propose amendments to specific facet files (persona / policy / knowledge / instruction / output-contract) with exact file paths and the text to add or change
+
+**Don't:**
+- Propose code changes to the orchestration system itself
+- Propose changes without naming the concrete facet file path and the amendment text
+- Blame the model or the runtime when the prompt is not at fault
+- Auto-apply proposals; a human decides adoption
+
+## Behavioral Principles
+
+- Ground every proposal in observed log evidence: cite the loop you saw, not a hypothetical one
+- Prefer few, high-impact proposals over many marginal ones
+- A proposal must state which facet file changes and what text is added or changed
+- When revising after a review rejection, keep adopted proposals stable and record rejected ones with their rejection reasons

--- a/builtins/en/workflows/loop-analysis.yaml
+++ b/builtins/en/workflows/loop-analysis.yaml
@@ -1,0 +1,36 @@
+name: loop-analysis
+description: Post-run loop analysis. Analyzes a finished run's session logs and reports, proposes prompt improvements that reduce unnecessary loops, and reviews the proposals with a bounded rework loop.
+max_steps: 6
+initial_step: analyze
+steps:
+  - name: analyze
+    edit: false
+    capabilities: readonly
+    persona: loop-analyzer
+    instruction: loop-analysis
+    output_contracts:
+      report:
+        - name: loop-analysis.md
+          format: loop-analysis
+    rules:
+      - condition: Analysis and proposals are complete
+        next: review
+      - condition: The run artifacts cannot be analyzed
+        next: ABORT
+
+  - name: review
+    edit: false
+    capabilities: readonly
+    persona: loop-analysis-reviewer
+    pass_previous_response: false
+    instruction: loop-analysis-review
+    output_contracts:
+      report:
+        - name: loop-analysis.md
+          format: loop-analysis
+          use_judge: false
+    rules:
+      - condition: approved
+        next: COMPLETE
+      - condition: rejected
+        next: analyze

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -602,6 +602,40 @@ declarations and the structural validation of `targets.companions` remain in
 place, but no companion provider is resolved or executed — a workflow that
 declares companions runs without any companion provider configuration.
 
+### Loop analysis (loop_analysis)
+
+Post-run loop analysis is an opt-in feature. Enable it with the top-level
+`loop_analysis` section:
+
+```yaml
+version: 1
+loop_analysis:
+  enabled: true
+  output: file        # file | pr-comment (default: file)
+```
+
+When enabled, every workflow run that reaches a terminal state — success,
+failure, or cancellation — automatically launches the builtin `loop-analysis`
+workflow as a detached background run. The analysis run reads the finished
+run's session logs, `trace.md`, and reports, then proposes prompt improvements
+(facet file paths plus concrete amendments) that reduce unnecessary loops. The
+source run never waits for the analysis run, and a launch failure is only
+logged; it never changes the source run's outcome. Analysis runs do not launch
+further analysis runs.
+
+The analysis report is always written to the analysis run's own
+`.takt/runs/<run>/reports/loop-analysis.md` via the normal output contract
+mechanism. With `output: pr-comment`, the finished analysis run additionally
+posts the identical report content as a comment on the source branch's pull
+request, but only when the source run resolved `auto_pr: true` and a pull
+request exists for the source branch. When `auto_pr` is unset or false, or
+when the source run has no PR, the report stays file-only.
+
+Provider assignment for the analysis agents uses the ordinary routing
+(`provider.targets.steps` / `personas` / internal agent seats); the
+`loop_analysis` section itself accepts no provider fields. Unknown `output`
+values fail at load time.
+
 Runtime mode is enabled by the presence of an active `provider` section, not by the file existing. A file that only contains `version: 1` is inactive and leaves the legacy `config.yaml` provider resolution in place.
 
 ### Configuration example

--- a/src/__tests__/it-loop-analysis-terminal-dispatch.test.ts
+++ b/src/__tests__/it-loop-analysis-terminal-dispatch.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Loop-analysis terminal dispatch coverage (order.md §2).
+ *
+ * A workflow run reaches its terminal publication through three distinct paths:
+ * the normal executeWorkflow finalization, the bootstrap-failure terminalization,
+ * and the force-fail storage. Each path must fire the loop-analysis terminal hook
+ * exactly once so an enabled analysis launches for finished runs regardless of how
+ * the run ended. The hook itself is replaced with a vi.mock double; its internal
+ * eligibility rules are covered by loopAnalysisHook.test.ts.
+ *
+ * Uses the real executeWorkflow path with the mock provider and a real filesystem,
+ * so this file stays in the integration gate.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { WorkflowConfig, WorkflowStep } from '../core/models/index.js';
+import { semanticRuleCandidatesOf } from '../core/models/workflow-rule-condition.js';
+import { RuleDetectionExhaustedError } from '../core/workflow/evaluation/RuleDetectionExhaustedError.js';
+import { detectCandidateIndex } from '../shared/utils/ruleIndex.js';
+import { normalizeRule } from '../infra/config/loaders/workflowRuleNormalizer.js';
+import { setMockScenario, resetScenario } from '../infra/mock/index.js';
+
+const hookMock = vi.hoisted(() => ({
+  launch: vi.fn(),
+}));
+
+vi.mock('../features/tasks/execute/loopAnalysisHook.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../features/tasks/execute/loopAnalysisHook.js')>()),
+  launchLoopAnalysisOnRunTerminal: hookMock.launch,
+}));
+
+vi.mock('../core/workflow/phase-runner.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../core/workflow/phase-runner.js')>()),
+  runStatusJudgmentPhase: vi.fn().mockImplementation((
+    step: WorkflowStep,
+    ctx: { lastResponse?: string },
+  ) => {
+    const candidateIndex = detectCandidateIndex(ctx.lastResponse ?? '', step.name);
+    const candidate = semanticRuleCandidatesOf(step.rules ?? [], false)[candidateIndex];
+    if (!candidate) {
+      throw new RuleDetectionExhaustedError(step.name);
+    }
+    return { label: candidate.label, method: 'phase3_tag' as const };
+  }),
+}));
+
+import { executeWorkflow } from '../features/tasks/execute/workflowExecution.js';
+import { createTaskRunForceFailStorage } from '../features/tasks/list/taskRunForceFailStorage.js';
+import {
+  claimLoopAnalysisDispatch,
+  onRunTerminal,
+} from '../features/tasks/execute/loopAnalysisHook.js';
+import { buildRunPaths } from '../core/workflow/run/run-paths.js';
+import { initNdjsonLog } from '../infra/fs/index.js';
+import type { TaskListItem } from '../infra/task/types.js';
+
+function makeConfig(): WorkflowConfig {
+  return {
+    name: 'loop-analysis-dispatch',
+    maxSteps: 3,
+    initialStep: 'implement',
+    steps: [
+      {
+        name: 'implement',
+        personaDisplayName: 'implement',
+        instruction: 'Implement {task}',
+        rules: [normalizeRule({ condition: 'done', next: 'COMPLETE' })],
+      },
+    ],
+  };
+}
+
+function createRunningTask(
+  projectDir: string,
+  runSlug: string,
+  overrides: { branch?: string; autoPr?: boolean } = {},
+): TaskListItem {
+  return {
+    kind: 'running',
+    name: 'running-task',
+    createdAt: '2026-04-09T00:00:00.000Z',
+    filePath: join(projectDir, '.takt', 'tasks.yaml'),
+    content: 'Force fail me',
+    taskDir: `.takt/tasks/${runSlug}`,
+    runSlug,
+    ownerPid: 4242,
+    ...(overrides.branch === undefined ? {} : { branch: overrides.branch }),
+    data: {
+      task: 'Force fail me\nwith full prompt',
+      ...(overrides.autoPr === undefined ? {} : { auto_pr: overrides.autoPr }),
+    },
+  };
+}
+
+function writeRunningRunMeta(projectDir: string, runSlug: string): void {
+  const runPaths = buildRunPaths(projectDir, runSlug);
+  const relativeRunRoot = join('.takt', 'runs', runSlug);
+  mkdirSync(dirname(runPaths.metaAbs), { recursive: true });
+  writeFileSync(runPaths.metaAbs, JSON.stringify({
+    task: 'Force fail me',
+    workflow: 'default',
+    runSlug,
+    runRoot: relativeRunRoot,
+    reportDirectory: join(relativeRunRoot, 'reports'),
+    contextDirectory: join(relativeRunRoot, 'context'),
+    logsDirectory: join(relativeRunRoot, 'logs'),
+    status: 'running',
+    startTime: '2026-04-09T00:00:00.000Z',
+    currentStep: 'implement',
+    currentIteration: 2,
+  }, null, 2), 'utf-8');
+  initNdjsonLog('force-fail-session', 'Force fail me', 'default', {
+    logsDir: runPaths.logsAbs,
+    startTime: '2026-04-09T00:00:00.000Z',
+  });
+}
+
+describe('loop-analysis terminal dispatch', () => {
+  let projectDir: string;
+  let globalConfigDir: string;
+  let originalTaktConfigDir: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectDir = mkdtempSync(join(tmpdir(), 'takt-loop-analysis-dispatch-'));
+    globalConfigDir = mkdtempSync(join(tmpdir(), 'takt-loop-analysis-dispatch-global-'));
+    originalTaktConfigDir = process.env.TAKT_CONFIG_DIR;
+    process.env.TAKT_CONFIG_DIR = globalConfigDir;
+  });
+
+  afterEach(() => {
+    resetScenario();
+    if (originalTaktConfigDir === undefined) {
+      delete process.env.TAKT_CONFIG_DIR;
+    } else {
+      process.env.TAKT_CONFIG_DIR = originalTaktConfigDir;
+    }
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(globalConfigDir, { recursive: true, force: true });
+  });
+
+  it('Given a workflow run that completes through the normal terminal path, When the run finishes, Then the terminal hook fires once with the completed status', async () => {
+    setMockScenario([
+      { status: 'done', content: '[IMPLEMENT:1]\n\ndone' },
+    ]);
+
+    const result = await executeWorkflow(makeConfig(), 'task', projectDir, {
+      projectCwd: projectDir,
+      provider: 'mock',
+    });
+
+    expect(result.success).toBe(true);
+    expect(hookMock.launch).toHaveBeenCalledTimes(1);
+    expect(hookMock.launch).toHaveBeenCalledWith(expect.objectContaining({
+      projectCwd: projectDir,
+      status: 'completed',
+      sourceAutoPr: false,
+    }));
+  });
+
+  it('Given a source run with autoPr, When the run finishes, Then the terminal hook receives the resolved autoPr flag', async () => {
+    setMockScenario([
+      { status: 'done', content: '[IMPLEMENT:1]\n\ndone' },
+    ]);
+
+    const result = await executeWorkflow(makeConfig(), 'task', projectDir, {
+      projectCwd: projectDir,
+      provider: 'mock',
+      autoPr: true,
+      traceTaskMetadata: { gitBranch: 'takt/dispatch-auto-pr' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(hookMock.launch).toHaveBeenCalledTimes(1);
+    expect(hookMock.launch).toHaveBeenCalledWith(expect.objectContaining({
+      projectCwd: projectDir,
+      status: 'completed',
+      gitBranch: 'takt/dispatch-auto-pr',
+      sourceAutoPr: true,
+    }));
+  });
+
+  it('Given a workflow run interrupted by a pre-aborted external signal, When the run reaches its terminal publication as cancelled, Then the terminal hook fires once with the cancelled status', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await executeWorkflow(makeConfig(), 'task', projectDir, {
+      projectCwd: projectDir,
+      provider: 'mock',
+      abortSignal: controller.signal,
+    });
+
+    expect(result.success).toBe(false);
+    expect(hookMock.launch).toHaveBeenCalledTimes(1);
+    expect(hookMock.launch).toHaveBeenCalledWith(expect.objectContaining({
+      projectCwd: projectDir,
+      status: 'cancelled',
+      sourceAutoPr: false,
+    }));
+  });
+
+  it('Given a workflow run that fails during bootstrap, When the run is terminalized, Then the terminal hook fires once with the failed status', async () => {
+    const runSlug = 'loop-analysis-bootstrap-failure';
+
+    await expect(executeWorkflow(makeConfig(), 'failed target task', projectDir, {
+      projectCwd: projectDir,
+      provider: 'mock',
+      reportDirName: runSlug,
+      taskSpec: {
+        runSlug,
+        sourceTaskDir: join(projectDir, 'missing-task-source'),
+        attachmentManifest: [{
+          relativePath: 'attachments/missing.png',
+          kind: 'file',
+          contentSha256: 'a'.repeat(64),
+        }],
+        taskPrompt: 'missing task prompt',
+        orderContent: 'missing task',
+        stagedOrderContent: 'missing task',
+      },
+    })).rejects.toThrow();
+
+    expect(hookMock.launch).toHaveBeenCalledTimes(1);
+    expect(hookMock.launch).toHaveBeenCalledWith(expect.objectContaining({
+      projectCwd: projectDir,
+      runRootAbs: join(projectDir, '.takt', 'runs', runSlug),
+      status: 'failed',
+      sourceAutoPr: false,
+    }));
+  });
+
+  it('Given a running task that is force-failed, When the run is terminalized, Then the terminal hook fires once with the failed status', async () => {
+    const runSlug = 'loop-analysis-force-fail';
+    writeRunningRunMeta(projectDir, runSlug);
+    const runPaths = buildRunPaths(projectDir, runSlug);
+    const storage = createTaskRunForceFailStorage({
+      task: createRunningTask(projectDir, runSlug),
+      projectDir,
+      onWarning: vi.fn(),
+    });
+
+    expect(storage).toBeDefined();
+    await expect(storage!.terminalize('manual force-fail')).resolves.toMatchObject({ issues: [] });
+
+    expect(hookMock.launch).toHaveBeenCalledTimes(1);
+    expect(hookMock.launch).toHaveBeenCalledWith(expect.objectContaining({
+      projectCwd: projectDir,
+      runRootAbs: runPaths.runRootAbs,
+      reportsAbs: runPaths.reportsAbs,
+      status: 'failed',
+      sourceAutoPr: false,
+    }));
+  });
+
+  it('Given a running task with a branch and auto_pr, When the run is force-failed, Then the terminal hook receives the branch and the resolved autoPr flag', async () => {
+    const runSlug = 'loop-analysis-force-fail-auto-pr';
+    writeRunningRunMeta(projectDir, runSlug);
+    const storage = createTaskRunForceFailStorage({
+      task: createRunningTask(projectDir, runSlug, { branch: 'takt/x', autoPr: true }),
+      projectDir,
+      onWarning: vi.fn(),
+    });
+
+    expect(storage).toBeDefined();
+    await expect(storage!.terminalize('manual force-fail')).resolves.toMatchObject({ issues: [] });
+
+    expect(hookMock.launch).toHaveBeenCalledTimes(1);
+    expect(hookMock.launch).toHaveBeenCalledWith(expect.objectContaining({
+      projectCwd: projectDir,
+      status: 'failed',
+      gitBranch: 'takt/x',
+      sourceAutoPr: true,
+    }));
+  });
+
+  it('Given a running task without auto_pr but with project config auto_pr, When the run is force-failed, Then the terminal hook receives the config-resolved autoPr flag', async () => {
+    const runSlug = 'loop-analysis-force-fail-config-auto-pr';
+    writeRunningRunMeta(projectDir, runSlug);
+    mkdirSync(join(projectDir, '.takt'), { recursive: true });
+    writeFileSync(join(projectDir, '.takt', 'config.yaml'), 'auto_pr: true\n', 'utf-8');
+    const storage = createTaskRunForceFailStorage({
+      task: createRunningTask(projectDir, runSlug),
+      projectDir,
+      onWarning: vi.fn(),
+    });
+
+    expect(storage).toBeDefined();
+    await expect(storage!.terminalize('manual force-fail')).resolves.toMatchObject({ issues: [] });
+
+    expect(hookMock.launch).toHaveBeenCalledTimes(1);
+    expect(hookMock.launch).toHaveBeenCalledWith(expect.objectContaining({
+      projectCwd: projectDir,
+      status: 'failed',
+      sourceAutoPr: true,
+    }));
+  });
+
+  it('Given the real dispatch claim on a shared run directory, When the terminal hook fires twice for the same run, Then only the first call spawns the analysis run', async () => {
+    const runSlug = 'loop-analysis-claim-idempotent';
+    writeRunningRunMeta(projectDir, runSlug);
+    const runPaths = buildRunPaths(projectDir, runSlug);
+    const spawn = vi.fn(() => ({ on: vi.fn(), unref: vi.fn() }));
+    const deps = {
+      resolveConfig: () => ({ enabled: true, output: 'file' as const }),
+      spawn,
+      env: {} as Record<string, string | undefined>,
+      gitProvider: {
+        findExistingPr: vi.fn(() => undefined),
+        commentOnPr: vi.fn(() => ({ success: true })),
+      },
+      readFile: vi.fn(() => 'report'),
+      sleep: vi.fn(async () => {}),
+      logger: { error: vi.fn() },
+      claimDispatch: claimLoopAnalysisDispatch,
+    };
+    const input = {
+      projectCwd: projectDir,
+      runRootAbs: runPaths.runRootAbs,
+      reportsAbs: runPaths.reportsAbs,
+      status: 'failed' as const,
+    };
+
+    await expect(onRunTerminal(deps, input)).resolves.toBeUndefined();
+    await expect(onRunTerminal(deps, input)).resolves.toBeUndefined();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/it-loop-analysis-workflow.test.ts
+++ b/src/__tests__/it-loop-analysis-workflow.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Loop-analysis builtin workflow IT (order.md §3/§4).
+ *
+ * Runs the real builtin `loop-analysis` workflow through WorkflowEngine with the
+ * mock provider. The report phase is the real one, so the analysis report is
+ * persisted through the actual output-contract machinery; only the Phase 3 status
+ * judgment is replaced with deterministic tag detection.
+ *
+ * Covered contracts:
+ * - a rejected review feeds back into the analyzer and the loop terminates
+ *   (approve -> COMPLETE, permanent rejection -> bounded iteration-limit abort)
+ * - the reviewer prompt embeds the analyzer's actual report via {report:...}
+ * - the final report file always exists under the run's reports/ directory with
+ *   the required sections, finalized by the review step (including the last
+ *   rejection at the iteration limit)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { setMockScenario, resetScenario } from '../infra/mock/index.js';
+import { ProviderNeutralStructuredCaller } from '../agents/structured-caller.js';
+import type { WorkflowStep } from '../core/models/index.js';
+import { semanticRuleCandidatesOf } from '../core/models/workflow-rule-condition.js';
+import { RuleDetectionExhaustedError } from '../core/workflow/evaluation/RuleDetectionExhaustedError.js';
+import { detectCandidateIndex } from '../shared/utils/ruleIndex.js';
+
+const mockCallLog = vi.hoisted(() => ({
+  calls: [] as { persona: string; prompt: string }[],
+}));
+
+vi.mock('../infra/mock/client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../infra/mock/client.js')>();
+  return {
+    ...actual,
+    callMock: (personaName: string, prompt: string, options: Parameters<typeof actual.callMock>[2]) => {
+      mockCallLog.calls.push({ persona: personaName, prompt });
+      return actual.callMock(personaName, prompt, options);
+    },
+    callMockCustom: (
+      personaName: string,
+      prompt: string,
+      systemPrompt: string,
+      options: Parameters<typeof actual.callMockCustom>[3],
+    ) => {
+      mockCallLog.calls.push({ persona: personaName, prompt });
+      return actual.callMockCustom(personaName, prompt, systemPrompt, options);
+    },
+  };
+});
+
+vi.mock('../core/workflow/phase-runner.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../core/workflow/phase-runner.js')>()),
+  runStatusJudgmentPhase: vi.fn().mockImplementation((
+    step: WorkflowStep,
+    ctx: { lastResponse?: string },
+  ) => {
+    const candidateIndex = detectCandidateIndex(ctx.lastResponse ?? '', step.name);
+    const candidate = semanticRuleCandidatesOf(step.rules ?? [], false)[candidateIndex];
+    if (!candidate) {
+      throw new RuleDetectionExhaustedError(step.name);
+    }
+    return { label: candidate.label, method: 'phase3_tag' as const };
+  }),
+}));
+
+import { WorkflowEngine } from '../core/workflow/index.js';
+import { loadWorkflowByIdentifier } from '../infra/config/index.js';
+
+const RUN_SLUG = 'loop-analysis-it-run';
+
+function buildReportContent(marker: string): string {
+  return [
+    '# Loop Analysis Report',
+    '',
+    '## Source Run',
+    '/project/.takt/runs/source-run',
+    '',
+    '## Observed Loops',
+    '| Loop | Evidence | Prompt-level cause |',
+    '|------|----------|--------------------|',
+    '| repeated reads | logs/session-1.jsonl | missing stop condition |',
+    '',
+    '## Adopted Proposals',
+    '| Facet file | Amendment |',
+    '|------------|-----------|',
+    '| builtins/en/facets/instructions/example.md | Add a stop condition |',
+    '',
+    '## Rejected Proposals',
+    '| Facet file | Proposal | Rejection reason |',
+    '|------------|----------|------------------|',
+    `| ${marker} | proposal | rejection reason |`,
+    '',
+  ].join('\n');
+}
+
+const REQUIRED_REPORT_SECTIONS = [
+  '## Source Run',
+  '## Observed Loops',
+  '## Adopted Proposals',
+  '## Rejected Proposals',
+];
+
+const REQUIRED_REPORT_VALUES = [
+  'builtins/en/facets/instructions/example.md',
+  'Add a stop condition',
+  'rejection reason',
+];
+
+describe('loop-analysis builtin workflow IT', () => {
+  let testDir: string;
+  let globalConfigDir: string;
+  let originalTaktConfigDir: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCallLog.calls.length = 0;
+    testDir = mkdtempSync(join(tmpdir(), 'takt-it-loop-analysis-'));
+    globalConfigDir = mkdtempSync(join(tmpdir(), 'takt-it-loop-analysis-global-'));
+    originalTaktConfigDir = process.env.TAKT_CONFIG_DIR;
+    process.env.TAKT_CONFIG_DIR = globalConfigDir;
+  });
+
+  afterEach(() => {
+    resetScenario();
+    if (originalTaktConfigDir === undefined) {
+      delete process.env.TAKT_CONFIG_DIR;
+    } else {
+      process.env.TAKT_CONFIG_DIR = originalTaktConfigDir;
+    }
+    rmSync(testDir, { recursive: true, force: true });
+    rmSync(globalConfigDir, { recursive: true, force: true });
+  });
+
+  function loadLoopAnalysisWorkflow() {
+    const workflow = loadWorkflowByIdentifier('loop-analysis', testDir);
+    if (workflow === null) {
+      throw new Error('builtin loop-analysis workflow did not load');
+    }
+    return workflow;
+  }
+
+  function runLoopAnalysis() {
+    const workflow = loadLoopAnalysisWorkflow();
+    const engine = new WorkflowEngine(workflow, testDir, 'Analyze the finished run', {
+      projectCwd: testDir,
+      provider: 'mock',
+      reportDirName: RUN_SLUG,
+      structuredCaller: new ProviderNeutralStructuredCaller(),
+    });
+    return engine.run();
+  }
+
+  function reportPath(): string {
+    return join(testDir, '.takt', 'runs', RUN_SLUG, 'reports', 'loop-analysis.md');
+  }
+
+  it('Given a rejected first review, When the loop feeds back and the second review approves, Then the run completes and the final report is persisted with all required sections', async () => {
+    const reportV1 = buildReportContent('v1-report-marker');
+    const reportV2 = buildReportContent('v2-report-marker');
+    const finalReport = buildReportContent('final-report-marker');
+    setMockScenario([
+      { persona: 'loop-analyzer', status: 'done', content: '[ANALYZE:1]\n\nAnalysis complete.' },
+      { persona: 'loop-analyzer', status: 'done', content: reportV1 },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: '[REVIEW:2]\n\nrejected: over-specialized proposal.' },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: reportV1 },
+      { persona: 'loop-analyzer', status: 'done', content: '[ANALYZE:1]\n\nRevised analysis complete.' },
+      { persona: 'loop-analyzer', status: 'done', content: reportV2 },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: '[REVIEW:1]\n\napproved.' },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: finalReport },
+    ]);
+
+    const state = await runLoopAnalysis();
+
+    expect(state.status).toBe('completed');
+    expect(state.iteration).toBe(4);
+    const analyzerCalls = mockCallLog.calls.filter((call) => call.persona === 'loop-analyzer');
+    const reviewerCalls = mockCallLog.calls.filter((call) => call.persona === 'loop-analysis-reviewer');
+    expect(analyzerCalls).toHaveLength(4);
+    expect(reviewerCalls).toHaveLength(4);
+    expect(reviewerCalls[0]!.prompt).toContain('v1-report-marker');
+    const secondReviewerPrompt = reviewerCalls[2]!.prompt;
+    expect(secondReviewerPrompt).toContain('v2-report-marker');
+
+    const finalReportPath = reportPath();
+    expect(existsSync(finalReportPath)).toBe(true);
+    const persisted = readFileSync(finalReportPath, 'utf-8');
+    for (const section of REQUIRED_REPORT_SECTIONS) {
+      expect(persisted).toContain(section);
+    }
+    for (const value of REQUIRED_REPORT_VALUES) {
+      expect(persisted).toContain(value);
+    }
+    expect(persisted).toContain('final-report-marker');
+  });
+
+  it('Given reviews that always reject, When the rework loop reaches its bound, Then the run aborts at the iteration limit and the final report keeps the last rejection', async () => {
+    const analysisReport = buildReportContent('analysis-report-marker');
+    const reviewReport = buildReportContent('review-report-marker');
+    const finalRejectionReport = buildReportContent('final-rejection-marker');
+    setMockScenario([
+      { persona: 'loop-analyzer', status: 'done', content: '[ANALYZE:1]\n\nAnalysis 1.' },
+      { persona: 'loop-analyzer', status: 'done', content: analysisReport },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: '[REVIEW:2]\n\nrejected 1.' },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: reviewReport },
+      { persona: 'loop-analyzer', status: 'done', content: '[ANALYZE:1]\n\nAnalysis 2.' },
+      { persona: 'loop-analyzer', status: 'done', content: analysisReport },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: '[REVIEW:2]\n\nrejected 2.' },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: reviewReport },
+      { persona: 'loop-analyzer', status: 'done', content: '[ANALYZE:1]\n\nAnalysis 3.' },
+      { persona: 'loop-analyzer', status: 'done', content: analysisReport },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: '[REVIEW:2]\n\nrejected 3.' },
+      { persona: 'loop-analysis-reviewer', status: 'done', content: finalRejectionReport },
+    ]);
+
+    const state = await runLoopAnalysis();
+
+    expect(state.status).toBe('aborted');
+    expect(state.iteration).toBe(6);
+    const analyzerCalls = mockCallLog.calls.filter((call) => call.persona === 'loop-analyzer');
+    const reviewerCalls = mockCallLog.calls.filter((call) => call.persona === 'loop-analysis-reviewer');
+    expect(analyzerCalls).toHaveLength(6);
+    expect(reviewerCalls).toHaveLength(6);
+
+    const finalReportPath = reportPath();
+    expect(existsSync(finalReportPath)).toBe(true);
+    const persisted = readFileSync(finalReportPath, 'utf-8');
+    for (const section of REQUIRED_REPORT_SECTIONS) {
+      expect(persisted).toContain(section);
+    }
+    for (const value of REQUIRED_REPORT_VALUES) {
+      expect(persisted).toContain(value);
+    }
+    expect(persisted).toContain('final-rejection-marker');
+  });
+});

--- a/src/__tests__/loopAnalysisHook.test.ts
+++ b/src/__tests__/loopAnalysisHook.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+// Module under test is implemented in the following `implement` step.
+import { onRunTerminal } from '../features/tasks/execute/loopAnalysisHook.js';
+
+/**
+ * Contracts covered (order.md §2/§5, plan.md C2/C5):
+ * - a terminal source run spawns the builtin loop-analysis workflow detached when enabled
+ * - the launch never blocks or fails the source run; the env marker suppresses recursion
+ * - with `output: pr-comment`, the finished analysis run posts its final report content
+ *   to the source branch PR; without a PR the report stays file-only
+ * - PR posting additionally requires the source run's resolved auto_pr marker
+ *   (`TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR`); without it no PR lookup ever happens
+ * - the PR lookup tolerates post-execution PR creation via a bounded retry and gives
+ *   up (file-only) once the bound is exhausted
+ * - the dispatch is claimed per source run, so duplicate terminal paths for the same
+ *   run (force-fail followed by the normal terminal, or a repeated force-fail) spawn
+ *   at most one analysis run
+ * - stale internal markers in the parent environment never leak into the analysis
+ *   child env; only the intended marker values are set
+ *
+ * Every dependency (spawn, env, git provider, config resolver, report reader, sleep,
+ * logger) is a test double, so this stays in the unit gate.
+ */
+
+const PROJECT_CWD = '/project';
+const SOURCE_RUN_ROOT = '/project/.takt/runs/source-run';
+const SOURCE_REPORTS_DIR = '/project/.takt/runs/source-run/reports';
+const ANALYSIS_RUN_ROOT = '/project/.takt/runs/loop-analysis-run';
+const ANALYSIS_REPORTS_DIR = '/project/.takt/runs/loop-analysis-run/reports';
+const SOURCE_BRANCH = 'feature/source';
+const REPORT_CONTENT = '# Loop analysis report\n\nAdopted proposals and rejected proposals.';
+
+function createDeps(overrides: Record<string, unknown> = {}) {
+  const child = { on: vi.fn(), unref: vi.fn() };
+  const deps = {
+    resolveConfig: vi.fn(() => ({ enabled: true, output: 'file' as const })),
+    spawn: vi.fn(() => child),
+    env: {} as Record<string, string | undefined>,
+    gitProvider: {
+      findExistingPr: vi.fn(() => undefined),
+      commentOnPr: vi.fn(() => ({ success: true })),
+    },
+    readFile: vi.fn(() => REPORT_CONTENT),
+    sleep: vi.fn(async () => {}),
+    logger: { error: vi.fn() },
+    claimDispatch: vi.fn((_runRootAbs: string) => true),
+    ...overrides,
+  };
+  return { deps, child };
+}
+
+function createInput(overrides: Record<string, unknown> = {}) {
+  return {
+    projectCwd: PROJECT_CWD,
+    runRootAbs: SOURCE_RUN_ROOT,
+    reportsAbs: SOURCE_REPORTS_DIR,
+    status: 'completed',
+    gitBranch: SOURCE_BRANCH,
+    ...overrides,
+  };
+}
+
+function createAnalysisRunEnv(overrides: Record<string, string | undefined> = {}) {
+  return {
+    TAKT_LOOP_ANALYSIS_RUN: '1',
+    TAKT_LOOP_ANALYSIS_SOURCE_BRANCH: SOURCE_BRANCH,
+    TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR: '1',
+    ...overrides,
+  };
+}
+
+describe('loop-analysis run-terminal hook', () => {
+  it.each(['completed', 'failed', 'cancelled'] as const)(
+    'Given loop_analysis enabled, When a run finishes with status %s, Then the analysis run is spawned detached with the source run markers',
+    async (status) => {
+      const { deps, child } = createDeps();
+
+      await onRunTerminal(deps, createInput({ status }));
+
+      expect(deps.spawn).toHaveBeenCalledTimes(1);
+      const [command, args, options] = deps.spawn.mock.calls[0] ?? [];
+      expect(command).toBe(process.execPath);
+      expect(args[0]).toBe(process.argv[1]);
+      const taskIndex = args.indexOf('--task');
+      expect(taskIndex).toBeGreaterThanOrEqual(0);
+      expect(args[taskIndex + 1]).toContain(SOURCE_RUN_ROOT);
+      const workflowIndex = args.indexOf('--workflow');
+      expect(workflowIndex).toBeGreaterThanOrEqual(0);
+      expect(args[workflowIndex + 1]).toBe('loop-analysis');
+      expect(options).toMatchObject({ cwd: PROJECT_CWD, detached: true, stdio: 'ignore' });
+      expect(options.env).toMatchObject({
+        TAKT_LOOP_ANALYSIS_RUN: '1',
+        TAKT_LOOP_ANALYSIS_SOURCE_RUN_DIR: SOURCE_RUN_ROOT,
+        TAKT_LOOP_ANALYSIS_SOURCE_BRANCH: SOURCE_BRANCH,
+      });
+      expect(child.on).toHaveBeenCalledWith('error', expect.any(Function));
+      expect(child.unref).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('Given loop_analysis enabled, When the analysis run is spawned, Then the child inherits the parent environment', async () => {
+    const { deps } = createDeps({ env: { TAKT_CONFIG_DIR: '/global-config' } });
+
+    await onRunTerminal(deps, createInput());
+
+    const [, , options] = deps.spawn.mock.calls[0] ?? [];
+    expect(options.env.TAKT_CONFIG_DIR).toBe('/global-config');
+  });
+
+  it('Given the source run resolved auto_pr, When the analysis run is spawned, Then the auto-pr marker is handed to the child', async () => {
+    const { deps } = createDeps();
+
+    await onRunTerminal(deps, createInput({ sourceAutoPr: true }));
+
+    const [, , options] = deps.spawn.mock.calls[0] ?? [];
+    expect(options.env).toMatchObject({ TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR: '1' });
+  });
+
+  it('Given the source run did not resolve auto_pr, When the analysis run is spawned, Then the auto-pr marker is absent', async () => {
+    const { deps } = createDeps();
+
+    await onRunTerminal(deps, createInput());
+
+    const [, , options] = deps.spawn.mock.calls[0] ?? [];
+    expect(options.env.TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR).toBeUndefined();
+  });
+
+  it('Given the dispatch claim succeeds, When a run finishes, Then the claim is taken for the source run root before spawning', async () => {
+    const { deps } = createDeps();
+
+    await onRunTerminal(deps, createInput());
+
+    expect(deps.claimDispatch).toHaveBeenCalledWith(SOURCE_RUN_ROOT);
+    expect(deps.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('Given the dispatch was already claimed, When another terminal path fires for the same run, Then no second analysis run is spawned', async () => {
+    const { deps } = createDeps({ claimDispatch: vi.fn(() => false) });
+
+    await expect(onRunTerminal(deps, createInput())).resolves.toBeUndefined();
+
+    expect(deps.claimDispatch).toHaveBeenCalledWith(SOURCE_RUN_ROOT);
+    expect(deps.spawn).not.toHaveBeenCalled();
+  });
+
+  it('Given stale internal markers in the parent environment and no branch or auto_pr input, When the analysis run is spawned, Then the stale markers are absent from the child env', async () => {
+    const { deps } = createDeps({
+      env: {
+        TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR: '1',
+        TAKT_LOOP_ANALYSIS_SOURCE_BRANCH: 'stale/branch',
+        TAKT_CONFIG_DIR: '/global-config',
+      },
+    });
+
+    await onRunTerminal(deps, createInput({ gitBranch: undefined }));
+
+    const [, , options] = deps.spawn.mock.calls[0] ?? [];
+    expect('TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR' in options.env).toBe(false);
+    expect('TAKT_LOOP_ANALYSIS_SOURCE_BRANCH' in options.env).toBe(false);
+    expect(options.env).toMatchObject({
+      TAKT_LOOP_ANALYSIS_RUN: '1',
+      TAKT_LOOP_ANALYSIS_SOURCE_RUN_DIR: SOURCE_RUN_ROOT,
+      TAKT_CONFIG_DIR: '/global-config',
+    });
+  });
+
+  it('Given stale internal markers in the parent environment and branch and auto_pr input, When the analysis run is spawned, Then the input values win over the stale markers', async () => {
+    const { deps } = createDeps({
+      env: {
+        TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR: '0',
+        TAKT_LOOP_ANALYSIS_SOURCE_BRANCH: 'stale/branch',
+      },
+    });
+
+    await onRunTerminal(deps, createInput({ sourceAutoPr: true }));
+
+    const [, , options] = deps.spawn.mock.calls[0] ?? [];
+    expect(options.env).toMatchObject({
+      TAKT_LOOP_ANALYSIS_SOURCE_BRANCH: SOURCE_BRANCH,
+      TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR: '1',
+    });
+  });
+
+  it('Given no loop_analysis section, When a run finishes, Then no analysis run is spawned', async () => {
+    const { deps } = createDeps({ resolveConfig: vi.fn(() => undefined) });
+
+    await onRunTerminal(deps, createInput());
+
+    expect(deps.spawn).not.toHaveBeenCalled();
+  });
+
+  it('Given loop_analysis disabled, When a run finishes, Then no analysis run is spawned', async () => {
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => ({ enabled: false, output: 'file' as const })),
+    });
+
+    await onRunTerminal(deps, createInput());
+
+    expect(deps.spawn).not.toHaveBeenCalled();
+  });
+
+  it('Given the analysis-run marker env is present, When the analysis run itself finishes, Then it does not spawn another analysis run', async () => {
+    const { deps } = createDeps({ env: { TAKT_LOOP_ANALYSIS_RUN: '1' } });
+
+    await onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+    }));
+
+    expect(deps.spawn).not.toHaveBeenCalled();
+    expect(deps.gitProvider.findExistingPr).not.toHaveBeenCalled();
+    expect(deps.gitProvider.commentOnPr).not.toHaveBeenCalled();
+  });
+
+  it('Given spawn throws, When launching the analysis run, Then the failure is logged and not propagated to the source run', async () => {
+    const { deps } = createDeps({
+      spawn: vi.fn(() => {
+        throw new Error('spawn failed');
+      }),
+    });
+
+    await expect(onRunTerminal(deps, createInput())).resolves.toBeUndefined();
+    expect(deps.logger.error).toHaveBeenCalled();
+  });
+
+  it('Given pr-comment output and a finished analysis run whose auto_pr source branch has a PR, When the hook runs, Then the final report content is posted to the source PR unchanged', async () => {
+    const findExistingPr = vi.fn(() => ({ number: 42, url: 'https://example.test/pr/42' }));
+    const commentOnPr = vi.fn(() => ({ success: true }));
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => ({ enabled: true, output: 'pr-comment' as const })),
+      env: createAnalysisRunEnv(),
+      gitProvider: { findExistingPr, commentOnPr },
+    });
+
+    await onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+      gitBranch: 'feature/analysis',
+    }));
+
+    expect(deps.spawn).not.toHaveBeenCalled();
+    expect(deps.readFile).toHaveBeenCalledWith(join(ANALYSIS_REPORTS_DIR, 'loop-analysis.md'));
+    expect(findExistingPr).toHaveBeenCalledWith(SOURCE_BRANCH, PROJECT_CWD);
+    expect(commentOnPr).toHaveBeenCalledWith(42, REPORT_CONTENT, PROJECT_CWD);
+  });
+
+  it('Given pr-comment output but no auto-pr marker, When the analysis run finishes and the source branch has a PR, Then no comment is posted and no PR lookup happens', async () => {
+    const findExistingPr = vi.fn(() => ({ number: 42, url: 'https://example.test/pr/42' }));
+    const commentOnPr = vi.fn(() => ({ success: true }));
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => ({ enabled: true, output: 'pr-comment' as const })),
+      env: {
+        TAKT_LOOP_ANALYSIS_RUN: '1',
+        TAKT_LOOP_ANALYSIS_SOURCE_BRANCH: SOURCE_BRANCH,
+      },
+      gitProvider: { findExistingPr, commentOnPr },
+    });
+
+    await onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+    }));
+
+    expect(findExistingPr).not.toHaveBeenCalled();
+    expect(commentOnPr).not.toHaveBeenCalled();
+  });
+
+  it('Given pr-comment output but no PR for the source branch, When the analysis run finishes, Then the lookup retries within the bound and no comment is posted', async () => {
+    const findExistingPr = vi.fn(() => undefined);
+    const commentOnPr = vi.fn(() => ({ success: true }));
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => ({ enabled: true, output: 'pr-comment' as const })),
+      env: createAnalysisRunEnv(),
+      gitProvider: { findExistingPr, commentOnPr },
+    });
+
+    await expect(onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+    }))).resolves.toBeUndefined();
+    expect(findExistingPr).toHaveBeenCalledTimes(4);
+    expect(deps.sleep).toHaveBeenCalledTimes(3);
+    expect(commentOnPr).not.toHaveBeenCalled();
+  });
+
+  it('Given the source PR appears after the analysis run finishes, When the retry finds it, Then the final report is posted to that PR', async () => {
+    const findExistingPr = vi.fn()
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(undefined)
+      .mockReturnValue({ number: 42, url: 'https://example.test/pr/42' });
+    const commentOnPr = vi.fn(() => ({ success: true }));
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => ({ enabled: true, output: 'pr-comment' as const })),
+      env: createAnalysisRunEnv(),
+      gitProvider: { findExistingPr, commentOnPr },
+    });
+
+    await onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+    }));
+
+    expect(findExistingPr).toHaveBeenCalledTimes(3);
+    expect(deps.sleep).toHaveBeenCalledTimes(2);
+    expect(commentOnPr).toHaveBeenCalledWith(42, REPORT_CONTENT, PROJECT_CWD);
+  });
+
+  it('Given file output, When the analysis run finishes, Then no PR lookup or comment happens', async () => {
+    const findExistingPr = vi.fn(() => ({ number: 42, url: 'https://example.test/pr/42' }));
+    const commentOnPr = vi.fn(() => ({ success: true }));
+    const { deps } = createDeps({
+      env: createAnalysisRunEnv(),
+      gitProvider: { findExistingPr, commentOnPr },
+    });
+
+    await onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+    }));
+
+    expect(findExistingPr).not.toHaveBeenCalled();
+    expect(commentOnPr).not.toHaveBeenCalled();
+  });
+
+  it('Given pr-comment output but no source branch marker, When the analysis run finishes, Then no comment is posted', async () => {
+    const findExistingPr = vi.fn(() => ({ number: 42, url: 'https://example.test/pr/42' }));
+    const commentOnPr = vi.fn(() => ({ success: true }));
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => ({ enabled: true, output: 'pr-comment' as const })),
+      env: {
+        TAKT_LOOP_ANALYSIS_RUN: '1',
+        TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR: '1',
+      },
+      gitProvider: { findExistingPr, commentOnPr },
+    });
+
+    await onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+    }));
+
+    expect(findExistingPr).not.toHaveBeenCalled();
+    expect(commentOnPr).not.toHaveBeenCalled();
+  });
+
+  it('Given pr-comment output, When the source run finishes, Then it launches the analysis run and does not comment on any PR itself', async () => {
+    const findExistingPr = vi.fn(() => ({ number: 42, url: 'https://example.test/pr/42' }));
+    const commentOnPr = vi.fn(() => ({ success: true }));
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => ({ enabled: true, output: 'pr-comment' as const })),
+      gitProvider: { findExistingPr, commentOnPr },
+    });
+
+    await onRunTerminal(deps, createInput());
+
+    expect(deps.spawn).toHaveBeenCalledTimes(1);
+    expect(findExistingPr).not.toHaveBeenCalled();
+    expect(commentOnPr).not.toHaveBeenCalled();
+  });
+
+  it('Given no loop_analysis section, When an analysis run finishes, Then nothing is launched or posted', async () => {
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => undefined),
+      env: createAnalysisRunEnv(),
+    });
+
+    await onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+    }));
+
+    expect(deps.spawn).not.toHaveBeenCalled();
+    expect(deps.gitProvider.findExistingPr).not.toHaveBeenCalled();
+    expect(deps.gitProvider.commentOnPr).not.toHaveBeenCalled();
+  });
+
+  it('Given the report file cannot be read, When posting to the PR, Then the failure is logged and no comment is posted', async () => {
+    const commentOnPr = vi.fn(() => ({ success: true }));
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => ({ enabled: true, output: 'pr-comment' as const })),
+      env: createAnalysisRunEnv(),
+      gitProvider: {
+        findExistingPr: vi.fn(() => ({ number: 42, url: 'https://example.test/pr/42' })),
+        commentOnPr,
+      },
+      readFile: vi.fn(() => {
+        throw new Error('read failed');
+      }),
+    });
+
+    await expect(onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+    }))).resolves.toBeUndefined();
+    expect(commentOnPr).not.toHaveBeenCalled();
+    expect(deps.logger.error).toHaveBeenCalled();
+  });
+
+  it('Given posting the comment throws, When the analysis run finishes, Then the failure is logged and not propagated', async () => {
+    const { deps } = createDeps({
+      resolveConfig: vi.fn(() => ({ enabled: true, output: 'pr-comment' as const })),
+      env: createAnalysisRunEnv(),
+      gitProvider: {
+        findExistingPr: vi.fn(() => ({ number: 42, url: 'https://example.test/pr/42' })),
+        commentOnPr: vi.fn(() => {
+          throw new Error('comment failed');
+        }),
+      },
+    });
+
+    await expect(onRunTerminal(deps, createInput({
+      runRootAbs: ANALYSIS_RUN_ROOT,
+      reportsAbs: ANALYSIS_REPORTS_DIR,
+    }))).resolves.toBeUndefined();
+    expect(deps.logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/pipeline-steps.test.ts
+++ b/src/__tests__/pipeline-steps.test.ts
@@ -7,7 +7,29 @@ vi.mock('../features/pipeline/templateExpander.js', () => ({
     mockExpandPipelineTemplate(...(args as [string, Record<string, string>])),
 }));
 
-const { buildCommitMessage } = await import('../features/pipeline/steps.js');
+const { mockExecuteTask } = vi.hoisted(() => ({
+  mockExecuteTask: vi.fn(),
+}));
+
+vi.mock('../features/tasks/index.js', () => ({
+  executeTask: (...args: unknown[]) => mockExecuteTask(...args),
+  confirmAndCreateWorktree: vi.fn(),
+}));
+
+vi.mock('../shared/ui/index.js', () => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock('../shared/ui/StatusLine.js', () => ({
+  statusLine: {
+    start: vi.fn(),
+    stop: vi.fn(),
+  },
+}));
+
+const { buildCommitMessage, runWorkflow } = await import('../features/pipeline/steps.js');
 
 describe('buildCommitMessage', () => {
   beforeEach(() => {
@@ -34,5 +56,47 @@ describe('buildCommitMessage', () => {
       title: 'Fix pipeline',
       issue: '42',
     });
+  });
+});
+
+describe('runWorkflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Given pipeline options with autoPr, When the workflow runs, Then executeTask receives the resolved autoPr', async () => {
+    mockExecuteTask.mockResolvedValue(true);
+
+    const result = await runWorkflow(
+      '/project',
+      'default',
+      'pipeline task',
+      '/project',
+      { autoPr: true },
+      { execCwd: '/project', isWorktree: false },
+    );
+
+    expect(result).toBe(true);
+    expect(mockExecuteTask).toHaveBeenCalledWith(
+      expect.objectContaining({ autoPr: true }),
+    );
+  });
+
+  it('Given pipeline options without autoPr, When the workflow runs, Then executeTask receives autoPr false', async () => {
+    mockExecuteTask.mockResolvedValue(true);
+
+    const result = await runWorkflow(
+      '/project',
+      'default',
+      'pipeline task',
+      '/project',
+      { autoPr: false },
+      { execCwd: '/project', isWorktree: false },
+    );
+
+    expect(result).toBe(true);
+    expect(mockExecuteTask).toHaveBeenCalledWith(
+      expect.objectContaining({ autoPr: false }),
+    );
   });
 });

--- a/src/__tests__/runtime-provider-loader.test.ts
+++ b/src/__tests__/runtime-provider-loader.test.ts
@@ -352,3 +352,113 @@ describe('runtime-provider loader', () => {
     expect(resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir })).toBeUndefined();
   });
 });
+
+describe('runtime.yaml loop_analysis section', () => {
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'takt-runtime-provider-loader-'));
+    globalDir = join(root, 'global-.takt');
+    projectDir = join(root, 'project-.takt');
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('Given loop_analysis with enabled only, When loading, Then it loads with output defaulting to file and no provider.defaults required', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'loop_analysis:',
+      '  enabled: true',
+    ]);
+    const loaded = loadRuntimeProviderFileAt(join(globalDir, RUNTIME_PROVIDER_FILENAME));
+    expect(loaded?.loop_analysis).toEqual({ enabled: true, output: 'file' });
+  });
+
+  it('Given loop_analysis with an explicit pr-comment output, When loading, Then the explicit output is preserved', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'loop_analysis:',
+      '  enabled: true',
+      '  output: pr-comment',
+    ]);
+    const loaded = loadRuntimeProviderFileAt(join(globalDir, RUNTIME_PROVIDER_FILENAME));
+    expect(loaded?.loop_analysis).toEqual({ enabled: true, output: 'pr-comment' });
+  });
+
+  it('Given loop_analysis explicitly disabled, When loading, Then it loads as disabled', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'loop_analysis:',
+      '  enabled: false',
+    ]);
+    const loaded = loadRuntimeProviderFileAt(join(globalDir, RUNTIME_PROVIDER_FILENAME));
+    expect(loaded?.loop_analysis).toEqual({ enabled: false, output: 'file' });
+  });
+
+  it('Given an unknown loop_analysis output value, When loading, Then it throws naming the failing file path', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'loop_analysis:',
+      '  enabled: true',
+      '  output: slack',
+    ]);
+    const filePath = join(globalDir, RUNTIME_PROVIDER_FILENAME);
+    expect(() => loadRuntimeProviderFileAt(filePath)).toThrow(filePath);
+  });
+
+  it('Given a provider assignment field inside loop_analysis, When loading, Then it throws naming the failing file path', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'loop_analysis:',
+      '  enabled: true',
+      '  provider: mock',
+    ]);
+    const filePath = join(globalDir, RUNTIME_PROVIDER_FILENAME);
+    expect(() => loadRuntimeProviderFileAt(filePath)).toThrow(filePath);
+  });
+
+  it('Given loop_analysis without enabled, When loading, Then it throws naming the failing file path', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'loop_analysis:',
+      '  output: file',
+    ]);
+    const filePath = join(globalDir, RUNTIME_PROVIDER_FILENAME);
+    expect(() => loadRuntimeProviderFileAt(filePath)).toThrow(filePath);
+  });
+
+  it('Given no loop_analysis section, When resolving, Then loop_analysis remains unset', () => {
+    writeRuntimeYaml(projectDir, ['version: 1']);
+    const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
+    expect(resolved).toBeDefined();
+    expect(resolved?.loop_analysis).toBeUndefined();
+  });
+
+  it('Given only the global file has loop_analysis, When resolving with an unrelated project file, Then the global loop_analysis is preserved', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'loop_analysis:',
+      '  enabled: true',
+      '  output: pr-comment',
+    ]);
+    writeRuntimeYaml(projectDir, ['version: 1']);
+    const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
+    expect(resolved?.loop_analysis).toEqual({ enabled: true, output: 'pr-comment' });
+  });
+
+  it('Given both files have loop_analysis, When resolving, Then the project loop_analysis wins', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'loop_analysis:',
+      '  enabled: true',
+    ]);
+    writeRuntimeYaml(projectDir, [
+      'version: 1',
+      'loop_analysis:',
+      '  enabled: false',
+      '  output: pr-comment',
+    ]);
+    const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
+    expect(resolved?.loop_analysis).toEqual({ enabled: false, output: 'pr-comment' });
+  });
+});

--- a/src/__tests__/taskExecution.test.ts
+++ b/src/__tests__/taskExecution.test.ts
@@ -284,6 +284,48 @@ describe('executeAndCompleteTask', () => {
     expect(workflowExecutionOptions.startStep).toBe('delegate');
   });
 
+  it('Given a task whose resolution enables auto_pr, When the task executes, Then the resolved autoPr reaches workflow execution options', async () => {
+    const task = createTask('task-auto-pr-propagation');
+    mockResolveTaskExecution.mockResolvedValueOnce({
+      execCwd: '/project',
+      workflowIdentifier: 'default',
+      isWorktree: false,
+      autoPr: true,
+      draftPr: false,
+      managedPr: false,
+      shouldPublishBranchToOrigin: true,
+      reportDirName: '20260216-task-auto-pr-propagation',
+    });
+
+    await executeAndCompleteTaskWithoutWorkflow(
+      task,
+      createTaskRunnerMock() as never,
+      '/project',
+    );
+
+    expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1);
+    const workflowExecutionOptions = mockExecuteWorkflow.mock.calls[0]?.[3] as {
+      autoPr?: boolean;
+    };
+    expect(workflowExecutionOptions.autoPr).toBe(true);
+  });
+
+  it('Given a task whose resolution disables auto_pr, When the task executes, Then workflow execution options carry autoPr false', async () => {
+    const task = createTask('task-no-auto-pr-propagation');
+
+    await executeAndCompleteTaskWithoutWorkflow(
+      task,
+      createTaskRunnerMock() as never,
+      '/project',
+    );
+
+    expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1);
+    const workflowExecutionOptions = mockExecuteWorkflow.mock.calls[0]?.[3] as {
+      autoPr?: boolean;
+    };
+    expect(workflowExecutionOptions.autoPr).toBe(false);
+  });
+
   it('Given silent task adapter options, When a task is executed, Then outputMode reaches executeWorkflow', async () => {
     const task = createTask('task-silent-output');
 

--- a/src/__tests__/workflowLoader.test.ts
+++ b/src/__tests__/workflowLoader.test.ts
@@ -179,6 +179,12 @@ describe('loadWorkflowByIdentifier', () => {
     expect(workflow!.name).toBe('default');
   });
 
+  it('should load the builtin loop-analysis workflow under the existing loader rules', () => {
+    const workflow = loadWorkflowByIdentifier('loop-analysis', process.cwd());
+    expect(workflow).not.toBeNull();
+    expect(workflow!.name).toBe('loop-analysis');
+  });
+
   it('should load workflow by absolute path', () => {
     const filePath = join(tempDir, 'test.yaml');
     writeFileSync(filePath, SAMPLE_WORKFLOW);

--- a/src/features/pipeline/steps.ts
+++ b/src/features/pipeline/steps.ts
@@ -336,7 +336,7 @@ export async function runWorkflow(
   workflow: string,
   task: string,
   execCwd: string,
-  options: Pick<PipelineExecutionOptions, 'provider' | 'model' | 'autoStrategy' | 'issueNumber' | 'prNumber'>,
+  options: Pick<PipelineExecutionOptions, 'provider' | 'model' | 'autoStrategy' | 'issueNumber' | 'prNumber' | 'autoPr'>,
   context: ExecutionContext,
 ): Promise<boolean> {
   const safeWorkflow = sanitizeTerminalText(workflow);
@@ -358,6 +358,7 @@ export async function runWorkflow(
       workflowIdentifier: workflow,
       projectCwd,
       agentOverrides,
+      autoPr: options.autoPr,
       traceTaskContext: buildPipelineTraceTaskContext(options, context),
       ...(context.prContext ? { prContext: context.prContext } : {}),
     });

--- a/src/features/tasks/execute/loopAnalysisHook.ts
+++ b/src/features/tasks/execute/loopAnalysisHook.ts
@@ -1,0 +1,276 @@
+/**
+ * Post-run loop analysis hook (order.md §2/§5).
+ *
+ * When `loop_analysis.enabled` is set in runtime.yaml, every terminal workflow run
+ * (completed / failed / cancelled) spawns the builtin `loop-analysis` workflow as a
+ * detached child process. The marker env `TAKT_LOOP_ANALYSIS_RUN=1` both suppresses
+ * recursion and routes the analysis run's own termination to the PR-comment path:
+ * with `output: pr-comment`, the finished analysis run posts its final report verbatim
+ * to the source branch's PR. Every failure is logged and swallowed so the source run's
+ * outcome is never affected.
+ *
+ * PR comment eligibility (order.md §5) is gated on the source run's resolved `auto_pr`:
+ * only a source run with `auto_pr: true` hands the `TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR`
+ * marker to the analysis run, and the analysis run posts solely when that marker is
+ * present. The source run creates its PR after the run finishes, so the PR lookup runs
+ * on a bounded retry instead of a single shot; when no PR appears within the bound the
+ * report stays file-only.
+ */
+
+import { spawn } from 'node:child_process';
+import { closeSync, openSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createLogger, getErrorMessage } from '../../../shared/utils/index.js';
+import { getGitProvider, type GitProvider } from '../../../infra/git/index.js';
+import { getGlobalConfigDir, getProjectConfigDir } from '../../../infra/config/paths.js';
+import { resolveRuntimeProviderFile } from '../../../infra/config/runtime-provider/loader.js';
+import type { RuntimeLoopAnalysis } from '../../../infra/config/runtime-provider/schema.js';
+import type { WorkflowRunTerminalStatus } from './workflowTerminalStatus.js';
+
+const LOOP_ANALYSIS_RUN_ENV = 'TAKT_LOOP_ANALYSIS_RUN';
+const LOOP_ANALYSIS_SOURCE_RUN_DIR_ENV = 'TAKT_LOOP_ANALYSIS_SOURCE_RUN_DIR';
+const LOOP_ANALYSIS_SOURCE_BRANCH_ENV = 'TAKT_LOOP_ANALYSIS_SOURCE_BRANCH';
+const LOOP_ANALYSIS_SOURCE_AUTO_PR_ENV = 'TAKT_LOOP_ANALYSIS_SOURCE_AUTO_PR';
+
+const LOOP_ANALYSIS_WORKFLOW_NAME = 'loop-analysis';
+const LOOP_ANALYSIS_REPORT_FILENAME = 'loop-analysis.md';
+
+/** Internal markers that must never leak from the parent environment into the analysis child. */
+const LOOP_ANALYSIS_INTERNAL_MARKER_ENVS = [
+  LOOP_ANALYSIS_RUN_ENV,
+  LOOP_ANALYSIS_SOURCE_RUN_DIR_ENV,
+  LOOP_ANALYSIS_SOURCE_BRANCH_ENV,
+  LOOP_ANALYSIS_SOURCE_AUTO_PR_ENV,
+] as const;
+
+/**
+ * Run-root marker that makes the analysis dispatch at-most-once per run across
+ * processes (normal terminal, bootstrap failure, and force-fail each fire the hook,
+ * possibly from different processes).
+ */
+const LOOP_ANALYSIS_DISPATCH_CLAIM_FILENAME = 'loop-analysis-dispatch.claim';
+
+/** Bounded wait for the source run's post-execution PR creation (initial attempt + 3 retries). */
+const PR_LOOKUP_MAX_ATTEMPTS = 4;
+const PR_LOOKUP_INTERVAL_MS = 20_000;
+
+export interface LoopAnalysisSpawnedProcess {
+  on(event: 'error', listener: (error: Error) => void): unknown;
+  unref(): unknown;
+}
+
+export type LoopAnalysisSpawn = (
+  command: string,
+  args: readonly string[],
+  options: {
+    cwd: string;
+    detached: boolean;
+    stdio: 'ignore';
+    env: Record<string, string | undefined>;
+  },
+) => LoopAnalysisSpawnedProcess;
+
+export interface LoopAnalysisHookDeps {
+  readonly resolveConfig: () => RuntimeLoopAnalysis | undefined;
+  readonly spawn: LoopAnalysisSpawn;
+  readonly env: Record<string, string | undefined>;
+  readonly gitProvider: Pick<GitProvider, 'findExistingPr' | 'commentOnPr'>;
+  readonly readFile: (path: string) => string;
+  readonly sleep: (ms: number) => Promise<void>;
+  readonly logger: { error(message: string, data?: unknown): void };
+  readonly claimDispatch: (runRootAbs: string) => boolean;
+}
+
+export interface LoopAnalysisRunTerminalInput {
+  readonly projectCwd: string;
+  readonly runRootAbs: string;
+  readonly reportsAbs: string;
+  readonly status: WorkflowRunTerminalStatus;
+  readonly gitBranch?: string;
+  readonly sourceAutoPr?: boolean;
+}
+
+export async function onRunTerminal(
+  deps: LoopAnalysisHookDeps,
+  input: LoopAnalysisRunTerminalInput,
+): Promise<void> {
+  try {
+    const config = deps.resolveConfig();
+    if (config === undefined || !config.enabled) {
+      return;
+    }
+    if (deps.env[LOOP_ANALYSIS_RUN_ENV] === '1') {
+      await postAnalysisReportToSourcePr(deps, input, config);
+      return;
+    }
+    launchAnalysisRun(deps, input);
+  } catch (error) {
+    deps.logger.error('Loop analysis hook failed', { error: getErrorMessage(error) });
+  }
+}
+
+function launchAnalysisRun(
+  deps: LoopAnalysisHookDeps,
+  input: LoopAnalysisRunTerminalInput,
+): void {
+  const entrypoint = process.argv[1];
+  if (entrypoint === undefined) {
+    throw new Error('Loop analysis run requires the CLI entrypoint path in process.argv[1]');
+  }
+  if (!deps.claimDispatch(input.runRootAbs)) {
+    return;
+  }
+  const task = buildLoopAnalysisTask(input.runRootAbs);
+  const child = deps.spawn(
+    process.execPath,
+    [entrypoint, '--task', task, '--workflow', LOOP_ANALYSIS_WORKFLOW_NAME],
+    {
+      cwd: input.projectCwd,
+      detached: true,
+      stdio: 'ignore',
+      env: buildAnalysisChildEnv(deps, input),
+    },
+  );
+  // A spawn failure surfaces as an 'error' event; without a listener it would crash the CLI.
+  child.on('error', (error) => {
+    deps.logger.error('Loop analysis run failed to start', { error: error.message });
+  });
+  child.unref();
+}
+
+/**
+ * The child env is a process-boundary input: internal markers are stripped from the
+ * inherited parent environment first, then only the intended values are set, so a
+ * stale `TAKT_LOOP_ANALYSIS_*` marker in the parent can never leak into the analysis
+ * run and flip its post-run PR-comment gate.
+ */
+function buildAnalysisChildEnv(
+  deps: LoopAnalysisHookDeps,
+  input: LoopAnalysisRunTerminalInput,
+): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...deps.env };
+  for (const marker of LOOP_ANALYSIS_INTERNAL_MARKER_ENVS) {
+    delete env[marker];
+  }
+  env[LOOP_ANALYSIS_RUN_ENV] = '1';
+  env[LOOP_ANALYSIS_SOURCE_RUN_DIR_ENV] = input.runRootAbs;
+  if (input.gitBranch !== undefined) {
+    env[LOOP_ANALYSIS_SOURCE_BRANCH_ENV] = input.gitBranch;
+  }
+  if (input.sourceAutoPr === true) {
+    env[LOOP_ANALYSIS_SOURCE_AUTO_PR_ENV] = '1';
+  }
+  return env;
+}
+
+async function postAnalysisReportToSourcePr(
+  deps: LoopAnalysisHookDeps,
+  input: LoopAnalysisRunTerminalInput,
+  config: RuntimeLoopAnalysis,
+): Promise<void> {
+  if (deps.env[LOOP_ANALYSIS_SOURCE_AUTO_PR_ENV] !== '1') {
+    return;
+  }
+  if (config.output !== 'pr-comment') {
+    return;
+  }
+  const sourceBranch = deps.env[LOOP_ANALYSIS_SOURCE_BRANCH_ENV];
+  if (sourceBranch === undefined || sourceBranch === '') {
+    return;
+  }
+  const report = deps.readFile(join(input.reportsAbs, LOOP_ANALYSIS_REPORT_FILENAME));
+  const pr = await findSourcePrWithRetry(deps, sourceBranch, input.projectCwd);
+  if (pr === undefined) {
+    return;
+  }
+  deps.gitProvider.commentOnPr(pr.number, report, input.projectCwd);
+}
+
+/**
+ * The source run creates its PR in post-execution, after the analysis run is already
+ * detached. Poll on a bounded schedule so a PR that appears shortly after the analysis
+ * finishes still receives the report; when no PR appears within the bound, the report
+ * stays file-only.
+ */
+async function findSourcePrWithRetry(
+  deps: LoopAnalysisHookDeps,
+  sourceBranch: string,
+  projectCwd: string,
+): Promise<ReturnType<GitProvider['findExistingPr']>> {
+  for (let attempt = 1; attempt <= PR_LOOKUP_MAX_ATTEMPTS; attempt += 1) {
+    const pr = deps.gitProvider.findExistingPr(sourceBranch, projectCwd);
+    if (pr !== undefined) {
+      return pr;
+    }
+    if (attempt < PR_LOOKUP_MAX_ATTEMPTS) {
+      await deps.sleep(PR_LOOKUP_INTERVAL_MS);
+    }
+  }
+  return undefined;
+}
+
+function buildLoopAnalysisTask(runRootAbs: string): string {
+  return [
+    `Analyze the finished workflow run stored at "${runRootAbs}" and propose prompt improvements that reduce unnecessary loops.`,
+    'The run directory contains the session logs under "logs/" (JSONL), "trace.md", and the reports under "reports/".',
+  ].join('\n');
+}
+
+const log = createLogger('loopAnalysis');
+
+/**
+ * Production dispatch claim: exclusively create a marker file in the source run
+ * directory. The first terminal path to claim wins; every later terminal path for
+ * the same run (any process) observes EEXIST and skips the dispatch. A spawn
+ * failure after a successful claim is not retried (at-most-once); claim failures
+ * other than EEXIST propagate to the hook's catch, which logs and swallows them.
+ */
+export function claimLoopAnalysisDispatch(runRootAbs: string): boolean {
+  try {
+    const fd = openSync(join(runRootAbs, LOOP_ANALYSIS_DISPATCH_CLAIM_FILENAME), 'wx', 0o600);
+    closeSync(fd);
+    return true;
+  } catch (error) {
+    if (isFileSystemErrorWithCode(error, 'EEXIST')) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isFileSystemErrorWithCode(
+  error: unknown,
+  code: string,
+): error is NodeJS.ErrnoException {
+  return error instanceof Error
+    && 'code' in error
+    && error.code === code;
+}
+
+/** Production wiring: build the real dependencies and fire the terminal hook. */
+export async function launchLoopAnalysisOnRunTerminal(
+  input: LoopAnalysisRunTerminalInput,
+): Promise<void> {
+  try {
+    await onRunTerminal(
+      {
+        resolveConfig: () => resolveRuntimeProviderFile({
+          globalConfigDir: getGlobalConfigDir(),
+          projectConfigDir: getProjectConfigDir(input.projectCwd),
+        })?.loop_analysis,
+        spawn,
+        env: process.env,
+        gitProvider: getGitProvider(),
+        readFile: (path) => readFileSync(path, 'utf-8'),
+        sleep: (ms) => new Promise((resolve) => {
+          setTimeout(resolve, ms);
+        }),
+        logger: log,
+        claimDispatch: claimLoopAnalysisDispatch,
+      },
+      input,
+    );
+  } catch (error) {
+    log.error('Loop analysis hook failed', { error: getErrorMessage(error) });
+  }
+}

--- a/src/features/tasks/execute/taskExecution.ts
+++ b/src/features/tasks/execute/taskExecution.ts
@@ -181,6 +181,7 @@ export async function executeTaskAndCompleteWithDetails(
       maxStepsOverride,
       initialIterationOverride,
       currentTaskIssueNumber: issueNumber,
+      autoPr,
       traceTaskMetadata: buildTraceTaskMetadata({
         task,
         taskContent: taskSpec?.taskPrompt ?? task.content,

--- a/src/features/tasks/execute/taskWorkflowExecution.ts
+++ b/src/features/tasks/execute/taskWorkflowExecution.ts
@@ -141,6 +141,7 @@ export async function executeTaskWorkflow(
     maxStepsOverride,
     initialIterationOverride,
     currentTaskIssueNumber,
+    autoPr,
     prContext,
   } = options;
   const traceTaskMetadata = resolveTraceTaskMetadata(options);
@@ -217,6 +218,7 @@ export async function executeTaskWorkflow(
     initialIterationOverride,
     currentTaskIssueNumber,
     traceTaskMetadata,
+    ...(autoPr === undefined ? {} : { autoPr }),
     ...(prContext ? { prContext } : {}),
   });
 }

--- a/src/features/tasks/execute/types.ts
+++ b/src/features/tasks/execute/types.ts
@@ -289,6 +289,8 @@ export interface WorkflowExecutionOptions {
   traceTaskMetadata?: WorkflowTraceTaskMetadata;
   /** Structured PR context used as prompt input. */
   prContext?: PullRequestContext;
+  /** Whether the source run creates a PR after execution (gates loop-analysis PR comments). */
+  autoPr?: boolean;
 }
 
 export interface TaskExecutionOptions {
@@ -377,6 +379,8 @@ export interface ExecuteTaskOptions {
   traceTaskMetadata?: WorkflowTraceTaskMetadata;
   /** Structured PR context used as prompt input. */
   prContext?: PullRequestContext;
+  /** Whether the source run creates a PR after execution (gates loop-analysis PR comments). */
+  autoPr?: boolean;
 }
 
 export interface PipelineExecutionOptions {

--- a/src/features/tasks/execute/workflowExecution.ts
+++ b/src/features/tasks/execute/workflowExecution.ts
@@ -74,6 +74,7 @@ import {
   prepareWorkflowExecutionBundle,
   publishWorkflowExecutionBundle,
 } from './workflowExecutionBundle.js';
+import { launchLoopAnalysisOnRunTerminal } from './loopAnalysisHook.js';
 
 export type { WorkflowExecutionResult, WorkflowExecutionOptions };
 
@@ -265,6 +266,10 @@ async function executeWorkflowInternal(
       projectCwd: options.projectCwd,
       primaryError: bootstrapError,
       resumeLineage,
+      ...(options.traceTaskMetadata?.gitBranch === undefined
+        ? {}
+        : { gitBranch: options.traceTaskMetadata.gitBranch }),
+      sourceAutoPr: options.autoPr === true,
     });
   }
   const executionBundle = loadWorkflowExecutionBundle(activeRun.runPaths);
@@ -555,6 +560,16 @@ async function executeWorkflowInternal(
         );
         finalizationIssues.push(...finalization.issues);
         committedPublication = terminalPublication;
+        await launchLoopAnalysisOnRunTerminal({
+          projectCwd: options.projectCwd,
+          runRootAbs: bootstrap.runPaths.runRootAbs,
+          reportsAbs: bootstrap.runPaths.reportsAbs,
+          status: terminalStatus,
+          ...(options.traceTaskMetadata?.gitBranch === undefined
+            ? {}
+            : { gitBranch: options.traceTaskMetadata.gitBranch }),
+          sourceAutoPr: options.autoPr === true,
+        });
       } catch (error) {
         terminalizationErrors.push(error);
       }
@@ -631,6 +646,8 @@ async function terminalizeBootstrapFailure(input: {
   readonly projectCwd: string;
   readonly primaryError: unknown;
   readonly resumeLineage?: WorkflowExecutionResumeLineage;
+  readonly gitBranch?: string;
+  readonly sourceAutoPr?: boolean;
 }): Promise<never> {
   const reason = getErrorMessage(input.primaryError);
   const finalizationErrors: unknown[] = [];
@@ -704,6 +721,14 @@ async function terminalizeBootstrapFailure(input: {
       reason,
     }, payload);
     finalizationErrors.push(...finalization.issues);
+    await launchLoopAnalysisOnRunTerminal({
+      projectCwd: input.projectCwd,
+      runRootAbs: input.activeRun.runPaths.runRootAbs,
+      reportsAbs: input.activeRun.runPaths.reportsAbs,
+      status: 'failed',
+      ...(input.gitBranch === undefined ? {} : { gitBranch: input.gitBranch }),
+      sourceAutoPr: input.sourceAutoPr === true,
+    });
   } catch (error) {
     finalizationErrors.push(error);
   }

--- a/src/features/tasks/execute/workflowRunForceFailAdapters.ts
+++ b/src/features/tasks/execute/workflowRunForceFailAdapters.ts
@@ -27,11 +27,14 @@ import type {
   WorkflowRunForceFailHandle,
 } from './workflowRunAdmin.js';
 import type { RunFinalization } from './workflowRunExecution.js';
+import { launchLoopAnalysisOnRunTerminal } from './loopAnalysisHook.js';
 
 interface TaskRunForceFailAdapterContext
   extends WorkflowRunForceFailContext {
   readonly projectDir: string;
   readonly cwd: string;
+  readonly gitBranch?: string;
+  readonly sourceAutoPr?: boolean;
 }
 
 const RUN_LOG_SIDECAR_FILE_SUFFIXES = Object.freeze([
@@ -68,6 +71,16 @@ class FileTaskRunForceFailStorage implements WorkflowRunForceFailHandle {
       iteration: payload.iterations,
       reason,
     }, payload);
+    await launchLoopAnalysisOnRunTerminal({
+      projectCwd: this.context.projectDir,
+      runRootAbs: runPaths.runRootAbs,
+      reportsAbs: runPaths.reportsAbs,
+      status: 'failed',
+      ...(this.context.gitBranch === undefined
+        ? {}
+        : { gitBranch: this.context.gitBranch }),
+      sourceAutoPr: this.context.sourceAutoPr === true,
+    });
     return result;
   }
 }

--- a/src/features/tasks/list/taskRunForceFailStorage.ts
+++ b/src/features/tasks/list/taskRunForceFailStorage.ts
@@ -4,6 +4,7 @@ import {
   type RunMeta,
 } from '../../../core/workflow/run/run-meta.js';
 import { resolveCloneBaseDir } from '../../../infra/task/clone.js';
+import { resolveWorkflowConfigValue } from '../../../infra/config/index.js';
 import type { TaskListItem } from '../../../infra/task/types.js';
 import { isPathInside } from '../../../shared/utils/index.js';
 import {
@@ -32,6 +33,10 @@ export function createTaskRunForceFailStorage(input: {
     meta: run.meta,
     cwd: run.cwd,
     projectDir: input.projectDir,
+    ...(input.task.branch === undefined ? {} : { gitBranch: input.task.branch }),
+    sourceAutoPr: input.task.data?.auto_pr
+      ?? resolveWorkflowConfigValue(input.projectDir, 'autoPr')
+      ?? false,
   });
 }
 

--- a/src/infra/config/runtime-provider/loader.ts
+++ b/src/infra/config/runtime-provider/loader.ts
@@ -86,16 +86,13 @@ function mergeRuntimeProviderFiles(
         enabled: global.companion?.enabled !== false
           && project.companion?.enabled !== false,
       };
-  return provider
-    ? {
-        version: RUNTIME_PROVIDER_VERSION,
-        ...(companion === undefined ? {} : { companion }),
-        provider,
-      }
-    : {
-        version: RUNTIME_PROVIDER_VERSION,
-        ...(companion === undefined ? {} : { companion }),
-      };
+  const loopAnalysis = project.loop_analysis ?? global.loop_analysis;
+  return {
+    version: RUNTIME_PROVIDER_VERSION,
+    ...(companion === undefined ? {} : { companion }),
+    ...(loopAnalysis === undefined ? {} : { loop_analysis: loopAnalysis }),
+    ...(provider === undefined ? {} : { provider }),
+  };
 }
 
 function mergeProviderSections(

--- a/src/infra/config/runtime-provider/schema.ts
+++ b/src/infra/config/runtime-provider/schema.ts
@@ -84,6 +84,17 @@ const RuntimeCompanionPolicySchema = z
   })
   .strict();
 
+/**
+ * Post-run loop analysis. Provider assignment is deliberately absent — it stays with
+ * the existing routing targets (provider.targets.steps / personas / internal agents).
+ */
+const RuntimeLoopAnalysisSchema = z
+  .object({
+    enabled: z.boolean(),
+    output: z.enum(['file', 'pr-comment']).default('file'),
+  })
+  .strict();
+
 /** An auto-routing pool candidate references a profile; it must not inline provider/model. */
 const CandidateSchema = z
   .object({
@@ -236,6 +247,7 @@ export const RuntimeProviderFileSchema = z
   .object({
     version: z.literal(RUNTIME_PROVIDER_VERSION),
     companion: RuntimeCompanionPolicySchema.optional(),
+    loop_analysis: RuntimeLoopAnalysisSchema.optional(),
     provider: ProviderSectionSchema.optional(),
   })
   .strict()
@@ -251,6 +263,7 @@ export const RuntimeProviderFileSchema = z
   });
 
 export type RuntimeProviderFile = z.infer<typeof RuntimeProviderFileSchema>;
+export type RuntimeLoopAnalysis = z.infer<typeof RuntimeLoopAnalysisSchema>;
 export type RuntimeProviderSection = z.infer<typeof ProviderSectionSchema>;
 export type RuntimeProviderProfile = z.infer<typeof ProfileSchema>;
 export type RuntimeProviderAssignment = z.infer<typeof AssignmentSchema>;


### PR DESCRIPTION
## Summary

# タスク指示書: ループ分析モード（post-run loop analysis）の実装

## 目的

ワークフロー実行完了後に、run の JSONL ログ・レポートを分析し、ループ削減のためのプロンプト改善提案を自動生成する opt-in 機能を実装する。`runtime.yaml` に設定がある場合のみ、終了したすべての run（成功・失敗・中断含む）で非同期に自動起動する。

---

## 優先度: 高

### 1. runtime.yaml スキーマ拡張

**対象:** runtime.yaml ローダー・スキーマ（`src/core/runtime/` 配下の runtime provider loader、および関連スキーマ定義。`src/__tests__/runtime-provider-loader.test.ts` が参照するローダー）

- トップレベルに新セクション `loop_analysis` を追加する:
  ```yaml
  loop_analysis:
    enabled: true
    output: file        # file | pr-comment（既定: file）
  ```
- 未設定時は従来どおり何も起きない（完全な後方互換）
- バリデーション: 未知の `output` 値はロード時エラーにする
- provider 割り当て自体は既存の routing（`provider.targets.steps` / `personas` / internal agent seat）に委ね、`loop_analysis` セクションには provider 系フィールドを持たせない

### 2. 完了後フック（自動起動の仕組み）

**対象:** ワークフロー実行の終了経路（run 終了を確定させる箇所。`src/features/tasks/execute/` および `src/core/workflow/` の実行完了ハンドリング）

- run が終了状態（成功・失敗・中断のいずれ）に遷移した時点で、`loop_analysis.enabled` が有効なら分析ワークフロー run を非同期で起動する
- 分析 run は元 run の結果を待たせず、元 run の終了処理をブロックしない
- 分析 run の起動失敗は元 run の成否に影響させない（ログに記録して握りつぶす）
- 分析 run 自体の終了時に再度分析を起動しない（無限連鎖の防止）

### 3. 分析ワークフロー（builtin 同梱）

**対象:** `builtins/en/workflows/`（新規 YAML 追加。例: `loop-analysis.yaml`）、必要に応じて `builtins/en/steps/`・`builtins/en/facet-pools/`

- 2段構成: 分析エージェント → レビューエージェント
- レビューで reject された提案は分析エージェントへ差し戻すフィードバックループ（上限つき、既定2回程度）
- レビューの目的は「エージェントが過剰に特化した提案をしがちな問題の排除」とプロンプトに明記する
- 入力: 元 run の `.takt/runs/<run>/` 配下のセッションログ JSONL（`logs/session-*.jsonl`）、`trace.md`、`monitor.json` 等の既存レポート。元 run の識別情報をワークフローへ引き渡す経路を用意する
- 分析エージェントのプロンプトは**汎用的に**書く。TAKT スタイルガイドへの参照・準拠は含めない
- 提案の出力形式: 具体的な facet ファイル（persona / policy / knowledge / instruction / output-contract）のパスを特定し、修正案（追記・変更内容）つき
- workflow YAML はローダーのルールに厳密準拠すること:
  - provider / model / provider_options を YAML に書かない（違反時は「configure provider/model/options in runtime.yaml」系エラーで reject される。`src/__tests__/models.test.ts:350`、`src/__tests__/workflowLoader.test.ts:191` 参照）
  - rules は `when(...)` 形式等の既存スキーマに従う
- 既存 builtin の `default` として扱える品質にする（まずは TAKT 専用として同梱）

### 4. レポート出力

**対象:** 既存の report 出力経路（`src/core/workflow/report-phase-runner.ts`。`.takt/runs/<run>/reports/` への output contract 保存は既存仕組みをそのまま利用。新規の配置仕組みは作らない）

- 分析レポートは常に分析 run の `reports/` に output contract 経由でファイル保存する
- レポートには採用された提案（facet パス＋修正案）と、棄却された提案＋棄却理由を含める

### 5. PR コメント出力

**対象:** `src/features/tasks/execute/postExecution.ts` 周辺、および `src/infra/git/` の GitProvider（`commentOnPr` は既存。`src/infra/git/types.ts:151`、`src/infra/github/pr.ts:88`）

- `loop_analysis.output: pr-comment` かつ元の run が auto_pr 有効で PR が存在する場合、最終レポートファイルの内容をそのまま元 run の PR に `commentOnPr` で投稿する
- ファイルとコメントは同一内容にする（別フォーマットを作らない）
- 元 run に PR が存在しない場合はファイルのみ（コメント投稿しない。フォールバック分岐は不要）
- 現状 PR 本文の `{report}` は固定プレースホルダ（`postExecution.ts:125`）であり、実レポートを PR に載せる経路は本機能で新設するが、PR 本文生成の既存挙動は変更しない

---

## 優先度: 中

### 6. テスト

**対象:** `src/__tests__/`

- runtime.yaml `loop_analysis` セクションのスキーマテスト（有効値・無効値・未設定）
- 完了フックのユニット/IT: enabled 時に分析 run が起動すること、disabled/未設定時に起動しないこと、失敗・中断 run でも起動すること、分析 run の終了では再帰起動しないこと
- PR コメント経路: pr-comment モード＋PR 存在時に `commentOnPr` が最終レポート内容で呼ばれること、PR 非存在時に呼ばれないこと
- 分類契約: IT を追加・変更した場合は `npm test -- src/__tests__/releaseVerificationWiring.test.ts` を単独実行
- heavy IT を追加した場合は handoff 前に対象テストを単独実行

### 7. ドキュメント

**対象:** `docs/`

- `loop_analysis` の設定項目、起動条件、出力先（file / pr-comment の挙動差）を記載

---

## 確認方法

1. `npm run build && npm run lint && npm test` が通ること
2. `npm run test:it` が通ること
3. 動作確認: `.takt/runtime.yaml` に `loop_analysis: { enabled: true }` を置いたプロジェクトで任意のワークフローを実行し、終了後に分析 run が非同期起動し、分析 run の `reports/` にレポートが生成されること
4. `output: pr-comment` で auto_pr run の場合、元 PR にレポート内容のコメントが投稿されること

## 受け入れ条件（Gherkin）

```gherkin
Feature: ループ分析モード（post-run loop analysis）

  Scenario: 未設定時は分析が起動しない
    Given runtime.yaml に loop_analysis 設定がない
    When ワークフローの run が終了する
    Then 分析ワークフローは起動しない

  Scenario: 有効時は終了したすべての run で分析が自動起動する
    Given runtime.yaml に loop_analysis.enabled: true が設定されている
    When ワークフローの run が成功・失敗・中断のいずれかで終了する
    Then 分析ワークフローが非同期で自動起動する

  Scenario: 分析結果は常にファイルに残る
    Given 分析ワークフローが実行された
    When 分析が完了する
    Then 分析 run の .takt/runs/<run>/reports/ にレポートファイルが保存されている
    And レポートには具体的な facet ファイルパスと修正案が含まれる

  Scenario: レビューで reject された提案は差し戻される
    Given 分析エージェントが提案を出力した
    When レビューエージェントが提案を reject する
    Then 上限回数まで分析エージェントへ差し戻され再分析される

  Scenario: pr-comment モードで auto_pr run の場合 PR にコメントされる
    Given loop_analysis.output: pr-comment が設定されている
    And 元の run が auto_pr 有効で PR が存在する
    When 分析が完了する
    Then 最終レポートと同一内容が元 run の PR にコメント投稿される

  Scenario: pr-comment モードでも非 auto_pr run はファイルのみ
    Given loop_analysis.output: pr-comment が設定されている
    And 元の run に PR が存在しない
    When 分析が完了する
    Then レポートはファイルにのみ保存され、PR コメントは投稿されない
```

## スコープ外（ユーザー明示）

- 実行中の並走レビュー（companion 相当の仕組みの変更）
- 提案の自動適用（採否は人間が判断）
- 分析エージェントのプロンプトでの TAKT スタイルガイド参照（含めない）

## Open Questions

- 元 run の識別情報（run ディレクトリパス等）を分析ワークフローへ引き渡す既存の受け渡し機構の有無（なければ完了フック側で変数注入する実装を追加する）
- `pr-comment` 投稿対象 PR の特定方法（元 run のブランチから `findExistingPr` で辿るのが既存実装と整合するかは実装時に確認）

## Execution Report

Workflow `takt-default` completed successfully.

Closes #1430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ワークフロー完了後に不要な反復を分析し、改善案をレポート化できるようになりました。
  * 分析結果をファイルへ保存し、条件に応じてPRへコメントできるようになりました。
  * 分析内容をレビューし、過度に特化した提案や根拠のない提案を除外します。
  * `loop_analysis` 設定で機能の有効化と出力形式を選択できます。

* **改善**
  * 成功・失敗・キャンセルを含む各終了状態で分析を実行します。
  * 同一実行の重複分析を防止し、分析起動時の失敗が元の実行結果へ影響しないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->