### PR TITLE
fix(ui): prevent spinner from corrupting terminal output

### DIFF
--- a/src/__tests__/StreamDisplay.test.ts
+++ b/src/__tests__/StreamDisplay.test.ts
@@ -227,6 +227,70 @@ describe('StreamDisplay', () => {
     });
   });
 
+  describe('tool spinner terminal output', () => {
+    it('should keep multiline Bash previews on one line', () => {
+      vi.useFakeTimers();
+      try {
+        const display = new StreamDisplay('test-agent', false);
+        display.showToolUse('Bash', { command: 'printf "first\\nsecond"\n echo third' });
+
+        vi.advanceTimersByTime(80);
+
+        const spinnerWrites = stdoutWriteSpy.mock.calls
+          .map(([chunk]) => String(chunk))
+          .filter((chunk) => chunk.startsWith('\r  '));
+        expect(spinnerWrites).toHaveLength(1);
+        expect(spinnerWrites[0]).not.toContain('\n');
+
+        display.flush();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should keep unregistered tool previews on one line', () => {
+      vi.useFakeTimers();
+      try {
+        const display = new StreamDisplay('test-agent', false);
+        display.showToolUse('CustomTool', { input: 'first\nsecond' });
+
+        vi.advanceTimersByTime(80);
+
+        const spinnerWrites = stdoutWriteSpy.mock.calls
+          .map(([chunk]) => String(chunk))
+          .filter((chunk) => chunk.startsWith('\r  '));
+        expect(spinnerWrites).toHaveLength(1);
+        expect(spinnerWrites[0]).not.toContain('\n');
+
+        display.flush();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should clear a spinner within a narrow terminal width', () => {
+      vi.useFakeTimers();
+      const savedColumns = process.stdout.columns;
+      Object.defineProperty(process.stdout, 'columns', { value: 40, configurable: true });
+      try {
+        const display = new StreamDisplay('test-agent', false);
+        display.showToolUse('Bash', { command: 'ls' });
+
+        vi.advanceTimersByTime(80);
+        display.flush();
+
+        const clearWrite = stdoutWriteSpy.mock.calls
+          .map(([chunk]) => String(chunk))
+          .find((chunk) => chunk === '\r\x1b[K');
+        expect(clearWrite).toBeDefined();
+        expect(clearWrite?.length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(40);
+      } finally {
+        Object.defineProperty(process.stdout, 'columns', { value: savedColumns, configurable: true });
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('showToolResult AskUserQuestion content suppression', () => {
     it('should suppress content preview for AskUserQuestion non-error result', () => {
       const display = new StreamDisplay('test-agent', false);

--- a/src/__tests__/StreamDisplay.test.ts
+++ b/src/__tests__/StreamDisplay.test.ts
@@ -232,7 +232,9 @@ describe('StreamDisplay', () => {
       vi.useFakeTimers();
       try {
         const display = new StreamDisplay('test-agent', false);
-        display.showToolUse('Bash', { command: 'printf "first\\nsecond"\n echo third' });
+        display.showToolUse('Bash', {
+          command: `first   second\n third    fourth ${'x'.repeat(50)}`,
+        });
 
         vi.advanceTimersByTime(80);
 
@@ -241,6 +243,7 @@ describe('StreamDisplay', () => {
           .filter((chunk) => chunk.startsWith('\r  '));
         expect(spinnerWrites).toHaveLength(1);
         expect(spinnerWrites[0]).not.toContain('\n');
+        expect(spinnerWrites[0]).toContain(`first second third fourth ${'x'.repeat(31)}...`);
 
         display.flush();
       } finally {
@@ -270,8 +273,6 @@ describe('StreamDisplay', () => {
 
     it('should clear a spinner within a narrow terminal width', () => {
       vi.useFakeTimers();
-      const savedColumns = process.stdout.columns;
-      Object.defineProperty(process.stdout, 'columns', { value: 40, configurable: true });
       try {
         const display = new StreamDisplay('test-agent', false);
         display.showToolUse('Bash', { command: 'ls' });
@@ -282,10 +283,8 @@ describe('StreamDisplay', () => {
         const clearWrite = stdoutWriteSpy.mock.calls
           .map(([chunk]) => String(chunk))
           .find((chunk) => chunk === '\r\x1b[K');
-        expect(clearWrite).toBeDefined();
-        expect(clearWrite?.length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(40);
+        expect(clearWrite).toBe('\r\x1b[K');
       } finally {
-        Object.defineProperty(process.stdout, 'columns', { value: savedColumns, configurable: true });
         vi.useRealTimers();
       }
     });

--- a/src/__tests__/statusLine.test.ts
+++ b/src/__tests__/statusLine.test.ts
@@ -25,6 +25,7 @@ describe('StatusLine', () => {
 
   afterEach(() => {
     statusLine.stop();
+    vi.useRealTimers();
     Object.defineProperty(process.stdout, 'isTTY', { value: savedStdoutIsTTY, configurable: true });
     process.stdout.write = savedStdoutWrite;
     process.stderr.write = savedStderrWrite;
@@ -130,6 +131,22 @@ describe('StatusLine', () => {
     vi.advanceTimersByTime(100);
 
     expect(stdoutChunks.some((chunk) => chunk.includes('updated'))).toBe(true);
+  });
+
+  it('should defer start after suspending an inactive status line', () => {
+    vi.useFakeTimers();
+    statusLine.stop();
+    statusLine.suspend();
+    statusLine.start('deferred');
+
+    vi.advanceTimersByTime(100);
+
+    expect(stdoutChunks.some((chunk) => chunk.includes('deferred'))).toBe(false);
+
+    statusLine.resume();
+    vi.advanceTimersByTime(100);
+
+    expect(stdoutChunks.some((chunk) => chunk.includes('deferred'))).toBe(true);
   });
 
   it('should be safe to call stop multiple times', () => {

--- a/src/__tests__/statusLine.test.ts
+++ b/src/__tests__/statusLine.test.ts
@@ -98,6 +98,40 @@ describe('StatusLine', () => {
     statusLine.stop();
   });
 
+  it('should defer start while suspended and resume with the latest message', () => {
+    vi.useFakeTimers();
+    statusLine.start('original');
+    statusLine.suspend();
+    stdoutChunks = [];
+
+    statusLine.start('deferred');
+    vi.advanceTimersByTime(100);
+
+    expect(stdoutChunks.some((chunk) => chunk.includes('deferred'))).toBe(false);
+
+    statusLine.resume();
+    vi.advanceTimersByTime(100);
+
+    expect(stdoutChunks.some((chunk) => chunk.includes('deferred'))).toBe(true);
+  });
+
+  it('should defer update while suspended and resume with the latest message', () => {
+    vi.useFakeTimers();
+    statusLine.start('original');
+    statusLine.suspend();
+    stdoutChunks = [];
+
+    statusLine.update('updated');
+    vi.advanceTimersByTime(100);
+
+    expect(stdoutChunks.some((chunk) => chunk.includes('updated'))).toBe(false);
+
+    statusLine.resume();
+    vi.advanceTimersByTime(100);
+
+    expect(stdoutChunks.some((chunk) => chunk.includes('updated'))).toBe(true);
+  });
+
   it('should be safe to call stop multiple times', () => {
     statusLine.start('test');
     statusLine.stop();
@@ -106,5 +140,34 @@ describe('StatusLine', () => {
 
   it('should be safe to call stop without start', () => {
     statusLine.stop(); // should not throw
+  });
+
+  it('should resume only after all nested suspensions are released', () => {
+    vi.useFakeTimers();
+    statusLine.start('Working...');
+    statusLine.suspend();
+    statusLine.suspend();
+    stdoutChunks = [];
+
+    statusLine.resume();
+    vi.advanceTimersByTime(100);
+    expect(stdoutChunks.some((chunk) => chunk.includes('Working...'))).toBe(false);
+
+    statusLine.resume();
+    vi.advanceTimersByTime(100);
+    expect(stdoutChunks.some((chunk) => chunk.includes('Working...'))).toBe(true);
+  });
+
+  it('should not resume after stop invalidates a suspension', () => {
+    vi.useFakeTimers();
+    statusLine.start('Working...');
+    statusLine.suspend();
+    statusLine.stop();
+    stdoutChunks = [];
+
+    statusLine.resume();
+    vi.advanceTimersByTime(100);
+
+    expect(stdoutChunks.some((chunk) => chunk.includes('Working...'))).toBe(false);
   });
 });

--- a/src/__tests__/userInputHandler-statusLine.test.ts
+++ b/src/__tests__/userInputHandler-statusLine.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { setupRawStdin, restoreStdin } from './helpers/stdinSimulator.js';
+import { confirm, promptInput, readMultilineFromStream } from '../shared/prompt/confirm.js';
+import { selectOption, selectOptionWithDefault } from '../shared/prompt/select.js';
+import { statusLine } from '../shared/ui/StatusLine.js';
+
+const readlineMocks = vi.hoisted(() => ({
+  createInterface: vi.fn(),
+}));
+
+vi.mock('node:readline', () => ({
+  createInterface: readlineMocks.createInterface,
+}));
+
+describe('user input and StatusLine', () => {
+  let savedStdoutIsTTY: boolean | undefined;
+  let savedStdinIsTTY: boolean | undefined;
+  let savedStdoutWrite: typeof process.stdout.write;
+  let savedStderrWrite: typeof process.stderr.write;
+  let savedStdinPause: typeof process.stdin.pause;
+  let savedNoTty: string | undefined;
+  let stdoutChunks: string[];
+
+  beforeEach(() => {
+    statusLine.stop();
+    savedStdoutIsTTY = process.stdout.isTTY;
+    savedStdinIsTTY = process.stdin.isTTY;
+    savedStdoutWrite = process.stdout.write;
+    savedStderrWrite = process.stderr.write;
+    savedStdinPause = process.stdin.pause;
+    savedNoTty = process.env.TAKT_NO_TTY;
+    stdoutChunks = [];
+
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    process.env.TAKT_NO_TTY = '0';
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    process.stdin.pause = (() => process.stdin) as typeof process.stdin.pause;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    statusLine.stop();
+    restoreStdin();
+    vi.useRealTimers();
+    Object.defineProperty(process.stdout, 'isTTY', { value: savedStdoutIsTTY, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: savedStdinIsTTY, configurable: true });
+    process.stdout.write = savedStdoutWrite;
+    process.stderr.write = savedStderrWrite;
+    process.stdin.pause = savedStdinPause;
+    if (savedNoTty === undefined) {
+      delete process.env.TAKT_NO_TTY;
+    } else {
+      process.env.TAKT_NO_TTY = savedNoTty;
+    }
+    readlineMocks.createInterface.mockReset();
+  });
+
+  it('should not redraw the status line while promptInput is waiting', async () => {
+    let answerCallback: ((answer: string) => void) | undefined;
+    readlineMocks.createInterface.mockImplementation(() => ({
+      question: (_prompt: string, callback: (answer: string) => void) => {
+        answerCallback = callback;
+      },
+      close: vi.fn(),
+    }));
+
+    statusLine.start('Running...');
+    const inputPromise = promptInput('Input');
+
+    vi.advanceTimersByTime(240);
+
+    expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(false);
+    expect(answerCallback).toBeDefined();
+
+    answerCallback?.('answer');
+    await expect(inputPromise).resolves.toBe('answer');
+
+    vi.advanceTimersByTime(100);
+    expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(true);
+  });
+
+  it('should not redraw the status line while readMultilineFromStream is waiting', async () => {
+    const actualReadline = await vi.importActual<typeof import('node:readline')>('node:readline');
+    readlineMocks.createInterface.mockImplementation((options) => actualReadline.createInterface(options));
+
+    const input = new PassThrough();
+    statusLine.start('Running...');
+    const inputPromise = readMultilineFromStream(input);
+    await Promise.resolve();
+    const waitingOutputStart = stdoutChunks.length;
+
+    vi.advanceTimersByTime(240);
+
+    const waitingOutput = stdoutChunks.slice(waitingOutputStart);
+    expect(waitingOutput.some((chunk) => chunk.includes('Running...'))).toBe(false);
+
+    input.end('first line\n\n');
+    await expect(inputPromise).resolves.toBe('first line');
+
+    vi.advanceTimersByTime(100);
+    expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(true);
+  });
+
+  it('should not redraw the status line while selectOption is waiting', async () => {
+    const controller = setupRawStdin([]);
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    statusLine.start('Running...');
+    const selectionPromise = selectOption('Select', [{ label: 'Option', value: 'option' }]);
+    await Promise.resolve();
+    const waitingOutputStart = stdoutChunks.length;
+
+    vi.advanceTimersByTime(240);
+
+    const waitingOutput = stdoutChunks.slice(waitingOutputStart);
+    expect(waitingOutput.some((chunk) => chunk.includes('Running...'))).toBe(false);
+
+    controller.send('\r');
+    await expect(selectionPromise).resolves.toBe('option');
+
+    vi.advanceTimersByTime(100);
+    expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(true);
+  });
+
+  it('should suspend and resume the status line while confirm is waiting', async () => {
+    let answerCallback: ((answer: string) => void) | undefined;
+    readlineMocks.createInterface.mockImplementation(() => ({
+      question: (_prompt: string, callback: (answer: string) => void) => {
+        answerCallback = callback;
+      },
+      close: vi.fn(),
+    }));
+
+    statusLine.start('Running...');
+    const confirmationPromise = confirm('Continue?');
+
+    vi.advanceTimersByTime(240);
+
+    expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(false);
+    expect(answerCallback).toBeDefined();
+
+    answerCallback?.('y');
+    await expect(confirmationPromise).resolves.toBe(true);
+
+    vi.advanceTimersByTime(100);
+    expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(true);
+  });
+
+  it('should suspend and resume the status line while confirm reads from a pipe', async () => {
+    let lineHandler: ((line: string) => void) | undefined;
+    let closeHandler: (() => void) | undefined;
+    readlineMocks.createInterface.mockImplementation(() => ({
+      on: (event: string, callback: (...args: unknown[]) => void) => {
+        if (event === 'line') lineHandler = (line: unknown) => callback(line);
+        if (event === 'close') closeHandler = () => callback();
+      },
+    }));
+
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    process.env.TAKT_NO_TTY = '1';
+    statusLine.start('Running...');
+    const confirmationPromise = confirm('Continue?');
+    await Promise.resolve();
+    const waitingOutputStart = stdoutChunks.length;
+
+    vi.advanceTimersByTime(240);
+
+    const waitingOutput = stdoutChunks.slice(waitingOutputStart);
+    expect(waitingOutput.some((chunk) => chunk.includes('Running...'))).toBe(false);
+    expect(lineHandler).toBeDefined();
+    expect(closeHandler).toBeDefined();
+
+    lineHandler?.('y');
+    closeHandler?.();
+    await expect(confirmationPromise).resolves.toBe(true);
+
+    vi.advanceTimersByTime(100);
+    expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(true);
+  });
+
+  it('should suspend and resume the status line while selectOptionWithDefault is waiting', async () => {
+    const controller = setupRawStdin([]);
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    statusLine.start('Running...');
+    const selectionPromise = selectOptionWithDefault(
+      'Select',
+      [{ label: 'Option', value: 'option' }],
+      'option',
+    );
+    await Promise.resolve();
+    const waitingOutputStart = stdoutChunks.length;
+
+    vi.advanceTimersByTime(240);
+
+    const waitingOutput = stdoutChunks.slice(waitingOutputStart);
+    expect(waitingOutput.some((chunk) => chunk.includes('Running...'))).toBe(false);
+
+    controller.send('\r');
+    await expect(selectionPromise).resolves.toBe('option');
+
+    vi.advanceTimersByTime(100);
+    expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(true);
+  });
+});

--- a/src/__tests__/userInputHandler-statusLine.test.ts
+++ b/src/__tests__/userInputHandler-statusLine.test.ts
@@ -20,6 +20,7 @@ describe('user input and StatusLine', () => {
   let savedStderrWrite: typeof process.stderr.write;
   let savedStdinPause: typeof process.stdin.pause;
   let savedNoTty: string | undefined;
+  let savedTouchTty: string | undefined;
   let stdoutChunks: string[];
 
   beforeEach(() => {
@@ -30,6 +31,7 @@ describe('user input and StatusLine', () => {
     savedStderrWrite = process.stderr.write;
     savedStdinPause = process.stdin.pause;
     savedNoTty = process.env.TAKT_NO_TTY;
+    savedTouchTty = process.env.TAKT_TEST_FLG_TOUCH_TTY;
     stdoutChunks = [];
 
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
@@ -58,6 +60,11 @@ describe('user input and StatusLine', () => {
     } else {
       process.env.TAKT_NO_TTY = savedNoTty;
     }
+    if (savedTouchTty === undefined) {
+      delete process.env.TAKT_TEST_FLG_TOUCH_TTY;
+    } else {
+      process.env.TAKT_TEST_FLG_TOUCH_TTY = savedTouchTty;
+    }
     readlineMocks.createInterface.mockReset();
   });
 
@@ -82,6 +89,18 @@ describe('user input and StatusLine', () => {
     await expect(inputPromise).resolves.toBe('answer');
 
     vi.advanceTimersByTime(100);
+    expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(true);
+  });
+
+  it('should resume the status line when promptInput rejects during forced TTY validation', async () => {
+    process.env.TAKT_TEST_FLG_TOUCH_TTY = '1';
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    statusLine.start('Running...');
+
+    await expect(promptInput('Input')).rejects.toThrow('TAKT_TEST_FLG_TOUCH_TTY=1 requires a TTY');
+
+    vi.advanceTimersByTime(100);
+
     expect(stdoutChunks.some((chunk) => chunk.includes('Running...'))).toBe(true);
   });
 

--- a/src/shared/prompt/confirm.ts
+++ b/src/shared/prompt/confirm.ts
@@ -8,6 +8,7 @@
 import * as readline from 'node:readline';
 import chalk from 'chalk';
 import { resolveTtyPolicy, assertTtyIfForced } from './tty.js';
+import { statusLine } from '../ui/StatusLine.js';
 
 function pauseStdinSafely(): void {
   try {
@@ -24,30 +25,36 @@ function pauseStdinSafely(): void {
  * @returns User input or null if cancelled
  */
 export async function promptInput(message: string): Promise<string | null> {
-  const { useTty, forceTouchTty } = resolveTtyPolicy();
-  assertTtyIfForced(forceTouchTty);
-  if (!useTty) {
-    return null;
-  }
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  return new Promise((resolve) => {
-    rl.question(chalk.green(message + ': '), (answer) => {
-      rl.close();
-      pauseStdinSafely();
-
-      const trimmed = answer.trim();
-      if (!trimmed) {
-        resolve(null);
-        return;
-      }
-
-      resolve(trimmed);
+  statusLine.suspend();
+  try {
+    const { useTty, forceTouchTty } = resolveTtyPolicy();
+    assertTtyIfForced(forceTouchTty);
+    if (!useTty) {
+      return null;
+    }
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
     });
-  });
+
+    const result = await new Promise<string | null>((resolve) => {
+      rl.question(chalk.green(message + ': '), (answer) => {
+        rl.close();
+        pauseStdinSafely();
+
+        const trimmed = answer.trim();
+        if (!trimmed) {
+          resolve(null);
+          return;
+        }
+
+        resolve(trimmed);
+      });
+    });
+    return result;
+  } finally {
+    statusLine.resume();
+  }
 }
 
 /**
@@ -55,38 +62,44 @@ export async function promptInput(message: string): Promise<string | null> {
  * An empty line finishes input. If the first line is empty, returns null.
  * Exported for testing.
  */
-export function readMultilineFromStream(input: NodeJS.ReadableStream): Promise<string | null> {
-  const lines: string[] = [];
-  const rl = readline.createInterface({ input });
+export async function readMultilineFromStream(input: NodeJS.ReadableStream): Promise<string | null> {
+  statusLine.suspend();
+  try {
+    const lines: string[] = [];
+    const rl = readline.createInterface({ input });
 
-  return new Promise((resolve) => {
-    let resolved = false;
+    const result = await new Promise<string | null>((resolve) => {
+      let resolved = false;
 
-    rl.on('line', (line) => {
-      if (line === '' && lines.length > 0) {
-        resolved = true;
-        rl.close();
-        const result = lines.join('\n').trim();
-        resolve(result || null);
-        return;
-      }
+      rl.on('line', (line) => {
+        if (line === '' && lines.length > 0) {
+          resolved = true;
+          rl.close();
+          const result = lines.join('\n').trim();
+          resolve(result || null);
+          return;
+        }
 
-      if (line === '' && lines.length === 0) {
-        resolved = true;
-        rl.close();
-        resolve(null);
-        return;
-      }
+        if (line === '' && lines.length === 0) {
+          resolved = true;
+          rl.close();
+          resolve(null);
+          return;
+        }
 
-      lines.push(line);
+        lines.push(line);
+      });
+
+      rl.on('close', () => {
+        if (!resolved) {
+          resolve(lines.length > 0 ? lines.join('\n').trim() : null);
+        }
+      });
     });
-
-    rl.on('close', () => {
-      if (!resolved) {
-        resolve(lines.length > 0 ? lines.join('\n').trim() : null);
-      }
-    });
-  });
+    return result;
+  } finally {
+    statusLine.resume();
+  }
 }
 
 /**
@@ -94,38 +107,44 @@ export function readMultilineFromStream(input: NodeJS.ReadableStream): Promise<s
  * @returns true for yes, false for no
  */
 export async function confirm(message: string, defaultYes = true): Promise<boolean> {
-  const { useTty, forceTouchTty } = resolveTtyPolicy();
-  assertTtyIfForced(forceTouchTty);
-  if (!useTty) {
-    // Support piped stdin (e.g. echo "y" | takt repertoire add ...)
-    // Once the pipe queue is initialized, stdin may be destroyed but queued lines remain.
-    if (pipeLineQueue !== null || (!process.stdin.isTTY && process.stdin.readable && !process.stdin.destroyed)) {
-      return readConfirmFromPipe(defaultYes);
-    }
-    return defaultYes;
-  }
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  const hint = defaultYes ? '[Y/n]' : '[y/N]';
-
-  return new Promise((resolve) => {
-    rl.question(chalk.green(`${message} ${hint}: `), (answer) => {
-      rl.close();
-      pauseStdinSafely();
-
-      const trimmed = answer.trim().toLowerCase();
-
-      if (!trimmed) {
-        resolve(defaultYes);
-        return;
+  statusLine.suspend();
+  try {
+    const { useTty, forceTouchTty } = resolveTtyPolicy();
+    assertTtyIfForced(forceTouchTty);
+    if (!useTty) {
+      // Support piped stdin (e.g. echo "y" | takt repertoire add ...)
+      // Once the pipe queue is initialized, stdin may be destroyed but queued lines remain.
+      if (pipeLineQueue !== null || (!process.stdin.isTTY && process.stdin.readable && !process.stdin.destroyed)) {
+        return await readConfirmFromPipe(defaultYes);
       }
-
-      resolve(trimmed === 'y' || trimmed === 'yes');
+      return defaultYes;
+    }
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
     });
-  });
+
+    const hint = defaultYes ? '[Y/n]' : '[y/N]';
+
+    const result = await new Promise<boolean>((resolve) => {
+      rl.question(chalk.green(`${message} ${hint}: `), (answer) => {
+        rl.close();
+        pauseStdinSafely();
+
+        const trimmed = answer.trim().toLowerCase();
+
+        if (!trimmed) {
+          resolve(defaultYes);
+          return;
+        }
+
+        resolve(trimmed === 'y' || trimmed === 'yes');
+      });
+    });
+    return result;
+  } finally {
+    statusLine.resume();
+  }
 }
 
 /**

--- a/src/shared/prompt/select.ts
+++ b/src/shared/prompt/select.ts
@@ -21,6 +21,7 @@ import {
   renderMenuWithViewport,
 } from './select-viewport.js';
 import { ESCAPE_SEQUENCE_TIMEOUT_MS, KeyInputDecoder } from './select-key-input.js';
+import { statusLine } from '../ui/StatusLine.js';
 
 const MAX_STDIN_CHUNK_BYTES = 64 * 1024;
 
@@ -386,20 +387,25 @@ export async function selectOption<T extends string>(
 ): Promise<T | null> {
   if (options.length === 0) return null;
 
-  const { selectedIndex, finalOptions } = await interactiveSelect(message, options, 0, true, callbacks);
+  statusLine.suspend();
+  try {
+    const { selectedIndex, finalOptions } = await interactiveSelect(message, options, 0, true, callbacks);
 
-  if (selectedIndex === finalOptions.length || selectedIndex === -1) {
+    if (selectedIndex === finalOptions.length || selectedIndex === -1) {
+      return null;
+    }
+
+    const selected = finalOptions[selectedIndex];
+    if (selected && callbacks?.showConfirmation !== false) {
+      console.log(chalk.green(`  ✓ ${selected.label}`));
+    }
+
+    if (selected) return selected.value;
+
     return null;
+  } finally {
+    statusLine.resume();
   }
-
-  const selected = finalOptions[selectedIndex];
-  if (selected && callbacks?.showConfirmation !== false) {
-    console.log(chalk.green(`  ✓ ${selected.label}`));
-  }
-
-  if (selected) return selected.value;
-
-  return null;
 }
 
 /**
@@ -413,25 +419,30 @@ export async function selectOptionWithDefault<T extends string>(
 ): Promise<T | null> {
   if (options.length === 0) return defaultValue;
 
-  const defaultIndex = options.findIndex((opt) => opt.value === defaultValue);
-  const initialIndex = defaultIndex >= 0 ? defaultIndex : 0;
+  statusLine.suspend();
+  try {
+    const defaultIndex = options.findIndex((opt) => opt.value === defaultValue);
+    const initialIndex = defaultIndex >= 0 ? defaultIndex : 0;
 
-  const decoratedOptions: SelectOptionItem<T>[] = options.map((opt) => ({
-    ...opt,
-    label: opt.value === defaultValue ? `${opt.label} ${chalk.green('(default)')}` : opt.label,
-  }));
+    const decoratedOptions: SelectOptionItem<T>[] = options.map((opt) => ({
+      ...opt,
+      label: opt.value === defaultValue ? `${opt.label} ${chalk.green('(default)')}` : opt.label,
+    }));
 
-  const { selectedIndex } = await interactiveSelect(message, decoratedOptions, initialIndex, true);
+    const { selectedIndex } = await interactiveSelect(message, decoratedOptions, initialIndex, true);
 
-  if (selectedIndex === options.length || selectedIndex === -1) {
-    return null;
+    if (selectedIndex === options.length || selectedIndex === -1) {
+      return null;
+    }
+
+    const selected = options[selectedIndex];
+    if (selected) {
+      console.log(chalk.green(`  ✓ ${selected.label}`));
+      return selected.value;
+    }
+
+    return defaultValue;
+  } finally {
+    statusLine.resume();
   }
-
-  const selected = options[selectedIndex];
-  if (selected) {
-    console.log(chalk.green(`  ✓ ${selected.label}`));
-    return selected.value;
-  }
-
-  return defaultValue;
 }

--- a/src/shared/ui/StatusLine.ts
+++ b/src/shared/ui/StatusLine.ts
@@ -73,7 +73,10 @@ class StatusLineImpl {
       this.suspendDepth++;
       return;
     }
-    if (!this.active) return;
+    if (!this.active) {
+      this.suspendDepth = 1;
+      return;
+    }
 
     const message = this.message;
     this.stop();

--- a/src/shared/ui/StatusLine.ts
+++ b/src/shared/ui/StatusLine.ts
@@ -21,8 +21,14 @@ class StatusLineImpl {
   private savedStdoutWrite?: typeof process.stdout.write;
   private savedStderrWrite?: typeof process.stderr.write;
   private rendering = false;
+  private suspendedMessage?: string;
+  private suspendDepth = 0;
 
   start(message: string): void {
+    if (this.suspendDepth > 0) {
+      this.suspendedMessage = message;
+      return;
+    }
     if (this.active) {
       this.message = message;
       return;
@@ -55,10 +61,40 @@ class StatusLineImpl {
   }
 
   update(message: string): void {
+    if (this.suspendDepth > 0) {
+      this.suspendedMessage = message;
+      return;
+    }
     this.message = message;
   }
 
+  suspend(): void {
+    if (this.suspendDepth > 0) {
+      this.suspendDepth++;
+      return;
+    }
+    if (!this.active) return;
+
+    const message = this.message;
+    this.stop();
+    this.suspendedMessage = message;
+    this.suspendDepth = 1;
+  }
+
+  resume(): void {
+    if (this.suspendDepth === 0) return;
+    this.suspendDepth--;
+    if (this.suspendDepth > 0) return;
+
+    if (this.suspendedMessage === undefined) return;
+    const message = this.suspendedMessage;
+    this.suspendedMessage = undefined;
+    this.start(message);
+  }
+
   stop(): void {
+    this.suspendDepth = 0;
+    this.suspendedMessage = undefined;
     if (!this.active) return;
     this.active = false;
     if (this.intervalId) {

--- a/src/shared/ui/StreamDisplay.ts
+++ b/src/shared/ui/StreamDisplay.ts
@@ -87,7 +87,7 @@ export class StreamDisplay {
   private stopToolSpinner(): void {
     if (this.toolSpinner) {
       clearInterval(this.toolSpinner.intervalId);
-      process.stdout.write('\r' + ' '.repeat(120) + '\r');
+      process.stdout.write('\r\x1b[K');
       this.toolSpinner = null;
       this.spinnerFrame = 0;
     }
@@ -291,27 +291,31 @@ export class StreamDisplay {
   private formatToolInput(tool: string, input: Record<string, unknown>): string {
     switch (tool) {
       case 'Bash':
-        return truncate(String(input.command || ''), 60);
+        return this.formatToolPreview(String(input.command || ''), 60);
       case 'Read':
-        return truncate(String(input.file_path || ''), 60);
+        return this.formatToolPreview(String(input.file_path || ''), 60);
       case 'Write':
       case 'Edit':
-        return truncate(String(input.file_path || ''), 60);
+        return this.formatToolPreview(String(input.file_path || ''), 60);
       case 'Glob':
-        return truncate(String(input.pattern || ''), 60);
+        return this.formatToolPreview(String(input.pattern || ''), 60);
       case 'Grep':
-        return truncate(String(input.pattern || ''), 60);
+        return this.formatToolPreview(String(input.pattern || ''), 60);
       default: {
         const keys = Object.keys(input);
         if (keys.length === 0) return '';
         const firstKey = keys[0];
         if (firstKey) {
           const value = input[firstKey];
-          return truncate(String(value || ''), 50);
+          return this.formatToolPreview(String(value || ''), 50);
         }
         return '';
       }
     }
+  }
+
+  private formatToolPreview(value: string, maxLength: number): string {
+    return truncate(value.replace(/\s+/g, ' '), maxLength);
   }
 
   private ensureToolOutputHeader(tool?: string): void {


### PR DESCRIPTION
## 概要

takt のスピナー/ステータス行が端末出力を壊す 3 件の独立した不具合を修正します。
発端: 長時間ワークフロー実行中に入力待ちプロンプトがスピナーに上書きされ、ユーザーが「固まった」と判断して Enter を押すと空入力=中止と解釈され、3時間の実行が失われた報告 (調査レポートより)。

## 変更内容

- **A: ツールプレビューの改行除去** (`StreamDisplay.ts`)
  複数行のツール入力 (複数行 Bash コマンド等) でスピナー行が 80ms ごとに増殖していた。`formatToolPreview` で改行・連続空白を単一スペースに潰してから truncate するよう `formatToolInput` の全分岐を修正。
- **B: スピナー消去の端末幅依存を解消** (`StreamDisplay.ts`)
  `stopToolSpinner` の `'\r' + ' '.repeat(120) + '\r'` (固定幅) を `'\r\x1b[K'` (行末までクリア) に変更。端末幅 120 桁未満での消し残しを解消。
- **C: 入力待ちプロンプトの上書き防止** (`StatusLine.ts`, `shared/prompt/`)
  `StatusLine` に深さカウンタ付き `suspend()`/`resume()` を追加し、`shared/prompt` の入力関数 (`promptInput`, `confirm`, `readMultilineFromStream`, `selectOption`, `selectOptionWithDefault`) 内で suspend/resume するよう配線。呼び出し側 (`iterationLimitHandler` 3箇所、`ask-user-question-tty` 4箇所等) を一元保護。
  - ネストした suspend/resume は最外周の resume のみ再開
  - suspend 中の `start()`/`update()` は描画せずメッセージのみ保留し、最外周 resume で最新メッセージで再開
  - `stop()` は保留中の suspend 状態を破棄

## テスト

- リグレッションテスト追加: `StreamDisplay.test.ts` +3件、`statusLine.test.ts` +4件、新規 `userInputHandler-statusLine.test.ts` 6件 (全て修正前に失敗することを確認済み)
- `npm test` (4シャード 5,558件)、`npm run test:it` (1,982件)、`npm run build`、`npm run lint` すべて成功

## スコープ外 (未対応・別 issue 候補)

調査レポートで指摘された付随事項: TTY 非対応時に `promptInput` がプロンプト無しで null を返す (キャンセルと区別されない)、`createUserInputHandler` が `playWarningSound()`/`enterInputWait()` を呼ばない、入力待ちにタイムアウトがない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 入力待機中のステータス表示のちらつきを抑え、入力完了後やエラー後に正しく再開するよう改善しました。
  * 複数行コマンドや未登録ツールのプレビューを1行に整形し、表示を見やすくしました。
  * スピナー停止時に表示が適切に消去されるよう改善しました。
  * 入れ子になった一時停止にも対応し、入力処理完了後にステータス表示を再開します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->