### PR TITLE
fix(workflows): remove completion retry from fix steps

### DIFF
--- a/builtins/en/workflows/development-remediation-dynamic.yaml
+++ b/builtins/en/workflows/development-remediation-dynamic.yaml
@@ -135,9 +135,6 @@ steps:
         $param: fix_pool
     companion:
       $param: fix_companions
-    completion_retry:
-      retry_instruction: fix-completion-retry
-      max_retry: 1
     rules:
       - condition: Fix complete
         next: fix-verifier
@@ -175,9 +172,6 @@ steps:
         $param: fix_pool
     companion:
       $param: fix_companions
-    completion_retry:
-      retry_instruction: fix-completion-retry
-      max_retry: 1
     rules:
       - condition: Fix complete
         next: fix-verifier

--- a/builtins/ja/workflows/development-remediation-dynamic.yaml
+++ b/builtins/ja/workflows/development-remediation-dynamic.yaml
@@ -135,9 +135,6 @@ steps:
         $param: fix_pool
     companion:
       $param: fix_companions
-    completion_retry:
-      retry_instruction: fix-completion-retry
-      max_retry: 1
     rules:
       - condition: 修正完了
         next: fix-verifier
@@ -175,9 +172,6 @@ steps:
         $param: fix_pool
     companion:
       $param: fix_companions
-    completion_retry:
-      retry_instruction: fix-completion-retry
-      max_retry: 1
     rules:
       - condition: 修正完了
         next: fix-verifier


### PR DESCRIPTION
## Summary

- Remove `completion_retry` from `fix` and `fix-retry` in the Japanese dynamic remediation workflow.
- Apply the same removal to the English counterpart.
- Keep the completion-retry engine and schema available for explicit opt-in use.

## Verification

- Workflow doctor passed for the Japanese and English workflow files.
- Workflow inspect tests: 51 passed.
- Independent Luna max review: no actionable findings.
- `git diff --check` passed.
- Confirmed no builtin workflow YAML currently enables `completion_retry`.

No issue linkage is intended for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 開発時の修正処理における完了時の自動再試行設定を見直しました。
  - 完了時の再試行指示と最大再試行回数の指定を削除し、処理フローを簡素化しました。
  - 日本語版・英語版のワークフローに同じ変更を適用しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->