### PR TITLE
fix(pi): fall back from unloadable npm extensions

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -333,7 +333,7 @@ steps:
 
 `provider` と `model` の宣言は TAKT 実行で使う provider、model、thinking level を選択するもので、Pi CLI の設定を取り込むものではありません。Pi の認証は Pi SDK credential store または provider-native 環境変数で別途処理されます。この境界により、グローバル設定への意図しない書き込みを防ぎ、プロジェクトローカル設定の信頼性と予測可能性を保ちます。
 
-`provider_options.pi` は、`extensions` や `no_*` の探索制御など、Pi リソースを読み込むための別経路です。これらの option は認証、model、thinking level を宣言するものではありません。明示したリソース source は TAKT 実行時だけ temporary resolution され、Pi settings には永続化されません。リソースの信頼境界については [Pi のリソース読み込み](#pi-resource-loading) を参照してください。
+`provider_options.pi` は、`extensions` や `no_*` の探索制御など、Pi リソースを読み込むための別経路です。これらの option は認証、model、thinking level を宣言するものではありません。version 指定のない明示 npm source は既存の project scope、user scope を順に再利用し、どちらも正常に読み込めない場合だけ temporary resolution に fallback します。version 指定付き npm source と npm 以外の source は常に temporary resolution されます。明示した source は Pi settings には永続化されません。リソースの信頼境界については [Pi のリソース読み込み](#pi-resource-loading) を参照してください。
 
 ### プロバイダ無応答 deadline と OpenCode 実行ガード
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -333,7 +333,7 @@ steps:
 
 The `provider` and `model` declarations select the provider, model, and thinking level for a TAKT run; they do not import Pi CLI settings. Pi authentication is handled separately through the Pi SDK credential store or provider-native environment variables. The boundary avoids unintended writes to global settings and keeps project-local configuration trustworthy and predictable.
 
-`provider_options.pi` is a separate path for loading Pi resources such as `extensions` and `no_*` discovery controls. These options do not declare authentication, model, or thinking level. Explicit resource sources are resolved temporarily for the TAKT run and are not persisted to Pi settings; see [Pi resource loading](#pi-resource-loading) for the resource trust boundary.
+`provider_options.pi` is a separate path for loading Pi resources such as `extensions` and `no_*` discovery controls. These options do not declare authentication, model, or thinking level. Bare explicit npm sources reuse an existing project-scope install, then an existing user-scope install, and fall back to temporary resolution only when neither candidate loads successfully; version-qualified npm sources and non-npm sources are always resolved temporarily. Explicit sources are not persisted to Pi settings; see [Pi resource loading](#pi-resource-loading) for the resource trust boundary.
 
 ### Provider inactivity deadline and OpenCode execution guards
 

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -331,7 +331,7 @@ steps:
     model: provider/model:high
 ```
 
-`provider` 和 `model` 声明选择 TAKT run 的 provider、model 和 thinking level；它们不会导入 Pi CLI 设置。Pi 认证由 Pi SDK credential store 或 provider 原生环境变量单独处理。`provider_options.pi` 是加载 `extensions` 和 `no_*` discovery 控制的独立路径；显式资源源只在本次 TAKT run 中临时解析，不会写入 Pi 设置。
+`provider` 和 `model` 声明选择 TAKT run 的 provider、model 和 thinking level；它们不会导入 Pi CLI 设置。Pi 认证由 Pi SDK credential store 或 provider 原生环境变量单独处理。`provider_options.pi` 是加载 `extensions` 和 `no_*` discovery 控制的独立路径；没有版本限定的显式 npm source 会依次复用已有的 project scope、user scope，只有两者都无法成功加载时才使用 temporary resolution；带版本的 npm source 和非 npm source 始终使用 temporary resolution。显式资源不会写入 Pi 设置。
 
 ### Provider inactivity deadline 与 OpenCode execution guard
 

--- a/scripts/pi-sdk-cross-platform-smoke.mjs
+++ b/scripts/pi-sdk-cross-platform-smoke.mjs
@@ -34,8 +34,8 @@ const extensionPath = join(root, 'platform-probe.js');
 const projectPackageRoot = join(cwd, '.pi', 'npm', 'node_modules', 'project-probe');
 const projectExtensionPath = join(projectPackageRoot, 'index.js');
 const brokenProjectPackageRoot = join(cwd, '.pi', 'npm', 'node_modules', 'broken-probe');
-const brokenUserPackageRoot = join(agentDir, 'npm', 'node_modules', 'broken-probe');
-const brokenUserExtensionPath = join(brokenUserPackageRoot, 'index.js');
+const fallbackUserPackageRoot = join(agentDir, 'npm', 'node_modules', 'broken-probe');
+const fallbackUserExtensionPath = join(fallbackUserPackageRoot, 'index.js');
 const implicitExtensionPath = join(cwd, '.pi', 'extensions', 'implicit-probe.js');
 
 try {
@@ -85,14 +85,14 @@ export default function projectProbe(pi) {
     name: 'broken-probe',
     version: '1.0.0',
   }, null, 2), 'utf8');
-  await mkdir(brokenUserPackageRoot, { recursive: true });
-  await writeFile(join(brokenUserPackageRoot, 'package.json'), JSON.stringify({
+  await mkdir(fallbackUserPackageRoot, { recursive: true });
+  await writeFile(join(fallbackUserPackageRoot, 'package.json'), JSON.stringify({
     name: 'broken-probe',
     version: '1.0.0',
     type: 'module',
     pi: { extensions: ['./index.js'] },
   }, null, 2), 'utf8');
-  await writeFile(brokenUserExtensionPath, `
+  await writeFile(fallbackUserExtensionPath, `
 export default function userProbe(pi) {
   pi.on('session_start', () => {});
 }
@@ -150,17 +150,17 @@ export default function implicitProbe(pi) {
   await brokenProjectLoader.reload();
   assert.ok(brokenProjectLoader.getExtensions().errors.length > 0);
 
-  const brokenUserInstallPath = operationalPackageManager.getInstalledPath('npm:broken-probe', 'user');
-  assert.equal(brokenUserInstallPath, brokenUserPackageRoot);
-  const brokenUserResources = await operationalPackageManager.resolveExtensionSources(
-    [brokenUserInstallPath],
+  const fallbackUserInstallPath = operationalPackageManager.getInstalledPath('npm:broken-probe', 'user');
+  assert.equal(fallbackUserInstallPath, fallbackUserPackageRoot);
+  const fallbackUserResources = await operationalPackageManager.resolveExtensionSources(
+    [fallbackUserInstallPath],
     { temporary: true },
   );
-  const brokenUserLoader = new DefaultResourceLoader({
+  const fallbackUserLoader = new DefaultResourceLoader({
     cwd,
     agentDir,
     settingsManager,
-    additionalExtensionPaths: brokenUserResources.extensions
+    additionalExtensionPaths: fallbackUserResources.extensions
       .filter((resource) => resource.enabled)
       .map((resource) => resource.path),
     noSkills: true,
@@ -168,8 +168,8 @@ export default function implicitProbe(pi) {
     noThemes: true,
     noContextFiles: true,
   });
-  await brokenUserLoader.reload();
-  assert.deepEqual(brokenUserLoader.getExtensions().errors, []);
+  await fallbackUserLoader.reload();
+  assert.deepEqual(fallbackUserLoader.getExtensions().errors, []);
 
   const projectResources = await operationalPackageManager.resolveExtensionSources(
     [projectInstallPath],

--- a/scripts/pi-sdk-cross-platform-smoke.mjs
+++ b/scripts/pi-sdk-cross-platform-smoke.mjs
@@ -33,6 +33,9 @@ const agentDir = join(root, 'agent');
 const extensionPath = join(root, 'platform-probe.js');
 const projectPackageRoot = join(cwd, '.pi', 'npm', 'node_modules', 'project-probe');
 const projectExtensionPath = join(projectPackageRoot, 'index.js');
+const brokenProjectPackageRoot = join(cwd, '.pi', 'npm', 'node_modules', 'broken-probe');
+const brokenUserPackageRoot = join(agentDir, 'npm', 'node_modules', 'broken-probe');
+const brokenUserExtensionPath = join(brokenUserPackageRoot, 'index.js');
 const implicitExtensionPath = join(cwd, '.pi', 'extensions', 'implicit-probe.js');
 
 try {
@@ -77,6 +80,23 @@ export default function projectProbe(pi) {
   });
 }
 `, 'utf8');
+  await mkdir(brokenProjectPackageRoot, { recursive: true });
+  await writeFile(join(brokenProjectPackageRoot, 'package.json'), JSON.stringify({
+    name: 'broken-probe',
+    version: '1.0.0',
+  }, null, 2), 'utf8');
+  await mkdir(brokenUserPackageRoot, { recursive: true });
+  await writeFile(join(brokenUserPackageRoot, 'package.json'), JSON.stringify({
+    name: 'broken-probe',
+    version: '1.0.0',
+    type: 'module',
+    pi: { extensions: ['./index.js'] },
+  }, null, 2), 'utf8');
+  await writeFile(brokenUserExtensionPath, `
+export default function userProbe(pi) {
+  pi.on('session_start', () => {});
+}
+`, 'utf8');
   await mkdir(join(cwd, '.pi', 'extensions'), { recursive: true });
   await writeFile(implicitExtensionPath, `
 export default function implicitProbe(pi) {
@@ -105,6 +125,52 @@ export default function implicitProbe(pi) {
   assert.equal(projectInstallPath, projectPackageRoot);
 
   const operationalPackageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
+  const brokenProjectInstallPath = projectLookupManager.getInstalledPath('npm:broken-probe', 'project');
+  assert.equal(brokenProjectInstallPath, brokenProjectPackageRoot);
+  const brokenProjectResources = await operationalPackageManager.resolveExtensionSources(
+    [brokenProjectInstallPath],
+    { temporary: true },
+  );
+  assert.deepEqual(
+    brokenProjectResources.extensions.filter((resource) => resource.enabled).map((resource) => resource.path),
+    [brokenProjectPackageRoot],
+  );
+  const brokenProjectLoader = new DefaultResourceLoader({
+    cwd,
+    agentDir,
+    settingsManager,
+    additionalExtensionPaths: brokenProjectResources.extensions
+      .filter((resource) => resource.enabled)
+      .map((resource) => resource.path),
+    noSkills: true,
+    noPromptTemplates: true,
+    noThemes: true,
+    noContextFiles: true,
+  });
+  await brokenProjectLoader.reload();
+  assert.ok(brokenProjectLoader.getExtensions().errors.length > 0);
+
+  const brokenUserInstallPath = operationalPackageManager.getInstalledPath('npm:broken-probe', 'user');
+  assert.equal(brokenUserInstallPath, brokenUserPackageRoot);
+  const brokenUserResources = await operationalPackageManager.resolveExtensionSources(
+    [brokenUserInstallPath],
+    { temporary: true },
+  );
+  const brokenUserLoader = new DefaultResourceLoader({
+    cwd,
+    agentDir,
+    settingsManager,
+    additionalExtensionPaths: brokenUserResources.extensions
+      .filter((resource) => resource.enabled)
+      .map((resource) => resource.path),
+    noSkills: true,
+    noPromptTemplates: true,
+    noThemes: true,
+    noContextFiles: true,
+  });
+  await brokenUserLoader.reload();
+  assert.deepEqual(brokenUserLoader.getExtensions().errors, []);
+
   const projectResources = await operationalPackageManager.resolveExtensionSources(
     [projectInstallPath],
     { temporary: true },

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -8,6 +8,9 @@ const mocks = vi.hoisted(() => {
   let promptOptions: unknown;
   let loaderOptions: unknown;
   let extensionLoadErrors: Array<{ path: string; error: string }> = [];
+  let loadedExtensions: Array<{ path: string }> = [];
+  let extensionLoadErrorSequence: Array<Array<{ path: string; error: string }>> = [];
+  let reloadResourceLoader = async (): Promise<void> => undefined;
   let pendingProviderRegistrations: Array<{
     name: string;
     config: Record<string, unknown>;
@@ -78,12 +81,13 @@ const mocks = vi.hoisted(() => {
   const sessionManager = {
     inMemory: vi.fn(() => ({ newSession: vi.fn() })),
   };
-  const extensionResult = () => ({
-    extensions: [],
-    errors: extensionLoadErrors,
+  const extensionResult = (errors = extensionLoadErrors) => ({
+    extensions: loadedExtensions,
+    errors,
     runtime: {
       pendingProviderRegistrations,
       pendingNativeProviderRegistrations: [],
+      invalidate: mocks.extensionRuntimeInvalidate,
     },
   });
 
@@ -97,11 +101,13 @@ const mocks = vi.hoisted(() => {
       return { session, extensionsResult: extensionResult() };
     }),
     modelRuntimeCreate: vi.fn(async () => modelRuntime),
+    extensionRuntimeInvalidate: vi.fn(),
     resourceLoader: vi.fn((options: unknown) => {
       loaderOptions = options;
+      const errors = extensionLoadErrorSequence.shift() ?? extensionLoadErrors;
       return {
-        reload: vi.fn(async () => undefined),
-        getExtensions: vi.fn(() => extensionResult()),
+        reload: vi.fn(() => reloadResourceLoader()),
+        getExtensions: vi.fn(() => extensionResult(errors)),
       };
     }),
     createBashToolDefinition: vi.fn(() => ({ name: 'bash' })),
@@ -121,6 +127,7 @@ const mocks = vi.hoisted(() => {
       promptOptions = undefined;
       loaderOptions = undefined;
       extensionLoadErrors = [];
+      loadedExtensions = [];
       pendingProviderRegistrations = [];
       mocks.session.setActiveToolsByName.mockClear();
       mocks.session.bindExtensions.mockClear();
@@ -133,6 +140,9 @@ const mocks = vi.hoisted(() => {
       mocks.session.getLastAssistantText.mockClear();
       mocks.createAgentSession.mockClear();
       mocks.resourceLoader.mockClear();
+      mocks.extensionRuntimeInvalidate.mockClear();
+      extensionLoadErrorSequence = [];
+      reloadResourceLoader = async () => undefined;
       mocks.packageManagerConstructor.mockClear();
       mocks.settingsManagerInMemory.mockClear();
       mocks.packageManager.getInstalledPath.mockReset();
@@ -147,6 +157,15 @@ const mocks = vi.hoisted(() => {
     },
     setExtensionLoadErrors: (errors: Array<{ path: string; error: string }>) => {
       extensionLoadErrors = errors;
+    },
+    setLoadedExtensions: (extensions: Array<{ path: string }>) => {
+      loadedExtensions = extensions;
+    },
+    setExtensionLoadErrorSequence: (sequence: Array<Array<{ path: string; error: string }>>) => {
+      extensionLoadErrorSequence = sequence;
+    },
+    setReloadResourceLoader: (reload: () => Promise<void>) => {
+      reloadResourceLoader = reload;
     },
     setPendingProviderRegistrations: (registrations: Array<{
       name: string;
@@ -223,6 +242,18 @@ describe('Pi SDK client', () => {
       onError: expect.any(Function),
     }));
     expect(mocks.createAgentSession.mock.calls.at(-1)?.[0]).not.toHaveProperty('tools');
+  });
+
+  it('invalidates extension runtime when SDK session creation fails', async () => {
+    mocks.resetTransient();
+    mocks.createAgentSession.mockRejectedValueOnce(new Error('session creation failed'));
+
+    const response = await callPi('worker', 'create the session', {
+      ...sessionOptions('pi-sdk-session-creation-failure'),
+    });
+
+    expect(response.status).toBe('error');
+    expect(mocks.extensionRuntimeInvalidate).toHaveBeenCalledOnce();
   });
 
   it('resolves npm extension sources temporarily when no user install exists', async () => {
@@ -484,11 +515,126 @@ describe('Pi SDK client', () => {
     );
   });
 
+  it.each(['npm:@scope/_foo', 'npm:@scope/.foo'])(
+    'accepts a scoped npm package member beginning with . or _: %s',
+    async (source) => {
+      mocks.resetTransient();
+      const temporary = {
+        extensions: [{ enabled: true, path: path.join(tmpdir(), 'scoped-extension.ts') }],
+        skills: [],
+        prompts: [],
+        themes: [],
+      };
+      mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce(temporary);
+
+      const response = await callPi('worker', 'use the extension', {
+        ...sessionOptions(`pi-sdk-scoped-${source}`),
+        providerOptions: { extensions: [source] },
+      });
+
+      expect(response.status).toBe('done');
+      expect(mocks.projectPackageLookup.getInstalledPath).toHaveBeenCalledWith(source, 'project');
+      expect(mocks.packageManager.getInstalledPath).toHaveBeenCalledWith(source, 'user');
+      expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledWith(
+        [source],
+        { temporary: true },
+      );
+    },
+  );
+
+  it('loads multiple successful extension sources only once', async () => {
+    mocks.resetTransient();
+    const firstSource = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'first-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    const secondSource = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'second-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.packageManager.resolveExtensionSources
+      .mockResolvedValueOnce(firstSource)
+      .mockResolvedValueOnce(secondSource);
+
+    const response = await callPi('worker', 'use the extensions', {
+      ...sessionOptions('pi-sdk-multiple-extension-sources'),
+      providerOptions: { extensions: ['npm:first-extension', 'npm:second-extension'] },
+    });
+
+    expect(response.status).toBe('done');
+    expect(mocks.resourceLoader).toHaveBeenCalledOnce();
+    expect(mocks.extensionRuntimeInvalidate).not.toHaveBeenCalled();
+    expect(mocks.getLoaderOptions()).toMatchObject({
+      additionalExtensionPaths: [
+        firstSource.extensions[0].path,
+        secondSource.extensions[0].path,
+      ],
+    });
+  });
+
+  it('replaces only the failed candidate when multiple extension sources are configured', async () => {
+    mocks.resetTransient();
+    const projectRoot = mkdtempSync(path.join(tmpdir(), 'takt-pi-project-multiple-fallback-'));
+    const projectInstallPath = path.join(projectRoot, '.pi', 'npm', 'node_modules', 'fallback-extension');
+    const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'fallback-extension');
+    const stablePath = path.join(tmpdir(), 'stable-extension.ts');
+    const userPath = path.join(tmpdir(), 'working-user-extension.ts');
+    mkdirSync(projectInstallPath, { recursive: true });
+    mocks.projectPackageLookup.getInstalledPath.mockReturnValue(projectInstallPath);
+    mocks.packageManager.getInstalledPath.mockReturnValue(userInstallPath);
+    mocks.packageManager.resolveExtensionSources
+      .mockResolvedValueOnce({
+        extensions: [{ enabled: true, path: stablePath }],
+        skills: [],
+        prompts: [],
+        themes: [],
+      })
+      .mockResolvedValueOnce({
+        extensions: [{ enabled: true, path: projectInstallPath }],
+        skills: [],
+        prompts: [],
+        themes: [],
+      })
+      .mockResolvedValueOnce({
+        extensions: [{ enabled: true, path: userPath }],
+        skills: [],
+        prompts: [],
+        themes: [],
+      });
+    mocks.setExtensionLoadErrorSequence([
+      [{ path: projectInstallPath, error: 'missing extension entry point' }],
+      [],
+    ]);
+
+    try {
+      const response = await callPi('worker', 'use the extensions', {
+        ...sessionOptions('pi-sdk-multiple-extension-fallback'),
+        cwd: projectRoot,
+        providerOptions: { extensions: ['./stable.ts', 'npm:fallback-extension'] },
+      });
+
+      expect(response.status).toBe('done');
+      expect(mocks.resourceLoader).toHaveBeenCalledTimes(2);
+      expect(mocks.extensionRuntimeInvalidate).toHaveBeenCalledOnce();
+      expect(mocks.getLoaderOptions()).toMatchObject({
+        additionalExtensionPaths: [stablePath, userPath],
+      });
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     'npm:../../../../evil',
     'npm:..\\..\\evil',
     'npm:foo/bar',
     'npm:@scope/../../evil',
+    'npm:@scope/.',
+    'npm:@scope/..',
     'npm:@/evil',
   ])('rejects unsafe npm package source %s before package lookup or resolution', async (source) => {
     mocks.resetTransient();
@@ -584,6 +730,144 @@ describe('Pi SDK client', () => {
     });
   });
 
+  it('falls through an empty project package directory that the SDK reports as an extension', async () => {
+    mocks.resetTransient();
+    const projectRoot = mkdtempSync(path.join(tmpdir(), 'takt-pi-project-load-error-'));
+    const projectInstallPath = path.join(projectRoot, '.pi', 'npm', 'node_modules', 'example-extension');
+    const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'example-extension');
+    mkdirSync(projectInstallPath, { recursive: true });
+    const projectScope = {
+      extensions: [{ enabled: true, path: projectInstallPath }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    const userScope = {
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'working-user-extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    };
+    mocks.projectPackageLookup.getInstalledPath.mockReturnValue(projectInstallPath);
+    mocks.packageManager.getInstalledPath.mockReturnValue(userInstallPath);
+    mocks.packageManager.resolveExtensionSources
+      .mockResolvedValueOnce(projectScope)
+      .mockResolvedValueOnce(userScope);
+    mocks.setExtensionLoadErrorSequence([
+      [{ path: projectScope.extensions[0].path, error: 'syntax error' }],
+      [],
+    ]);
+
+    try {
+      const response = await callPi('worker', 'use the extension', {
+        ...sessionOptions('pi-sdk-project-load-error-user-fallback'),
+        cwd: projectRoot,
+        providerOptions: { extensions: ['npm:example-extension'] },
+      });
+
+      expect(response.status).toBe('done');
+      expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+        1,
+        [projectInstallPath],
+        { temporary: true },
+      );
+      expect(mocks.packageManager.resolveExtensionSources).toHaveBeenNthCalledWith(
+        2,
+        [userInstallPath],
+        { temporary: true },
+      );
+      expect(mocks.resourceLoader).toHaveBeenCalledTimes(2);
+      expect(mocks.extensionRuntimeInvalidate).toHaveBeenCalledOnce();
+      expect(mocks.getLoaderOptions()).toMatchObject({
+        additionalExtensionPaths: [userScope.extensions[0].path],
+      });
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps project and user candidate failures in the final temporary resolution error', async () => {
+    mocks.resetTransient();
+    mocks.projectPackageLookup.getInstalledPath.mockImplementation(() => {
+      throw new Error('project lookup failed at /private/tmp/secret-project');
+    });
+    mocks.packageManager.getInstalledPath.mockImplementation(() => {
+      throw new Error('user lookup failed');
+    });
+    mocks.packageManager.resolveExtensionSources.mockRejectedValueOnce(
+      new Error('temporary resolution failed'),
+    );
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-candidate-failure-diagnostics'),
+      providerOptions: { extensions: ['npm:example-extension'] },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.error).toContain('project: project lookup failed at [path]');
+    expect(response.error).not.toContain('/private/tmp/secret-project');
+    expect(response.error).toContain('user: user lookup failed');
+    expect(response.error).toContain('temporary: temporary resolution failed');
+    expect(mocks.resourceLoader).not.toHaveBeenCalled();
+  });
+
+  it('keeps earlier scope failures when the temporary candidate fails to load', async () => {
+    mocks.resetTransient();
+    const temporaryPath = path.join(tmpdir(), 'topsecret-extension.ts');
+    mocks.projectPackageLookup.getInstalledPath.mockImplementation(() => {
+      throw new Error('project lookup failed token=topsecret');
+    });
+    mocks.packageManager.getInstalledPath.mockImplementation(() => {
+      throw new Error('user lookup failed');
+    });
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce({
+      extensions: [{ enabled: true, path: temporaryPath }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    });
+    mocks.setExtensionLoadErrors([{ path: temporaryPath, error: 'syntax error' }]);
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-candidate-load-failure-diagnostics'),
+      providerOptions: { extensions: ['npm:example-extension'] },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.error).toContain('project: project lookup failed token=[REDACTED]');
+    expect(response.error).toContain('user: user lookup failed');
+    expect(response.error).toContain('temporary: Pi extension loading failed');
+    expect(response.error).not.toContain('topsecret');
+    expect(response.error).not.toContain('topsecret-extension.ts');
+    expect(mocks.extensionRuntimeInvalidate).toHaveBeenCalledOnce();
+  });
+
+  it('does not treat SDK conflict diagnostics as extension load failures', async () => {
+    mocks.resetTransient();
+    const extensionPath = path.join(tmpdir(), 'conflicting-extension.ts');
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce({
+      extensions: [{ enabled: true, path: extensionPath }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    });
+    mocks.setLoadedExtensions([{ path: extensionPath }]);
+    mocks.setExtensionLoadErrors([{
+      path: extensionPath,
+      error: 'Tool "duplicate" conflicts with /private/tmp/other-extension.ts',
+    }]);
+
+    const response = await callPi('worker', 'load extension', {
+      ...sessionOptions('pi-sdk-extension-conflict'),
+      providerOptions: { extensions: ['./conflicting-extension.ts'] },
+    });
+
+    expect(response.status).toBe('error');
+    expect(mocks.packageManager.resolveExtensionSources).toHaveBeenCalledOnce();
+    expect(mocks.resourceLoader).toHaveBeenCalledOnce();
+    expect(response.error).not.toContain('/private/tmp/other-extension.ts');
+  });
+
   it('falls back to temporary when an existing user-scope npm extension has no enabled resources', async () => {
     mocks.resetTransient();
     const userInstallPath = path.join(tmpdir(), 'pi-agent-test', 'npm', 'node_modules', 'example-extension');
@@ -667,6 +951,40 @@ describe('Pi SDK client', () => {
     );
     expect(mocks.resourceLoader).not.toHaveBeenCalled();
     expect(mocks.createAgentSession).not.toHaveBeenCalled();
+  });
+
+  it('stops fallback when resource loading observes an abort', async () => {
+    mocks.resetTransient();
+    const projectRoot = mkdtempSync(path.join(tmpdir(), 'takt-pi-project-load-abort-'));
+    const projectInstallPath = path.join(projectRoot, '.pi', 'npm', 'node_modules', 'example-extension');
+    mkdirSync(projectInstallPath, { recursive: true });
+    const abortController = new AbortController();
+    mocks.projectPackageLookup.getInstalledPath.mockReturnValue(projectInstallPath);
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce({
+      extensions: [{ enabled: true, path: projectInstallPath }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    });
+    mocks.setReloadResourceLoader(async () => {
+      abortController.abort('cancelled during resource loading');
+    });
+
+    try {
+      const response = await callPi('worker', 'use the extension', {
+        ...sessionOptions('pi-sdk-resource-load-abort'),
+        cwd: projectRoot,
+        abortSignal: abortController.signal,
+        providerOptions: { extensions: ['npm:example-extension'] },
+      });
+
+      expect(response.status).toBe('error');
+      expect(response.failureCategory).toBe('external_abort');
+      expect(mocks.packageManager.getInstalledPath).not.toHaveBeenCalled();
+      expect(mocks.extensionRuntimeInvalidate).toHaveBeenCalledOnce();
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 
   it.each([

--- a/src/__tests__/pi-client.test.ts
+++ b/src/__tests__/pi-client.test.ts
@@ -987,6 +987,48 @@ describe('Pi SDK client', () => {
     }
   });
 
+  it('adds resource-loading context when the SDK loader rejects', async () => {
+    mocks.resetTransient();
+    mocks.packageManager.resolveExtensionSources.mockResolvedValueOnce({
+      extensions: [{ enabled: true, path: path.join(tmpdir(), 'extension.ts') }],
+      skills: [],
+      prompts: [],
+      themes: [],
+    });
+    mocks.setReloadResourceLoader(async () => {
+      throw new Error('loader rejected');
+    });
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-resource-load-error'),
+      providerOptions: { extensions: ['./extension.ts'] },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.error).toContain('Pi extension resource loading failed: loader rejected');
+    expect(mocks.extensionRuntimeInvalidate).toHaveBeenCalledOnce();
+    expect(mocks.createAgentSession).not.toHaveBeenCalled();
+  });
+
+  it('labels a local source without exposing its filename when resolution fails', async () => {
+    mocks.resetTransient();
+    mocks.packageManager.resolveExtensionSources.mockRejectedValueOnce(
+      new Error('resolution failed'),
+    );
+
+    const response = await callPi('worker', 'use the extension', {
+      ...sessionOptions('pi-sdk-local-source-resolution-error'),
+      providerOptions: { extensions: ['./confidential-extension.ts'] },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.error).toContain(
+      'Pi extension source could not be resolved for local source (temporary: resolution failed)',
+    );
+    expect(response.error).not.toContain('nfidential-extension.ts');
+    expect(mocks.resourceLoader).not.toHaveBeenCalled();
+  });
+
   it.each([
     { label: 'git', source: 'git:https://example.invalid/extension.git' },
     { label: 'local path', source: './local-extension.ts' },

--- a/src/core/models/workflow-provider-options.ts
+++ b/src/core/models/workflow-provider-options.ts
@@ -143,7 +143,11 @@ export interface DeepSeekHarnessProviderOptions {
   runtimeMode?: 'exe' | 'node';
 }
 
-/** Pi SDK resource-loading options. Extension sources are resolved temporarily. */
+/**
+ * Pi SDK resource-loading options. Bare npm sources try existing project and user
+ * installs before temporary resolution; version-qualified npm and non-npm sources
+ * are always temporary and explicit sources are never persisted to Pi settings.
+ */
 export interface PiProviderOptions {
   guards?: ProviderGuardOptions;
   extensions?: string[];

--- a/src/infra/pi/client.ts
+++ b/src/infra/pi/client.ts
@@ -34,6 +34,7 @@ import {
 } from '../../shared/types/agent-failure.js';
 import type { StreamCallback } from '../../shared/types/provider.js';
 import { createLogger, getErrorMessage } from '../../shared/utils/index.js';
+import { safeExternalErrorMessage } from '../../shared/utils/safeExternalErrorMessage.js';
 import { sanitizeSensitiveText } from '../../shared/utils/sensitiveText.js';
 import type { ProviderImageAttachment } from '../providers/types.js';
 import { validateProviderImageAttachments } from '../providers/imageAttachments.js';
@@ -259,6 +260,15 @@ function countEnabledResolvedResources(paths: ResolvedPaths): number {
     + enabledResourcePaths(paths, 'themes').length;
 }
 
+function mergeResolvedPaths(base: ResolvedPaths, additions: ResolvedPaths): ResolvedPaths {
+  return {
+    extensions: [...base.extensions, ...additions.extensions],
+    skills: [...base.skills, ...additions.skills],
+    prompts: [...base.prompts, ...additions.prompts],
+    themes: [...base.themes, ...additions.themes],
+  };
+}
+
 function isNpmExtensionSource(source: string): boolean {
   return source.trim().startsWith('npm:');
 }
@@ -270,7 +280,13 @@ function getSafeNpmPackageName(source: string): string | undefined {
     : spec.indexOf('@');
   const packageName = versionDelimiter >= 0 ? spec.slice(0, versionDelimiter) : spec;
   const unscopedName = /^[a-z0-9][a-z0-9._~-]*$/u;
-  const scopedName = /^@[a-z0-9][a-z0-9._~-]*\/[a-z0-9][a-z0-9._~-]*$/u;
+  const scopedName = /^@[a-z0-9][a-z0-9._~-]*\/[a-z0-9._~-]+$/u;
+  if (scopedName.test(packageName)) {
+    const member = packageName.slice(packageName.indexOf('/') + 1);
+    if (member === '.' || member === '..') {
+      return undefined;
+    }
+  }
   return unscopedName.test(packageName) || scopedName.test(packageName)
     ? packageName
     : undefined;
@@ -283,6 +299,31 @@ function isVersionQualifiedNpmExtensionSource(source: string): boolean {
 
 interface InstalledPackageLookup {
   getInstalledPath(source: string): string | undefined;
+}
+
+type ExtensionSourceScope = 'project' | 'user' | 'temporary';
+
+interface ExtensionCandidateFailure {
+  scope: ExtensionSourceScope;
+  reason: string;
+}
+
+type ExtensionLoadError = LoadExtensionsResult['errors'][number];
+
+interface ResolvedExtensionCandidate {
+  scope: ExtensionSourceScope;
+  paths: ResolvedPaths;
+}
+
+interface ExtensionSourceSearch {
+  source: string;
+  scopes: readonly ExtensionSourceScope[];
+  nextScopeIndex: number;
+  failures: ExtensionCandidateFailure[];
+}
+
+interface ExtensionSourceResolution extends ExtensionSourceSearch {
+  candidate: ResolvedExtensionCandidate;
 }
 
 type ExtensionPackageManager = Pick<
@@ -315,111 +356,332 @@ function createProjectInstalledPackageLookup(
       try {
         canonicalProjectPackageRoot = realpathSync(projectPackageRoot);
         canonicalInstalledPath = realpathSync(installedPath);
-      } catch {
-        return undefined;
+      } catch (error) {
+        throw new Error(
+          `Project package path could not be verified: ${getErrorMessage(error)}`,
+          { cause: error },
+        );
       }
       const relativePath = path.relative(canonicalProjectPackageRoot, canonicalInstalledPath);
       if (relativePath === '' || relativePath === '..' || relativePath.startsWith(`..${path.sep}`)
         || path.isAbsolute(relativePath)) {
-        return undefined;
+        throw new Error('Project package path is outside project package storage');
       }
       return canonicalInstalledPath;
     },
   };
 }
 
-async function resolveExtensionSourcePaths(
-  packageManager: ExtensionPackageManager,
-  projectLookup: InstalledPackageLookup,
-  source: string,
-  abortSignal: AbortSignal | undefined,
-): Promise<ResolvedPaths> {
-  if (!isNpmExtensionSource(source) || isVersionQualifiedNpmExtensionSource(source)) {
-    const sourcePaths = await packageManager.resolveExtensionSources([source], { temporary: true });
-    if (isAbortRequested(abortSignal)) {
-      throw new Error('Pi session aborted');
-    }
-    return sourcePaths;
+function extensionSourceDiagnosticLabel(source: string): string {
+  const packageName = getSafeNpmPackageName(source);
+  if (packageName !== undefined) {
+    return `npm:${packageName}`;
   }
-
-  const existingInstallLookups: InstalledPackageLookup[] = [
-    projectLookup,
-    {
-      getInstalledPath: (npmSource) => packageManager.getInstalledPath(npmSource, 'user'),
-    },
-  ];
-  for (const lookup of existingInstallLookups) {
-    let installedPath: string | undefined;
-    try {
-      installedPath = lookup.getInstalledPath(source);
-    } catch {
-      // A read-only lookup failure must not prevent checking the next existing
-      // install or the temporary fallback.
-    }
-    if (isAbortRequested(abortSignal)) {
-      throw new Error('Pi session aborted');
-    }
-
-    if (installedPath) {
-      try {
-        // Resolve the discovered absolute path as a local source. Passing the original
-        // npm spec here would make the SDK install a missing package into that scope.
-        const sourcePaths = await packageManager.resolveExtensionSources(
-          [installedPath],
-          { temporary: true },
-        );
-        if (isAbortRequested(abortSignal)) {
-          throw new Error('Pi session aborted');
-        }
-        if (countEnabledResolvedResources(sourcePaths) > 0) {
-          return sourcePaths;
-        }
-      } catch {
-        if (isAbortRequested(abortSignal)) {
-          throw new Error('Pi session aborted');
-        }
-      }
-    }
+  const trimmed = source.trim();
+  if (trimmed.startsWith('git:')) {
+    return 'git source';
   }
-
-  const sourcePaths = await packageManager.resolveExtensionSources([source], { temporary: true });
-  if (isAbortRequested(abortSignal)) {
-    throw new Error('Pi session aborted');
-  }
-  return sourcePaths;
+  return 'local source';
 }
 
-async function resolvePiResources(
+function extensionCandidateFailureReason(error: unknown): string {
+  const reason = safeExternalErrorMessage(error).trim();
+  return reason || 'unknown resolution failure';
+}
+
+function recordExtensionCandidateFailure(
+  source: string,
+  failures: ExtensionCandidateFailure[],
+  scope: ExtensionSourceScope,
+  error: unknown,
+): void {
+  const reason = extensionCandidateFailureReason(error);
+  failures.push({ scope, reason });
+  log.debug('Pi extension candidate failed', {
+    source: extensionSourceDiagnosticLabel(source),
+    scope,
+    reason,
+  });
+}
+
+function formatExtensionSourceResolutionFailure(
+  source: string,
+  failures: readonly ExtensionCandidateFailure[],
+): Error {
+  const details = failures.length === 0
+    ? ''
+    : ` (${failures.map(({ scope, reason }) => `${scope}: ${reason}`).join('; ')})`;
+  return new Error(
+    `Pi extension source could not be resolved for ${extensionSourceDiagnosticLabel(source)}${details}`,
+  );
+}
+
+function extensionSourceScopes(source: string): readonly ExtensionSourceScope[] {
+  return isNpmExtensionSource(source) && !isVersionQualifiedNpmExtensionSource(source)
+    ? ['project', 'user', 'temporary']
+    : ['temporary'];
+}
+
+function createExtensionSourceSearch(source: string): ExtensionSourceSearch {
+  return {
+    source,
+    scopes: extensionSourceScopes(source),
+    nextScopeIndex: 0,
+    failures: [],
+  };
+}
+
+function createPiResourceLoader(
   cwd: string,
   agentDir: string,
   options: PiCallOptions,
   settingsManager: SettingsManager,
-): Promise<ResolvedPaths> {
-  const sources = (options.providerOptions?.extensions ?? []).map((source) => source.trim());
-  if (sources.length === 0) {
-    return { extensions: [], skills: [], prompts: [], themes: [] };
+  resolvedResources: ResolvedPaths,
+): DefaultResourceLoader {
+  const providerOptions = options.providerOptions;
+  return new DefaultResourceLoader({
+    cwd,
+    agentDir,
+    settingsManager,
+    additionalExtensionPaths: enabledResourcePaths(resolvedResources, 'extensions'),
+    additionalSkillPaths: enabledResourcePaths(resolvedResources, 'skills'),
+    additionalPromptTemplatePaths: enabledResourcePaths(resolvedResources, 'prompts'),
+    additionalThemePaths: enabledResourcePaths(resolvedResources, 'themes'),
+    noExtensions: providerOptions?.noExtensions,
+    noSkills: providerOptions?.noSkills,
+    noPromptTemplates: providerOptions?.noPromptTemplates,
+    noThemes: providerOptions?.noThemes,
+    noContextFiles: providerOptions?.noContextFiles,
+    ...(options.systemPrompt !== undefined ? { systemPrompt: options.systemPrompt } : {}),
+  });
+}
+
+function throwPiSessionAborted(): never {
+  throw new Error('Pi session aborted');
+}
+
+function assertPiSessionNotAborted(abortSignal: AbortSignal | undefined): void {
+  if (isAbortRequested(abortSignal)) {
+    throwPiSessionAborted();
+  }
+}
+
+function candidateSourceForScope(
+  packageManager: ExtensionPackageManager,
+  projectLookup: InstalledPackageLookup,
+  source: string,
+  scope: ExtensionSourceScope,
+): string | undefined {
+  switch (scope) {
+    case 'project':
+      return projectLookup.getInstalledPath(source);
+    case 'user':
+      return packageManager.getInstalledPath(source, 'user');
+    case 'temporary':
+      return source;
+  }
+}
+
+async function resolveNextExtensionCandidate(
+  packageManager: ExtensionPackageManager,
+  projectLookup: InstalledPackageLookup,
+  search: ExtensionSourceSearch,
+  abortSignal: AbortSignal | undefined,
+): Promise<ResolvedExtensionCandidate> {
+  while (search.nextScopeIndex < search.scopes.length) {
+    const scope = search.scopes[search.nextScopeIndex];
+    if (scope === undefined) {
+      break;
+    }
+    search.nextScopeIndex += 1;
+    try {
+      const candidateSource = candidateSourceForScope(
+        packageManager,
+        projectLookup,
+        search.source,
+        scope,
+      );
+      assertPiSessionNotAborted(abortSignal);
+      if (candidateSource === undefined) {
+        continue;
+      }
+      const paths = await packageManager.resolveExtensionSources(
+        [candidateSource],
+        { temporary: true },
+      );
+      assertPiSessionNotAborted(abortSignal);
+      if (countEnabledResolvedResources(paths) === 0) {
+        recordExtensionCandidateFailure(
+          search.source,
+          search.failures,
+          scope,
+          'no enabled resources',
+        );
+        continue;
+      }
+      return { scope, paths };
+    } catch (error) {
+      if (isAbortRequested(abortSignal)) {
+        throwPiSessionAborted();
+      }
+      recordExtensionCandidateFailure(
+        search.source,
+        search.failures,
+        scope,
+        error,
+      );
+    }
   }
 
-  assertSafeExtensionSources(sources);
+  throw formatExtensionSourceResolutionFailure(search.source, search.failures);
+}
+
+function mergeExtensionSourcePaths(
+  resolutions: readonly ExtensionSourceResolution[],
+): ResolvedPaths {
+  return resolutions.reduce<ResolvedPaths>(
+    (resolved, resolution) => mergeResolvedPaths(resolved, resolution.candidate.paths),
+    { extensions: [], skills: [], prompts: [], themes: [] },
+  );
+}
+
+function extensionPathKey(cwd: string, extensionPath: string): string {
+  return path.resolve(cwd, extensionPath);
+}
+
+function failedExtensionSources(
+  cwd: string,
+  resolutions: readonly ExtensionSourceResolution[],
+  loadErrors: readonly ExtensionLoadError[],
+): Set<ExtensionSourceResolution> | undefined {
+  const ownersByPath = new Map<string, ExtensionSourceResolution[]>();
+  for (const resolution of resolutions) {
+    for (const extensionPath of enabledResourcePaths(resolution.candidate.paths, 'extensions')) {
+      const key = extensionPathKey(cwd, extensionPath);
+      ownersByPath.set(key, [...(ownersByPath.get(key) ?? []), resolution]);
+    }
+  }
+
+  const failedResolutions = new Set<ExtensionSourceResolution>();
+  for (const loadError of loadErrors) {
+    const owners = ownersByPath.get(extensionPathKey(cwd, loadError.path));
+    if (owners?.length !== 1) {
+      return undefined;
+    }
+    const owner = owners[0];
+    if (owner === undefined) {
+      return undefined;
+    }
+    failedResolutions.add(owner);
+  }
+  return failedResolutions;
+}
+
+function actualExtensionLoadErrors(
+  cwd: string,
+  extensionsResult: LoadExtensionsResult,
+): ExtensionLoadError[] {
+  const loadedExtensionPaths = new Set(
+    extensionsResult.extensions.map((extension) => extensionPathKey(cwd, extension.path)),
+  );
+  return extensionsResult.errors.filter((error) => (
+    !loadedExtensionPaths.has(extensionPathKey(cwd, error.path))
+  ));
+}
+
+function loadErrorsForResolution(
+  cwd: string,
+  resolution: ExtensionSourceResolution,
+  loadErrors: readonly ExtensionLoadError[],
+): ExtensionLoadError[] {
+  const candidatePaths = new Set(
+    enabledResourcePaths(resolution.candidate.paths, 'extensions')
+      .map((extensionPath) => extensionPathKey(cwd, extensionPath)),
+  );
+  return loadErrors.filter((loadError) => candidatePaths.has(extensionPathKey(cwd, loadError.path)));
+}
+
+function invalidateRejectedResourceLoader(resourceLoader: DefaultResourceLoader): void {
+  resourceLoader.getExtensions().runtime.invalidate('Pi extension candidate was rejected');
+}
+
+async function resolvePiResourceLoader(
+  cwd: string,
+  agentDir: string,
+  options: PiCallOptions,
+  settingsManager: SettingsManager,
+): Promise<DefaultResourceLoader> {
+  assertPiSessionNotAborted(options.abortSignal);
+  const sources = (options.providerOptions?.extensions ?? []).map((source) => source.trim());
+  if (sources.length > 0) {
+    assertSafeExtensionSources(sources);
+  }
+
   const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
   const projectLookup = createProjectInstalledPackageLookup(cwd, agentDir);
-  const resolved: ResolvedPaths = { extensions: [], skills: [], prompts: [], themes: [] };
-  for (const source of sources) {
-    const sourcePaths = await resolveExtensionSourcePaths(
+  const resolutions: ExtensionSourceResolution[] = [];
+  for (const search of sources.map(createExtensionSourceSearch)) {
+    const candidate = await resolveNextExtensionCandidate(
       packageManager,
       projectLookup,
-      source,
+      search,
       options.abortSignal,
     );
-    if (countEnabledResolvedResources(sourcePaths) === 0) {
-      throw new Error('Pi extension source could not be resolved');
-    }
-    resolved.extensions.push(...sourcePaths.extensions);
-    resolved.skills.push(...sourcePaths.skills);
-    resolved.prompts.push(...sourcePaths.prompts);
-    resolved.themes.push(...sourcePaths.themes);
+    resolutions.push({ ...search, candidate });
   }
-  return resolved;
+
+  while (true) {
+    assertPiSessionNotAborted(options.abortSignal);
+    const resolved = mergeExtensionSourcePaths(resolutions);
+    const resourceLoader = createPiResourceLoader(cwd, agentDir, options, settingsManager, resolved);
+    try {
+      assertPiSessionNotAborted(options.abortSignal);
+      await resourceLoader.reload();
+    } catch (error) {
+      invalidateRejectedResourceLoader(resourceLoader);
+      if (isAbortRequested(options.abortSignal)) {
+        throwPiSessionAborted();
+      }
+      throw new Error(safeExternalErrorMessage(error), { cause: error });
+    }
+    if (isAbortRequested(options.abortSignal)) {
+      invalidateRejectedResourceLoader(resourceLoader);
+      throwPiSessionAborted();
+    }
+
+    const extensionsResult = resourceLoader.getExtensions();
+    const loadErrors = actualExtensionLoadErrors(cwd, extensionsResult);
+    if (loadErrors.length === 0) {
+      return resourceLoader;
+    }
+
+    const failedResolutions = failedExtensionSources(cwd, resolutions, loadErrors);
+    if (failedResolutions === undefined || failedResolutions.size === 0) {
+      invalidateRejectedResourceLoader(resourceLoader);
+      throw new Error(`Pi extension loading failed: ${formatExtensionLoadErrors(loadErrors)}`);
+    }
+
+    for (const resolution of failedResolutions) {
+      const candidate = resolution.candidate;
+      const candidateErrors = loadErrorsForResolution(cwd, resolution, loadErrors);
+      recordExtensionCandidateFailure(
+        resolution.source,
+        resolution.failures,
+        candidate.scope,
+        `Pi extension loading failed: ${formatExtensionLoadErrors(candidateErrors)}`,
+      );
+    }
+
+    invalidateRejectedResourceLoader(resourceLoader);
+    for (const resolution of failedResolutions) {
+      resolution.candidate = await resolveNextExtensionCandidate(
+        packageManager,
+        projectLookup,
+        resolution,
+        options.abortSignal,
+      );
+    }
+  }
 }
 
 function inferImageMimeType(filePath: string): string {
@@ -582,13 +844,12 @@ function formatExtensionLoadErrors(
   errors: ReadonlyArray<{ path: string; error: string }>,
 ): string {
   return errors
-    .map((error) => `${path.basename(error.path) || 'extension'}: ${sanitizeSensitiveText(error.error)}`)
+    .map((error) => `extension: ${safeExternalErrorMessage(error.error)}`)
     .join('; ');
 }
 
 function formatExtensionRuntimeError(error: ExtensionError): string {
-  const extension = path.basename(error.extensionPath) || 'extension';
-  return `${extension} (${error.event}): ${sanitizeSensitiveText(error.error)}`;
+  return `extension (${error.event}): ${safeExternalErrorMessage(error.error)}`;
 }
 
 function registerPendingExtensionProviders(
@@ -716,56 +977,49 @@ async function createPiSession(
   if (isAbortRequested(options.abortSignal)) {
     throw new Error('Pi session aborted');
   }
-  const resolvedResources = await resolvePiResources(options.cwd, agentDir, options, settingsManager);
-  if (isAbortRequested(options.abortSignal)) {
-    throw new Error('Pi session aborted');
-  }
-  const providerOptions = options.providerOptions;
-  const resourceLoader = new DefaultResourceLoader({
-    cwd: options.cwd,
-    agentDir,
-    settingsManager,
-    additionalExtensionPaths: enabledResourcePaths(resolvedResources, 'extensions'),
-    additionalSkillPaths: enabledResourcePaths(resolvedResources, 'skills'),
-    additionalPromptTemplatePaths: enabledResourcePaths(resolvedResources, 'prompts'),
-    additionalThemePaths: enabledResourcePaths(resolvedResources, 'themes'),
-    noExtensions: providerOptions?.noExtensions,
-    noSkills: providerOptions?.noSkills,
-    noPromptTemplates: providerOptions?.noPromptTemplates,
-    noThemes: providerOptions?.noThemes,
-    noContextFiles: providerOptions?.noContextFiles,
-    ...(options.systemPrompt !== undefined ? { systemPrompt: options.systemPrompt } : {}),
-  });
-  await resourceLoader.reload();
-  if (isAbortRequested(options.abortSignal)) {
-    throw new Error('Pi session aborted');
-  }
-  const extensionsResult = resourceLoader.getExtensions();
-  const loadErrors = extensionsResult.errors;
-  if (loadErrors.length > 0) {
-    throw new Error(`Pi extension loading failed: ${formatExtensionLoadErrors(loadErrors)}`);
-  }
-  registerPendingExtensionProviders(runtime, extensionsResult);
-  const sessionManager = SessionManager.inMemory(
+  const resourceLoader = await resolvePiResourceLoader(
     options.cwd,
-    options.sessionId === undefined ? undefined : { id: options.sessionId },
-  );
-
-  const bashTool = createBashToolDefinition(options.cwd, {
-    spawnHook: (context) => ({
-      ...context,
-      env: buildEnvWithNestedObservabilitySnapshot(context.env, options.childProcessEnv),
-    }),
-  }) as unknown as NonNullable<CreateAgentSessionOptions['customTools']>[number];
-  const result = await createAgentSession({
-    cwd: options.cwd,
     agentDir,
-    modelRuntime: runtime,
-    resourceLoader,
-    sessionManager,
+    options,
     settingsManager,
-    customTools: [bashTool],
-  });
+  );
+  let result: Awaited<ReturnType<typeof createAgentSession>>;
+  try {
+    if (isAbortRequested(options.abortSignal)) {
+      throw new Error('Pi session aborted');
+    }
+    const extensionsResult = resourceLoader.getExtensions();
+    const loadErrors = extensionsResult.errors;
+    if (loadErrors.length > 0) {
+      throw new Error(`Pi extension loading failed: ${formatExtensionLoadErrors(loadErrors)}`);
+    }
+    registerPendingExtensionProviders(runtime, extensionsResult);
+    const sessionManager = SessionManager.inMemory(
+      options.cwd,
+      options.sessionId === undefined ? undefined : { id: options.sessionId },
+    );
+
+    const bashTool = createBashToolDefinition(options.cwd, {
+      spawnHook: (context) => ({
+        ...context,
+        env: buildEnvWithNestedObservabilitySnapshot(context.env, options.childProcessEnv),
+      }),
+    }) as unknown as NonNullable<CreateAgentSessionOptions['customTools']>[number];
+    result = await createAgentSession({
+      cwd: options.cwd,
+      agentDir,
+      modelRuntime: runtime,
+      resourceLoader,
+      sessionManager,
+      settingsManager,
+      customTools: [bashTool],
+    });
+  } catch (error) {
+    // No session owns the loader yet, so release event-bus subscriptions from
+    // an extension factory when setup or session creation fails.
+    invalidateRejectedResourceLoader(resourceLoader);
+    throw error;
+  }
   try {
     if (isAbortRequested(options.abortSignal)) {
       throw new Error('Pi session aborted');

--- a/src/infra/pi/client.ts
+++ b/src/infra/pi/client.ts
@@ -274,7 +274,11 @@ function isNpmExtensionSource(source: string): boolean {
 }
 
 function getSafeNpmPackageName(source: string): string | undefined {
-  const spec = source.trim().slice('npm:'.length);
+  const trimmed = source.trim();
+  if (!trimmed.startsWith('npm:')) {
+    return undefined;
+  }
+  const spec = trimmed.slice('npm:'.length);
   const versionDelimiter = spec.startsWith('@')
     ? spec.indexOf('@', spec.indexOf('/') + 1)
     : spec.indexOf('@');
@@ -373,9 +377,9 @@ function createProjectInstalledPackageLookup(
 }
 
 function extensionSourceDiagnosticLabel(source: string): string {
-  const packageName = getSafeNpmPackageName(source);
-  if (packageName !== undefined) {
-    return `npm:${packageName}`;
+  if (isNpmExtensionSource(source)) {
+    const packageName = getSafeNpmPackageName(source);
+    return packageName === undefined ? 'npm source' : `npm:${packageName}`;
   }
   const trimmed = source.trim();
   if (trimmed.startsWith('git:')) {
@@ -642,7 +646,10 @@ async function resolvePiResourceLoader(
       if (isAbortRequested(options.abortSignal)) {
         throwPiSessionAborted();
       }
-      throw new Error(safeExternalErrorMessage(error), { cause: error });
+      throw new Error(
+        `Pi extension resource loading failed: ${safeExternalErrorMessage(error)}`,
+        { cause: error },
+      );
     }
     if (isAbortRequested(options.abortSignal)) {
       invalidateRejectedResourceLoader(resourceLoader);
@@ -989,6 +996,7 @@ async function createPiSession(
       throw new Error('Pi session aborted');
     }
     const extensionsResult = resourceLoader.getExtensions();
+    // SDK conflicts do not select a fallback candidate, but they still make the final session unsafe.
     const loadErrors = extensionsResult.errors;
     if (loadErrors.length > 0) {
       throw new Error(`Pi extension loading failed: ${formatExtensionLoadErrors(loadErrors)}`);


### PR DESCRIPTION
## Summary

- Validate bare npm extension candidates through the Pi resource loader and advance project → user → temporary when loading fails.
- Preserve scoped lookup, resolution, and load diagnostics without exposing source paths or credentials.
- Accept scoped npm package members beginning with `.` or `_`, and align Pi resource-loading documentation.

## Execution Report

- `npm test -- src/__tests__/pi-client.test.ts` (65 passed)
- `npm run test:pi-sdk-smoke`
- `npm run build`
- `npm run lint`
- `npm test`
- `npm run test:it`
- `npm run test:e2e:mock`

## Notes

- Follow-up to #1423.
- This does not add Pi settings persistence or project/user installation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 明示した npm 拡張ソースは、既存のプロジェクト設定、ユーザー設定の順に再利用し、解決できない場合のみ一時的に読み込むようになりました。
  * バージョン指定付き npm ソースや npm 以外のソースは、一時的に読み込まれます。
  * 拡張の読み込み失敗時に、より安全で分かりやすいエラーメッセージを表示します。
  * 読み込み処理の中断を正しく検知し、不要なフォールバックを停止します。

* **ドキュメント**
  * 拡張ソースの解決と一時利用に関する説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
