### PR TITLE
fix: handle CSI-u Ctrl-C during task runs

### DIFF
--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -205,7 +205,7 @@ GitHub Actions の CI（`ci.yml`）が実行する E2E は `test:e2e:mock` の�
     - `takt run --provider mock` を起動し、`=== Running Workflow:` が出たら `Ctrl+C` を送る。
     - 3件目タスク（`sigint-c`）が開始されないことを確認する。
     - `=== Tasks Summary ===` 以降に新規タスク開始やクローン作成ログが出ないことを確認する。
-    - `concurrency: 3` の実 PTY 上で3タスクすべてが mock provider の応答待ちに入ったことを call log で確認し、共有 stdin を pause した後に Ctrl+C バイトを送って、3呼び出しが abort されプロセスが速やかに終了することを確認する。
+    - `concurrency: 3` の実 PTY 上で3タスクすべてが mock provider の応答待ちに入ったことを call log で確認し、共有 stdin を pause した後に Kitty keyboard protocol の Ctrl+C（CSI-u）を送って、3呼び出しが abort されプロセスが速やかに終了することを確認する。
 - Runtime config injection with provider（`e2e/specs/runtime-config-provider.e2e.ts`）
   - 目的: `config.yaml` の `runtime.prepare` が provider 呼び出し前に反映される正例と未設定時のenv未注入をmockで確認し、任意の実provider E2Eでは子プロセスへの伝播も確認。
   - LLM: 通常CIでは呼び出さない（mockでprovider呼び出し時のruntime環境を検証）。`TAKT_E2E_PROVIDER` が `claude` / `claude-sdk` / `codex` / `opencode` の場合のみ、実コマンド伝播の追加テストを実行。

--- a/e2e/specs/run-sigint-graceful.e2e.ts
+++ b/e2e/specs/run-sigint-graceful.e2e.ts
@@ -53,7 +53,7 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
     }
   });
 
-  it('should honor terminal Ctrl+C while three concurrent providers await responses', async () => {
+  it('should honor Kitty CSI-u Ctrl+C while three concurrent providers await responses', async () => {
     const workflowPath = resolve(__dirname, '../fixtures/workflows/mock-single-step.yaml');
     const scenarioPath = resolve(__dirname, '../fixtures/scenarios/run-sigint-paused-stdin.json');
     const preloadPath = resolve(__dirname, '../fixtures/preload/pause-stdin-after-data-listener.mjs');
@@ -137,7 +137,7 @@ describe('E2E: Run tasks graceful shutdown on SIGINT (parallel)', () => {
     await ptySession.waitForOutput('[e2e] stdin paused', 10_000);
 
     const startedAt = Date.now();
-    ptySession.write('\u0003');
+    ptySession.write('\x1b[99;5u');
     const exitCode = await ptySession.waitForExit(10_000);
 
     expect([0, 130]).toContain(exitCode);

--- a/src/__tests__/immediateSigintExit.test.ts
+++ b/src/__tests__/immediateSigintExit.test.ts
@@ -47,6 +47,40 @@ describe('installImmediateSigintExit', () => {
     expect(sigintListener).toHaveBeenCalledTimes(1);
   });
 
+  it('run では Kitty keyboard protocol の Ctrl+C を SIGINT に流す', () => {
+    const runtime = new FakeProcess();
+    const sigintListener = vi.fn();
+    runtime.on('SIGINT', sigintListener);
+
+    install('run', runtime);
+    runtime.stdin.emit('data', Buffer.from('\x1b[99;5u', 'utf-8'));
+
+    expect(sigintListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('分割された Kitty keyboard protocol の Ctrl+C も検出する', () => {
+    const runtime = new FakeProcess();
+    const sigintListener = vi.fn();
+    runtime.on('SIGINT', sigintListener);
+
+    install('run', runtime);
+    runtime.stdin.emit('data', Buffer.from('\x1b[99;', 'utf-8'));
+    runtime.stdin.emit('data', Buffer.from('5u', 'utf-8'));
+
+    expect(sigintListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('Kitty keyboard protocol の Ctrl+C release は SIGINT に流さない', () => {
+    const runtime = new FakeProcess();
+    const sigintListener = vi.fn();
+    runtime.on('SIGINT', sigintListener);
+
+    install('run', runtime);
+    runtime.stdin.emit('data', Buffer.from('\x1b[99;5:3u', 'utf-8'));
+
+    expect(sigintListener).not.toHaveBeenCalled();
+  });
+
   it('watch では複数回の Ctrl+C をそのまま SIGINT に流す', () => {
     const runtime = new FakeProcess();
     const sigintListener = vi.fn();

--- a/src/app/cli/immediateSigintExit.ts
+++ b/src/app/cli/immediateSigintExit.ts
@@ -20,6 +20,33 @@ function isRunLikeCommand(commandName: string | undefined): boolean {
   return commandName === 'run' || commandName === 'watch';
 }
 
+const KITTY_KEY_BODY_PATTERN =
+  /^(\d+)(?::\d+)*(?:;(\d+)(?::(\d+))?)?(?:;[\d:]+)?u$/;
+const MAX_KEY_SEQUENCE_LENGTH = 64;
+
+function isKittyCtrlC(sequence: string): boolean {
+  if (!sequence.startsWith('\x1b[')) {
+    return false;
+  }
+
+  const match = KITTY_KEY_BODY_PATTERN.exec(sequence.slice(2));
+  if (!match) {
+    return false;
+  }
+
+  const codepoint = Number(match[1]);
+  const encodedModifiers = match[2] === undefined ? 1 : Number(match[2]);
+  const eventType = match[3] === undefined ? 1 : Number(match[3]);
+  const modifiers = Math.max(0, encodedModifiers - 1);
+  const hasCtrlModifier = modifiers % 8 >= 4;
+
+  if (eventType === 3) {
+    return false;
+  }
+
+  return codepoint === 3 || (codepoint === 99 && hasCtrlModifier);
+}
+
 export function installImmediateSigintExit(
   commandName: string | undefined,
   runtime: ProcessLike = process as unknown as ProcessLike,
@@ -32,6 +59,7 @@ export function installImmediateSigintExit(
   const hadRawMode = stdin.isRaw === true;
   let enabledRawMode = false;
   let cleanedUp = false;
+  let pendingKeySequence = '';
 
   if (!stdin.isTTY) {
     return () => {};
@@ -44,8 +72,38 @@ export function installImmediateSigintExit(
 
   const onData = (chunk: Buffer | string): void => {
     const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
-    if (text.includes('\u0003')) {
-      runtime.emit('SIGINT');
+
+    for (const character of text) {
+      if (character === '\u0003') {
+        pendingKeySequence = '';
+        runtime.emit('SIGINT');
+        continue;
+      }
+
+      if (character === '\x1b') {
+        pendingKeySequence = character;
+        continue;
+      }
+
+      if (pendingKeySequence === '\x1b') {
+        pendingKeySequence = character === '[' ? '\x1b[' : '';
+        continue;
+      }
+
+      if (!pendingKeySequence.startsWith('\x1b[')) {
+        continue;
+      }
+
+      if (/^[\d:;]$/.test(character) && pendingKeySequence.length < MAX_KEY_SEQUENCE_LENGTH) {
+        pendingKeySequence += character;
+        continue;
+      }
+
+      const sequence = character === 'u' ? `${pendingKeySequence}u` : '';
+      pendingKeySequence = '';
+      if (sequence !== '' && isKittyCtrlC(sequence)) {
+        runtime.emit('SIGINT');
+      }
     }
   };
 


### PR DESCRIPTION
## 概要

- Kitty keyboard protocol 環境で `Ctrl-C` が CSI-u として届く場合も、`takt run` / `takt watch` の即時終了監視で SIGINT に変換する
- 分割された CSI-u 入力を保持し、key release は二度目の SIGINT として扱わない
- 3並列の provider 応答待ちを実 PTY 上で再現する E2E を、raw `0x03` ではなく実端末相当の `ESC[99;5u` 入力へ更新する

## RED / GREEN

- RED: 現行実装では単体テストの SIGINT 呼び出しが0回、3並列 E2E は10秒でタイムアウト
- GREEN: 修正後は単体テストが通過し、3 provider の abort を確認して約4.2秒で終了

## 検証

- `npm run build`
- `npm run lint`
- `npm test`
- `npm run test:it`
- `npm run test:e2e:smoke`
- `TAKT_E2E_PROVIDER=mock npx vitest run --config vitest.config.e2e.mock.ts e2e/specs/run-sigint-graceful.e2e.ts`

`npm run test:opencode-probe` はローカルの asdf に OpenCode のバージョン設定がなく、shim が exit 126 を返すため実行不能でした。

## レビュー

Codex Luna Max の敵対レビューで blocking finding なし（APPROVE）。
