### PR TITLE
fix: ignore prompt logs when force-failing tasks

### DIFF
--- a/src/__tests__/taskForceFailActions.test.ts
+++ b/src/__tests__/taskForceFailActions.test.ts
@@ -11,6 +11,7 @@ import { createUsageEventLogger } from '../core/logging/usageEventLogger.js';
 import {
   OTEL_SESSION_SHADOW_LOG_FILE_SUFFIX,
   PHASE_USAGE_EVENTS_LOG_FILE_SUFFIX,
+  PROMPT_LOG_FILE_SUFFIX,
   PROVIDER_EVENTS_LOG_FILE_SUFFIX,
 } from '../core/logging/contracts.js';
 
@@ -325,7 +326,7 @@ describe('forceFailRunningTask', () => {
       .not.toContain('"type":"workflow_abort"');
   });
 
-  it('観測sidecarが併存してもsession logをforce-failする', async () => {
+  it('観測sidecarとdebug prompt logが併存してもsession logをforce-failする', async () => {
     const runSlug = '20260409-usage-sidecar';
     const runPaths = buildRunPaths(projectDir, runSlug);
     writeMeta(projectDir, runSlug, {
@@ -378,6 +379,22 @@ describe('forceFailRunningTask', () => {
         task: 'Stored from run context',
         workflowName: 'default',
         startTime: '2026-04-09T00:00:00.000Z',
+      })}\n`,
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(runPaths.logsAbs, `force-fail-session${PROMPT_LOG_FILE_SUFFIX}`),
+      `${JSON.stringify({
+        step: 'implement',
+        phase: 1,
+        iteration: 1,
+        scope: '{"step":"implement","stack":[]}',
+        phaseExecutionId: 'implement:1:1:1',
+        prompt: 'prompt',
+        systemPrompt: 'system prompt',
+        userInstruction: 'user instruction',
+        response: 'response',
+        timestamp: '2026-04-09T00:00:00.000Z',
       })}\n`,
       'utf-8',
     );

--- a/src/core/logging/contracts.ts
+++ b/src/core/logging/contracts.ts
@@ -4,6 +4,7 @@ export const PROVIDER_EVENTS_LOG_FILE_SUFFIX = '-provider-events.jsonl';
 export const USAGE_EVENTS_LOG_FILE_SUFFIX = '-usage-events.jsonl';
 export const PHASE_USAGE_EVENTS_LOG_FILE_SUFFIX = '-usage-events.phase.jsonl';
 export const OTEL_SESSION_SHADOW_LOG_FILE_SUFFIX = '-otel-session-shadow.jsonl';
+export const PROMPT_LOG_FILE_SUFFIX = '-prompts.jsonl';
 
 export const USAGE_MISSING_REASONS = {
   NOT_AVAILABLE: 'usage_not_available',

--- a/src/features/tasks/execute/workflowExecutionBootstrap.ts
+++ b/src/features/tasks/execute/workflowExecutionBootstrap.ts
@@ -62,6 +62,7 @@ import { initializeOtelFoundation, type OtelFoundationHandle } from '../../../in
 import {
   OTEL_SESSION_SHADOW_LOG_FILE_SUFFIX,
   PHASE_USAGE_EVENTS_LOG_FILE_SUFFIX,
+  PROMPT_LOG_FILE_SUFFIX,
 } from '../../../core/logging/contracts.js';
 import {
   resolveEffectiveAutoRouting,
@@ -535,7 +536,7 @@ export async function createWorkflowExecutionBootstrap(
     },
   );
   const promptLogPath = isDebugEnabled()
-    ? join(runPaths.logsAbs, `${workflowSessionId}-prompts.jsonl`)
+    ? join(runPaths.logsAbs, `${workflowSessionId}${PROMPT_LOG_FILE_SUFFIX}`)
     : undefined;
   const sessionLogger = new SessionLogger(
     ndjsonLogPath,

--- a/src/features/tasks/execute/workflowRunForceFailAdapters.ts
+++ b/src/features/tasks/execute/workflowRunForceFailAdapters.ts
@@ -6,6 +6,7 @@ import { basename, extname, join } from 'node:path';
 import {
   OTEL_SESSION_SHADOW_LOG_FILE_SUFFIX,
   PHASE_USAGE_EVENTS_LOG_FILE_SUFFIX,
+  PROMPT_LOG_FILE_SUFFIX,
   PROVIDER_EVENTS_LOG_FILE_SUFFIX,
   USAGE_EVENTS_LOG_FILE_SUFFIX,
 } from '../../../core/logging/contracts.js';
@@ -47,6 +48,7 @@ const RUN_LOG_SIDECAR_FILE_SUFFIXES = Object.freeze([
   USAGE_EVENTS_LOG_FILE_SUFFIX,
   PHASE_USAGE_EVENTS_LOG_FILE_SUFFIX,
   OTEL_SESSION_SHADOW_LOG_FILE_SUFFIX,
+  PROMPT_LOG_FILE_SUFFIX,
 ]);
 
 class FileTaskRunForceFailStorage implements WorkflowRunForceFailHandle {


### PR DESCRIPTION
## Summary

- exclude debug prompt logs from force-fail session log discovery
- share the prompt log suffix between log creation and sidecar filtering
- cover force-fail behavior when observation sidecars and a debug prompt log coexist

## Root cause

Debug runs create a `*-prompts.jsonl` sidecar. The manual force-fail path treated every unrecognized JSONL file as a session log, so parsing the prompt log failed before the task could transition to `failed`.

## Verification

- `npm test -- src/__tests__/taskForceFailActions.test.ts`
- `npm test -- src/__tests__/workflowExecution-debug-prompts.test.ts`
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * デバッグ用プロンプトログが存在する場合でも、通常のセッションログを正しく強制失敗できるようになりました。
  * プロンプトログがセッションログとして誤って扱われる問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->