### PR TITLE
test: 3並列のprovider応答待ち中Ctrl-CをE2E検証

### DIFF
--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -205,7 +205,7 @@ GitHub Actions の CI（`ci.yml`）が実行する E2E は `test:e2e:mock` の�
     - `takt run --provider mock` を起動し、`=== Running Workflow:` が出たら `Ctrl+C` を送る。
     - 3件目タスク（`sigint-c`）が開始されないことを確認する。
     - `=== Tasks Summary ===` 以降に新規タスク開始やクローン作成ログが出ないことを確認する。
-    - 実 PTY 上で mock provider を待機させた2タスクを並列実行し、共有 stdin を pause した後に Ctrl+C バイトを送って、プロセスが速やかに終了することを確認する。
+    - `concurrency: 3` の実 PTY 上で3タスクすべてが mock provider の応答待ちに入ったことを call log で確認し、共有 stdin を pause した後に Ctrl+C バイトを送って、3呼び出しが abort されプロセスが速やかに終了することを確認する。
 - Runtime config injection with provider（`e2e/specs/runtime-config-provider.e2e.ts`）
   - 目的: `config.yaml` の `runtime.prepare` が provider 呼び出し前に反映される正例と未設定時のenv未注入をmockで確認し、任意の実provider E2Eでは子プロセスへの伝播も確認。
   - LLM: 通常CIでは呼び出さない（mockでprovider呼び出し時のruntime環境を検証）。`TAKT_E2E_PROVIDER` が `claude` / `claude-sdk` / `codex` / `opencode` の場合のみ、実コマンド伝播の追加テストを実行。

--- a/e2e/fixtures/preload/pause-stdin-after-data-listener.mjs
+++ b/e2e/fixtures/preload/pause-stdin-after-data-listener.mjs
@@ -5,7 +5,7 @@ if (!triggerPath) {
   throw new Error('TAKT_E2E_PAUSE_STDIN_TRIGGER is required');
 }
 
-const deadline = Date.now() + 40_000;
+const deadline = Date.now() + 20_000;
 
 const timer = setInterval(() => {
   if (

--- a/e2e/fixtures/preload/pause-stdin-after-data-listener.mjs
+++ b/e2e/fixtures/preload/pause-stdin-after-data-listener.mjs
@@ -5,7 +5,7 @@ if (!triggerPath) {
   throw new Error('TAKT_E2E_PAUSE_STDIN_TRIGGER is required');
 }
 
-const deadline = Date.now() + 10_000;
+const deadline = Date.now() + 40_000;
 
 const timer = setInterval(() => {
   if (

--- a/e2e/fixtures/scenarios/run-sigint-paused-stdin.json
+++ b/e2e/fixtures/scenarios/run-sigint-paused-stdin.json
@@ -8,5 +8,10 @@
     "status": "done",
     "content": "Done",
     "wait_for_abort": true
+  },
+  {
+    "status": "done",
+    "content": "Done",
+    "wait_for_abort": true
   }
 ]

--- a/e2e/specs/run-sigint-graceful.e2e.ts
+++ b/e2e/specs/run-sigint-graceful.e2e.ts
@@ -53,14 +53,16 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
     }
   });
 
-  it('should honor terminal Ctrl+C after shared stdin is paused during concurrent execution', async () => {
+  it('should honor terminal Ctrl+C while three concurrent providers await responses', async () => {
     const workflowPath = resolve(__dirname, '../fixtures/workflows/mock-single-step.yaml');
     const scenarioPath = resolve(__dirname, '../fixtures/scenarios/run-sigint-paused-stdin.json');
     const preloadPath = resolve(__dirname, '../fixtures/preload/pause-stdin-after-data-listener.mjs');
 
     const tasksFile = join(testRepo.path, '.takt', 'tasks.yaml');
+    const mockCallLog = join(testRepo.path, '.takt', 'mock-calls.jsonl');
     const pauseTriggerPath = join(testRepo.path, '.takt', 'pause-stdin.trigger');
     mkdirSync(join(testRepo.path, '.takt'), { recursive: true });
+    updateIsolatedConfig(isolatedEnv.taktDir, { concurrency: 3 });
 
     const now = new Date().toISOString();
     writeFileSync(
@@ -83,6 +85,14 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
         '    started_at: null',
         '    completed_at: null',
         '    owner_pid: null',
+        '  - name: paused-stdin-c',
+        '    status: pending',
+        '    content: "E2E paused stdin task C"',
+        `    workflow: "${workflowPath}"`,
+        `    created_at: "${now}"`,
+        '    started_at: null',
+        '    completed_at: null',
+        '    owner_pid: null',
       ].join('\n'),
       'utf-8',
     );
@@ -95,17 +105,25 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
         ...isolatedEnv.env,
         NODE_OPTIONS: `--import=${pathToFileURL(preloadPath).href}`,
         TAKT_E2E_PAUSE_STDIN_TRIGGER: pauseTriggerPath,
+        TAKT_MOCK_CALL_LOG: mockCallLog,
         TAKT_MOCK_SCENARIO: scenarioPath,
       },
     });
 
-    const workersFilled = await waitFor(
+    const providersAwaitingResponses = await waitFor(
       () => {
         try {
           const parsed = parseYaml(readFileSync(tasksFile, 'utf-8')) as {
             tasks?: Array<{ status?: string }>;
           };
-          return parsed.tasks?.filter((task) => task.status === 'running').length === 2;
+          if (parsed.tasks?.filter((task) => task.status === 'running').length !== 3) {
+            return false;
+          }
+          const records = readFileSync(mockCallLog, 'utf-8')
+            .trim()
+            .split('\n')
+            .map((line) => JSON.parse(line) as { event?: string });
+          return records.filter((record) => record.event === 'start').length === 3;
         } catch {
           return false;
         }
@@ -113,7 +131,7 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
       30_000,
       20,
     );
-    expect(workersFilled, `output:\n${ptySession.output()}`).toBe(true);
+    expect(providersAwaitingResponses, `output:\n${ptySession.output()}`).toBe(true);
 
     writeFileSync(pauseTriggerPath, '', 'utf-8');
     await ptySession.waitForOutput('[e2e] stdin paused', 10_000);
@@ -124,6 +142,15 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
 
     expect([0, 130]).toContain(exitCode);
     expect(Date.now() - startedAt).toBeLessThan(5_000);
+
+    const finalRecords = readFileSync(mockCallLog, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { event?: string; aborted?: boolean });
+    expect(finalRecords.filter((record) => record.event === 'start')).toHaveLength(3);
+    expect(
+      finalRecords.filter((record) => record.event === 'complete' && record.aborted === true),
+    ).toHaveLength(3);
   }, 60_000);
 
   it('should stop scheduling new clone work after SIGINT and exit cleanly', async () => {


### PR DESCRIPTION
## 目的

#1475 の回帰 E2E を、実際に報告された3並列・provider応答待ちの条件へ強化します。

## 変更内容

- `takt run --provider mock` を `concurrency: 3` で実行
- 3タスクすべてが `running` かつ mock provider の `start` が3件記録されたことを確認
- provider応答待ち中に共有stdinをpauseし、実PTYへCtrl-Cバイトを送信
- 3 provider呼び出しすべてのabortと、5秒未満のプロセス終了を検証
- preloadの監視期限を、provider到達待ちより長い40秒へ調整

## 検証結果

- 修正前相当: `takt did not exit within 10000ms` で失敗
- 現行コード: 対象E2Eが約4.4秒で成功
- `npm run build`
- `npm run lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * SIGINTによる正常終了のE2E検証を、同時実行2件から3件に拡張しました。
  * 3件すべての処理が中断され、プロセスが速やかに終了することを確認します。
  * 標準入力の一時停止状態や、処理完了後の表示内容に関するシナリオを追加しました。
  * テスト環境での入力待機時間を延長し、安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->