### PR TITLE
feat: runtime.yaml に provider.assignments / provider.directories を追加

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -701,6 +701,45 @@ provider:
         fallback_profile: sol-high
 ```
 
+### ディレクトリ別 assignment
+
+`provider.assignments` には、起動ディレクトリごとに選択する名前付きの provider 設定セットを定義できます。
+各 entry は `defaults` または `targets` の少なくとも一方を持つ必要があり、空の assignment は指定できません。
+`defaults` はトップレベルの `provider.defaults` と同じく `profile` または `ladder` の一方を指定します。
+`targets` はトップレベルの `provider.targets` と同じ形で、`personas`、`tags`、`steps`、`internal_agents` は
+`profile`、`pool`、`ladder`、`companions` は固定 `profile` を指定できます。
+
+`provider.directories` はディレクトリパスから assignment 名への map です。照合対象は起動時の project
+ディレクトリで、キーは `~` を展開して絶対パス化した後、存在するパスについて realpath 相当に正規化して
+完全一致で照合します。前方一致や glob は使いません。値の assignment 名が未定義の場合は読み込み時に
+fail-fast します。ディレクトリが一致すると、assignment の `defaults`（省略時はトップレベルの
+`provider.defaults`）を使用し、assignment に `targets` がある場合はトップレベルの `provider.targets` 全体を
+置き換えます。`personas` だけを残すような map 単位のマージは行いません。`targets` を省略した assignment
+はトップレベルの `provider.targets` をそのまま引き継ぎます。`profiles` と `auto_routing` は共有されたままです。
+
+```yaml
+provider:
+  assignments:
+    project-sol:
+      defaults:
+        profile: sol-medium
+      targets:
+        personas:
+          coder:
+            profile: sol-medium
+        steps:
+          default/implement:
+            pool: sol-pool
+
+  directories:
+    ~/work/example: project-sol
+```
+
+global と project のレイヤーで `assignments` が定義されている場合、同名 entry は project が全体を置き換え、
+異なる名前は両方残ります。`directories` は正規化後の同じパスキーについて project が優先し、異なるパスは
+両方残ります。これらのマージは assignment の選択前に行われます。assignment 内の profile、pool、ladder
+参照も通常の runtime provider 参照と同じく、未定義なら agent 実行前に fail-fast します。
+
 `provider.profiles` は名前付きの provider/model/options 定義を保持します。profile のフラットな `options` はその profile の provider に適用されます（例えば `reasoning_effort` は Codex の `reasoning_effort` オプションになります）。任意の `capabilities` には provider-options preset 名、または適用順の preset 名リストを指定します。workflow の `capabilities` と同じ project → global → builtin の順で解決し、inline の `options` が preset より優先されます。任意の `permission_mode` は provider の正確な permission mode を設定します。profile は明示的な `extends` で別の profile を継承できます。global と project で同名の profile を field 単位で暗黙に混ぜることはなく、project の定義が profile 全体を置き換えます。
 
 TAKT が所有する structured agent は常に fresh session で起動します。native structured output 対応 provider には schema を直接渡し、非対応 provider には JSON schema instruction を渡して返却 object を parse・validate します。TAKT は internal agent 専用の permission、tool、network、sandbox、skill、MCP、bypass policy を追加しません。role を制限する場合は `capabilities` と `permission_mode` の一方または両方を明示した profile を割り当てます。両方を省略した場合は通常の provider 設定をそのまま使用します。

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -706,8 +706,9 @@ provider:
 `provider.assignments` には、起動ディレクトリごとに選択する名前付きの provider 設定セットを定義できます。
 各 entry は `defaults` または `targets` の少なくとも一方を持つ必要があり、空の assignment は指定できません。
 `defaults` はトップレベルの `provider.defaults` と同じく `profile` または `ladder` の一方を指定します。
-`targets` はトップレベルの `provider.targets` と同じ形で、`personas`、`tags`、`steps`、`internal_agents` は
-`profile`、`pool`、`ladder`、`companions` は固定 `profile` を指定できます。
+`targets` はトップレベルの `provider.targets` と同じ形で、`personas`、`tags`、`steps` は
+`profile`、`pool`、`ladder` のいずれか、`internal_agents` は `profile` または `ladder`、
+`companions` は固定 `profile` を指定できます。
 
 `provider.directories` はディレクトリパスから assignment 名への map です。照合対象は起動時の project
 ディレクトリで、キーは `~` を展開して絶対パス化した後、存在するパスについて realpath 相当に正規化して

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -726,8 +726,8 @@ provider:
 project directory. Each entry must contain `defaults` or `targets`; an empty assignment is not
 valid. `defaults` has the same shape as top-level `provider.defaults` and must choose exactly one
 of `profile` or `ladder`. `targets` has the same shape as top-level `provider.targets`:
-`personas`, `tags`, `steps`, and `internal_agents` may use `profile`, `pool`, or `ladder`, while
-`companions` may use only a fixed `profile`.
+`personas`, `tags`, and `steps` may use `profile`, `pool`, or `ladder`; `internal_agents` may use
+`profile` or `ladder`, while `companions` may use only a fixed `profile`.
 
 `provider.directories` maps a directory path to an assignment name. The lookup target is the
 startup project directory. Keys expand `~`, become absolute, and then receive realpath-equivalent

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -720,6 +720,49 @@ provider:
         fallback_profile: sol-high
 ```
 
+### Directory-specific assignments
+
+`provider.assignments` defines named provider configuration sets that can be selected for a
+project directory. Each entry must contain `defaults` or `targets`; an empty assignment is not
+valid. `defaults` has the same shape as top-level `provider.defaults` and must choose exactly one
+of `profile` or `ladder`. `targets` has the same shape as top-level `provider.targets`:
+`personas`, `tags`, `steps`, and `internal_agents` may use `profile`, `pool`, or `ladder`, while
+`companions` may use only a fixed `profile`.
+
+`provider.directories` maps a directory path to an assignment name. The lookup target is the
+startup project directory. Keys expand `~`, become absolute, and then receive realpath-equivalent
+normalization for existing paths before exact comparison. Prefix matching and globs are not used.
+An unknown assignment name in this map fails fast while loading. When a directory matches, the
+assignment's `defaults` are used; if omitted, top-level `provider.defaults` is used. If the
+assignment has `targets`, it replaces the entire top-level `provider.targets` map; individual
+target maps are not merged. An assignment that omits `targets` keeps the top-level
+`provider.targets`. `profiles` and `auto_routing` remain shared.
+
+```yaml
+provider:
+  assignments:
+    project-sol:
+      defaults:
+        profile: sol-medium
+      targets:
+        personas:
+          coder:
+            profile: sol-medium
+        steps:
+          default/implement:
+            pool: sol-pool
+
+  directories:
+    ~/work/example: project-sol
+```
+
+Across global and project layers, `assignments` follow the profile rule: a same-name project
+entry replaces the global entry wholesale, while differently named entries coexist. For
+`directories`, project wins when normalized keys are equal and otherwise both mappings remain.
+These merges happen before directory assignment selection. Profile, pool, and ladder references
+inside assignments are validated with the other runtime provider references and fail fast before
+an agent runs.
+
 `provider.profiles` holds named provider/model/options definitions. A profile's flat `options` bag applies to that profile's provider (for example `reasoning_effort` maps to the Codex `reasoning_effort` option). Optional `capabilities` names one provider-options preset or a list of presets applied in order. Presets resolve project → global → builtin, like workflow capabilities, and inline `options` override preset values. Optional `permission_mode` selects the provider's exact permission mode. Profiles may reuse another profile with an explicit `extends`; there is no field-level merge between same-name profiles across the global and project files — the project definition replaces the whole profile.
 
 TAKT-owned structured agents always start a fresh session. Providers with native structured output receive the schema directly; other providers receive a JSON schema instruction, and TAKT parses and validates the returned object. TAKT does not add internal-agent-specific permission, tool, network, sandbox, skill, MCP, or bypass policy. Assign a profile with `capabilities`, `permission_mode`, or both when a role needs restrictions. If both are omitted, normal provider configuration is used unchanged.

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -587,6 +587,44 @@ provider:
         fallback_profile: sol-high
 ```
 
+### 按目录选择 assignment
+
+`provider.assignments` 用于定义按项目目录选择的命名 provider 配置集合。每个 entry 必须至少包含
+`defaults` 或 `targets`，不能使用空 assignment。`defaults` 与顶层 `provider.defaults` 形状完全相同，必须
+在 `profile` 和 `ladder` 中选择一个。`targets` 与顶层 `provider.targets` 形状相同：`personas`、`tags`、
+`steps`、`internal_agents` 可以使用 `profile`、`pool` 或 `ladder`，而 `companions` 只能使用固定的
+`profile`。
+
+`provider.directories` 将目录路径映射到 assignment 名称。匹配对象是启动时的 project 目录。路径键会先展开
+`~`、转换为绝对路径，并对存在的路径进行 realpath 等价的规范化，然后进行完全匹配；不支持前缀匹配和 glob。
+如果目录值引用了未定义的 assignment，加载时会快速失败。目录匹配成功后使用 assignment 的 `defaults`；如果
+省略，则回退到顶层 `provider.defaults`。如果 assignment 提供了 `targets`，它会整体替换顶层
+`provider.targets`，不会按 `personas` 等子 map 合并。省略 `targets` 的 assignment 会继续使用顶层
+`provider.targets`。`profiles` 和 `auto_routing` 继续共享。
+
+```yaml
+provider:
+  assignments:
+    project-sol:
+      defaults:
+        profile: sol-medium
+      targets:
+        personas:
+          coder:
+            profile: sol-medium
+        steps:
+          default/implement:
+            pool: sol-pool
+
+  directories:
+    ~/work/example: project-sol
+```
+
+global 与 project 层之间，`assignments` 遵循与 profile 相同的规则：同名 entry 由 project 整体替换，不同名称
+的 entry 共存。`directories` 在规范化后的键相同时由 project 优先，不同路径则共存。上述合并发生在目录
+assignment 选择之前。assignment 内的 profile、pool、ladder 引用与其他 runtime provider 引用一样会被校验，
+并在 agent 运行前快速失败。
+
 `provider.profiles` 保存命名的 provider/model/options 定义。`provider.defaults` 必须在每个有效 provider section 中选择一个固定 `profile` 或有序 `ladder`；不能指定 `pool`。`provider.targets.personas`、`provider.targets.tags` 和 `provider.targets.steps` 可以选择固定 profile、有序 ladder 或显式 auto-routing pool；`internal_agents` 只能使用固定 profile 或 ladder；`companions` 必须使用固定 profile。
 
 provider target 的覆盖优先级为：

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -592,8 +592,8 @@ provider:
 `provider.assignments` 用于定义按项目目录选择的命名 provider 配置集合。每个 entry 必须至少包含
 `defaults` 或 `targets`，不能使用空 assignment。`defaults` 与顶层 `provider.defaults` 形状完全相同，必须
 在 `profile` 和 `ladder` 中选择一个。`targets` 与顶层 `provider.targets` 形状相同：`personas`、`tags`、
-`steps`、`internal_agents` 可以使用 `profile`、`pool` 或 `ladder`，而 `companions` 只能使用固定的
-`profile`。
+`steps` 可以使用 `profile`、`pool` 或 `ladder`，`internal_agents` 只能使用 `profile` 或 `ladder`，
+而 `companions` 只能使用固定的 `profile`。
 
 `provider.directories` 将目录路径映射到 assignment 名称。匹配对象是启动时的 project 目录。路径键会先展开
 `~`、转换为绝对路径，并对存在的路径进行 realpath 等价的规范化，然后进行完全匹配；不支持前缀匹配和 glob。

--- a/src/__tests__/runtime-provider-loader.test.ts
+++ b/src/__tests__/runtime-provider-loader.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
+
+const mockedHome = vi.hoisted(() => ({ value: '' }));
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: () => mockedHome.value || actual.homedir() };
+});
+
 // New module under test (implemented in the following `implement` step).
 import {
   loadRuntimeProviderFileAt,
@@ -36,9 +44,11 @@ describe('runtime-provider loader', () => {
     root = mkdtempSync(join(tmpdir(), 'takt-runtime-provider-loader-'));
     globalDir = join(root, 'global-.takt');
     projectDir = join(root, 'project-.takt');
+    mockedHome.value = dirname(projectDir);
   });
 
   afterEach(() => {
+    mockedHome.value = '';
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -262,6 +272,232 @@ describe('runtime-provider loader', () => {
     // section-level replacement: project targets wins wholesale, global `personas` disappears.
     expect(resolved?.provider?.targets?.tags?.['high-stakes']?.profile).toBe('p');
     expect(resolved?.provider?.targets?.personas).toBeUndefined();
+  });
+
+  it('applies the matching assignment, falls back to top-level defaults, and replaces targets as a whole', () => {
+    const projectRoot = dirname(projectDir);
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'provider:',
+      '  defaults:',
+      '    profile: base',
+      '  profiles:',
+      '    base:',
+      '      provider: mock',
+      '      model: base-model',
+      '    selected:',
+      '      provider: codex',
+      '      model: selected-model',
+      '  targets:',
+      '    personas:',
+      '      coder:',
+      '        profile: base',
+      '  assignments:',
+      '    project:',
+      '      targets:',
+      '        tags:',
+      '          high-stakes:',
+      '            profile: selected',
+      '  directories:',
+      `    ${projectRoot}: project`,
+    ]);
+
+    const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
+
+    expect(resolved?.provider?.defaults).toEqual({ profile: 'base' });
+    expect(resolved?.provider?.targets).toEqual({
+      tags: { 'high-stakes': { profile: 'selected' } },
+    });
+    expect(resolved?.provider?.targets?.personas).toBeUndefined();
+  });
+
+  it('falls back to top-level targets when a matching assignment omits targets', () => {
+    const projectRoot = dirname(projectDir);
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'provider:',
+      '  defaults:',
+      '    profile: base',
+      '  profiles:',
+      '    base:',
+      '      provider: mock',
+      '      model: base-model',
+      '    selected:',
+      '      provider: codex',
+      '      model: selected-model',
+      '  targets:',
+      '    personas:',
+      '      coder:',
+      '        profile: base',
+      '  assignments:',
+      '    project:',
+      '      defaults:',
+      '        profile: selected',
+      '  directories:',
+      `    ${projectRoot}: project`,
+    ]);
+
+    const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
+
+    expect(resolved?.provider?.defaults).toEqual({ profile: 'selected' });
+    expect(resolved?.provider?.targets).toEqual({
+      personas: { coder: { profile: 'base' } },
+    });
+  });
+
+  it('leaves the top-level assignment unchanged when no directory matches', () => {
+    const projectRoot = dirname(projectDir);
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'provider:',
+      '  defaults:',
+      '    profile: base',
+      '  profiles:',
+      '    base:',
+      '      provider: mock',
+      '      model: base-model',
+      '    selected:',
+      '      provider: codex',
+      '      model: selected-model',
+      '  targets:',
+      '    personas:',
+      '      coder:',
+      '        profile: base',
+      '  assignments:',
+      '    other:',
+      '      targets:',
+      '        tags:',
+      '          high-stakes:',
+      '            profile: selected',
+      '  directories:',
+      `    ${join(projectRoot, 'other-project')}: other`,
+    ]);
+
+    const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
+
+    expect(resolved?.provider?.defaults).toEqual({ profile: 'base' });
+    expect(resolved?.provider?.targets).toEqual({
+      personas: { coder: { profile: 'base' } },
+    });
+  });
+
+  it('merges assignments by name and directories by normalized key with project priority', () => {
+    const projectRoot = dirname(projectDir);
+    const globalOnlyRoot = join(root, 'global-project');
+    const projectOnlyRoot = join(root, 'project-only');
+    mkdirSync(globalOnlyRoot);
+    mkdirSync(projectOnlyRoot);
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'provider:',
+      '  defaults:',
+      '    profile: base',
+      '  profiles:',
+      '    base:',
+      '      provider: mock',
+      '      model: base-model',
+      '    global:',
+      '      provider: mock',
+      '      model: global-model',
+      '    project:',
+      '      provider: mock',
+      '      model: global-project-model',
+      '  assignments:',
+      '    shared:',
+      '      defaults:',
+      '        profile: global',
+      '    global-only:',
+      '      defaults:',
+      '        profile: global',
+      '  directories:',
+      `    ${join(projectRoot, '.')}: shared`,
+      `    ${globalOnlyRoot}: global-only`,
+    ]);
+    writeRuntimeYaml(projectDir, [
+      'version: 1',
+      'provider:',
+      '  defaults:',
+      '    profile: base',
+      '  profiles:',
+      '    project:',
+      '      provider: codex',
+      '      model: project-model',
+      '  assignments:',
+      '    shared:',
+      '      defaults:',
+      '        profile: project',
+      '    project-only:',
+      '      defaults:',
+      '        profile: project',
+      '  directories:',
+      `    ${projectRoot}: project-only`,
+      `    ${projectOnlyRoot}: project-only`,
+    ]);
+
+    const resolved = resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir });
+
+    expect(resolved?.provider?.assignments).toEqual({
+      shared: { defaults: { profile: 'project' } },
+      'global-only': { defaults: { profile: 'global' } },
+      'project-only': { defaults: { profile: 'project' } },
+    });
+    expect(resolved?.provider?.directories?.[projectRoot]).toBe('project-only');
+    expect(resolved?.provider?.directories?.[globalOnlyRoot]).toBe('global-only');
+    expect(resolved?.provider?.directories?.[projectOnlyRoot]).toBe('project-only');
+    expect(resolved?.provider?.defaults).toEqual({ profile: 'project' });
+  });
+
+  it('fails fast when a directory points to an unknown assignment', () => {
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'provider:',
+      '  defaults:',
+      '    profile: base',
+      '  profiles:',
+      '    base:',
+      '      provider: mock',
+      '      model: base-model',
+      '  directories:',
+      `    ${dirname(projectDir)}: missing`,
+    ]);
+
+    expect(() => resolveRuntimeProviderFile({ globalConfigDir: globalDir, projectConfigDir: projectDir }))
+      .toThrow(/unknown assignment/i);
+  });
+
+  it('expands `~` and compares real paths for the project directory', () => {
+    const realProjectRoot = join(root, 'real-project');
+    const linkedProjectRoot = join(root, 'linked-project');
+    mkdirSync(realProjectRoot);
+    symlinkSync(realProjectRoot, linkedProjectRoot, 'dir');
+    const linkedProjectConfigDir = join(linkedProjectRoot, '.takt');
+    mockedHome.value = realProjectRoot;
+    writeRuntimeYaml(globalDir, [
+      'version: 1',
+      'provider:',
+      '  defaults:',
+      '    profile: base',
+      '  profiles:',
+      '    base:',
+      '      provider: mock',
+      '      model: base-model',
+      '    selected:',
+      '      provider: codex',
+      '      model: selected-model',
+      '  assignments:',
+      '    selected:',
+      '      defaults:',
+      '        profile: selected',
+      '  directories:',
+      '    ~/.: selected',
+    ]);
+
+    const resolved = resolveRuntimeProviderFile({
+      globalConfigDir: globalDir,
+      projectConfigDir: linkedProjectConfigDir,
+    });
+
+    expect(resolved?.provider?.defaults).toEqual({ profile: 'selected' });
   });
 
   it('Given project has an active provider section without defaults, When resolving with a valid global file, Then the project file is rejected', () => {

--- a/src/__tests__/runtime-provider-policy.test.ts
+++ b/src/__tests__/runtime-provider-policy.test.ts
@@ -130,6 +130,35 @@ describe('validateRuntimeProviderSection — unknown reference fail-fast (C10)',
     };
     expect(() => validateRuntimeProviderSection(section)).toThrow(/provider.*model|model.*provider/i);
   });
+
+  it('fails fast on a profile referenced by a named assignment default', () => {
+    const section: RuntimeProviderSection = {
+      defaults: { profile: 'real' },
+      profiles: { real: { provider: 'mock', model: 'm' } },
+      assignments: { project: { defaults: { profile: 'ghost' } } },
+    };
+    expect(() => validateRuntimeProviderSection(section)).toThrow(/ghost|unknown profile/i);
+  });
+
+  it('fails fast on a pool referenced by a named assignment target', () => {
+    const section: RuntimeProviderSection = {
+      defaults: { profile: 'real' },
+      profiles: { real: { provider: 'mock', model: 'm' } },
+      assignments: {
+        project: { targets: { steps: { implement: { pool: 'missing' } } } },
+      },
+    };
+    expect(() => validateRuntimeProviderSection(section)).toThrow(/missing|unknown pool/i);
+  });
+
+  it('fails fast on a ladder profile referenced by a named assignment default', () => {
+    const section: RuntimeProviderSection = {
+      defaults: { profile: 'real' },
+      profiles: { real: { provider: 'mock', model: 'm' } },
+      assignments: { project: { defaults: { ladder: ['missing'] } } },
+    };
+    expect(() => validateRuntimeProviderSection(section)).toThrow(/missing|unknown profile/i);
+  });
 });
 
 describe('validateRuntimeProviderSection — auto_routing references (C9/C10)', () => {

--- a/src/__tests__/runtime-provider-schema.test.ts
+++ b/src/__tests__/runtime-provider-schema.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 // New module under test (implemented in the following `implement` step).
 // Import errors here are expected until then.
-import { RuntimeProviderFileSchema } from '../infra/config/runtime-provider/schema.js';
+import {
+  getEffectiveRuntimeProviderFile,
+  RuntimeProviderFileSchema,
+} from '../infra/config/runtime-provider/schema.js';
 
 /**
  * Contracts covered (see plan.md 完了契約):
@@ -137,6 +140,67 @@ describe('RuntimeProviderFileSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('Given a disabled companion-only named assignment without top-level defaults, When parsed, Then it remains inactive', () => {
+    const result = RuntimeProviderFileSchema.safeParse({
+      version: 1,
+      companion: { enabled: false },
+      provider: {
+        profiles: {
+          security: { provider: 'mock', model: 'mock-security' },
+        },
+        assignments: {
+          security: {
+            targets: { companions: { security: { profile: 'security' } } },
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('Given disabled companions, When applying the effective section, Then named companion targets and profiles are removed', () => {
+    const file = RuntimeProviderFileSchema.parse({
+      version: 1,
+      companion: { enabled: false },
+      provider: {
+        defaults: { profile: 'default' },
+        profiles: {
+          default: { provider: 'mock', model: 'default-model' },
+          security: { provider: 'mock', model: 'mock-security' },
+        },
+        assignments: {
+          security: {
+            targets: { companions: { security: { profile: 'security' } } },
+          },
+        },
+      },
+    });
+
+    const effective = getEffectiveRuntimeProviderFile(file);
+
+    expect(effective?.provider?.assignments).toBeUndefined();
+    expect(effective?.provider?.profiles).toEqual({
+      default: { provider: 'mock', model: 'default-model' },
+    });
+  });
+
+  it('Given an active named assignment without top-level defaults, When parsed, Then it is rejected', () => {
+    const result = RuntimeProviderFileSchema.safeParse({
+      version: 1,
+      provider: {
+        profiles: {
+          default: { provider: 'mock', model: 'default-model' },
+        },
+        assignments: {
+          project: { defaults: { profile: 'default' } },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('Given enabled companion-only targets without defaults, When parsed, Then it is rejected for missing defaults', () => {
     const result = RuntimeProviderFileSchema.safeParse({
       version: 1,
@@ -246,6 +310,57 @@ describe('RuntimeProviderFileSchema', () => {
     const doc = fullExample();
     doc.provider.targets.personas.coder = {};
     const result = RuntimeProviderFileSchema.safeParse(doc);
+    expect(result.success).toBe(false);
+  });
+
+  it('Given named assignments with defaults and targets, When parsed, Then the documented forms are accepted', () => {
+    const result = RuntimeProviderFileSchema.safeParse({
+      version: 1,
+      provider: {
+        defaults: { profile: 'default' },
+        profiles: {
+          default: { provider: 'mock', model: 'default-model' },
+          selected: { provider: 'mock', model: 'selected-model' },
+        },
+        assignments: {
+          project: {
+            defaults: { ladder: ['default', 'selected'] },
+            targets: {
+              personas: { coder: { profile: 'selected' } },
+              companions: { security: { profile: 'selected' } },
+            },
+          },
+        },
+        directories: { '~/work/project': 'project' },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('Given an empty named assignment, When parsed, Then it is rejected', () => {
+    const result = RuntimeProviderFileSchema.safeParse({
+      version: 1,
+      provider: {
+        defaults: { profile: 'default' },
+        profiles: { default: { provider: 'mock', model: 'default-model' } },
+        assignments: { empty: {} },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('Given an unknown key in a named assignment, When parsed, Then strict validation rejects it', () => {
+    const result = RuntimeProviderFileSchema.safeParse({
+      version: 1,
+      provider: {
+        defaults: { profile: 'default' },
+        profiles: { default: { provider: 'mock', model: 'default-model' } },
+        assignments: { project: { defaults: { profile: 'default' }, use: 'forbidden' } },
+      },
+    });
+
     expect(result.success).toBe(false);
   });
 

--- a/src/infra/config/runtime-provider/loader.ts
+++ b/src/infra/config/runtime-provider/loader.ts
@@ -6,13 +6,15 @@
  * homedir/cwd fallback and no `runtime_file` indirection. When both files exist, project
  * wins: same-name profiles are replaced wholesale (no field-level merge, per order.md:37),
  * disjoint profiles are retained, and the other sections take the project value when present.
+ * Named assignments and directory mappings are resolved after the two layers are merged.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 import { RUNTIME_PROVIDER_FILENAME, RUNTIME_PROVIDER_VERSION } from './constants.js';
+import { expandHomePath } from '../pathExpansion.js';
 import {
   RuntimeProviderFileSchema,
   type RuntimeProviderFile,
@@ -62,8 +64,12 @@ export function resolveRuntimeProviderFileWithOrigins(
   for (const name of Object.keys(project?.provider?.profiles ?? {})) {
     profileOrigins.set(name, 'project');
   }
+  const merged = !global ? project : !project ? global : mergeRuntimeProviderFiles(global, project);
+  const normalized = merged === undefined ? undefined : normalizeRuntimeProviderDirectories(merged);
   return {
-    runtimeFile: !global ? project : !project ? global : mergeRuntimeProviderFiles(global, project),
+    runtimeFile: normalized === undefined
+      ? undefined
+      : applyDirectoryAssignment(normalized, input.projectConfigDir),
     profileOrigins,
   };
 }
@@ -118,6 +124,14 @@ function mergeProviderSections(
     merged.profiles = { ...(global.profiles ?? {}), ...(project.profiles ?? {}) };
   }
 
+  if (global.assignments || project.assignments) {
+    merged.assignments = { ...(global.assignments ?? {}), ...(project.assignments ?? {}) };
+  }
+
+  if (global.directories || project.directories) {
+    merged.directories = mergeDirectoryMappings(global.directories, project.directories);
+  }
+
   const targets = project.targets ?? global.targets;
   if (targets) {
     merged.targets = targets;
@@ -129,4 +143,89 @@ function mergeProviderSections(
   }
 
   return merged;
+}
+
+function mergeDirectoryMappings(
+  global: Record<string, string> | undefined,
+  project: Record<string, string> | undefined,
+): Record<string, string> {
+  return {
+    ...normalizeDirectoryMappings(global),
+    ...normalizeDirectoryMappings(project),
+  };
+}
+
+function normalizeRuntimeProviderDirectories(file: RuntimeProviderFile): RuntimeProviderFile {
+  const directories = file.provider?.directories;
+  if (directories === undefined) {
+    return file;
+  }
+  return {
+    ...file,
+    provider: {
+      ...file.provider,
+      directories: normalizeDirectoryMappings(directories),
+    },
+  };
+}
+
+function normalizeDirectoryMappings(
+  directories: Record<string, string> | undefined,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [directory, assignment] of Object.entries(directories ?? {})) {
+    normalized[normalizeDirectoryPath(directory)] = assignment;
+  }
+  return normalized;
+}
+
+function normalizeDirectoryPath(directory: string): string {
+  const absolutePath = resolve(expandHomePath(directory));
+  return existsSync(absolutePath) ? realpathSync(absolutePath) : absolutePath;
+}
+
+function applyDirectoryAssignment(
+  file: RuntimeProviderFile,
+  projectConfigDir: string,
+): RuntimeProviderFile {
+  const provider = file.provider;
+  if (provider?.directories === undefined) {
+    return file;
+  }
+
+  const assignments = provider.assignments ?? {};
+  for (const [directory, assignmentName] of Object.entries(provider.directories)) {
+    if (!Object.prototype.hasOwnProperty.call(assignments, assignmentName)) {
+      throw new Error(
+        `runtime.yaml provider.directories["${directory}"] references unknown assignment "${assignmentName}"`,
+      );
+    }
+  }
+
+  const projectDirectory = normalizeDirectoryPath(dirname(projectConfigDir));
+  const assignmentName = provider.directories[projectDirectory];
+  if (assignmentName === undefined) {
+    return file;
+  }
+  const assignment = assignments[assignmentName];
+  if (assignment === undefined) {
+    throw new Error(`runtime.yaml provider.directories references unknown assignment "${assignmentName}"`);
+  }
+
+  const selectedProvider = { ...provider };
+  if (assignment.defaults !== undefined) {
+    selectedProvider.defaults = assignment.defaults;
+  } else if (provider.defaults !== undefined) {
+    selectedProvider.defaults = provider.defaults;
+  } else {
+    delete selectedProvider.defaults;
+  }
+  if (assignment.targets !== undefined) {
+    selectedProvider.targets = assignment.targets;
+  }
+
+  return {
+    ...file,
+    provider: selectedProvider,
+  };
 }

--- a/src/infra/config/runtime-provider/policy.ts
+++ b/src/infra/config/runtime-provider/policy.ts
@@ -140,20 +140,31 @@ function validateReferences(
     }
   };
 
-  if (section.defaults) {
-    assertAssignment(section.defaults, 'defaults');
-  }
-
-  const targets = section.targets;
-  if (targets) {
-    for (const [mapName, map] of Object.entries(targets)) {
+  const assertTargetMaps = (
+    targets: RuntimeProviderSection['targets'] | undefined,
+    referencedBy: string,
+  ): void => {
+    for (const [mapName, map] of Object.entries(targets ?? {})) {
       if (map === undefined) {
         continue;
       }
       for (const [key, assignment] of Object.entries(map)) {
-        assertAssignment(assignment, `targets.${mapName}.${key}`);
+        assertAssignment(assignment, `${referencedBy}.${mapName}.${key}`);
       }
     }
+  };
+
+  if (section.defaults) {
+    assertAssignment(section.defaults, 'defaults');
+  }
+
+  assertTargetMaps(section.targets, 'targets');
+
+  for (const [assignmentName, assignmentSet] of Object.entries(section.assignments ?? {})) {
+    if (assignmentSet.defaults !== undefined) {
+      assertAssignment(assignmentSet.defaults, `assignments.${assignmentName}.defaults`);
+    }
+    assertTargetMaps(assignmentSet.targets, `assignments.${assignmentName}.targets`);
   }
 
   const autoRouting = section.auto_routing;

--- a/src/infra/config/runtime-provider/schema.ts
+++ b/src/infra/config/runtime-provider/schema.ts
@@ -125,16 +125,35 @@ const TargetsSchema = z
   })
   .strict();
 
+const ProviderAssignmentSetSchema = z
+  .object({
+    defaults: DefaultAssignmentSchema.optional(),
+    targets: TargetsSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.defaults === undefined && value.targets === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'provider assignment must specify `defaults` or `targets`',
+      });
+    }
+  });
+
 const ProviderSectionSchema = z
   .object({
     defaults: DefaultAssignmentSchema.optional(),
     profiles: z.record(z.string(), ProfileSchema).optional(),
     targets: TargetsSchema.optional(),
+    assignments: z.record(z.string(), ProviderAssignmentSetSchema).optional(),
+    directories: z.record(z.string(), z.string().min(1)).optional(),
     auto_routing: AutoRoutingSchema.optional(),
   })
   .strict();
 
 type RuntimeProviderSectionShape = z.infer<typeof ProviderSectionSchema>;
+type RuntimeProviderTargets = z.infer<typeof TargetsSchema>;
+type RuntimeProviderAssignmentSetShape = z.infer<typeof ProviderAssignmentSetSchema>;
 
 function addAssignmentProfiles(
   profiles: Set<string>,
@@ -167,17 +186,40 @@ function collectProfileClosure(
   return closure;
 }
 
+function withoutCompanionTargets(
+  targets: RuntimeProviderTargets | undefined,
+): RuntimeProviderTargets | undefined {
+  if (targets === undefined || targets.companions === undefined) {
+    return targets;
+  }
+  const remaining = { ...targets };
+  delete remaining.companions;
+  return remaining;
+}
+
+function hasTargetContent(targets: RuntimeProviderTargets | undefined): boolean {
+  return Object.values(targets ?? {}).some(
+    (targetMap) => targetMap !== undefined && Object.keys(targetMap).length > 0,
+  );
+}
+
 function getEffectiveProviderSection(
   section: RuntimeProviderSectionShape | undefined,
   companionEnabled: boolean,
 ): RuntimeProviderSectionShape | undefined {
-  const companionTargets = section?.targets?.companions;
-  if (section === undefined || companionEnabled || companionTargets === undefined) {
+  const hasCompanionTargets = section?.targets?.companions !== undefined
+    || Object.values(section?.assignments ?? {}).some(
+      (assignment) => assignment.targets?.companions !== undefined,
+    );
+  if (section === undefined || companionEnabled || !hasCompanionTargets) {
     return section;
   }
 
   const profiles = section.profiles ?? {};
-  const companionRoots = new Set(Object.values(companionTargets).map((target) => target.profile));
+  const companionRoots = new Set<string>();
+  for (const target of Object.values(section.targets?.companions ?? {})) {
+    companionRoots.add(target.profile);
+  }
   const nonCompanionRoots = new Set<string>();
   if (section.defaults !== undefined) {
     addAssignmentProfiles(nonCompanionRoots, section.defaults);
@@ -191,6 +233,24 @@ function getEffectiveProviderSection(
     Object.values(targetMap ?? {}).forEach((assignment) => {
       addAssignmentProfiles(nonCompanionRoots, assignment);
     });
+  }
+  for (const assignment of Object.values(section.assignments ?? {})) {
+    if (assignment.defaults !== undefined) {
+      addAssignmentProfiles(nonCompanionRoots, assignment.defaults);
+    }
+    for (const targetMap of [
+      assignment.targets?.personas,
+      assignment.targets?.tags,
+      assignment.targets?.steps,
+      assignment.targets?.internal_agents,
+    ]) {
+      Object.values(targetMap ?? {}).forEach((target) => {
+        addAssignmentProfiles(nonCompanionRoots, target);
+      });
+    }
+    for (const target of Object.values(assignment.targets?.companions ?? {})) {
+      companionRoots.add(target.profile);
+    }
   }
   if (section.auto_routing?.router_profile !== undefined) {
     nonCompanionRoots.add(section.auto_routing.router_profile);
@@ -209,13 +269,32 @@ function getEffectiveProviderSection(
       !companionClosure.has(name) || nonCompanionClosure.has(name)
     )),
   );
-  const targets = { ...section.targets };
-  delete targets.companions;
-  return {
+  const targets = withoutCompanionTargets(section.targets);
+  const effectiveSection: RuntimeProviderSectionShape = {
     ...section,
     profiles: effectiveProfiles,
     targets,
   };
+  if (section.assignments !== undefined) {
+    const assignments: Record<string, RuntimeProviderAssignmentSetShape> = {};
+    for (const [name, assignment] of Object.entries(section.assignments)) {
+      const remainingTargets = withoutCompanionTargets(assignment.targets);
+      const hasRemainingTargets = hasTargetContent(remainingTargets);
+      if (assignment.defaults === undefined && !hasRemainingTargets) {
+        continue;
+      }
+      assignments[name] = {
+        ...(assignment.defaults === undefined ? {} : { defaults: assignment.defaults }),
+        ...(hasRemainingTargets ? { targets: remainingTargets } : {}),
+      };
+    }
+    if (Object.keys(assignments).length > 0) {
+      effectiveSection.assignments = assignments;
+    } else {
+      delete effectiveSection.assignments;
+    }
+  }
+  return effectiveSection;
 }
 
 /** Determine whether a provider section has active runtime configuration. */
@@ -227,14 +306,17 @@ export function hasActiveProviderContent(
   if (effectiveSection === undefined) {
     return false;
   }
-  const hasTargets = Object.values(effectiveSection.targets ?? {}).some(
-    (targetMap) => targetMap !== undefined && Object.keys(targetMap).length > 0,
-  );
+  const hasTargets = hasTargetContent(effectiveSection.targets);
+  const hasAssignments = Object.values(effectiveSection.assignments ?? {}).some((assignment) => (
+    (assignment.defaults !== undefined && Object.keys(assignment.defaults).length > 0)
+    || hasTargetContent(assignment.targets)
+  ));
   const hasDefaults = effectiveSection.defaults !== undefined
     && Object.keys(effectiveSection.defaults).length > 0;
   return hasDefaults
     || (effectiveSection.profiles !== undefined && Object.keys(effectiveSection.profiles).length > 0)
     || hasTargets
+    || hasAssignments
     || (effectiveSection.auto_routing !== undefined
       && Object.keys(effectiveSection.auto_routing).length > 0);
 }
@@ -262,6 +344,7 @@ export type RuntimeProviderFile = z.infer<typeof RuntimeProviderFileSchema>;
 export type RuntimeProviderSection = z.infer<typeof ProviderSectionSchema>;
 export type RuntimeProviderProfile = z.infer<typeof ProfileSchema>;
 export type RuntimeProviderAssignment = z.infer<typeof AssignmentSchema>;
+export type RuntimeProviderAssignmentSet = z.infer<typeof ProviderAssignmentSetSchema>;
 export type RuntimeCompanionProviderAssignment = z.infer<typeof CompanionAssignmentSchema>;
 export type RuntimeProviderAutoRouting = z.infer<typeof AutoRoutingSchema>;
 


### PR DESCRIPTION
## 目的

同一リポジトリの複数チェックアウト（例: takt, takt2, takt3）で異なる provider 割り当てを使い分けたい場合、現状は project の `.takt/runtime.yaml` を都度編集するしかない。runtime.yaml に名前付きセットと起動ディレクトリによる選択を追加し、グローバル設定だけでインスタンスごとの切り替えを可能にする。CLI フラグ・環境変数は追加しない。

## 変更内容

- `provider.assignments`: `{ defaults?, targets? }` の名前付きセット。`defaults` / `targets` はトップレベルと完全に同形（`targets` は personas/tags/steps/internal_agents/companions、割り当ては profile/pool/ladder）。空の assignment は拒否。
- `provider.directories`: 起動プロジェクトディレクトリ（`~` 展開・絶対パス化・realpath 正規化のうえ完全一致）→ assignment 名のマッピング。
- 解決: global+project マージ後に適用。マッチした assignment の `defaults` / `targets` がトップレベルをキー単位で置換（`targets` はマップ全体置換、部分マージなし）。省略キーはトップレベルにフォールバック。`profiles` / `auto_routing` は共有。
- マージ規則: `assignments` は profiles と同じ（同名は project 全体置換・異名併存）、`directories` は正規化キーで project 優先。
- バリデーション: 未知の assignment 名参照、assignment 内の未知 profile/pool/ladder 参照はロード時 fail-fast。既存の「active セクションはトップレベル defaults 必須」ルールは維持。companion 無効時の effective section 処理も assignments 内の companions targets と整合。
- ドキュメント: `docs/configuration.{md,ja.md,zh-CN.md}` に説明と設定例を追加。

## テスト

- `runtime-provider-loader.test.ts`: 選択適用・フォールバック・targets 全体置換・非マッチ・マージ規則・fail-fast・`~` 展開/シンボリックリンク正規化
- `runtime-provider-policy.test.ts`: assignment 内の未知 profile/pool/ladder 参照の fail-fast
- `runtime-provider-schema.test.ts`: 受入/拒否（空 assignment・未知キー・defaults 必須ルール）、companion 無効時の effective 処理
- 実施済み: `npm run build`、`npm run lint`、`npm test`（4 shard 全成功）、`npm test -- src/__tests__/releaseVerificationWiring.test.ts`

## レビュー経緯

gpt-5.6-luna (reasoning max) による実装 + 別セッション同モデルによる独立レビュー（luna-go スキル）を実施。独立レビューで targets 省略時のフォールバック契約違反1件を検出・修正済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - プロジェクトディレクトリごとに、使用するプロバイダー設定を切り替えられるようになりました。
  - 共通の既定値または対象別設定を割り当て、ディレクトリ単位で設定を管理できます。
  - ホームディレクトリ表記や実体パスを考慮して、正確に割り当てを判定します。
  - グローバル設定とプロジェクト設定を統合し、プロジェクト側の同名設定を優先します。
- **バグ修正**
  - 未定義の割り当て名や無効なプロファイル、プール、ladder参照を検出します。
- **ドキュメント**
  - 新しいプロバイダー割り当て設定の使い方と優先順位を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->