### PR TITLE
[#1428] fix-run-scoped-prompts

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1224,7 +1224,7 @@ logging:
   debug: true
 ```
 
-デバッグログは `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log` に NDJSON 形式で出力され、プロンプト/レスポンスログは同じディレクトリの `debug-{timestamp}-prompts.jsonl` に出力されます。
+デバッグログは `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log` に NDJSON 形式で出力されます。プロンプト/レスポンスログは workflow run ごとに `.takt/runs/{run}/logs/{sessionId}-prompts.jsonl` へ出力されます。
 
 ### 詳細コンソール出力
 
@@ -1236,7 +1236,7 @@ logging:
   level: debug
 ```
 
-これは CLI 内部の verbose console mode も有効にします。さらに `logging.level: debug` だけでデバッグロガーも有効になるため、上記の `debug-{timestamp}.log` と `debug-{timestamp}-prompts.jsonl` は `logging.debug` を別途設定しなくても出力されます。`logging.debug: true`、`logging.trace: true`、`logging.level: debug` のいずれかで有効になります。
+これは CLI 内部の verbose console mode も有効にします。さらに `logging.level: debug` だけでデバッグロガーも有効になるため、上記の `debug-{timestamp}.log` と run ごとの `{sessionId}-prompts.jsonl` は `logging.debug` を別途設定しなくても出力されます。`logging.debug: true`、`logging.trace: true`、`logging.level: debug` のいずれかで有効になります。
 
 ## Companion の provider target
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1268,7 +1268,7 @@ logging:
   debug: true
 ```
 
-Debug logs are written to `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log` in NDJSON format, and prompt/response logs to `debug-{timestamp}-prompts.jsonl` in the same directory.
+Debug logs are written to `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log` in NDJSON format. Prompt/response logs are written per workflow run to `.takt/runs/{run}/logs/{sessionId}-prompts.jsonl`.
 
 ### Detailed Console Output
 
@@ -1280,7 +1280,7 @@ logging:
   level: debug
 ```
 
-This also enables the internal verbose console mode used by the CLI. `logging.level: debug` alone additionally enables the debug logger, so the `debug-{timestamp}.log` and `debug-{timestamp}-prompts.jsonl` artifacts above are produced without setting `logging.debug` separately. Any of `logging.debug: true`, `logging.trace: true`, or `logging.level: debug` enables them.
+This also enables the internal verbose console mode used by the CLI. `logging.level: debug` alone additionally enables the debug logger, so the `debug-{timestamp}.log` and per-run `{sessionId}-prompts.jsonl` artifacts above are produced without setting `logging.debug` separately. Any of `logging.debug: true`, `logging.trace: true`, or `logging.level: debug` enables them.
 
 ## Companion provider targets
 

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -1047,7 +1047,7 @@ logging:
   debug: true
 ```
 
-debug 日志以 NDJSON 写入 `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log`，prompt/response 日志写入同目录的 `debug-{timestamp}-prompts.jsonl`。
+debug 日志以 NDJSON 写入 `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log`，prompt/response 日志按 workflow run 写入 `.takt/runs/{run}/logs/{sessionId}-prompts.jsonl`。
 
 ### 详细控制台输出
 

--- a/src/__tests__/debug.test.ts
+++ b/src/__tests__/debug.test.ts
@@ -14,22 +14,12 @@ import {
   debugLog,
   infoLog,
   errorLog,
-  writePromptLog,
 } from '../shared/utils/index.js';
-import { existsSync, readFileSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, readdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const TEST_TMPDIR = realpathSync(tmpdir());
-
-function resolvePromptsLogFilePath(): string {
-  const debugLogFile = getDebugLogFile();
-  expect(debugLogFile).not.toBeNull();
-  if (!debugLogFile!.endsWith('.log')) {
-    throw new Error(`unexpected debug log file path: ${debugLogFile!}`);
-  }
-  return debugLogFile!.replace(/\.log$/, '-prompts.jsonl');
-}
 
 function readPersistedDebugData(logFile: string, message: string): string {
   const persisted = readFileSync(logFile, 'utf-8');
@@ -102,16 +92,15 @@ describe('debug logging', () => {
       }
     });
 
-    it('should create prompts log file with -prompts suffix', () => {
-      const projectDir = mkdtempSync(join(TEST_TMPDIR, 'takt-test-debug-prompts-'));
+    it('should not create a prompts log file during initialization', () => {
+      const projectDir = mkdtempSync(join(TEST_TMPDIR, 'takt-test-debug-no-prompts-'));
 
       try {
         initDebugLogger({ enabled: true }, projectDir);
-        const promptsLogFile = resolvePromptsLogFilePath();
-        expect(promptsLogFile).toContain(join(projectDir, '.takt', 'runs'));
-        expect(promptsLogFile).toContain('/logs/');
-        expect(promptsLogFile).toMatch(/debug-.*-prompts\.jsonl$/);
-        expect(existsSync(promptsLogFile)).toBe(true);
+        const logFile = getDebugLogFile();
+        expect(logFile).not.toBeNull();
+        const entries = readdirSync(dirname(logFile!));
+        expect(entries.filter((entry) => entry.endsWith('-prompts.jsonl'))).toEqual([]);
       } finally {
         rmSync(projectDir, { recursive: true, force: true });
       }
@@ -130,9 +119,7 @@ describe('debug logging', () => {
       try {
         initDebugLogger({ enabled: true, logFile }, '/tmp');
         expect(getDebugLogFile()).toBe(logFile);
-        expect(resolvePromptsLogFilePath()).toBe(join(logDir, 'test-prompts.jsonl'));
         expect(existsSync(logFile)).toBe(true);
-        expect(existsSync(join(logDir, 'test-prompts.jsonl'))).toBe(true);
 
         const content = readFileSync(logFile, 'utf-8');
         expect(content).toContain('TAKT Debug Log');
@@ -167,68 +154,6 @@ describe('debug logging', () => {
       expect(isDebugEnabled()).toBe(false);
       expect(getDebugLogFile()).toBeNull();
       expect(isVerboseConsole()).toBe(false);
-    });
-  });
-
-  describe('writePromptLog', () => {
-    it('should append prompt log record when debug is enabled', () => {
-      const projectDir = mkdtempSync(join(TEST_TMPDIR, 'takt-test-debug-write-prompts-'));
-
-      try {
-        initDebugLogger({ enabled: true }, projectDir);
-        const promptsLogFile = resolvePromptsLogFilePath();
-
-        writePromptLog({
-          step: 'plan',
-          phase: 1,
-          iteration: 2,
-          scope: '{"step":"plan","stack":[]}',
-          systemPrompt: 'system prompt',
-          userInstruction: 'prompt text',
-          prompt: 'prompt text',
-          response: 'response text',
-          timestamp: '2026-02-07T00:00:00.000Z',
-        });
-
-        const content = readFileSync(promptsLogFile, 'utf-8').trim();
-        expect(content).not.toBe('');
-        const parsed = JSON.parse(content) as {
-          step: string;
-          phase: number;
-          iteration: number;
-          systemPrompt: string;
-          userInstruction: string;
-          prompt: string;
-          response: string;
-          timestamp: string;
-        };
-        expect(parsed.step).toBe('plan');
-        expect(parsed.phase).toBe(1);
-        expect(parsed.iteration).toBe(2);
-        expect(parsed.systemPrompt).toBe('system prompt');
-        expect(parsed.userInstruction).toBe('prompt text');
-        expect(parsed.prompt).toBe('prompt text');
-        expect(parsed.response).toBe('response text');
-        expect(parsed.timestamp).toBe('2026-02-07T00:00:00.000Z');
-      } finally {
-        rmSync(projectDir, { recursive: true, force: true });
-      }
-    });
-
-    it('should do nothing when debug is disabled', () => {
-      writePromptLog({
-        step: 'plan',
-          phase: 1,
-          iteration: 1,
-          scope: '{"step":"plan","stack":[]}',
-        systemPrompt: 'system prompt',
-        userInstruction: 'ignored prompt',
-        prompt: 'ignored prompt',
-        response: 'ignored response',
-        timestamp: '2026-02-07T00:00:00.000Z',
-      });
-
-      expect(getDebugLogFile()).toBeNull();
     });
   });
 

--- a/src/__tests__/notification-sound.test.ts
+++ b/src/__tests__/notification-sound.test.ts
@@ -264,7 +264,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => {
     playWarningSound: mockPlayWarningSound,
     preventSleep: vi.fn(),
     isDebugEnabled: vi.fn().mockReturnValue(false),
-    writePromptLog: vi.fn(),
     generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
     isValidReportDirName: vi.fn().mockImplementation((value: string) => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)),
   };

--- a/src/__tests__/sigint-interrupt.test.ts
+++ b/src/__tests__/sigint-interrupt.test.ts
@@ -212,7 +212,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => {
     playWarningSound: vi.fn(),
     preventSleep: vi.fn(),
     isDebugEnabled: vi.fn().mockReturnValue(false),
-    writePromptLog: vi.fn(),
     generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
     isValidReportDirName: vi.fn().mockImplementation((value: string) => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)),
   };

--- a/src/__tests__/traceReport.test.ts
+++ b/src/__tests__/traceReport.test.ts
@@ -7,6 +7,7 @@ import {
   renderTraceReportFromRecords,
   renderTraceReportMarkdown,
 } from '../features/tasks/execute/traceReport.js';
+import { buildWorkflowStepScopeKey } from '../features/tasks/execute/workflowStepScope.js';
 
 describe('traceReport', () => {
   it('returns no optional trace report when session records are absent', () => {
@@ -376,6 +377,106 @@ describe('traceReport', () => {
     expect(markdown).not.toContain('xyz987');
     expect(markdown).not.toContain('ghp_abcdef1234567890');
     expect(markdown).not.toContain('xoxb-1234abcd-5678efgh');
+  });
+
+  it('correlates a prompt log record to its phase by scope and phaseExecutionId', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'trace-report-prompt-correlation-'));
+    const sessionPath = join(dir, 'session.jsonl');
+    const promptsPath = join(dir, 'prompts.jsonl');
+    writeFileSync(sessionPath, [
+      JSON.stringify({ type: 'workflow_start', task: 'task', workflowName: 'workflow', startTime: '2026-03-04T11:59:00.000Z' }),
+      JSON.stringify({ type: 'phase_start', step: 'plan', iteration: 1, phase: 1, phaseName: 'execute', phaseExecutionId: 'plan:1:1:1', timestamp: '2026-03-04T11:59:02.000Z' }),
+      JSON.stringify({ type: 'phase_complete', step: 'plan', iteration: 1, phase: 1, phaseName: 'execute', phaseExecutionId: 'plan:1:1:1', status: 'done', content: 'phase response from session', timestamp: '2026-03-04T11:59:03.000Z' }),
+      JSON.stringify({ type: 'workflow_complete', iterations: 1, endTime: '2026-03-04T12:00:00.000Z' }),
+      '',
+    ].join('\n'));
+    writeFileSync(promptsPath, [
+      JSON.stringify({
+        step: 'plan',
+        phase: 1,
+        iteration: 1,
+        scope: buildWorkflowStepScopeKey('plan', undefined),
+        phaseExecutionId: 'plan:1:1:1',
+        prompt: 'user instruction from prompt log',
+        systemPrompt: 'system prompt from prompt log',
+        userInstruction: 'user instruction from prompt log',
+        response: 'phase response from session',
+        timestamp: '2026-03-04T11:59:03.000Z',
+      }),
+      '',
+    ].join('\n'));
+
+    const markdown = renderTraceReportFromLogs(
+      {
+        tracePath: join(dir, 'trace.md'),
+        workflowName: 'workflow',
+        task: 'task',
+        runSlug: 'run-prompt-correlation',
+        status: 'completed',
+        iterations: 1,
+        endTime: '2026-03-04T12:00:00.000Z',
+      },
+      sessionPath,
+      promptsPath,
+      'full',
+    );
+
+    expect(markdown).toBeDefined();
+    expect(markdown).toContain('system prompt from prompt log');
+    expect(markdown).toContain('user instruction from prompt log');
+  });
+
+  it('throws when one run holds duplicate prompt records for the same scope and phaseExecutionId', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'trace-report-duplicate-prompt-'));
+    const sessionPath = join(dir, 'session.jsonl');
+    const promptsPath = join(dir, 'prompts.jsonl');
+    writeFileSync(sessionPath, [
+      JSON.stringify({ type: 'workflow_start', task: 'task', workflowName: 'workflow', startTime: '2026-03-04T11:59:00.000Z' }),
+      '',
+    ].join('\n'));
+    const scope = buildWorkflowStepScopeKey('plan', undefined);
+    writeFileSync(promptsPath, [
+      JSON.stringify({
+        step: 'plan',
+        phase: 1,
+        iteration: 1,
+        scope,
+        phaseExecutionId: 'plan:1:1:1',
+        prompt: 'prompt text',
+        systemPrompt: 'system prompt',
+        userInstruction: 'prompt text',
+        response: 'first response',
+        timestamp: '2026-03-04T11:59:03.000Z',
+      }),
+      JSON.stringify({
+        step: 'plan',
+        phase: 1,
+        iteration: 1,
+        scope,
+        phaseExecutionId: 'plan:1:1:1',
+        prompt: 'prompt text',
+        systemPrompt: 'system prompt',
+        userInstruction: 'prompt text',
+        response: 'second response',
+        timestamp: '2026-03-04T11:59:04.000Z',
+      }),
+      '',
+    ].join('\n'));
+
+    expect(() => renderTraceReportFromLogs(
+      {
+        tracePath: join(dir, 'trace.md'),
+        workflowName: 'workflow',
+        task: 'task',
+        runSlug: 'run-duplicate-prompt',
+        status: 'completed',
+        iterations: 1,
+        endTime: '2026-03-04T12:00:00.000Z',
+      },
+      sessionPath,
+      promptsPath,
+      'full',
+    )).toThrow('Duplicate prompt execution');
   });
 
 });

--- a/src/__tests__/workflow-execution-canonical.test.ts
+++ b/src/__tests__/workflow-execution-canonical.test.ts
@@ -106,9 +106,9 @@ vi.mock('../shared/utils/index.js', () => ({
   notifySuccess: vi.fn(),
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
+  isDebugEnabled: vi.fn(() => false),
   generateReportDir: vi.fn(() => 'test-report-dir'),
   isValidReportDirName: vi.fn(() => true),
-  getDebugPromptsLogFile: vi.fn(() => undefined),
 }));
 
 vi.mock('../core/logging/providerEventLogger.js', () => ({

--- a/src/__tests__/workflowExecution-ask-user-question.test.ts
+++ b/src/__tests__/workflowExecution-ask-user-question.test.ts
@@ -219,8 +219,6 @@ vi.mock('../shared/utils/index.js', () => ({
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
   isDebugEnabled: vi.fn().mockReturnValue(false),
-  writePromptLog: vi.fn(),
-  getDebugPromptsLogFile: vi.fn().mockReturnValue(null),
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
   isValidReportDirName: vi.fn().mockReturnValue(true),
   playWarningSound: vi.fn(),

--- a/src/__tests__/workflowExecution-debug-prompts.test.ts
+++ b/src/__tests__/workflowExecution-debug-prompts.test.ts
@@ -2,7 +2,7 @@
  * Integration tests: debug prompt log wiring in executeWorkflow().
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, it, expect, beforeEach, vi } from 'vitest';
@@ -12,9 +12,10 @@ import { buildPhaseExecutionId } from '../shared/utils/phaseExecutionId.js';
 const {
   disabledObservability,
   mockIsDebugEnabled,
-  mockWritePromptLog,
   mockInitNdjsonLog,
   mockAppendNdjsonLine,
+  traceWriterCalls,
+  traceFullState,
   MockWorkflowEngine,
 } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -25,7 +26,8 @@ const {
   const path = require('node:path') as typeof import('node:path');
 
   const mockIsDebugEnabled = vi.fn().mockReturnValue(true);
-  const mockWritePromptLog = vi.fn();
+  const traceWriterCalls: Array<{ tracePath: string; promptLogPath?: string }> = [];
+  const traceFullState = { enabled: false };
   const mockInitNdjsonLog = vi.fn((
     sessionId: string,
     task: string,
@@ -49,14 +51,16 @@ const {
   class MockWorkflowEngine extends EE {
     private config: WorkflowConfig;
     private task: string;
+    private cwd: string;
 
-    constructor(config: WorkflowConfig, _cwd: string, task: string, _options: unknown) {
+    constructor(config: WorkflowConfig, cwd: string, task: string, _options: unknown) {
       super();
       if (task === 'constructor-throw-task') {
         throw new Error('mock constructor failure');
       }
       this.config = config;
       this.task = task;
+      this.cwd = cwd;
     }
 
     abort(): void {}
@@ -100,9 +104,9 @@ const {
           userInstruction: 'phase prompt second',
         }, executePhaseSecondId, 1);
       } else {
-        this.emit('phase:start', step, 1, 'execute', shouldEmitSensitive ? 'token=plain-secret' : 'phase prompt', {
-          systemPrompt: shouldEmitSensitive ? 'Authorization: Bearer super-secret-token' : '../agents/coder.md',
-          userInstruction: shouldEmitSensitive ? 'api_key=plain-secret' : 'phase prompt',
+        this.emit('phase:start', step, 1, 'execute', shouldEmitSensitive ? 'token=plain-secret' : `phase prompt for ${this.task}`, {
+          systemPrompt: shouldEmitSensitive ? 'Authorization: Bearer super-secret-token' : `system prompt for ${this.task}`,
+          userInstruction: shouldEmitSensitive ? 'api_key=plain-secret' : `user instruction for ${this.task}`,
         }, executePhaseId, 1);
       }
       this.emit('phase:start', step, 3, 'judge', 'phase3 prompt', {
@@ -136,7 +140,7 @@ const {
         this.emit('phase:complete', step, 1, 'execute', 'phase response second', 'done', undefined, executePhaseSecondId, 1);
         this.emit('phase:complete', step, 1, 'execute', 'phase response first', 'done', undefined, executePhaseId, 1);
       } else {
-        this.emit('phase:complete', step, 1, 'execute', shouldEmitSensitive ? 'password=plain-secret' : 'phase response', 'done', undefined, executePhaseId, 1);
+        this.emit('phase:complete', step, 1, 'execute', shouldEmitSensitive ? 'password=plain-secret' : `phase response for ${this.task} in ${this.cwd}`, 'done', undefined, executePhaseId, 1);
       }
       if (shouldDuplicatePhase) {
         this.emit('phase:start', step, 1, 'execute', 'phase prompt second', {
@@ -151,7 +155,7 @@ const {
         {
           persona: step.personaDisplayName,
           status: 'done',
-          content: 'step response',
+          content: `step response for ${this.task}`,
           timestamp,
         },
         'step instruction',
@@ -209,9 +213,10 @@ const {
       usageEventsPhase: false,
     },
     mockIsDebugEnabled,
-    mockWritePromptLog,
     mockInitNdjsonLog,
     mockAppendNdjsonLine,
+    traceWriterCalls,
+    traceFullState,
     MockWorkflowEngine,
   };
 });
@@ -258,16 +263,16 @@ vi.mock('../infra/config/index.js', () => ({
   updateWorktreeSession: vi.fn(),
   loadProjectConfig: vi.fn(() => ({})),
   loadGlobalConfig: vi.fn(() => ({})),
-  resolveWorkflowConfigValues: vi.fn().mockReturnValue({
+  resolveWorkflowConfigValues: vi.fn().mockImplementation(() => ({
     notificationSound: true,
     notificationSoundEvents: {},
     provider: 'claude',
     runtime: undefined,
     preventSleep: false,
     model: undefined,
-    logging: undefined,
+    logging: traceFullState.enabled ? { trace: true } : undefined,
     observability: disabledObservability,
-  }),
+  })),
   saveSessionState: vi.fn(),
   ensureDir: vi.fn(),
   writeFileAtomic: vi.fn(),
@@ -301,6 +306,10 @@ vi.mock('../features/tasks/execute/traceReportWriter.js', async () => {
         reason?: string;
       };
     }) => {
+      traceWriterCalls.push({
+        tracePath: input.tracePath,
+        ...(input.promptLogPath === undefined ? {} : { promptLogPath: input.promptLogPath }),
+      });
       const markdown = renderTraceReportFromLogs(
         {
           tracePath: input.tracePath,
@@ -366,7 +375,8 @@ vi.mock('../infra/fs/index.js', async (importOriginal) => ({
   appendNdjsonLine: mockAppendNdjsonLine,
 }));
 
-vi.mock('../shared/utils/index.js', () => ({
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   createLogger: vi.fn().mockReturnValue({
     debug: vi.fn(),
     info: vi.fn(),
@@ -377,8 +387,6 @@ vi.mock('../shared/utils/index.js', () => ({
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
   isDebugEnabled: mockIsDebugEnabled,
-  writePromptLog: mockWritePromptLog,
-  getDebugPromptsLogFile: vi.fn().mockReturnValue(null),
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
   isValidReportDirName: vi.fn().mockImplementation((value: string) => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)),
 }));
@@ -402,11 +410,14 @@ import { appendNdjsonLine } from '../infra/fs/index.js';
 import { normalizeRule } from '../infra/config/loaders/workflowRuleNormalizer.js';
 
 describe('executeWorkflow debug prompts logging', () => {
+  const TEST_SESSION_ID = 'test-session-id';
   let projectDir: string;
 
   beforeEach(() => {
-    projectDir = mkdtempSync(join(tmpdir(), 'takt-debug-prompts-'));
+    projectDir = mkdtempSync(join(realpathSync(tmpdir()), 'takt-debug-prompts-'));
     vi.clearAllMocks();
+    traceWriterCalls.length = 0;
+    traceFullState.enabled = false;
     mockIsDebugEnabled.mockReturnValue(true);
   });
 
@@ -432,22 +443,79 @@ describe('executeWorkflow debug prompts logging', () => {
     };
   }
 
-  it('should write prompt log record when debug is enabled', async () => {
-    mockIsDebugEnabled.mockReturnValue(true);
+  function runLogsDir(cwd: string, runSlug: string): string {
+    return join(cwd, '.takt', 'runs', runSlug, 'logs');
+  }
 
+  function runPromptsLogPath(cwd: string, runSlug: string): string {
+    return join(runLogsDir(cwd, runSlug), `${TEST_SESSION_ID}-prompts.jsonl`);
+  }
+
+  function readRunPromptRecords(cwd: string, runSlug: string): Array<Record<string, unknown>> {
+    return readFileSync(runPromptsLogPath(cwd, runSlug), 'utf-8')
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+  }
+
+  function readWrittenTrace(runSlug: string): string | undefined {
+    const call = vi.mocked(writeFileAtomic).mock.calls.find(
+      (entry) => String(entry[0]).endsWith(`${runSlug}/trace.md`),
+    );
+    return call === undefined ? undefined : String(call[1]);
+  }
+
+  function expectIsolatedRunArtifacts(alphaCwd: string, betaCwd: string): void {
+    const alphaRecords = readRunPromptRecords(alphaCwd, 'run-alpha');
+    const betaRecords = readRunPromptRecords(betaCwd, 'run-beta');
+    expect(alphaRecords.length).toBeGreaterThan(0);
+    expect(betaRecords.length).toBeGreaterThan(0);
+    const alphaPhaseOne = alphaRecords.find((record) => record.phase === 1)!;
+    const betaPhaseOne = betaRecords.find((record) => record.phase === 1)!;
+    expect(alphaPhaseOne.scope).toBe(betaPhaseOne.scope);
+    expect(alphaPhaseOne.phaseExecutionId).toBe(betaPhaseOne.phaseExecutionId);
+    expect(JSON.stringify(alphaRecords)).toContain('alpha-task-body');
+    expect(JSON.stringify(alphaRecords)).not.toContain('beta-task-body');
+    expect(JSON.stringify(betaRecords)).toContain('beta-task-body');
+    expect(JSON.stringify(betaRecords)).not.toContain('alpha-task-body');
+
+    const alphaTrace = readWrittenTrace('run-alpha');
+    const betaTrace = readWrittenTrace('run-beta');
+    expect(alphaTrace).toBeDefined();
+    expect(betaTrace).toBeDefined();
+    expect(alphaTrace!).toContain('alpha-task-body');
+    expect(alphaTrace!).not.toContain('beta-task-body');
+    expect(alphaTrace!).not.toContain(betaCwd);
+    expect(betaTrace!).toContain('beta-task-body');
+    expect(betaTrace!).not.toContain('alpha-task-body');
+    expect(betaTrace!).not.toContain(alphaCwd);
+
+    const alphaTraceCall = traceWriterCalls.find((call) => call.tracePath.includes('run-alpha'));
+    const betaTraceCall = traceWriterCalls.find((call) => call.tracePath.includes('run-beta'));
+    expect(alphaTraceCall?.promptLogPath).toBe(runPromptsLogPath(alphaCwd, 'run-alpha'));
+    expect(betaTraceCall?.promptLogPath).toBe(runPromptsLogPath(betaCwd, 'run-beta'));
+
+    for (const [cwd, runSlug, task] of [
+      [alphaCwd, 'run-alpha', 'alpha-task-body'],
+      [betaCwd, 'run-beta', 'beta-task-body'],
+    ] as const) {
+      const sessionLines = readFileSync(join(runLogsDir(cwd, runSlug), `${TEST_SESSION_ID}.jsonl`), 'utf-8')
+        .split('\n')
+        .filter((line) => line.length > 0);
+      const firstRecord = JSON.parse(sessionLines[0]!) as { type: string; task: string };
+      expect(firstRecord.type).toBe('workflow_start');
+      expect(firstRecord.task).toBe(task);
+    }
+  }
+
+  it('should write prompt log records to the run-scoped prompts log when debug is enabled', async () => {
     await executeWorkflow(makeConfig(), 'task', projectDir, {
       projectCwd: projectDir,
+      reportDirName: 'debug-run',
     });
 
-    expect(mockWritePromptLog).toHaveBeenCalledTimes(2);
-    const records = mockWritePromptLog.mock.calls.map((call) => call[0]) as Array<{
-      step: string;
-      phase: number;
-      iteration: number;
-      prompt: string;
-      response: string;
-      timestamp: string;
-    }>;
+    const records = readRunPromptRecords(projectDir, 'debug-run');
+    expect(records).toHaveLength(2);
     const record = records.find((entry) => entry.phase === 1)!;
     expect(record.step).toBe('implement');
     expect(record.phase).toBe(1);
@@ -457,49 +525,123 @@ describe('executeWorkflow debug prompts logging', () => {
     expect(record.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
-  it('should separate system prompt and user instruction in debug prompt records', async () => {
-    mockIsDebugEnabled.mockReturnValue(true);
-
+  it('should separate system prompt and user instruction in run-scoped prompt records', async () => {
     await executeWorkflow(makeConfig(), 'task', projectDir, {
       projectCwd: projectDir,
+      reportDirName: 'debug-run',
     });
 
-    expect(mockWritePromptLog).toHaveBeenCalledTimes(2);
-    const records = mockWritePromptLog.mock.calls.map((call) => call[0]) as Array<Record<string, unknown> & { phase: number }>;
+    const records = readRunPromptRecords(projectDir, 'debug-run');
     const record = records.find((entry) => entry.phase === 1)!;
-    expect(record).toHaveProperty('systemPrompt');
-    expect(record).toHaveProperty('userInstruction');
     expect(record.systemPrompt).toBeTypeOf('string');
     expect(record.userInstruction).toBeTypeOf('string');
   });
 
-  it('should not write prompt log record when debug is disabled', async () => {
+  it('should not create a prompts log file when debug is disabled', async () => {
     mockIsDebugEnabled.mockReturnValue(false);
 
     await executeWorkflow(makeConfig(), 'task', projectDir, {
       projectCwd: projectDir,
+      reportDirName: 'debug-disabled-run',
     });
 
-    expect(mockWritePromptLog).not.toHaveBeenCalled();
+    const logEntries = readdirSync(runLogsDir(projectDir, 'debug-disabled-run'));
+    expect(logEntries.filter((entry) => entry.endsWith('-prompts.jsonl'))).toEqual([]);
+    const traceCall = traceWriterCalls.find((call) => call.tracePath.includes('debug-disabled-run'));
+    expect(traceCall?.promptLogPath).toBeUndefined();
   });
 
-  it('should handle repeated phase starts for same step and phase without missing debug prompt', async () => {
-    mockIsDebugEnabled.mockReturnValue(true);
-
+  it('should keep repeated phase starts in the same run as distinct prompt records', async () => {
     await executeWorkflow(makeConfig(), 'duplicate-phase-task', projectDir, {
       projectCwd: projectDir,
+      reportDirName: 'debug-run',
     });
 
-    expect(mockWritePromptLog).toHaveBeenCalledTimes(3);
-    const records = mockWritePromptLog.mock.calls.map((call) => call[0]) as Array<{
-      phase: number;
-      response: string;
-    }>;
+    const records = readRunPromptRecords(projectDir, 'debug-run');
+    expect(records).toHaveLength(3);
     const phase1Responses = records
       .filter((record) => record.phase === 1)
       .map((record) => record.response);
     expect(phase1Responses).toHaveLength(2);
     expect(phase1Responses.every((response) => typeof response === 'string' && response.length > 0)).toBe(true);
+  });
+
+  it('should write the run-scoped prompts log as a private file with sanitized records', async () => {
+    await executeWorkflow(makeConfig(), 'sensitive-content-task', projectDir, {
+      projectCwd: projectDir,
+      reportDirName: 'debug-sensitive-run',
+    });
+
+    const promptsPath = runPromptsLogPath(projectDir, 'debug-sensitive-run');
+    expect(statSync(promptsPath).mode & 0o777).toBe(0o600);
+    const content = readFileSync(promptsPath, 'utf-8');
+    expect(content).toContain('[REDACTED]');
+    expect(content).not.toContain('plain-secret');
+    expect(content).not.toContain('super-secret-token');
+  });
+
+  it('should isolate prompt records and traces between sequential runs in the same process', async () => {
+    const alphaCwd = join(projectDir, 'alpha-work');
+    const betaCwd = join(projectDir, 'beta-work');
+    mkdirSync(alphaCwd, { recursive: true });
+    mkdirSync(betaCwd, { recursive: true });
+
+    await executeWorkflow(makeConfig(), 'alpha-task-body', alphaCwd, {
+      projectCwd: projectDir,
+      reportDirName: 'run-alpha',
+    });
+    await executeWorkflow(makeConfig(), 'beta-task-body', betaCwd, {
+      projectCwd: projectDir,
+      reportDirName: 'run-beta',
+    });
+
+    expectIsolatedRunArtifacts(alphaCwd, betaCwd);
+  });
+
+  it('should isolate prompt records and traces between concurrent runs in the same process', async () => {
+    const alphaCwd = join(projectDir, 'alpha-work');
+    const betaCwd = join(projectDir, 'beta-work');
+    mkdirSync(alphaCwd, { recursive: true });
+    mkdirSync(betaCwd, { recursive: true });
+
+    await Promise.all([
+      executeWorkflow(makeConfig(), 'alpha-task-body', alphaCwd, {
+        projectCwd: projectDir,
+        reportDirName: 'run-alpha',
+      }),
+      executeWorkflow(makeConfig(), 'beta-task-body', betaCwd, {
+        projectCwd: projectDir,
+        reportDirName: 'run-beta',
+      }),
+    ]);
+
+    expectIsolatedRunArtifacts(alphaCwd, betaCwd);
+  });
+
+  it('should not mix task body, cwd, or response across runs in full trace mode', async () => {
+    traceFullState.enabled = true;
+    const alphaCwd = join(projectDir, 'alpha-work');
+    const betaCwd = join(projectDir, 'beta-work');
+    mkdirSync(alphaCwd, { recursive: true });
+    mkdirSync(betaCwd, { recursive: true });
+
+    await executeWorkflow(makeConfig(), 'alpha-task-body', alphaCwd, {
+      projectCwd: projectDir,
+      reportDirName: 'run-alpha',
+    });
+    await executeWorkflow(makeConfig(), 'beta-task-body', betaCwd, {
+      projectCwd: projectDir,
+      reportDirName: 'run-beta',
+    });
+
+    expectIsolatedRunArtifacts(alphaCwd, betaCwd);
+
+    const alphaTrace = readWrittenTrace('run-alpha');
+    const betaTrace = readWrittenTrace('run-beta');
+    expect(alphaTrace!).toContain(`phase response for alpha-task-body in ${alphaCwd}`);
+    expect(alphaTrace!).not.toContain('phase response for beta-task-body');
+    expect(betaTrace!).toContain(`phase response for beta-task-body in ${betaCwd}`);
+    expect(betaTrace!).not.toContain('phase response for alpha-task-body');
   });
 
   it('should fail fast when taskPrefix is provided without taskColorIndex', async () => {

--- a/src/__tests__/workflowExecution-session-loading.test.ts
+++ b/src/__tests__/workflowExecution-session-loading.test.ts
@@ -273,8 +273,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
   isDebugEnabled: vi.fn().mockReturnValue(false),
-  writePromptLog: vi.fn(),
-  getDebugPromptsLogFile: vi.fn().mockReturnValue(null),
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
   isValidReportDirName: vi.fn().mockReturnValue(true),
   playWarningSound: vi.fn(),

--- a/src/__tests__/workflowExecution-structured-caller.test.ts
+++ b/src/__tests__/workflowExecution-structured-caller.test.ts
@@ -230,8 +230,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
   isDebugEnabled: vi.fn().mockReturnValue(false),
-  writePromptLog: vi.fn(),
-  getDebugPromptsLogFile: vi.fn().mockReturnValue(null),
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
   ensureCurrentTmpDirExists: mockEnsureCurrentTmpDirExists,
   isValidReportDirName: vi.fn().mockReturnValue(true),

--- a/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
+++ b/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
@@ -90,7 +90,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
     warn: mockLogWarn,
   })),
   generateReportDir: vi.fn(() => 'generated-run'),
-  getDebugPromptsLogFile: vi.fn(() => undefined),
   isPathInside: vi.fn(() => true),
   isValidReportDirName: mockIsValidReportDirName,
   preventSleep: vi.fn(),

--- a/src/core/logging/contracts.ts
+++ b/src/core/logging/contracts.ts
@@ -4,6 +4,7 @@ export const PROVIDER_EVENTS_LOG_FILE_SUFFIX = '-provider-events.jsonl';
 export const USAGE_EVENTS_LOG_FILE_SUFFIX = '-usage-events.jsonl';
 export const PHASE_USAGE_EVENTS_LOG_FILE_SUFFIX = '-usage-events.phase.jsonl';
 export const OTEL_SESSION_SHADOW_LOG_FILE_SUFFIX = '-otel-session-shadow.jsonl';
+export const DEBUG_PROMPTS_LOG_FILE_SUFFIX = '-prompts.jsonl';
 
 export const USAGE_MISSING_REASONS = {
   NOT_AVAILABLE: 'usage_not_available',

--- a/src/features/tasks/execute/sessionLogger.ts
+++ b/src/features/tasks/execute/sessionLogger.ts
@@ -9,7 +9,7 @@ import {
   parseNdjsonRecord,
 } from '../../../infra/fs/index.js';
 import type { InteractiveMetadata } from './types.js';
-import { createLogger, isDebugEnabled, writePromptLog } from '../../../shared/utils/index.js';
+import { createLogger, isDebugEnabled } from '../../../shared/utils/index.js';
 import type { PromptLogRecord, NdjsonRecord } from '../../../shared/utils/index.js';
 import type { WorkflowResumePointEntry, WorkflowStep, AgentResponse, WorkflowState } from '../../../core/models/index.js';
 import type {
@@ -48,6 +48,7 @@ import type {
   NdjsonCompanionReviewRound,
 } from '../../../shared/utils/types.js';
 import {
+  appendPrivateFile,
   PrivateArtifactPublicationConflictError,
   readPrivateFileState,
   writePrivateFileWithModeExpected,
@@ -172,6 +173,7 @@ function sameTerminalSessionRecord(
 export class SessionLogger {
   private readonly ndjsonLogPath: string;
   private readonly allowSensitiveData: boolean;
+  private readonly promptLogPath: string | undefined;
   private readonly phaseTracker = new SessionLoggerPhaseTracker();
   private readonly activeStepIterations = new Map<string, number>();
   private readonly ndjsonRecords: NdjsonRecord[] = [];
@@ -179,9 +181,10 @@ export class SessionLogger {
   private workflowTerminalLogged = false;
   private companionAuditWriteFailureReported = false;
 
-  constructor(ndjsonLogPath: string, allowSensitiveData: boolean) {
+  constructor(ndjsonLogPath: string, allowSensitiveData: boolean, promptLogPath?: string) {
     this.ndjsonLogPath = ndjsonLogPath;
     this.allowSensitiveData = allowSensitiveData;
+    this.promptLogPath = promptLogPath;
   }
 
   writeInteractiveMetadata(meta: InteractiveMetadata): void {
@@ -285,7 +288,7 @@ export class SessionLogger {
         completedAt,
         this.sanitizeText.bind(this),
       );
-      writePromptLog(promptRecord);
+      this.appendPromptRecord(promptRecord);
       this.promptRecords.push(promptRecord);
     }
   }
@@ -441,6 +444,20 @@ export class SessionLogger {
   private appendRecord(record: NdjsonRecord): void {
     this.ndjsonRecords.push(record);
     appendNdjsonLine(this.ndjsonLogPath, record);
+  }
+
+  private appendPromptRecord(record: PromptLogRecord): void {
+    if (this.promptLogPath === undefined) {
+      return;
+    }
+    try {
+      appendPrivateFile(this.promptLogPath, `${JSON.stringify(record)}\n`);
+    } catch (error) {
+      // デバッグ用 prompt ログの書き込み失敗で workflow 本体を止めない。
+      log.warn('Debug prompt record could not be persisted; continuing workflow', {
+        error: safeExternalErrorMessage(error),
+      });
+    }
   }
 
   private appendCompanionAuditRecord(

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -51,7 +51,7 @@ import { TaskPrefixWriter } from '../../../shared/ui/TaskPrefixWriter.js';
 import { getErrorMessage } from '../../../shared/utils/error.js';
 import {
   createLogger,
-  getDebugPromptsLogFile,
+  isDebugEnabled,
   isValidReportDirName,
   preventSleep,
 } from '../../../shared/utils/index.js';
@@ -60,6 +60,7 @@ import { sanitizeTerminalText } from '../../../shared/utils/text.js';
 import { createUsageEventLogger, isUsageEventsEnabled } from '../../../core/logging/usageEventLogger.js';
 import { initializeOtelFoundation, type OtelFoundationHandle } from '../../../infra/observability/otelFoundation.js';
 import {
+  DEBUG_PROMPTS_LOG_FILE_SUFFIX,
   OTEL_SESSION_SHADOW_LOG_FILE_SUFFIX,
   PHASE_USAGE_EVENTS_LOG_FILE_SUFFIX,
 } from '../../../core/logging/contracts.js';
@@ -517,7 +518,13 @@ export async function createWorkflowExecutionBootstrap(
       startTime: runBootstrap.startedAt,
     },
   );
-  const sessionLogger = new SessionLogger(ndjsonLogPath, allowSensitiveData);
+  // debug prompt ログは terminal trace の入力になるため、process 共通ではなく
+  // run 専用ファイル（logs/{sessionId}-prompts.jsonl）へ分離する。別 run の
+  // 同一 phaseExecutionId が共有ファイルで衝突する問題（#1428）を防ぐ。
+  const promptLogPath = isDebugEnabled()
+    ? join(runPaths.logsAbs, `${workflowSessionId}${DEBUG_PROMPTS_LOG_FILE_SUFFIX}`)
+    : undefined;
+  const sessionLogger = new SessionLogger(ndjsonLogPath, allowSensitiveData, promptLogPath);
   if (options.interactiveMetadata) {
     sessionLogger.writeInteractiveMetadata(options.interactiveMetadata);
   }
@@ -676,7 +683,6 @@ export async function createWorkflowExecutionBootstrap(
         updateWorktreeSession(projectCwd, cwd, personaName, personaSessionId, currentProvider)
     : (persona: string, personaSessionId: string | undefined) =>
         updatePersonaSession(projectCwd, persona, personaSessionId, currentProvider);
-  const promptLogPath = getDebugPromptsLogFile() ?? undefined;
   const observabilityOptions = globalConfig.observability.enabled
     && (
       globalConfig.observability.sessionLogExporter

--- a/src/shared/utils/debug.ts
+++ b/src/shared/utils/debug.ts
@@ -5,7 +5,6 @@
  */
 
 import { dirname, join } from 'node:path';
-import type { PromptLogRecord } from './types.js';
 import {
   appendPrivateFile,
   ensurePrivateDirectory,
@@ -45,7 +44,6 @@ export class DebugLogger {
   private debugEnabled = false;
   private traceEnabled = false;
   private debugLogFile: string | null = null;
-  private debugPromptsLogFile: string | null = null;
   private initialized = false;
   private verboseConsoleEnabled = false;
 
@@ -82,15 +80,9 @@ export class DebugLogger {
     if (this.debugEnabled) {
       if (config?.logFile) {
         this.debugLogFile = config.logFile;
-        if (config.logFile.endsWith('.log')) {
-          this.debugPromptsLogFile = config.logFile.slice(0, -4) + '-prompts.jsonl';
-        } else {
-          this.debugPromptsLogFile = `${config.logFile}-prompts.jsonl`;
-        }
       } else if (projectDir) {
         const logPrefix = DebugLogger.getDefaultLogPrefix(projectDir);
         this.debugLogFile = `${logPrefix}.log`;
-        this.debugPromptsLogFile = `${logPrefix}-prompts.jsonl`;
       }
 
       if (this.debugLogFile) {
@@ -111,15 +103,6 @@ export class DebugLogger {
 
         writePrivateFile(this.debugLogFile, header);
       }
-
-      if (this.debugPromptsLogFile) {
-        const promptsLogDir = dirname(this.debugPromptsLogFile);
-        ensurePrivateDirectory(promptsLogDir);
-        if (!config?.logFile) {
-          repairPrivateDirectory(promptsLogDir);
-        }
-        writePrivateFile(this.debugPromptsLogFile, '');
-      }
     }
 
     this.initialized = true;
@@ -130,7 +113,6 @@ export class DebugLogger {
     this.debugEnabled = false;
     this.traceEnabled = false;
     this.debugLogFile = null;
-    this.debugPromptsLogFile = null;
     this.initialized = false;
     this.verboseConsoleEnabled = false;
   }
@@ -153,11 +135,6 @@ export class DebugLogger {
   /** Get current debug log file path */
   getLogFile(): string | null {
     return this.debugLogFile;
-  }
-
-  /** Get current debug prompts log file path */
-  getPromptsLogFile(): string | null {
-    return this.debugPromptsLogFile;
   }
 
   /** Format log message with timestamp and level */
@@ -198,19 +175,6 @@ export class DebugLogger {
 
     try {
       appendPrivateFile(this.debugLogFile, logLine + '\n');
-    } catch {
-      // Silently fail - logging errors should not interrupt main flow
-    }
-  }
-
-  /** Write a prompt/response debug log entry */
-  writePromptLog(record: PromptLogRecord): void {
-    if (!this.debugEnabled || !this.debugPromptsLogFile) {
-      return;
-    }
-
-    try {
-      appendPrivateFile(this.debugPromptsLogFile, JSON.stringify(record) + '\n');
     } catch {
       // Silently fail - logging errors should not interrupt main flow
     }
@@ -258,10 +222,6 @@ export function getDebugLogFile(): string | null {
   return DebugLogger.getInstance().getLogFile();
 }
 
-export function getDebugPromptsLogFile(): string | null {
-  return DebugLogger.getInstance().getPromptsLogFile();
-}
-
 export function debugLog(component: string, message: string, data?: unknown): void {
   DebugLogger.getInstance().writeLog('DEBUG', component, message, data);
 }
@@ -272,10 +232,6 @@ export function infoLog(component: string, message: string, data?: unknown): voi
 
 export function errorLog(component: string, message: string, data?: unknown): void {
   DebugLogger.getInstance().writeLog('ERROR', component, message, data);
-}
-
-export function writePromptLog(record: PromptLogRecord): void {
-  DebugLogger.getInstance().writePromptLog(record);
 }
 
 export function traceEnter(component: string, funcName: string, args?: Record<string, unknown>): void {


### PR DESCRIPTION
## Summary

# debug promptsログをrun単位に分離し、複数task実行時のtrace生成失敗を防ぐ

## 背景・目的

`logging.debug: true` で `takt run` のworker poolが複数taskを処理すると、各workflow runのprompt/responseが同じ `*-prompts.jsonl` に保存される。

phase execution IDはrun内でのみ一意であり、別runでは同じworkflow構造から同じIDが正常に生成される。ところがterminal trace生成は共有promptsログ全体を読み、`scope + phaseExecutionId`だけを一意キーとして扱うため、別runの正常な記録を重複実行と誤認して失敗する。

デバッグpromptの保存・参照境界をworkflow run単位に分離し、並列・直列を問わず、同じCLIプロセスで複数taskを処理しても各runのtraceが自分のpromptだけから生成されるようにする。

## 実測した事象

同じCLIプロセスが処理した3 taskのpromptが、次の1ファイルへ混在した。

```text
.takt/runs/debug-2026-08-19T13-56-33/logs/
  debug-2026-08-19T13-56-33-prompts.jsonl
```

同一の `scope + phaseExecutionId` を持つ正常な3レコード:

| task | timestamp | phaseExecutionId |
|---|---|---|
| Issue #1335 | `2026-08-19T14:03:46.263Z` | `plan:1:1:1` |
| Issue #1137 | `2026-08-19T14:13:27.943Z` | `plan:1:1:1` |
| Issue #1425 | `2026-08-19T21:35:46.872Z` | `plan:1:1:1` |

#1335のsessionログには該当phaseのstart/completeが各1件しかなく、単一run内の二重実行ではない。#1137と#1425のsessionログにも、それぞれ自分の正常な `plan:1:1:1` が1件ずつ存在する。

#1335はworkflow本体とfinal gateが完了した後、terminal trace生成で次の例外になった。

```text
Duplicate prompt execution: {"step":"plan","stack":[...]}:plan:1:1:1
```

その結果、runの `meta.json` は `status: completed`、タスク台帳は `status: failed` となり、自動commit・push・PR作成へ進まなかった。

## 根本原因（コード実測）

### 1. DebugLoggerがCLIプロセス単位で一度だけ初期化される

- `src/app/cli/initialization.ts`
- `src/shared/utils/debug.ts`

CLI起動時にsingletonの `DebugLogger` が初期化され、時刻ベースの単一 `debugPromptsLogFile` が作られる。worker pool内のtaskごとには再初期化されない。

### 2. 各workflow runが同じpromptLogPathを取得する

- `src/features/tasks/execute/workflowExecutionBootstrap.ts`

各runは `getDebugPromptsLogFile()` からprocess-globalな同一パスを取得し、terminal payloadの `promptLogPath` として保持する。

### 3. PromptLogRecordにrun identityがない

- `src/shared/utils/types.ts`
- `src/features/tasks/execute/sessionLoggerRecordFactory.ts`
- `src/features/tasks/execute/sessionLogger.ts`

prompt recordにはworkflow scopeと `phaseExecutionId` はあるが、どのworkflow runに属するかを識別するrun IDがない。同じファイルへ複数runが追記されると、読み取り時に安全に分離できない。

### 4. terminal trace生成が共有ファイル全体を現在runの入力として扱う

- `src/features/tasks/execute/traceReport.ts`
- `src/features/tasks/execute/traceReportParser.ts`
- `src/features/tasks/execute/traceReportWriter.ts`
- `src/features/tasks/execute/workflowTerminalProjection.ts`

`renderTraceReportFromLogs()` は `promptLogPath` 全体を読み込む。`buildTraceFromRecords()` は `scope + phaseExecutionId` が重複すると例外を投げるため、別runの正常なレコード同士が衝突する。

書き込み内容自体は壊れておらず、約7時間離れた直列taskのレコードも衝突している。したがって、ファイル書き込みのmutexやキューイングでは解消しない。

## 作業範囲

### 優先度：高

#### run単位のprompt所有権を確立する

- terminal traceへ渡すprompt入力は、対象workflow runのレコードだけで構成する。
- 推奨は、各runの `runPaths.logsAbs` 配下にrun専用promptsログを作り、`promptLogPath` 自体をrun-scopedにすること。
- 別案としてrecordへrun identityを永続化して対象runだけを厳密に抽出してもよい。ただし、run identityの欠落時や不一致時に別runのrecordを採用しないこと。
- CLI全体の一般デバッグログをprocess-scopedのまま維持することは許容する。今回分離が必須なのはterminal traceの入力になるprompt/response recordである。
- run専用ログのファイル権限とsensitive dataの扱いは、既存private-file・trace redaction契約を維持する。

#### terminal traceの相関契約を維持する

- 同一run内では、`scope + phaseExecutionId` によるpromptとphase start/completeの対応を維持する。
- 同一run内の真の重複、prompt欠落、phase相関不整合は、従来どおり検出する。
- 別runのrecordを先勝ち・後勝ちで黙って採用しない。
- redacted/full/offのtrace mode契約を変更しない。

#### worker pool経路を対象にする

- `concurrency > 1` で同じworkflow構造を持つ複数taskが並列実行される場合を修正対象にする。
- `concurrency = 1` でも、同じ長寿命CLIプロセスが後続taskをpollして実行する場合を修正対象にする。
- taskごとにCLIプロセスを再起動することを回避策または前提にしない。

### 優先度：中

#### テスト

既存のテスト構成・分類に合わせ、少なくとも次を追加または更新する。

- 同一run内のprompt/phase相関が維持されるunit test
- 異なるrunに同じ `scope + phaseExecutionId` が存在しても、各traceが自分のpromptだけを含むtest
- 2 taskを同一CLIプロセスで並列処理し、両方のterminal trace生成が成功するtest
- 2 taskを同一CLIプロセスで直列処理し、後続taskが先行taskのpromptを読み込まないtest
- 同一run内の真の重複は引き続き失敗するnegative test
- full traceに別taskのtask本文・作業ディレクトリ・responseが混入しないtest
- redacted traceとdebug無効時の既存動作の回帰test

integration testを追加または変更した場合は、対象testと `src/__tests__/releaseVerificationWiring.test.ts` を個別実行する。heavy ITに分類される場合は、PR全体のCIを初回実行にせず対象testを先に実行する。

## 明示された制約・対象外

- prompt recordの重複を無条件にdeduplicateして例外を隠さない。
- 「最初のrecordを使う」「最後のrecordを使う」といった順序依存の解決にしない。
- ファイル書き込みのmutex・キューイングだけで解決したことにしない。
- worker poolの並列度を1へ固定しない。
- `phaseExecutionId`をプロセス全体で一意にするためだけに、既存のrun内ID形式を変更しない。
- provider-eventsログ、usage-eventsログ、通常sessionログの既存run分離契約を壊さない。
- 一般デバッグログ全体の再設計は行わない。

## Gherkin受け入れ条件

```gherkin
Feature: debug prompt recordsのworkflow run分離

  Rule: terminal traceは対象runのpromptだけから生成する

    Scenario: 同じphase IDを持つtaskを並列実行する
      Given logging.debugが有効である
      And 同じworkflow構造を使う2つのtaskを同一CLIプロセスで実行する
      When worker poolが2つのtaskを並列に完了する
      Then 両方のworkflow runがterminal traceを生成できる
      And Duplicate prompt executionでは失敗しない
      And 各traceには自分のtaskのpromptとresponseだけが含まれる

    Scenario: 同じphase IDを持つtaskを直列実行する
      Given logging.debugが有効である
      And 同じCLIプロセスが先行taskの完了後に後続taskを取得する
      When 両taskでplan:1:1:1が生成される
      Then 後続taskのtrace生成は先行taskのprompt recordと衝突しない
      And 後続taskのtraceに先行taskの内容は含まれない

    Scenario: 同一run内の真の重複を検出する
      Given 1つのworkflow runに同じscopeとphaseExecutionIdを持つprompt recordが複数存在する
      When terminal traceを生成する
      Then 相関不整合として失敗する
      And 別run分離の修正によって重複が黙って隠されない

    Scenario: debug loggingが無効である
      Given logging.debugが無効である
      When workflow runが完了する
      Then promptログを必要とせず既存のredacted trace契約で完了する
```

## 確認方法

1. 追加・変更したunit/integration testを対象ファイル単位で実行する。
2. ITを変更した場合は `npm test -- src/__tests__/releaseVerificationWiring.test.ts` を実行する。
3. `npm run build`、`npm run lint`、`npm test`、`npm run test:it` を実行する。
4. CLIを1回起動したまま同一workflow構造のtaskを並列・直列に処理し、各runの `trace.md` とtask終端状態を確認する。
5. 各traceに別taskのprompt、response、作業ディレクトリが混入していないことを確認する。

## 完了条件

- prompt recordの所有権がworkflow run単位で一意に定義されている。
- 並列・直列worker poolの双方で、別runの同一phase IDが衝突しない。
- 各terminal traceが対象runのpromptだけを使用する。
- 同一run内の真の相関不整合は引き続き検出される。
- workflow本体がcompletedなのにpromptログ混在を理由としてtaskだけfailedになる再現ケースが解消する。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #1428