### PR TITLE
feat(deepseek-harness): route付きmodel参照をサポート

### DIFF
--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1193,14 +1193,16 @@ model 参照だけの形式と、`openai/gpt-5.4` や
 最初の `/` より前を provider route として使い、それより後の `/` は model
 参照の一部として保持します。route を省略した場合は後方互換のため
 `deepseek-official` を使います。route は記述された値のまま公式 SDK に渡し、TAKT
-独自の allowlist や provider alias 変換は行いません。`openai/gpt-5.4:high` のような
-effort suffix は、この bridge が effort を model ID と別に渡せないため、model ID に
-混ぜず actionable な設定エラーとして拒否します。
+独自の allowlist や provider alias 変換は行いません。route と model の各部分は、
+前後の空白や model 内の `:` も含め、記述された値のまま渡します。TAKT はこの
+provider の effort suffix を解析しません。`ollama/qwen3.5:397b` や
+`gpt-5.6-luna:max` は完全な model ID として SDK の解釈に委ねます。
 空文字列、`/gpt-5.4`（空の route）、`openai/`（空の model）などの形式不正は
-bridge 起動前に拒否され、入力された参照と検証箇所を含むエラーになります。未知の
-route や model ID は TAKT で事前検証せず、記述された値のまま provider と model の
-別フィールドとして bridge/SDK に渡します。SDK が拒否した場合は、入力された参照と
-bridge/SDK で失敗した箇所を含むエラーになります。
+bridge 起動前に拒否されます。空白だけの route または model も空として扱います。
+エラーには入力された参照と検証箇所が含まれます。未知の route や model ID は TAKT
+で事前検証せず、記述された値のまま provider と model の別フィールドとして
+bridge/SDK に渡します。SDK が拒否した場合は、入力された参照と bridge/SDK で
+失敗した箇所を含むエラーになります。
 
 credential safety のため、`python_path` は信頼できる global config または `TAKT_PROVIDER_OPTIONS_DEEPSEEK_HARNESS_PYTHON_PATH` からのみ設定できます。workflow と project-local provider options では既定の `python3` executable を使用してください。`cordis` も実行する tool composition を選択するため、信頼できる global config または `TAKT_PROVIDER_OPTIONS_DEEPSEEK_HARNESS_CORDIS` からのみ設定できます。上の例では両方の項目を意図的に省略しています。同じ制約は project の `runtime.yaml` profile にも適用されます。global runtime profile では信頼できる値を選択できます。project runtime profile の `base_url` は loopback のみ使用できます。
 

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1187,6 +1187,21 @@ provider_options:
     runtime_mode: exe                  # exe または node
 ```
 
+DeepSeek Harness の `model` フィールドは、`deepseek-v4-flash` のような
+model 参照だけの形式と、`openai/gpt-5.4` や
+`my-gateway/org/custom-model` のような `<route>/<model>` 形式を受け付けます。
+最初の `/` より前を provider route として使い、それより後の `/` は model
+参照の一部として保持します。route を省略した場合は後方互換のため
+`deepseek-official` を使います。route は記述された値のまま公式 SDK に渡し、TAKT
+独自の allowlist や provider alias 変換は行いません。`openai/gpt-5.4:high` のような
+effort suffix は、この bridge が effort を model ID と別に渡せないため、model ID に
+混ぜず actionable な設定エラーとして拒否します。
+空文字列、`/gpt-5.4`（空の route）、`openai/`（空の model）などの形式不正は
+bridge 起動前に拒否され、入力された参照と検証箇所を含むエラーになります。未知の
+route や model ID は TAKT で事前検証せず、記述された値のまま provider と model の
+別フィールドとして bridge/SDK に渡します。SDK が拒否した場合は、入力された参照と
+bridge/SDK で失敗した箇所を含むエラーになります。
+
 credential safety のため、`python_path` は信頼できる global config または `TAKT_PROVIDER_OPTIONS_DEEPSEEK_HARNESS_PYTHON_PATH` からのみ設定できます。workflow と project-local provider options では既定の `python3` executable を使用してください。`cordis` も実行する tool composition を選択するため、信頼できる global config または `TAKT_PROVIDER_OPTIONS_DEEPSEEK_HARNESS_CORDIS` からのみ設定できます。上の例では両方の項目を意図的に省略しています。同じ制約は project の `runtime.yaml` profile にも適用されます。global runtime profile では信頼できる値を選択できます。project runtime profile の `base_url` は loopback のみ使用できます。
 
 `session_root` と `cordis` は設定された作業ディレクトリからの相対パスとして解決されます。workflow が `session_key` を指定するとセッションを再利用し、one-shot call は bridge を直ちに close します。`request_timeout_ms` は Python bridge request 全体を終了させ、TAKT call の abort は bridge の process tree を終了させます。公式 `session.event` notification は TAKT の text、thinking、tool-use、tool-result、error、result event へ変換されます。system prompt、TAKT の `allowed_tools`、MCP server map、画像添付、structured output、permission mode、`maxTurns` は公式 SDK の call に存在しないため warning とともに無視されます。system/tool composition は Cordis で設定してください。

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -1194,9 +1194,9 @@ model 参照だけの形式と、`openai/gpt-5.4` や
 参照の一部として保持します。route を省略した場合は後方互換のため
 `deepseek-official` を使います。route は記述された値のまま公式 SDK に渡し、TAKT
 独自の allowlist や provider alias 変換は行いません。route と model の各部分は、
-前後の空白や model 内の `:` も含め、記述された値のまま渡します。TAKT はこの
-provider の effort suffix を解析しません。`ollama/qwen3.5:397b` や
-`gpt-5.6-luna:max` は完全な model ID として SDK の解釈に委ねます。
+前後の空白や model 内の `:` も含め、記述された値のまま渡します。TAKT は model
+部分を不透明な model ID として扱います。たとえば `ollama/qwen3.5:397b` は完全な
+model ID のまま SDK の解釈に委ねます。
 空文字列、`/gpt-5.4`（空の route）、`openai/`（空の model）などの形式不正は
 bridge 起動前に拒否されます。空白だけの route または model も空として扱います。
 エラーには入力された参照と検証箇所が含まれます。未知の route や model ID は TAKT

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1251,9 +1251,9 @@ provider route and preserves every later `/` in the model reference. A bare
 model uses the backward-compatible `deepseek-official` route. Routes are passed
 to the official SDK as written; TAKT does not apply a route allowlist or
 provider-specific aliases. The route and model substrings are passed as written,
-including surrounding whitespace and any `:` in the model. TAKT does not parse
-effort suffixes for this provider; values such as `ollama/qwen3.5:397b` and
-`gpt-5.6-luna:max` remain complete model IDs for the SDK to interpret.
+including surrounding whitespace and any `:` in the model. TAKT treats the model
+substring as an opaque model ID; for example, `ollama/qwen3.5:397b` remains a
+complete model ID for the SDK to interpret.
 Malformed references such as an empty value, `/gpt-5.4`, or `openai/` are
 rejected before the bridge starts; route and model values containing only
 whitespace are also empty. The error includes the supplied reference and the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1244,6 +1244,22 @@ provider_options:
     runtime_mode: exe                  # exe or node; node is for explicit SDK development mode
 ```
 
+The DeepSeek Harness `model` field accepts either a bare model reference such as
+`deepseek-v4-flash` or `<route>/<model>` such as `openai/gpt-5.4` and
+`my-gateway/org/custom-model`. TAKT uses the text before the first `/` as the
+provider route and preserves every later `/` in the model reference. A bare
+model uses the backward-compatible `deepseek-official` route. Routes are passed
+to the official SDK as written; TAKT does not apply a route allowlist or
+provider-specific aliases. Effort suffixes such as `openai/gpt-5.4:high` are
+rejected with an actionable configuration error because this bridge cannot pass
+effort separately from the model ID.
+Malformed references such as an empty value, `/gpt-5.4`, or `openai/` are
+rejected before the bridge starts; the error includes the supplied reference
+and the validation point. Unknown routes or model IDs are not validated by
+TAKT and are passed unchanged as separate provider/model fields to the
+bridge/SDK; an SDK rejection identifies the supplied reference and the
+bridge/SDK failure point.
+
 For credential safety, `python_path` is accepted only from trusted global configuration or `TAKT_PROVIDER_OPTIONS_DEEPSEEK_HARNESS_PYTHON_PATH`; workflow and project-local provider options must use the default `python3` executable. `cordis` is also accepted only from trusted global configuration or `TAKT_PROVIDER_OPTIONS_DEEPSEEK_HARNESS_CORDIS`, because it selects executable tool composition. The example above intentionally omits both fields. The same restrictions apply to project `runtime.yaml` profiles; global runtime profiles may select trusted values. Project runtime profiles may use only loopback `base_url` values.
 
 `session_root` and `cordis` are resolved relative to the configured working directory. Sessions are reused when a workflow supplies `session_key`; one-shot calls close the bridge immediately. `request_timeout_ms` terminates the complete Python bridge request, and aborting a TAKT call terminates the bridge process tree. Stream events are converted from official `session.event` notifications into TAKT text, thinking, tool-use, tool-result, error, and result events. System prompts, TAKT `allowed_tools`, MCP server maps, image attachments, structured output, permission modes, and `maxTurns` are not part of the official SDK call and are ignored with a warning; configure system/tool composition through Cordis instead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1250,15 +1250,16 @@ The DeepSeek Harness `model` field accepts either a bare model reference such as
 provider route and preserves every later `/` in the model reference. A bare
 model uses the backward-compatible `deepseek-official` route. Routes are passed
 to the official SDK as written; TAKT does not apply a route allowlist or
-provider-specific aliases. Effort suffixes such as `openai/gpt-5.4:high` are
-rejected with an actionable configuration error because this bridge cannot pass
-effort separately from the model ID.
+provider-specific aliases. The route and model substrings are passed as written,
+including surrounding whitespace and any `:` in the model. TAKT does not parse
+effort suffixes for this provider; values such as `ollama/qwen3.5:397b` and
+`gpt-5.6-luna:max` remain complete model IDs for the SDK to interpret.
 Malformed references such as an empty value, `/gpt-5.4`, or `openai/` are
-rejected before the bridge starts; the error includes the supplied reference
-and the validation point. Unknown routes or model IDs are not validated by
-TAKT and are passed unchanged as separate provider/model fields to the
-bridge/SDK; an SDK rejection identifies the supplied reference and the
-bridge/SDK failure point.
+rejected before the bridge starts; route and model values containing only
+whitespace are also empty. The error includes the supplied reference and the
+validation point. Unknown routes or model IDs are not validated by TAKT and are
+passed unchanged as separate provider/model fields to the bridge/SDK; an SDK
+rejection identifies the supplied reference and the bridge/SDK failure point.
 
 For credential safety, `python_path` is accepted only from trusted global configuration or `TAKT_PROVIDER_OPTIONS_DEEPSEEK_HARNESS_PYTHON_PATH`; workflow and project-local provider options must use the default `python3` executable. `cordis` is also accepted only from trusted global configuration or `TAKT_PROVIDER_OPTIONS_DEEPSEEK_HARNESS_CORDIS`, because it selects executable tool composition. The example above intentionally omits both fields. The same restrictions apply to project `runtime.yaml` profiles; global runtime profiles may select trusted values. Project runtime profiles may use only loopback `base_url` values.
 

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -917,9 +917,8 @@ DeepSeek Harness 的 `model` 字段既接受 `deepseek-v4-flash` 这样的纯 mo
 并将后续所有 `/` 保留为 model 引用的一部分。省略 route 时，为保持向后兼容，
 使用 `deepseek-official`。route 会按原样传给官方 SDK；TAKT 不使用 route
 allowlist，也不转换 provider alias。route 和 model 两部分都会按原样传递，
-包括首尾空白以及 model 中的 `:`。TAKT 不解析此 provider 的 effort suffix；
-`ollama/qwen3.5:397b` 和 `gpt-5.6-luna:max` 等值会作为完整 model ID 交由
-SDK 解释。
+包括首尾空白以及 model 中的 `:`。TAKT 将 model 部分视为不透明的 model ID；
+例如，`ollama/qwen3.5:397b` 会作为完整 model ID 交由 SDK 解释。
 空值、`/gpt-5.4`（空 route）和 `openai/`（空 model）等格式会在 bridge
 启动前被拒绝。仅含空白的 route 或 model 也视为空值。错误会包含原始引用和
 验证位置。TAKT 不会预先验证未知 route 或 model ID，而是将原值分别作为

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -911,6 +911,21 @@ provider_options:
     runtime_mode: exe                  # exe 或 node；node 仅用于显式 SDK 开发模式
 ```
 
+DeepSeek Harness 的 `model` 字段既接受 `deepseek-v4-flash` 这样的纯 model
+引用，也接受 `openai/gpt-5.4` 或 `my-gateway/org/custom-model` 这样的
+`<route>/<model>` 格式。TAKT 将第一个 `/` 之前的文本作为 provider route，
+并将后续所有 `/` 保留为 model 引用的一部分。省略 route 时，为保持向后兼容，
+使用 `deepseek-official`。route 会按原样传给官方 SDK；TAKT 不使用 route
+allowlist，也不转换 provider alias。route 和 model 两部分都会按原样传递，
+包括首尾空白以及 model 中的 `:`。TAKT 不解析此 provider 的 effort suffix；
+`ollama/qwen3.5:397b` 和 `gpt-5.6-luna:max` 等值会作为完整 model ID 交由
+SDK 解释。
+空值、`/gpt-5.4`（空 route）和 `openai/`（空 model）等格式会在 bridge
+启动前被拒绝。仅含空白的 route 或 model 也视为空值。错误会包含原始引用和
+验证位置。TAKT 不会预先验证未知 route 或 model ID，而是将原值分别作为
+provider 和 model 字段传给 bridge/SDK；若 SDK 拒绝，错误会标明原始引用以及
+bridge/SDK 的失败位置。
+
 `python_path` 和 `cordis` 只允许来自受信任的全局配置或对应环境变量；项目设置使用默认 `python3`。`session_root` 和 `cordis` 相对配置的工作目录解析。带有 `session_key` 的 workflow 会复用 session；one-shot call 会立即关闭 bridge。官方 event 会转换成 TAKT 的 text、thinking、tool-use、tool-result、error 和 result event。system prompt、TAKT `allowed_tools`、MCP server map、图片附件、structured output、permission mode 和 `maxTurns` 不属于官方 SDK 调用，会被警告并忽略；工具组合请通过 Cordis 配置。
 
 #### 网络访问（`network_access`）

--- a/src/__tests__/deepseek-harness-client.test.ts
+++ b/src/__tests__/deepseek-harness-client.test.ts
@@ -260,6 +260,7 @@ class DeepSeekHarness:
     ['my-gateway/org/custom-model', 'my-gateway', 'org/custom-model'],
     ['my-gateway/ollama/qwen3.5:397b', 'my-gateway', 'ollama/qwen3.5:397b'],
     ['openai-codex/gpt-5.6-luna:max', 'openai-codex', 'gpt-5.6-luna:max'],
+    ['route//model', 'route', '/model'],
     [' unknown-route / unknown-model ', ' unknown-route ', ' unknown-model '],
     ['deepseek-v4-flash', 'deepseek-official', 'deepseek-v4-flash'],
     [' deepseek-v4-flash ', 'deepseek-official', ' deepseek-v4-flash '],
@@ -276,6 +277,25 @@ class DeepSeekHarness:
 
     expect(response.status).toBe('done');
     expect(configuration).toMatchObject({ provider, model: modelId });
+  });
+
+  it.each([
+    ['', '""'],
+    ['   ', '   '],
+    ['/model', '/model'],
+    ['route/', 'route/'],
+  ] as const)('rejects malformed model reference %s before starting the bridge', async (model, referenceContext) => {
+    const response = await callDeepSeekHarness('worker', 'hello', {
+      cwd: root,
+      model,
+      providerOptions: { pythonPath, requestTimeoutMs: 10_000 },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.content).toContain(referenceContext);
+    expect(response.content).toMatch(/empty|route|model/iu);
+    await expect(readFile(path.join(root, 'bridge-start-configs.jsonl'), 'utf8'))
+      .rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it.each([

--- a/src/__tests__/deepseek-harness-client.test.ts
+++ b/src/__tests__/deepseek-harness-client.test.ts
@@ -109,6 +109,8 @@ class DeepSeekHarness:
             raise RuntimeError('SDK provider route not found "not-found-route"')
         if kwargs.get('model') == 'enoent-model':
             raise RuntimeError('ENOENT: SDK model not found "enoent-model"')
+        if kwargs.get('model') == 'runtime-unavailable-model':
+            raise FileNotFoundError('missing DeepSeek Harness runtime wheel')
         if kwargs.get('model') == 'terminal-diagnostic-model':
             raise RuntimeError('SDK diagnostic \\x1b]52;clipboard\\x07\\x1b[31mraw\\x1b[0m\\x01')
         counter_file = kwargs.get('session_root')
@@ -256,7 +258,11 @@ class DeepSeekHarness:
   it.each([
     ['openai/gpt-5.4', 'openai', 'gpt-5.4'],
     ['my-gateway/org/custom-model', 'my-gateway', 'org/custom-model'],
+    ['my-gateway/ollama/qwen3.5:397b', 'my-gateway', 'ollama/qwen3.5:397b'],
+    ['openai-codex/gpt-5.6-luna:max', 'openai-codex', 'gpt-5.6-luna:max'],
+    [' unknown-route / unknown-model ', ' unknown-route ', ' unknown-model '],
     ['deepseek-v4-flash', 'deepseek-official', 'deepseek-v4-flash'],
+    [' deepseek-v4-flash ', 'deepseek-official', ' deepseek-v4-flash '],
   ] as const)('passes the effective route and model separately to the SDK for %s', async (model, provider, modelId) => {
     const response = await callDeepSeekHarness('worker', 'hello', {
       cwd: root,
@@ -362,10 +368,8 @@ class DeepSeekHarness:
     expect(streamedMessages.some((message) => message.includes('SDK diagnostic'))).toBe(true);
   });
 
-  it.each([
-    'openai/gpt-5.4:max',
-    'my-gateway/org/custom-model:high',
-  ] as const)('rejects an effort suffix with an actionable reference error: %s', async (reference) => {
+  it('preserves runtime setup diagnostics for a routed model', async () => {
+    const reference = 'known-route/runtime-unavailable-model';
     const response = await callDeepSeekHarness('worker', 'hello', {
       cwd: root,
       model: reference,
@@ -373,9 +377,8 @@ class DeepSeekHarness:
     });
 
     expect(response.status).toBe('error');
-    expect(response.content).toContain(reference);
-    expect(response.content).toMatch(/effort|suffix/iu);
-    expect(response.content).toMatch(/model reference|configuration|parser/iu);
+    expect(response.content).toContain('Unable to start DeepSeek Harness Python bridge');
+    expect(response.content).toContain('Install Python 3.10+ and deepseek-harness-sdk');
   });
 
   it('preserves multiple assistant messages when the SDK omits chunk events', async () => {

--- a/src/__tests__/deepseek-harness-client.test.ts
+++ b/src/__tests__/deepseek-harness-client.test.ts
@@ -98,6 +98,19 @@ class DeepSeekHarness:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.closed = False
+        config_file = os.path.join(kwargs['cwd'], 'bridge-start-configs.jsonl')
+        with open(config_file, 'a', encoding='utf-8') as config:
+            config.write(json.dumps(kwargs, sort_keys=True) + '\\n')
+        if kwargs.get('provider') == 'unknown-route':
+            raise RuntimeError('SDK rejected unknown provider route "unknown-route"')
+        if kwargs.get('model') == 'unknown-model':
+            raise RuntimeError('SDK rejected unknown model "unknown-model"')
+        if kwargs.get('provider') == 'not-found-route':
+            raise RuntimeError('SDK provider route not found "not-found-route"')
+        if kwargs.get('model') == 'enoent-model':
+            raise RuntimeError('ENOENT: SDK model not found "enoent-model"')
+        if kwargs.get('model') == 'terminal-diagnostic-model':
+            raise RuntimeError('SDK diagnostic \\x1b]52;clipboard\\x07\\x1b[31mraw\\x1b[0m\\x01')
         counter_file = kwargs.get('session_root')
         if counter_file:
             with open(counter_file, 'a', encoding='utf-8') as counter:
@@ -229,6 +242,140 @@ class DeepSeekHarness:
       .filter((event) => event.type === 'init' || event.type === 'result')
       .map((event) => event.data.sessionId))
       .toEqual([response.sessionId, response.sessionId]);
+
+    const [configuration] = (await readFile(path.join(root, 'bridge-start-configs.jsonl'), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(configuration).toMatchObject({
+      provider: 'deepseek-official',
+      model: 'deepseek-v4-flash',
+    });
+  });
+
+  it.each([
+    ['openai/gpt-5.4', 'openai', 'gpt-5.4'],
+    ['my-gateway/org/custom-model', 'my-gateway', 'org/custom-model'],
+    ['deepseek-v4-flash', 'deepseek-official', 'deepseek-v4-flash'],
+  ] as const)('passes the effective route and model separately to the SDK for %s', async (model, provider, modelId) => {
+    const response = await callDeepSeekHarness('worker', 'hello', {
+      cwd: root,
+      model,
+      providerOptions: { pythonPath, requestTimeoutMs: 10_000 },
+    });
+    const [configuration] = (await readFile(path.join(root, 'bridge-start-configs.jsonl'), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(response.status).toBe('done');
+    expect(configuration).toMatchObject({ provider, model: modelId });
+  });
+
+  it.each([
+    [
+      'unknown-route/known-model',
+      'unknown-route',
+      'known-model',
+      'SDK rejected unknown provider route "unknown-route"',
+    ],
+    [
+      'known-route/unknown-model',
+      'known-route',
+      'unknown-model',
+      'SDK rejected unknown model "unknown-model"',
+    ],
+    [
+      'not-found-route/known-model',
+      'not-found-route',
+      'known-model',
+      'SDK provider route not found "not-found-route"',
+    ],
+    [
+      'known-route/enoent-model',
+      'known-route',
+      'enoent-model',
+      'ENOENT: SDK model not found "enoent-model"',
+    ],
+  ] as const)('reports the original reference and bridge/SDK failure for %s', async (reference, provider, modelId, sdkFailure) => {
+    const events: Array<{ type: string; data: Record<string, unknown> }> = [];
+    const response = await callDeepSeekHarness('worker', 'hello', {
+      cwd: root,
+      model: reference,
+      providerOptions: { pythonPath, requestTimeoutMs: 10_000 },
+      onStream: (event) => events.push(event as { type: string; data: Record<string, unknown> }),
+    });
+    const [configuration] = (await readFile(path.join(root, 'bridge-start-configs.jsonl'), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(response.status).toBe('error');
+    expect(configuration).toMatchObject({ provider, model: modelId });
+    expect(response.content).toContain(reference);
+    expect(response.content).toContain(provider);
+    expect(response.content).toContain(modelId);
+    expect(response.content).toContain(sdkFailure);
+    expect(events).toEqual(expect.arrayContaining([
+      { type: 'error', data: { message: response.content, raw: response.content } },
+      expect.objectContaining({
+        type: 'result',
+        data: expect.objectContaining({
+          error: response.content,
+          success: false,
+          failureCategory: 'provider_error',
+        }),
+      }),
+    ]));
+    expect(events.some((event) => event.type === 'result' && event.data.success === true)).toBe(false);
+  });
+
+  it('sanitizes terminal control sequences in provider errors and stream events', async () => {
+    const reference = '\u009d52;c;X\u007fterminal-route/terminal-diagnostic-model';
+    const sanitizedReference = `DeepSeek Harness model reference ${JSON.stringify(reference)}`
+      .replace('\u009d', '\\x9d')
+      .replace('\u007f', '\\x7f');
+    const events: Array<{ type: string; data: Record<string, unknown> }> = [];
+    const response = await callDeepSeekHarness('worker', 'hello', {
+      cwd: root,
+      model: reference,
+      providerOptions: { pythonPath, requestTimeoutMs: 10_000 },
+      onStream: (event) => events.push(event as { type: string; data: Record<string, unknown> }),
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.content).toContain(sanitizedReference);
+    expect(response.content).toContain('SDK diagnostic');
+    expect(response.content).toContain('raw');
+    expect(response.content).toContain('\\x01');
+    expect(response.content).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/u);
+
+    const streamedFailureEvents = events.filter((event) => event.type === 'error' || event.type === 'result');
+    expect(streamedFailureEvents).toHaveLength(2);
+    const streamedMessages = streamedFailureEvents.flatMap((event) => Object.values(event.data)
+      .filter((value): value is string => typeof value === 'string'));
+    expect(streamedMessages).not.toHaveLength(0);
+    for (const message of streamedMessages) {
+      expect(message).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/u);
+    }
+    expect(streamedMessages.some((message) => message.includes(sanitizedReference))).toBe(true);
+    expect(streamedMessages.some((message) => message.includes('SDK diagnostic'))).toBe(true);
+  });
+
+  it.each([
+    'openai/gpt-5.4:max',
+    'my-gateway/org/custom-model:high',
+  ] as const)('rejects an effort suffix with an actionable reference error: %s', async (reference) => {
+    const response = await callDeepSeekHarness('worker', 'hello', {
+      cwd: root,
+      model: reference,
+      providerOptions: { pythonPath, requestTimeoutMs: 10_000 },
+    });
+
+    expect(response.status).toBe('error');
+    expect(response.content).toContain(reference);
+    expect(response.content).toMatch(/effort|suffix/iu);
+    expect(response.content).toMatch(/model reference|configuration|parser/iu);
   });
 
   it('preserves multiple assistant messages when the SDK omits chunk events', async () => {
@@ -371,6 +518,69 @@ class DeepSeekHarness:
     expect(response.status).toBe(status);
     expect(response.content).toContain(message);
     expect(response.status).not.toBe('done');
+  });
+
+  it('maps an SDK aborted finish reason to external_abort without reporting success', async () => {
+    const events: Array<{ type: string; data: Record<string, unknown> }> = [];
+    const response = await callDeepSeekHarness('worker', 'reason:aborted', {
+      cwd: root,
+      providerOptions: { pythonPath, requestTimeoutMs: 10_000 },
+      onStream: (event) => events.push(event as { type: string; data: Record<string, unknown> }),
+    });
+
+    expect(response).toMatchObject({
+      status: 'error',
+      failureCategory: 'external_abort',
+      error: response.content,
+    });
+    expect(response.content).toContain('DeepSeek Harness execution aborted');
+    expect(response.content).not.toContain('provider bridge/SDK');
+    expect(events).toEqual(expect.arrayContaining([
+      { type: 'error', data: { message: response.content, raw: response.content } },
+      expect.objectContaining({
+        type: 'result',
+        data: expect.objectContaining({
+          error: response.content,
+          success: false,
+          failureCategory: 'external_abort',
+        }),
+      }),
+    ]));
+    expect(events.some((event) => event.type === 'result' && event.data.success === true)).toBe(false);
+  });
+
+  it.each([
+    ['my-gateway/org/custom-model', 'my-gateway/org/custom-model'],
+    [undefined, 'deepseek-v4-flash'],
+  ] as const)('preserves structured provider error context for model %s', async (model, modelReference) => {
+    const events: Array<{ type: string; data: Record<string, unknown> }> = [];
+    const response = await callDeepSeekHarness('worker', 'reason:error', {
+      cwd: root,
+      ...(model === undefined ? {} : { model }),
+      providerOptions: { pythonPath, requestTimeoutMs: 10_000 },
+      onStream: (event) => events.push(event as { type: string; data: Record<string, unknown> }),
+    });
+
+    expect(response).toMatchObject({
+      status: 'error',
+      failureCategory: 'provider_error',
+      error: response.content,
+    });
+    expect(response.content).toContain(modelReference);
+    expect(response.content).toContain('provider bridge/SDK');
+    expect(response.content).toContain('FAKE: provider failure');
+    expect(events).toEqual(expect.arrayContaining([
+      { type: 'error', data: { message: response.content, raw: response.content } },
+      expect.objectContaining({
+        type: 'result',
+        data: expect.objectContaining({
+          error: response.content,
+          success: false,
+          failureCategory: 'provider_error',
+        }),
+      }),
+    ]));
+    expect(events.some((event) => event.type === 'result' && event.data.success === true)).toBe(false);
   });
 
   it('rejects an unknown finish reason as a provider stream protocol error', async () => {
@@ -542,6 +752,51 @@ class DeepSeekHarness:
     expect(first).toMatchObject({ status: 'done', sessionId: 'persistent-session' });
     expect(second).toMatchObject({ status: 'done', sessionId: 'persistent-session' });
     expect((await readFile(counterFile, 'utf8')).trim().split('\n')).toEqual(['initialized']);
+  });
+
+  it('reuses one process when bare and explicit default routes have the same effective identity', async () => {
+    const counterFile = path.join(root, 'default-route-starts.txt');
+    const first = await callDeepSeekHarness('worker', 'hello', {
+      cwd: root,
+      model: 'deepseek-v4-flash',
+      sessionId: 'default-route-session',
+      providerOptions: { pythonPath, sessionRoot: counterFile, requestTimeoutMs: 10_000 },
+    });
+    const second = await callDeepSeekHarness('worker', 'hello', {
+      cwd: root,
+      model: 'deepseek-official/deepseek-v4-flash',
+      sessionId: 'default-route-session',
+      providerOptions: { pythonPath, sessionRoot: counterFile, requestTimeoutMs: 10_000 },
+    });
+
+    expect(first.status).toBe('done');
+    expect(second.status).toBe('done');
+    expect((await readFile(counterFile, 'utf8')).trim().split('\n')).toEqual(['initialized']);
+  });
+
+  it('does not share a process when the effective route or model changes', async () => {
+    const counterFile = path.join(root, 'routing-starts.txt');
+    const calls = [
+      ['route-a-session', 'openai/gpt-5.4'],
+      ['model-b-session', 'openai/gpt-5.5'],
+      ['route-b-session', 'anthropic/gpt-5.4'],
+    ] as const;
+
+    for (const [sessionId, model] of calls) {
+      const response = await callDeepSeekHarness('worker', 'hello', {
+        cwd: root,
+        model,
+        sessionId,
+        providerOptions: { pythonPath, sessionRoot: counterFile, requestTimeoutMs: 10_000 },
+      });
+      expect(response.status).toBe('done');
+    }
+
+    expect((await readFile(counterFile, 'utf8')).trim().split('\n')).toEqual([
+      'initialized',
+      'initialized',
+      'initialized',
+    ]);
   });
 
   it('rejects a relative session root that traverses a symlink outside the project', async () => {

--- a/src/__tests__/deepseek-harness-client.test.ts
+++ b/src/__tests__/deepseek-harness-client.test.ts
@@ -259,7 +259,6 @@ class DeepSeekHarness:
     ['openai/gpt-5.4', 'openai', 'gpt-5.4'],
     ['my-gateway/org/custom-model', 'my-gateway', 'org/custom-model'],
     ['my-gateway/ollama/qwen3.5:397b', 'my-gateway', 'ollama/qwen3.5:397b'],
-    ['openai-codex/gpt-5.6-luna:max', 'openai-codex', 'gpt-5.6-luna:max'],
     ['route//model', 'route', '/model'],
     [' unknown-route / unknown-model ', ' unknown-route ', ' unknown-model '],
     ['deepseek-v4-flash', 'deepseek-official', 'deepseek-v4-flash'],

--- a/src/__tests__/deepseek-harness-model-reference.test.ts
+++ b/src/__tests__/deepseek-harness-model-reference.test.ts
@@ -28,7 +28,6 @@ describe('DeepSeek Harness model references', () => {
     ['anthropic/claude-sonnet-4-6', { provider: 'anthropic', model: 'claude-sonnet-4-6' }],
     ['my-gateway/org/custom-model', { provider: 'my-gateway', model: 'org/custom-model' }],
     ['my-gateway/ollama/qwen3.5:397b', { provider: 'my-gateway', model: 'ollama/qwen3.5:397b' }],
-    ['openai-codex/gpt-5.6-luna:max', { provider: 'openai-codex', model: 'gpt-5.6-luna:max' }],
     ['route//model', { provider: 'route', model: '/model' }],
     ['deepseek-v4-flash', { provider: 'deepseek-official', model: 'deepseek-v4-flash' }],
   ] as const)('separates the route from the model for %s', (reference, expected) => {

--- a/src/__tests__/deepseek-harness-model-reference.test.ts
+++ b/src/__tests__/deepseek-harness-model-reference.test.ts
@@ -27,19 +27,18 @@ describe('DeepSeek Harness model references', () => {
     ['openai-codex/gpt-5.6-luna', { provider: 'openai-codex', model: 'gpt-5.6-luna' }],
     ['anthropic/claude-sonnet-4-6', { provider: 'anthropic', model: 'claude-sonnet-4-6' }],
     ['my-gateway/org/custom-model', { provider: 'my-gateway', model: 'org/custom-model' }],
+    ['my-gateway/ollama/qwen3.5:397b', { provider: 'my-gateway', model: 'ollama/qwen3.5:397b' }],
+    ['openai-codex/gpt-5.6-luna:max', { provider: 'openai-codex', model: 'gpt-5.6-luna:max' }],
     ['deepseek-v4-flash', { provider: 'deepseek-official', model: 'deepseek-v4-flash' }],
   ] as const)('separates the route from the model for %s', (reference, expected) => {
     expect(parseDeepSeekHarnessModelReference(reference)).toEqual(expected);
   });
 
   it.each([
-    'openai/gpt-5.4:max',
-    'openai-codex/gpt-5.6-luna:max',
-    'my-gateway/org/custom-model:high',
-    'deepseek-v4-flash:max',
-    'deepseek-v4-flash:',
-  ] as const)('rejects an effort suffix without forwarding it as part of the model: %s', (reference) => {
-    expectActionableParseError(reference, /effort|suffix/iu);
+    [' unknown-route / unknown-model ', { provider: ' unknown-route ', model: ' unknown-model ' }],
+    [' deepseek-v4-flash ', { provider: 'deepseek-official', model: ' deepseek-v4-flash ' }],
+  ] as const)('preserves surrounding whitespace for %s', (reference, expected) => {
+    expect(parseDeepSeekHarnessModelReference(reference)).toEqual(expected);
   });
 
   it.each([
@@ -47,6 +46,9 @@ describe('DeepSeek Harness model references', () => {
     'openai/',
     '/',
     '',
+    '   ',
+    '   /model',
+    'route/   ',
   ] as const)('rejects an empty or malformed model reference: %s', (reference) => {
     expectActionableParseError(reference, /model reference|route|model|empty/iu);
   });

--- a/src/__tests__/deepseek-harness-model-reference.test.ts
+++ b/src/__tests__/deepseek-harness-model-reference.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { parseDeepSeekHarnessModelReference } from '../infra/deepseek-harness/model-reference.js';
+
+function expectActionableParseError(reference: string, location: RegExp): void {
+  let message: string | undefined;
+  try {
+    parseDeepSeekHarnessModelReference(reference);
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+
+  expect(message).toBeDefined();
+  if (message === undefined) {
+    throw new Error('DeepSeek Harness model reference was accepted unexpectedly');
+  }
+  if (reference.length > 0) {
+    expect(message).toContain(reference);
+  } else {
+    expect(message).toMatch(/empty|""/iu);
+  }
+  expect(message).toMatch(location);
+}
+
+describe('DeepSeek Harness model references', () => {
+  it.each([
+    ['openai/gpt-5.4', { provider: 'openai', model: 'gpt-5.4' }],
+    ['openai-codex/gpt-5.6-luna', { provider: 'openai-codex', model: 'gpt-5.6-luna' }],
+    ['anthropic/claude-sonnet-4-6', { provider: 'anthropic', model: 'claude-sonnet-4-6' }],
+    ['my-gateway/org/custom-model', { provider: 'my-gateway', model: 'org/custom-model' }],
+    ['deepseek-v4-flash', { provider: 'deepseek-official', model: 'deepseek-v4-flash' }],
+  ] as const)('separates the route from the model for %s', (reference, expected) => {
+    expect(parseDeepSeekHarnessModelReference(reference)).toEqual(expected);
+  });
+
+  it.each([
+    'openai/gpt-5.4:max',
+    'openai-codex/gpt-5.6-luna:max',
+    'my-gateway/org/custom-model:high',
+    'deepseek-v4-flash:max',
+    'deepseek-v4-flash:',
+  ] as const)('rejects an effort suffix without forwarding it as part of the model: %s', (reference) => {
+    expectActionableParseError(reference, /effort|suffix/iu);
+  });
+
+  it.each([
+    '/gpt-5.4',
+    'openai/',
+    '/',
+    '',
+  ] as const)('rejects an empty or malformed model reference: %s', (reference) => {
+    expectActionableParseError(reference, /model reference|route|model|empty/iu);
+  });
+});

--- a/src/__tests__/deepseek-harness-model-reference.test.ts
+++ b/src/__tests__/deepseek-harness-model-reference.test.ts
@@ -29,6 +29,7 @@ describe('DeepSeek Harness model references', () => {
     ['my-gateway/org/custom-model', { provider: 'my-gateway', model: 'org/custom-model' }],
     ['my-gateway/ollama/qwen3.5:397b', { provider: 'my-gateway', model: 'ollama/qwen3.5:397b' }],
     ['openai-codex/gpt-5.6-luna:max', { provider: 'openai-codex', model: 'gpt-5.6-luna:max' }],
+    ['route//model', { provider: 'route', model: '/model' }],
     ['deepseek-v4-flash', { provider: 'deepseek-official', model: 'deepseek-v4-flash' }],
   ] as const)('separates the route from the model for %s', (reference, expected) => {
     expect(parseDeepSeekHarnessModelReference(reference)).toEqual(expected);

--- a/src/infra/deepseek-harness/client.ts
+++ b/src/infra/deepseek-harness/client.ts
@@ -94,7 +94,10 @@ class DeepSeekHarnessProtocolError extends Error {
 }
 
 class DeepSeekHarnessTransportError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly bridgeCode?: string,
+  ) {
     super(message);
     this.name = 'DeepSeekHarnessTransportError';
   }
@@ -528,7 +531,17 @@ function bridgeError(error: BridgeErrorPayload | undefined, knownSecrets: Record
   if (code === 'malformed-response' || code === 'protocol-error') {
     return new DeepSeekHarnessProtocolError(formatted);
   }
-  return new DeepSeekHarnessTransportError(formatted);
+  return new DeepSeekHarnessTransportError(formatted, code);
+}
+
+function isRuntimeSetupFailure(error: unknown, diagnostic: string): boolean {
+  if (error instanceof DeepSeekHarnessTransportError) {
+    return error.bridgeCode === 'runtime-unavailable';
+  }
+  return (
+    diagnostic.includes('ENOENT')
+    || diagnostic.toLowerCase().includes('no such file or directory')
+  );
 }
 
 function abortError(reason: unknown): Error {
@@ -894,20 +907,20 @@ class DeepSeekHarnessProcess {
       this.ready = true;
     } catch (error) {
       await this.terminate();
-      if (
-        error instanceof DeepSeekHarnessTransportError
-        || error instanceof DeepSeekHarnessProviderError
-      ) {
-        throw error;
-      }
       const diagnostic = safeMessage(error, this.knownSecrets);
-      if (diagnostic.includes('ENOENT') || diagnostic.toLowerCase().includes('not found')) {
+      if (isRuntimeSetupFailure(error, diagnostic)) {
         throw new Error(
           `Unable to start DeepSeek Harness Python bridge with "${this.pythonPath}". `
           + 'Install Python 3.10+ and deepseek-harness-sdk with its matching runtime wheel, '
           + 'or set provider_options.deepseek_harness.python_path.',
           { cause: error },
         );
+      }
+      if (
+        error instanceof DeepSeekHarnessTransportError
+        || error instanceof DeepSeekHarnessProviderError
+      ) {
+        throw error;
       }
       throw error;
     }

--- a/src/infra/deepseek-harness/client.ts
+++ b/src/infra/deepseek-harness/client.ts
@@ -916,12 +916,6 @@ class DeepSeekHarnessProcess {
           { cause: error },
         );
       }
-      if (
-        error instanceof DeepSeekHarnessTransportError
-        || error instanceof DeepSeekHarnessProviderError
-      ) {
-        throw error;
-      }
       throw error;
     }
   }

--- a/src/infra/deepseek-harness/client.ts
+++ b/src/infra/deepseek-harness/client.ts
@@ -22,6 +22,7 @@ import {
   assertPathSegmentsAreSafe,
   getErrorMessage,
   isAbsolutePathLike,
+  sanitizeTerminalText,
   spawnManagedProcess,
   type ManagedProcess,
 } from '../../shared/utils/index.js';
@@ -32,6 +33,7 @@ import {
 } from '../../shared/utils/sensitiveText.js';
 import type { DeepSeekHarnessProviderOptions } from '../../core/models/workflow-types.js';
 import { DEEPSEEK_HARNESS_DEFAULT_MODEL } from './constants.js';
+import { parseDeepSeekHarnessModelReference } from './model-reference.js';
 import type { DeepSeekHarnessCallOptions } from './types.js';
 const DEEPSEEK_HARNESS_STARTUP_TIMEOUT_MS = 30_000;
 const DEEPSEEK_HARNESS_CALL_TIMEOUT_MS = 3_600_000;
@@ -112,6 +114,13 @@ class DeepSeekHarnessTurnEndError extends Error {
   ) {
     super(message);
     this.name = 'DeepSeekHarnessTurnEndError';
+  }
+}
+
+class DeepSeekHarnessProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DeepSeekHarnessProviderError';
   }
 }
 
@@ -284,12 +293,8 @@ function resolveBridgeConfiguration(
   options: DeepSeekHarnessCallOptions,
   providerOptions: DeepSeekHarnessProviderOptions | undefined,
 ): ResolvedBridgeConfiguration {
-  const model = options.model === undefined
-    ? DEEPSEEK_HARNESS_DEFAULT_MODEL
-    : options.model.trim();
-  if (model.length === 0) {
-    throw new Error('DeepSeek Harness model must not be empty');
-  }
+  const modelReference = options.model ?? DEEPSEEK_HARNESS_DEFAULT_MODEL;
+  const { provider, model } = parseDeepSeekHarnessModelReference(modelReference);
   assertSafeSessionId(options.sessionId);
   const cwd = canonicalizePathWithMissingTail(path.resolve(options.cwd));
   const maxTokens = requirePositiveSafeInteger(providerOptions?.maxTokens, 'maxTokens');
@@ -328,7 +333,7 @@ function resolveBridgeConfiguration(
     ? undefined
     : canonicalizePathWithMissingTail(resolvedCordis);
   return {
-    provider: 'deepseek-official',
+    provider,
     model,
     cwd,
     ...(sessionRoot === undefined ? {} : { sessionRoot }),
@@ -500,7 +505,9 @@ function sanitizeKnownSecrets(text: string, knownSecrets: Record<string, string>
 }
 
 function safeMessage(value: unknown, knownSecrets: Record<string, string>): string {
-  const sanitized = sanitizeKnownSecrets(getErrorMessage(value), knownSecrets);
+  const sanitized = sanitizeTerminalText(
+    sanitizeKnownSecrets(getErrorMessage(value), knownSecrets),
+  );
   if (Buffer.byteLength(sanitized, 'utf8') <= DEEPSEEK_HARNESS_MAX_ERROR_BYTES) {
     return sanitized;
   }
@@ -887,6 +894,12 @@ class DeepSeekHarnessProcess {
       this.ready = true;
     } catch (error) {
       await this.terminate();
+      if (
+        error instanceof DeepSeekHarnessTransportError
+        || error instanceof DeepSeekHarnessProviderError
+      ) {
+        throw error;
+      }
       const diagnostic = safeMessage(error, this.knownSecrets);
       if (diagnostic.includes('ENOENT') || diagnostic.toLowerCase().includes('not found')) {
         throw new Error(
@@ -1468,6 +1481,19 @@ function getOrCreateProcess(options: DeepSeekHarnessCallOptions): DeepSeekHarnes
   return processRecord;
 }
 
+function formatProviderBridgeFailure(
+  error: Error,
+  options: DeepSeekHarnessCallOptions,
+  knownSecrets: Record<string, string>,
+): AgentFailureDetail {
+  const modelReference = options.model ?? DEEPSEEK_HARNESS_DEFAULT_MODEL;
+  const reason = `DeepSeek Harness model reference ${JSON.stringify(modelReference)} `
+    + `failed at the provider bridge/SDK: ${getErrorMessage(error)}`;
+  return createProviderErrorFailure(
+    safeMessage(reason, knownSecrets),
+  );
+}
+
 function failureDetail(
   error: unknown,
   options: DeepSeekHarnessCallOptions,
@@ -1483,7 +1509,11 @@ function failureDetail(
   if (error instanceof DeepSeekHarnessProtocolError) {
     return createProviderStreamParseFailure(safeMessage(error, knownSecrets));
   }
-  return createProviderErrorFailure(safeMessage(error, knownSecrets));
+  if (error instanceof DeepSeekHarnessTransportError || error instanceof DeepSeekHarnessProviderError) {
+    return formatProviderBridgeFailure(error, options, knownSecrets);
+  }
+  const reason = safeMessage(error, knownSecrets);
+  return createProviderErrorFailure(reason);
 }
 
 function emitFailure(
@@ -1510,7 +1540,7 @@ function emitFailure(
 
 function finishReasonFailure(state: HarnessStreamState): Error {
   const reason = state.failureReason ?? 'DeepSeek Harness turn ended with an error';
-  return new Error(reason);
+  return new DeepSeekHarnessProviderError(reason);
 }
 
 function createSuccessResponse(

--- a/src/infra/deepseek-harness/constants.ts
+++ b/src/infra/deepseek-harness/constants.ts
@@ -1,1 +1,2 @@
+export const DEEPSEEK_HARNESS_DEFAULT_PROVIDER = 'deepseek-official';
 export const DEEPSEEK_HARNESS_DEFAULT_MODEL = 'deepseek-v4-flash';

--- a/src/infra/deepseek-harness/model-reference.ts
+++ b/src/infra/deepseek-harness/model-reference.ts
@@ -1,0 +1,44 @@
+import { DEEPSEEK_HARNESS_DEFAULT_PROVIDER } from './constants.js';
+
+export interface DeepSeekHarnessModelReference {
+  provider: string;
+  model: string;
+}
+
+function invalidModelReference(reference: string, reason: string): Error {
+  return new Error(`Invalid DeepSeek Harness model reference ${JSON.stringify(reference)}: ${reason}`);
+}
+
+export function parseDeepSeekHarnessModelReference(
+  reference: string,
+): DeepSeekHarnessModelReference {
+  const normalizedReference = reference.trim();
+  if (normalizedReference.length === 0) {
+    throw invalidModelReference(reference, 'model reference must not be empty');
+  }
+
+  const separatorIndex = normalizedReference.indexOf('/');
+  const rawProvider = separatorIndex === -1
+    ? DEEPSEEK_HARNESS_DEFAULT_PROVIDER
+    : normalizedReference.slice(0, separatorIndex);
+  const rawModel = separatorIndex === -1
+    ? normalizedReference
+    : normalizedReference.slice(separatorIndex + 1);
+  const provider = rawProvider.trim();
+  const model = rawModel.trim();
+
+  if (provider.length === 0) {
+    throw invalidModelReference(reference, 'provider route must not be empty');
+  }
+  if (model.length === 0) {
+    throw invalidModelReference(reference, 'model must not be empty');
+  }
+  if (model.includes(':')) {
+    throw invalidModelReference(
+      reference,
+      'effort suffixes are not supported because the DeepSeek Harness SDK has no separate effort field',
+    );
+  }
+
+  return { provider, model };
+}

--- a/src/infra/deepseek-harness/model-reference.ts
+++ b/src/infra/deepseek-harness/model-reference.ts
@@ -12,33 +12,24 @@ function invalidModelReference(reference: string, reason: string): Error {
 export function parseDeepSeekHarnessModelReference(
   reference: string,
 ): DeepSeekHarnessModelReference {
-  const normalizedReference = reference.trim();
-  if (normalizedReference.length === 0) {
+  if (reference.trim().length === 0) {
     throw invalidModelReference(reference, 'model reference must not be empty');
   }
 
-  const separatorIndex = normalizedReference.indexOf('/');
+  const separatorIndex = reference.indexOf('/');
   const rawProvider = separatorIndex === -1
     ? DEEPSEEK_HARNESS_DEFAULT_PROVIDER
-    : normalizedReference.slice(0, separatorIndex);
+    : reference.slice(0, separatorIndex);
   const rawModel = separatorIndex === -1
-    ? normalizedReference
-    : normalizedReference.slice(separatorIndex + 1);
-  const provider = rawProvider.trim();
-  const model = rawModel.trim();
+    ? reference
+    : reference.slice(separatorIndex + 1);
 
-  if (provider.length === 0) {
+  if (rawProvider.trim().length === 0) {
     throw invalidModelReference(reference, 'provider route must not be empty');
   }
-  if (model.length === 0) {
+  if (rawModel.trim().length === 0) {
     throw invalidModelReference(reference, 'model must not be empty');
   }
-  if (model.includes(':')) {
-    throw invalidModelReference(
-      reference,
-      'effort suffixes are not supported because the DeepSeek Harness SDK has no separate effort field',
-    );
-  }
 
-  return { provider, model };
+  return { provider: rawProvider, model: rawModel };
 }


### PR DESCRIPTION
## 概要

- DeepSeek Harness provider の `model` で `<route>/<model>` 形式を受け付ける
- 最初の `/` より前を provider route、残りを model として公式 SDK へ分離して渡す
- route 省略時は従来どおり `deepseek-official` を使用する
- route/model の実効値を process 再利用キーへ反映する

## 変更内容

- DeepSeek Harness 専用の model reference parser を追加
- 追加の `/` と model 内の `:` を model ID の一部として保持
- 空 route、空 model、空白だけの要素を入力値付きエラーとして拒否
- 有効な route/model の前後の空白は削除せず、記述された値のまま SDK へ渡す
- SDK が未知の route/model を拒否した場合、元の参照と bridge/SDK 境界をエラーへ追加
- `runtime-unavailable` は従来の Python/SDK セットアップ診断を維持
- provider エラーの terminal control sequence を無害化
- 英語・日本語・簡体字中国語の設定ドキュメントを同期

## レビュー指摘への対応

- CodeRabbit: route/model の空白保持と回帰テストを追加
- Codex: `qwen3.5:397b` や `gpt-5.6-luna:max` を model ID として透過
- Codex: provider rejection と runtime setup failure を構造化 code で区別

## 検証

- DeepSeek Harness model reference tests: 16 passed
- DeepSeek Harness client tests: 59 passed / 1 skipped
- `npm run lint`
- `npm run build`
- `npm test`
- `git diff --check`

DeepSeek 以外の route を使う live smoke は、利用可能な credential に依存するため必須検証には含めていません。

Closes #1478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - DeepSeek Harnessで、単一のモデル名に加えて「route/model」形式を指定できるようになりました。
  - route省略時は、既定の`deepseek-official`が使用されます。
  - モデル内の空白、`:`、追加の`/`はそのままSDKへ渡されます。

- **改善**
  - 空の値や不正な指定を、起動前に分かりやすく通知します。
  - プロバイダーやSDKのエラーを、詳細を保持して報告します。
  - エラーメッセージから端末制御文字を除去します。

- **ドキュメント**
  - モデル指定形式とエラー条件の説明を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->