### PR TITLE
fix(e2e): make smoke tests portable on Windows

### DIFF
--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -24,7 +24,7 @@ E2Eテストを追加・変更した場合は、このドキュメントも更�
 - `~/.takt/config.yaml` はE2Eでは参照されないため、通常実行の設定には影響しない。
 
 ## 実行コマンド
-- `npm run test:e2e:smoke`: 対象を絞ったローカル確認向けの高速な mock E2E smoke を実行。
+- `npm run test:e2e:smoke`: 対象を絞ったローカル確認向けの高速な mock E2E smoke を実行。provider はVitest設定内で `mock` を既定化するため、POSIX shell・PowerShellのどちらからも追加の環境変数構文なしで実行できる。
 - `npm run test:e2e`: `test:e2e:mock` のラッパー。GitHub接続エラー検出とmacOS通知も行う。
 - `npm run test:e2e:mock`: mock固定のフルE2Eを複数シャードで並列実行。
 - `npm run test:e2e:mock:serial`: mock固定のフルE2Eを従来どおり単一Vitestプロセスで実行。

--- a/e2e/helpers/test-repo.ts
+++ b/e2e/helpers/test-repo.ts
@@ -30,7 +30,11 @@ export function createLocalRepo(): LocalRepo {
   return {
     path: repoPath,
     cleanup: () => {
-      rmSync(repoPath, { recursive: true, force: true });
+      try {
+        rmSync(repoPath, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      } catch {
+        // Best-effort cleanup: Windows may retain transient Git/process handles.
+      }
     },
   };
 }
@@ -114,7 +118,7 @@ export function createOfflineTestRepo(options?: CreateTestRepoOptions): TestRepo
     branch: currentBranch,
     cleanup: () => {
       try {
-        rmSync(sandboxPath, { recursive: true, force: true });
+        rmSync(sandboxPath, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       } catch {
         // Best-effort cleanup
       }
@@ -237,7 +241,7 @@ export function createTestRepo(options?: CreateTestRepoOptions): TestRepo {
 
       // Delete local directory last
       try {
-        rmSync(repoPath, { recursive: true, force: true });
+        rmSync(repoPath, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       } catch {
         // Best-effort cleanup
       }

--- a/e2e/specs/list-non-interactive.e2e.ts
+++ b/e2e/specs/list-non-interactive.e2e.ts
@@ -3,7 +3,7 @@ import { execFileSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parse as parseYaml } from 'yaml';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import {
   createIsolatedEnv,
   updateIsolatedConfig,
@@ -71,17 +71,18 @@ function writePendingWorktreeTask(repoPath: string, name: string, content: strin
   const now = new Date().toISOString();
   writeFileSync(
     join(taktDir, 'tasks.yaml'),
-    [
-      'tasks:',
-      `  - name: ${name}`,
-      '    status: pending',
-      `    content: "${content.replaceAll('"', '\\"')}"`,
-      `    workflow: "${MOCK_WORKFLOW_PATH}"`,
-      '    worktree: true',
-      `    created_at: "${now}"`,
-      '    started_at: null',
-      '    completed_at: null',
-    ].join('\n'),
+    stringifyYaml({
+      tasks: [{
+        name,
+        status: 'pending',
+        content,
+        workflow: MOCK_WORKFLOW_PATH,
+        worktree: true,
+        created_at: now,
+        started_at: null,
+        completed_at: null,
+      }],
+    }),
     'utf-8',
   );
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test:prompt-evals": "npm run test:opencode-probe",
     "test:watch": "vitest --config vitest.config.unit.parallel.ts",
     "test:e2e": "tmp=\"$(mktemp -t takt-e2e.XXXXXX)\"; npm run test:e2e:mock >\"$tmp\" 2>&1; code=$?; cat \"$tmp\"; if grep -q \"error connecting to api.github.com\" \"$tmp\"; then echo \"[takt] GitHub connectivity error detected in E2E output\"; code=1; fi; rm -f \"$tmp\"; if [ \"$code\" -eq 0 ]; then msg='test:e2e passed'; else msg=\"test:e2e failed (exit=$code)\"; fi; if command -v osascript >/dev/null 2>&1; then osascript -e \"display notification \\\"$msg\\\" with title \\\"takt\\\" subtitle \\\"E2E\\\"\" >/dev/null 2>&1 || true; fi; echo \"[takt] $msg\"; exit $code",
-    "test:e2e:smoke": "TAKT_E2E_PROVIDER=mock vitest run --config vitest.config.e2e.smoke.ts --outputFile.json=e2e/results/smoke.json",
+    "test:e2e:smoke": "vitest run --config vitest.config.e2e.smoke.ts --outputFile.json=e2e/results/smoke.json",
     "test:e2e:mock": "node scripts/run-e2e-mock-shards.mjs",
     "test:e2e:mock:serial": "TAKT_E2E_PROVIDER=mock vitest run --config vitest.config.e2e.mock.ts --outputFile.json=e2e/results/mock.json",
     "test:e2e:all": "npm run test:e2e:mock && npm run test:e2e:provider",

--- a/src/__tests__/eject-builtin-rollback.test.ts
+++ b/src/__tests__/eject-builtin-rollback.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolve } from 'node:path';
+
+const builtinWorkflowsDir = resolve('builtin', 'workflows');
+const projectDir = resolve('project');
 
 const mocks = vi.hoisted(() => ({
   copyFragments: vi.fn(),
@@ -36,7 +40,7 @@ vi.mock('node:fs', async (importOriginal) => {
 });
 
 vi.mock('../infra/config/index.js', () => ({
-  getBuiltinWorkflowsDir: () => '/builtin/workflows',
+  getBuiltinWorkflowsDir: () => builtinWorkflowsDir,
   getGlobalStepsDir: () => '/global/steps',
   getGlobalWorkflowsDir: () => '/global/workflows',
   getLanguage: () => 'en',
@@ -64,15 +68,16 @@ describe('ejectBuiltin rollback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     let workflowDirCreated = false;
+    const workflowDir = resolve(projectDir, '.takt', 'workflows');
     mocks.existsSync.mockImplementation((path: string) => (
-      path === '/builtin/workflows/default.yaml'
-      || (path === '/project/.takt/workflows' && workflowDirCreated)
+      path === resolve(builtinWorkflowsDir, 'default.yaml')
+      || (path === workflowDir && workflowDirCreated)
     ));
     mocks.pathExistsForEject.mockImplementation((path: string) => (
-      path === '/project/.takt/workflows' && workflowDirCreated
+      path === resolve(workflowDir, 'default.yaml') && workflowDirCreated
     ));
     mocks.mkdirSync.mockImplementation((path: string) => {
-      if (path === '/project/.takt/workflows') {
+      if (path === workflowDir) {
         workflowDirCreated = true;
       }
     });
@@ -86,7 +91,7 @@ describe('ejectBuiltin rollback', () => {
   });
 
   it('should delegate workflow cleanup to the safe writer when the workflow write fails', async () => {
-    await expect(ejectBuiltin('default', { projectDir: '/project' })).rejects.toThrow('simulated workflow write failure');
+    await expect(ejectBuiltin('default', { projectDir })).rejects.toThrow('simulated workflow write failure');
 
     expect(mocks.copyFragments.mock.results[0]?.value).toHaveBeenCalledOnce();
     expect(mocks.rmSync).not.toHaveBeenCalled();
@@ -100,7 +105,7 @@ describe('ejectBuiltin rollback', () => {
     const stepFragmentRollback = vi.fn();
     mocks.copyFragments.mockReturnValue(stepFragmentRollback);
 
-    await expect(ejectBuiltin('default', { projectDir: '/project' })).rejects.toThrow('simulated pool copy failure');
+    await expect(ejectBuiltin('default', { projectDir })).rejects.toThrow('simulated pool copy failure');
 
     expect(stepFragmentRollback).toHaveBeenCalledOnce();
   });

--- a/src/__tests__/it-operation-journal-store.test.ts
+++ b/src/__tests__/it-operation-journal-store.test.ts
@@ -12,6 +12,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../shared/utils/private-file.js', async (importOriginal) => ({
@@ -155,8 +156,9 @@ function runStoreProcess(
   const storeModule = resolve(
     'src/infra/workflow/operation-journal-store.ts',
   );
+  const storeModuleUrl = pathToFileURL(storeModule).href;
   const script = `
-    import { createOperationJournalStore } from ${JSON.stringify(storeModule)};
+    import { createOperationJournalStore } from ${JSON.stringify(storeModuleUrl)};
     const waitForParentMessage = (expected) =>
       new Promise((resolveMessage, rejectMessage) => {
         const onMessage = (message) => {
@@ -207,9 +209,10 @@ function runInternalStoreProcess(journalPath: string, body: string): ManagedChil
   const storeModule = resolve(
     'src/infra/workflow/operation-journal-store.ts',
   );
+  const storeModuleUrl = pathToFileURL(storeModule).href;
   const script = `
     import { existsSync } from 'node:fs';
-    import { createOperationJournalStore } from ${JSON.stringify(storeModule)};
+    import { createOperationJournalStore } from ${JSON.stringify(storeModuleUrl)};
     const waitForFile = (path, timeoutMs = 5_000) => {
       const deadline = Date.now() + timeoutMs;
       while (!existsSync(path)) {
@@ -344,7 +347,9 @@ describe('operation journal store', () => {
     const reopened = createOperationJournalStore(journalPath);
     expect(reopened.getParent('parent-1').children).toHaveLength(2);
     expect(reopened.listParents().map((parent) => parent.id)).toEqual(['parent-1']);
-    expect(statSync(journalPath).mode & 0o777).toBe(0o600);
+    if (process.platform !== 'win32') {
+      expect(statSync(journalPath).mode & 0o777).toBe(0o600);
+    }
     expect(existsSync(`${journalPath}.lock`)).toBe(false);
   });
 

--- a/vitest.config.e2e.smoke.ts
+++ b/vitest.config.e2e.smoke.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
 import { e2eBaseTestConfig } from './vitest.config.e2e.base';
 
+process.env.TAKT_E2E_PROVIDER ??= 'mock';
+
 export default defineConfig({
   test: {
     ...e2eBaseTestConfig,

--- a/vitest.config.e2e.smoke.ts
+++ b/vitest.config.e2e.smoke.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import { e2eBaseTestConfig } from './vitest.config.e2e.base';
 
-process.env.TAKT_E2E_PROVIDER ??= 'mock';
+process.env.TAKT_E2E_PROVIDER = 'mock';
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary
- serialize tasks.yaml with yaml.stringify so Windows absolute paths stay valid
- make temporary repository cleanup retry and best-effort on transient Windows handles
- move the mock-provider default into the Vitest smoke config so the npm script is shell-portable

## Verification
- npm run build: passed
- npm run lint: passed
- npm run test:e2e:smoke: 17 passed, 1 skipped
- full npm test and test:it remain non-green on Windows due broader existing path/mock assumptions outside this patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - E2Eスモークテストでモック環境が標準設定になり、追加の環境変数なしで実行できるようになりました。
  - POSIXシェルとPowerShellのどちらでも、同じ手順でテストを実行できます。
  - 一時的なテスト用リポジトリの削除処理が安定し、削除に失敗した場合も再試行するようになりました。
  - 保留中のworktreeタスク定義が、より正確なYAML形式で出力されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->