### PR TITLE
[#1494] update-requeue-resume-path

### DIFF
--- a/src/__tests__/taskRetryActions.test.ts
+++ b/src/__tests__/taskRetryActions.test.ts
@@ -850,6 +850,7 @@ describe('requeueFailedTask', () => {
   });
 
   it('should pass resume_point when selected step matches root workflow_call step', async () => {
+    const expectedResumeLabel = 'Resume failed position: "default" > "delegate" > "coding" > "review"';
     const resumePoint = {
       version: 2 as const,
       stack: [
@@ -862,8 +863,8 @@ describe('requeueFailedTask', () => {
           call_instance: 1,
         },
         {
-          workflow: 'takt/coding',
-          workflow_ref: 'takt/coding',
+          workflow: 'coding',
+          workflow_ref: 'coding',
           step: 'review',
           kind: 'agent' as const,
           occurrence: 1,
@@ -878,11 +879,22 @@ describe('requeueFailedTask', () => {
       ...defaultWorkflowConfig,
       initialStep: 'delegate',
       steps: [
-        { name: 'delegate', kind: 'workflow_call', instruction: '', call: 'takt/coding', personaDisplayName: 'delegate', passPreviousResponse: true },
+        { name: 'delegate', kind: 'workflow_call', instruction: '', call: 'coding', personaDisplayName: 'delegate', passPreviousResponse: true },
         { name: 'final_review', persona: 'supervisor', instruction: '', personaDisplayName: 'supervisor', passPreviousResponse: true },
       ],
     });
-    selectStartCandidate('Resume failed position: default > delegate > takt/coding > review [default]');
+    mockSelectOptionWithDefault.mockImplementationOnce(
+      (
+        _message: string,
+        options: Array<{ label: string; value: string }>,
+        defaultValue: string,
+      ) => {
+        const resumeOption = options.find((option) => option.label === expectedResumeLabel);
+        expect(resumeOption).toBeDefined();
+        expect(defaultValue).toBe(resumeOption?.value);
+        return defaultValue;
+      },
+    );
     const task = makeFailedTask({
       data: {
         task: 'Do something',
@@ -905,6 +917,9 @@ describe('requeueFailedTask', () => {
         sourceRunSlug: undefined,
         restartPoint: undefined,
       },
+    );
+    expect(mockInfo).toHaveBeenCalledWith(
+      `Selected start position: ${expectedResumeLabel}`,
     );
   });
 

--- a/src/__tests__/taskRetryStartSelection.test.ts
+++ b/src/__tests__/taskRetryStartSelection.test.ts
@@ -418,6 +418,56 @@ describe('tree restart picker contracts', () => {
 });
 
 describe('resume checkpoint is preserved across the tree picker', () => {
+  it('should display the complete resolved path for a nested Resume default', async () => {
+    const child = makeWorkflow({
+      name: 'coding',
+      ref: 'project:child',
+      callable: true,
+      steps: [agentStep('review')],
+    });
+    const root = makeWorkflow({
+      name: 'default',
+      ref: 'project:root',
+      steps: [callStep('delegate', 'coding')],
+    });
+    const resumePoint: WorkflowResumePoint = {
+      version: 2,
+      stack: [
+        {
+          workflow: 'default',
+          workflow_ref: 'project:root',
+          step: 'delegate',
+          kind: 'workflow_call',
+          call_instance: 1,
+        },
+        {
+          workflow: 'coding',
+          workflow_ref: 'project:child',
+          step: 'review',
+          kind: 'agent',
+        },
+      ],
+      iteration: 4,
+      elapsed_ms: 1_000,
+      workflow_call_invocations: {},
+      workflow_step_participations: {},
+    };
+    mockResolveWorkflowCallTarget.mockReturnValue(child);
+
+    const cap = await capturePicker(
+      root,
+      { ...pathContext, resumePoint },
+      (_options, defaultValue) => defaultValue,
+    );
+
+    const resumeOption = cap.options.find((option) => option.value === 'resume-checkpoint');
+    expect(resumeOption?.label).toBe(
+      'Resume failed position: "default" > "delegate" > "coding" > "review"',
+    );
+    expect(cap.defaultValue).toBe(resumeOption?.value);
+    expect(cap.result?.selection).toEqual({ kind: 'resume', resumePoint });
+  });
+
   it('should keep a synthesized checkpoint available and default through Resume', async () => {
     const root = makeWorkflow({
       name: 'default',
@@ -440,7 +490,7 @@ describe('resume checkpoint is preserved across the tree picker', () => {
     expect(cap.options.some((option) => option.label.startsWith('Restart from: '))).toBe(false);
     // The synthesized checkpoint is never presented as a selectable restart leaf.
     expect(cap.options.some(
-      (option) => !isHeading(option) && option.label.includes('engine-step'),
+      (option) => option.value.startsWith('restart:') && option.label.includes('engine-step'),
     )).toBe(false);
   });
 

--- a/src/features/tasks/list/taskRetryStartSelection.ts
+++ b/src/features/tasks/list/taskRetryStartSelection.ts
@@ -51,9 +51,6 @@ function createResumeOption(
   if (options.resumePoint === undefined) {
     return undefined;
   }
-  // Resolve only to confirm the checkpoint still maps onto the current
-  // workflow; the tree UI drops the long serialized path, so the label names
-  // the workflow rather than repeating each nested step.
   const resolved = resolveTaskRetryStackPath(
     rootWorkflow,
     options.resumePoint.stack,
@@ -65,7 +62,7 @@ function createResumeOption(
   }
   return {
     value: RESUME_SELECTION_VALUE,
-    label: `${RESUME_LABEL_PREFIX}${formatTaskRetryPath([rootWorkflow.name])}`,
+    label: `${RESUME_LABEL_PREFIX}${formatTaskRetryPath(resolved.segments)}`,
     selection: { kind: 'resume', resumePoint: options.resumePoint },
   };
 }


### PR DESCRIPTION
## Summary

# タスク: requeue の再開位置を完全なワークフロー経路で表示する

## 背景・目的

`requeue` の開始位置選択画面では、保存済み checkpoint の既定候補がルート workflow 名だけで表示され、実際にどのネストされた step から再開するのか判断できない。

解決済みの再開経路を利用し、ルート workflow から最終再開 step までを一意に判別できる表示へ変更する。選択後のログにも同じ経路を表示する。

## 作業範囲

### 優先度: 高 — requeue 開始位置選択 UI

対象:

- `src/app/cli/` 配下の requeue 開始位置選択処理
- checkpoint の既定候補ラベルを生成しているモジュール

作業内容:

- 保存済み checkpoint から得られる解決済み再開経路を、既定候補の表示に使用する。
- 経路にはルート workflow、workflow 呼び出し step、呼び出し先 workflow、最終再開 stepを含める。
- 各経路要素を引用符付きで表示する。
- 経路要素の区切りに ` > ` を使用する。
- 既定候補を示す既存の `(default)` 表示を維持する。

### 優先度: 高 — 選択結果ログ

対象:

- `src/app/cli/` 配下の開始位置選択結果を出力する処理
- Resume 候補の表示ラベルを生成・保持する関連モジュール

作業内容:

- Resume 候補を選択した後の `Selected start position` ログにも、開始位置選択画面と同じ完全経路を使用する。
- UI とログで経路の組み立て方が食い違わないよう、同一の表示データまたは共通の整形処理を利用する。

### 優先度: 高 — テスト

対象:

- `src/__tests__/` 配下の requeue、checkpoint、開始位置選択 UI に関するテスト
- 対象処理に既存の近接テストファイルがある場合は、そのファイルを優先して更新する

作業内容:

- ネストした workflow 内の step を指す checkpoint を用意し、完全経路が表示されることを検証する。
- 開始位置選択画面と選択後ログの両方を検証する。
- 既存テストのうち、ルート workflow 名だけを期待している箇所を新しい表示へ更新する。

## 受け入れ条件

```gherkin
Feature: Requeue の再開位置表示

  Rule: 解決済みの再開経路を省略せず表示する

    Scenario: ネストした checkpoint が既定候補になる
      Given 再開経路が "default", "delegate", "coding", "review" と解決されている
      When requeue の開始位置選択画面を表示する
      Then 既定候補は `Resume failed position: "default" > "delegate" > "coding" > "review" (default)` と表示される

    Scenario: 完全経路を持つ既定候補を選択する
      Given 完全な再開経路を示す Resume 候補が表示されている
      When ユーザーがその候補を選択する
      Then ログに `Selected start position: Resume failed position: "default" > "delegate" > "coding" > "review"` と表示される
```

## 再現・確認方法

1. ルート workflow から subworkflow を呼び出し、その内部 step で失敗した checkpoint を準備する。
2. 対象実行に対して `requeue` の開始位置選択画面を開く。
3. 既定候補と、選択後に出力されるログが Gherkin の振る舞いを満たすことを確認する。
4. 変更したテストを対象指定で実行する。
5. 以下の検証を実行する。

```bash
npm test -- <変更したテストファイル>
npm run lint
npm run build
```

## Quint 仕様

```quint
module RequeueResumeDisplay {
  type DisplayState = {
    resolvedPath: List[str],
    promptPath: List[str],
    selectedLogPath: List[str],
  }

  pure def quote(segment: str): str =
    "\"" + segment + "\""

  pure def renderPath(path: List[str]): str =
    path.foldl(
      "",
      (rendered, segment) =>
        if (rendered == "") {
          quote(segment)
        } else {
          rendered + " > " + quote(segment)
        }
    )

  pure def resumeLabel(path: List[str]): str =
    "Resume failed position: " + renderPath(path)

  pure def promptLabel(path: List[str]): str =
    resumeLabel(path) + " (default)"

  pure def selectedLog(path: List[str]): str =
    "Selected start position: " + resumeLabel(path)

  pure def preservesResolvedPath(state: DisplayState): bool =
    state.promptPath == state.resolvedPath and
    state.selectedLogPath == state.resolvedPath
}
```

## Alloy 仕様

```alloy
module requeue_resume_display

sig Segment {}

one sig ResumeDisplay {
  resolvedPath: seq Segment,
  promptPath: seq Segment,
  selectedLogPath: seq Segment
}

fact ResolvedPathIsDisplayedCompletely {
  ResumeDisplay.promptPath = ResumeDisplay.resolvedPath
  ResumeDisplay.selectedLogPath = ResumeDisplay.resolvedPath
}

assert NoResolvedSegmentIsOmitted {
  ResumeDisplay.promptPath = ResumeDisplay.resolvedPath
  ResumeDisplay.selectedLogPath = ResumeDisplay.resolvedPath
}

check NoResolvedSegmentIsOmitted for 8 Segment
```

## Execution Report

Workflow `takt-default` completed successfully.

Closes #1494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ネストされたワークフローの再開時に、チェックポイントの選択肢へ解決済みのフルパスを表示するようになりました。
  - 再開位置の既定選択と、選択後に表示される開始位置の案内が、より正確になりました。
  - 合成ステップの再起動候補を正しく判定できるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->