### PR TITLE
feat: ワークフロー選択の説明を専用の薄色行で表示

### DIFF
--- a/src/__tests__/workflow-selection.test.ts
+++ b/src/__tests__/workflow-selection.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { WorkflowDirEntry } from '../infra/config/loaders/workflowLoader.js';
 import type { CategorizedWorkflows } from '../infra/config/loaders/workflowCategories.js';
 import type { WorkflowWithSource } from '../infra/config/loaders/workflowResolver.js';
+import type { SelectionOption } from '../features/workflowSelection/index.js';
 
 const selectOptionMock = vi.fn();
 const bookmarkState = vi.hoisted(() => ({
@@ -238,7 +239,7 @@ describe('selectWorkflowFromCategorizedWorkflows', () => {
 
     await selectWorkflowFromCategorizedWorkflows(categorized);
 
-    const workflowOptions = selectOptionMock.mock.calls[1]![1] as { label: string; value: string; description?: string }[];
+    const workflowOptions = selectOptionMock.mock.calls[1]![1] as SelectionOption[];
     expect(workflowOptions).toEqual([
       {
         label: '🎼 my-workflow',

--- a/src/__tests__/workflow-selection.test.ts
+++ b/src/__tests__/workflow-selection.test.ts
@@ -238,9 +238,13 @@ describe('selectWorkflowFromCategorizedWorkflows', () => {
 
     await selectWorkflowFromCategorizedWorkflows(categorized);
 
-    const workflowOptions = selectOptionMock.mock.calls[1]![1] as { label: string; value: string }[];
+    const workflowOptions = selectOptionMock.mock.calls[1]![1] as { label: string; value: string; description?: string }[];
     expect(workflowOptions).toEqual([
-      { label: '🎼 my-workflow — Configured description\\nwith control text', value: 'my-workflow' },
+      {
+        label: '🎼 my-workflow',
+        value: 'my-workflow',
+        description: 'Configured description\\nwith control text',
+      },
     ]);
   });
 
@@ -257,7 +261,11 @@ describe('selectWorkflowFromCategorizedWorkflows', () => {
 
     expect(selected).toBe('flat-workflow');
     expect(selectOptionMock.mock.calls[0]![1]).toEqual([
-      { label: '🎼 flat-workflow — Flat description\\twith control text', value: 'flat-workflow' },
+      {
+        label: '🎼 flat-workflow',
+        value: 'flat-workflow',
+        description: 'Flat description\\twith control text',
+      },
     ]);
   });
 
@@ -586,7 +594,7 @@ describe('selectWorkflow', () => {
     });
     expect(configMock.getWorkflowDescriptions).toHaveBeenCalledWith('/cwd');
     expect(selectOptionMock.mock.calls[1]![1]).toEqual(expect.arrayContaining([
-      { label: '🎼 custom-flow — Custom workflow', value: 'custom-flow' },
+      { label: '🎼 custom-flow', value: 'custom-flow', description: 'Custom workflow' },
     ]));
   });
 

--- a/src/__tests__/workflowSelectionHelpers.test.ts
+++ b/src/__tests__/workflowSelectionHelpers.test.ts
@@ -18,7 +18,7 @@ describe('workflow selection helpers', () => {
       { label: '📁 frontend/', value: '__category__:frontend' },
     ]);
     expect(buildTopLevelSelectOptions(items, { default: 'Standard coding workflow' })).toEqual([
-      { label: 'default — Standard coding workflow', value: 'default' },
+      { label: 'default', value: 'default', description: 'Standard coding workflow' },
       { label: '📁 frontend/', value: '__category__:frontend' },
     ]);
   });

--- a/src/features/workflowSelection/categorizedSelection.ts
+++ b/src/features/workflowSelection/categorizedSelection.ts
@@ -7,7 +7,7 @@ import { sanitizeTerminalText } from '../../shared/utils/index.js';
 import {
   applyBookmarks,
   formatWorkflowLabel,
-  getWorkflowDescription,
+  getWorkflowDescriptionOption,
   type SelectionOption,
   parseCategorySelection,
   CATEGORY_VALUE_PREFIX,
@@ -45,8 +45,9 @@ function buildCategoryLevelOptions(
 
   for (const workflowName of workflows) {
     options.push({
-      label: formatWorkflowLabel(workflowName, getWorkflowDescription(workflowName, workflowDescriptions), true),
+      label: formatWorkflowLabel(workflowName, true),
       value: workflowName,
+      description: getWorkflowDescriptionOption(workflowName, workflowDescriptions),
     });
   }
 
@@ -138,12 +139,9 @@ async function selectTopLevelWorkflowOption(
 
     for (const workflowName of getSelectableBookmarkedWorkflows(categorized)) {
       options.push({
-        label: `${formatWorkflowLabel(
-          workflowName,
-          getWorkflowDescription(workflowName, categorized.workflowDescriptions),
-          true,
-        )} [*]`,
+        label: `${formatWorkflowLabel(workflowName, true)} [*]`,
         value: workflowName,
+        description: getWorkflowDescriptionOption(workflowName, categorized.workflowDescriptions),
       });
     }
 

--- a/src/features/workflowSelection/entrySelection.ts
+++ b/src/features/workflowSelection/entrySelection.ts
@@ -9,7 +9,7 @@ import {
   buildTopLevelSelectOptions,
   buildWorkflowSelectionItems,
   formatWorkflowLabel,
-  getWorkflowDescription,
+  getWorkflowDescriptionOption,
   parseCategorySelection,
   type SelectionOption,
 } from './options.js';
@@ -28,8 +28,9 @@ async function selectWorkflowFromEntriesWithCategories(
 
   if (!hasCategories) {
     const baseOptions: SelectionOption[] = availableWorkflows.map((name) => ({
-      label: formatWorkflowLabel(name, getWorkflowDescription(name, workflowDescriptions), true),
+      label: formatWorkflowLabel(name, true),
       value: name,
+      description: getWorkflowDescriptionOption(name, workflowDescriptions),
     }));
     const buildFlatOptions = (): SelectionOption[] =>
       applyBookmarks(baseOptions, getBookmarkedWorkflows());

--- a/src/features/workflowSelection/options.ts
+++ b/src/features/workflowSelection/options.ts
@@ -9,6 +9,7 @@ export type WorkflowSelectionItem =
 export interface SelectionOption {
   label: string;
   value: string;
+  description?: string;
 }
 
 export const CATEGORY_VALUE_PREFIX = '__category__:';
@@ -27,16 +28,18 @@ export function getWorkflowDescription(
   return workflowDescriptions[workflowName];
 }
 
-export function formatWorkflowLabel(
+/** Description rendered on the option's second line (dimmed by the select menu). */
+export function getWorkflowDescriptionOption(
   workflowName: string,
-  workflowDescription: string | undefined,
-  includeIcon: boolean,
-): string {
+  workflowDescriptions?: Readonly<Record<string, string>>,
+): string | undefined {
+  const description = getWorkflowDescription(workflowName, workflowDescriptions);
+  return description === undefined ? undefined : sanitizeTerminalText(description);
+}
+
+export function formatWorkflowLabel(workflowName: string, includeIcon: boolean): string {
   const safeName = sanitizeTerminalText(workflowName);
-  const label = includeIcon ? `🎼 ${safeName}` : safeName;
-  return workflowDescription === undefined
-    ? label
-    : `${label} — ${sanitizeTerminalText(workflowDescription)}`;
+  return includeIcon ? `🎼 ${safeName}` : safeName;
 }
 
 export function buildWorkflowSelectionItems(entries: WorkflowDirEntry[]): WorkflowSelectionItem[] {
@@ -67,8 +70,9 @@ export function buildTopLevelSelectOptions(
   return items.map((item) => {
     if (item.type === 'workflow') {
       return {
-        label: formatWorkflowLabel(item.name, getWorkflowDescription(item.name, workflowDescriptions), false),
+        label: formatWorkflowLabel(item.name, false),
         value: item.name,
+        description: getWorkflowDescriptionOption(item.name, workflowDescriptions),
       };
     }
     return {
@@ -100,8 +104,9 @@ export function buildCategoryWorkflowOptions(
   return categoryItem.workflows.map((qualifiedName) => {
     const displayName = qualifiedName.split('/').pop() ?? qualifiedName;
     return {
-      label: formatWorkflowLabel(displayName, getWorkflowDescription(qualifiedName, workflowDescriptions), false),
+      label: formatWorkflowLabel(displayName, false),
       value: qualifiedName,
+      description: getWorkflowDescriptionOption(qualifiedName, workflowDescriptions),
     };
   });
 }


### PR DESCRIPTION
## 目的

ワークフロー選択の説明文（#1456 で追加）がラベルに ` — 説明` と連結されていたため、名前と同じ色・太さで表示されていた。説明は補助情報なので、thinking 表示と同じ薄い色（`chalk.gray`）で出したい。

## 変更内容

- ラベル連結をやめ、選択コンポーネント純正の `SelectOptionItem.description` フィールドに載せ替え。`renderSingleOption` が説明を2行目に `chalk.gray`（ESC[90m、thinking と同色）で描画する既存経路に乗るため、共有コンポーネントの改修はなし。
- モード選択・exec プリセット選択・セッション選択と同じ見た目に統一される。
- 全選択経路（カテゴリツリー型・フラット型・ブックマーク一覧）を切り替え。
- レイアウト: 1行 → 2行表示になる（ビューポートのスクロール計算は `countItemLines` が対応済み）。

## テスト

- `workflow-selection.test.ts` / `workflowSelectionHelpers.test.ts` を新構造（label + description 分離）に更新
- 実施済み: `npm run build`、`npm run lint`、`npm test`（全シャード成功）
- FORCE_COLOR 強制下で `renderMenu` の出力を目視確認し、説明行が `ESC[90m` で描画され、選択行の強調が説明に漏れないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ワークフロー選択画面で、説明文をラベルから分離して表示するよう改善しました。
  * カテゴリ内、ブックマーク済み、フラット形式の各ワークフローで、名称と説明がより見やすく表示されます。
  * 説明文がない場合も、選択肢を適切に表示できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->