### PR TITLE
Release v0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.62.0] - 2026-08-25
+
+### Added
+
+- Conversation settings commands in interactive mode (#1471). `/workflow`, `/interaction`, and `/provider` reopen the usual selectors, and `/model <value>` and `/effort <value>` set free-form overrides for the current conversation. Selections are temporary and never persisted: workflow, mode, provider, and model changes start a new assistant session on the next ordinary message or `/go`, with the prior transcript included once as reference context; an effort-only change applies to the next call; changing provider clears the temporary model and effort overrides; when several commands run before the next input, only the last value per setting is applied. These overrides do not affect workflow execution.
+- Rule field `command_gates` (#1127). Rule conditions and the transition are now resolved before command quality gates run. `required` (the default when omitted) runs the step's gates after rule resolution and applies the transition only when they succeed; a failed gate is fed back to the same step as before. `skip` applies the selected transition without running gates, so a `needs_fix` or `ABORT` transition can leave a read-only reviewer step even when its gate would fail. Invalid values fail at load, and parallel sub-steps follow the same policy.
+- Companion reviews for Team Leader steps (#1435). A Team Leader step declares `companion` like a normal agent step. Each part gets its own Companion runtime: after the part responds, the current cumulative diff is reviewed, accepted findings go back to the same part session, and the part result is published only after that loop settles while other parts keep running. Once every part is complete and the Team Leader proposes no further work, a Team completion review runs before aggregation; its findings feed the existing additional-part planner, and correction parts are followed by another completion review. `takt-default-team`, `development-implement-team`, and `development-remediation-team` now wire their companions to the Team Leader step.
+
+### Changed
+
+- **BREAKING:** The `quiet` and `passthrough` interactive modes and the workflow-level `interactive_mode` field were removed (#1471). Interactive mode offers `assistant`, `grill-me`, and `persona`; a workflow YAML that still contains `interactive_mode` fails to load, so remove the field. Pass the task as a command-line argument when you previously relied on `passthrough`.
+- Gherkin guidance is limited to development and implementation tasks, and Gherkin keywords stay in English (#1471, #1497). The assistant first decides whether a task creates or changes code, configuration, infrastructure, or tests; research, analysis, review, planning, documentation, and other non-implementation tasks are written entirely in Markdown. `Feature`, `Scenario`, `Given`, `When`, `Then`, and the other structural keywords are always written in English even in Japanese instructions, with no `# language` directive; descriptions after the keywords may use the instruction language.
+- Submitted user messages are highlighted in the conversation TUI (#1490). Each submitted message is drawn on a full-width background band with one blank row above and below and a `❯ ` marker; the colors adapt to the terminal background when the terminal reports it, falling back to dark gray and white. The unsubmitted draft keeps the normal input styling.
+- The `requeue` start-position picker shows the full resume path (#1494). The default resume candidate lists the root workflow, each `workflow_call` step, the called workflow, and the final step as quoted segments joined by ` > `, and the `Selected start position` log prints the same path.
+- Loop analysis (experimental) keeps a private copy of the complete report (#1495). Before sanitizing, the worker saves the full report and a `source.json` describing the source run under `loop-analysis/<source-run-slug>-<hash>/` in the global config directory, and the sanitized report and PR comment end with a `source run: <slug>` line.
+
+### Fixed
+
+- Loop analysis reports no longer mask relative paths (#1495). Paths such as `reports/subworkflows/**/plan.md` were turned into `[path]` because the `/` after `**` was treated as an absolute path; the shared path sanitizer now decides from the path boundary, keeping relative paths, globs, `//` comments, HTML closing tags, and URLs while still masking POSIX, Windows, UNC, `file://`, and `~/` paths in reports and external error messages.
+
+### Internal
+
+- Prompt eval suites are organized under `eval/agents/<step>/` and `eval/scenarios/<flow>/`, with recursive suite discovery and duplicate suite ID rejection (#1482).
+
 ## [0.61.0] - 2026-08-23
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,30 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.62.0] - 2026-08-25
+
+### Added
+
+- 対話モードの会話設定コマンド (#1471)。`/workflow`、`/interaction`、`/provider` は起動時と同じ選択 UI を開き直し、`/model <value>` と `/effort <value>` は会話中だけ有効な自由入力の上書きを設定します。選択は一時的で保存されません。workflow・モード・provider・model の変更は次の通常メッセージか `/go` の時点で新しいアシスタントセッションを開始し、それまでの会話履歴を参考情報として一度だけ引き継ぎます。effort だけの変更は次の呼び出しから適用され、provider を変更すると一時的な model・effort の上書きは解除されます。次の入力前に複数回実行した場合は設定ごとに最後の値だけが適用されます。これらの上書きは workflow 実行には影響しません。
+- rule フィールド `command_gates` (#1127)。rule の condition と遷移先を確定してから command quality gate を実行するようになりました。`required`（省略時の既定値）は rule 確定後に step の gate を実行し、成功した場合だけ遷移を適用します。失敗時は従来どおり同じ step へ失敗情報を渡して再実行します。`skip` は gate を実行せずに選択された遷移を適用するため、gate が失敗する状況でも readonly のレビュー step から `needs_fix` や `ABORT` で抜けられます。不正な値はロード時に失敗し、parallel のサブ step も同じポリシーに従います。
+- Team Leader step の Companion レビュー (#1435)。Team Leader step でも通常 agent step と同じ `companion` を宣言できます。各 part は専用の Companion runtime を持ち、part が応答した直後にその時点の累積 diff をレビューし、採用された finding を同じ part セッションへ届け、そのループが収束してから part の結果を公開します。ほかの part は並行して実行を続けます。全 part が完了し Team Leader が追加作業なしと判断すると、集約前に Team 全体の完了レビューを実行します。その finding は既存の追加 part 計画へ渡され、修正 part の後には再び完了レビューが行われます。`takt-default-team`、`development-implement-team`、`development-remediation-team` は Companion を Team Leader step に接続しました。
+
+### Changed
+
+- **BREAKING:** 対話モードの `quiet` と `passthrough`、および workflow の `interactive_mode` フィールドを削除しました (#1471)。対話モードは `assistant`、`grill-me`、`persona` の 3 種類です。`interactive_mode` を含む workflow YAML はロードに失敗するため、フィールドを削除してください。`passthrough` の代わりにはタスクをコマンドライン引数で渡してください。
+- Gherkin ガイダンスを開発・実装タスクに限定し、Gherkin の予約語を常に英語にしました (#1471, #1497)。アシスタントはまずタスクがコード・設定・インフラ・テストを作成または変更するかを判断し、調査・分析・レビュー・企画・文書作成などの実装以外のタスクは Markdown だけで記述します。`Feature`、`Scenario`、`Given`、`When`、`Then` などの構造予約語は日本語の指示書でも英語で書き、`# language` ディレクティブは使用しません。予約語に続く説明は指示書の言語で記述できます。
+- 会話 TUI で送信済みのユーザー発言を強調表示します (#1490)。送信済みの発言は表示幅いっぱいの背景帯に上下 1 行の余白と `❯ ` マーカー付きで描画されます。端末が背景色を報告する場合はその色に合わせ、報告しない場合は暗いグレーと白にフォールバックします。送信前の入力は通常の入力欄の表示のままです。
+- `requeue` の開始位置選択で完全な再開経路を表示します (#1494)。既定の再開候補はルート workflow、各 `workflow_call` step、呼び出し先 workflow、最終 step を引用符付きで ` > ` 区切りに並べて表示し、`Selected start position` のログにも同じ経路を出力します。
+- ループ分析（experimental）が完全版レポートの非公開コピーを保存します (#1495)。worker はサニタイズ前に完全版レポートと source run を記述する `source.json` をグローバル設定ディレクトリの `loop-analysis/<source-run-slug>-<hash>/` へ保存し、サニタイズ後のレポートと PR コメントの末尾に `source run: <slug>` 行を付けます。
+
+### Fixed
+
+- ループ分析レポートで相対パスがマスクされなくなりました (#1495)。`reports/subworkflows/**/plan.md` のようなパスは `**` 直後の `/` が絶対パスとして扱われ `[path]` に化けていました。共通のパス sanitizer はパス境界で判定するようになり、相対パス・glob・`//` コメント・HTML 閉じタグ・URL を保持したまま、レポートと外部向けエラーメッセージ内の POSIX・Windows・UNC・`file://`・`~/` のパスをマスクします。
+
+### Internal
+
+- プロンプト eval スイートを `eval/agents/<step>/` と `eval/scenarios/<flow>/` に整理し、再帰的なスイート検出と重複スイート ID の拒否を追加しました (#1482)。
+
 ## [0.61.0] - 2026-08-23
 
 ### Added

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-j3yO/Y4XCE5alKlQqOwPf2LOGQsqSba+pio2JFncOjI=";
+            npmDepsHash = "sha256-fD7yx/Vj0y/zWtiEIvufxN2buIxiFyBrLYC0Qc/VgRQ=";
             npmDepsFetcherVersion = 2;
             nodejs = nodejs;
             ONNXRUNTIME_NODE_INSTALL = "skip";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.61.0",
+      "version": "0.62.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Workflow control for AI coding agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes


### Added

- Conversation settings commands in interactive mode (#1471). `/workflow`, `/interaction`, and `/provider` reopen the usual selectors, and `/model <value>` and `/effort <value>` set free-form overrides for the current conversation. Selections are temporary and never persisted: workflow, mode, provider, and model changes start a new assistant session on the next ordinary message or `/go`, with the prior transcript included once as reference context; an effort-only change applies to the next call; changing provider clears the temporary model and effort overrides; when several commands run before the next input, only the last value per setting is applied. These overrides do not affect workflow execution.
- Rule field `command_gates` (#1127). Rule conditions and the transition are now resolved before command quality gates run. `required` (the default when omitted) runs the step's gates after rule resolution and applies the transition only when they succeed; a failed gate is fed back to the same step as before. `skip` applies the selected transition without running gates, so a `needs_fix` or `ABORT` transition can leave a read-only reviewer step even when its gate would fail. Invalid values fail at load, and parallel sub-steps follow the same policy.
- Companion reviews for Team Leader steps (#1435). A Team Leader step declares `companion` like a normal agent step. Each part gets its own Companion runtime: after the part responds, the current cumulative diff is reviewed, accepted findings go back to the same part session, and the part result is published only after that loop settles while other parts keep running. Once every part is complete and the Team Leader proposes no further work, a Team completion review runs before aggregation; its findings feed the existing additional-part planner, and correction parts are followed by another completion review. `takt-default-team`, `development-implement-team`, and `development-remediation-team` now wire their companions to the Team Leader step.

### Changed

- **BREAKING:** The `quiet` and `passthrough` interactive modes and the workflow-level `interactive_mode` field were removed (#1471). Interactive mode offers `assistant`, `grill-me`, and `persona`; a workflow YAML that still contains `interactive_mode` fails to load, so remove the field. Pass the task as a command-line argument when you previously relied on `passthrough`.
- Gherkin guidance is limited to development and implementation tasks, and Gherkin keywords stay in English (#1471, #1497). The assistant first decides whether a task creates or changes code, configuration, infrastructure, or tests; research, analysis, review, planning, documentation, and other non-implementation tasks are written entirely in Markdown. `Feature`, `Scenario`, `Given`, `When`, `Then`, and the other structural keywords are always written in English even in Japanese instructions, with no `# language` directive; descriptions after the keywords may use the instruction language.
- Submitted user messages are highlighted in the conversation TUI (#1490). Each submitted message is drawn on a full-width background band with one blank row above and below and a `❯ ` marker; the colors adapt to the terminal background when the terminal reports it, falling back to dark gray and white. The unsubmitted draft keeps the normal input styling.
- The `requeue` start-position picker shows the full resume path (#1494). The default resume candidate lists the root workflow, each `workflow_call` step, the called workflow, and the final step as quoted segments joined by ` > `, and the `Selected start position` log prints the same path.
- Loop analysis (experimental) keeps a private copy of the complete report (#1495). Before sanitizing, the worker saves the full report and a `source.json` describing the source run under `loop-analysis/<source-run-slug>-<hash>/` in the global config directory, and the sanitized report and PR comment end with a `source run: <slug>` line.

### Fixed

- Loop analysis reports no longer mask relative paths (#1495). Paths such as `reports/subworkflows/**/plan.md` were turned into `[path]` because the `/` after `**` was treated as an absolute path; the shared path sanitizer now decides from the path boundary, keeping relative paths, globs, `//` comments, HTML closing tags, and URLs while still masking POSIX, Windows, UNC, `file://`, and `~/` paths in reports and external error messages.

### Internal

- Prompt eval suites are organized under `eval/agents/<step>/` and `eval/scenarios/<flow>/`, with recursive suite discovery and duplicate suite ID rejection (#1482).

## Commits

- db77e58b Release v0.62.0
- 12c612bd fix: keep Gherkin keywords in English (#1497)
- acd68f5c [#1435] add-team-companion-review (#1489)
- ed1000e6 fix(loop-analysis): archive the full report locally and stop masking relative paths (#1495)
- 4e4b9bda takt: update-requeue-resume-path (#1496)
- 12afec59 [#1127] update-command-gate-order (#1484)
- ec67d324 [#1490] highlight-submitted-messages (#1491)
- 1db6e65f refactor(eval): organize suites by agent and scenario (#1482)
- b25dbb91 [#1471] implement-interactive-switchin (#1488)

## Closes

All referenced issues (#1127, #1435, #1471, #1490, #1494) are already closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 対話モードに、ワークフロー・対話方式・プロバイダー・モデル・処理負荷を設定するコマンドを追加。
  - ルールごとのコマンド実行制御と、Team Leader ステップのレビュー機能に対応。
- **変更**
  - TUIで送信メッセージを見やすく強調表示。
  - `requeue` の再開位置選択で、完全な再開経路を表示。
  - Gherkin ガイダンスを開発タスク向けに変更。
- **不具合修正**
  - ループ解析レポートの相対パスが適切に表示されない問題を修正。
- **リリース**
  - バージョン 0.62.0（2026年8月25日）を公開。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->