### PR TITLE
fix(test): DeepSeek Harness テストのプラットフォーム判定と Python 判定を分離

### DIFF
--- a/src/__tests__/deepseek-harness-client.test.ts
+++ b/src/__tests__/deepseek-harness-client.test.ts
@@ -46,17 +46,25 @@ function findPython(): string | undefined {
   return undefined;
 }
 
-const supportedRuntime = (
+const supportedPlatform = (
   (process.platform === 'linux' && (process.arch === 'x64' || process.arch === 'arm64'))
   || (process.platform === 'darwin' && process.arch === 'arm64')
-) && findPython() !== undefined;
+);
+const supportedRuntime = supportedPlatform && findPython() !== undefined;
 
-it.skipIf(supportedRuntime)('DeepSeek Harness fails fast with an actionable unsupported-platform error', async () => {
+it.skipIf(supportedPlatform)('DeepSeek Harness fails fast with an actionable unsupported-platform error', async () => {
   const response = await callDeepSeekHarness('worker', 'hello', { cwd: process.cwd() });
 
   expect(response.status).toBe('error');
   expect(response.content).toContain('Linux x64/arm64 or macOS arm64');
   expect(response.content).toContain('no provider fallback is available');
+});
+
+it.skipIf(!supportedPlatform || supportedRuntime)('DeepSeek Harness fails fast with an actionable missing-Python error on a supported platform', async () => {
+  const response = await callDeepSeekHarness('worker', 'hello', { cwd: process.cwd() });
+
+  expect(response.status).toBe('error');
+  expect(response.content).toContain('Python 3.10');
 });
 
 describe.skipIf(!supportedRuntime)('DeepSeek Harness bridge lifecycle', () => {

--- a/src/__tests__/deepseek-harness-client.test.ts
+++ b/src/__tests__/deepseek-harness-client.test.ts
@@ -15,8 +15,7 @@ function isSupportedPythonVersion(version: readonly [number, number]): boolean {
     || (version[0] === minimum[0] && version[1] >= minimum[1]);
 }
 
-function findPython(): string | undefined {
-  const candidates = process.platform === 'win32' ? ['python'] : ['python3', 'python'];
+function findPython(candidates: readonly string[]): string | undefined {
   for (const candidate of candidates) {
     try {
       const details = execFileSync(candidate, [
@@ -46,11 +45,17 @@ function findPython(): string | undefined {
   return undefined;
 }
 
+function findLifecyclePython(): string | undefined {
+  const candidates = process.platform === 'win32' ? ['python'] : ['python3', 'python'];
+  return findPython(candidates);
+}
+
 const supportedPlatform = (
   (process.platform === 'linux' && (process.arch === 'x64' || process.arch === 'arm64'))
   || (process.platform === 'darwin' && process.arch === 'arm64')
 );
-const supportedRuntime = supportedPlatform && findPython() !== undefined;
+const defaultRuntimeSupported = supportedPlatform && findPython(['python3']) !== undefined;
+const lifecycleRuntimeSupported = supportedPlatform && findLifecyclePython() !== undefined;
 
 it.skipIf(supportedPlatform)('DeepSeek Harness fails fast with an actionable unsupported-platform error', async () => {
   const response = await callDeepSeekHarness('worker', 'hello', { cwd: process.cwd() });
@@ -60,19 +65,19 @@ it.skipIf(supportedPlatform)('DeepSeek Harness fails fast with an actionable uns
   expect(response.content).toContain('no provider fallback is available');
 });
 
-it.skipIf(!supportedPlatform || supportedRuntime)('DeepSeek Harness fails fast with an actionable missing-Python error on a supported platform', async () => {
+it.skipIf(!supportedPlatform || defaultRuntimeSupported)('DeepSeek Harness fails fast with an actionable missing-Python error on a supported platform', async () => {
   const response = await callDeepSeekHarness('worker', 'hello', { cwd: process.cwd() });
 
   expect(response.status).toBe('error');
   expect(response.content).toContain('Python 3.10');
 });
 
-describe.skipIf(!supportedRuntime)('DeepSeek Harness bridge lifecycle', () => {
+describe.skipIf(!lifecycleRuntimeSupported)('DeepSeek Harness bridge lifecycle', () => {
   let root: string;
   let pythonPath: string;
 
   beforeEach(async () => {
-    const python = findPython();
+    const python = findLifecyclePython();
     if (python === undefined) {
       throw new Error('Python 3.10+ was detected during suite selection but is unavailable');
     }


### PR DESCRIPTION
## 問題

`npm run check:release` が macOS arm64 + Python 3.9 環境で失敗した。

`src/__tests__/deepseek-harness-client.test.ts` のガード変数 `supportedRuntime` が「プラットフォーム対応か」と「Python 3.10+ があるか」を 1 つにまとめていたため、対応プラットフォームでも Python が古いだけで unsupported-platform エラー文言（`Linux x64/arm64 or macOS arm64`）を期待するテストが実行される。実際のプロダクションコードはこの環境で `DeepSeek Harness requires Python 3.10 or newer` を返すため、期待と食い違って失敗する。プロダクション側の挙動は正しく、テスト側の問題。

## 修正

- `supportedPlatform`（OS/arch のみ）を分離し、unsupported-platform テストは非対応プラットフォームでのみ実行
- 「対応プラットフォームだが Python 3.10+ がない」環境向けに、エラーへ `Python 3.10` が含まれることを検証するテストを追加

CI（Linux + Python 3.10+）では従来どおり両テストがスキップされ lifecycle スイートが走るため、CI の挙動は変わらない。

## 検証

- `npm test -- src/__tests__/deepseek-harness-client.test.ts` → 1 passed / 64 skipped（macOS arm64 + Python 3.9 環境で追加テストが実行され通過）
- `npm test -- src/__tests__/releaseVerificationWiring.test.ts` → 20 passed

https://claude.ai/code/session_013oYZwugBps6ruE2vFzSjrg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 対応プラットフォームと Python 実行環境の確認を分離しました。
  * 非対応プラットフォームで適切なエラーが表示されるケースを追加しました。
  * 対応プラットフォームでも Python が利用できない場合のエラーケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->