### PR TITLE
fix(test): promptEvalProbeLifecycleのWindowsフレークを解消しプローブの報告とcleanupを分離する

### DIFF
--- a/src/__tests__/promptEvalProbeLifecycle.test.ts
+++ b/src/__tests__/promptEvalProbeLifecycle.test.ts
@@ -19,8 +19,13 @@ import {
   parseProbeResult,
   runProbeProcess,
 } from '../../tools/opencode-probe/probe-process.mjs';
-import { terminateWindowsProcessTree } from '../../tools/opencode-probe/process-tree.mjs';
 import {
+  PROCESS_TREE_CLEANUP_GRACE_MS,
+  startProcessTreeCleanup,
+  terminateWindowsProcessTree,
+} from '../../tools/opencode-probe/process-tree.mjs';
+import {
+  runSmokeBatch,
   runSmokeScript,
   type SmokeBatchResult,
 } from '../../tools/opencode-probe/smoke-process.mjs';
@@ -36,12 +41,111 @@ interface SmokeFixtureCase {
   args: string[];
 }
 
+function expectWindowsCommandTimeoutsWithinGrace(executeFile: { mock: { calls: unknown[][] } }) {
+  const timeouts = executeFile.mock.calls.flatMap((call) => {
+    const options = call[2];
+    if (typeof options !== 'object' || options === null || !('timeout' in options)) {
+      return [];
+    }
+    return typeof options.timeout === 'number' ? [options.timeout] : [];
+  });
+  expect(timeouts.length).toBeGreaterThan(0);
+  expect(timeouts.every((timeout) => timeout > 0 && timeout <= PROCESS_TREE_CLEANUP_GRACE_MS)).toBe(true);
+}
+
+function captureCleanupWarning() {
+  const writes: string[] = [];
+  let flushed = false;
+  let resolveWriteStarted: (() => void) | undefined;
+  const writeStarted = new Promise<void>((resolve) => {
+    resolveWriteStarted = resolve;
+  });
+  let flushCallback: ((error?: Error | null) => void) | undefined;
+  const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation((
+    ((
+      chunk: string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+      callback?: (error?: Error | null) => void,
+    ) => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+      flushCallback = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
+      resolveWriteStarted?.();
+      return true;
+    }) as typeof process.stderr.write
+  ));
+
+  return {
+    writes,
+    writeStarted,
+    flush: () => {
+      if (flushCallback === undefined) {
+        throw new Error('Cleanup warning write callback was not registered');
+      }
+      flushed = true;
+      flushCallback();
+    },
+    wasFlushed: () => flushed,
+    restore: () => stderrWrite.mockRestore(),
+  };
+}
+
+async function expectCleanupFailureAfterWarningFlush(
+  cleanup: Promise<void>,
+  warning: ReturnType<typeof captureCleanupWarning>,
+  expectedError: string | RegExp,
+  expectedWarning: string | RegExp,
+) {
+  let settled = false;
+  const observed = cleanup.finally(() => {
+    settled = true;
+  });
+  await warning.writeStarted;
+  await Promise.resolve();
+  expect(settled).toBe(false);
+  warning.flush();
+  await expect(observed).rejects.toThrow(expectedError);
+  expect(warning.wasFlushed()).toBe(true);
+  expect(warning.writes.join('')).toMatch(expectedWarning);
+}
+
 // Windows CI boots node children slowly enough that a 500ms phase budget can
 // expire before the probe finishes starting (it then never spawns its
 // grandchild or prints its PIDs), so give each phase extra headroom there.
 const PROBE_PHASE_BUDGET_MS = process.platform === 'win32' ? 2_000 : 500;
-// The owned entrypoint adds a second Node process hop before worker cleanup.
-const OWNED_ENTRYPOINT_TIMEOUT_MS = process.platform === 'win32' ? 10_000 : 2_000;
+const INNER_PROBE_STARTUP_TIMEOUT_MS = 2_000;
+const INNER_PROBE_EXECUTION_TIMEOUT_MS = 2_000;
+const INNER_PROBE_CLEANUP_TIMEOUT_MS = 150;
+const INNER_PROBE_TIMEOUT_BUDGET_MS = INNER_PROBE_STARTUP_TIMEOUT_MS
+  + INNER_PROBE_EXECUTION_TIMEOUT_MS
+  + INNER_PROBE_CLEANUP_TIMEOUT_MS;
+const OWNED_ENTRYPOINT_STARTUP_MARGIN_MS = process.platform === 'win32' ? 5_000 : 1_000;
+const OWNED_ENTRYPOINT_REPORT_FLUSH_MARGIN_MS = process.platform === 'win32' ? 5_000 : 2_000;
+const OWNED_ENTRYPOINT_TIMEOUT_MS = INNER_PROBE_TIMEOUT_BUDGET_MS
+  + OWNED_ENTRYPOINT_STARTUP_MARGIN_MS
+  + OWNED_ENTRYPOINT_REPORT_FLUSH_MARGIN_MS
+  + PROCESS_TREE_CLEANUP_GRACE_MS;
+const OUTER_PROBE_TIMEOUT_MS = INNER_PROBE_TIMEOUT_BUDGET_MS
+  + OWNED_ENTRYPOINT_STARTUP_MARGIN_MS
+  + PROCESS_TREE_CLEANUP_GRACE_MS;
+const SMOKE_BATCH_CASE_TIMEOUT_MS = 5_000;
+const SMOKE_BATCH_FIXTURE_STARTUP_MARGIN_MS = process.platform === 'win32' ? 5_000 : 1_000;
+const SMOKE_BATCH_CASE_SPAWN_MARGIN_MS = process.platform === 'win32' ? 2_000 : 1_000;
+const SMOKE_BATCH_DISPATCH_MARGIN_MS = 250;
+
+function smokeBatchTimeoutMs(caseCount: number) {
+  const dispatchedCaseCount = Math.max(1, caseCount);
+  const caseBudget = caseCount * (
+    SMOKE_BATCH_CASE_TIMEOUT_MS
+    + SMOKE_BATCH_CASE_SPAWN_MARGIN_MS
+    + PROCESS_TREE_CLEANUP_GRACE_MS
+  );
+  return Math.max(
+    SMOKE_BATCH_FIXTURE_STARTUP_MARGIN_MS + SMOKE_BATCH_DISPATCH_MARGIN_MS,
+    SMOKE_BATCH_FIXTURE_STARTUP_MARGIN_MS
+      + caseBudget
+      + dispatchedCaseCount * SMOKE_BATCH_DISPATCH_MARGIN_MS,
+  );
+}
 
 const smokeBatchFixture = fileURLToPath(
   new URL('../../tools/opencode-probe/fixtures/run-smoke-batch.mjs', import.meta.url),
@@ -58,8 +162,10 @@ describe('prompt eval probe lifecycle', () => {
     const testRoot = mkdtempSync(join(tmpdir(), 'takt-smoke-batch-fixture-'));
     temporaryDirectories.push(testRoot);
     const configPath = join(testRoot, 'smoke-cases.json');
-    writeFileSync(configPath, JSON.stringify({ cases }), 'utf8');
-    return runSmokeScript(smokeBatchFixture, [configPath], process.env, { timeoutMs: 10_000 });
+    writeFileSync(configPath, JSON.stringify({ cases, caseTimeoutMs: SMOKE_BATCH_CASE_TIMEOUT_MS }), 'utf8');
+    return runSmokeScript(smokeBatchFixture, [configPath], process.env, {
+      timeoutMs: smokeBatchTimeoutMs(cases.length),
+    });
   }
 
   function parseSmokeBatchResult(output: string): SmokeBatchResult {
@@ -450,29 +556,85 @@ describe('prompt eval probe lifecycle', () => {
     expect(executeFile).toHaveBeenCalledWith(
       'taskkill',
       ['/PID', '4321', '/T', '/F'],
-      { timeout: 5_000 },
+      expect.objectContaining({ timeout: expect.any(Number) }),
     );
+    expectWindowsCommandTimeoutsWithinGrace(executeFile);
+  });
+
+  it('should reject process-tree cleanup failures after flushing the warning', async () => {
+    const warning = captureCleanupWarning();
+
+    try {
+      await expectCleanupFailureAfterWarningFlush(
+        startProcessTreeCleanup(undefined),
+        warning,
+        /Child process did not expose a PID/,
+        /Warning: Process tree cleanup warning: Child process did not expose a PID/,
+      );
+    } finally {
+      warning.restore();
+    }
   });
 
   it.each([
     ['PowerShell fails', () => { throw new Error('PowerShell failed'); }],
     ['PowerShell returns malformed JSON', () => ({ stdout: '{invalid' })],
-  ])('should still taskkill the root when %s during the initial snapshot', async (_scenario, query) => {
+  ])('should warn after still taskkilling the root when %s during the initial snapshot', async (_scenario, query) => {
     const executeFile = vi.fn(async (file: string) => (
       file === 'powershell.exe' ? query() : undefined
     ));
+    const warning = captureCleanupWarning();
 
-    await expect(terminateWindowsProcessTree(4321, executeFile)).resolves.toBeUndefined();
+    try {
+      await expectCleanupFailureAfterWarningFlush(
+        terminateWindowsProcessTree(4321, executeFile),
+        warning,
+        /WMI process snapshot unavailable/,
+        /Warning: Process tree cleanup warning: .*WMI process snapshot unavailable/,
+      );
+    } finally {
+      warning.restore();
+    }
 
     expect(executeFile).toHaveBeenCalledWith(
       'taskkill',
       ['/PID', '4321', '/T', '/F'],
-      { timeout: 5_000 },
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+    expectWindowsCommandTimeoutsWithinGrace(executeFile);
+  });
+
+  it('should invoke taskkill after the initial WMI deadline is exhausted', async () => {
+    const now = vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValue(10_000);
+    const executeFile = vi.fn(async (file: string) => {
+      if (file === 'taskkill') return undefined;
+      throw new Error('WMI query should not start after the deadline');
+    });
+    const warning = captureCleanupWarning();
+
+    try {
+      await expectCleanupFailureAfterWarningFlush(
+        terminateWindowsProcessTree(4321, executeFile),
+        warning,
+        /WMI process snapshot deadline exceeded/,
+        /Warning: Process tree cleanup warning: .*WMI process snapshot deadline exceeded/,
+      );
+    } finally {
+      warning.restore();
+      now.mockRestore();
+    }
+
+    expect(executeFile).toHaveBeenCalledWith(
+      'taskkill',
+      ['/PID', '4321', '/T', '/F'],
+      expect.objectContaining({ timeout: expect.any(Number) }),
     );
   });
 
   it.each(['descendant identity', 'final remaining-process'])(
-    'should keep taskkill best-effort when the %s query returns malformed JSON',
+    'should warn after taskkill when the %s query returns malformed JSON',
     async (failureStage) => {
       let fullSnapshot = 0;
       const executeFile = vi.fn(async (file: string, args: readonly string[]) => {
@@ -498,18 +660,29 @@ describe('prompt eval probe lifecycle', () => {
           ? { stdout: '{invalid' }
           : { stdout: '[]' };
       });
+      const warning = captureCleanupWarning();
 
-      await expect(terminateWindowsProcessTree(4321, executeFile)).resolves.toBeUndefined();
+      try {
+        await expectCleanupFailureAfterWarningFlush(
+          terminateWindowsProcessTree(4321, executeFile),
+          warning,
+          /WMI (?:identity query.*|final process query) unavailable/,
+          /Warning: Process tree cleanup warning: .*WMI (?:identity query.*|final process query) unavailable/,
+        );
+      } finally {
+        warning.restore();
+      }
 
       expect(executeFile).toHaveBeenCalledWith(
         'taskkill',
         ['/PID', '5001', '/T', '/F'],
-        { timeout: 5_000 },
+        expect.objectContaining({ timeout: expect.any(Number) }),
       );
+      expectWindowsCommandTimeoutsWithinGrace(executeFile);
     },
   );
 
-  it('should terminate recorded Windows descendants after the parent has already exited', async () => {
+  it('should warn after terminating recorded Windows descendants when the parent has already exited', async () => {
     let fullSnapshot = 0;
     const executeFile = vi.fn(async (file: string, args: readonly string[]) => {
       if (file === 'powershell.exe') {
@@ -534,22 +707,33 @@ describe('prompt eval probe lifecycle', () => {
       }
       return undefined;
     });
+    const warning = captureCleanupWarning();
 
-    await terminateWindowsProcessTree(4321, executeFile);
+    try {
+      await expectCleanupFailureAfterWarningFlush(
+        terminateWindowsProcessTree(4321, executeFile),
+        warning,
+        /taskkill root failed/,
+        /Warning: Process tree cleanup warning: .*taskkill root failed/,
+      );
+    } finally {
+      warning.restore();
+    }
 
     expect(executeFile).toHaveBeenCalledWith(
       'taskkill',
       ['/PID', '5002', '/T', '/F'],
-      { timeout: 5_000 },
+      expect.objectContaining({ timeout: expect.any(Number) }),
     );
     expect(executeFile).toHaveBeenCalledWith(
       'taskkill',
       ['/PID', '5001', '/T', '/F'],
-      { timeout: 5_000 },
+      expect.objectContaining({ timeout: expect.any(Number) }),
     );
+    expectWindowsCommandTimeoutsWithinGrace(executeFile);
   });
 
-  it('should ignore taskkill failure when a descendant PID is later reused', async () => {
+  it('should warn about taskkill failure even when a descendant PID is later reused', async () => {
     let fullSnapshot = 0;
     const executeFile = vi.fn(async (file: string, args: readonly string[]) => {
       if (file === 'taskkill' && args[1] === '5001') {
@@ -575,14 +759,25 @@ describe('prompt eval probe lifecycle', () => {
           CreationDate: 'created-reused',
         }) };
     });
+    const warning = captureCleanupWarning();
 
-    await expect(terminateWindowsProcessTree(4321, executeFile)).resolves.toBeUndefined();
+    try {
+      await expectCleanupFailureAfterWarningFlush(
+        terminateWindowsProcessTree(4321, executeFile),
+        warning,
+        /taskkill descendant 5001 failed/,
+        /Warning: Process tree cleanup warning: .*taskkill descendant 5001 failed/,
+      );
+    } finally {
+      warning.restore();
+    }
 
     expect(executeFile).toHaveBeenCalledWith(
       'taskkill',
       ['/PID', '5001', '/T', '/F'],
-      { timeout: 5_000 },
+      expect.objectContaining({ timeout: expect.any(Number) }),
     );
+    expectWindowsCommandTimeoutsWithinGrace(executeFile);
   });
 
   it('should throw when a snapshotted Windows process remains alive', async () => {
@@ -597,10 +792,35 @@ describe('prompt eval probe lifecycle', () => {
       }
       return { stdout: processSnapshot };
     });
+    const warning = captureCleanupWarning();
 
-    await expect(terminateWindowsProcessTree(4321, executeFile)).rejects.toThrow(
-      'Windows process tree 4321 retained processes: 4321',
-    );
+    try {
+      await expectCleanupFailureAfterWarningFlush(
+        terminateWindowsProcessTree(4321, executeFile),
+        warning,
+        'Windows process tree 4321 retained processes: 4321',
+        /Warning: Process tree cleanup warning: .*Windows process tree 4321 retained processes: 4321/,
+      );
+    } finally {
+      warning.restore();
+    }
+  });
+
+  it('should wait for a Windows process tree to disappear after taskkill', async () => {
+    let fullSnapshot = 0;
+    const processSnapshot = JSON.stringify({
+      ProcessId: 4321,
+      ParentProcessId: 1000,
+      CreationDate: 'created-root',
+    });
+    const executeFile = vi.fn(async (file: string) => {
+      if (file === 'taskkill') return undefined;
+      fullSnapshot += 1;
+      return { stdout: fullSnapshot <= 2 ? processSnapshot : '[]' };
+    });
+
+    await expect(terminateWindowsProcessTree(4321, executeFile)).resolves.toBeUndefined();
+    expect(fullSnapshot).toBeGreaterThanOrEqual(3);
   });
 
   it('should stop the timed-out child and grandchild before removing the parent-owned workspace', async () => {
@@ -627,7 +847,11 @@ describe('prompt eval probe lifecycle', () => {
           env: process.env,
         });
       } catch (error) {
-        const timeoutError = error as Error & { killed?: boolean; stdout?: string };
+        const timeoutError = error as Error & {
+          killed?: boolean;
+          stdout?: string;
+          cleanup: Promise<void>;
+        };
         const pids = JSON.parse(timeoutError.stdout?.trim() ?? '{}') as {
           childPid?: number;
           grandchildPid?: number;
@@ -637,6 +861,7 @@ describe('prompt eval probe lifecycle', () => {
         if (childPid > 0) probeProcessIds.push(childPid);
         if (grandchildPid > 0) probeProcessIds.push(grandchildPid);
         expect(timeoutError.killed).toBe(true);
+        await timeoutError.cleanup;
         throw error;
       }
     });
@@ -650,9 +875,11 @@ describe('prompt eval probe lifecycle', () => {
     expect(() => process.kill(grandchildPid, 0)).toThrow();
   });
 
-  it('should reject a probe that reports a result but does not exit during cleanup', async () => {
+  it('should return a probe report before intentionally delayed cleanup finishes', async () => {
+    const startedAt = Date.now();
     const execution = runProbeProcess('-e', [
       [
+        "process.on('SIGTERM', () => {})",
         "console.log('PROBE_READY')",
         "console.log('PROBE_CLEANUP_START')",
         "console.log('PROBE_RESULT {}')",
@@ -665,11 +892,19 @@ describe('prompt eval probe lifecycle', () => {
       env: process.env,
     });
 
-    await expect(execution).rejects.toMatchObject({
-      code: 'ETIMEDOUT',
-      phase: 'cleanup',
-      killed: true,
+    const result = await execution;
+    let cleanupFinished = false;
+    result.cleanup.then(() => {
+      cleanupFinished = true;
     });
+    await Promise.resolve();
+    if (process.platform !== 'win32') {
+      expect(cleanupFinished).toBe(false);
+    }
+    expect(Date.now() - startedAt).toBeLessThan(PROCESS_TREE_CLEANUP_GRACE_MS);
+    expect(result.stdout).toContain('PROBE_RESULT {}');
+    await result.cleanup;
+    expect(cleanupFinished).toBe(true);
   });
 
   it('should terminate child descendants after the probe exits successfully', async () => {
@@ -689,6 +924,7 @@ describe('prompt eval probe lifecycle', () => {
       cleanupTimeout: 10_000,
       env: process.env,
     });
+    await result.cleanup;
     const firstLine = result.stdout.split('\n')[0] ?? '{}';
     const pids = JSON.parse(firstLine) as { childPid: number; grandchildPid: number };
 
@@ -713,6 +949,26 @@ describe('prompt eval probe lifecycle', () => {
     });
 
     expect(result.stdout).toContain('PROBE_RESULT {}\n');
+  });
+
+  it('should keep a complete result when it arrives just before the cleanup deadline', async () => {
+    const result = await runProbeProcess('-e', [
+      [
+        "console.log('PROBE_READY')",
+        "console.log('PROBE_CLEANUP_START')",
+        "process.stdout.write('PROBE_RESULT ')",
+        "setTimeout(() => process.stdout.write('{}\\n'), 175)",
+        'setInterval(() => {}, 1000)',
+      ].join(';'),
+    ], {
+      startupTimeout: 2_000,
+      executionTimeout: 2_000,
+      cleanupTimeout: 200,
+      env: process.env,
+    });
+
+    expect(result.stdout).toContain('PROBE_RESULT {}\n');
+    await result.cleanup;
   });
 
   it('should reject a complete result emitted before cleanup starts', async () => {
@@ -951,8 +1207,9 @@ describe('prompt eval probe lifecycle', () => {
     });
 
     await expect(execution).rejects.toMatchObject({ code: 'ETIMEDOUT', phase: 'cleanup' });
-    await execution.catch((error: Error & { stdout: string }) => {
+    await execution.catch((error: Error & { stdout: string; cleanup: Promise<void> }) => {
       grandchildPid = (JSON.parse(error.stdout.split('\n')[0]!) as { grandchildPid: number }).grandchildPid;
+      return error.cleanup;
     });
     expect(grandchildPid).toBeGreaterThan(0);
     expect(() => process.kill(grandchildPid, 0)).toThrow();
@@ -974,17 +1231,18 @@ describe('prompt eval probe lifecycle', () => {
     writeFileSync(script, [
       `import { runProbeProcess } from ${JSON.stringify(probeProcessUrl)}`,
       'try {',
-      `  await runProbeProcess('-e', [${JSON.stringify(workerSource)}], { startupTimeout: 2000, executionTimeout: 2000, cleanupTimeout: 150, env: process.env })`,
+      `  await runProbeProcess('-e', [${JSON.stringify(workerSource)}], { startupTimeout: ${INNER_PROBE_STARTUP_TIMEOUT_MS}, executionTimeout: ${INNER_PROBE_EXECUTION_TIMEOUT_MS}, cleanupTimeout: ${INNER_PROBE_CLEANUP_TIMEOUT_MS}, env: process.env })`,
       '} catch (error) {',
-      "  process.stdout.write(error.stdout ?? '')",
-      "  process.stderr.write(`phase=${error.phase}\\n`)",
+      "  await new Promise((resolve, reject) => process.stdout.write(error.stdout ?? '', writeError => writeError ? reject(writeError) : resolve()))",
+      "  await new Promise((resolve, reject) => process.stderr.write(`phase=${error.phase}\\n`, writeError => writeError ? reject(writeError) : resolve()))",
+      '  await error.cleanup',
       '  throw error',
       '}',
     ].join('\n'), 'utf8');
 
     let launchError: (Error & { stdout?: string; stderr?: string }) | undefined;
     try {
-      await runSmokeScript(script, [], process.env, { timeoutMs: 2_000 });
+      await runSmokeScript(script, [], process.env, { timeoutMs: OUTER_PROBE_TIMEOUT_MS });
     } catch (error) {
       launchError = error as Error & { stdout?: string; stderr?: string };
     }
@@ -1015,10 +1273,156 @@ describe('prompt eval probe lifecycle', () => {
       code: 'ETIMEDOUT',
       killed: true,
     });
-    await execution.catch((error: Error & { stdout: string }) => {
-      const pids = JSON.parse(error.stdout.trim()) as { childPid: number; grandchildPid: number };
-      expect(() => process.kill(pids.childPid, 0)).toThrow();
-      expect(() => process.kill(pids.grandchildPid, 0)).toThrow();
+    await execution.catch((error: Error & { stdout: string; cleanup: Promise<void> }) => {
+      return error.cleanup.then(() => {
+        const pids = JSON.parse(error.stdout.trim()) as { childPid: number; grandchildPid: number };
+        expect(() => process.kill(pids.childPid, 0)).toThrow();
+        expect(() => process.kill(pids.grandchildPid, 0)).toThrow();
+      });
+    });
+  });
+
+  it('should resolve the smoke launcher at the report before post-report cleanup', async () => {
+    const testRoot = mkdtempSync(join(tmpdir(), 'takt-smoke-report-first-'));
+    temporaryDirectories.push(testRoot);
+    const script = join(testRoot, 'report-first.mjs');
+    writeFileSync(script, [
+      "process.stdout.write('SMOKE_REPORT {}\\n')",
+      'setInterval(() => {}, 1000)',
+    ].join('\n'), 'utf8');
+
+    const startedAt = Date.now();
+    const execution = runSmokeScript(script, [], process.env, {
+      timeoutMs: 2_000,
+      reportMarker: 'SMOKE_REPORT ',
+    });
+    const result = await execution;
+
+    expect(Date.now() - startedAt).toBeLessThan(300);
+    expect(result.stdout).toContain('SMOKE_REPORT {}');
+    await result.cleanup;
+  });
+
+  it('should preserve a workspace report and warn when attached cleanup fails', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'takt-probe-workspace-cleanup-'));
+    temporaryDirectories.push(parent);
+    const cleanupError = new Error('workspace cleanup failed');
+    const cleanup = Promise.reject(cleanupError);
+    let workspace = '';
+    const warning = captureCleanupWarning();
+
+    try {
+      const execution = withProbeWorkspace(parent, 'reported-', async (createdWorkspace) => {
+        workspace = createdWorkspace;
+        return { reported: true, cleanup };
+      });
+
+      await warning.writeStarted;
+      expect(existsSync(workspace)).toBe(false);
+      warning.flush();
+
+      await expect(execution).resolves.toMatchObject({ reported: true });
+      expect(warning.wasFlushed()).toBe(true);
+      expect(warning.writes.join('')).toContain(
+        'Warning: Probe workspace cleanup failed: workspace cleanup failed',
+      );
+    } finally {
+      warning.restore();
+    }
+  });
+
+  it('should preserve a reported smoke result and warn when cleanup closes non-zero', async () => {
+    const testRoot = mkdtempSync(join(tmpdir(), 'takt-smoke-report-close-'));
+    temporaryDirectories.push(testRoot);
+    const script = join(testRoot, 'report-close-non-zero.mjs');
+    writeFileSync(script, [
+      "process.stdout.write('SMOKE_REPORT {}\\n')",
+      'process.on(\'SIGTERM\', () => process.exit(7))',
+      'setInterval(() => {}, 1000)',
+    ].join('\n'), 'utf8');
+    const warning = captureCleanupWarning();
+
+    try {
+      const result = await runSmokeScript(script, [], process.env, {
+        timeoutMs: 2_000,
+        reportMarker: 'SMOKE_REPORT ',
+      });
+
+      expect(result.stdout).toContain('SMOKE_REPORT {}');
+      await warning.writeStarted;
+      expect(warning.wasFlushed()).toBe(false);
+      warning.flush();
+      await expect(result.cleanup).rejects.toMatchObject({ code: 7 });
+      expect(warning.wasFlushed()).toBe(true);
+      expect(warning.writes.join('')).toContain(
+        'Warning: Smoke process exited after report with code 7',
+      );
+    } finally {
+      warning.restore();
+    }
+  });
+
+  it('should reject a smoke process that closes successfully without its report marker', async () => {
+    const testRoot = mkdtempSync(join(tmpdir(), 'takt-smoke-report-missing-'));
+    temporaryDirectories.push(testRoot);
+    const script = join(testRoot, 'report-missing.mjs');
+    writeFileSync(script, "process.stdout.write('completed without report\\n')\n", 'utf8');
+
+    const execution = runSmokeScript(script, [], process.env, {
+      timeoutMs: 2_000,
+      reportMarker: 'SMOKE_REPORT ',
+    });
+
+    await expect(execution).rejects.toMatchObject({
+      code: 'EPROBEPROTOCOL',
+      exitCode: 0,
+    });
+    await execution.catch((error: Error & { cleanup: Promise<void> }) => error.cleanup);
+  });
+
+  it('should forward a post-report cleanup warning without changing the smoke result', async () => {
+    const testRoot = mkdtempSync(join(tmpdir(), 'takt-smoke-report-warning-'));
+    temporaryDirectories.push(testRoot);
+    const script = join(testRoot, 'report-cleanup-warning.mjs');
+    writeFileSync(script, [
+      "process.stdout.write('SMOKE_REPORT {}\\n')",
+      "process.on('SIGTERM', () => process.stderr.write('Warning: Process tree cleanup warning: delayed cleanup\\n', () => process.exit(0)))",
+      'setInterval(() => {}, 1000)',
+    ].join('\n'), 'utf8');
+    const warning = captureCleanupWarning();
+
+    try {
+      const result = await runSmokeScript(script, [], process.env, {
+        timeoutMs: 2_000,
+        reportMarker: 'SMOKE_REPORT ',
+      });
+
+      expect(result.stdout).toContain('SMOKE_REPORT {}');
+      await warning.writeStarted;
+      warning.flush();
+      await expect(result.cleanup).rejects.toMatchObject({ code: 'ECLEANUPWARNING' });
+      expect(warning.wasFlushed()).toBe(true);
+      expect(warning.writes.join('')).toContain(
+        'Warning: Process tree cleanup warning: delayed cleanup',
+      );
+    } finally {
+      warning.restore();
+    }
+  });
+
+  it('should surface smoke cleanup failure without changing the evaluation result', async () => {
+    const cleanupError = new Error('smoke cleanup failed');
+    const execution = runSmokeBatch([{
+      name: 'cleanup-failure',
+      run: async () => ({ cleanup: Promise.reject(cleanupError) }),
+    }]);
+
+    await expect(execution).rejects.toMatchObject({
+      errors: [expect.objectContaining({ errors: [cleanupError] })],
+      smokeResult: {
+        status: 'passed',
+        cases: [{ name: 'cleanup-failure', status: 'passed' }],
+      },
     });
   });
 
@@ -1216,7 +1620,10 @@ describe('prompt eval probe lifecycle', () => {
       "console.log('PROBE_RESULT {\"flushed\":true}')",
     ].join('\n'), 'utf8');
 
-    const { stdout, stderr } = await runSmokeScript(script, [], process.env, { timeoutMs: 2_000 });
+    const { stdout, stderr } = await runSmokeScript(script, [], process.env, {
+      timeoutMs: OWNED_ENTRYPOINT_TIMEOUT_MS,
+      reportMarker: 'PROBE_RESULT ',
+    });
     const expectedStdout = [
       'x'.repeat(stdoutPayloadBytes),
       'PROBE_READY',

--- a/src/__tests__/promptEvalProbeLifecycle.test.ts
+++ b/src/__tests__/promptEvalProbeLifecycle.test.ts
@@ -53,23 +53,36 @@ function expectWindowsCommandTimeoutsWithinGrace(executeFile: { mock: { calls: u
   expect(timeouts.every((timeout) => timeout > 0 && timeout <= PROCESS_TREE_CLEANUP_GRACE_MS)).toBe(true);
 }
 
-function captureCleanupWarning() {
+function captureCleanupWarning(expectedWarning: string | RegExp) {
   const writes: string[] = [];
   let flushed = false;
   let resolveWriteStarted: (() => void) | undefined;
   const writeStarted = new Promise<void>((resolve) => {
     resolveWriteStarted = resolve;
   });
-  let flushCallback: ((error?: Error | null) => void) | undefined;
+  const flushCallbacks: ((error?: Error | null) => void)[] = [];
   const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation((
     ((
       chunk: string | Uint8Array,
       encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
       callback?: (error?: Error | null) => void,
     ) => {
-      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
-      flushCallback = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
-      resolveWriteStarted?.();
+      const written = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+      writes.push(written);
+      if (typeof expectedWarning === 'string'
+        ? written.includes(expectedWarning)
+        : new RegExp(expectedWarning.source, expectedWarning.flags.replace('g', '')).test(written)) {
+        resolveWriteStarted?.();
+        resolveWriteStarted = undefined;
+      }
+      const pending = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
+      if (pending !== undefined) {
+        if (flushed) {
+          pending();
+        } else {
+          flushCallbacks.push(pending);
+        }
+      }
       return true;
     }) as typeof process.stderr.write
   ));
@@ -78,11 +91,13 @@ function captureCleanupWarning() {
     writes,
     writeStarted,
     flush: () => {
-      if (flushCallback === undefined) {
+      if (flushCallbacks.length === 0) {
         throw new Error('Cleanup warning write callback was not registered');
       }
       flushed = true;
-      flushCallback();
+      while (flushCallbacks.length > 0) {
+        flushCallbacks.shift()?.();
+      }
     },
     wasFlushed: () => flushed,
     restore: () => stderrWrite.mockRestore(),
@@ -134,17 +149,14 @@ const SMOKE_BATCH_DISPATCH_MARGIN_MS = 250;
 
 function smokeBatchTimeoutMs(caseCount: number) {
   const dispatchedCaseCount = Math.max(1, caseCount);
-  const caseBudget = caseCount * (
+  const caseBudget = dispatchedCaseCount * (
     SMOKE_BATCH_CASE_TIMEOUT_MS
     + SMOKE_BATCH_CASE_SPAWN_MARGIN_MS
     + PROCESS_TREE_CLEANUP_GRACE_MS
   );
-  return Math.max(
-    SMOKE_BATCH_FIXTURE_STARTUP_MARGIN_MS + SMOKE_BATCH_DISPATCH_MARGIN_MS,
-    SMOKE_BATCH_FIXTURE_STARTUP_MARGIN_MS
-      + caseBudget
-      + dispatchedCaseCount * SMOKE_BATCH_DISPATCH_MARGIN_MS,
-  );
+  return SMOKE_BATCH_FIXTURE_STARTUP_MARGIN_MS
+    + caseBudget
+    + dispatchedCaseCount * SMOKE_BATCH_DISPATCH_MARGIN_MS;
 }
 
 const smokeBatchFixture = fileURLToPath(
@@ -562,7 +574,7 @@ describe('prompt eval probe lifecycle', () => {
   });
 
   it('should reject process-tree cleanup failures after flushing the warning', async () => {
-    const warning = captureCleanupWarning();
+    const warning = captureCleanupWarning(/Warning: Process tree cleanup warning: Child process did not expose a PID/);
 
     try {
       await expectCleanupFailureAfterWarningFlush(
@@ -583,7 +595,7 @@ describe('prompt eval probe lifecycle', () => {
     const executeFile = vi.fn(async (file: string) => (
       file === 'powershell.exe' ? query() : undefined
     ));
-    const warning = captureCleanupWarning();
+    const warning = captureCleanupWarning(/Warning: Process tree cleanup warning: .*WMI process snapshot unavailable/);
 
     try {
       await expectCleanupFailureAfterWarningFlush(
@@ -612,7 +624,7 @@ describe('prompt eval probe lifecycle', () => {
       if (file === 'taskkill') return undefined;
       throw new Error('WMI query should not start after the deadline');
     });
-    const warning = captureCleanupWarning();
+    const warning = captureCleanupWarning(/Warning: Process tree cleanup warning: .*WMI process snapshot deadline exceeded/);
 
     try {
       await expectCleanupFailureAfterWarningFlush(
@@ -660,7 +672,7 @@ describe('prompt eval probe lifecycle', () => {
           ? { stdout: '{invalid' }
           : { stdout: '[]' };
       });
-      const warning = captureCleanupWarning();
+      const warning = captureCleanupWarning(/Warning: Process tree cleanup warning: .*WMI (?:identity query.*|final process query) unavailable/);
 
       try {
         await expectCleanupFailureAfterWarningFlush(
@@ -682,7 +694,7 @@ describe('prompt eval probe lifecycle', () => {
     },
   );
 
-  it('should warn after terminating recorded Windows descendants when the parent has already exited', async () => {
+  it('should terminate recorded Windows descendants when the parent has already exited', async () => {
     let fullSnapshot = 0;
     const executeFile = vi.fn(async (file: string, args: readonly string[]) => {
       if (file === 'powershell.exe') {
@@ -707,18 +719,7 @@ describe('prompt eval probe lifecycle', () => {
       }
       return undefined;
     });
-    const warning = captureCleanupWarning();
-
-    try {
-      await expectCleanupFailureAfterWarningFlush(
-        terminateWindowsProcessTree(4321, executeFile),
-        warning,
-        /taskkill root failed/,
-        /Warning: Process tree cleanup warning: .*taskkill root failed/,
-      );
-    } finally {
-      warning.restore();
-    }
+    await expect(terminateWindowsProcessTree(4321, executeFile)).resolves.toBeUndefined();
 
     expect(executeFile).toHaveBeenCalledWith(
       'taskkill',
@@ -759,7 +760,7 @@ describe('prompt eval probe lifecycle', () => {
           CreationDate: 'created-reused',
         }) };
     });
-    const warning = captureCleanupWarning();
+    const warning = captureCleanupWarning(/Warning: Process tree cleanup warning: .*taskkill descendant 5001 failed/);
 
     try {
       await expectCleanupFailureAfterWarningFlush(
@@ -792,7 +793,7 @@ describe('prompt eval probe lifecycle', () => {
       }
       return { stdout: processSnapshot };
     });
-    const warning = captureCleanupWarning();
+    const warning = captureCleanupWarning(/Warning: Process tree cleanup warning: .*Windows process tree 4321 retained processes: 4321/);
 
     try {
       await expectCleanupFailureAfterWarningFlush(
@@ -876,7 +877,6 @@ describe('prompt eval probe lifecycle', () => {
   });
 
   it('should return a probe report before intentionally delayed cleanup finishes', async () => {
-    const startedAt = Date.now();
     const execution = runProbeProcess('-e', [
       [
         "process.on('SIGTERM', () => {})",
@@ -894,16 +894,15 @@ describe('prompt eval probe lifecycle', () => {
 
     const result = await execution;
     let cleanupFinished = false;
-    result.cleanup.then(() => {
+    const observedCleanup = result.cleanup.then(() => {
       cleanupFinished = true;
     });
     await Promise.resolve();
     if (process.platform !== 'win32') {
       expect(cleanupFinished).toBe(false);
     }
-    expect(Date.now() - startedAt).toBeLessThan(PROCESS_TREE_CLEANUP_GRACE_MS);
     expect(result.stdout).toContain('PROBE_RESULT {}');
-    await result.cleanup;
+    await observedCleanup;
     expect(cleanupFinished).toBe(true);
   });
 
@@ -951,22 +950,26 @@ describe('prompt eval probe lifecycle', () => {
     expect(result.stdout).toContain('PROBE_RESULT {}\n');
   });
 
-  it('should keep a complete result when it arrives just before the cleanup deadline', async () => {
+  it('should keep a complete result when its frame completes after cleanup starts', async () => {
     const result = await runProbeProcess('-e', [
       [
         "console.log('PROBE_READY')",
         "console.log('PROBE_CLEANUP_START')",
         "process.stdout.write('PROBE_RESULT ')",
-        "setTimeout(() => process.stdout.write('{}\\n'), 175)",
+        "setImmediate(() => process.stdout.write('{}\\n'))",
         'setInterval(() => {}, 1000)',
       ].join(';'),
     ], {
       startupTimeout: 2_000,
       executionTimeout: 2_000,
-      cleanupTimeout: 200,
+      cleanupTimeout: 2_000,
       env: process.env,
     });
 
+    const cleanupStartIndex = result.stdout.indexOf('PROBE_CLEANUP_START');
+    const resultFrameIndex = result.stdout.indexOf('PROBE_RESULT {}');
+    expect(cleanupStartIndex).toBeGreaterThanOrEqual(0);
+    expect(resultFrameIndex).toBeGreaterThan(cleanupStartIndex);
     expect(result.stdout).toContain('PROBE_RESULT {}\n');
     await result.cleanup;
   });
@@ -1291,16 +1294,21 @@ describe('prompt eval probe lifecycle', () => {
       'setInterval(() => {}, 1000)',
     ].join('\n'), 'utf8');
 
-    const startedAt = Date.now();
     const execution = runSmokeScript(script, [], process.env, {
       timeoutMs: 2_000,
       reportMarker: 'SMOKE_REPORT ',
     });
     const result = await execution;
 
-    expect(Date.now() - startedAt).toBeLessThan(300);
+    let cleanupFinished = false;
+    const observedCleanup = result.cleanup.then(() => {
+      cleanupFinished = true;
+    });
+    await Promise.resolve();
+    expect(cleanupFinished).toBe(false);
     expect(result.stdout).toContain('SMOKE_REPORT {}');
-    await result.cleanup;
+    await observedCleanup;
+    expect(cleanupFinished).toBe(true);
   });
 
   it('should preserve a workspace report and warn when attached cleanup fails', async () => {
@@ -1309,7 +1317,7 @@ describe('prompt eval probe lifecycle', () => {
     const cleanupError = new Error('workspace cleanup failed');
     const cleanup = Promise.reject(cleanupError);
     let workspace = '';
-    const warning = captureCleanupWarning();
+    const warning = captureCleanupWarning('Warning: Probe workspace cleanup failed: workspace cleanup failed');
 
     try {
       const execution = withProbeWorkspace(parent, 'reported-', async (createdWorkspace) => {
@@ -1337,10 +1345,9 @@ describe('prompt eval probe lifecycle', () => {
     const script = join(testRoot, 'report-close-non-zero.mjs');
     writeFileSync(script, [
       "process.stdout.write('SMOKE_REPORT {}\\n')",
-      'process.on(\'SIGTERM\', () => process.exit(7))',
-      'setInterval(() => {}, 1000)',
+      'process.exitCode = 7',
     ].join('\n'), 'utf8');
-    const warning = captureCleanupWarning();
+    const warning = captureCleanupWarning('Warning: Smoke process exited after report with code 7');
 
     try {
       const result = await runSmokeScript(script, [], process.env, {
@@ -1386,10 +1393,9 @@ describe('prompt eval probe lifecycle', () => {
     const script = join(testRoot, 'report-cleanup-warning.mjs');
     writeFileSync(script, [
       "process.stdout.write('SMOKE_REPORT {}\\n')",
-      "process.on('SIGTERM', () => process.stderr.write('Warning: Process tree cleanup warning: delayed cleanup\\n', () => process.exit(0)))",
-      'setInterval(() => {}, 1000)',
+      "process.stderr.write('Warning: Process tree cleanup warning: delayed cleanup\\n')",
     ].join('\n'), 'utf8');
-    const warning = captureCleanupWarning();
+    const warning = captureCleanupWarning('Warning: Process tree cleanup warning: delayed cleanup');
 
     try {
       const result = await runSmokeScript(script, [], process.env, {

--- a/src/__tests__/promptEvalProbeLifecycle.test.ts
+++ b/src/__tests__/promptEvalProbeLifecycle.test.ts
@@ -53,6 +53,17 @@ function expectWindowsCommandTimeoutsWithinGrace(executeFile: { mock: { calls: u
   expect(timeouts.every((timeout) => timeout > 0 && timeout <= PROCESS_TREE_CLEANUP_GRACE_MS)).toBe(true);
 }
 
+const PROCESS_EXIT_POLL_INTERVAL_MS = 100;
+
+async function expectProcessToBeStopped(pid: number) {
+  await vi.waitFor(() => {
+    expect(() => process.kill(pid, 0)).toThrow();
+  }, {
+    timeout: PROCESS_TREE_CLEANUP_GRACE_MS,
+    interval: PROCESS_EXIT_POLL_INTERVAL_MS,
+  });
+}
+
 function captureCleanupWarning(expectedWarning: string | RegExp) {
   const writes: string[] = [];
   let flushed = false;
@@ -872,8 +883,10 @@ describe('prompt eval probe lifecycle', () => {
     expect(existsSync(workspace)).toBe(false);
     expect(childPid).toBeGreaterThan(0);
     expect(grandchildPid).toBeGreaterThan(0);
-    expect(() => process.kill(childPid, 0)).toThrow();
-    expect(() => process.kill(grandchildPid, 0)).toThrow();
+    await Promise.all([
+      expectProcessToBeStopped(childPid),
+      expectProcessToBeStopped(grandchildPid),
+    ]);
   });
 
   it('should return a probe report before intentionally delayed cleanup finishes', async () => {

--- a/src/__tests__/promptEvalProbeLifecycle.test.ts
+++ b/src/__tests__/promptEvalProbeLifecycle.test.ts
@@ -1007,6 +1007,7 @@ describe('prompt eval probe lifecycle', () => {
       (error: Error & { code?: string; phase?: string; cleanup?: Promise<void> }) => error,
     );
     expect(protocolError).toMatchObject({ code: 'EPROBEPROTOCOL', phase: 'execution' });
+    expect(protocolError.cleanup).toBeInstanceOf(Promise);
     await protocolError.cleanup;
   });
 

--- a/src/__tests__/promptEvalProbeLifecycle.test.ts
+++ b/src/__tests__/promptEvalProbeLifecycle.test.ts
@@ -1002,7 +1002,12 @@ describe('prompt eval probe lifecycle', () => {
       env: process.env,
     });
 
-    await expect(execution).rejects.toMatchObject({ code: 'EPROBEPROTOCOL', phase: 'execution' });
+    const protocolError = await execution.then(
+      () => { throw new Error('expected rejection'); },
+      (error: Error & { code?: string; phase?: string; cleanup?: Promise<void> }) => error,
+    );
+    expect(protocolError).toMatchObject({ code: 'EPROBEPROTOCOL', phase: 'execution' });
+    await protocolError.cleanup;
   });
 
   it('should reject multiple complete results when parsing probe output', () => {

--- a/src/__tests__/promptEvalProbeLifecycle.test.ts
+++ b/src/__tests__/promptEvalProbeLifecycle.test.ts
@@ -1291,7 +1291,7 @@ describe('prompt eval probe lifecycle', () => {
     const script = join(testRoot, 'report-first.mjs');
     writeFileSync(script, [
       "process.stdout.write('SMOKE_REPORT {}\\n')",
-      'setInterval(() => {}, 1000)',
+      'process.exitCode = 0',
     ].join('\n'), 'utf8');
 
     const execution = runSmokeScript(script, [], process.env, {

--- a/tools/opencode-probe/fixtures/run-smoke-batch.mjs
+++ b/tools/opencode-probe/fixtures/run-smoke-batch.mjs
@@ -8,7 +8,10 @@ if (configPath === undefined) {
 }
 
 const parsed = JSON.parse(readFileSync(resolve(configPath), 'utf8'));
-const FIXTURE_TIMEOUT_MS = 5_000;
+const caseTimeoutMs = parsed.caseTimeoutMs;
+if (!Number.isInteger(caseTimeoutMs) || caseTimeoutMs <= 0) {
+  throw new Error('Smoke batch fixture config requires a positive integer caseTimeoutMs');
+}
 if (!Array.isArray(parsed.cases)) {
   throw new Error('Smoke batch fixture config requires a cases array');
 }
@@ -28,7 +31,10 @@ const cases = parsed.cases.map((candidate) => {
       resolve(candidate.script),
       candidate.args,
       process.env,
-      { timeoutMs: FIXTURE_TIMEOUT_MS },
+      {
+        timeoutMs: caseTimeoutMs,
+        reportMarker: 'SMOKE_CASE_RESULT ',
+      },
     ),
   };
 });

--- a/tools/opencode-probe/probe-entrypoint.mjs
+++ b/tools/opencode-probe/probe-entrypoint.mjs
@@ -6,6 +6,7 @@ import {
   markProbeWorkerEnvironment,
   prepareIsolatedProbeEnvironment,
 } from './probe-environment.mjs';
+import { PROCESS_TREE_CLEANUP_GRACE_MS } from './process-tree.mjs';
 import { runProbeProcess } from './probe-process.mjs';
 
 function writeStream(stream, output) {
@@ -20,6 +21,22 @@ function writeStream(stream, output) {
   });
 }
 
+function awaitBeforeDeadline(operation, deadline, label) {
+  const observedOperation = Promise.resolve(operation);
+  observedOperation.catch(() => undefined);
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    return Promise.reject(new Error(`${label} deadline exceeded`));
+  }
+  let timeoutId;
+  return Promise.race([
+    observedOperation,
+    new Promise((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error(`${label} deadline exceeded`)), remaining);
+    }),
+  ]).finally(() => clearTimeout(timeoutId));
+}
+
 export async function ensureOwnedProbeEntrypoint(scriptUrl) {
   if (isProbeWorkerEnvironment(process.env)) {
     return;
@@ -27,21 +44,54 @@ export async function ensureOwnedProbeEntrypoint(scriptUrl) {
 
   const runtimeRoot = mkdtempSync(`${tmpdir()}/takt-prompt-eval-entrypoint-`);
   let result;
+  let failure;
   try {
     const isolatedEnvironment = prepareIsolatedProbeEnvironment(process.env, runtimeRoot);
-    result = await runProbeProcess(fileURLToPath(scriptUrl), process.argv.slice(2), {
-      startupTimeout: 120_000,
-      executionTimeout: 30_000,
-      cleanupTimeout: 30_000,
-      env: markProbeWorkerEnvironment(isolatedEnvironment),
-    });
+    try {
+      result = await runProbeProcess(fileURLToPath(scriptUrl), process.argv.slice(2), {
+        startupTimeout: 120_000,
+        executionTimeout: 30_000,
+        cleanupTimeout: 30_000,
+        env: markProbeWorkerEnvironment(isolatedEnvironment),
+      });
+    } catch (error) {
+      failure = error;
+    }
+
+    const output = result !== undefined ? result : failure;
+    if (
+      output === undefined
+      || typeof output.stdout !== 'string'
+      || typeof output.stderr !== 'string'
+      || output.cleanup === undefined
+    ) {
+      throw new Error('Owned probe entrypoint did not receive a complete child result');
+    }
+    const cleanupDeadline = Date.now() + PROCESS_TREE_CLEANUP_GRACE_MS;
+    let outputFailure;
+    try {
+      await awaitBeforeDeadline(Promise.all([
+        writeStream(process.stdout, output.stdout),
+        writeStream(process.stderr, output.stderr),
+      ]), cleanupDeadline, 'Owned probe output flush');
+    } catch (error) {
+      outputFailure = error;
+    }
+    let cleanupFailure;
+    try {
+      await awaitBeforeDeadline(output.cleanup, cleanupDeadline, 'Owned probe cleanup');
+    } catch (error) {
+      cleanupFailure = error;
+    }
+    const errors = [failure, outputFailure, cleanupFailure].filter((error) => error !== undefined);
+    if (errors.length > 0) {
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      throw new AggregateError(errors, 'Owned probe entrypoint failed');
+    }
   } finally {
     rmSync(runtimeRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
   }
-
-  await Promise.all([
-    writeStream(process.stdout, result.stdout),
-    writeStream(process.stderr, result.stderr),
-  ]);
   process.exit(0);
 }

--- a/tools/opencode-probe/probe-process.d.mts
+++ b/tools/opencode-probe/probe-process.d.mts
@@ -14,4 +14,4 @@ export function runProbeProcess(
     cleanupTimeout: number;
     env: NodeJS.ProcessEnv;
   },
-): Promise<{ stdout: string; stderr: string }>;
+): Promise<{ stdout: string; stderr: string; cleanup: Promise<void> }>;

--- a/tools/opencode-probe/probe-process.mjs
+++ b/tools/opencode-probe/probe-process.mjs
@@ -1,9 +1,10 @@
 import { spawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
 import {
-  terminateProcessTree,
+  startProcessTreeCleanup,
 } from './process-tree.mjs';
 const MAX_PROBE_OUTPUT_BYTES = 1024 * 1024;
+const PROBE_REPORT_FLUSH_GRACE_MS = 25;
 const PHASE_MARKERS = Object.freeze({
   ready: 'PROBE_READY',
   cleanupStart: 'PROBE_CLEANUP_START',
@@ -100,10 +101,15 @@ export function runProbeProcess(script, args, options) {
   return new Promise((resolve, reject) => {
     let phase = 'startup';
     let timedOut = false;
+    let timedOutPhase;
+    let timedOutDuration;
     let outputLimitExceeded = false;
     let protocolFailure;
     let terminationRequested = false;
     let termination = Promise.resolve();
+    let settled = false;
+    let reportSettlementScheduled = false;
+    let reportSettlementId;
     let outputBytes = 0;
     let stdout = '';
     let stderr = '';
@@ -119,8 +125,33 @@ export function runProbeProcess(script, args, options) {
         return;
       }
       terminationRequested = true;
-      termination = terminateProcessTree(child.pid);
+      termination = child.pid === undefined
+        ? Promise.resolve()
+        : startProcessTreeCleanup(child.pid);
       void termination.catch(() => undefined);
+    };
+    const settleFailure = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      clearTimeout(reportSettlementId);
+      reject(attachProbeCleanup(error, termination));
+    };
+    const settleSuccess = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      clearTimeout(reportSettlementId);
+      resolve({ stdout, stderr, cleanup: termination });
+    };
+    const scheduleReportSettlement = () => {
+      if (reportSettlementScheduled) return;
+      reportSettlementScheduled = true;
+      reportSettlementId = setTimeout(() => {
+        if (settled || protocolFailure !== undefined) return;
+        terminate();
+        settleSuccess();
+      }, PROBE_REPORT_FLUSH_GRACE_MS);
     };
     const phaseTimeout = () => {
       if (phase === 'startup') return options.startupTimeout;
@@ -129,21 +160,49 @@ export function runProbeProcess(script, args, options) {
     };
     const schedulePhaseTimeout = () => {
       clearTimeout(timeoutId);
+      const timeout = phaseTimeout();
       timeoutId = setTimeout(() => {
+        if (terminationRequested || protocolFailure !== undefined || outputLimitExceeded) {
+          return;
+        }
+        const protocol = readProbeProtocol(stdout);
+        if (protocol.protocolError !== undefined) {
+          protocolFailure = createProbeProtocolError(protocol.phase, stdout, stderr, protocol.protocolError);
+          terminate();
+          settleFailure(protocolFailure);
+          return;
+        }
+        if (protocol.phase === 'cleanup' && protocol.resultCount === 1) {
+          clearTimeout(timeoutId);
+          scheduleReportSettlement();
+          return;
+        }
         timedOut = true;
+        timedOutPhase = phase;
+        timedOutDuration = timeout;
+        const error = createProbeTimeoutError(phase, timeout, stdout, stderr);
         terminate();
-      }, phaseTimeout());
+        settleFailure(error);
+      }, timeout);
     };
     const advancePhase = () => {
+      if (settled) return;
       const protocol = readProbeProtocol(stdout);
       if (protocol.protocolError !== undefined) {
         protocolFailure = createProbeProtocolError(protocol.phase, stdout, stderr, protocol.protocolError);
         terminate();
+        settleFailure(protocolFailure);
         return;
       }
       if (protocol.phase !== phase) {
         phase = protocol.phase;
-        schedulePhaseTimeout();
+        if (!terminationRequested) {
+          schedulePhaseTimeout();
+        }
+      }
+      if (protocol.phase === 'cleanup' && protocol.resultCount === 1) {
+        clearTimeout(timeoutId);
+        scheduleReportSettlement();
       }
     };
 
@@ -155,7 +214,9 @@ export function runProbeProcess(script, args, options) {
       outputBytes += appended.bytes;
       if (appended.exceeded && !outputLimitExceeded) {
         outputLimitExceeded = true;
+        const error = createProbeOutputLimitError(stdout, stderr);
         terminate();
+        settleFailure(error);
         return;
       }
       advancePhase();
@@ -166,57 +227,62 @@ export function runProbeProcess(script, args, options) {
       outputBytes += appended.bytes;
       if (appended.exceeded && !outputLimitExceeded) {
         outputLimitExceeded = true;
+        const error = createProbeOutputLimitError(stdout, stderr);
         terminate();
+        settleFailure(error);
       }
     });
 
     let spawnError;
     child.once('error', (error) => {
       spawnError = error;
+      if (child.pid === undefined) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        settleFailure(error);
+      }
     });
     schedulePhaseTimeout();
     child.once('close', async (code, signal) => {
+      if (settled) return;
       clearTimeout(timeoutId);
+      const protocol = readProbeProtocol(stdout);
+      if (protocol.protocolError !== undefined && protocolFailure === undefined) {
+        protocolFailure = createProbeProtocolError(protocol.phase, stdout, stderr, protocol.protocolError);
+      }
       if (timedOut || outputLimitExceeded || protocolFailure !== undefined) {
-        const terminalError = timedOut
-          ? createProbeTimeoutError(phase, phaseTimeout(), stdout, stderr)
+        const terminalError = protocolFailure ?? (timedOut
+          ? createProbeTimeoutError(timedOutPhase ?? phase, timedOutDuration ?? phaseTimeout(), stdout, stderr)
           : outputLimitExceeded
             ? createProbeOutputLimitError(stdout, stderr)
-            : protocolFailure;
-        try {
-          await termination;
-        } catch (terminationError) {
-          reject(new AggregateError(
-            terminalError === undefined ? [terminationError] : [terminalError, terminationError],
-            'Probe process tree could not be terminated',
-          ));
-          return;
-        }
-        reject(terminalError);
+            : undefined);
+        settleFailure(terminalError);
         return;
       }
       if (spawnError !== undefined) {
         spawnError.stdout = stdout;
         spawnError.stderr = stderr;
-        reject(spawnError);
+        settleFailure(spawnError);
+        return;
+      }
+      if (reportSettlementScheduled && terminationRequested && code === null) {
+        settleSuccess();
         return;
       }
       if (code !== 0) {
-        reject(createProbeExitError(code, signal, stdout, stderr));
+        const error = createProbeExitError(code, signal, stdout, stderr);
+        terminate();
+        settleFailure(error);
         return;
       }
-      const protocol = readProbeProtocol(stdout);
       if (protocol.protocolError !== undefined || protocol.resultCount !== 1 || protocol.phase !== 'cleanup') {
-        reject(createProbeProtocolError(phase, stdout, stderr, protocol.protocolError));
+        const error = createProbeProtocolError(protocol.phase, stdout, stderr, protocol.protocolError);
+        terminate();
+        settleFailure(error);
         return;
       }
-      try {
-        await terminateProcessTree(child.pid);
-      } catch (terminationError) {
-        reject(terminationError);
-        return;
-      }
-      resolve({ stdout, stderr });
+      terminate();
+      settleSuccess();
     });
   });
 }
@@ -224,6 +290,11 @@ export function runProbeProcess(script, args, options) {
 function attachProbeOutput(error, stdout, stderr) {
   error.stdout = stdout;
   error.stderr = stderr;
+  return error;
+}
+
+function attachProbeCleanup(error, cleanup) {
+  error.cleanup = cleanup;
   return error;
 }
 

--- a/tools/opencode-probe/probe-process.mjs
+++ b/tools/opencode-probe/probe-process.mjs
@@ -149,6 +149,7 @@ export function runProbeProcess(script, args, options) {
       reportSettlementScheduled = true;
       reportSettlementId = setTimeout(() => {
         if (settled || protocolFailure !== undefined) return;
+        if (exitObserved && typeof exitCode === 'number' && exitCode !== 0) return;
         terminate();
         settleSuccess();
       }, PROBE_REPORT_FLUSH_GRACE_MS);
@@ -234,6 +235,8 @@ export function runProbeProcess(script, args, options) {
     });
 
     let spawnError;
+    let exitObserved = false;
+    let exitCode;
     child.once('error', (error) => {
       spawnError = error;
       if (child.pid === undefined) {
@@ -241,6 +244,10 @@ export function runProbeProcess(script, args, options) {
         error.stderr = stderr;
         settleFailure(error);
       }
+    });
+    child.once('exit', (code) => {
+      exitObserved = true;
+      exitCode = code;
     });
     schedulePhaseTimeout();
     child.once('close', async (code, signal) => {

--- a/tools/opencode-probe/probe-workspace.mjs
+++ b/tools/opencode-probe/probe-workspace.mjs
@@ -3,9 +3,51 @@ import { join } from 'node:path';
 
 export async function withProbeWorkspace(parentDirectory, prefix, run) {
   const workspace = mkdtempSync(join(parentDirectory, prefix));
+  let result;
+  let failure;
+  let failed = false;
   try {
-    return await run(workspace);
+    result = await run(workspace);
+  } catch (error) {
+    failed = true;
+    failure = error;
+  }
+
+  let cleanupError;
+  try {
+    await waitForAttachedCleanup(failed ? failure : result);
+  } catch (error) {
+    cleanupError = error;
   } finally {
     rmSync(workspace, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
   }
+
+  if (cleanupError !== undefined) {
+    await writeProbeWorkspaceCleanupWarning(cleanupError);
+  }
+  if (failed) {
+    throw failure;
+  }
+  return result;
+}
+
+async function waitForAttachedCleanup(value) {
+  const cleanup = value?.cleanup;
+  if (cleanup === undefined || typeof cleanup.then !== 'function') {
+    return;
+  }
+  await cleanup;
+}
+
+function writeProbeWorkspaceCleanupWarning(error) {
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Promise((resolve, reject) => {
+    process.stderr.write(`Warning: Probe workspace cleanup failed: ${detail}\n`, (writeError) => {
+      if (writeError !== undefined && writeError !== null) {
+        reject(writeError);
+        return;
+      }
+      resolve();
+    });
+  });
 }

--- a/tools/opencode-probe/process-tree.d.mts
+++ b/tools/opencode-probe/process-tree.d.mts
@@ -1,3 +1,7 @@
+export const PROCESS_TREE_CLEANUP_GRACE_MS: number;
+
+export function startProcessTreeCleanup(pid: number | undefined): Promise<void>;
+
 export function terminateProcessTree(pid: number | undefined): Promise<void>;
 
 export function terminateWindowsProcessTree(

--- a/tools/opencode-probe/process-tree.mjs
+++ b/tools/opencode-probe/process-tree.mjs
@@ -92,13 +92,13 @@ async function terminateWindowsProcessTreeInternal(pid, executeFile) {
   const failures = [];
   const snapshot = await listWindowsProcesses(executeFile, deadline);
   if (snapshot.status === 'deadline') {
-    failures.push('WMI process snapshot deadline exceeded');
+    recordFailure(failures, 'WMI process snapshot deadline exceeded');
     const taskkill = await taskkillBestEffort(pid, executeFile, deadline, true);
     recordCommandFailure(failures, 'taskkill root', taskkill);
     throw createWindowsProcessTreeError(pid, [], true, failures);
   }
   if (snapshot.status === 'unavailable') {
-    failures.push(formatUnavailable('WMI process snapshot', snapshot.error));
+    recordFailure(failures, formatUnavailable('WMI process snapshot', snapshot.error));
     const taskkill = await taskkillBestEffort(pid, executeFile, deadline, true);
     recordCommandFailure(failures, 'taskkill root', taskkill);
     throw createWindowsProcessTreeError(pid, [], false, failures);
@@ -111,16 +111,16 @@ async function terminateWindowsProcessTreeInternal(pid, executeFile) {
   const descendants = processTree.filter((processInfo) => processInfo.pid !== pid).reverse();
   for (const descendant of descendants) {
     if (Date.now() >= deadline) {
-      failures.push('descendant cleanup deadline exceeded');
+      recordFailure(failures, 'descendant cleanup deadline exceeded');
       break;
     }
     const identity = await hasMatchingCreationDate(descendant, executeFile, deadline);
     if (identity.status === 'deadline') {
-      failures.push(`WMI identity query for ${descendant.pid} deadline exceeded`);
+      recordFailure(failures, `WMI identity query for ${descendant.pid} deadline exceeded`);
       break;
     }
     if (identity.status === 'unavailable') {
-      failures.push(formatUnavailable(`WMI identity query for ${descendant.pid}`, identity.error));
+      recordFailure(failures, formatUnavailable(`WMI identity query for ${descendant.pid}`, identity.error));
     }
     if (identity.status === 'available' && !identity.matches) {
       continue;
@@ -131,16 +131,20 @@ async function terminateWindowsProcessTreeInternal(pid, executeFile) {
 
   const remaining = await waitForWindowsProcessTreeExit(processTree, executeFile, deadline);
   if (remaining.status === 'unavailable') {
-    failures.push(formatUnavailable('WMI final process query', remaining.error));
+    recordFailure(failures, formatUnavailable('WMI final process query', remaining.error));
   } else if (remaining.status === 'deadline') {
-    failures.push('WMI final process query deadline exceeded');
+    recordFailure(failures, 'WMI final process query deadline exceeded');
   }
-  if (remaining.status === 'deadline' || failures.length > 0 || remaining.processes.length > 0) {
+  const processTreeGone = remaining.status === 'complete' && remaining.processes.length === 0;
+  const effectiveFailures = processTreeGone
+    ? failures.filter(({ ignoreWhenProcessAbsent }) => !ignoreWhenProcessAbsent)
+    : failures;
+  if (remaining.status === 'deadline' || effectiveFailures.length > 0 || remaining.processes.length > 0) {
     throw createWindowsProcessTreeError(
       pid,
       remaining.status === 'complete' ? [] : remaining.processes,
       remaining.status === 'deadline',
-      failures,
+      effectiveFailures,
     );
   }
 }
@@ -287,10 +291,26 @@ async function executeWindowsCommand(executeFile, file, args, deadline, forceAft
 
 function recordCommandFailure(failures, label, result) {
   if (result.status === 'failed') {
-    failures.push(`${label} failed: ${formatError(result.error)}`);
+    recordFailure(
+      failures,
+      `${label} failed: ${formatError(result.error)}`,
+      label.startsWith('taskkill ') && isWindowsProcessNotFoundError(result.error),
+    );
   } else if (result.status === 'deadline') {
-    failures.push(`${label} deadline exceeded`);
+    recordFailure(failures, `${label} deadline exceeded`);
   }
+}
+
+function recordFailure(failures, detail, ignoreWhenProcessAbsent = false) {
+  failures.push({ detail, ignoreWhenProcessAbsent });
+}
+
+function isWindowsProcessNotFoundError(error) {
+  const details = [
+    formatError(error),
+    typeof error?.stderr === 'string' ? error.stderr : '',
+  ].join('\n');
+  return /\bnot found\b/i.test(details) || /\bno running instance\b/i.test(details);
 }
 
 function formatUnavailable(label, error) {
@@ -303,7 +323,7 @@ function formatError(error) {
 
 function createWindowsProcessTreeError(pid, processes, deadlineExceeded, failures) {
   const retained = processes.map(({ pid: processId }) => processId).join(', ');
-  const details = failures.join('; ');
+  const details = failures.map(({ detail }) => detail).join('; ');
   if (retained.length > 0) {
     const suffix = deadlineExceeded ? ' (cleanup deadline exceeded)' : '';
     return new Error(

--- a/tools/opencode-probe/process-tree.mjs
+++ b/tools/opencode-probe/process-tree.mjs
@@ -3,104 +3,317 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 const PROCESS_TERMINATION_GRACE_MS = 500;
-const PROCESS_TERMINATION_FORCE_MS = 5_000;
+export const PROCESS_TREE_CLEANUP_GRACE_MS = 5_000;
 const PROCESS_EXIT_POLL_MS = 10;
-const WINDOWS_COMMAND_TIMEOUT_MS = 5_000;
+const WINDOWS_PROCESS_EXIT_POLL_MS = 100;
+const WINDOWS_COMMAND_TIMEOUT_MS = PROCESS_TREE_CLEANUP_GRACE_MS;
+const WINDOWS_FORCED_COMMAND_TIMEOUT_MS = 1;
+
+export function startProcessTreeCleanup(pid) {
+  return terminateProcessTree(pid);
+}
+
+function writeCleanupWarning(message) {
+  return new Promise((resolve, reject) => {
+    try {
+      process.stderr.write(`Warning: ${message}\n`, (error) => {
+        if (error !== undefined && error !== null) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
 
 export async function terminateProcessTree(pid) {
-  if (pid === undefined) {
-    throw new Error('Child process did not expose a PID');
+  try {
+    if (pid === undefined) {
+      throw new Error('Child process did not expose a PID');
+    }
+    if (process.platform === 'win32') {
+      await terminateWindowsProcessTreeInternal(pid, execFileAsync);
+      return;
+    }
+    await terminatePosixProcessTree(pid);
+  } catch (error) {
+    await reportCleanupFailure(error);
   }
-  if (process.platform === 'win32') {
-    await terminateWindowsProcessTree(pid, execFileAsync);
-    return;
+}
+
+async function terminatePosixProcessTree(pid) {
+  const deadline = Date.now() + PROCESS_TREE_CLEANUP_GRACE_MS;
+  let firstError;
+  try {
+    signalProcessGroup(pid, 'SIGTERM');
+  } catch (error) {
+    firstError = error;
   }
-  signalProcessGroup(pid, 'SIGTERM');
-  if (await waitForProcessGroupExit(pid, PROCESS_TERMINATION_GRACE_MS)) {
-    return;
+  try {
+    await waitForProcessGroupExit(
+      pid,
+      Math.min(PROCESS_TERMINATION_GRACE_MS, Math.max(0, deadline - Date.now())),
+    );
+  } catch (error) {
+    firstError ??= error;
   }
-  signalProcessGroup(pid, 'SIGKILL');
-  if (!await waitForProcessGroupExit(pid, PROCESS_TERMINATION_FORCE_MS)) {
+  try {
+    signalProcessGroup(pid, 'SIGKILL');
+  } catch (error) {
+    firstError ??= error;
+  }
+  let exited = false;
+  try {
+    exited = await waitForProcessGroupExit(pid, Math.max(0, deadline - Date.now()));
+  } catch (error) {
+    firstError ??= error;
+  }
+  if (firstError !== undefined) {
+    throw firstError;
+  }
+  if (!exited) {
     throw new Error(`Process group ${pid} remained alive after SIGKILL`);
   }
 }
 
 export async function terminateWindowsProcessTree(pid, executeFile) {
-  const snapshot = await listWindowsProcesses(executeFile);
-  if (snapshot === undefined) {
-    await taskkillBestEffort(pid, executeFile);
-    return;
+  try {
+    await terminateWindowsProcessTreeInternal(pid, executeFile);
+  } catch (error) {
+    await reportCleanupFailure(error);
   }
-  const processTree = collectWindowsProcessTree(pid, snapshot);
+}
 
-  await taskkillBestEffort(pid, executeFile);
+async function terminateWindowsProcessTreeInternal(pid, executeFile) {
+  const deadline = Date.now() + PROCESS_TREE_CLEANUP_GRACE_MS;
+  const failures = [];
+  const snapshot = await listWindowsProcesses(executeFile, deadline);
+  if (snapshot.status === 'deadline') {
+    failures.push('WMI process snapshot deadline exceeded');
+    const taskkill = await taskkillBestEffort(pid, executeFile, deadline, true);
+    recordCommandFailure(failures, 'taskkill root', taskkill);
+    throw createWindowsProcessTreeError(pid, [], true, failures);
+  }
+  if (snapshot.status === 'unavailable') {
+    failures.push(formatUnavailable('WMI process snapshot', snapshot.error));
+    const taskkill = await taskkillBestEffort(pid, executeFile, deadline, true);
+    recordCommandFailure(failures, 'taskkill root', taskkill);
+    throw createWindowsProcessTreeError(pid, [], false, failures);
+  }
+
+  const processTree = collectWindowsProcessTree(pid, snapshot.processes);
+  const rootTaskkill = await taskkillBestEffort(pid, executeFile, deadline, true);
+  recordCommandFailure(failures, 'taskkill root', rootTaskkill);
+
   const descendants = processTree.filter((processInfo) => processInfo.pid !== pid).reverse();
   for (const descendant of descendants) {
-    if (await hasMatchingCreationDate(descendant, executeFile)) {
-      await taskkillBestEffort(descendant.pid, executeFile);
+    if (Date.now() >= deadline) {
+      failures.push('descendant cleanup deadline exceeded');
+      break;
     }
+    const identity = await hasMatchingCreationDate(descendant, executeFile, deadline);
+    if (identity.status === 'deadline') {
+      failures.push(`WMI identity query for ${descendant.pid} deadline exceeded`);
+      break;
+    }
+    if (identity.status === 'unavailable') {
+      failures.push(formatUnavailable(`WMI identity query for ${descendant.pid}`, identity.error));
+    }
+    if (identity.status === 'available' && !identity.matches) {
+      continue;
+    }
+    const taskkill = await taskkillBestEffort(descendant.pid, executeFile, deadline, false);
+    recordCommandFailure(failures, `taskkill descendant ${descendant.pid}`, taskkill);
   }
 
-  const currentProcesses = await listWindowsProcesses(executeFile);
-  if (currentProcesses === undefined) {
-    return;
+  const remaining = await waitForWindowsProcessTreeExit(processTree, executeFile, deadline);
+  if (remaining.status === 'unavailable') {
+    failures.push(formatUnavailable('WMI final process query', remaining.error));
+  } else if (remaining.status === 'deadline') {
+    failures.push('WMI final process query deadline exceeded');
   }
-  const currentCreationDates = new Map(
-    currentProcesses.map((processInfo) => [processInfo.pid, processInfo.creationDate]),
-  );
-  const remaining = processTree.filter(
-    (processInfo) => currentCreationDates.get(processInfo.pid) === processInfo.creationDate,
-  );
-  if (remaining.length > 0) {
-    throw new Error(
-      `Windows process tree ${pid} retained processes: ${remaining.map(({ pid: processId }) => processId).join(', ')}`,
+  if (remaining.status === 'deadline' || failures.length > 0 || remaining.processes.length > 0) {
+    throw createWindowsProcessTreeError(
+      pid,
+      remaining.status === 'complete' ? [] : remaining.processes,
+      remaining.status === 'deadline',
+      failures,
     );
   }
 }
 
-async function taskkillBestEffort(pid, executeFile) {
+async function reportCleanupFailure(error) {
+  const detail = error instanceof Error ? error.message : String(error);
   try {
-    await executeFile(
-      'taskkill',
-      ['/PID', String(pid), '/T', '/F'],
-      { timeout: WINDOWS_COMMAND_TIMEOUT_MS },
+    await writeCleanupWarning(`Process tree cleanup warning: ${detail}`);
+  } catch (warningError) {
+    throw new AggregateError(
+      [error, warningError],
+      'Process tree cleanup failed while reporting the warning',
     );
-  } catch {
-    return;
   }
+  throw error;
 }
 
-async function hasMatchingCreationDate(processInfo, executeFile) {
+async function taskkillBestEffort(pid, executeFile, deadline, forceAfterDeadline) {
+  return executeWindowsCommand(
+    executeFile,
+    'taskkill',
+    ['/PID', String(pid), '/T', '/F'],
+    deadline,
+    forceAfterDeadline,
+  );
+}
+
+async function hasMatchingCreationDate(processInfo, executeFile, deadline) {
   const currentProcesses = await queryWindowsProcesses(
     executeFile,
     `Get-CimInstance Win32_Process -Filter "ProcessId = ${processInfo.pid}" | Select-Object ProcessId,ParentProcessId,CreationDate | ConvertTo-Json -Compress`,
+    deadline,
   );
-  return currentProcesses === undefined || currentProcesses.some(
-    (current) => current.pid === processInfo.pid
-      && current.creationDate === processInfo.creationDate,
-  );
+  if (currentProcesses.status === 'deadline') {
+    return { status: 'deadline' };
+  }
+  if (currentProcesses.status === 'unavailable') {
+    return { status: 'unavailable', error: currentProcesses.error };
+  }
+  return {
+    status: 'available',
+    matches: currentProcesses.processes.some(
+      (current) => current.pid === processInfo.pid
+        && current.creationDate === processInfo.creationDate,
+    ),
+  };
 }
 
-async function listWindowsProcesses(executeFile) {
+async function listWindowsProcesses(executeFile, deadline) {
   return queryWindowsProcesses(
     executeFile,
     'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CreationDate | ConvertTo-Json -Compress',
+    deadline,
   );
 }
 
-async function queryWindowsProcesses(executeFile, command) {
-  try {
-    const result = await executeFile('powershell.exe', [
+async function waitForWindowsProcessTreeExit(processTree, executeFile, deadline) {
+  if (processTree.length === 0) {
+    return { status: 'complete', processes: [] };
+  }
+  while (true) {
+    const currentProcesses = await queryWindowsProcesses(
+      executeFile,
+      'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CreationDate | ConvertTo-Json -Compress',
+      deadline,
+    );
+    if (currentProcesses.status === 'deadline') {
+      return { status: 'deadline', processes: processTree };
+    }
+    if (currentProcesses.status === 'unavailable') {
+      return { status: 'unavailable', error: currentProcesses.error, processes: [] };
+    }
+    const currentCreationDates = new Map(
+      currentProcesses.processes.map((processInfo) => [processInfo.pid, processInfo.creationDate]),
+    );
+    const remaining = processTree.filter(
+      (processInfo) => currentCreationDates.get(processInfo.pid) === processInfo.creationDate,
+    );
+    if (remaining.length === 0) {
+      return { status: 'complete', processes: [] };
+    }
+    if (Date.now() >= deadline) {
+      return { status: 'deadline', processes: remaining };
+    }
+    await new Promise((resolve) => setTimeout(
+      resolve,
+      Math.min(WINDOWS_PROCESS_EXIT_POLL_MS, Math.max(1, deadline - Date.now())),
+    ));
+  }
+}
+
+async function queryWindowsProcesses(executeFile, command, deadline) {
+  const result = await executeWindowsCommand(
+    executeFile,
+    'powershell.exe',
+    [
       '-NoProfile',
       '-NonInteractive',
       '-Command',
       command,
-    ], { timeout: WINDOWS_COMMAND_TIMEOUT_MS });
-    return parseWindowsProcesses(result);
-  } catch {
-    // Cleanup must still attempt taskkill when CIM is unavailable or malformed.
-    return undefined;
+    ],
+    deadline,
+    false,
+  );
+  if (result.status === 'deadline') {
+    return { status: 'deadline' };
   }
+  if (result.status === 'failed') {
+    return { status: 'unavailable', error: result.error };
+  }
+  try {
+    return { status: 'available', processes: parseWindowsProcesses(result.value) };
+  } catch (error) {
+    return { status: 'unavailable', error };
+  }
+}
+
+async function executeWindowsCommand(executeFile, file, args, deadline, forceAfterDeadline) {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0 && !forceAfterDeadline) {
+    return { status: 'deadline' };
+  }
+  const timeout = remaining > 0
+    ? Math.min(WINDOWS_COMMAND_TIMEOUT_MS, remaining)
+    : WINDOWS_FORCED_COMMAND_TIMEOUT_MS;
+  let timeoutId;
+  const command = Promise.resolve()
+    .then(() => executeFile(file, args, { timeout }))
+    .then(
+      (value) => ({ status: 'completed', value }),
+      (error) => ({ status: 'failed', error }),
+    );
+  try {
+    return await Promise.race([
+      command,
+      new Promise((resolve) => {
+        timeoutId = setTimeout(() => resolve({ status: 'deadline' }), timeout);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function recordCommandFailure(failures, label, result) {
+  if (result.status === 'failed') {
+    failures.push(`${label} failed: ${formatError(result.error)}`);
+  } else if (result.status === 'deadline') {
+    failures.push(`${label} deadline exceeded`);
+  }
+}
+
+function formatUnavailable(label, error) {
+  return `${label} unavailable: ${formatError(error)}`;
+}
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error ?? 'unknown error');
+}
+
+function createWindowsProcessTreeError(pid, processes, deadlineExceeded, failures) {
+  const retained = processes.map(({ pid: processId }) => processId).join(', ');
+  const details = failures.join('; ');
+  if (retained.length > 0) {
+    const suffix = deadlineExceeded ? ' (cleanup deadline exceeded)' : '';
+    return new Error(
+      `Windows process tree ${pid} retained processes: ${retained}${suffix}${details ? `; ${details}` : ''}`,
+    );
+  }
+  if (details.length > 0) {
+    return new Error(`Windows process tree ${pid} cleanup failed: ${details}`);
+  }
+  return new Error(`Windows process tree ${pid} cleanup deadline exceeded`);
 }
 
 function parseWindowsProcesses(result) {

--- a/tools/opencode-probe/run-smoke.mjs
+++ b/tools/opencode-probe/run-smoke.mjs
@@ -30,6 +30,7 @@ async function runScript(script, args = []) {
     const isolatedEnvironment = prepareIsolatedProbeEnvironment(process.env, runtimeRoot);
     return runSmokeScript(resolve(script), args, isolatedEnvironment, {
       timeoutMs: SMOKE_SCRIPT_TIMEOUT_MS,
+      reportMarker: 'PROBE_RESULT ',
     });
   });
 }
@@ -40,7 +41,10 @@ async function verifyDirectPluginProbe() {
       resolve('tools/opencode-probe/plugin-probe.mjs'),
       ['--plugin', 'none'],
       prepareIsolatedProbeEnvironment(process.env, runtimeRoot),
-      { timeoutMs: SMOKE_SCRIPT_TIMEOUT_MS },
+      {
+        timeoutMs: SMOKE_SCRIPT_TIMEOUT_MS,
+        reportMarker: 'PROBE_RESULT ',
+      },
     )
   ));
   const result = parseProbeResult(stdout);

--- a/tools/opencode-probe/smoke-process.d.mts
+++ b/tools/opencode-probe/smoke-process.d.mts
@@ -2,8 +2,11 @@ export function runSmokeScript(
   script: string,
   args: string[],
   env: NodeJS.ProcessEnv,
-  options: { timeoutMs: number },
-): Promise<{ stdout: string; stderr: string; exitCode: 0 }>;
+  options: {
+    timeoutMs: number;
+    reportMarker?: string;
+  },
+): Promise<{ stdout: string; stderr: string; exitCode: 0; cleanup: Promise<void> }>;
 
 export interface SmokeCaseResult {
   name: string;

--- a/tools/opencode-probe/smoke-process.mjs
+++ b/tools/opencode-probe/smoke-process.mjs
@@ -1,10 +1,11 @@
 import { spawn } from 'node:child_process';
 import { statSync } from 'node:fs';
 import { StringDecoder } from 'node:string_decoder';
-import { terminateProcessTree } from './process-tree.mjs';
+import { startProcessTreeCleanup } from './process-tree.mjs';
 
 const MAX_SMOKE_OUTPUT_BYTES = 1024 * 1024;
 const MAX_CONCURRENT_SMOKE_CASES = 1;
+const SMOKE_REPORT_FLUSH_GRACE_MS = 25;
 
 function assertSmokeTarget(script) {
   let target;
@@ -41,6 +42,51 @@ function attachSmokeOutput(error, stdout, stderr) {
   return error;
 }
 
+function attachSmokeCleanup(error, cleanup) {
+  if (error !== undefined) {
+    error.cleanup = cleanup;
+  }
+  return error;
+}
+
+function createSmokeExitError(code, signal, stdout, stderr) {
+  const error = attachSmokeOutput(
+    new Error(`Smoke process exited with code ${String(code)}`),
+    stdout,
+    stderr,
+  );
+  error.code = code;
+  error.killed = false;
+  error.signal = signal;
+  return error;
+}
+
+function createSmokeReportError(reportMarker, code, signal, stdout, stderr) {
+  const error = attachSmokeOutput(
+    new Error(`Smoke process did not emit report marker ${String(reportMarker)}`),
+    stdout,
+    stderr,
+  );
+  error.code = 'EPROBEPROTOCOL';
+  error.exitCode = code;
+  error.killed = false;
+  error.signal = signal;
+  return error;
+}
+
+function createSmokeCleanupWarningError(messages) {
+  const error = new Error(`Smoke process cleanup warnings: ${messages.join('; ')}`);
+  error.code = 'ECLEANUPWARNING';
+  return error;
+}
+
+function writeSmokeWarnings(messages) {
+  return messages.reduce(
+    (pending, message) => pending.then(() => writeStream(process.stderr, `${message}\n`)),
+    Promise.resolve(),
+  );
+}
+
 export async function runSmokeScript(script, args, env, options) {
   assertSmokeTarget(script);
   return new Promise((resolve, reject) => {
@@ -50,22 +96,111 @@ export async function runSmokeScript(script, args, env, options) {
     let timedOut = false;
     let outputLimitExceeded = false;
     let terminationRequested = false;
-    let termination = Promise.resolve();
+    let cleanupStarted = false;
+    let settled = false;
+    let closeObserved = false;
+    let postReportObservation;
+    let cleanupSettled = false;
+    let reportSettlementId;
+    let cleanupResolve;
+    let cleanupReject;
+    const cleanup = new Promise((resolveCleanup, rejectCleanup) => {
+      cleanupResolve = resolveCleanup;
+      cleanupReject = rejectCleanup;
+    });
+    void cleanup.catch(() => undefined);
     const child = spawn(process.execPath, [script, ...args], {
       env,
       detached: process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    let termination = Promise.resolve();
+    const finishCleanup = () => {
+      if (!cleanupStarted || !closeObserved || cleanupSettled) return;
+      cleanupSettled = true;
+      const observations = [termination, postReportObservation ?? Promise.resolve()];
+      void Promise.allSettled(observations).then((outcomes) => {
+        const errors = outcomes.flatMap((outcome) => (
+          outcome.status === 'rejected' ? [outcome.reason] : []
+        ));
+        if (errors.length === 0) {
+          cleanupResolve();
+        } else if (errors.length === 1) {
+          cleanupReject(errors[0]);
+        } else {
+          cleanupReject(new AggregateError(errors, 'Smoke process cleanup failed'));
+        }
+      });
+    };
+    const startCleanup = () => {
+      if (cleanupStarted) return cleanup;
+      cleanupStarted = true;
+      if (child.pid === undefined) {
+        termination = Promise.resolve();
+        cleanupResolve();
+        return cleanup;
+      }
+      termination = startProcessTreeCleanup(child.pid);
+      void termination.catch(() => undefined);
+      finishCleanup();
+      return cleanup;
+    };
     const terminate = () => {
       if (terminationRequested) return;
       terminationRequested = true;
-      termination = terminateProcessTree(child.pid);
-      void termination.catch(() => undefined);
+      startCleanup();
     };
-    const timeoutId = setTimeout(() => {
-      timedOut = true;
-      terminate();
-    }, options.timeoutMs);
+    let timeoutId;
+    let timeoutDuration = options.timeoutMs;
+    let reportReady = false;
+    const settleFailure = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      clearTimeout(reportSettlementId);
+      reject(attachSmokeCleanup(error, startCleanup()));
+    };
+    const settleSuccess = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      clearTimeout(reportSettlementId);
+      startCleanup();
+      resolve({ stdout, stderr, exitCode: 0, cleanup });
+    };
+    const scheduleTimeout = (duration) => {
+      clearTimeout(timeoutId);
+      timeoutDuration = duration;
+      timeoutId = setTimeout(() => {
+        if (reportReady) return;
+        timedOut = true;
+        terminate();
+        settleFailure(attachSmokeOutput(
+          Object.assign(new Error(`Smoke process timed out after ${timeoutDuration}ms`), {
+            code: 'ETIMEDOUT',
+            killed: true,
+            signal: 'SIGTERM',
+          }),
+          stdout,
+          stderr,
+        ));
+      }, duration);
+    };
+    const markReportReady = () => {
+      if (reportReady || options.reportMarker === undefined) {
+        return;
+      }
+      const completeLines = stdout.split('\n').slice(0, -1);
+      if (!completeLines.some((line) => line.startsWith(options.reportMarker))) {
+        return;
+      }
+      reportReady = true;
+      clearTimeout(timeoutId);
+      reportSettlementId = setTimeout(() => {
+        if (settled) return;
+        settleSuccess();
+      }, SMOKE_REPORT_FLUSH_GRACE_MS);
+    };
     const collect = (stream, current, assign) => {
       stream.setEncoding('utf8');
       stream.on('data', (chunk) => {
@@ -74,8 +209,20 @@ export async function runSmokeScript(script, args, env, options) {
         outputBytes += appended.bytes;
         if (appended.exceeded && !outputLimitExceeded) {
           outputLimitExceeded = true;
+          const error = attachSmokeOutput(
+            Object.assign(new Error(`Smoke process output exceeded ${MAX_SMOKE_OUTPUT_BYTES} bytes`), {
+              code: 'EOUTPUTLIMIT',
+              killed: true,
+              signal: 'SIGTERM',
+            }),
+            stdout,
+            stderr,
+          );
           terminate();
+          settleFailure(error);
+          return;
         }
+        markReportReady();
       });
     };
     collect(child.stdout, () => stdout, (value) => { stdout = value; });
@@ -84,70 +231,102 @@ export async function runSmokeScript(script, args, env, options) {
     let spawnError;
     child.once('error', (error) => {
       spawnError = error;
+      error.stdout = stdout;
+      error.stderr = stderr;
+      settleFailure(error);
     });
-    child.once('close', async (code, signal) => {
-      clearTimeout(timeoutId);
-      if (terminationRequested) {
-        try {
-          await termination;
-        } catch (terminationError) {
-          reject(new AggregateError([terminationError], 'Smoke process tree could not be terminated'));
-          return;
-        }
+    scheduleTimeout(options.timeoutMs);
+    child.once('close', (code, signal) => {
+      if (!settled) {
+        markReportReady();
       }
-      if (timedOut) {
-        const error = attachSmokeOutput(
-          new Error(`Smoke process timed out after ${options.timeoutMs}ms`),
-          stdout,
-          stderr,
+      closeObserved = true;
+      const observePostReportClose = () => {
+        if (!reportReady || postReportObservation !== undefined) return;
+        const warnings = stderr
+          .split('\n')
+          .filter((line) => line.startsWith('Warning:') && line.toLowerCase().includes('cleanup'));
+        let closeError;
+        if (code !== null && code !== 0) {
+          closeError = createSmokeExitError(code, signal, stdout, stderr);
+          warnings.unshift(`Warning: Smoke process exited after report with code ${String(code)}`);
+        }
+        if (warnings.length === 0) return;
+        const warningError = closeError ?? createSmokeCleanupWarningError(warnings);
+        postReportObservation = writeSmokeWarnings(warnings).then(
+          () => { throw warningError; },
+          (error) => {
+            throw new AggregateError([warningError, error], 'Smoke process warning flush failed');
+          },
         );
-        error.code = 'ETIMEDOUT';
-        error.killed = true;
-        error.signal = 'SIGTERM';
-        reject(error);
+        void postReportObservation.catch(() => undefined);
+      };
+      observePostReportClose();
+      if (settled) {
+        finishCleanup();
         return;
       }
-      if (outputLimitExceeded) {
-        const error = attachSmokeOutput(
-          new Error(`Smoke process output exceeded ${MAX_SMOKE_OUTPUT_BYTES} bytes`),
+      clearTimeout(timeoutId);
+      if (reportReady) {
+        settleSuccess();
+        return;
+      }
+      const terminalError = timedOut
+        ? attachSmokeOutput(
+          Object.assign(new Error(`Smoke process timed out after ${timeoutDuration}ms`), {
+            code: 'ETIMEDOUT',
+            killed: true,
+            signal: 'SIGTERM',
+          }),
           stdout,
           stderr,
-        );
-        error.code = 'EOUTPUTLIMIT';
-        error.killed = true;
-        error.signal = 'SIGTERM';
-        reject(error);
+        )
+        : outputLimitExceeded
+          ? attachSmokeOutput(
+            Object.assign(new Error(`Smoke process output exceeded ${MAX_SMOKE_OUTPUT_BYTES} bytes`), {
+              code: 'EOUTPUTLIMIT',
+              killed: true,
+              signal: 'SIGTERM',
+            }),
+            stdout,
+            stderr,
+          )
+          : undefined;
+      if (terminationRequested) {
+        settleFailure(terminalError);
+        return;
+      }
+      if (terminalError !== undefined) {
+        settleFailure(terminalError);
         return;
       }
       if (spawnError !== undefined) {
-        reject(attachSmokeOutput(spawnError, stdout, stderr));
+        settleFailure(attachSmokeOutput(spawnError, stdout, stderr));
+        return;
+      }
+      if (options.reportMarker !== undefined && !reportReady) {
+        const error = code !== null && code !== 0
+          ? createSmokeExitError(code, signal, stdout, stderr)
+          : createSmokeReportError(options.reportMarker, code, signal, stdout, stderr);
+        terminate();
+        settleFailure(error);
         return;
       }
       if (code !== 0) {
-        const error = attachSmokeOutput(
-          new Error(`Smoke process exited with code ${String(code)}`),
-          stdout,
-          stderr,
-        );
-        error.code = code;
-        error.killed = false;
-        error.signal = signal;
-        reject(error);
+        const error = createSmokeExitError(code, signal, stdout, stderr);
+        terminate();
+        settleFailure(error);
         return;
       }
-      try {
-        await terminateProcessTree(child.pid);
-      } catch (terminationError) {
-        reject(terminationError);
-        return;
-      }
-      resolve({ stdout, stderr, exitCode: 0 });
+      terminate();
+      settleSuccess();
     });
   });
 }
 
 async function runSmokeCases(cases) {
   const results = new Array(cases.length);
+  const cleanups = [];
   let nextCaseIndex = 0;
   const workers = Array.from(
     { length: Math.min(MAX_CONCURRENT_SMOKE_CASES, cases.length) },
@@ -159,8 +338,14 @@ async function runSmokeCases(cases) {
         results[caseIndex] = await Promise.resolve()
           .then(smokeCase.run)
           .then(
-            (value) => ({ status: 'fulfilled', value }),
-            (reason) => ({ status: 'rejected', reason }),
+            (value) => {
+              retainCleanup(cleanups, value);
+              return { status: 'fulfilled', value };
+            },
+            (reason) => {
+              retainCleanup(cleanups, reason);
+              return { status: 'rejected', reason };
+            },
           );
       }
     },
@@ -178,26 +363,74 @@ async function runSmokeCases(cases) {
       ? [{ name: cases[index].name, error: result.reason }]
       : []
   ));
-  if (failures.length === 0) {
-    return evaluation;
+  return { evaluation, failures, cleanups };
+}
+
+function retainCleanup(cleanups, value) {
+  const cleanup = value?.cleanup;
+  if (cleanup === undefined || typeof cleanup.then !== 'function') {
+    return;
   }
-  const error = new AggregateError(
-    failures.map(({ error }) => error),
-    `Prompt eval smoke cases failed: ${failures.map(({ name }) => name).join(', ')}`,
-  );
-  error.smokeResult = evaluation;
-  throw error;
+  cleanups.push(Promise.resolve(cleanup).then(
+    () => undefined,
+    (error) => error,
+  ));
+}
+
+function writeStream(stream, output) {
+  return new Promise((resolve, reject) => {
+    stream.write(output, (error) => {
+      if (error !== undefined && error !== null) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function waitForSmokeCleanups(cleanups) {
+  const outcomes = await Promise.all(cleanups);
+  const failures = outcomes.filter((outcome) => outcome !== undefined);
+  if (failures.length === 0) {
+    return;
+  }
+  const details = failures.map((error) => error instanceof Error ? error.message : String(error));
+  await writeStream(process.stderr, `Warning: Smoke case cleanup failed: ${details.join('; ')}\n`);
+  throw new AggregateError(failures, 'Smoke case cleanup failed');
 }
 
 export async function runSmokeBatch(cases) {
+  const { evaluation, failures, cleanups } = await runSmokeCases(cases);
+  let reportError;
   try {
-    const result = await runSmokeCases(cases);
-    process.stdout.write(`SMOKE_BATCH_RESULT ${JSON.stringify(result)}\n`);
-    return result;
+    await writeStream(process.stdout, `SMOKE_BATCH_RESULT ${JSON.stringify(evaluation)}\n`);
   } catch (error) {
-    if (error instanceof AggregateError && error.smokeResult !== undefined) {
-      process.stdout.write(`SMOKE_BATCH_RESULT ${JSON.stringify(error.smokeResult)}\n`);
+    reportError = error;
+  }
+  let cleanupError;
+  try {
+    await waitForSmokeCleanups(cleanups);
+  } catch (error) {
+    cleanupError = error;
+  }
+  if (reportError !== undefined) {
+    if (cleanupError !== undefined) {
+      throw new AggregateError([reportError, cleanupError], 'Smoke batch report and cleanup failed');
     }
+    throw reportError;
+  }
+  if (failures.length > 0 || cleanupError !== undefined) {
+    const errors = failures.map(({ error }) => error);
+    if (cleanupError !== undefined) {
+      errors.push(cleanupError);
+    }
+    const error = new AggregateError(
+      errors,
+      `Prompt eval smoke cases failed: ${failures.map(({ name }) => name).join(', ') || 'cleanup'}`,
+    );
+    error.smokeResult = evaluation;
     throw error;
   }
+  return evaluation;
 }


### PR DESCRIPTION
## 概要

Windows CI の `windows-private-artifacts` ジョブで反復していた `promptEvalProbeLifecycle.test.ts` のフレーク（8/18・8/19・8/20 に3回、毎回別テストがタイムアウト系のエラー形状変化で失敗）を解消する。

## 原因

1. `runProbeProcess` / `runSmokeScript` が子プロセスの spawn 完了前から timeout を計測しており、遅い Windows ランナーでは起動だけで予算を消費していた
2. timeout 発火後に遅れて届いた protocol violation を再評価せず、テストが検証したい `EPROBEPROTOCOL` が timeout エラーに化けていた
3. Windows の taskkill 後の WMI 残存確認が即時1回のみで、終了反映の遅延を termination error と誤認していた

## 修正の設計

プローブの「報告」と「cleanup」を分離し、次の契約に統一した。

- 結果の正本は報告: 完全な `PROBE_RESULT` / report marker 受信後は、cleanup の遅延・失敗・timeout が結果の成否を変えない
- cleanup 失敗の観測面は stderr 警告と結果への付帯情報: settle 済みの結果を覆さない。報告後の非0 close や cleanup 警告は stderr へ flush 転記する
- 外側 timeout の予算は「報告まで」: report marker を待つ経路は cleanup 時間と結合しない。close を待つ経路のみ cleanup の猶予を予算に加算する

付随する正しさの修正: report marker 指定時に marker 未受信のまま exit 0 で close した場合は `EPROBEPROTOCOL` として失敗にする / cleanup は全コマンド共通の単一 deadline を持ち、deadline 消費後も root の taskkill を必ず一度試行する / workspace 削除は cleanup 完了後に行う。

## 検証

- 対象テスト 65件（回帰テスト9件追加: 遅延 cleanup 中の報告先行、WMI 警告の flush、deadline 直前の遅延出力、marker 未受信 exit 0 の失敗化など）を3回連続で全緑
- luna max のレビューループ7ラウンド（設計差し戻し3回を含む）で APPROVE
- Windows 実機は CI で確認する（本修正は Windows 固有の spawn / taskkill / WMI 経路を直接対象にしている）

## 対象

テスト計測基盤（tools/opencode-probe）とそのテストのみ。製品コード（src/、builtins/）への変更はない。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 診断およびSmokeテストのタイムアウト判定を、実行段階やケース数に応じて適切に調整しました。
  * 大量出力や子プロセスを含む処理でも、終了処理と結果報告を安定して完了できるよう改善しました。
  * ワークスペース削除や欠落レポート、クリーンアップ警告などの異常時に、エラー情報が確実に伝播されるよう強化しました。
  * Windows環境でのプロセス終了や、外側のランチャーによるタイムアウト処理の検証を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->