### PR TITLE
chore(takt): implement/fix 系ゲートに軽量 IT (npm run test:it) を追加

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -9,7 +9,8 @@ workflow_overrides:
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
         - "Run `npm test` after completing edits and verify the fast unit gate passes"
-        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:it` after the unit gate and verify the light integration gate passes"
+        - "Besides the required `npm test`, `npm run test:it`, and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
         - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     fix:
       quality_gates:
@@ -17,7 +18,8 @@ workflow_overrides:
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
         - "Run `npm test` after completing edits and verify the fast unit gate passes"
-        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:it` after the unit gate and verify the light integration gate passes"
+        - "Besides the required `npm test`, `npm run test:it`, and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
         - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     ai_fix:
       quality_gates:
@@ -25,7 +27,8 @@ workflow_overrides:
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
         - "Run `npm test` after completing edits and verify the fast unit gate passes"
-        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:it` after the unit gate and verify the light integration gate passes"
+        - "Besides the required `npm test`, `npm run test:it`, and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
         - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     ai-antipattern-fix:
       quality_gates:
@@ -33,7 +36,8 @@ workflow_overrides:
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
         - "Run `npm test` after completing edits and verify the fast unit gate passes"
-        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:it` after the unit gate and verify the light integration gate passes"
+        - "Besides the required `npm test`, `npm run test:it`, and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
         - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     fix_supervisor:
       quality_gates:
@@ -41,7 +45,8 @@ workflow_overrides:
         - "Run `npm run lint` and verify lint passes"
         - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
         - "Run `npm test` after completing edits and verify the fast unit gate passes"
-        - "Besides the required `npm test` and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
+        - "Run `npm run test:it` after the unit gate and verify the light integration gate passes"
+        - "Besides the required `npm test`, `npm run test:it`, and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
         - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     merge-readiness-review:
       quality_gates:


### PR DESCRIPTION
## 目的

実装・修正ステップの品質ゲートで統合破壊を早期検出する。

## 変更

- `.takt/config.yaml` の `implement` / `fix` / `ai_fix` / `ai-antipattern-fix` / `fix_supervisor` の5ステップに「`npm run test:it` で軽量 integration ゲートが通ること」を追加
- あわせて「required」の列挙に `npm run test:it` を追記

## 根拠

- 軽量 IT はローカル実測31秒と安価（#1464 でユニットゲートも高速化済み）
- 現状は merge-readiness-review で初めて `test:it` が走るため、統合破壊の検出が遅れる
- mock E2E（CI ジョブ全体で158〜209秒、実プロセス生成を伴う）は引き続き merge-readiness-review と条件付き smoke のみとし、implement ゲートには追加しない
- ゲートの「テストコマンドは逐次実行」の指示は維持（`npm test` が適応型でコアを使い切るため、同時実行は過負荷・birpc タイムアウトのリスク）

## テスト

設定ファイルのみの変更のためコードテストへの影響なし。