### PR TITLE
Release v0.64.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.64.1] - 2026-09-05
+
+### Internal
+
+- Provider SDK updates (#1534): `@anthropic-ai/claude-agent-sdk` 0.3.206 → 0.3.261, `@openai/codex-sdk` 0.147.0 → 0.153.3, `@opencode-ai/sdk` 1.18.2 → 1.18.28.
+
 ## [0.64.0] - 2026-09-01
 
 ### Added

--- a/docs/CHANGELOG.ja.md
+++ b/docs/CHANGELOG.ja.md
@@ -6,6 +6,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づいています。
 
+## [0.64.1] - 2026-09-05
+
+### Internal
+
+- プロバイダ SDK を更新しました (#1534)。`@anthropic-ai/claude-agent-sdk` 0.3.206 → 0.3.261、`@openai/codex-sdk` 0.147.0 → 0.153.3、`@opencode-ai/sdk` 1.18.2 → 1.18.28。
+
 ## [0.64.0] - 2026-09-01
 
 ### Added

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             version = packageJson.version;
             src = ./.;
 
-            npmDepsHash = "sha256-m6IYt0w9Tk0GCwmXp/wcYL2XPhHdKkTHbAci7YsCueE=";
+            npmDepsHash = "sha256-48aZGO6tsUzbcC2+L6kb9mU7kqO7NvbddY648q1+ku4=";
             npmDepsFetcherVersion = 2;
             nodejs = nodejs;
             ONNXRUNTIME_NODE_INSTALL = "skip";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "takt",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "takt",
-      "version": "0.64.0",
+      "version": "0.64.1",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takt",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Workflow control for AI coding agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Changes

### Internal

- Provider SDK updates (#1534): `@anthropic-ai/claude-agent-sdk` 0.3.206 → 0.3.261, `@openai/codex-sdk` 0.147.0 → 0.153.3, `@opencode-ai/sdk` 1.18.2 → 1.18.28.

## Commits

- 39473959 chore: update provider SDKs (#1534)
- 81cd5443 Release v0.64.1

## Verification

- `npm run test:e2e:provider:claude-sdk`: 22/22 passed
- `npm run test:e2e:provider:codex`: 21/21 passed
- `npm run test:e2e:provider:opencode`: 22/23 on first run; the timed-out spec passed on an isolated rerun
- `nix build .#default`: passed with the updated `npmDepsHash`

https://claude.ai/code/session_014HdRrUxsKbWB1mQbCnihAN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更点**
  - バージョンを **0.64.1** に更新しました。
  - AIプロバイダー関連の内部コンポーネントを更新し、最新の互換性・安定性を反映しました。
  - Nix環境の依存関係情報を更新しました。
- **ドキュメント**
  - 英語版・日本語版の変更履歴に、今回のリリース情報を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->