### PR TITLE
chore(takt): 存在しないステップ名のゲート設定を削除

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -21,25 +21,7 @@ workflow_overrides:
         - "Run `npm run test:it` after the unit gate and verify the light integration gate passes"
         - "Besides the required `npm test`, `npm run test:it`, and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
         - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
-    ai_fix:
-      quality_gates:
-        - "Run `npm run build` and verify the build succeeds"
-        - "Run `npm run lint` and verify lint passes"
-        - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
-        - "Run `npm test` after completing edits and verify the fast unit gate passes"
-        - "Run `npm run test:it` after the unit gate and verify the light integration gate passes"
-        - "Besides the required `npm test`, `npm run test:it`, and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
-        - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
     ai-antipattern-fix:
-      quality_gates:
-        - "Run `npm run build` and verify the build succeeds"
-        - "Run `npm run lint` and verify lint passes"
-        - "Identify the specific test files covering the code you changed and run them as whole files (e.g. `npm test -- src/__tests__/<name>.test.ts`; integration test files work the same way). Do not filter to individual test cases. If no covering test files exist, state that explicitly in your report. All must pass"
-        - "Run `npm test` after completing edits and verify the fast unit gate passes"
-        - "Run `npm run test:it` after the unit gate and verify the light integration gate passes"
-        - "Besides the required `npm test`, `npm run test:it`, and the specific covering test files above, do not run unrelated full suites or whole test groups. Run an affected broader group only when you changed test infrastructure itself (vitest configs, test runner scripts, shared fixtures/setup), or re-run the exact failing command when fixing a failure reported from a quality gate or final-gate run. Run test commands sequentially and do not duplicate overlapping runs"
-        - "Run `npm run test:e2e:smoke` only when the changed behavior affects CLI startup, workflow execution, provider selection, config loading, sandboxing, or runtime preparation, and verify the smoke E2E passes"
-    fix_supervisor:
       quality_gates:
         - "Run `npm run build` and verify the build succeeds"
         - "Run `npm run lint` and verify lint passes"


### PR DESCRIPTION
## 目的

`.takt/config.yaml` の quality_gates オーバーライドから、どのステップにも適用されない死んだ設定を削除する。

## 変更

- `ai_fix` ブロックを削除: ステップ名は過去の breaking change（CHANGELOG 記載）で `ai-antipattern-fix` にリネーム済みで、`ai-antipattern-fix` ブロックは別途存在する
- `fix_supervisor` ブロックを削除: builtins 全ワークフローに該当ステップ名が存在しない

残るキー: `implement` / `fix` / `ai-antipattern-fix` / `merge-readiness-review`

## 検出経緯

#1467 の独立レビュー（Luna max, read-only）でのエスカレーションを検証して特定。

## テスト

- `npm test -- src/__tests__/projectConfig.test.ts src/__tests__/qualityGateOverrides.test.ts src/__tests__/commandQualityGateRunner.test.ts`: 207テスト成功
- YAML パースとキー一覧を確認済み