### PR TITLE
test(acp): #1460のUser Commentフレーミングにacpテストを追従

### DIFF
--- a/src/__tests__/acpAgent.test.ts
+++ b/src/__tests__/acpAgent.test.ts
@@ -387,7 +387,12 @@ describe('TAKT ACP agent adapter', () => {
         });
 
         expect(mockCallAIWithRetry).toHaveBeenCalledOnce();
-        expect(mockCallAIWithRetry.mock.calls[0]?.[0]).toBe('describe parser states');
+        // #1460: assistant conversation input is framed as a user comment so
+        // fix-shaped remarks are not misread as implementation requests. The
+        // original ACP protocol text must survive inside the framed prompt.
+        const sentPrompt = mockCallAIWithRetry.mock.calls[0]?.[0] as string;
+        expect(sentPrompt).toContain('describe parser states');
+        expect(sentPrompt).toContain('## User Comment');
         const systemPrompt = mockCallAIWithRetry.mock.calls[0]?.[1] as string;
         expect(systemPrompt).toMatch(/Gherkin/);
         if (expectedFormalSpec) {


### PR DESCRIPTION
## 背景

#1460 で assistant 会話のユーザーメッセージに「## User Comment」フレーミングが付与されるようになった。ACP の会話も同じ `createAssistantConversationPlan` の `transformPrompt` を通るため、素通しを前提にしていた `acpAgent.test.ts` の2件（Y/n / y/N formal spec default）が失敗し、main の `test:it:heavy` shard 4 が赤になっている。

- main (6a4fdb3a) の CI: https://github.com/nrslib/takt/actions/runs/32579800824 と同一の失敗

## 変更

- プロンプトの完全一致 assertion を「元の ACP 入力がフレーム内に保持される」+「User Comment フレーミングが存在する」の2点検証へ変更

ACP も対話で指示書を組み立てる経路なので、#1460 の意図（修正依頼の形のコメントを実装依頼と誤読させない）は ACP 入力にも適用されるのが正しい、という判断でテスト側を追従させた。

## 検証

- `npm test -- src/__tests__/acpAgent.test.ts` 全件パス