### PR TITLE
test(companion): completion modeのreadDiff期待回数を#1447のライフサイクルへ追従

### DIFF
--- a/src/__tests__/companion-runtime-lifecycle.integration.test.ts
+++ b/src/__tests__/companion-runtime-lifecycle.integration.test.ts
@@ -188,7 +188,7 @@ describe('companion runtime lifecycle', () => {
       await expect(runtime.complete(workflowState, 'part two complete', { followUpRound: 1 }))
         .resolves.toEqual({ findings: [] });
 
-      expect(diffReader.readDiff).toHaveBeenCalledTimes(3);
+      expect(diffReader.readDiff).toHaveBeenCalledTimes(2);
       for (const [, baselineSha] of diffReader.readDiff.mock.calls) {
         expect(baselineSha).toBe('baseline');
       }


### PR DESCRIPTION
## 背景

main (49fa9b2e) の `test:it:heavy` shard 3 が `companion-runtime-lifecycle.integration.test.ts` の1件で失敗している。

- 失敗: `expect(diffReader.readDiff).toHaveBeenCalledTimes(3)` が実際は2回
- 原因: #1439 と #1447 のほぼ同時マージによる意味的衝突。#1439 のテストは「初期化時1回 + completion review 2回 = 3回」という旧ライフサイクルを前提にしていたが、#1447 で `reviewMode: 'completion'` は live scheduler と初期 snapshot 読み取りを作成しなくなった

## 判断

completion coordinator は completion review ごとに `readSnapshot()` を1回だけ呼び、detector へは同じ snapshot を渡す（追加の readDiff なし）。「各 completion review で最新 diff を再読する」という #1439 の意図は現行コードで満たされており、読み直しの欠落ではない。したがって production code は変更せず、テスト期待値を 3 → 2 に更新した。

## 検証

- 当該テスト 11/11、companion unit 13ファイル 140/140、companion heavy IT 6ファイル 49/49、companion-diff-runtime.integration 30/30 通過
- `npx tsc --noEmit -p tsconfig.json` 成功