### PR TITLE
[#1428] fix-prompt-log-isolation

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1224,7 +1224,7 @@ logging:
   debug: true
 ```
 
-デバッグログは `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log` に NDJSON 形式で出力され、プロンプト/レスポンスログは同じディレクトリの `debug-{timestamp}-prompts.jsonl` に出力されます。
+一般デバッグログはプロセス単位で `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log` に NDJSON 形式で出力されます。プロンプト/レスポンスログは workflow run 単位で `.takt/runs/<run>/logs/<sessionId>-prompts.jsonl` に出力されます。
 
 ### 詳細コンソール出力
 
@@ -1236,7 +1236,7 @@ logging:
   level: debug
 ```
 
-これは CLI 内部の verbose console mode も有効にします。さらに `logging.level: debug` だけでデバッグロガーも有効になるため、上記の `debug-{timestamp}.log` と `debug-{timestamp}-prompts.jsonl` は `logging.debug` を別途設定しなくても出力されます。`logging.debug: true`、`logging.trace: true`、`logging.level: debug` のいずれかで有効になります。
+これは CLI 内部の verbose console mode も有効にします。さらに `logging.level: debug` だけで、上記のプロセス単位の一般デバッグログと workflow run 単位のプロンプト/レスポンスログが、`logging.debug` を別途設定しなくても出力されます。`logging.debug: true`、`logging.trace: true`、`logging.level: debug` のいずれかで有効になります。
 
 ## Companion の provider target
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1268,7 +1268,7 @@ logging:
   debug: true
 ```
 
-Debug logs are written to `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log` in NDJSON format, and prompt/response logs to `debug-{timestamp}-prompts.jsonl` in the same directory.
+General debug logs are process-scoped and written to `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log` in NDJSON format. Prompt/response logs are workflow-run-scoped and written to `.takt/runs/<run>/logs/<sessionId>-prompts.jsonl`.
 
 ### Detailed Console Output
 
@@ -1280,7 +1280,7 @@ logging:
   level: debug
 ```
 
-This also enables the internal verbose console mode used by the CLI. `logging.level: debug` alone additionally enables the debug logger, so the `debug-{timestamp}.log` and `debug-{timestamp}-prompts.jsonl` artifacts above are produced without setting `logging.debug` separately. Any of `logging.debug: true`, `logging.trace: true`, or `logging.level: debug` enables them.
+This also enables the internal verbose console mode used by the CLI. `logging.level: debug` alone additionally enables both the process-scoped general debug log and workflow-run-scoped prompt/response logs described above without setting `logging.debug` separately. Any of `logging.debug: true`, `logging.trace: true`, or `logging.level: debug` enables them.
 
 ## Companion provider targets
 

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -1047,7 +1047,7 @@ logging:
   debug: true
 ```
 
-debug 日志以 NDJSON 写入 `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log`，prompt/response 日志写入同目录的 `debug-{timestamp}-prompts.jsonl`。
+常规 debug 日志按进程写入 `.takt/runs/debug-{timestamp}/logs/debug-{timestamp}.log`，格式为 NDJSON。prompt/response 日志按 workflow run 写入 `.takt/runs/<run>/logs/<sessionId>-prompts.jsonl`。
 
 ### 详细控制台输出
 
@@ -1057,7 +1057,7 @@ logging:
   level: debug
 ```
 
-`logging.level: debug` 会启用 CLI 的详细输出和上面的 debug logger；`logging.debug: true`、`logging.trace: true` 或 `logging.level: debug` 任一设置都可以生成 debug 产物。
+`logging.level: debug` 会启用 CLI 的详细输出，以及上面按进程保存的常规 debug 日志和按 workflow run 保存的 prompt/response 日志；`logging.debug: true`、`logging.trace: true` 或 `logging.level: debug` 任一设置都可以生成这些产物。
 
 ## Companion Provider Target
 

--- a/src/__tests__/debug.test.ts
+++ b/src/__tests__/debug.test.ts
@@ -14,22 +14,18 @@ import {
   debugLog,
   infoLog,
   errorLog,
-  writePromptLog,
 } from '../shared/utils/index.js';
-import { existsSync, readFileSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  readFileSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const TEST_TMPDIR = realpathSync(tmpdir());
-
-function resolvePromptsLogFilePath(): string {
-  const debugLogFile = getDebugLogFile();
-  expect(debugLogFile).not.toBeNull();
-  if (!debugLogFile!.endsWith('.log')) {
-    throw new Error(`unexpected debug log file path: ${debugLogFile!}`);
-  }
-  return debugLogFile!.replace(/\.log$/, '-prompts.jsonl');
-}
 
 function readPersistedDebugData(logFile: string, message: string): string {
   const persisted = readFileSync(logFile, 'utf-8');
@@ -102,21 +98,6 @@ describe('debug logging', () => {
       }
     });
 
-    it('should create prompts log file with -prompts suffix', () => {
-      const projectDir = mkdtempSync(join(TEST_TMPDIR, 'takt-test-debug-prompts-'));
-
-      try {
-        initDebugLogger({ enabled: true }, projectDir);
-        const promptsLogFile = resolvePromptsLogFilePath();
-        expect(promptsLogFile).toContain(join(projectDir, '.takt', 'runs'));
-        expect(promptsLogFile).toContain('/logs/');
-        expect(promptsLogFile).toMatch(/debug-.*-prompts\.jsonl$/);
-        expect(existsSync(promptsLogFile)).toBe(true);
-      } finally {
-        rmSync(projectDir, { recursive: true, force: true });
-      }
-    });
-
     it('should not create log file when projectDir is not provided', () => {
       initDebugLogger({ enabled: true });
       expect(isDebugEnabled()).toBe(true);
@@ -130,9 +111,7 @@ describe('debug logging', () => {
       try {
         initDebugLogger({ enabled: true, logFile }, '/tmp');
         expect(getDebugLogFile()).toBe(logFile);
-        expect(resolvePromptsLogFilePath()).toBe(join(logDir, 'test-prompts.jsonl'));
         expect(existsSync(logFile)).toBe(true);
-        expect(existsSync(join(logDir, 'test-prompts.jsonl'))).toBe(true);
 
         const content = readFileSync(logFile, 'utf-8');
         expect(content).toContain('TAKT Debug Log');
@@ -167,68 +146,6 @@ describe('debug logging', () => {
       expect(isDebugEnabled()).toBe(false);
       expect(getDebugLogFile()).toBeNull();
       expect(isVerboseConsole()).toBe(false);
-    });
-  });
-
-  describe('writePromptLog', () => {
-    it('should append prompt log record when debug is enabled', () => {
-      const projectDir = mkdtempSync(join(TEST_TMPDIR, 'takt-test-debug-write-prompts-'));
-
-      try {
-        initDebugLogger({ enabled: true }, projectDir);
-        const promptsLogFile = resolvePromptsLogFilePath();
-
-        writePromptLog({
-          step: 'plan',
-          phase: 1,
-          iteration: 2,
-          scope: '{"step":"plan","stack":[]}',
-          systemPrompt: 'system prompt',
-          userInstruction: 'prompt text',
-          prompt: 'prompt text',
-          response: 'response text',
-          timestamp: '2026-02-07T00:00:00.000Z',
-        });
-
-        const content = readFileSync(promptsLogFile, 'utf-8').trim();
-        expect(content).not.toBe('');
-        const parsed = JSON.parse(content) as {
-          step: string;
-          phase: number;
-          iteration: number;
-          systemPrompt: string;
-          userInstruction: string;
-          prompt: string;
-          response: string;
-          timestamp: string;
-        };
-        expect(parsed.step).toBe('plan');
-        expect(parsed.phase).toBe(1);
-        expect(parsed.iteration).toBe(2);
-        expect(parsed.systemPrompt).toBe('system prompt');
-        expect(parsed.userInstruction).toBe('prompt text');
-        expect(parsed.prompt).toBe('prompt text');
-        expect(parsed.response).toBe('response text');
-        expect(parsed.timestamp).toBe('2026-02-07T00:00:00.000Z');
-      } finally {
-        rmSync(projectDir, { recursive: true, force: true });
-      }
-    });
-
-    it('should do nothing when debug is disabled', () => {
-      writePromptLog({
-        step: 'plan',
-          phase: 1,
-          iteration: 1,
-          scope: '{"step":"plan","stack":[]}',
-        systemPrompt: 'system prompt',
-        userInstruction: 'ignored prompt',
-        prompt: 'ignored prompt',
-        response: 'ignored response',
-        timestamp: '2026-02-07T00:00:00.000Z',
-      });
-
-      expect(getDebugLogFile()).toBeNull();
     });
   });
 

--- a/src/__tests__/it-runAllTasks-auto-requeue.test.ts
+++ b/src/__tests__/it-runAllTasks-auto-requeue.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -8,6 +8,7 @@ import { setMockScenario, resetScenario } from '../infra/mock/index.js';
 import { runAllTasks } from '../features/tasks/index.js';
 import { TaskRunner } from '../infra/task/index.js';
 import { invalidateGlobalConfigCache } from '../infra/config/index.js';
+import { initDebugLogger, resetDebugLogger } from '../shared/utils/debug.js';
 
 vi.mock('../core/workflow/phase-runner.js', () => ({
   runReportPhase: vi.fn().mockResolvedValue(undefined),
@@ -77,6 +78,137 @@ function loadTasks(projectDir: string): Array<Record<string, unknown>> {
   return (parseYaml(raw) as { tasks: Array<Record<string, unknown>> }).tasks;
 }
 
+interface PromptArtifactRecord {
+  phase: number;
+  phaseExecutionId?: string;
+  systemPrompt: string;
+  userInstruction: string;
+  prompt: string;
+  response: string;
+}
+
+interface TaskRunArtifacts {
+  task: string;
+  runSlug: string;
+  promptPath: string;
+  promptRecords: PromptArtifactRecord[];
+  trace: string;
+}
+
+function configurePromptTraceScenario(env: TestEnv, concurrency: 1 | 2): void {
+  writeFileSync(
+    join(env.projectDir, '.takt', 'config.yaml'),
+    [
+      'provider: mock',
+      `concurrency: ${concurrency}`,
+      'auto_requeue_max_attempts: 0',
+      'task_poll_interval_ms: 100',
+    ].join('\n'),
+    'utf-8',
+  );
+  writeFileSync(
+    join(env.globalDir, 'config.yaml'),
+    [
+      'logging:',
+      '  debug: true',
+      '  trace: true',
+    ].join('\n'),
+    'utf-8',
+  );
+  invalidateGlobalConfigCache();
+  initDebugLogger({ enabled: true, trace: true }, env.projectDir);
+}
+
+function loadTaskRunArtifacts(projectDir: string): TaskRunArtifacts[] {
+  return loadTasks(projectDir).map((task) => {
+    const taskContent = task.content;
+    const runSlug = task.run_slug;
+    if (typeof taskContent !== 'string' || typeof runSlug !== 'string') {
+      throw new Error('completed task must retain content and run_slug');
+    }
+    const runRoot = join(projectDir, '.takt', 'runs', runSlug);
+    const logsDir = join(runRoot, 'logs');
+    const promptFiles = readdirSync(logsDir)
+      .filter((file) => file.endsWith('-prompts.jsonl'));
+    if (promptFiles.length !== 1) {
+      throw new Error(`expected one run prompt file for ${runSlug}, found ${promptFiles.length}`);
+    }
+    const promptPath = join(logsDir, promptFiles[0]!);
+    const promptRecords = readFileSync(promptPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as PromptArtifactRecord);
+    return {
+      task: taskContent,
+      runSlug,
+      promptPath,
+      promptRecords,
+      trace: readFileSync(join(runRoot, 'trace.md'), 'utf-8'),
+    };
+  });
+}
+
+function expectPromptTraceIsolation(projectDir: string, taskBodies: string[]): void {
+  const tasks = loadTasks(projectDir);
+  expect(tasks).toHaveLength(2);
+  expect(tasks.map((task) => task.status)).toEqual(['completed', 'completed']);
+
+  const artifacts = loadTaskRunArtifacts(projectDir);
+  expect(artifacts).toHaveLength(2);
+  const phaseOneRecords = artifacts.map((artifact) => {
+    expect(artifact.promptPath).toContain(join('.takt', 'runs', artifact.runSlug, 'logs'));
+    const record = artifact.promptRecords.find((entry) => entry.phase === 1);
+    expect(record).toBeDefined();
+    if (record === undefined) {
+      throw new Error(`phase 1 prompt record is missing for ${artifact.runSlug}`);
+    }
+    expect(record.userInstruction).toContain(artifact.task);
+    expect(artifact.trace).toContain(artifact.task);
+    expect(artifact.trace).toContain(record.response);
+
+    const otherTask = taskBodies.find((taskBody) => taskBody !== artifact.task);
+    if (otherTask === undefined) {
+      throw new Error(`other task body is missing for ${artifact.task}`);
+    }
+    for (const field of [
+      record.systemPrompt,
+      record.userInstruction,
+      record.prompt,
+      record.response,
+    ]) {
+      expect(field).not.toContain(otherTask);
+    }
+    expect(artifact.trace).not.toContain(otherTask);
+    return record;
+  });
+
+  expect(phaseOneRecords[0]?.phaseExecutionId).toBe('plan:1:1:1');
+  expect(phaseOneRecords[1]?.phaseExecutionId).toBe('plan:1:1:1');
+  expect(phaseOneRecords[0]?.response).not.toBe(phaseOneRecords[1]?.response);
+  expect(artifacts[0]?.trace).not.toContain(phaseOneRecords[1]!.response);
+  expect(artifacts[1]?.trace).not.toContain(phaseOneRecords[0]!.response);
+}
+
+async function runPromptTraceIsolationScenario(env: TestEnv, concurrency: 1 | 2): Promise<void> {
+  const taskBodies = [
+    `prompt isolation task A concurrency ${concurrency}`,
+    `prompt isolation task B concurrency ${concurrency}`,
+  ];
+  configurePromptTraceScenario(env, concurrency);
+  const runner = new TaskRunner(env.projectDir);
+  for (const taskBody of taskBodies) {
+    runner.addTask(taskBody, { workflow: 'auto-requeue-it' });
+  }
+  setMockScenario([
+    { persona: 'planner', status: 'done', content: `response A concurrency ${concurrency}` },
+    { persona: 'planner', status: 'done', content: `response B concurrency ${concurrency}` },
+  ]);
+
+  await runAllTasks(env.projectDir);
+
+  expectPromptTraceIsolation(env.projectDir, taskBodies);
+}
+
 describe('IT: runAllTasks auto requeue', () => {
   let env: TestEnv;
   let originalConfigDir: string | undefined;
@@ -87,10 +219,12 @@ describe('IT: runAllTasks auto requeue', () => {
     process.env.TAKT_CONFIG_DIR = env.globalDir;
     invalidateGlobalConfigCache();
     resetScenario();
+    resetDebugLogger();
   });
 
   afterEach(() => {
     resetScenario();
+    resetDebugLogger();
     if (originalConfigDir === undefined) {
       delete process.env.TAKT_CONFIG_DIR;
     } else {
@@ -161,5 +295,13 @@ describe('IT: runAllTasks auto requeue', () => {
     expect(tasks[0]?.failure).toEqual(expect.objectContaining({
       step: 'plan',
     }));
+  });
+
+  it('isolates terminal prompt traces for two parallel tasks in one CLI process', async () => {
+    await runPromptTraceIsolationScenario(env, 2);
+  });
+
+  it('isolates the later terminal prompt trace for two sequential tasks in one CLI process', async () => {
+    await runPromptTraceIsolationScenario(env, 1);
   });
 });

--- a/src/__tests__/it-runAllTasks-auto-requeue.test.ts
+++ b/src/__tests__/it-runAllTasks-auto-requeue.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -29,11 +30,21 @@ interface TestEnv {
   globalDir: string;
 }
 
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function configureGit(cwd: string): void {
+  git(cwd, ['config', 'user.name', 'TAKT test']);
+  git(cwd, ['config', 'user.email', 'takt-test@example.test']);
+}
+
 function createEnv(): TestEnv {
   const root = join(tmpdir(), `takt-it-auto-requeue-${randomUUID()}`);
   const projectDir = join(root, 'project');
   const globalDir = join(root, 'global');
   mkdirSync(join(projectDir, '.takt', 'workflows', 'personas'), { recursive: true });
+  mkdirSync(join(projectDir, '.takt', 'worktrees'), { recursive: true });
   mkdirSync(globalDir, { recursive: true });
 
   writeFileSync(
@@ -69,8 +80,64 @@ function createEnv(): TestEnv {
     'You are planner.',
     'utf-8',
   );
+  for (const fixture of [
+    {
+      workflow: 'auto-requeue-it-a',
+      persona: 'planner-a',
+      personaContent: 'You are planner A. system prompt marker planner-a.',
+    },
+    {
+      workflow: 'auto-requeue-it-b',
+      persona: 'planner-b',
+      personaContent: 'You are planner B. system prompt marker planner-b.',
+    },
+  ]) {
+    writeFileSync(
+      join(projectDir, '.takt', 'workflows', `${fixture.workflow}.yaml`),
+      [
+        `name: ${fixture.workflow}`,
+        'description: prompt isolation integration test',
+        'max_steps: 2',
+        'initial_step: plan',
+        'steps:',
+        '  - name: plan',
+        `    persona: ./personas/${fixture.persona}.md`,
+        '    instruction: "{task}"',
+        '    rules:',
+        '      - condition: when(true)',
+        '        next: COMPLETE',
+      ].join('\n'),
+      'utf-8',
+    );
+    writeFileSync(
+      join(projectDir, '.takt', 'workflows', 'personas', `${fixture.persona}.md`),
+      fixture.personaContent,
+      'utf-8',
+    );
+  }
+  writeFileSync(
+    join(projectDir, '.gitignore'),
+    ['.takt/runs/', '.takt/tasks.yaml', '.takt/worktrees/'].join('\n') + '\n',
+    'utf-8',
+  );
+  git(projectDir, ['init']);
+  configureGit(projectDir);
+  git(projectDir, ['checkout', '-b', 'main']);
+  git(projectDir, ['add', '.gitignore', '.takt']);
+  git(projectDir, ['commit', '-m', 'prompt isolation fixture']);
 
   return { root, projectDir, globalDir };
+}
+
+function createPromptTraceWorktrees(env: TestEnv): Array<{ path: string; branch: string }> {
+  return ['a', 'b'].map((suffix) => {
+    const path = join(env.projectDir, '.takt', 'worktrees', `prompt-isolation-${suffix}`);
+    const branch = `takt/prompt-isolation-${suffix}`;
+    git(env.projectDir, ['clone', env.projectDir, path]);
+    configureGit(path);
+    git(path, ['checkout', '-b', branch, 'main']);
+    return { path, branch };
+  });
 }
 
 function loadTasks(projectDir: string): Array<Record<string, unknown>> {
@@ -89,10 +156,23 @@ interface PromptArtifactRecord {
 
 interface TaskRunArtifacts {
   task: string;
+  prompt: string;
+  systemPrompt: string;
+  response: string;
+  executionCwd: string;
   runSlug: string;
   promptPath: string;
   promptRecords: PromptArtifactRecord[];
   trace: string;
+}
+
+interface PromptTraceIdentity {
+  task: string;
+  workflow: string;
+  prompt: string;
+  systemPrompt: string;
+  response: string;
+  executionCwd: string;
 }
 
 function configurePromptTraceScenario(env: TestEnv, concurrency: 1 | 2): void {
@@ -119,14 +199,26 @@ function configurePromptTraceScenario(env: TestEnv, concurrency: 1 | 2): void {
   initDebugLogger({ enabled: true, trace: true }, env.projectDir);
 }
 
-function loadTaskRunArtifacts(projectDir: string): TaskRunArtifacts[] {
+function loadTaskRunArtifacts(
+  projectDir: string,
+  identities: PromptTraceIdentity[],
+): TaskRunArtifacts[] {
   return loadTasks(projectDir).map((task) => {
     const taskContent = task.content;
     const runSlug = task.run_slug;
     if (typeof taskContent !== 'string' || typeof runSlug !== 'string') {
       throw new Error('completed task must retain content and run_slug');
     }
-    const runRoot = join(projectDir, '.takt', 'runs', runSlug);
+    const identity = identities.find((candidate) => candidate.task === taskContent);
+    if (identity === undefined) {
+      throw new Error(`missing prompt isolation identity for ${taskContent}`);
+    }
+    const executionCwd = task.worktree_path;
+    if (typeof executionCwd !== 'string') {
+      throw new Error(`completed task must retain worktree_path for ${taskContent}`);
+    }
+    expect(executionCwd).toBe(identity.executionCwd);
+    const runRoot = join(executionCwd, '.takt', 'runs', runSlug);
     const logsDir = join(runRoot, 'logs');
     const promptFiles = readdirSync(logsDir)
       .filter((file) => file.endsWith('-prompts.jsonl'));
@@ -140,6 +232,10 @@ function loadTaskRunArtifacts(projectDir: string): TaskRunArtifacts[] {
       .map((line) => JSON.parse(line) as PromptArtifactRecord);
     return {
       task: taskContent,
+      prompt: identity.prompt,
+      systemPrompt: identity.systemPrompt,
+      response: identity.response,
+      executionCwd,
       runSlug,
       promptPath,
       promptRecords,
@@ -148,12 +244,18 @@ function loadTaskRunArtifacts(projectDir: string): TaskRunArtifacts[] {
   });
 }
 
-function expectPromptTraceIsolation(projectDir: string, taskBodies: string[]): void {
+function expectPromptTraceIsolation(
+  projectDir: string,
+  identities: PromptTraceIdentity[],
+): void {
   const tasks = loadTasks(projectDir);
   expect(tasks).toHaveLength(2);
   expect(tasks.map((task) => task.status)).toEqual(['completed', 'completed']);
+  expect(tasks.map((task) => task.content).sort()).toEqual(
+    identities.map((identity) => identity.task).sort(),
+  );
 
-  const artifacts = loadTaskRunArtifacts(projectDir);
+  const artifacts = loadTaskRunArtifacts(projectDir, identities);
   expect(artifacts).toHaveLength(2);
   const phaseOneRecords = artifacts.map((artifact) => {
     expect(artifact.promptPath).toContain(join('.takt', 'runs', artifact.runSlug, 'logs'));
@@ -162,23 +264,46 @@ function expectPromptTraceIsolation(projectDir: string, taskBodies: string[]): v
     if (record === undefined) {
       throw new Error(`phase 1 prompt record is missing for ${artifact.runSlug}`);
     }
-    expect(record.userInstruction).toContain(artifact.task);
+    expect(record.userInstruction).toContain(artifact.prompt);
+    expect(record.prompt).toContain(artifact.prompt);
+    expect(record.systemPrompt).toContain(artifact.systemPrompt);
+    expect(record.response).toContain(artifact.response);
     expect(artifact.trace).toContain(artifact.task);
-    expect(artifact.trace).toContain(record.response);
+    expect(artifact.trace).toContain(artifact.response);
 
-    const otherTask = taskBodies.find((taskBody) => taskBody !== artifact.task);
-    if (otherTask === undefined) {
+    const other = artifacts.find((candidate) => candidate.task !== artifact.task);
+    if (other === undefined) {
       throw new Error(`other task body is missing for ${artifact.task}`);
     }
-    for (const field of [
-      record.systemPrompt,
-      record.userInstruction,
-      record.prompt,
-      record.response,
-    ]) {
-      expect(field).not.toContain(otherTask);
+
+    for (const promptRecord of artifact.promptRecords) {
+      const serializedRecord = JSON.stringify(promptRecord);
+      for (const [field, value] of Object.entries({
+        prompt: other.prompt,
+        systemPrompt: other.systemPrompt,
+        response: other.response,
+        task: other.task,
+      })) {
+        expect(serializedRecord, `${artifact.task} prompt record leaked ${field}`)
+          .not.toContain(value);
+      }
     }
-    expect(artifact.trace).not.toContain(otherTask);
+
+    for (const [field, value] of Object.entries({
+      prompt: other.prompt,
+      systemPrompt: other.systemPrompt,
+      response: other.response,
+      task: other.task,
+    })) {
+      expect(artifact.trace, `${artifact.task} trace leaked ${field}`).not.toContain(value);
+    }
+
+    expect(artifact.executionCwd).not.toBe(other.executionCwd);
+    const serializedPromptArtifact = JSON.stringify(artifact.promptRecords);
+    expect(serializedPromptArtifact, `${artifact.task} prompt artifact leaked cwd`)
+      .not.toContain(other.executionCwd);
+    expect(artifact.trace, `${artifact.task} trace leaked cwd`)
+      .not.toContain(other.executionCwd);
     return record;
   });
 
@@ -190,23 +315,45 @@ function expectPromptTraceIsolation(projectDir: string, taskBodies: string[]): v
 }
 
 async function runPromptTraceIsolationScenario(env: TestEnv, concurrency: 1 | 2): Promise<void> {
-  const taskBodies = [
-    `prompt isolation task A concurrency ${concurrency}`,
-    `prompt isolation task B concurrency ${concurrency}`,
-  ];
   configurePromptTraceScenario(env, concurrency);
+  git(env.projectDir, ['add', '.takt/config.yaml']);
+  git(env.projectDir, ['commit', '-m', `prompt isolation concurrency ${concurrency}`]);
+  const worktrees = createPromptTraceWorktrees(env);
+  const identities: PromptTraceIdentity[] = [
+    {
+      task: `prompt isolation task A concurrency ${concurrency} prompt-token-a`,
+      workflow: 'auto-requeue-it-a',
+      prompt: `prompt isolation task A concurrency ${concurrency} prompt-token-a`,
+      systemPrompt: 'system prompt marker planner-a',
+      response: `response A concurrency ${concurrency}`,
+      executionCwd: worktrees[0]!.path,
+    },
+    {
+      task: `prompt isolation task B concurrency ${concurrency} prompt-token-b`,
+      workflow: 'auto-requeue-it-b',
+      prompt: `prompt isolation task B concurrency ${concurrency} prompt-token-b`,
+      systemPrompt: 'system prompt marker planner-b',
+      response: `response B concurrency ${concurrency}`,
+      executionCwd: worktrees[1]!.path,
+    },
+  ];
   const runner = new TaskRunner(env.projectDir);
-  for (const taskBody of taskBodies) {
-    runner.addTask(taskBody, { workflow: 'auto-requeue-it' });
+  for (const [index, identity] of identities.entries()) {
+    runner.addTask(identity.task, {
+      workflow: identity.workflow,
+      worktree: true,
+      branch: worktrees[index]!.branch,
+      worktree_path: identity.executionCwd,
+    });
   }
   setMockScenario([
-    { persona: 'planner', status: 'done', content: `response A concurrency ${concurrency}` },
-    { persona: 'planner', status: 'done', content: `response B concurrency ${concurrency}` },
+    { persona: 'planner-a', status: 'done', content: identities[0]!.response },
+    { persona: 'planner-b', status: 'done', content: identities[1]!.response },
   ]);
 
   await runAllTasks(env.projectDir);
 
-  expectPromptTraceIsolation(env.projectDir, taskBodies);
+  expectPromptTraceIsolation(env.projectDir, identities);
 }
 
 describe('IT: runAllTasks auto requeue', () => {

--- a/src/__tests__/notification-sound.test.ts
+++ b/src/__tests__/notification-sound.test.ts
@@ -264,7 +264,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => {
     playWarningSound: mockPlayWarningSound,
     preventSleep: vi.fn(),
     isDebugEnabled: vi.fn().mockReturnValue(false),
-    writePromptLog: vi.fn(),
     generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
     isValidReportDirName: vi.fn().mockImplementation((value: string) => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)),
   };

--- a/src/__tests__/sessionLogger.test.ts
+++ b/src/__tests__/sessionLogger.test.ts
@@ -9,7 +9,24 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockPromptLogWarn } = vi.hoisted(() => ({
+  mockPromptLogWarn: vi.fn(),
+}));
+
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../shared/utils/index.js')>()),
+  createLogger: vi.fn(() => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockPromptLogWarn,
+    error: vi.fn(),
+    enter: vi.fn(),
+    exit: vi.fn(),
+  })),
+}));
 import { initNdjsonLog, parseNdjsonRecord } from '../infra/fs/session.js';
 import { SessionLogger } from '../features/tasks/execute/sessionLogger.js';
 import { buildTraceFromRecords } from '../features/tasks/execute/traceReportParser.js';
@@ -45,6 +62,7 @@ function createPromptLogRecord(): PromptLogRecord {
 }
 
 afterEach(() => {
+  mockPromptLogWarn.mockClear();
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -57,10 +75,21 @@ describe('SessionLogger', () => {
     const promptLogPath = join(logsDir, 'run-one', 'logs', 'session-one-prompts.jsonl');
     mkdirSync(join(logsDir, 'run-one', 'logs'), { recursive: true });
 
-    writePromptLog(promptLogPath, createPromptLogRecord());
+    const firstRecord = createPromptLogRecord();
+    const secondRecord = {
+      ...firstRecord,
+      phaseExecutionId: 'plan:2:1:2',
+      response: 'second response',
+    };
 
-    expect(JSON.parse(readFileSync(promptLogPath, 'utf-8').trim()))
-      .toEqual(createPromptLogRecord());
+    writePromptLog(promptLogPath, firstRecord);
+    writePromptLog(promptLogPath, secondRecord);
+
+    const records = readFileSync(promptLogPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(records).toEqual([firstRecord, secondRecord]);
     if (process.platform !== 'win32') {
       expect(statSync(promptLogPath).mode & 0o777).toBe(0o600);
     }
@@ -75,6 +104,11 @@ describe('SessionLogger', () => {
     expect(() => writePromptLog(promptLogPath, createPromptLogRecord()))
       .not.toThrow();
     expect(existsSync(promptLogPath)).toBe(false);
+    expect(mockPromptLogWarn).toHaveBeenCalledWith(
+      'Prompt log could not be persisted; continuing workflow',
+      { error: expect.stringContaining('[path]') },
+    );
+    expect(JSON.stringify(mockPromptLogWarn.mock.calls[0])).not.toContain(logsDir);
   });
 
   it('companion review round と queue coalescing を run NDJSON に永続化する', () => {

--- a/src/__tests__/sessionLogger.test.ts
+++ b/src/__tests__/sessionLogger.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -9,9 +17,9 @@ import { buildWorkflowStepScopeKey } from '../features/tasks/execute/workflowSte
 import { AGENT_FAILURE_CATEGORIES } from '../shared/types/agent-failure.js';
 import { buildPhaseExecutionId } from '../shared/utils/phaseExecutionId.js';
 import {
-  initDebugLogger,
-  resetDebugLogger,
-} from '../shared/utils/debug.js';
+  writePromptLog,
+  type PromptLogRecord,
+} from '../features/tasks/execute/promptLog.js';
 
 const tempDirs = new Set<string>();
 
@@ -21,8 +29,22 @@ function createTempLogsDir(): string {
   return dir;
 }
 
+function createPromptLogRecord(): PromptLogRecord {
+  return {
+    step: 'plan',
+    phase: 1,
+    iteration: 2,
+    scope: '{"step":"plan","stack":[]}',
+    phaseExecutionId: 'plan:2:1:1',
+    systemPrompt: 'system prompt',
+    userInstruction: 'prompt text',
+    prompt: 'prompt text',
+    response: 'response text',
+    timestamp: '2026-02-07T00:00:00.000Z',
+  };
+}
+
 afterEach(() => {
-  resetDebugLogger();
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -30,6 +52,31 @@ afterEach(() => {
 });
 
 describe('SessionLogger', () => {
+  it('explicit run path へ private prompt record を追記する', () => {
+    const logsDir = createTempLogsDir();
+    const promptLogPath = join(logsDir, 'run-one', 'logs', 'session-one-prompts.jsonl');
+    mkdirSync(join(logsDir, 'run-one', 'logs'), { recursive: true });
+
+    writePromptLog(promptLogPath, createPromptLogRecord());
+
+    expect(JSON.parse(readFileSync(promptLogPath, 'utf-8').trim()))
+      .toEqual(createPromptLogRecord());
+    if (process.platform !== 'win32') {
+      expect(statSync(promptLogPath).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('prompt record の永続化失敗で workflow を中断しない', () => {
+    const logsDir = createTempLogsDir();
+    const blockingPath = join(logsDir, 'not-a-directory');
+    const promptLogPath = join(blockingPath, 'session-one-prompts.jsonl');
+    writeFileSync(blockingPath, 'blocking file');
+
+    expect(() => writePromptLog(promptLogPath, createPromptLogRecord()))
+      .not.toThrow();
+    expect(existsSync(promptLogPath)).toBe(false);
+  });
+
   it('companion review round と queue coalescing を run NDJSON に永続化する', () => {
     const logsDir = createTempLogsDir();
     const ndjsonPath = initNdjsonLog('session-companion', 'task', 'workflow', { logsDir });
@@ -410,14 +457,14 @@ describe('SessionLogger', () => {
 
   it('debug prompt と trace parser は同名 parallel child を scope で相関する', () => {
     const logsDir = createTempLogsDir();
-    initDebugLogger({ enabled: true }, logsDir);
     const ndjsonPath = initNdjsonLog(
       'session-parallel-prompts',
       'task',
       'parent',
       { logsDir },
     );
-    const logger = new SessionLogger(ndjsonPath, true);
+    const promptLogPath = join(logsDir, 'session-parallel-prompts-prompts.jsonl');
+    const logger = new SessionLogger(ndjsonPath, true, promptLogPath);
     const step = {
       name: 'review',
       kind: 'agent' as const,
@@ -522,7 +569,11 @@ describe('SessionLogger', () => {
       timestamp: new Date('2026-04-13T00:00:02.000Z'),
     }, 'slow', slowStack);
 
-    const promptRecords = logger.getPromptRecords();
+    const promptRecords = readFileSync(promptLogPath, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line)) as ReturnType<SessionLogger['getPromptRecords']>;
+    expect(promptRecords).toEqual(logger.getPromptRecords());
     expect(promptRecords.map((record) => ({
       scope: record.scope,
       systemPrompt: record.systemPrompt,

--- a/src/__tests__/sigint-interrupt.test.ts
+++ b/src/__tests__/sigint-interrupt.test.ts
@@ -212,7 +212,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => {
     playWarningSound: vi.fn(),
     preventSleep: vi.fn(),
     isDebugEnabled: vi.fn().mockReturnValue(false),
-    writePromptLog: vi.fn(),
     generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
     isValidReportDirName: vi.fn().mockImplementation((value: string) => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)),
   };

--- a/src/__tests__/traceReport.test.ts
+++ b/src/__tests__/traceReport.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -376,6 +376,74 @@ describe('traceReport', () => {
     expect(markdown).not.toContain('xyz987');
     expect(markdown).not.toContain('ghp_abcdef1234567890');
     expect(markdown).not.toContain('xoxb-1234abcd-5678efgh');
+  });
+
+  it('should reject duplicate prompt executions within one run', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'trace-report-duplicate-prompt-'));
+    const sessionPath = join(dir, 'session.jsonl');
+    const promptPath = join(dir, 'session-prompts.jsonl');
+    const scope = '{"step":"plan","stack":[]}';
+    const promptRecord = {
+      step: 'plan',
+      phase: 1,
+      iteration: 1,
+      scope,
+      phaseExecutionId: 'plan:1:1:1',
+      systemPrompt: 'system prompt',
+      userInstruction: 'user prompt',
+      prompt: 'user prompt',
+      response: 'response',
+      timestamp: '2026-03-04T11:59:03.000Z',
+    };
+
+    try {
+      writeFileSync(sessionPath, [
+        JSON.stringify({ type: 'workflow_start', task: 'task', workflowName: 'workflow', startTime: '2026-03-04T11:59:00.000Z' }),
+        JSON.stringify({ type: 'step_start', step: 'plan', persona: 'planner', iteration: 1, timestamp: '2026-03-04T11:59:01.000Z' }),
+        JSON.stringify({ type: 'phase_start', step: 'plan', iteration: 1, phase: 1, phaseName: 'execute', phaseExecutionId: 'plan:1:1:1', instruction: 'user prompt', systemPrompt: 'system prompt', userInstruction: 'user prompt', timestamp: '2026-03-04T11:59:02.000Z' }),
+        JSON.stringify({ type: 'phase_complete', step: 'plan', iteration: 1, phase: 1, phaseName: 'execute', phaseExecutionId: 'plan:1:1:1', status: 'done', content: 'response', timestamp: '2026-03-04T11:59:03.000Z' }),
+        '',
+      ].join('\n'));
+      writeFileSync(promptPath, [
+        JSON.stringify(promptRecord),
+        JSON.stringify(promptRecord),
+        '',
+      ].join('\n'));
+
+      expect(() => renderTraceReportFromLogs(
+        {
+          tracePath: join(dir, 'trace.md'),
+          workflowName: 'workflow',
+          task: 'task',
+          runSlug: 'run-duplicate',
+          status: 'completed',
+          iterations: 1,
+          endTime: '2026-03-04T12:00:00.000Z',
+        },
+        sessionPath,
+        promptPath,
+        'full',
+      )).toThrow('Duplicate prompt execution');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should not require session or prompt logs when trace mode is off', () => {
+    expect(renderTraceReportFromLogs(
+      {
+        tracePath: '/missing/trace.md',
+        workflowName: 'workflow',
+        task: 'task',
+        runSlug: 'run-off',
+        status: 'completed',
+        iterations: 1,
+        endTime: '2026-03-04T12:00:00.000Z',
+      },
+      '/missing/session.jsonl',
+      '/missing/session-prompts.jsonl',
+      'off',
+    )).toBeUndefined();
   });
 
 });

--- a/src/__tests__/workflow-execution-canonical.test.ts
+++ b/src/__tests__/workflow-execution-canonical.test.ts
@@ -106,9 +106,9 @@ vi.mock('../shared/utils/index.js', () => ({
   notifySuccess: vi.fn(),
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
+  isDebugEnabled: vi.fn(() => false),
   generateReportDir: vi.fn(() => 'test-report-dir'),
   isValidReportDirName: vi.fn(() => true),
-  getDebugPromptsLogFile: vi.fn(() => undefined),
 }));
 
 vi.mock('../core/logging/providerEventLogger.js', () => ({

--- a/src/__tests__/workflowExecution-ask-user-question.test.ts
+++ b/src/__tests__/workflowExecution-ask-user-question.test.ts
@@ -219,8 +219,6 @@ vi.mock('../shared/utils/index.js', () => ({
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
   isDebugEnabled: vi.fn().mockReturnValue(false),
-  writePromptLog: vi.fn(),
-  getDebugPromptsLogFile: vi.fn().mockReturnValue(null),
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
   isValidReportDirName: vi.fn().mockReturnValue(true),
   playWarningSound: vi.fn(),

--- a/src/__tests__/workflowExecution-debug-prompts.test.ts
+++ b/src/__tests__/workflowExecution-debug-prompts.test.ts
@@ -2,16 +2,18 @@
  * Integration tests: debug prompt log wiring in executeWorkflow().
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, it, expect, beforeEach, vi } from 'vitest';
 import type { WorkflowConfig } from '../core/models/index.js';
 import { buildPhaseExecutionId } from '../shared/utils/phaseExecutionId.js';
+import type { PromptLogRecord } from '../features/tasks/execute/promptLog.js';
 
 const {
   disabledObservability,
   mockIsDebugEnabled,
+  mockResolveWorkflowConfigValues,
   mockWritePromptLog,
   mockInitNdjsonLog,
   mockAppendNdjsonLine,
@@ -24,8 +26,30 @@ const {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const path = require('node:path') as typeof import('node:path');
 
+  const disabledObservability = {
+    enabled: false,
+    monitor: false,
+    sessionLogExporter: false,
+    usageEventsPhase: false,
+  };
   const mockIsDebugEnabled = vi.fn().mockReturnValue(true);
-  const mockWritePromptLog = vi.fn();
+  const mockResolveWorkflowConfigValues = vi.fn().mockReturnValue({
+    notificationSound: true,
+    notificationSoundEvents: {},
+    provider: 'claude',
+    runtime: undefined,
+    preventSleep: false,
+    model: undefined,
+    logging: undefined,
+    observability: disabledObservability,
+  });
+  const mockWritePromptLog = vi.fn((promptLogPath: string, record: unknown) => {
+    if (typeof promptLogPath !== 'string' || record === undefined) {
+      return;
+    }
+    fs.mkdirSync(path.dirname(promptLogPath), { recursive: true });
+    fs.appendFileSync(promptLogPath, `${JSON.stringify(record)}\n`);
+  });
   const mockInitNdjsonLog = vi.fn((
     sessionId: string,
     task: string,
@@ -49,14 +73,16 @@ const {
   class MockWorkflowEngine extends EE {
     private config: WorkflowConfig;
     private task: string;
+    private cwd: string;
 
-    constructor(config: WorkflowConfig, _cwd: string, task: string, _options: unknown) {
+    constructor(config: WorkflowConfig, cwd: string, task: string, _options: unknown) {
       super();
       if (task === 'constructor-throw-task') {
         throw new Error('mock constructor failure');
       }
       this.config = config;
       this.task = task;
+      this.cwd = cwd;
     }
 
     abort(): void {}
@@ -70,6 +96,10 @@ const {
       const shouldEmitSensitive = this.task === 'sensitive-content-task';
       const shouldRepeatStep = this.task === 'repeat-step-task';
       const shouldReversePhaseCompletion = this.task === 'reverse-phase-complete-task';
+      const shouldEmitIsolationValues = this.task.startsWith('isolated-');
+      const isolationInstruction = `prompt for ${this.task}`;
+      const isolationSystemPrompt = `execution directory ${this.cwd}`;
+      const isolationResponse = `response for ${this.task}`;
       const providerInfo = { provider: undefined, model: undefined };
       const executePhaseId = buildPhaseExecutionId({
         step: step.name,
@@ -100,9 +130,15 @@ const {
           userInstruction: 'phase prompt second',
         }, executePhaseSecondId, 1);
       } else {
-        this.emit('phase:start', step, 1, 'execute', shouldEmitSensitive ? 'token=plain-secret' : 'phase prompt', {
-          systemPrompt: shouldEmitSensitive ? 'Authorization: Bearer super-secret-token' : '../agents/coder.md',
-          userInstruction: shouldEmitSensitive ? 'api_key=plain-secret' : 'phase prompt',
+        this.emit('phase:start', step, 1, 'execute', shouldEmitSensitive
+          ? 'token=plain-secret'
+          : shouldEmitIsolationValues ? isolationInstruction : 'phase prompt', {
+          systemPrompt: shouldEmitSensitive
+            ? 'Authorization: Bearer super-secret-token'
+            : shouldEmitIsolationValues ? isolationSystemPrompt : '../agents/coder.md',
+          userInstruction: shouldEmitSensitive
+            ? 'api_key=plain-secret'
+            : shouldEmitIsolationValues ? isolationInstruction : 'phase prompt',
         }, executePhaseId, 1);
       }
       this.emit('phase:start', step, 3, 'judge', 'phase3 prompt', {
@@ -136,7 +172,9 @@ const {
         this.emit('phase:complete', step, 1, 'execute', 'phase response second', 'done', undefined, executePhaseSecondId, 1);
         this.emit('phase:complete', step, 1, 'execute', 'phase response first', 'done', undefined, executePhaseId, 1);
       } else {
-        this.emit('phase:complete', step, 1, 'execute', shouldEmitSensitive ? 'password=plain-secret' : 'phase response', 'done', undefined, executePhaseId, 1);
+        this.emit('phase:complete', step, 1, 'execute', shouldEmitSensitive
+          ? 'password=plain-secret'
+          : shouldEmitIsolationValues ? isolationResponse : 'phase response', 'done', undefined, executePhaseId, 1);
       }
       if (shouldDuplicatePhase) {
         this.emit('phase:start', step, 1, 'execute', 'phase prompt second', {
@@ -202,13 +240,9 @@ const {
   }
 
   return {
-    disabledObservability: {
-      enabled: false,
-      monitor: false,
-      sessionLogExporter: false,
-      usageEventsPhase: false,
-    },
+    disabledObservability,
     mockIsDebugEnabled,
+    mockResolveWorkflowConfigValues,
     mockWritePromptLog,
     mockInitNdjsonLog,
     mockAppendNdjsonLine,
@@ -258,16 +292,7 @@ vi.mock('../infra/config/index.js', () => ({
   updateWorktreeSession: vi.fn(),
   loadProjectConfig: vi.fn(() => ({})),
   loadGlobalConfig: vi.fn(() => ({})),
-  resolveWorkflowConfigValues: vi.fn().mockReturnValue({
-    notificationSound: true,
-    notificationSoundEvents: {},
-    provider: 'claude',
-    runtime: undefined,
-    preventSleep: false,
-    model: undefined,
-    logging: undefined,
-    observability: disabledObservability,
-  }),
+  resolveWorkflowConfigValues: mockResolveWorkflowConfigValues,
   saveSessionState: vi.fn(),
   ensureDir: vi.fn(),
   writeFileAtomic: vi.fn(),
@@ -366,7 +391,8 @@ vi.mock('../infra/fs/index.js', async (importOriginal) => ({
   appendNdjsonLine: mockAppendNdjsonLine,
 }));
 
-vi.mock('../shared/utils/index.js', () => ({
+vi.mock('../shared/utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../shared/utils/index.js')>()),
   createLogger: vi.fn().mockReturnValue({
     debug: vi.fn(),
     info: vi.fn(),
@@ -377,10 +403,12 @@ vi.mock('../shared/utils/index.js', () => ({
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
   isDebugEnabled: mockIsDebugEnabled,
-  writePromptLog: mockWritePromptLog,
-  getDebugPromptsLogFile: vi.fn().mockReturnValue(null),
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
   isValidReportDirName: vi.fn().mockImplementation((value: string) => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)),
+}));
+
+vi.mock('../features/tasks/execute/promptLog.js', () => ({
+  writePromptLog: mockWritePromptLog,
 }));
 
 vi.mock('../shared/prompt/index.js', () => ({
@@ -408,6 +436,16 @@ describe('executeWorkflow debug prompts logging', () => {
     projectDir = mkdtempSync(join(tmpdir(), 'takt-debug-prompts-'));
     vi.clearAllMocks();
     mockIsDebugEnabled.mockReturnValue(true);
+    mockResolveWorkflowConfigValues.mockReturnValue({
+      notificationSound: true,
+      notificationSoundEvents: {},
+      provider: 'claude',
+      runtime: undefined,
+      preventSleep: false,
+      model: undefined,
+      logging: undefined,
+      observability: disabledObservability,
+    });
   });
 
   afterEach(() => {
@@ -440,7 +478,7 @@ describe('executeWorkflow debug prompts logging', () => {
     });
 
     expect(mockWritePromptLog).toHaveBeenCalledTimes(2);
-    const records = mockWritePromptLog.mock.calls.map((call) => call[0]) as Array<{
+    const records = mockWritePromptLog.mock.calls.map((call) => call[1]) as Array<{
       step: string;
       phase: number;
       iteration: number;
@@ -465,7 +503,7 @@ describe('executeWorkflow debug prompts logging', () => {
     });
 
     expect(mockWritePromptLog).toHaveBeenCalledTimes(2);
-    const records = mockWritePromptLog.mock.calls.map((call) => call[0]) as Array<Record<string, unknown> & { phase: number }>;
+    const records = mockWritePromptLog.mock.calls.map((call) => call[1]) as Array<Record<string, unknown> & { phase: number }>;
     const record = records.find((entry) => entry.phase === 1)!;
     expect(record).toHaveProperty('systemPrompt');
     expect(record).toHaveProperty('userInstruction');
@@ -481,6 +519,9 @@ describe('executeWorkflow debug prompts logging', () => {
     });
 
     expect(mockWritePromptLog).not.toHaveBeenCalled();
+    expect(vi.mocked(writeFileAtomic).mock.calls.some(
+      (call) => String(call[0]).endsWith('/trace.md'),
+    )).toBe(true);
   });
 
   it('should handle repeated phase starts for same step and phase without missing debug prompt', async () => {
@@ -491,7 +532,7 @@ describe('executeWorkflow debug prompts logging', () => {
     });
 
     expect(mockWritePromptLog).toHaveBeenCalledTimes(3);
-    const records = mockWritePromptLog.mock.calls.map((call) => call[0]) as Array<{
+    const records = mockWritePromptLog.mock.calls.map((call) => call[1]) as Array<{
       phase: number;
       response: string;
     }>;
@@ -500,6 +541,78 @@ describe('executeWorkflow debug prompts logging', () => {
       .map((record) => record.response);
     expect(phase1Responses).toHaveLength(2);
     expect(phase1Responses.every((response) => typeof response === 'string' && response.length > 0)).toBe(true);
+  });
+
+  it('should isolate prompt artifacts and full terminal traces between workflow runs', async () => {
+    const firstCwd = join(projectDir, 'first-worktree');
+    const secondCwd = join(projectDir, 'second-worktree');
+    mkdirSync(firstCwd, { recursive: true });
+    mkdirSync(secondCwd, { recursive: true });
+    mockResolveWorkflowConfigValues.mockReturnValue({
+      notificationSound: true,
+      notificationSoundEvents: {},
+      provider: 'claude',
+      runtime: undefined,
+      preventSleep: false,
+      model: undefined,
+      logging: { trace: true },
+      observability: disabledObservability,
+    });
+
+    await executeWorkflow(makeConfig(), 'isolated-first-task', firstCwd, {
+      projectCwd: firstCwd,
+      reportDirName: 'isolated-first-run',
+    });
+    await executeWorkflow(makeConfig(), 'isolated-second-task', secondCwd, {
+      projectCwd: secondCwd,
+      reportDirName: 'isolated-second-run',
+    });
+
+    const firstPromptPath = join(
+      firstCwd,
+      '.takt',
+      'runs',
+      'isolated-first-run',
+      'logs',
+      'test-session-id-prompts.jsonl',
+    );
+    const secondPromptPath = join(
+      secondCwd,
+      '.takt',
+      'runs',
+      'isolated-second-run',
+      'logs',
+      'test-session-id-prompts.jsonl',
+    );
+    const phaseOnePromptCalls = mockWritePromptLog.mock.calls.filter(
+      (call) => (call[1] as { phase?: number } | undefined)?.phase === 1,
+    );
+    expect(phaseOnePromptCalls.map((call) => call[0])).toEqual([
+      firstPromptPath,
+      secondPromptPath,
+    ]);
+
+    const firstTraceCall = vi.mocked(writeFileAtomic).mock.calls.find(
+      (call) => String(call[0]) === join(firstCwd, '.takt', 'runs', 'isolated-first-run', 'trace.md'),
+    );
+    const secondTraceCall = vi.mocked(writeFileAtomic).mock.calls.find(
+      (call) => String(call[0]) === join(secondCwd, '.takt', 'runs', 'isolated-second-run', 'trace.md'),
+    );
+    expect(firstTraceCall).toBeDefined();
+    expect(secondTraceCall).toBeDefined();
+
+    const firstTrace = String(firstTraceCall?.[1]);
+    const secondTrace = String(secondTraceCall?.[1]);
+    expect(firstTrace).toContain('isolated-first-task');
+    expect(firstTrace).toContain(firstCwd);
+    expect(firstTrace).toContain('response for isolated-first-task');
+    expect(firstTrace).not.toContain('isolated-second-task');
+    expect(firstTrace).not.toContain(secondCwd);
+    expect(secondTrace).toContain('isolated-second-task');
+    expect(secondTrace).toContain(secondCwd);
+    expect(secondTrace).toContain('response for isolated-second-task');
+    expect(secondTrace).not.toContain('isolated-first-task');
+    expect(secondTrace).not.toContain(firstCwd);
   });
 
   it('should fail fast when taskPrefix is provided without taskColorIndex', async () => {
@@ -669,6 +782,26 @@ describe('executeWorkflow debug prompts logging', () => {
     expect(recordText).toContain('[REDACTED]');
     expect(recordText).not.toContain('plain-secret');
     expect(recordText).not.toContain('super-secret-token');
+
+    const promptRecord = mockWritePromptLog.mock.calls
+      .map((call) => call[1] as PromptLogRecord)
+      .find((record) => (
+        record.phase === 1
+        && record.step === 'implement'
+        && record.response.includes('[REDACTED]')
+      ));
+    expect(promptRecord).toBeDefined();
+    if (promptRecord === undefined) {
+      throw new Error('phase 1 prompt record is required');
+    }
+    expect(promptRecord.systemPrompt).toContain('[REDACTED]');
+    expect(promptRecord.systemPrompt).not.toContain('super-secret-token');
+    expect(promptRecord.userInstruction).toContain('[REDACTED]');
+    expect(promptRecord.userInstruction).not.toContain('plain-secret');
+    expect(promptRecord.prompt).toContain('[REDACTED]');
+    expect(promptRecord.prompt).not.toContain('plain-secret');
+    expect(promptRecord.response).toContain('[REDACTED]');
+    expect(promptRecord.response).not.toContain('plain-secret');
   });
 
   it('should keep phaseExecutionId bindings consistent in trace when completions arrive in reverse order', async () => {

--- a/src/__tests__/workflowExecution-debug-prompts.test.ts
+++ b/src/__tests__/workflowExecution-debug-prompts.test.ts
@@ -2,7 +2,7 @@
  * Integration tests: debug prompt log wiring in executeWorkflow().
  */
 
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, it, expect, beforeEach, vi } from 'vitest';
@@ -17,6 +17,7 @@ const {
   mockWritePromptLog,
   mockInitNdjsonLog,
   mockAppendNdjsonLine,
+  isolationPhaseBarrier,
   MockWorkflowEngine,
 } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -69,6 +70,32 @@ const {
   const mockAppendNdjsonLine = vi.fn((filePath: string, record: unknown) => {
     fs.appendFileSync(filePath, `${JSON.stringify(record)}\n`);
   });
+
+  class PhaseBarrier {
+    readonly arrivals = new Set<string>();
+    private promise: Promise<void> = Promise.resolve();
+    private resolve: (() => void) | undefined;
+    released = false;
+
+    reset(): void {
+      this.arrivals.clear();
+      this.released = false;
+      this.promise = new Promise<void>((resolve) => {
+        this.resolve = resolve;
+      });
+    }
+
+    async wait(task: string): Promise<void> {
+      this.arrivals.add(task);
+      if (this.arrivals.size === 2) {
+        this.released = true;
+        this.resolve?.();
+      }
+      await this.promise;
+    }
+  }
+
+  const isolationPhaseBarrier = new PhaseBarrier();
 
   class MockWorkflowEngine extends EE {
     private config: WorkflowConfig;
@@ -140,6 +167,9 @@ const {
             ? 'api_key=plain-secret'
             : shouldEmitIsolationValues ? isolationInstruction : 'phase prompt',
         }, executePhaseId, 1);
+      }
+      if (shouldEmitIsolationValues) {
+        await isolationPhaseBarrier.wait(this.task);
       }
       this.emit('phase:start', step, 3, 'judge', 'phase3 prompt', {
         systemPrompt: 'conductor',
@@ -246,6 +276,7 @@ const {
     mockWritePromptLog,
     mockInitNdjsonLog,
     mockAppendNdjsonLine,
+    isolationPhaseBarrier,
     MockWorkflowEngine,
   };
 });
@@ -559,14 +590,22 @@ describe('executeWorkflow debug prompts logging', () => {
       observability: disabledObservability,
     });
 
-    await executeWorkflow(makeConfig(), 'isolated-first-task', firstCwd, {
-      projectCwd: firstCwd,
-      reportDirName: 'isolated-first-run',
-    });
-    await executeWorkflow(makeConfig(), 'isolated-second-task', secondCwd, {
-      projectCwd: secondCwd,
-      reportDirName: 'isolated-second-run',
-    });
+    isolationPhaseBarrier.reset();
+    await Promise.all([
+      executeWorkflow(makeConfig(), 'isolated-first-task', firstCwd, {
+        projectCwd: firstCwd,
+        reportDirName: 'isolated-first-run',
+      }),
+      executeWorkflow(makeConfig(), 'isolated-second-task', secondCwd, {
+        projectCwd: secondCwd,
+        reportDirName: 'isolated-second-run',
+      }),
+    ]);
+    expect(isolationPhaseBarrier.arrivals).toEqual(new Set([
+      'isolated-first-task',
+      'isolated-second-task',
+    ]));
+    expect(isolationPhaseBarrier.released).toBe(true);
 
     const firstPromptPath = join(
       firstCwd,
@@ -601,18 +640,67 @@ describe('executeWorkflow debug prompts logging', () => {
     expect(firstTraceCall).toBeDefined();
     expect(secondTraceCall).toBeDefined();
 
-    const firstTrace = String(firstTraceCall?.[1]);
-    const secondTrace = String(secondTraceCall?.[1]);
-    expect(firstTrace).toContain('isolated-first-task');
-    expect(firstTrace).toContain(firstCwd);
-    expect(firstTrace).toContain('response for isolated-first-task');
-    expect(firstTrace).not.toContain('isolated-second-task');
-    expect(firstTrace).not.toContain(secondCwd);
-    expect(secondTrace).toContain('isolated-second-task');
-    expect(secondTrace).toContain(secondCwd);
-    expect(secondTrace).toContain('response for isolated-second-task');
-    expect(secondTrace).not.toContain('isolated-first-task');
-    expect(secondTrace).not.toContain(firstCwd);
+    const artifacts = [
+      {
+        task: 'isolated-first-task',
+        cwd: firstCwd,
+        prompt: 'prompt for isolated-first-task',
+        systemPrompt: `execution directory ${firstCwd}`,
+        response: 'response for isolated-first-task',
+        promptRecords: readFileSync(firstPromptPath, 'utf-8')
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line) as PromptLogRecord),
+        trace: String(firstTraceCall?.[1]),
+      },
+      {
+        task: 'isolated-second-task',
+        cwd: secondCwd,
+        prompt: 'prompt for isolated-second-task',
+        systemPrompt: `execution directory ${secondCwd}`,
+        response: 'response for isolated-second-task',
+        promptRecords: readFileSync(secondPromptPath, 'utf-8')
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line) as PromptLogRecord),
+        trace: String(secondTraceCall?.[1]),
+      },
+    ];
+
+    for (const artifact of artifacts) {
+      expect(artifact.promptRecords.map((record) => record.phaseExecutionId))
+        .toEqual(expect.arrayContaining(['implement:1:1:1', 'implement:1:3:1']));
+      expect(artifact.promptRecords).toHaveLength(2);
+    }
+
+    for (const [index, artifact] of artifacts.entries()) {
+      const phaseOneRecord = artifact.promptRecords.find((record) => record.phase === 1);
+      expect(phaseOneRecord).toMatchObject({
+        phaseExecutionId: 'implement:1:1:1',
+        prompt: artifact.prompt,
+        systemPrompt: artifact.systemPrompt,
+        userInstruction: artifact.prompt,
+        response: artifact.response,
+      });
+      expect(artifact.trace).toContain(artifact.task);
+      expect(artifact.trace).toContain(artifact.cwd);
+      expect(artifact.trace).toContain(artifact.prompt);
+      expect(artifact.trace).toContain(artifact.systemPrompt);
+      expect(artifact.trace).toContain(artifact.response);
+
+      const other = artifacts[1 - index]!;
+      const promptArtifact = JSON.stringify(artifact.promptRecords);
+      for (const [field, value] of Object.entries({
+        prompt: other.prompt,
+        systemPrompt: other.systemPrompt,
+        response: other.response,
+        task: other.task,
+        cwd: other.cwd,
+      })) {
+        expect(promptArtifact, `${artifact.task} prompt artifact leaked ${field}`).not.toContain(value);
+        expect(artifact.trace, `${artifact.task} trace leaked ${field}`).not.toContain(value);
+      }
+    }
   });
 
   it('should fail fast when taskPrefix is provided without taskColorIndex', async () => {

--- a/src/__tests__/workflowExecution-session-loading.test.ts
+++ b/src/__tests__/workflowExecution-session-loading.test.ts
@@ -273,8 +273,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
   isDebugEnabled: vi.fn().mockReturnValue(false),
-  writePromptLog: vi.fn(),
-  getDebugPromptsLogFile: vi.fn().mockReturnValue(null),
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
   isValidReportDirName: vi.fn().mockReturnValue(true),
   playWarningSound: vi.fn(),

--- a/src/__tests__/workflowExecution-structured-caller.test.ts
+++ b/src/__tests__/workflowExecution-structured-caller.test.ts
@@ -230,8 +230,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
   notifyError: vi.fn(),
   preventSleep: vi.fn(),
   isDebugEnabled: vi.fn().mockReturnValue(false),
-  writePromptLog: vi.fn(),
-  getDebugPromptsLogFile: vi.fn().mockReturnValue(null),
   generateReportDir: vi.fn().mockReturnValue('test-report-dir'),
   ensureCurrentTmpDirExists: mockEnsureCurrentTmpDirExists,
   isValidReportDirName: vi.fn().mockReturnValue(true),

--- a/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
+++ b/src/__tests__/workflowExecutionBootstrapDirectResume.test.ts
@@ -90,7 +90,6 @@ vi.mock('../shared/utils/index.js', async (importOriginal) => ({
     warn: mockLogWarn,
   })),
   generateReportDir: vi.fn(() => 'generated-run'),
-  getDebugPromptsLogFile: vi.fn(() => undefined),
   isPathInside: vi.fn(() => true),
   isValidReportDirName: mockIsValidReportDirName,
   preventSleep: vi.fn(),

--- a/src/features/tasks/execute/promptLog.ts
+++ b/src/features/tasks/execute/promptLog.ts
@@ -1,0 +1,25 @@
+import { appendPrivateFile } from '../../../shared/utils/private-file.js';
+
+export interface PromptLogRecord {
+  step: string;
+  phase: 1 | 2 | 3;
+  iteration: number;
+  scope: string;
+  phaseExecutionId: string;
+  prompt: string;
+  systemPrompt: string;
+  userInstruction: string;
+  response: string;
+  timestamp: string;
+}
+
+export function writePromptLog(
+  promptLogPath: string,
+  record: PromptLogRecord,
+): void {
+  try {
+    appendPrivateFile(promptLogPath, JSON.stringify(record) + '\n');
+  } catch {
+    // Logging errors must not interrupt the workflow.
+  }
+}

--- a/src/features/tasks/execute/promptLog.ts
+++ b/src/features/tasks/execute/promptLog.ts
@@ -1,4 +1,8 @@
 import { appendPrivateFile } from '../../../shared/utils/private-file.js';
+import { safeExternalErrorMessage } from '../../../shared/utils/safeExternalErrorMessage.js';
+import { createLogger } from '../../../shared/utils/index.js';
+
+const log = createLogger('prompt-log');
 
 export interface PromptLogRecord {
   step: string;
@@ -19,7 +23,9 @@ export function writePromptLog(
 ): void {
   try {
     appendPrivateFile(promptLogPath, JSON.stringify(record) + '\n');
-  } catch {
-    // Logging errors must not interrupt the workflow.
+  } catch (error) {
+    log.warn('Prompt log could not be persisted; continuing workflow', {
+      error: safeExternalErrorMessage(error),
+    });
   }
 }

--- a/src/features/tasks/execute/sessionLogger.ts
+++ b/src/features/tasks/execute/sessionLogger.ts
@@ -9,8 +9,8 @@ import {
   parseNdjsonRecord,
 } from '../../../infra/fs/index.js';
 import type { InteractiveMetadata } from './types.js';
-import { createLogger, isDebugEnabled, writePromptLog } from '../../../shared/utils/index.js';
-import type { PromptLogRecord, NdjsonRecord } from '../../../shared/utils/index.js';
+import { createLogger } from '../../../shared/utils/index.js';
+import type { NdjsonRecord } from '../../../shared/utils/index.js';
 import type { WorkflowResumePointEntry, WorkflowStep, AgentResponse, WorkflowState } from '../../../core/models/index.js';
 import type {
   JudgeStageEntry,
@@ -52,6 +52,7 @@ import {
   readPrivateFileState,
   writePrivateFileWithModeExpected,
 } from '../../../shared/utils/private-file.js';
+import { writePromptLog, type PromptLogRecord } from './promptLog.js';
 
 const SESSION_LOG_MODE = 0o600;
 const log = createLogger('session-logger');
@@ -172,6 +173,7 @@ function sameTerminalSessionRecord(
 export class SessionLogger {
   private readonly ndjsonLogPath: string;
   private readonly allowSensitiveData: boolean;
+  private readonly promptLogPath: string | undefined;
   private readonly phaseTracker = new SessionLoggerPhaseTracker();
   private readonly activeStepIterations = new Map<string, number>();
   private readonly ndjsonRecords: NdjsonRecord[] = [];
@@ -179,9 +181,14 @@ export class SessionLogger {
   private workflowTerminalLogged = false;
   private companionAuditWriteFailureReported = false;
 
-  constructor(ndjsonLogPath: string, allowSensitiveData: boolean) {
+  constructor(
+    ndjsonLogPath: string,
+    allowSensitiveData: boolean,
+    promptLogPath?: string,
+  ) {
     this.ndjsonLogPath = ndjsonLogPath;
     this.allowSensitiveData = allowSensitiveData;
+    this.promptLogPath = promptLogPath;
   }
 
   writeInteractiveMetadata(meta: InteractiveMetadata): void {
@@ -203,14 +210,14 @@ export class SessionLogger {
     if (!instruction) {
       throw new Error(`Missing phase instruction for ${step.name}:${phase}`);
     }
-    const debugEnabled = isDebugEnabled();
+    const capturePrompt = this.promptLogPath !== undefined;
     const resolvedPhaseExecutionId = this.phaseTracker.trackStart({
       stepName: step.name,
       phase,
       phaseExecutionId,
       iteration,
       promptParts,
-      capturePrompt: debugEnabled,
+      capturePrompt,
       scopeKey: buildWorkflowStepScopeKey(step.name, workflowStack),
     });
     const record = buildPhaseStartRecord(
@@ -241,13 +248,13 @@ export class SessionLogger {
     if (!phaseStatus) {
       throw new Error(`Missing phase status for ${step.name}:${phase}`);
     }
-    const debugEnabled = isDebugEnabled();
+    const capturePrompt = this.promptLogPath !== undefined;
     const trackedPhase = this.phaseTracker.trackCompletion({
       stepName: step.name,
       phase,
       phaseExecutionId,
       iteration,
-      requirePrompt: debugEnabled,
+      requirePrompt: capturePrompt,
       scopeKey: buildWorkflowStepScopeKey(step.name, workflowStack),
     });
     const completedAt = new Date().toISOString();
@@ -266,7 +273,7 @@ export class SessionLogger {
     );
     this.appendRecord(record);
 
-    if (debugEnabled && trackedPhase.promptParts) {
+    if (this.promptLogPath !== undefined && trackedPhase.promptParts) {
       const promptIteration = iteration
         ?? parsePhaseExecutionId(trackedPhase.phaseExecutionId)?.iteration;
       if (promptIteration === undefined) {
@@ -285,7 +292,7 @@ export class SessionLogger {
         completedAt,
         this.sanitizeText.bind(this),
       );
-      writePromptLog(promptRecord);
+      writePromptLog(this.promptLogPath, promptRecord);
       this.promptRecords.push(promptRecord);
     }
   }

--- a/src/features/tasks/execute/sessionLoggerRecordFactory.ts
+++ b/src/features/tasks/execute/sessionLoggerRecordFactory.ts
@@ -16,7 +16,7 @@ import type {
   NdjsonCompanionReviewSkipped,
   NdjsonCompanionReviewTrigger,
 } from '../../../infra/fs/index.js';
-import type { PromptLogRecord } from '../../../shared/utils/index.js';
+import type { PromptLogRecord } from './promptLog.js';
 import type {
   AgentResponse,
   WorkflowResumePointEntry,

--- a/src/features/tasks/execute/traceReport.ts
+++ b/src/features/tasks/execute/traceReport.ts
@@ -1,4 +1,4 @@
-import type { NdjsonRecord, PromptLogRecord } from '../../../shared/utils/index.js';
+import type { NdjsonRecord } from '../../../shared/utils/index.js';
 import type {
   TraceReportMode,
   TraceReportParams,
@@ -8,6 +8,7 @@ import type {
 import { parseJsonl, buildTraceFromRecords, type PromptRecord } from './traceReportParser.js';
 import { cloneStepsForMode, sanitizeTraceParamsForMode } from './traceReportRedaction.js';
 import { assertTraceParams, renderTraceReportMarkdown } from './traceReportRenderer.js';
+import type { PromptLogRecord } from './promptLog.js';
 
 export type {
   TraceReportMode,

--- a/src/features/tasks/execute/traceReportParser.ts
+++ b/src/features/tasks/execute/traceReportParser.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import type { NdjsonRecord, NdjsonWorkflowStackEntry, PromptLogRecord } from '../../../shared/utils/index.js';
+import type { NdjsonRecord, NdjsonWorkflowStackEntry } from '../../../shared/utils/index.js';
 import {
   buildPhaseExecutionId,
   parsePhaseExecutionId,
@@ -9,6 +9,7 @@ import type {
   TracePhase,
 } from './traceReportTypes.js';
 import { buildWorkflowStepScopeKey } from './workflowStepScope.js';
+import type { PromptLogRecord } from './promptLog.js';
 
 interface PromptRecord extends PromptLogRecord {
   timestamp: string;

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -51,7 +51,7 @@ import { TaskPrefixWriter } from '../../../shared/ui/TaskPrefixWriter.js';
 import { getErrorMessage } from '../../../shared/utils/error.js';
 import {
   createLogger,
-  getDebugPromptsLogFile,
+  isDebugEnabled,
   isValidReportDirName,
   preventSleep,
 } from '../../../shared/utils/index.js';
@@ -517,7 +517,14 @@ export async function createWorkflowExecutionBootstrap(
       startTime: runBootstrap.startedAt,
     },
   );
-  const sessionLogger = new SessionLogger(ndjsonLogPath, allowSensitiveData);
+  const promptLogPath = isDebugEnabled()
+    ? join(runPaths.logsAbs, `${workflowSessionId}-prompts.jsonl`)
+    : undefined;
+  const sessionLogger = new SessionLogger(
+    ndjsonLogPath,
+    allowSensitiveData,
+    promptLogPath,
+  );
   if (options.interactiveMetadata) {
     sessionLogger.writeInteractiveMetadata(options.interactiveMetadata);
   }
@@ -676,7 +683,6 @@ export async function createWorkflowExecutionBootstrap(
         updateWorktreeSession(projectCwd, cwd, personaName, personaSessionId, currentProvider)
     : (persona: string, personaSessionId: string | undefined) =>
         updatePersonaSession(projectCwd, persona, personaSessionId, currentProvider);
-  const promptLogPath = getDebugPromptsLogFile() ?? undefined;
   const observabilityOptions = globalConfig.observability.enabled
     && (
       globalConfig.observability.sessionLogExporter

--- a/src/shared/utils/debug.ts
+++ b/src/shared/utils/debug.ts
@@ -5,7 +5,6 @@
  */
 
 import { dirname, join } from 'node:path';
-import type { PromptLogRecord } from './types.js';
 import {
   appendPrivateFile,
   ensurePrivateDirectory,
@@ -45,7 +44,6 @@ export class DebugLogger {
   private debugEnabled = false;
   private traceEnabled = false;
   private debugLogFile: string | null = null;
-  private debugPromptsLogFile: string | null = null;
   private initialized = false;
   private verboseConsoleEnabled = false;
 
@@ -82,15 +80,9 @@ export class DebugLogger {
     if (this.debugEnabled) {
       if (config?.logFile) {
         this.debugLogFile = config.logFile;
-        if (config.logFile.endsWith('.log')) {
-          this.debugPromptsLogFile = config.logFile.slice(0, -4) + '-prompts.jsonl';
-        } else {
-          this.debugPromptsLogFile = `${config.logFile}-prompts.jsonl`;
-        }
       } else if (projectDir) {
         const logPrefix = DebugLogger.getDefaultLogPrefix(projectDir);
         this.debugLogFile = `${logPrefix}.log`;
-        this.debugPromptsLogFile = `${logPrefix}-prompts.jsonl`;
       }
 
       if (this.debugLogFile) {
@@ -111,15 +103,6 @@ export class DebugLogger {
 
         writePrivateFile(this.debugLogFile, header);
       }
-
-      if (this.debugPromptsLogFile) {
-        const promptsLogDir = dirname(this.debugPromptsLogFile);
-        ensurePrivateDirectory(promptsLogDir);
-        if (!config?.logFile) {
-          repairPrivateDirectory(promptsLogDir);
-        }
-        writePrivateFile(this.debugPromptsLogFile, '');
-      }
     }
 
     this.initialized = true;
@@ -130,7 +113,6 @@ export class DebugLogger {
     this.debugEnabled = false;
     this.traceEnabled = false;
     this.debugLogFile = null;
-    this.debugPromptsLogFile = null;
     this.initialized = false;
     this.verboseConsoleEnabled = false;
   }
@@ -153,11 +135,6 @@ export class DebugLogger {
   /** Get current debug log file path */
   getLogFile(): string | null {
     return this.debugLogFile;
-  }
-
-  /** Get current debug prompts log file path */
-  getPromptsLogFile(): string | null {
-    return this.debugPromptsLogFile;
   }
 
   /** Format log message with timestamp and level */
@@ -198,19 +175,6 @@ export class DebugLogger {
 
     try {
       appendPrivateFile(this.debugLogFile, logLine + '\n');
-    } catch {
-      // Silently fail - logging errors should not interrupt main flow
-    }
-  }
-
-  /** Write a prompt/response debug log entry */
-  writePromptLog(record: PromptLogRecord): void {
-    if (!this.debugEnabled || !this.debugPromptsLogFile) {
-      return;
-    }
-
-    try {
-      appendPrivateFile(this.debugPromptsLogFile, JSON.stringify(record) + '\n');
     } catch {
       // Silently fail - logging errors should not interrupt main flow
     }
@@ -258,10 +222,6 @@ export function getDebugLogFile(): string | null {
   return DebugLogger.getInstance().getLogFile();
 }
 
-export function getDebugPromptsLogFile(): string | null {
-  return DebugLogger.getInstance().getPromptsLogFile();
-}
-
 export function debugLog(component: string, message: string, data?: unknown): void {
   DebugLogger.getInstance().writeLog('DEBUG', component, message, data);
 }
@@ -272,10 +232,6 @@ export function infoLog(component: string, message: string, data?: unknown): voi
 
 export function errorLog(component: string, message: string, data?: unknown): void {
   DebugLogger.getInstance().writeLog('ERROR', component, message, data);
-}
-
-export function writePromptLog(record: PromptLogRecord): void {
-  DebugLogger.getInstance().writePromptLog(record);
 }
 
 export function traceEnter(component: string, funcName: string, args?: Record<string, unknown>): void {

--- a/src/shared/utils/types.ts
+++ b/src/shared/utils/types.ts
@@ -325,17 +325,3 @@ export type NdjsonRecord =
   | NdjsonCompanionQueueCoalesced
   | NdjsonCompanionCall
   | NdjsonCompanionReviewSkipped;
-
-/** Record for debug prompt/response log (debug-*-prompts.jsonl) */
-export interface PromptLogRecord {
-  step: string;
-  phase: 1 | 2 | 3;
-  iteration: number;
-  scope: string;
-  phaseExecutionId: string;
-  prompt: string;
-  systemPrompt: string;
-  userInstruction: string;
-  response: string;
-  timestamp: string;
-}


### PR DESCRIPTION
## Summary

# debug promptsログをrun単位に分離し、複数task実行時のtrace生成失敗を防ぐ

## 背景・目的

`logging.debug: true` で `takt run` のworker poolが複数taskを処理すると、各workflow runのprompt/responseが同じ `*-prompts.jsonl` に保存される。

phase execution IDはrun内でのみ一意であり、別runでは同じworkflow構造から同じIDが正常に生成される。ところがterminal trace生成は共有promptsログ全体を読み、`scope + phaseExecutionId`だけを一意キーとして扱うため、別runの正常な記録を重複実行と誤認して失敗する。

デバッグpromptの保存・参照境界をworkflow run単位に分離し、並列・直列を問わず、同じCLIプロセスで複数taskを処理しても各runのtraceが自分のpromptだけから生成されるようにする。

## 実測した事象

同じCLIプロセスが処理した3 taskのpromptが、次の1ファイルへ混在した。

```text
.takt/runs/debug-2026-08-19T13-56-33/logs/
  debug-2026-08-19T13-56-33-prompts.jsonl
```

同一の `scope + phaseExecutionId` を持つ正常な3レコード:

| task | timestamp | phaseExecutionId |
|---|---|---|
| Issue #1335 | `2026-08-19T14:03:46.263Z` | `plan:1:1:1` |
| Issue #1137 | `2026-08-19T14:13:27.943Z` | `plan:1:1:1` |
| Issue #1425 | `2026-08-19T21:35:46.872Z` | `plan:1:1:1` |

#1335のsessionログには該当phaseのstart/completeが各1件しかなく、単一run内の二重実行ではない。#1137と#1425のsessionログにも、それぞれ自分の正常な `plan:1:1:1` が1件ずつ存在する。

#1335はworkflow本体とfinal gateが完了した後、terminal trace生成で次の例外になった。

```text
Duplicate prompt execution: {"step":"plan","stack":[...]}:plan:1:1:1
```

その結果、runの `meta.json` は `status: completed`、タスク台帳は `status: failed` となり、自動commit・push・PR作成へ進まなかった。

## 根本原因（コード実測）

### 1. DebugLoggerがCLIプロセス単位で一度だけ初期化される

- `src/app/cli/initialization.ts`
- `src/shared/utils/debug.ts`

CLI起動時にsingletonの `DebugLogger` が初期化され、時刻ベースの単一 `debugPromptsLogFile` が作られる。worker pool内のtaskごとには再初期化されない。

### 2. 各workflow runが同じpromptLogPathを取得する

- `src/features/tasks/execute/workflowExecutionBootstrap.ts`

各runは `getDebugPromptsLogFile()` からprocess-globalな同一パスを取得し、terminal payloadの `promptLogPath` として保持する。

### 3. PromptLogRecordにrun identityがない

- `src/shared/utils/types.ts`
- `src/features/tasks/execute/sessionLoggerRecordFactory.ts`
- `src/features/tasks/execute/sessionLogger.ts`

prompt recordにはworkflow scopeと `phaseExecutionId` はあるが、どのworkflow runに属するかを識別するrun IDがない。同じファイルへ複数runが追記されると、読み取り時に安全に分離できない。

### 4. terminal trace生成が共有ファイル全体を現在runの入力として扱う

- `src/features/tasks/execute/traceReport.ts`
- `src/features/tasks/execute/traceReportParser.ts`
- `src/features/tasks/execute/traceReportWriter.ts`
- `src/features/tasks/execute/workflowTerminalProjection.ts`

`renderTraceReportFromLogs()` は `promptLogPath` 全体を読み込む。`buildTraceFromRecords()` は `scope + phaseExecutionId` が重複すると例外を投げるため、別runの正常なレコード同士が衝突する。

書き込み内容自体は壊れておらず、約7時間離れた直列taskのレコードも衝突している。したがって、ファイル書き込みのmutexやキューイングでは解消しない。

## 作業範囲

### 優先度：高

#### run単位のprompt所有権を確立する

- terminal traceへ渡すprompt入力は、対象workflow runのレコードだけで構成する。
- 推奨は、各runの `runPaths.logsAbs` 配下にrun専用promptsログを作り、`promptLogPath` 自体をrun-scopedにすること。
- 別案としてrecordへrun identityを永続化して対象runだけを厳密に抽出してもよい。ただし、run identityの欠落時や不一致時に別runのrecordを採用しないこと。
- CLI全体の一般デバッグログをprocess-scopedのまま維持することは許容する。今回分離が必須なのはterminal traceの入力になるprompt/response recordである。
- run専用ログのファイル権限とsensitive dataの扱いは、既存private-file・trace redaction契約を維持する。

#### terminal traceの相関契約を維持する

- 同一run内では、`scope + phaseExecutionId` によるpromptとphase start/completeの対応を維持する。
- 同一run内の真の重複、prompt欠落、phase相関不整合は、従来どおり検出する。
- 別runのrecordを先勝ち・後勝ちで黙って採用しない。
- redacted/full/offのtrace mode契約を変更しない。

#### worker pool経路を対象にする

- `concurrency > 1` で同じworkflow構造を持つ複数taskが並列実行される場合を修正対象にする。
- `concurrency = 1` でも、同じ長寿命CLIプロセスが後続taskをpollして実行する場合を修正対象にする。
- taskごとにCLIプロセスを再起動することを回避策または前提にしない。

### 優先度：中

#### テスト

既存のテスト構成・分類に合わせ、少なくとも次を追加または更新する。

- 同一run内のprompt/phase相関が維持されるunit test
- 異なるrunに同じ `scope + phaseExecutionId` が存在しても、各traceが自分のpromptだけを含むtest
- 2 taskを同一CLIプロセスで並列処理し、両方のterminal trace生成が成功するtest
- 2 taskを同一CLIプロセスで直列処理し、後続taskが先行taskのpromptを読み込まないtest
- 同一run内の真の重複は引き続き失敗するnegative test
- full traceに別taskのtask本文・作業ディレクトリ・responseが混入しないtest
- redacted traceとdebug無効時の既存動作の回帰test

integration testを追加または変更した場合は、対象testと `src/__tests__/releaseVerificationWiring.test.ts` を個別実行する。heavy ITに分類される場合は、PR全体のCIを初回実行にせず対象testを先に実行する。

## 明示された制約・対象外

- prompt recordの重複を無条件にdeduplicateして例外を隠さない。
- 「最初のrecordを使う」「最後のrecordを使う」といった順序依存の解決にしない。
- ファイル書き込みのmutex・キューイングだけで解決したことにしない。
- worker poolの並列度を1へ固定しない。
- `phaseExecutionId`をプロセス全体で一意にするためだけに、既存のrun内ID形式を変更しない。
- provider-eventsログ、usage-eventsログ、通常sessionログの既存run分離契約を壊さない。
- 一般デバッグログ全体の再設計は行わない。

## Gherkin受け入れ条件

```gherkin
Feature: debug prompt recordsのworkflow run分離

  Rule: terminal traceは対象runのpromptだけから生成する

    Scenario: 同じphase IDを持つtaskを並列実行する
      Given logging.debugが有効である
      And 同じworkflow構造を使う2つのtaskを同一CLIプロセスで実行する
      When worker poolが2つのtaskを並列に完了する
      Then 両方のworkflow runがterminal traceを生成できる
      And Duplicate prompt executionでは失敗しない
      And 各traceには自分のtaskのpromptとresponseだけが含まれる

    Scenario: 同じphase IDを持つtaskを直列実行する
      Given logging.debugが有効である
      And 同じCLIプロセスが先行taskの完了後に後続taskを取得する
      When 両taskでplan:1:1:1が生成される
      Then 後続taskのtrace生成は先行taskのprompt recordと衝突しない
      And 後続taskのtraceに先行taskの内容は含まれない

    Scenario: 同一run内の真の重複を検出する
      Given 1つのworkflow runに同じscopeとphaseExecutionIdを持つprompt recordが複数存在する
      When terminal traceを生成する
      Then 相関不整合として失敗する
      And 別run分離の修正によって重複が黙って隠されない

    Scenario: debug loggingが無効である
      Given logging.debugが無効である
      When workflow runが完了する
      Then promptログを必要とせず既存のredacted trace契約で完了する
```

## 確認方法

1. 追加・変更したunit/integration testを対象ファイル単位で実行する。
2. ITを変更した場合は `npm test -- src/__tests__/releaseVerificationWiring.test.ts` を実行する。
3. `npm run build`、`npm run lint`、`npm test`、`npm run test:it` を実行する。
4. CLIを1回起動したまま同一workflow構造のtaskを並列・直列に処理し、各runの `trace.md` とtask終端状態を確認する。
5. 各traceに別taskのprompt、response、作業ディレクトリが混入していないことを確認する。

## 完了条件

- prompt recordの所有権がworkflow run単位で一意に定義されている。
- 並列・直列worker poolの双方で、別runの同一phase IDが衝突しない。
- 各terminal traceが対象runのpromptだけを使用する。
- 同一run内の真の相関不整合は引き続き検出される。
- workflow本体がcompletedなのにpromptログ混在を理由としてtaskだけfailedになる再現ケースが解消する。

## Execution Report

Workflow `takt-default` completed successfully.

Closes #1428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - デバッグログの保存単位を明確化しました。通常ログはプロセス単位、プロンプト／レスポンスログはワークフロー実行単位で保存されます。
  - `logging.level: debug` を設定するだけで、両方のログが有効になることを追記しました。
- **改善**
  - プロンプト／レスポンスログの書き込みに失敗しても、ワークフロー実行が中断されないようになりました。
  - 複数タスク実行時も、各タスクのログとトレースが混在しないよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->