### PR TITLE
fix: keep Ctrl-C responsive during concurrent runs

### DIFF
--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -196,7 +196,7 @@ GitHub Actions の CI（`ci.yml`）が実行する E2E は `test:e2e:mock` の�
       - グローバル `config.yaml` 不在の環境で `takt add` を2回実行し、`takt run --provider mock` を実行する。
       - タスク実行完了後に `.takt/tasks/` 配下の2タスクディレクトリ生成、`.takt/.gitignore` 生成、`.takt/tasks.yaml` に2件の completed 履歴が残ることを確認する。
 - Run tasks graceful shutdown on SIGINT（`e2e/specs/run-sigint-graceful.e2e.ts`）
-  - 目的: `takt run` を並列実行中に `Ctrl+C` した際、新規クローン投入を止めてグレースフルに終了することを確認。
+  - 目的: `takt run` を並列実行中に `Ctrl+C` した際、新規クローン投入を止めてグレースフルに終了することと、共有 stdin が pause された後も実 PTY の Ctrl+C を受信できることを確認。
   - LLM: 呼び出さない（`--provider mock` 固定）
   - 手順（ユーザー行動/コマンド）:
     - `.takt/tasks.yaml` に `worktree: true` の pending タスクを3件投入する（`concurrency: 2`）。
@@ -205,6 +205,7 @@ GitHub Actions の CI（`ci.yml`）が実行する E2E は `test:e2e:mock` の�
     - `takt run --provider mock` を起動し、`=== Running Workflow:` が出たら `Ctrl+C` を送る。
     - 3件目タスク（`sigint-c`）が開始されないことを確認する。
     - `=== Tasks Summary ===` 以降に新規タスク開始やクローン作成ログが出ないことを確認する。
+    - 実 PTY 上で mock provider を待機させた2タスクを並列実行し、共有 stdin を pause した後に Ctrl+C バイトを送って、プロセスが速やかに終了することを確認する。
 - Runtime config injection with provider（`e2e/specs/runtime-config-provider.e2e.ts`）
   - 目的: `config.yaml` の `runtime.prepare` が provider 呼び出し前に反映される正例と未設定時のenv未注入をmockで確認し、任意の実provider E2Eでは子プロセスへの伝播も確認。
   - LLM: 通常CIでは呼び出さない（mockでprovider呼び出し時のruntime環境を検証）。`TAKT_E2E_PROVIDER` が `claude` / `claude-sdk` / `codex` / `opencode` の場合のみ、実コマンド伝播の追加テストを実行。

--- a/e2e/fixtures/preload/pause-stdin-after-data-listener.mjs
+++ b/e2e/fixtures/preload/pause-stdin-after-data-listener.mjs
@@ -1,7 +1,18 @@
+import { existsSync } from 'node:fs';
+
+const triggerPath = process.env.TAKT_E2E_PAUSE_STDIN_TRIGGER;
+if (!triggerPath) {
+  throw new Error('TAKT_E2E_PAUSE_STDIN_TRIGGER is required');
+}
+
 const deadline = Date.now() + 10_000;
 
 const timer = setInterval(() => {
-  if (process.stdin.isTTY && process.stdin.listenerCount('data') > 0) {
+  if (
+    existsSync(triggerPath)
+    && process.stdin.isTTY
+    && process.stdin.listenerCount('data') > 0
+  ) {
     clearInterval(timer);
     process.stdin.pause();
     process.stdout.write('[e2e] stdin paused\n');

--- a/e2e/fixtures/preload/pause-stdin-after-data-listener.mjs
+++ b/e2e/fixtures/preload/pause-stdin-after-data-listener.mjs
@@ -1,0 +1,17 @@
+const deadline = Date.now() + 10_000;
+
+const timer = setInterval(() => {
+  if (process.stdin.isTTY && process.stdin.listenerCount('data') > 0) {
+    clearInterval(timer);
+    process.stdin.pause();
+    process.stdout.write('[e2e] stdin paused\n');
+    return;
+  }
+
+  if (Date.now() >= deadline) {
+    clearInterval(timer);
+    process.stderr.write('[e2e] stdin data listener was not registered\n');
+  }
+}, 10);
+
+timer.unref();

--- a/e2e/fixtures/scenarios/run-sigint-paused-stdin.json
+++ b/e2e/fixtures/scenarios/run-sigint-paused-stdin.json
@@ -1,0 +1,12 @@
+[
+  {
+    "status": "done",
+    "content": "Done",
+    "wait_for_abort": true
+  },
+  {
+    "status": "done",
+    "content": "Done",
+    "wait_for_abort": true
+  }
+]

--- a/e2e/helpers/wait.ts
+++ b/e2e/helpers/wait.ts
@@ -5,6 +5,8 @@
 
 import { spawn } from 'node:child_process';
 
+const FORCE_KILL_GRACE_MS = 1_000;
+
 /**
  * Poll a predicate until it returns true or the timeout expires.
  * Returns true if the predicate became true, false on timeout.
@@ -24,7 +26,7 @@ export async function waitFor(
 
 /**
  * Wait for a spawned child process to exit.
- * Kills the process with SIGKILL and rejects if the timeout is exceeded.
+ * On timeout, sends SIGKILL and rejects after termination is observed.
  */
 export async function waitForClose(
   child: ReturnType<typeof spawn>,
@@ -38,16 +40,73 @@ export async function waitForClose(
   }
 
   return new Promise((resolve, reject) => {
+    let timeoutError: Error | undefined;
+    let forceKillTimeout: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      if (forceKillTimeout) {
+        clearTimeout(forceKillTimeout);
+      }
+      child.removeListener('close', onClose);
+      child.removeListener('exit', onExit);
+    };
+
+    const rejectAfterCleanup = (error: unknown): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (timeoutError) {
+        reject(timeoutError);
+        return;
+      }
+      resolve({ code, signal });
+    };
+
+    const onExit = (): void => {
+      if (timeoutError) {
+        rejectAfterCleanup(timeoutError);
+      }
+    };
+
     const timeout = setTimeout(() => {
-      child.kill('SIGKILL');
-      reject(new Error(`Process did not exit within ${timeoutMs}ms`));
+      timeoutError = new Error(`Process did not exit within ${timeoutMs}ms`);
+      try {
+        if (!child.kill('SIGKILL')) {
+          rejectAfterCleanup(timeoutError);
+          return;
+        }
+      } catch (error) {
+        rejectAfterCleanup(error);
+        return;
+      }
+
+      if (settled) {
+        return;
+      }
+      forceKillTimeout = setTimeout(() => {
+        rejectAfterCleanup(new Error(
+          `Process did not terminate within ${FORCE_KILL_GRACE_MS}ms after SIGKILL`,
+        ));
+      }, FORCE_KILL_GRACE_MS);
+      forceKillTimeout.unref?.();
     }, timeoutMs);
     timeout.unref?.();
 
-    child.once('close', (code, signal) => {
-      clearTimeout(timeout);
-      resolve({ code, signal });
-    });
+    child.once('close', onClose);
+    child.once('exit', onExit);
   });
 }
 

--- a/e2e/specs/run-sigint-graceful.e2e.ts
+++ b/e2e/specs/run-sigint-graceful.e2e.ts
@@ -10,7 +10,7 @@ import {
   type IsolatedEnv,
 } from '../helpers/isolated-env';
 import { createTestRepo, type TestRepo } from '../helpers/test-repo';
-import { startTaktPty, type TaktPtySession } from '../helpers/takt-pty-runner.js';
+import { startTaktPty, type TaktPtySession } from '../helpers/takt-pty-runner';
 import { cleanupChildProcess, cleanupTestResource, waitFor, waitForClose } from '../helpers/wait.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -36,12 +36,21 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
   });
 
   afterEach(async () => {
-    await cleanupChildProcess(child);
-    child = undefined;
-    await ptySession?.dispose();
-    ptySession = undefined;
-    cleanupTestResource('testRepo', () => testRepo.cleanup());
-    cleanupTestResource('isolatedEnv', () => isolatedEnv.cleanup());
+    try {
+      await cleanupChildProcess(child);
+    } finally {
+      child = undefined;
+      try {
+        await ptySession?.dispose();
+      } finally {
+        ptySession = undefined;
+        try {
+          cleanupTestResource('testRepo', () => testRepo.cleanup());
+        } finally {
+          cleanupTestResource('isolatedEnv', () => isolatedEnv.cleanup());
+        }
+      }
+    }
   });
 
   it('should honor terminal Ctrl+C after shared stdin is paused during concurrent execution', async () => {

--- a/e2e/specs/run-sigint-graceful.e2e.ts
+++ b/e2e/specs/run-sigint-graceful.e2e.ts
@@ -50,6 +50,7 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
     const preloadPath = resolve(__dirname, '../fixtures/preload/pause-stdin-after-data-listener.mjs');
 
     const tasksFile = join(testRepo.path, '.takt', 'tasks.yaml');
+    const pauseTriggerPath = join(testRepo.path, '.takt', 'pause-stdin.trigger');
     mkdirSync(join(testRepo.path, '.takt'), { recursive: true });
 
     const now = new Date().toISOString();
@@ -84,11 +85,11 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
       env: {
         ...isolatedEnv.env,
         NODE_OPTIONS: `--import=${pathToFileURL(preloadPath).href}`,
+        TAKT_E2E_PAUSE_STDIN_TRIGGER: pauseTriggerPath,
         TAKT_MOCK_SCENARIO: scenarioPath,
       },
     });
 
-    await ptySession.waitForOutput('[e2e] stdin paused', 10_000);
     const workersFilled = await waitFor(
       () => {
         try {
@@ -104,6 +105,9 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
       20,
     );
     expect(workersFilled, `output:\n${ptySession.output()}`).toBe(true);
+
+    writeFileSync(pauseTriggerPath, '', 'utf-8');
+    await ptySession.waitForOutput('[e2e] stdin paused', 10_000);
 
     const startedAt = Date.now();
     ptySession.write('\u0003');

--- a/e2e/specs/run-sigint-graceful.e2e.ts
+++ b/e2e/specs/run-sigint-graceful.e2e.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 import {
   createIsolatedEnv,
@@ -10,6 +10,7 @@ import {
   type IsolatedEnv,
 } from '../helpers/isolated-env';
 import { createTestRepo, type TestRepo } from '../helpers/test-repo';
+import { startTaktPty, type TaktPtySession } from '../helpers/takt-pty-runner.js';
 import { cleanupChildProcess, cleanupTestResource, waitFor, waitForClose } from '../helpers/wait.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -20,6 +21,7 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
   let isolatedEnv: IsolatedEnv;
   let testRepo: TestRepo;
   let child: ReturnType<typeof spawn> | undefined;
+  let ptySession: TaktPtySession | undefined;
 
   beforeEach(() => {
     isolatedEnv = createIsolatedEnv();
@@ -36,9 +38,80 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
   afterEach(async () => {
     await cleanupChildProcess(child);
     child = undefined;
+    await ptySession?.dispose();
+    ptySession = undefined;
     cleanupTestResource('testRepo', () => testRepo.cleanup());
     cleanupTestResource('isolatedEnv', () => isolatedEnv.cleanup());
   });
+
+  it('should honor terminal Ctrl+C after shared stdin is paused during concurrent execution', async () => {
+    const workflowPath = resolve(__dirname, '../fixtures/workflows/mock-single-step.yaml');
+    const scenarioPath = resolve(__dirname, '../fixtures/scenarios/run-sigint-paused-stdin.json');
+    const preloadPath = resolve(__dirname, '../fixtures/preload/pause-stdin-after-data-listener.mjs');
+
+    const tasksFile = join(testRepo.path, '.takt', 'tasks.yaml');
+    mkdirSync(join(testRepo.path, '.takt'), { recursive: true });
+
+    const now = new Date().toISOString();
+    writeFileSync(
+      tasksFile,
+      [
+        'tasks:',
+        '  - name: paused-stdin-a',
+        '    status: pending',
+        '    content: "E2E paused stdin task A"',
+        `    workflow: "${workflowPath}"`,
+        `    created_at: "${now}"`,
+        '    started_at: null',
+        '    completed_at: null',
+        '    owner_pid: null',
+        '  - name: paused-stdin-b',
+        '    status: pending',
+        '    content: "E2E paused stdin task B"',
+        `    workflow: "${workflowPath}"`,
+        `    created_at: "${now}"`,
+        '    started_at: null',
+        '    completed_at: null',
+        '    owner_pid: null',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    ptySession = startTaktPty({
+      args: ['run', '--provider', 'mock'],
+      cwd: testRepo.path,
+      injectProvider: false,
+      env: {
+        ...isolatedEnv.env,
+        NODE_OPTIONS: `--import=${pathToFileURL(preloadPath).href}`,
+        TAKT_MOCK_SCENARIO: scenarioPath,
+      },
+    });
+
+    await ptySession.waitForOutput('[e2e] stdin paused', 10_000);
+    const workersFilled = await waitFor(
+      () => {
+        try {
+          const parsed = parseYaml(readFileSync(tasksFile, 'utf-8')) as {
+            tasks?: Array<{ status?: string }>;
+          };
+          return parsed.tasks?.filter((task) => task.status === 'running').length === 2;
+        } catch {
+          return false;
+        }
+      },
+      30_000,
+      20,
+    );
+    expect(workersFilled, `output:\n${ptySession.output()}`).toBe(true);
+
+    const startedAt = Date.now();
+    ptySession.write('\u0003');
+    const exitCode = await ptySession.waitForExit(10_000);
+
+    expect([0, 130]).toContain(exitCode);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  }, 60_000);
 
   it('should stop scheduling new clone work after SIGINT and exit cleanly', async () => {
     const binPath = resolve(__dirname, '../../bin/takt');

--- a/src/__tests__/e2e-helpers.test.ts
+++ b/src/__tests__/e2e-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -459,6 +460,69 @@ describe('wait helper child process cleanup', () => {
     } as unknown as ReturnType<typeof spawn>;
 
     await expect(cleanupChildProcess(child, 1_000)).rejects.toThrow('kill failed');
+  });
+
+  it('should wait for termination after timeout force-kills a child', async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null;
+      signalCode: NodeJS.Signals | null;
+      kill: (signal?: NodeJS.Signals | number) => boolean;
+    };
+    child.exitCode = null;
+    child.signalCode = null;
+    let terminated = false;
+    child.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+      if (signal === 'SIGKILL') {
+        setTimeout(() => {
+          child.signalCode = 'SIGKILL';
+          terminated = true;
+          child.emit('exit', null, 'SIGKILL');
+          child.emit('close', null, 'SIGKILL');
+        }, 20);
+      }
+      return true;
+    });
+
+    await expect(
+      cleanupChildProcess(child as unknown as ReturnType<typeof spawn>, 10),
+    ).rejects.toThrow('Process did not exit within 10ms');
+
+    expect(child.kill).toHaveBeenNthCalledWith(1, 'SIGINT');
+    expect(child.kill).toHaveBeenNthCalledWith(2, 'SIGKILL');
+    expect(terminated).toBe(true);
+    expect(child.signalCode).toBe('SIGKILL');
+    expect(child.listenerCount('close')).toBe(0);
+    expect(child.listenerCount('exit')).toBe(0);
+  });
+
+  it('should stop waiting when a force-killed child never reports termination', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = new EventEmitter() as EventEmitter & {
+        exitCode: number | null;
+        signalCode: NodeJS.Signals | null;
+        kill: (signal?: NodeJS.Signals | number) => boolean;
+      };
+      child.exitCode = null;
+      child.signalCode = null;
+      child.kill = vi.fn(() => true);
+
+      const cleanup = cleanupChildProcess(
+        child as unknown as ReturnType<typeof spawn>,
+        10,
+      );
+      const rejection = expect(cleanup).rejects.toThrow(
+        'Process did not terminate within 1000ms after SIGKILL',
+      );
+
+      await vi.advanceTimersByTimeAsync(1_010);
+      await rejection;
+
+      expect(child.listenerCount('close')).toBe(0);
+      expect(child.listenerCount('exit')).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('should rethrow cleanup errors with the resource label', () => {

--- a/src/__tests__/immediateSigintExit.test.ts
+++ b/src/__tests__/immediateSigintExit.test.ts
@@ -17,6 +17,7 @@ class FakeStdin extends EventEmitter {
 
   pause(): void {
     this.paused = true;
+    this.emit('pause');
   }
 }
 
@@ -126,6 +127,19 @@ describe('installImmediateSigintExit', () => {
     expect(sigintListener).not.toHaveBeenCalled();
     expect(runtime.stdin.isRaw).toBe(false);
     expect(runtime.stdin.paused).toBe(true);
+  });
+
+  it('run 中に共有 stdin が pause されても Ctrl+C 監視を維持する', () => {
+    const runtime = new FakeProcess();
+    const sigintListener = vi.fn();
+    runtime.on('SIGINT', sigintListener);
+
+    install('run', runtime);
+    runtime.stdin.pause();
+    runtime.stdin.emit('data', Buffer.from('\u0003', 'utf-8'));
+
+    expect(runtime.stdin.paused).toBe(false);
+    expect(sigintListener).toHaveBeenCalledTimes(1);
   });
 
   it('cleanup は複数回呼んでも安全', () => {

--- a/src/app/cli/immediateSigintExit.ts
+++ b/src/app/cli/immediateSigintExit.ts
@@ -49,7 +49,14 @@ export function installImmediateSigintExit(
     }
   };
 
+  const onPause = (): void => {
+    if (!cleanedUp) {
+      stdin.resume();
+    }
+  };
+
   stdin.on('data', onData);
+  stdin.on('pause', onPause);
   stdin.resume();
 
   const cleanup = (): void => {
@@ -58,6 +65,7 @@ export function installImmediateSigintExit(
     }
     cleanedUp = true;
     stdin.removeListener('data', onData);
+    stdin.removeListener('pause', onPause);
     stdin.pause();
     if (enabledRawMode && typeof stdin.setRawMode === 'function') {
       stdin.setRawMode(false);


### PR DESCRIPTION
## 概要

- `takt run` の Ctrl-C 監視中に共有 stdin が pause されても、入力監視を再開する
- cleanup 時は pause listener を先に解除し、既存の stdin 復元動作を維持する
- concurrency 実行中の prompt cleanup を再現する回帰テストを追加する

## 根本原因

`run` は Ctrl-C を即時検出するため stdin を raw mode にし、入力データの `\u0003` を監視しています。一方、共有 stdin を使う対話 prompt の cleanup が `process.stdin.pause()` を呼ぶと、raw mode のまま入力データの配送が止まり、カーネルの SIGINT 変換も無効なため Ctrl-C が届かなくなっていました。

## 検証

- `npm run build`
- `npm run lint`
- `npm test`（5,817 tests passed）
- `npm run test:it`（2,136 tests passed）
- `npm test -- src/__tests__/immediateSigintExit.test.ts`（最新 base 上で 9 tests passed）
- `TAKT_E2E_PROVIDER=mock npx vitest run e2e/specs/run-sigint-graceful.e2e.ts --config vitest.config.e2e.mock.ts`（4 tests passed、共有 stdin pause 後の実 PTY Ctrl-C を含む）
- 実 PTY で stdin pause 後の Ctrl-C を確認（修正前: 未検出、修正後: SIGINT 受信）
- Independent review: APPROVE（blocking findings: 0）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 標準入力が一時停止された場合でも、実行モード中の Ctrl+C（SIGINT）の監視が継続されるようになりました。
  * 標準入力の再開後、Ctrl+C が適切に1回だけ処理されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->